### PR TITLE
fix(EMI-1224): Update ACH/SEPA form style

### DIFF
--- a/src/Components/BankDebitForm/BankDebitProvider.tsx
+++ b/src/Components/BankDebitForm/BankDebitProvider.tsx
@@ -83,7 +83,6 @@ export const BankDebitProvider: FC<Props> = ({ order, onError }) => {
 
   const appearance: Appearance = {
     theme: "stripe",
-    labels: "floating",
     variables: {
       colorPrimary: THEME.colors.black100,
       colorBackground: THEME.colors.white100,


### PR DESCRIPTION
The type of this PR is: **Fix**

⚠️ This PR is to be merged to `review-app-new-input` ⚠️

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-1224]

### Description
This PR updates the label style in the Stripe forms to be above the input field instead of inside

### Screenshots

| Method | Before | After |
|---|---|---|
| SEPA | <img width="1180" alt="image" src="https://github.com/artsy/force/assets/20655703/01852f66-42b7-42fe-b252-0c8c5ec9a290"> | <img width="1164" alt="image" src="https://github.com/artsy/force/assets/20655703/e6156fe2-91b5-4739-a0fb-3e98f6622b04"> |
| ACH | <img width="1162" alt="image" src="https://github.com/artsy/force/assets/20655703/24f090d8-6ea8-4171-9e02-b7c3a2f2eff1"> | <img width="1120" alt="image" src="https://github.com/artsy/force/assets/20655703/f4c58152-95e8-48fd-a7cf-f79991b75a2b"> |


<!-- Implementation description -->
