### PR TITLE
Revert "[#FF] refactor: bank account auto-selection hook"

### DIFF
--- a/src/Apps/Order/Components/BankAccountPicker.tsx
+++ b/src/Apps/Order/Components/BankAccountPicker.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect } from "react"
+import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { StripeError } from "@stripe/stripe-js"
 
@@ -27,7 +27,10 @@ interface Props {
 }
 
 export const BankAccountPicker: FC<Props> = props => {
-  const { me, order } = props
+  const {
+    me: { bankAccounts },
+    order,
+  } = props
 
   const {
     bankAccountSelection,
@@ -42,7 +45,7 @@ export const BankAccountPicker: FC<Props> = props => {
 
   const bankAccountsArray: BankAccountRecord[] =
     selectedPaymentMethod === "US_BANK_ACCOUNT"
-      ? extractNodes(me.bankAccounts)
+      ? extractNodes(bankAccounts)
       : []
 
   if (order?.paymentMethodDetails?.internalID) {
@@ -58,64 +61,6 @@ export const BankAccountPicker: FC<Props> = props => {
   }
 
   const { submitMutation: setPaymentMutation } = useSetPayment()
-
-  /**
-   * This hook is responsible for setting the bankAccountSelection state
-   * properties that are used by this component to display an appropriate
-   * payment details section to users.
-   */
-  useEffect(() => {
-    if (bankAccountSelection) {
-      /**
-       * If a selection has been made once, do not repeat this hook unless that
-       * selection is cleared.
-       */
-      return
-    } else if (
-      selectedPaymentMethod === "US_BANK_ACCOUNT" &&
-      order.bankAccountId
-    ) {
-      /**
-       * If an ACH debit account has been saved to the order, indicate that it
-       * should be selected. This happens when the user returns to the Payment
-       * step after having completed it before.
-       */
-      setBankAccountSelection({
-        type: "existing",
-        id: order.bankAccountId,
-      })
-    } else if (
-      selectedPaymentMethod === "US_BANK_ACCOUNT" &&
-      bankAccountsArray.length > 0
-    ) {
-      /**
-       * If the user has one or more ACH debit accounts, indicate that the first
-       * one in the list should be selected. This happens the first time that a
-       * user is performing the Payment step for an order.
-       */
-      setBankAccountSelection({
-        type: "existing",
-        id: bankAccountsArray[0]?.internalID!,
-      })
-    } else if (
-      selectedPaymentMethod === "US_BANK_ACCOUNT" ||
-      selectedPaymentMethod === "SEPA_DEBIT"
-    ) {
-      /**
-       * If the user doesn't have any ACH debit accounts, or is paying with a
-       * SEPA debit account, indicate that a form should be displayed. This
-       * happens the first time that a user is performing the Payment step for
-       * an order.
-       */
-      setBankAccountSelection({ type: "new" })
-    }
-  }, [
-    bankAccountsArray,
-    bankAccountSelection,
-    order.bankAccountId,
-    selectedPaymentMethod,
-    setBankAccountSelection,
-  ])
 
   const handleContinue = async () => {
     setBalanceCheckComplete(false)

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -21,7 +21,10 @@ import {
   CommitMutation,
   injectCommitMutation,
 } from "Apps/Order/Utils/commitMutation"
-import { getInitialPaymentMethodValue } from "Apps/Order/Utils/orderUtils"
+import {
+  getInitialPaymentMethodValue,
+  getInitialBankAccountSelection,
+} from "Apps/Order/Utils/orderUtils"
 import { useStripePaymentBySetupIntentId } from "Apps/Order/Hooks/useStripePaymentBySetupIntentId"
 import { useSetPayment } from "Apps/Order/Mutations/useSetPayment"
 import { useOrderPaymentContext } from "./PaymentContext/OrderPaymentContext"
@@ -79,6 +82,7 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
   const CreditCardPicker = createRef<CreditCardPicker>()
 
   const {
+    bankAccountSelection,
     selectedBankAccountId,
     selectedPaymentMethod,
     balanceCheckComplete,
@@ -96,6 +100,21 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
     selectedPaymentMethod === "US_BANK_ACCOUNT"
 
   const artworkVersion = extractNodes(order.lineItems)[0]?.artworkVersion
+
+  useEffect(() => {
+    if (!bankAccountSelection && selectedPaymentMethod) {
+      const bankAccountsArray =
+        selectedPaymentMethod !== "SEPA_DEBIT"
+          ? extractNodes(me.bankAccounts)
+          : []
+
+      setBankAccountSelection(
+        getInitialBankAccountSelection(order, bankAccountsArray)
+      )
+    }
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [bankAccountSelection, selectedPaymentMethod])
 
   useEffect(() => {
     const bankAccountsArray =

--- a/src/Apps/Order/Utils/orderUtils.ts
+++ b/src/Apps/Order/Utils/orderUtils.ts
@@ -1,3 +1,4 @@
+import { BankAccountSelection } from "Apps/Order/Routes/Payment"
 import {
   CommercePaymentMethodEnum,
   Payment_order$data,
@@ -35,3 +36,22 @@ export const getInitialPaymentMethodValue = ({
     : initialPaymentMethods.find(method =>
         availablePaymentMethods.includes(method)
       )!
+
+export const getInitialBankAccountSelection = (
+  { bankAccountId },
+  bankAccountsArray
+): BankAccountSelection => {
+  if (bankAccountId) {
+    return {
+      type: "existing",
+      id: bankAccountId,
+    }
+  } else {
+    return bankAccountsArray.length > 0
+      ? {
+          type: "existing",
+          id: bankAccountsArray[0]?.internalID!,
+        }
+      : { type: "new" }
+  }
+}


### PR DESCRIPTION
Reverts artsy/force#12590 because I noticed two issues while testing with "closed account" and "insufficient funds" accounts on staging:

1. After connecting the bank accounts and continuing to the Review step, I was correctly returned to the Payment step and shown an error message. However, the bank account that I had just connected was not visible in the list of bank accounts.
2. When I select another bank account from the list after recovering from the error in (1) the form is automatically re-submitted. The submission process takes several seconds, and when it is complete I see the Review step with the bank account from (1) selected.

I would like to test this again without these changes to confirm whether this is a regression or not.