### PR TITLE
[#FF] refactor: bank account auto-selection hook

### DIFF
--- a/src/Apps/Order/Components/BankAccountPicker.tsx
+++ b/src/Apps/Order/Components/BankAccountPicker.tsx
@@ -1,4 +1,4 @@
-import { FC } from "react"
+import { FC, useEffect } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { StripeError } from "@stripe/stripe-js"
 
@@ -61,6 +61,31 @@ export const BankAccountPicker: FC<Props> = props => {
   }
 
   const { submitMutation: setPaymentMutation } = useSetPayment()
+
+  useEffect(() => {
+    if (bankAccountSelection) {
+      return
+    }
+
+    if (selectedPaymentMethod === "SEPA_DEBIT") {
+      setBankAccountSelection({ type: "new" })
+    } else if (selectedPaymentMethod === "US_BANK_ACCOUNT") {
+      if (order.bankAccountId) {
+        setBankAccountSelection({
+          type: "existing",
+          id: order.bankAccountId,
+        })
+      } else if (bankAccountsArray.length > 0) {
+        setBankAccountSelection({
+          type: "existing",
+          id: bankAccountsArray[0]?.internalID!,
+        })
+      } else {
+        setBankAccountSelection({ type: "new" })
+      }
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [bankAccountSelection, selectedPaymentMethod])
 
   const handleContinue = async () => {
     setBalanceCheckComplete(false)

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -21,10 +21,7 @@ import {
   CommitMutation,
   injectCommitMutation,
 } from "Apps/Order/Utils/commitMutation"
-import {
-  getInitialPaymentMethodValue,
-  getInitialBankAccountSelection,
-} from "Apps/Order/Utils/orderUtils"
+import { getInitialPaymentMethodValue } from "Apps/Order/Utils/orderUtils"
 import { useStripePaymentBySetupIntentId } from "Apps/Order/Hooks/useStripePaymentBySetupIntentId"
 import { useSetPayment } from "Apps/Order/Mutations/useSetPayment"
 import { useOrderPaymentContext } from "./PaymentContext/OrderPaymentContext"
@@ -82,7 +79,6 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
   const CreditCardPicker = createRef<CreditCardPicker>()
 
   const {
-    bankAccountSelection,
     selectedBankAccountId,
     selectedPaymentMethod,
     balanceCheckComplete,
@@ -100,21 +96,6 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
     selectedPaymentMethod === "US_BANK_ACCOUNT"
 
   const artworkVersion = extractNodes(order.lineItems)[0]?.artworkVersion
-
-  useEffect(() => {
-    if (!bankAccountSelection && selectedPaymentMethod) {
-      const bankAccountsArray =
-        selectedPaymentMethod !== "SEPA_DEBIT"
-          ? extractNodes(me.bankAccounts)
-          : []
-
-      setBankAccountSelection(
-        getInitialBankAccountSelection(order, bankAccountsArray)
-      )
-    }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [bankAccountSelection, selectedPaymentMethod])
 
   useEffect(() => {
     const bankAccountsArray =

--- a/src/Apps/Order/Utils/orderUtils.ts
+++ b/src/Apps/Order/Utils/orderUtils.ts
@@ -1,4 +1,3 @@
-import { BankAccountSelection } from "Apps/Order/Routes/Payment"
 import {
   CommercePaymentMethodEnum,
   Payment_order$data,
@@ -36,22 +35,3 @@ export const getInitialPaymentMethodValue = ({
     : initialPaymentMethods.find(method =>
         availablePaymentMethods.includes(method)
       )!
-
-export const getInitialBankAccountSelection = (
-  { bankAccountId },
-  bankAccountsArray
-): BankAccountSelection => {
-  if (bankAccountId) {
-    return {
-      type: "existing",
-      id: bankAccountId,
-    }
-  } else {
-    return bankAccountsArray.length > 0
-      ? {
-          type: "existing",
-          id: bankAccountsArray[0]?.internalID!,
-        }
-      : { type: "new" }
-  }
-}


### PR DESCRIPTION
This PR is an attempt to understand how the payment route works by refactoring the hook that is responsible for picking a bank account to be selected when either `US_BANK_ACCOUNT` or `SEPA_DEBIT` is the selected payment method.

I want to refactor it for the following reasons:

1. I don't think that this hook should do anything when `CREDIT_CARD` or `WIRE_TRANSFER` is selected. (It currently updates the `bankAccountSelection` state property to `{ type: "new" }`)
1. I think that this logic would be easier to read if it were in simple if-else statements.
1. I think that the `BankAccountPicker` component should house this logic.

I would also like to see if I can remove the `// eslint-disable-next-line` by resolving the warning that it otherwise generates.