### PR TITLE
chore: adds search example using autocomplete input

### DIFF
--- a/cypress/e2e/artist.cy.ts
+++ b/cypress/e2e/artist.cy.ts
@@ -1,19 +1,22 @@
-/* eslint-disable jest/expect-expect */
+import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
+
 describe("/artist/:id", () => {
   before(() => {
-    cy.visit("/artist/pablo-picasso", { timeout: 10000 })
+    visitWithStatusRetries("/artist/pablo-picasso/about", {
+      timeout: 30000,
+    })
   })
 
   it("renders metadata", () => {
     cy.title().should(
       "contain",
-      "Pablo Picasso - Artworks for Sale & More | Artsy"
+      "Pablo Picasso - Biography, Shows, Articles & More | Artsy"
     )
     cy.get("meta[name='description']")
       .should("have.attr", "content")
       .and(
         "contain",
-        "Discover and purchase Pablo Picasso’s artworks, available for sale. Browse our selection of paintings, prints, and sculptures by the artist, and find art you love."
+        "Explore Pablo Picasso’s biography, achievements, artworks, auction results, and shows on Artsy. Perhaps the most influential artist of the 20th century, Pablo Picasso"
       )
   })
 

--- a/cypress/helpers/visitWithStatusRetries.ts
+++ b/cypress/helpers/visitWithStatusRetries.ts
@@ -1,3 +1,10 @@
-export const visitWithStatusRetries = url => {
-  cy.visit(url, { retryOnStatusCodeFailure: true, retryOnNetworkFailure: true })
+export const visitWithStatusRetries = (
+  url: string,
+  options?: Partial<Cypress.VisitOptions>
+) => {
+  cy.visit(url, {
+    ...options,
+    retryOnStatusCodeFailure: true,
+    retryOnNetworkFailure: true,
+  })
 }

--- a/src/Apps/Example/ExampleApp.tsx
+++ b/src/Apps/Example/ExampleApp.tsx
@@ -47,6 +47,9 @@ const ExampleApp: React.FC<ExampleAppProps> = ({ system, children }) => {
           <RouterLink to="/example/add-to-collection">
             <Text>Add To Collection</Text>
           </RouterLink>
+          <RouterLink to="/example/search">
+            <Text>Search</Text>
+          </RouterLink>
         </Join>
       </Flex>
 

--- a/src/Apps/Example/Routes/Search/SearchRoute.tsx
+++ b/src/Apps/Example/Routes/Search/SearchRoute.tsx
@@ -1,0 +1,73 @@
+import { AutocompleteInput } from "@artsy/palette"
+import { useClientQuery } from "Utils/Hooks/useClientQuery"
+import { extractNodes } from "Utils/extractNodes"
+import { compact, debounce } from "lodash"
+import { FC, useMemo, useState } from "react"
+import { graphql } from "react-relay"
+import { SearchRouteQuery } from "__generated__/SearchRouteQuery.graphql"
+import { SearchRouteOptionFragmentContainer } from "Apps/Example/Routes/Search/SearchRouteOption"
+
+export const SearchRoute: FC = () => {
+  const [query, setQuery] = useState("")
+
+  const { data, loading } = useClientQuery<SearchRouteQuery>({
+    query: QUERY,
+    variables: { query },
+  })
+
+  const options = compact(
+    extractNodes(data?.matchConnection).map(node => {
+      if (!node) return null
+
+      return {
+        // Internally, `AutocompleteInput` requires a display `text` and a `value`
+        value: node.value!,
+        text: node.text!,
+        // Pass on the node for the fragment container
+        artist: node,
+      }
+    })
+  )
+
+  const handleChange = useMemo(
+    () =>
+      debounce(({ target: { value } }: React.ChangeEvent<HTMLInputElement>) => {
+        console.log("setting value", value)
+        setQuery(value)
+      }, 250),
+    []
+  )
+
+  return (
+    <AutocompleteInput
+      placeholder="Search by Artist Name"
+      options={options}
+      onChange={handleChange}
+      loading={loading}
+      renderOption={({ artist }) => {
+        return <SearchRouteOptionFragmentContainer artist={artist} />
+      }}
+    />
+  )
+}
+
+const QUERY = graphql`
+  query SearchRouteQuery($query: String!) {
+    matchConnection(
+      term: $query
+      entities: ARTIST
+      mode: AUTOSUGGEST
+      first: 7
+    ) {
+      edges {
+        node {
+          ... on Artist {
+            ...SearchRouteOption_artist
+            text: name
+            value: slug
+          }
+        }
+      }
+    }
+  }
+`

--- a/src/Apps/Example/Routes/Search/SearchRouteOption.tsx
+++ b/src/Apps/Example/Routes/Search/SearchRouteOption.tsx
@@ -1,0 +1,51 @@
+import { Avatar, Box, Flex, Text } from "@artsy/palette"
+import { FC } from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { SearchRouteOption_artist$data } from "__generated__/SearchRouteOption_artist.graphql"
+
+interface SearchRouteOptionProps {
+  artist: SearchRouteOption_artist$data
+}
+
+export const SearchRouteOption: FC<SearchRouteOptionProps> = ({ artist }) => {
+  return (
+    <Flex px={2} py={1} gap={1} alignItems="center">
+      <Avatar
+        size="xs"
+        initials={artist.initials!}
+        {...artist.image?.cropped}
+      />
+
+      <Box>
+        <Text variant="sm-display" overflowEllipsis>
+          {artist.name}
+        </Text>
+
+        {artist.formattedNationalityAndBirthday && (
+          <Text variant="xs" color="black60" overflowEllipsis>
+            {artist.formattedNationalityAndBirthday}
+          </Text>
+        )}
+      </Box>
+    </Flex>
+  )
+}
+
+export const SearchRouteOptionFragmentContainer = createFragmentContainer(
+  SearchRouteOption,
+  {
+    artist: graphql`
+      fragment SearchRouteOption_artist on Artist {
+        name
+        initials
+        formattedNationalityAndBirthday
+        image {
+          cropped(height: 200, width: 200) {
+            src
+            srcSet
+          }
+        }
+      }
+    `,
+  }
+)

--- a/src/Apps/Example/exampleRoutes.tsx
+++ b/src/Apps/Example/exampleRoutes.tsx
@@ -61,6 +61,16 @@ const AddToCollectionRoute = loadable(
   }
 )
 
+const SearchRoute = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "exampleBundle" */ "./Routes/Search/SearchRoute"
+    ),
+  {
+    resolveComponent: component => component.SearchRoute,
+  }
+)
+
 export const exampleRoutes: AppRouteConfig[] = [
   {
     path: "/example",
@@ -144,6 +154,13 @@ export const exampleRoutes: AppRouteConfig[] = [
             }
           }
         `,
+      },
+      {
+        path: "search",
+        getComponent: () => SearchRoute,
+        onClientSideRender: () => {
+          SearchRoute.preload()
+        },
       },
     ],
   },

--- a/src/__generated__/SearchRouteOption_artist.graphql.ts
+++ b/src/__generated__/SearchRouteOption_artist.graphql.ts
@@ -1,0 +1,111 @@
+/**
+ * @generated SignedSource<<fd86f2dbe163acf089dd08b739de18b2>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { Fragment, ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type SearchRouteOption_artist$data = {
+  readonly formattedNationalityAndBirthday: string | null;
+  readonly image: {
+    readonly cropped: {
+      readonly src: string;
+      readonly srcSet: string;
+    } | null;
+  } | null;
+  readonly initials: string | null;
+  readonly name: string | null;
+  readonly " $fragmentType": "SearchRouteOption_artist";
+};
+export type SearchRouteOption_artist$key = {
+  readonly " $data"?: SearchRouteOption_artist$data;
+  readonly " $fragmentSpreads": FragmentRefs<"SearchRouteOption_artist">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "SearchRouteOption_artist",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "initials",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "formattedNationalityAndBirthday",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Image",
+      "kind": "LinkedField",
+      "name": "image",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "height",
+              "value": 200
+            },
+            {
+              "kind": "Literal",
+              "name": "width",
+              "value": 200
+            }
+          ],
+          "concreteType": "CroppedImageUrl",
+          "kind": "LinkedField",
+          "name": "cropped",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "src",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "srcSet",
+              "storageKey": null
+            }
+          ],
+          "storageKey": "cropped(height:200,width:200)"
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Artist",
+  "abstractKey": null
+};
+
+(node as any).hash = "ca575e5eafad02bee7b8bf13c01d5093";
+
+export default node;

--- a/src/__generated__/SearchRouteQuery.graphql.ts
+++ b/src/__generated__/SearchRouteQuery.graphql.ts
@@ -1,0 +1,305 @@
+/**
+ * @generated SignedSource<<419dc03abb80f571f03e3740d9694921>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type SearchRouteQuery$variables = {
+  query: string;
+};
+export type SearchRouteQuery$data = {
+  readonly matchConnection: {
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly text?: string | null;
+        readonly value?: string;
+        readonly " $fragmentSpreads": FragmentRefs<"SearchRouteOption_artist">;
+      } | null;
+    } | null> | null;
+  } | null;
+};
+export type SearchRouteQuery = {
+  response: SearchRouteQuery$data;
+  variables: SearchRouteQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "query"
+  }
+],
+v1 = [
+  {
+    "kind": "Literal",
+    "name": "entities",
+    "value": "ARTIST"
+  },
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 7
+  },
+  {
+    "kind": "Literal",
+    "name": "mode",
+    "value": "AUTOSUGGEST"
+  },
+  {
+    "kind": "Variable",
+    "name": "term",
+    "variableName": "query"
+  }
+],
+v2 = {
+  "alias": "text",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v3 = {
+  "alias": "value",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v4 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "id",
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SearchRouteQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "MatchConnection",
+        "kind": "LinkedField",
+        "name": "matchConnection",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "MatchEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": null,
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      {
+                        "args": null,
+                        "kind": "FragmentSpread",
+                        "name": "SearchRouteOption_artist"
+                      },
+                      (v2/*: any*/),
+                      (v3/*: any*/)
+                    ],
+                    "type": "Artist",
+                    "abstractKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SearchRouteQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "MatchConnection",
+        "kind": "LinkedField",
+        "name": "matchConnection",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "MatchEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": null,
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "__typename",
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "name",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "initials",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "formattedNationalityAndBirthday",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "height",
+                                "value": 200
+                              },
+                              {
+                                "kind": "Literal",
+                                "name": "width",
+                                "value": 200
+                              }
+                            ],
+                            "concreteType": "CroppedImageUrl",
+                            "kind": "LinkedField",
+                            "name": "cropped",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "src",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "srcSet",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": "cropped(height:200,width:200)"
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      (v2/*: any*/),
+                      (v3/*: any*/)
+                    ],
+                    "type": "Artist",
+                    "abstractKey": null
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": (v4/*: any*/),
+                    "type": "Node",
+                    "abstractKey": "__isNode"
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": (v4/*: any*/),
+                    "type": "Feature",
+                    "abstractKey": null
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": (v4/*: any*/),
+                    "type": "Page",
+                    "abstractKey": null
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": (v4/*: any*/),
+                    "type": "Profile",
+                    "abstractKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "f127b8c34938b7ecf723c22bc14c6e93",
+    "id": null,
+    "metadata": {},
+    "name": "SearchRouteQuery",
+    "operationKind": "query",
+    "text": "query SearchRouteQuery(\n  $query: String!\n) {\n  matchConnection(term: $query, entities: ARTIST, mode: AUTOSUGGEST, first: 7) {\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          ...SearchRouteOption_artist\n          text: name\n          value: slug\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n        ... on Feature {\n          id\n        }\n        ... on Page {\n          id\n        }\n        ... on Profile {\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment SearchRouteOption_artist on Artist {\n  name\n  initials\n  formattedNationalityAndBirthday\n  image {\n    cropped(height: 200, width: 200) {\n      src\n      srcSet\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "ca8e810dbd2c6e07c2a378ac7a4dccef";
+
+export default node;


### PR DESCRIPTION
@nickskalkin was wondering how to use a fragment container with the `AutocompleteInput` — the answer is: it just works. Use the `matchConnection` instead of the `searchConnection` (to be deprecated), however.

https://github.com/artsy/force/assets/112297/f1de9123-5c1e-4069-8907-dc799421e47b

