### PR TITLE
feat(onyx-114): Do not dispatch new artwork lists behavior when clicking on 'Watch lot' on artwork page

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActionsSaveButton.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActionsSaveButton.tsx
@@ -23,7 +23,7 @@ const ArtworkActionsSaveButton: React.FC<ArtworkActionsSaveButtonProps> = ({
   })
 
   const { isAuction, isClosed } = artwork.sale ?? {}
-  const isOpenSale = isAuction && !isClosed
+  const isOpenOrUpcomingSale = isAuction && !isClosed
   const isSaved = !!artwork.isSaved
 
   if (isArtworksListEnabled) {
@@ -35,7 +35,7 @@ const ArtworkActionsSaveButton: React.FC<ArtworkActionsSaveButtonProps> = ({
   }
 
   // If an Auction, use Bell (for notifications); if a standard artwork use Heart
-  if (isOpenSale) {
+  if (isOpenOrUpcomingSale) {
     return (
       <ArtworkActionsWatchLotButtonFragmentContainer
         isSaved={isSaved}


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [ONYX-114]

### Description

Do not dispatch new artwork lists behavior when clicking on 'Watch lot' on artwork page. Demo below:


https://github.com/artsy/force/assets/3934579/a77bbc3f-4e46-4463-aeee-6e1ea2b6b425



[ONYX-114]: https://artsyproduct.atlassian.net/browse/ONYX-114?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ