### PR TITLE
Future friday: pending orders

### DIFF
--- a/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchases.tsx
+++ b/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchases.tsx
@@ -1,6 +1,6 @@
 import { useState, FC } from "react"
 import { RelayRefetchProp, createRefetchContainer, graphql } from "react-relay"
-import { Join, Spacer, Message } from "@artsy/palette"
+import { Join, Spacer, Message, Text } from "@artsy/palette"
 import { extractNodes } from "Utils/extractNodes"
 import {
   SettingsPurchasesRowFragmentContainer,
@@ -8,17 +8,47 @@ import {
 } from "./SettingsPurchasesRow"
 import { SettingsPurchases_me$data } from "__generated__/SettingsPurchases_me.graphql"
 import { CommercePaginationFragmentContainer } from "Components/Pagination/CommercePagination"
+import { uniqBy, sortBy } from "lodash"
 
 export interface SettingsPurchasesProps {
   me: SettingsPurchases_me$data
   relay: RelayRefetchProp
 }
 
+type PendingOrder = NonNullable<
+  NonNullable<
+    NonNullable<
+      NonNullable<SettingsPurchases_me$data["pendingOrders"]>["edges"]
+    >[number]
+  >["node"]
+>
+
 const SettingsPurchases: FC<SettingsPurchasesProps> = ({
   me,
   relay,
 }: SettingsPurchasesProps) => {
   const [loading, setLoading] = useState(false)
+
+  const pendingOrders = sortBy<PendingOrder>(
+    extractNodes(me.pendingOrders),
+    order => {
+      return -Date.parse(order.createdAt)
+    }
+  ) as PendingOrder[]
+
+  console.log(
+    pendingOrders.map(({ createdAt, code }) => ({
+      createdAt,
+      code,
+    }))
+  )
+
+  const uniquePendingOrders = uniqBy(pendingOrders, order => {
+    return order.lineItems!.nodes!.map(order => {
+      const { artworkId, editionSetId } = order!
+      return `${artworkId}-${editionSetId}`
+    })
+  })
 
   const orders = extractNodes(me.orders)
   const hasNextPage = me.orders?.pageInfo.hasNextPage ?? false
@@ -64,6 +94,21 @@ const SettingsPurchases: FC<SettingsPurchasesProps> = ({
 
   return !loading ? (
     <>
+      <Text variant="lg" mb={2}>
+        Pending orders
+      </Text>
+      <Join separator={<Spacer y={4} />}>
+        {uniquePendingOrders.map(order => (
+          <SettingsPurchasesRowFragmentContainer
+            key={order.code}
+            order={order}
+          />
+        ))}
+      </Join>
+      <Spacer y={4} />
+      <Text variant="lg" mb={2}>
+        Past orders
+      </Text>
       <Join separator={<Spacer y={4} />}>
         {orders.map(order => (
           <SettingsPurchasesRowFragmentContainer
@@ -112,6 +157,31 @@ export const SettingsPurchasesFragmentContainer = createRefetchContainer(
           }
         ) {
         name
+        pendingOrders: orders(states: [PENDING], first: 100) {
+          totalCount
+          pageInfo {
+            hasNextPage
+            endCursor
+          }
+          pageCursors {
+            ...CommercePagination_pageCursors
+          }
+
+          edges {
+            node {
+              code
+              source
+              createdAt
+              lineItems {
+                nodes {
+                  artworkId
+                  editionSetId
+                }
+              }
+              ...SettingsPurchasesRow_order
+            }
+          }
+        }
         orders(states: $states, first: $first, after: $after) {
           totalCount
           pageInfo {

--- a/src/__generated__/SettingsPurchasesQuery.graphql.ts
+++ b/src/__generated__/SettingsPurchasesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<54bbc74cbaa8cc7a9c7875218079eed3>>
+ * @generated SignedSource<<03dca8f914531463bc3bd07150f68218>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -70,19 +70,51 @@ v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "cursor",
+  "name": "totalCount",
   "storageKey": null
 },
 v6 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "CommercePageInfo",
+  "kind": "LinkedField",
+  "name": "pageInfo",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "hasNextPage",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "endCursor",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cursor",
+  "storageKey": null
+},
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "page",
   "storageKey": null
 },
-v7 = [
-  (v5/*: any*/),
-  (v6/*: any*/),
+v9 = [
+  (v7/*: any*/),
+  (v8/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -91,21 +123,96 @@ v7 = [
     "storageKey": null
   }
 ],
-v8 = {
+v10 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "CommercePageCursors",
+  "kind": "LinkedField",
+  "name": "pageCursors",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "CommercePageCursor",
+      "kind": "LinkedField",
+      "name": "around",
+      "plural": true,
+      "selections": (v9/*: any*/),
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "CommercePageCursor",
+      "kind": "LinkedField",
+      "name": "first",
+      "plural": false,
+      "selections": (v9/*: any*/),
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "CommercePageCursor",
+      "kind": "LinkedField",
+      "name": "last",
+      "plural": false,
+      "selections": (v9/*: any*/),
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "CommercePageCursor",
+      "kind": "LinkedField",
+      "name": "previous",
+      "plural": false,
+      "selections": [
+        (v7/*: any*/),
+        (v8/*: any*/)
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v9 = {
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "code",
+  "storageKey": null
+},
+v13 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "source",
+  "storageKey": null
+},
+v14 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "createdAt",
+  "storageKey": null
+},
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v10 = [
+v16 = [
   {
     "alias": null,
     "args": [
@@ -143,11 +250,306 @@ v10 = [
     "storageKey": "cropped(height:45,width:45)"
   }
 ],
-v11 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
+  "storageKey": null
+},
+v18 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "CommerceLineItemEdge",
+  "kind": "LinkedField",
+  "name": "edges",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "CommerceLineItem",
+      "kind": "LinkedField",
+      "name": "node",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ArtworkVersion",
+          "kind": "LinkedField",
+          "name": "artworkVersion",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Image",
+              "kind": "LinkedField",
+              "name": "image",
+              "plural": false,
+              "selections": (v16/*: any*/),
+              "storageKey": null
+            },
+            (v15/*: any*/)
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Artwork",
+          "kind": "LinkedField",
+          "name": "artwork",
+          "plural": false,
+          "selections": [
+            (v17/*: any*/),
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Partner",
+              "kind": "LinkedField",
+              "name": "partner",
+              "plural": false,
+              "selections": [
+                (v17/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "initials",
+                  "storageKey": null
+                },
+                (v4/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "Profile",
+                  "kind": "LinkedField",
+                  "name": "profile",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "Image",
+                      "kind": "LinkedField",
+                      "name": "icon",
+                      "plural": false,
+                      "selections": (v16/*: any*/),
+                      "storageKey": null
+                    },
+                    (v15/*: any*/)
+                  ],
+                  "storageKey": null
+                },
+                (v15/*: any*/)
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "shippingOrigin",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "title",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "artistNames",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Artist",
+              "kind": "LinkedField",
+              "name": "artists",
+              "plural": true,
+              "selections": [
+                (v17/*: any*/),
+                (v15/*: any*/)
+              ],
+              "storageKey": null
+            },
+            (v15/*: any*/)
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "first",
+              "value": 1
+            }
+          ],
+          "concreteType": "CommerceFulfillmentConnection",
+          "kind": "LinkedField",
+          "name": "fulfillments",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "CommerceFulfillmentEdge",
+              "kind": "LinkedField",
+              "name": "edges",
+              "plural": true,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "CommerceFulfillment",
+                  "kind": "LinkedField",
+                  "name": "node",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "trackingId",
+                      "storageKey": null
+                    },
+                    (v15/*: any*/)
+                  ],
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": "fulfillments(first:1)"
+        },
+        (v15/*: any*/)
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v19 = {
+  "kind": "TypeDiscriminator",
+  "abstractKey": "__isCommerceOrder"
+},
+v20 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v21 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "displayState",
+  "storageKey": null
+},
+v22 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "state",
+  "storageKey": null
+},
+v23 = {
+  "alias": null,
+  "args": null,
+  "concreteType": null,
+  "kind": "LinkedField",
+  "name": "requestedFulfillment",
+  "plural": false,
+  "selections": [
+    (v11/*: any*/)
+  ],
+  "storageKey": null
+},
+v24 = {
+  "alias": null,
+  "args": null,
+  "concreteType": null,
+  "kind": "LinkedField",
+  "name": "paymentMethodDetails",
+  "plural": false,
+  "selections": [
+    (v11/*: any*/),
+    {
+      "kind": "InlineFragment",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "lastDigits",
+          "storageKey": null
+        },
+        (v15/*: any*/)
+      ],
+      "type": "CreditCard",
+      "abstractKey": null
+    },
+    {
+      "kind": "InlineFragment",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "last4",
+          "storageKey": null
+        },
+        (v15/*: any*/)
+      ],
+      "type": "BankAccount",
+      "abstractKey": null
+    },
+    {
+      "kind": "InlineFragment",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "isManualPayment",
+          "storageKey": null
+        }
+      ],
+      "type": "WireTransfer",
+      "abstractKey": null
+    }
+  ],
+  "storageKey": null
+},
+v25 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Literal",
+      "name": "precision",
+      "value": 2
+    }
+  ],
+  "kind": "ScalarField",
+  "name": "buyerTotal",
+  "storageKey": "buyerTotal(precision:2)"
+},
+v26 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "currencyCode",
   "storageKey": null
 };
 return {
@@ -201,99 +603,29 @@ return {
         "selections": [
           (v4/*: any*/),
           {
-            "alias": null,
-            "args": (v3/*: any*/),
+            "alias": "pendingOrders",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 100
+              },
+              {
+                "kind": "Literal",
+                "name": "states",
+                "value": [
+                  "PENDING"
+                ]
+              }
+            ],
             "concreteType": "CommerceOrderConnectionWithTotalCount",
             "kind": "LinkedField",
             "name": "orders",
             "plural": false,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "totalCount",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "CommercePageInfo",
-                "kind": "LinkedField",
-                "name": "pageInfo",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "hasNextPage",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "endCursor",
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "CommercePageCursors",
-                "kind": "LinkedField",
-                "name": "pageCursors",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "CommercePageCursor",
-                    "kind": "LinkedField",
-                    "name": "around",
-                    "plural": true,
-                    "selections": (v7/*: any*/),
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "CommercePageCursor",
-                    "kind": "LinkedField",
-                    "name": "first",
-                    "plural": false,
-                    "selections": (v7/*: any*/),
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "CommercePageCursor",
-                    "kind": "LinkedField",
-                    "name": "last",
-                    "plural": false,
-                    "selections": (v7/*: any*/),
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "CommercePageCursor",
-                    "kind": "LinkedField",
-                    "name": "previous",
-                    "plural": false,
-                    "selections": [
-                      (v5/*: any*/),
-                      (v6/*: any*/)
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
+              (v5/*: any*/),
+              (v6/*: any*/),
+              (v10/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -310,141 +642,10 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v8/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "code",
-                        "storageKey": null
-                      },
-                      {
-                        "kind": "TypeDiscriminator",
-                        "abstractKey": "__isCommerceOrder"
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "source",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "internalID",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "displayState",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "state",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": null,
-                        "kind": "LinkedField",
-                        "name": "requestedFulfillment",
-                        "plural": false,
-                        "selections": [
-                          (v8/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": null,
-                        "kind": "LinkedField",
-                        "name": "paymentMethodDetails",
-                        "plural": false,
-                        "selections": [
-                          (v8/*: any*/),
-                          {
-                            "kind": "InlineFragment",
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "lastDigits",
-                                "storageKey": null
-                              },
-                              (v9/*: any*/)
-                            ],
-                            "type": "CreditCard",
-                            "abstractKey": null
-                          },
-                          {
-                            "kind": "InlineFragment",
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "last4",
-                                "storageKey": null
-                              },
-                              (v9/*: any*/)
-                            ],
-                            "type": "BankAccount",
-                            "abstractKey": null
-                          },
-                          {
-                            "kind": "InlineFragment",
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "isManualPayment",
-                                "storageKey": null
-                              }
-                            ],
-                            "type": "WireTransfer",
-                            "abstractKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "precision",
-                            "value": 2
-                          }
-                        ],
-                        "kind": "ScalarField",
-                        "name": "buyerTotal",
-                        "storageKey": "buyerTotal(precision:2)"
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "createdAt",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "currencyCode",
-                        "storageKey": null
-                      },
+                      (v11/*: any*/),
+                      (v12/*: any*/),
+                      (v13/*: any*/),
+                      (v14/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -456,189 +657,103 @@ return {
                           {
                             "alias": null,
                             "args": null,
-                            "concreteType": "CommerceLineItemEdge",
+                            "concreteType": "CommerceLineItem",
                             "kind": "LinkedField",
-                            "name": "edges",
+                            "name": "nodes",
                             "plural": true,
                             "selections": [
                               {
                                 "alias": null,
                                 "args": null,
-                                "concreteType": "CommerceLineItem",
-                                "kind": "LinkedField",
-                                "name": "node",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "ArtworkVersion",
-                                    "kind": "LinkedField",
-                                    "name": "artworkVersion",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "Image",
-                                        "kind": "LinkedField",
-                                        "name": "image",
-                                        "plural": false,
-                                        "selections": (v10/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      (v9/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Artwork",
-                                    "kind": "LinkedField",
-                                    "name": "artwork",
-                                    "plural": false,
-                                    "selections": [
-                                      (v11/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "Partner",
-                                        "kind": "LinkedField",
-                                        "name": "partner",
-                                        "plural": false,
-                                        "selections": [
-                                          (v11/*: any*/),
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "initials",
-                                            "storageKey": null
-                                          },
-                                          (v4/*: any*/),
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "concreteType": "Profile",
-                                            "kind": "LinkedField",
-                                            "name": "profile",
-                                            "plural": false,
-                                            "selections": [
-                                              {
-                                                "alias": null,
-                                                "args": null,
-                                                "concreteType": "Image",
-                                                "kind": "LinkedField",
-                                                "name": "icon",
-                                                "plural": false,
-                                                "selections": (v10/*: any*/),
-                                                "storageKey": null
-                                              },
-                                              (v9/*: any*/)
-                                            ],
-                                            "storageKey": null
-                                          },
-                                          (v9/*: any*/)
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "shippingOrigin",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "title",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "artistNames",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "Artist",
-                                        "kind": "LinkedField",
-                                        "name": "artists",
-                                        "plural": true,
-                                        "selections": [
-                                          (v11/*: any*/),
-                                          (v9/*: any*/)
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      (v9/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": [
-                                      {
-                                        "kind": "Literal",
-                                        "name": "first",
-                                        "value": 1
-                                      }
-                                    ],
-                                    "concreteType": "CommerceFulfillmentConnection",
-                                    "kind": "LinkedField",
-                                    "name": "fulfillments",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "CommerceFulfillmentEdge",
-                                        "kind": "LinkedField",
-                                        "name": "edges",
-                                        "plural": true,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "concreteType": "CommerceFulfillment",
-                                            "kind": "LinkedField",
-                                            "name": "node",
-                                            "plural": false,
-                                            "selections": [
-                                              {
-                                                "alias": null,
-                                                "args": null,
-                                                "kind": "ScalarField",
-                                                "name": "trackingId",
-                                                "storageKey": null
-                                              },
-                                              (v9/*: any*/)
-                                            ],
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": "fulfillments(first:1)"
-                                  },
-                                  (v9/*: any*/)
-                                ],
+                                "kind": "ScalarField",
+                                "name": "artworkId",
                                 "storageKey": null
-                              }
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "editionSetId",
+                                "storageKey": null
+                              },
+                              (v15/*: any*/)
                             ],
                             "storageKey": null
-                          }
+                          },
+                          (v18/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v9/*: any*/)
+                      (v19/*: any*/),
+                      (v20/*: any*/),
+                      (v21/*: any*/),
+                      (v22/*: any*/),
+                      (v23/*: any*/),
+                      (v24/*: any*/),
+                      (v25/*: any*/),
+                      (v26/*: any*/),
+                      (v15/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "orders(first:100,states:[\"PENDING\"])"
+          },
+          {
+            "alias": null,
+            "args": (v3/*: any*/),
+            "concreteType": "CommerceOrderConnectionWithTotalCount",
+            "kind": "LinkedField",
+            "name": "orders",
+            "plural": false,
+            "selections": [
+              (v5/*: any*/),
+              (v6/*: any*/),
+              (v10/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "CommerceOrderEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": null,
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v11/*: any*/),
+                      (v12/*: any*/),
+                      (v19/*: any*/),
+                      (v13/*: any*/),
+                      (v20/*: any*/),
+                      (v21/*: any*/),
+                      (v22/*: any*/),
+                      (v23/*: any*/),
+                      (v24/*: any*/),
+                      (v25/*: any*/),
+                      (v14/*: any*/),
+                      (v26/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "CommerceLineItemConnection",
+                        "kind": "LinkedField",
+                        "name": "lineItems",
+                        "plural": false,
+                        "selections": [
+                          (v18/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      (v15/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -648,19 +763,19 @@ return {
             ],
             "storageKey": null
           },
-          (v9/*: any*/)
+          (v15/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "7d1e702541ff92a9b93e7d56fa9b3a64",
+    "cacheID": "d4fc298e20535cf4603ed53a49be2065",
     "id": null,
     "metadata": {},
     "name": "SettingsPurchasesQuery",
     "operationKind": "query",
-    "text": "query SettingsPurchasesQuery(\n  $states: [CommerceOrderStateEnum!]\n  $first: Int!\n  $after: String\n) {\n  me {\n    ...SettingsPurchases_me_4tp0sF\n    id\n  }\n}\n\nfragment CommercePagination_pageCursors on CommercePageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SettingsPurchasesRow_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  source\n  internalID\n  code\n  displayState\n  state\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      lastDigits\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  buyerTotal(precision: 2)\n  createdAt\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artworkVersion {\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          id\n        }\n        artwork {\n          href\n          partner {\n            href\n            initials\n            name\n            profile {\n              icon {\n                cropped(width: 45, height: 45) {\n                  src\n                  srcSet\n                }\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          title\n          artistNames\n          artists {\n            href\n            id\n          }\n          id\n        }\n        fulfillments(first: 1) {\n          edges {\n            node {\n              trackingId\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SettingsPurchases_me_4tp0sF on Me {\n  name\n  orders(states: $states, first: $first, after: $after) {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...CommercePagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        code\n        ...SettingsPurchasesRow_order\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query SettingsPurchasesQuery(\n  $states: [CommerceOrderStateEnum!]\n  $first: Int!\n  $after: String\n) {\n  me {\n    ...SettingsPurchases_me_4tp0sF\n    id\n  }\n}\n\nfragment CommercePagination_pageCursors on CommercePageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SettingsPurchasesRow_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  source\n  internalID\n  code\n  displayState\n  state\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      lastDigits\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  buyerTotal(precision: 2)\n  createdAt\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artworkVersion {\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          id\n        }\n        artwork {\n          href\n          partner {\n            href\n            initials\n            name\n            profile {\n              icon {\n                cropped(width: 45, height: 45) {\n                  src\n                  srcSet\n                }\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          title\n          artistNames\n          artists {\n            href\n            id\n          }\n          id\n        }\n        fulfillments(first: 1) {\n          edges {\n            node {\n              trackingId\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SettingsPurchases_me_4tp0sF on Me {\n  name\n  pendingOrders: orders(states: [PENDING], first: 100) {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...CommercePagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        code\n        source\n        createdAt\n        lineItems {\n          nodes {\n            artworkId\n            editionSetId\n            id\n          }\n        }\n        ...SettingsPurchasesRow_order\n        id\n      }\n    }\n  }\n  orders(states: $states, first: $first, after: $after) {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...CommercePagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        code\n        ...SettingsPurchasesRow_order\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SettingsPurchases_Test_Query.graphql.ts
+++ b/src/__generated__/SettingsPurchases_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6b61413653d78096a8e3630a0285d1b7>>
+ * @generated SignedSource<<036651e2d5a9dadc3ed9acc8ee563e38>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -33,19 +33,51 @@ v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "cursor",
+  "name": "totalCount",
   "storageKey": null
 },
 v2 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "CommercePageInfo",
+  "kind": "LinkedField",
+  "name": "pageInfo",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "hasNextPage",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "endCursor",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cursor",
+  "storageKey": null
+},
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "page",
   "storageKey": null
 },
-v3 = [
-  (v1/*: any*/),
-  (v2/*: any*/),
+v5 = [
+  (v3/*: any*/),
+  (v4/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -54,21 +86,96 @@ v3 = [
     "storageKey": null
   }
 ],
-v4 = {
+v6 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "CommercePageCursors",
+  "kind": "LinkedField",
+  "name": "pageCursors",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "CommercePageCursor",
+      "kind": "LinkedField",
+      "name": "around",
+      "plural": true,
+      "selections": (v5/*: any*/),
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "CommercePageCursor",
+      "kind": "LinkedField",
+      "name": "first",
+      "plural": false,
+      "selections": (v5/*: any*/),
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "CommercePageCursor",
+      "kind": "LinkedField",
+      "name": "last",
+      "plural": false,
+      "selections": (v5/*: any*/),
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "CommercePageCursor",
+      "kind": "LinkedField",
+      "name": "previous",
+      "plural": false,
+      "selections": [
+        (v3/*: any*/),
+        (v4/*: any*/)
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v5 = {
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "code",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "source",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "createdAt",
+  "storageKey": null
+},
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v6 = [
+v12 = [
   {
     "alias": null,
     "args": [
@@ -106,60 +213,518 @@ v6 = [
     "storageKey": "cropped(height:45,width:45)"
   }
 ],
-v7 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v8 = {
+v14 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "CommerceLineItemEdge",
+  "kind": "LinkedField",
+  "name": "edges",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "CommerceLineItem",
+      "kind": "LinkedField",
+      "name": "node",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ArtworkVersion",
+          "kind": "LinkedField",
+          "name": "artworkVersion",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Image",
+              "kind": "LinkedField",
+              "name": "image",
+              "plural": false,
+              "selections": (v12/*: any*/),
+              "storageKey": null
+            },
+            (v11/*: any*/)
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Artwork",
+          "kind": "LinkedField",
+          "name": "artwork",
+          "plural": false,
+          "selections": [
+            (v13/*: any*/),
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Partner",
+              "kind": "LinkedField",
+              "name": "partner",
+              "plural": false,
+              "selections": [
+                (v13/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "initials",
+                  "storageKey": null
+                },
+                (v0/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "Profile",
+                  "kind": "LinkedField",
+                  "name": "profile",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "Image",
+                      "kind": "LinkedField",
+                      "name": "icon",
+                      "plural": false,
+                      "selections": (v12/*: any*/),
+                      "storageKey": null
+                    },
+                    (v11/*: any*/)
+                  ],
+                  "storageKey": null
+                },
+                (v11/*: any*/)
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "shippingOrigin",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "title",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "artistNames",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Artist",
+              "kind": "LinkedField",
+              "name": "artists",
+              "plural": true,
+              "selections": [
+                (v13/*: any*/),
+                (v11/*: any*/)
+              ],
+              "storageKey": null
+            },
+            (v11/*: any*/)
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "first",
+              "value": 1
+            }
+          ],
+          "concreteType": "CommerceFulfillmentConnection",
+          "kind": "LinkedField",
+          "name": "fulfillments",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "CommerceFulfillmentEdge",
+              "kind": "LinkedField",
+              "name": "edges",
+              "plural": true,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "CommerceFulfillment",
+                  "kind": "LinkedField",
+                  "name": "node",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "trackingId",
+                      "storageKey": null
+                    },
+                    (v11/*: any*/)
+                  ],
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": "fulfillments(first:1)"
+        },
+        (v11/*: any*/)
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v15 = {
+  "kind": "TypeDiscriminator",
+  "abstractKey": "__isCommerceOrder"
+},
+v16 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v17 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "displayState",
+  "storageKey": null
+},
+v18 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "state",
+  "storageKey": null
+},
+v19 = {
+  "alias": null,
+  "args": null,
+  "concreteType": null,
+  "kind": "LinkedField",
+  "name": "requestedFulfillment",
+  "plural": false,
+  "selections": [
+    (v7/*: any*/)
+  ],
+  "storageKey": null
+},
+v20 = {
+  "alias": null,
+  "args": null,
+  "concreteType": null,
+  "kind": "LinkedField",
+  "name": "paymentMethodDetails",
+  "plural": false,
+  "selections": [
+    (v7/*: any*/),
+    {
+      "kind": "InlineFragment",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "lastDigits",
+          "storageKey": null
+        },
+        (v11/*: any*/)
+      ],
+      "type": "CreditCard",
+      "abstractKey": null
+    },
+    {
+      "kind": "InlineFragment",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "last4",
+          "storageKey": null
+        },
+        (v11/*: any*/)
+      ],
+      "type": "BankAccount",
+      "abstractKey": null
+    },
+    {
+      "kind": "InlineFragment",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "isManualPayment",
+          "storageKey": null
+        }
+      ],
+      "type": "WireTransfer",
+      "abstractKey": null
+    }
+  ],
+  "storageKey": null
+},
+v21 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Literal",
+      "name": "precision",
+      "value": 2
+    }
+  ],
+  "kind": "ScalarField",
+  "name": "buyerTotal",
+  "storageKey": "buyerTotal(precision:2)"
+},
+v22 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "currencyCode",
+  "storageKey": null
+},
+v23 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v9 = {
+v24 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v10 = {
+v25 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "CommerceOrderConnectionWithTotalCount"
+},
+v26 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": true,
+  "type": "CommerceOrderEdge"
+},
+v27 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "CommerceOrder"
+},
+v28 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v11 = {
+v29 = {
+  "enumValues": [
+    "ABANDONED",
+    "APPROVED",
+    "CANCELED",
+    "FULFILLED",
+    "IN_TRANSIT",
+    "PENDING",
+    "PROCESSING",
+    "PROCESSING_APPROVAL",
+    "REFUNDED",
+    "SUBMITTED"
+  ],
+  "nullable": false,
+  "plural": false,
+  "type": "CommerceOrderDisplayStateEnum"
+},
+v30 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "CommerceLineItemConnection"
+},
+v31 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": true,
+  "type": "CommerceLineItemEdge"
+},
+v32 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "CommerceLineItem"
+},
+v33 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Artwork"
+},
+v34 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": true,
+  "type": "Artist"
+},
+v35 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Partner"
+},
+v36 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Profile"
+},
+v37 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Image"
 },
-v12 = {
+v38 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "CroppedImageUrl"
 },
-v13 = {
+v39 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "ArtworkVersion"
+},
+v40 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "CommerceFulfillmentConnection"
+},
+v41 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": true,
+  "type": "CommerceFulfillmentEdge"
+},
+v42 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "CommerceFulfillment"
+},
+v43 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "PaymentMethodUnion"
+},
+v44 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Boolean"
 },
-v14 = {
+v45 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "CommerceRequestedFulfillmentUnion"
+},
+v46 = {
+  "enumValues": [
+    "artwork_page",
+    "inquiry",
+    "private_sale"
+  ],
+  "nullable": false,
+  "plural": false,
+  "type": "CommerceOrderSourceEnum"
+},
+v47 = {
+  "enumValues": [
+    "ABANDONED",
+    "APPROVED",
+    "CANCELED",
+    "FULFILLED",
+    "IN_REVIEW",
+    "PENDING",
+    "PROCESSING_APPROVAL",
+    "REFUNDED",
+    "SUBMITTED"
+  ],
+  "nullable": false,
+  "plural": false,
+  "type": "CommerceOrderStateEnum"
+},
+v48 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "CommercePageCursors"
+},
+v49 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": true,
+  "type": "CommercePageCursor"
+},
+v50 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Int"
 },
-v15 = {
+v51 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "CommercePageCursor"
+},
+v52 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "CommercePageInfo"
+},
+v53 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Int"
 };
 return {
   "fragment": {
@@ -204,6 +769,106 @@ return {
         "selections": [
           (v0/*: any*/),
           {
+            "alias": "pendingOrders",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 100
+              },
+              {
+                "kind": "Literal",
+                "name": "states",
+                "value": [
+                  "PENDING"
+                ]
+              }
+            ],
+            "concreteType": "CommerceOrderConnectionWithTotalCount",
+            "kind": "LinkedField",
+            "name": "orders",
+            "plural": false,
+            "selections": [
+              (v1/*: any*/),
+              (v2/*: any*/),
+              (v6/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "CommerceOrderEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": null,
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v7/*: any*/),
+                      (v8/*: any*/),
+                      (v9/*: any*/),
+                      (v10/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "CommerceLineItemConnection",
+                        "kind": "LinkedField",
+                        "name": "lineItems",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "CommerceLineItem",
+                            "kind": "LinkedField",
+                            "name": "nodes",
+                            "plural": true,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "artworkId",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "editionSetId",
+                                "storageKey": null
+                              },
+                              (v11/*: any*/)
+                            ],
+                            "storageKey": null
+                          },
+                          (v14/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      (v15/*: any*/),
+                      (v16/*: any*/),
+                      (v17/*: any*/),
+                      (v18/*: any*/),
+                      (v19/*: any*/),
+                      (v20/*: any*/),
+                      (v21/*: any*/),
+                      (v22/*: any*/),
+                      (v11/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "orders(first:100,states:[\"PENDING\"])"
+          },
+          {
             "alias": null,
             "args": [
               {
@@ -229,92 +894,9 @@ return {
             "name": "orders",
             "plural": false,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "totalCount",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "CommercePageInfo",
-                "kind": "LinkedField",
-                "name": "pageInfo",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "hasNextPage",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "endCursor",
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "CommercePageCursors",
-                "kind": "LinkedField",
-                "name": "pageCursors",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "CommercePageCursor",
-                    "kind": "LinkedField",
-                    "name": "around",
-                    "plural": true,
-                    "selections": (v3/*: any*/),
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "CommercePageCursor",
-                    "kind": "LinkedField",
-                    "name": "first",
-                    "plural": false,
-                    "selections": (v3/*: any*/),
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "CommercePageCursor",
-                    "kind": "LinkedField",
-                    "name": "last",
-                    "plural": false,
-                    "selections": (v3/*: any*/),
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "CommercePageCursor",
-                    "kind": "LinkedField",
-                    "name": "previous",
-                    "plural": false,
-                    "selections": [
-                      (v1/*: any*/),
-                      (v2/*: any*/)
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
+              (v1/*: any*/),
+              (v2/*: any*/),
+              (v6/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -331,141 +913,18 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v4/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "code",
-                        "storageKey": null
-                      },
-                      {
-                        "kind": "TypeDiscriminator",
-                        "abstractKey": "__isCommerceOrder"
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "source",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "internalID",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "displayState",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "state",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": null,
-                        "kind": "LinkedField",
-                        "name": "requestedFulfillment",
-                        "plural": false,
-                        "selections": [
-                          (v4/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": null,
-                        "kind": "LinkedField",
-                        "name": "paymentMethodDetails",
-                        "plural": false,
-                        "selections": [
-                          (v4/*: any*/),
-                          {
-                            "kind": "InlineFragment",
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "lastDigits",
-                                "storageKey": null
-                              },
-                              (v5/*: any*/)
-                            ],
-                            "type": "CreditCard",
-                            "abstractKey": null
-                          },
-                          {
-                            "kind": "InlineFragment",
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "last4",
-                                "storageKey": null
-                              },
-                              (v5/*: any*/)
-                            ],
-                            "type": "BankAccount",
-                            "abstractKey": null
-                          },
-                          {
-                            "kind": "InlineFragment",
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "isManualPayment",
-                                "storageKey": null
-                              }
-                            ],
-                            "type": "WireTransfer",
-                            "abstractKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "precision",
-                            "value": 2
-                          }
-                        ],
-                        "kind": "ScalarField",
-                        "name": "buyerTotal",
-                        "storageKey": "buyerTotal(precision:2)"
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "createdAt",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "currencyCode",
-                        "storageKey": null
-                      },
+                      (v7/*: any*/),
+                      (v8/*: any*/),
+                      (v15/*: any*/),
+                      (v9/*: any*/),
+                      (v16/*: any*/),
+                      (v17/*: any*/),
+                      (v18/*: any*/),
+                      (v19/*: any*/),
+                      (v20/*: any*/),
+                      (v21/*: any*/),
+                      (v10/*: any*/),
+                      (v22/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -474,192 +933,11 @@ return {
                         "name": "lineItems",
                         "plural": false,
                         "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "CommerceLineItemEdge",
-                            "kind": "LinkedField",
-                            "name": "edges",
-                            "plural": true,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "CommerceLineItem",
-                                "kind": "LinkedField",
-                                "name": "node",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "ArtworkVersion",
-                                    "kind": "LinkedField",
-                                    "name": "artworkVersion",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "Image",
-                                        "kind": "LinkedField",
-                                        "name": "image",
-                                        "plural": false,
-                                        "selections": (v6/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      (v5/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Artwork",
-                                    "kind": "LinkedField",
-                                    "name": "artwork",
-                                    "plural": false,
-                                    "selections": [
-                                      (v7/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "Partner",
-                                        "kind": "LinkedField",
-                                        "name": "partner",
-                                        "plural": false,
-                                        "selections": [
-                                          (v7/*: any*/),
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "initials",
-                                            "storageKey": null
-                                          },
-                                          (v0/*: any*/),
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "concreteType": "Profile",
-                                            "kind": "LinkedField",
-                                            "name": "profile",
-                                            "plural": false,
-                                            "selections": [
-                                              {
-                                                "alias": null,
-                                                "args": null,
-                                                "concreteType": "Image",
-                                                "kind": "LinkedField",
-                                                "name": "icon",
-                                                "plural": false,
-                                                "selections": (v6/*: any*/),
-                                                "storageKey": null
-                                              },
-                                              (v5/*: any*/)
-                                            ],
-                                            "storageKey": null
-                                          },
-                                          (v5/*: any*/)
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "shippingOrigin",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "title",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "artistNames",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "Artist",
-                                        "kind": "LinkedField",
-                                        "name": "artists",
-                                        "plural": true,
-                                        "selections": [
-                                          (v7/*: any*/),
-                                          (v5/*: any*/)
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      (v5/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": [
-                                      {
-                                        "kind": "Literal",
-                                        "name": "first",
-                                        "value": 1
-                                      }
-                                    ],
-                                    "concreteType": "CommerceFulfillmentConnection",
-                                    "kind": "LinkedField",
-                                    "name": "fulfillments",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "CommerceFulfillmentEdge",
-                                        "kind": "LinkedField",
-                                        "name": "edges",
-                                        "plural": true,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "concreteType": "CommerceFulfillment",
-                                            "kind": "LinkedField",
-                                            "name": "node",
-                                            "plural": false,
-                                            "selections": [
-                                              {
-                                                "alias": null,
-                                                "args": null,
-                                                "kind": "ScalarField",
-                                                "name": "trackingId",
-                                                "storageKey": null
-                                              },
-                                              (v5/*: any*/)
-                                            ],
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": "fulfillments(first:1)"
-                                  },
-                                  (v5/*: any*/)
-                                ],
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          }
+                          (v14/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v5/*: any*/)
+                      (v11/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -669,14 +947,14 @@ return {
             ],
             "storageKey": "orders(first:10,states:[\"APPROVED\",\"CANCELED\",\"FULFILLED\",\"REFUNDED\",\"SUBMITTED\",\"PROCESSING_APPROVAL\"])"
           },
-          (v5/*: any*/)
+          (v11/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "1ac19a04dae6a6212cdfaf04cfd4f83d",
+    "cacheID": "a026c92109a56440c0d778db4b4002f0",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -686,230 +964,176 @@ return {
           "plural": false,
           "type": "Me"
         },
-        "me.id": (v8/*: any*/),
-        "me.name": (v9/*: any*/),
-        "me.orders": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "CommerceOrderConnectionWithTotalCount"
-        },
-        "me.orders.edges": {
+        "me.id": (v23/*: any*/),
+        "me.name": (v24/*: any*/),
+        "me.orders": (v25/*: any*/),
+        "me.orders.edges": (v26/*: any*/),
+        "me.orders.edges.node": (v27/*: any*/),
+        "me.orders.edges.node.__isCommerceOrder": (v28/*: any*/),
+        "me.orders.edges.node.__typename": (v28/*: any*/),
+        "me.orders.edges.node.buyerTotal": (v24/*: any*/),
+        "me.orders.edges.node.code": (v28/*: any*/),
+        "me.orders.edges.node.createdAt": (v28/*: any*/),
+        "me.orders.edges.node.currencyCode": (v28/*: any*/),
+        "me.orders.edges.node.displayState": (v29/*: any*/),
+        "me.orders.edges.node.id": (v23/*: any*/),
+        "me.orders.edges.node.internalID": (v23/*: any*/),
+        "me.orders.edges.node.lineItems": (v30/*: any*/),
+        "me.orders.edges.node.lineItems.edges": (v31/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node": (v32/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artwork": (v33/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artwork.artistNames": (v24/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artwork.artists": (v34/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artwork.artists.href": (v24/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artwork.artists.id": (v23/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artwork.href": (v24/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artwork.id": (v23/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artwork.partner": (v35/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artwork.partner.href": (v24/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artwork.partner.id": (v23/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artwork.partner.initials": (v24/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artwork.partner.name": (v24/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artwork.partner.profile": (v36/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artwork.partner.profile.icon": (v37/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artwork.partner.profile.icon.cropped": (v38/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artwork.partner.profile.icon.cropped.src": (v28/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artwork.partner.profile.icon.cropped.srcSet": (v28/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artwork.partner.profile.id": (v23/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artwork.shippingOrigin": (v24/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artwork.title": (v24/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artworkVersion": (v39/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artworkVersion.id": (v23/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artworkVersion.image": (v37/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artworkVersion.image.cropped": (v38/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artworkVersion.image.cropped.src": (v28/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.artworkVersion.image.cropped.srcSet": (v28/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.fulfillments": (v40/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.fulfillments.edges": (v41/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.fulfillments.edges.node": (v42/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.fulfillments.edges.node.id": (v23/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.fulfillments.edges.node.trackingId": (v24/*: any*/),
+        "me.orders.edges.node.lineItems.edges.node.id": (v23/*: any*/),
+        "me.orders.edges.node.paymentMethodDetails": (v43/*: any*/),
+        "me.orders.edges.node.paymentMethodDetails.__typename": (v28/*: any*/),
+        "me.orders.edges.node.paymentMethodDetails.id": (v23/*: any*/),
+        "me.orders.edges.node.paymentMethodDetails.isManualPayment": (v44/*: any*/),
+        "me.orders.edges.node.paymentMethodDetails.last4": (v28/*: any*/),
+        "me.orders.edges.node.paymentMethodDetails.lastDigits": (v28/*: any*/),
+        "me.orders.edges.node.requestedFulfillment": (v45/*: any*/),
+        "me.orders.edges.node.requestedFulfillment.__typename": (v28/*: any*/),
+        "me.orders.edges.node.source": (v46/*: any*/),
+        "me.orders.edges.node.state": (v47/*: any*/),
+        "me.orders.pageCursors": (v48/*: any*/),
+        "me.orders.pageCursors.around": (v49/*: any*/),
+        "me.orders.pageCursors.around.cursor": (v28/*: any*/),
+        "me.orders.pageCursors.around.isCurrent": (v44/*: any*/),
+        "me.orders.pageCursors.around.page": (v50/*: any*/),
+        "me.orders.pageCursors.first": (v51/*: any*/),
+        "me.orders.pageCursors.first.cursor": (v28/*: any*/),
+        "me.orders.pageCursors.first.isCurrent": (v44/*: any*/),
+        "me.orders.pageCursors.first.page": (v50/*: any*/),
+        "me.orders.pageCursors.last": (v51/*: any*/),
+        "me.orders.pageCursors.last.cursor": (v28/*: any*/),
+        "me.orders.pageCursors.last.isCurrent": (v44/*: any*/),
+        "me.orders.pageCursors.last.page": (v50/*: any*/),
+        "me.orders.pageCursors.previous": (v51/*: any*/),
+        "me.orders.pageCursors.previous.cursor": (v28/*: any*/),
+        "me.orders.pageCursors.previous.page": (v50/*: any*/),
+        "me.orders.pageInfo": (v52/*: any*/),
+        "me.orders.pageInfo.endCursor": (v24/*: any*/),
+        "me.orders.pageInfo.hasNextPage": (v44/*: any*/),
+        "me.orders.totalCount": (v53/*: any*/),
+        "me.pendingOrders": (v25/*: any*/),
+        "me.pendingOrders.edges": (v26/*: any*/),
+        "me.pendingOrders.edges.node": (v27/*: any*/),
+        "me.pendingOrders.edges.node.__isCommerceOrder": (v28/*: any*/),
+        "me.pendingOrders.edges.node.__typename": (v28/*: any*/),
+        "me.pendingOrders.edges.node.buyerTotal": (v24/*: any*/),
+        "me.pendingOrders.edges.node.code": (v28/*: any*/),
+        "me.pendingOrders.edges.node.createdAt": (v28/*: any*/),
+        "me.pendingOrders.edges.node.currencyCode": (v28/*: any*/),
+        "me.pendingOrders.edges.node.displayState": (v29/*: any*/),
+        "me.pendingOrders.edges.node.id": (v23/*: any*/),
+        "me.pendingOrders.edges.node.internalID": (v23/*: any*/),
+        "me.pendingOrders.edges.node.lineItems": (v30/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges": (v31/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node": (v32/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.artwork": (v33/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.artwork.artistNames": (v24/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.artwork.artists": (v34/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.artwork.artists.href": (v24/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.artwork.artists.id": (v23/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.artwork.href": (v24/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.artwork.id": (v23/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.artwork.partner": (v35/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.artwork.partner.href": (v24/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.artwork.partner.id": (v23/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.artwork.partner.initials": (v24/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.artwork.partner.name": (v24/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.artwork.partner.profile": (v36/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.artwork.partner.profile.icon": (v37/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.artwork.partner.profile.icon.cropped": (v38/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.artwork.partner.profile.icon.cropped.src": (v28/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.artwork.partner.profile.icon.cropped.srcSet": (v28/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.artwork.partner.profile.id": (v23/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.artwork.shippingOrigin": (v24/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.artwork.title": (v24/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.artworkVersion": (v39/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.artworkVersion.id": (v23/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.artworkVersion.image": (v37/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.artworkVersion.image.cropped": (v38/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.artworkVersion.image.cropped.src": (v28/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.artworkVersion.image.cropped.srcSet": (v28/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.fulfillments": (v40/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.fulfillments.edges": (v41/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.fulfillments.edges.node": (v42/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.fulfillments.edges.node.id": (v23/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.fulfillments.edges.node.trackingId": (v24/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.edges.node.id": (v23/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.nodes": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
-          "type": "CommerceOrderEdge"
-        },
-        "me.orders.edges.node": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "CommerceOrder"
-        },
-        "me.orders.edges.node.__isCommerceOrder": (v10/*: any*/),
-        "me.orders.edges.node.__typename": (v10/*: any*/),
-        "me.orders.edges.node.buyerTotal": (v9/*: any*/),
-        "me.orders.edges.node.code": (v10/*: any*/),
-        "me.orders.edges.node.createdAt": (v10/*: any*/),
-        "me.orders.edges.node.currencyCode": (v10/*: any*/),
-        "me.orders.edges.node.displayState": {
-          "enumValues": [
-            "ABANDONED",
-            "APPROVED",
-            "CANCELED",
-            "FULFILLED",
-            "IN_TRANSIT",
-            "PENDING",
-            "PROCESSING",
-            "PROCESSING_APPROVAL",
-            "REFUNDED",
-            "SUBMITTED"
-          ],
-          "nullable": false,
-          "plural": false,
-          "type": "CommerceOrderDisplayStateEnum"
-        },
-        "me.orders.edges.node.id": (v8/*: any*/),
-        "me.orders.edges.node.internalID": (v8/*: any*/),
-        "me.orders.edges.node.lineItems": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "CommerceLineItemConnection"
-        },
-        "me.orders.edges.node.lineItems.edges": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": true,
-          "type": "CommerceLineItemEdge"
-        },
-        "me.orders.edges.node.lineItems.edges.node": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
           "type": "CommerceLineItem"
         },
-        "me.orders.edges.node.lineItems.edges.node.artwork": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Artwork"
-        },
-        "me.orders.edges.node.lineItems.edges.node.artwork.artistNames": (v9/*: any*/),
-        "me.orders.edges.node.lineItems.edges.node.artwork.artists": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": true,
-          "type": "Artist"
-        },
-        "me.orders.edges.node.lineItems.edges.node.artwork.artists.href": (v9/*: any*/),
-        "me.orders.edges.node.lineItems.edges.node.artwork.artists.id": (v8/*: any*/),
-        "me.orders.edges.node.lineItems.edges.node.artwork.href": (v9/*: any*/),
-        "me.orders.edges.node.lineItems.edges.node.artwork.id": (v8/*: any*/),
-        "me.orders.edges.node.lineItems.edges.node.artwork.partner": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Partner"
-        },
-        "me.orders.edges.node.lineItems.edges.node.artwork.partner.href": (v9/*: any*/),
-        "me.orders.edges.node.lineItems.edges.node.artwork.partner.id": (v8/*: any*/),
-        "me.orders.edges.node.lineItems.edges.node.artwork.partner.initials": (v9/*: any*/),
-        "me.orders.edges.node.lineItems.edges.node.artwork.partner.name": (v9/*: any*/),
-        "me.orders.edges.node.lineItems.edges.node.artwork.partner.profile": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Profile"
-        },
-        "me.orders.edges.node.lineItems.edges.node.artwork.partner.profile.icon": (v11/*: any*/),
-        "me.orders.edges.node.lineItems.edges.node.artwork.partner.profile.icon.cropped": (v12/*: any*/),
-        "me.orders.edges.node.lineItems.edges.node.artwork.partner.profile.icon.cropped.src": (v10/*: any*/),
-        "me.orders.edges.node.lineItems.edges.node.artwork.partner.profile.icon.cropped.srcSet": (v10/*: any*/),
-        "me.orders.edges.node.lineItems.edges.node.artwork.partner.profile.id": (v8/*: any*/),
-        "me.orders.edges.node.lineItems.edges.node.artwork.shippingOrigin": (v9/*: any*/),
-        "me.orders.edges.node.lineItems.edges.node.artwork.title": (v9/*: any*/),
-        "me.orders.edges.node.lineItems.edges.node.artworkVersion": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ArtworkVersion"
-        },
-        "me.orders.edges.node.lineItems.edges.node.artworkVersion.id": (v8/*: any*/),
-        "me.orders.edges.node.lineItems.edges.node.artworkVersion.image": (v11/*: any*/),
-        "me.orders.edges.node.lineItems.edges.node.artworkVersion.image.cropped": (v12/*: any*/),
-        "me.orders.edges.node.lineItems.edges.node.artworkVersion.image.cropped.src": (v10/*: any*/),
-        "me.orders.edges.node.lineItems.edges.node.artworkVersion.image.cropped.srcSet": (v10/*: any*/),
-        "me.orders.edges.node.lineItems.edges.node.fulfillments": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "CommerceFulfillmentConnection"
-        },
-        "me.orders.edges.node.lineItems.edges.node.fulfillments.edges": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": true,
-          "type": "CommerceFulfillmentEdge"
-        },
-        "me.orders.edges.node.lineItems.edges.node.fulfillments.edges.node": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "CommerceFulfillment"
-        },
-        "me.orders.edges.node.lineItems.edges.node.fulfillments.edges.node.id": (v8/*: any*/),
-        "me.orders.edges.node.lineItems.edges.node.fulfillments.edges.node.trackingId": (v9/*: any*/),
-        "me.orders.edges.node.lineItems.edges.node.id": (v8/*: any*/),
-        "me.orders.edges.node.paymentMethodDetails": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "PaymentMethodUnion"
-        },
-        "me.orders.edges.node.paymentMethodDetails.__typename": (v10/*: any*/),
-        "me.orders.edges.node.paymentMethodDetails.id": (v8/*: any*/),
-        "me.orders.edges.node.paymentMethodDetails.isManualPayment": (v13/*: any*/),
-        "me.orders.edges.node.paymentMethodDetails.last4": (v10/*: any*/),
-        "me.orders.edges.node.paymentMethodDetails.lastDigits": (v10/*: any*/),
-        "me.orders.edges.node.requestedFulfillment": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "CommerceRequestedFulfillmentUnion"
-        },
-        "me.orders.edges.node.requestedFulfillment.__typename": (v10/*: any*/),
-        "me.orders.edges.node.source": {
-          "enumValues": [
-            "artwork_page",
-            "inquiry",
-            "private_sale"
-          ],
-          "nullable": false,
-          "plural": false,
-          "type": "CommerceOrderSourceEnum"
-        },
-        "me.orders.edges.node.state": {
-          "enumValues": [
-            "ABANDONED",
-            "APPROVED",
-            "CANCELED",
-            "FULFILLED",
-            "IN_REVIEW",
-            "PENDING",
-            "PROCESSING_APPROVAL",
-            "REFUNDED",
-            "SUBMITTED"
-          ],
-          "nullable": false,
-          "plural": false,
-          "type": "CommerceOrderStateEnum"
-        },
-        "me.orders.pageCursors": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "CommercePageCursors"
-        },
-        "me.orders.pageCursors.around": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": true,
-          "type": "CommercePageCursor"
-        },
-        "me.orders.pageCursors.around.cursor": (v10/*: any*/),
-        "me.orders.pageCursors.around.isCurrent": (v13/*: any*/),
-        "me.orders.pageCursors.around.page": (v14/*: any*/),
-        "me.orders.pageCursors.first": (v15/*: any*/),
-        "me.orders.pageCursors.first.cursor": (v10/*: any*/),
-        "me.orders.pageCursors.first.isCurrent": (v13/*: any*/),
-        "me.orders.pageCursors.first.page": (v14/*: any*/),
-        "me.orders.pageCursors.last": (v15/*: any*/),
-        "me.orders.pageCursors.last.cursor": (v10/*: any*/),
-        "me.orders.pageCursors.last.isCurrent": (v13/*: any*/),
-        "me.orders.pageCursors.last.page": (v14/*: any*/),
-        "me.orders.pageCursors.previous": (v15/*: any*/),
-        "me.orders.pageCursors.previous.cursor": (v10/*: any*/),
-        "me.orders.pageCursors.previous.page": (v14/*: any*/),
-        "me.orders.pageInfo": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "CommercePageInfo"
-        },
-        "me.orders.pageInfo.endCursor": (v9/*: any*/),
-        "me.orders.pageInfo.hasNextPage": (v13/*: any*/),
-        "me.orders.totalCount": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Int"
-        }
+        "me.pendingOrders.edges.node.lineItems.nodes.artworkId": (v28/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.nodes.editionSetId": (v24/*: any*/),
+        "me.pendingOrders.edges.node.lineItems.nodes.id": (v23/*: any*/),
+        "me.pendingOrders.edges.node.paymentMethodDetails": (v43/*: any*/),
+        "me.pendingOrders.edges.node.paymentMethodDetails.__typename": (v28/*: any*/),
+        "me.pendingOrders.edges.node.paymentMethodDetails.id": (v23/*: any*/),
+        "me.pendingOrders.edges.node.paymentMethodDetails.isManualPayment": (v44/*: any*/),
+        "me.pendingOrders.edges.node.paymentMethodDetails.last4": (v28/*: any*/),
+        "me.pendingOrders.edges.node.paymentMethodDetails.lastDigits": (v28/*: any*/),
+        "me.pendingOrders.edges.node.requestedFulfillment": (v45/*: any*/),
+        "me.pendingOrders.edges.node.requestedFulfillment.__typename": (v28/*: any*/),
+        "me.pendingOrders.edges.node.source": (v46/*: any*/),
+        "me.pendingOrders.edges.node.state": (v47/*: any*/),
+        "me.pendingOrders.pageCursors": (v48/*: any*/),
+        "me.pendingOrders.pageCursors.around": (v49/*: any*/),
+        "me.pendingOrders.pageCursors.around.cursor": (v28/*: any*/),
+        "me.pendingOrders.pageCursors.around.isCurrent": (v44/*: any*/),
+        "me.pendingOrders.pageCursors.around.page": (v50/*: any*/),
+        "me.pendingOrders.pageCursors.first": (v51/*: any*/),
+        "me.pendingOrders.pageCursors.first.cursor": (v28/*: any*/),
+        "me.pendingOrders.pageCursors.first.isCurrent": (v44/*: any*/),
+        "me.pendingOrders.pageCursors.first.page": (v50/*: any*/),
+        "me.pendingOrders.pageCursors.last": (v51/*: any*/),
+        "me.pendingOrders.pageCursors.last.cursor": (v28/*: any*/),
+        "me.pendingOrders.pageCursors.last.isCurrent": (v44/*: any*/),
+        "me.pendingOrders.pageCursors.last.page": (v50/*: any*/),
+        "me.pendingOrders.pageCursors.previous": (v51/*: any*/),
+        "me.pendingOrders.pageCursors.previous.cursor": (v28/*: any*/),
+        "me.pendingOrders.pageCursors.previous.page": (v50/*: any*/),
+        "me.pendingOrders.pageInfo": (v52/*: any*/),
+        "me.pendingOrders.pageInfo.endCursor": (v24/*: any*/),
+        "me.pendingOrders.pageInfo.hasNextPage": (v44/*: any*/),
+        "me.pendingOrders.totalCount": (v53/*: any*/)
       }
     },
     "name": "SettingsPurchases_Test_Query",
     "operationKind": "query",
-    "text": "query SettingsPurchases_Test_Query {\n  me {\n    ...SettingsPurchases_me\n    id\n  }\n}\n\nfragment CommercePagination_pageCursors on CommercePageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SettingsPurchasesRow_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  source\n  internalID\n  code\n  displayState\n  state\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      lastDigits\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  buyerTotal(precision: 2)\n  createdAt\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artworkVersion {\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          id\n        }\n        artwork {\n          href\n          partner {\n            href\n            initials\n            name\n            profile {\n              icon {\n                cropped(width: 45, height: 45) {\n                  src\n                  srcSet\n                }\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          title\n          artistNames\n          artists {\n            href\n            id\n          }\n          id\n        }\n        fulfillments(first: 1) {\n          edges {\n            node {\n              trackingId\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SettingsPurchases_me on Me {\n  name\n  orders(states: [APPROVED, CANCELED, FULFILLED, REFUNDED, SUBMITTED, PROCESSING_APPROVAL], first: 10) {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...CommercePagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        code\n        ...SettingsPurchasesRow_order\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query SettingsPurchases_Test_Query {\n  me {\n    ...SettingsPurchases_me\n    id\n  }\n}\n\nfragment CommercePagination_pageCursors on CommercePageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SettingsPurchasesRow_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  source\n  internalID\n  code\n  displayState\n  state\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      lastDigits\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  buyerTotal(precision: 2)\n  createdAt\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artworkVersion {\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          id\n        }\n        artwork {\n          href\n          partner {\n            href\n            initials\n            name\n            profile {\n              icon {\n                cropped(width: 45, height: 45) {\n                  src\n                  srcSet\n                }\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          title\n          artistNames\n          artists {\n            href\n            id\n          }\n          id\n        }\n        fulfillments(first: 1) {\n          edges {\n            node {\n              trackingId\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SettingsPurchases_me on Me {\n  name\n  pendingOrders: orders(states: [PENDING], first: 100) {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...CommercePagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        code\n        source\n        createdAt\n        lineItems {\n          nodes {\n            artworkId\n            editionSetId\n            id\n          }\n        }\n        ...SettingsPurchasesRow_order\n        id\n      }\n    }\n  }\n  orders(states: [APPROVED, CANCELED, FULFILLED, REFUNDED, SUBMITTED, PROCESSING_APPROVAL], first: 10) {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...CommercePagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        code\n        ...SettingsPurchasesRow_order\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SettingsPurchases_me.graphql.ts
+++ b/src/__generated__/SettingsPurchases_me.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4b2317577656e8cae75fa0375cae10e6>>
+ * @generated SignedSource<<904fc90653629d8a02a2b1d10c95ce5e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,6 +9,7 @@
 // @ts-nocheck
 
 import { Fragment, ReaderFragment } from 'relay-runtime';
+export type CommerceOrderSourceEnum = "artwork_page" | "inquiry" | "private_sale" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type SettingsPurchases_me$data = {
   readonly name: string | null;
@@ -28,6 +29,30 @@ export type SettingsPurchases_me$data = {
     };
     readonly totalCount: number | null;
   } | null;
+  readonly pendingOrders: {
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly code: string;
+        readonly createdAt: string;
+        readonly lineItems: {
+          readonly nodes: ReadonlyArray<{
+            readonly artworkId: string;
+            readonly editionSetId: string | null;
+          } | null> | null;
+        } | null;
+        readonly source: CommerceOrderSourceEnum;
+        readonly " $fragmentSpreads": FragmentRefs<"SettingsPurchasesRow_order">;
+      } | null;
+    } | null> | null;
+    readonly pageCursors: {
+      readonly " $fragmentSpreads": FragmentRefs<"CommercePagination_pageCursors">;
+    } | null;
+    readonly pageInfo: {
+      readonly endCursor: string | null;
+      readonly hasNextPage: boolean;
+    };
+    readonly totalCount: number | null;
+  } | null;
   readonly " $fragmentType": "SettingsPurchases_me";
 };
 export type SettingsPurchases_me$key = {
@@ -35,7 +60,68 @@ export type SettingsPurchases_me$key = {
   readonly " $fragmentSpreads": FragmentRefs<"SettingsPurchases_me">;
 };
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "totalCount",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "CommercePageInfo",
+  "kind": "LinkedField",
+  "name": "pageInfo",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "hasNextPage",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "endCursor",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "CommercePageCursors",
+  "kind": "LinkedField",
+  "name": "pageCursors",
+  "plural": false,
+  "selections": [
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "CommercePagination_pageCursors"
+    }
+  ],
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "code",
+  "storageKey": null
+},
+v4 = {
+  "args": null,
+  "kind": "FragmentSpread",
+  "name": "SettingsPurchasesRow_order"
+};
+return {
   "argumentDefinitions": [
     {
       "defaultValue": null,
@@ -72,6 +158,107 @@ const node: ReaderFragment = {
       "storageKey": null
     },
     {
+      "alias": "pendingOrders",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 100
+        },
+        {
+          "kind": "Literal",
+          "name": "states",
+          "value": [
+            "PENDING"
+          ]
+        }
+      ],
+      "concreteType": "CommerceOrderConnectionWithTotalCount",
+      "kind": "LinkedField",
+      "name": "orders",
+      "plural": false,
+      "selections": [
+        (v0/*: any*/),
+        (v1/*: any*/),
+        (v2/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "CommerceOrderEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": null,
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                (v3/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "source",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "createdAt",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "CommerceLineItemConnection",
+                  "kind": "LinkedField",
+                  "name": "lineItems",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "CommerceLineItem",
+                      "kind": "LinkedField",
+                      "name": "nodes",
+                      "plural": true,
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "artworkId",
+                          "storageKey": null
+                        },
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "editionSetId",
+                          "storageKey": null
+                        }
+                      ],
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                },
+                (v4/*: any*/)
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "orders(first:100,states:[\"PENDING\"])"
+    },
+    {
       "alias": null,
       "args": [
         {
@@ -95,54 +282,9 @@ const node: ReaderFragment = {
       "name": "orders",
       "plural": false,
       "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "totalCount",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": "CommercePageInfo",
-          "kind": "LinkedField",
-          "name": "pageInfo",
-          "plural": false,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "hasNextPage",
-              "storageKey": null
-            },
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "endCursor",
-              "storageKey": null
-            }
-          ],
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": "CommercePageCursors",
-          "kind": "LinkedField",
-          "name": "pageCursors",
-          "plural": false,
-          "selections": [
-            {
-              "args": null,
-              "kind": "FragmentSpread",
-              "name": "CommercePagination_pageCursors"
-            }
-          ],
-          "storageKey": null
-        },
+        (v0/*: any*/),
+        (v1/*: any*/),
+        (v2/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -159,18 +301,8 @@ const node: ReaderFragment = {
               "name": "node",
               "plural": false,
               "selections": [
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "code",
-                  "storageKey": null
-                },
-                {
-                  "args": null,
-                  "kind": "FragmentSpread",
-                  "name": "SettingsPurchasesRow_order"
-                }
+                (v3/*: any*/),
+                (v4/*: any*/)
               ],
               "storageKey": null
             }
@@ -184,7 +316,8 @@ const node: ReaderFragment = {
   "type": "Me",
   "abstractKey": null
 };
+})();
 
-(node as any).hash = "fdad90e8481ba3fb8caf0b87e155d541";
+(node as any).hash = "d8c6ce274cad110bbc36ea24c4bd87ac";
 
 export default node;

--- a/src/__generated__/settingsRoutes_PurchasesRouteQuery.graphql.ts
+++ b/src/__generated__/settingsRoutes_PurchasesRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e9a10fba59f8080dcb2a99f28ecbf45e>>
+ * @generated SignedSource<<1bd5158ccdf9773efa2a07f9b4e5a7d1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -33,19 +33,51 @@ v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "cursor",
+  "name": "totalCount",
   "storageKey": null
 },
 v2 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "CommercePageInfo",
+  "kind": "LinkedField",
+  "name": "pageInfo",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "hasNextPage",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "endCursor",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cursor",
+  "storageKey": null
+},
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "page",
   "storageKey": null
 },
-v3 = [
-  (v1/*: any*/),
-  (v2/*: any*/),
+v5 = [
+  (v3/*: any*/),
+  (v4/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -54,21 +86,96 @@ v3 = [
     "storageKey": null
   }
 ],
-v4 = {
+v6 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "CommercePageCursors",
+  "kind": "LinkedField",
+  "name": "pageCursors",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "CommercePageCursor",
+      "kind": "LinkedField",
+      "name": "around",
+      "plural": true,
+      "selections": (v5/*: any*/),
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "CommercePageCursor",
+      "kind": "LinkedField",
+      "name": "first",
+      "plural": false,
+      "selections": (v5/*: any*/),
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "CommercePageCursor",
+      "kind": "LinkedField",
+      "name": "last",
+      "plural": false,
+      "selections": (v5/*: any*/),
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "CommercePageCursor",
+      "kind": "LinkedField",
+      "name": "previous",
+      "plural": false,
+      "selections": [
+        (v3/*: any*/),
+        (v4/*: any*/)
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v5 = {
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "code",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "source",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "createdAt",
+  "storageKey": null
+},
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v6 = [
+v12 = [
   {
     "alias": null,
     "args": [
@@ -106,11 +213,306 @@ v6 = [
     "storageKey": "cropped(height:45,width:45)"
   }
 ],
-v7 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
+  "storageKey": null
+},
+v14 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "CommerceLineItemEdge",
+  "kind": "LinkedField",
+  "name": "edges",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "CommerceLineItem",
+      "kind": "LinkedField",
+      "name": "node",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ArtworkVersion",
+          "kind": "LinkedField",
+          "name": "artworkVersion",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Image",
+              "kind": "LinkedField",
+              "name": "image",
+              "plural": false,
+              "selections": (v12/*: any*/),
+              "storageKey": null
+            },
+            (v11/*: any*/)
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Artwork",
+          "kind": "LinkedField",
+          "name": "artwork",
+          "plural": false,
+          "selections": [
+            (v13/*: any*/),
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Partner",
+              "kind": "LinkedField",
+              "name": "partner",
+              "plural": false,
+              "selections": [
+                (v13/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "initials",
+                  "storageKey": null
+                },
+                (v0/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "Profile",
+                  "kind": "LinkedField",
+                  "name": "profile",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "Image",
+                      "kind": "LinkedField",
+                      "name": "icon",
+                      "plural": false,
+                      "selections": (v12/*: any*/),
+                      "storageKey": null
+                    },
+                    (v11/*: any*/)
+                  ],
+                  "storageKey": null
+                },
+                (v11/*: any*/)
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "shippingOrigin",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "title",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "artistNames",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Artist",
+              "kind": "LinkedField",
+              "name": "artists",
+              "plural": true,
+              "selections": [
+                (v13/*: any*/),
+                (v11/*: any*/)
+              ],
+              "storageKey": null
+            },
+            (v11/*: any*/)
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "first",
+              "value": 1
+            }
+          ],
+          "concreteType": "CommerceFulfillmentConnection",
+          "kind": "LinkedField",
+          "name": "fulfillments",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "CommerceFulfillmentEdge",
+              "kind": "LinkedField",
+              "name": "edges",
+              "plural": true,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "CommerceFulfillment",
+                  "kind": "LinkedField",
+                  "name": "node",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "trackingId",
+                      "storageKey": null
+                    },
+                    (v11/*: any*/)
+                  ],
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": "fulfillments(first:1)"
+        },
+        (v11/*: any*/)
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v15 = {
+  "kind": "TypeDiscriminator",
+  "abstractKey": "__isCommerceOrder"
+},
+v16 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v17 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "displayState",
+  "storageKey": null
+},
+v18 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "state",
+  "storageKey": null
+},
+v19 = {
+  "alias": null,
+  "args": null,
+  "concreteType": null,
+  "kind": "LinkedField",
+  "name": "requestedFulfillment",
+  "plural": false,
+  "selections": [
+    (v7/*: any*/)
+  ],
+  "storageKey": null
+},
+v20 = {
+  "alias": null,
+  "args": null,
+  "concreteType": null,
+  "kind": "LinkedField",
+  "name": "paymentMethodDetails",
+  "plural": false,
+  "selections": [
+    (v7/*: any*/),
+    {
+      "kind": "InlineFragment",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "lastDigits",
+          "storageKey": null
+        },
+        (v11/*: any*/)
+      ],
+      "type": "CreditCard",
+      "abstractKey": null
+    },
+    {
+      "kind": "InlineFragment",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "last4",
+          "storageKey": null
+        },
+        (v11/*: any*/)
+      ],
+      "type": "BankAccount",
+      "abstractKey": null
+    },
+    {
+      "kind": "InlineFragment",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "isManualPayment",
+          "storageKey": null
+        }
+      ],
+      "type": "WireTransfer",
+      "abstractKey": null
+    }
+  ],
+  "storageKey": null
+},
+v21 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Literal",
+      "name": "precision",
+      "value": 2
+    }
+  ],
+  "kind": "ScalarField",
+  "name": "buyerTotal",
+  "storageKey": "buyerTotal(precision:2)"
+},
+v22 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "currencyCode",
   "storageKey": null
 };
 return {
@@ -156,6 +558,106 @@ return {
         "selections": [
           (v0/*: any*/),
           {
+            "alias": "pendingOrders",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 100
+              },
+              {
+                "kind": "Literal",
+                "name": "states",
+                "value": [
+                  "PENDING"
+                ]
+              }
+            ],
+            "concreteType": "CommerceOrderConnectionWithTotalCount",
+            "kind": "LinkedField",
+            "name": "orders",
+            "plural": false,
+            "selections": [
+              (v1/*: any*/),
+              (v2/*: any*/),
+              (v6/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "CommerceOrderEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": null,
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v7/*: any*/),
+                      (v8/*: any*/),
+                      (v9/*: any*/),
+                      (v10/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "CommerceLineItemConnection",
+                        "kind": "LinkedField",
+                        "name": "lineItems",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "CommerceLineItem",
+                            "kind": "LinkedField",
+                            "name": "nodes",
+                            "plural": true,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "artworkId",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "editionSetId",
+                                "storageKey": null
+                              },
+                              (v11/*: any*/)
+                            ],
+                            "storageKey": null
+                          },
+                          (v14/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      (v15/*: any*/),
+                      (v16/*: any*/),
+                      (v17/*: any*/),
+                      (v18/*: any*/),
+                      (v19/*: any*/),
+                      (v20/*: any*/),
+                      (v21/*: any*/),
+                      (v22/*: any*/),
+                      (v11/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "orders(first:100,states:[\"PENDING\"])"
+          },
+          {
             "alias": null,
             "args": [
               {
@@ -181,92 +683,9 @@ return {
             "name": "orders",
             "plural": false,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "totalCount",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "CommercePageInfo",
-                "kind": "LinkedField",
-                "name": "pageInfo",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "hasNextPage",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "endCursor",
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "CommercePageCursors",
-                "kind": "LinkedField",
-                "name": "pageCursors",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "CommercePageCursor",
-                    "kind": "LinkedField",
-                    "name": "around",
-                    "plural": true,
-                    "selections": (v3/*: any*/),
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "CommercePageCursor",
-                    "kind": "LinkedField",
-                    "name": "first",
-                    "plural": false,
-                    "selections": (v3/*: any*/),
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "CommercePageCursor",
-                    "kind": "LinkedField",
-                    "name": "last",
-                    "plural": false,
-                    "selections": (v3/*: any*/),
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "CommercePageCursor",
-                    "kind": "LinkedField",
-                    "name": "previous",
-                    "plural": false,
-                    "selections": [
-                      (v1/*: any*/),
-                      (v2/*: any*/)
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
+              (v1/*: any*/),
+              (v2/*: any*/),
+              (v6/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -283,141 +702,18 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v4/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "code",
-                        "storageKey": null
-                      },
-                      {
-                        "kind": "TypeDiscriminator",
-                        "abstractKey": "__isCommerceOrder"
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "source",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "internalID",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "displayState",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "state",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": null,
-                        "kind": "LinkedField",
-                        "name": "requestedFulfillment",
-                        "plural": false,
-                        "selections": [
-                          (v4/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": null,
-                        "kind": "LinkedField",
-                        "name": "paymentMethodDetails",
-                        "plural": false,
-                        "selections": [
-                          (v4/*: any*/),
-                          {
-                            "kind": "InlineFragment",
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "lastDigits",
-                                "storageKey": null
-                              },
-                              (v5/*: any*/)
-                            ],
-                            "type": "CreditCard",
-                            "abstractKey": null
-                          },
-                          {
-                            "kind": "InlineFragment",
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "last4",
-                                "storageKey": null
-                              },
-                              (v5/*: any*/)
-                            ],
-                            "type": "BankAccount",
-                            "abstractKey": null
-                          },
-                          {
-                            "kind": "InlineFragment",
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "isManualPayment",
-                                "storageKey": null
-                              }
-                            ],
-                            "type": "WireTransfer",
-                            "abstractKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "precision",
-                            "value": 2
-                          }
-                        ],
-                        "kind": "ScalarField",
-                        "name": "buyerTotal",
-                        "storageKey": "buyerTotal(precision:2)"
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "createdAt",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "currencyCode",
-                        "storageKey": null
-                      },
+                      (v7/*: any*/),
+                      (v8/*: any*/),
+                      (v15/*: any*/),
+                      (v9/*: any*/),
+                      (v16/*: any*/),
+                      (v17/*: any*/),
+                      (v18/*: any*/),
+                      (v19/*: any*/),
+                      (v20/*: any*/),
+                      (v21/*: any*/),
+                      (v10/*: any*/),
+                      (v22/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -426,192 +722,11 @@ return {
                         "name": "lineItems",
                         "plural": false,
                         "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "CommerceLineItemEdge",
-                            "kind": "LinkedField",
-                            "name": "edges",
-                            "plural": true,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "CommerceLineItem",
-                                "kind": "LinkedField",
-                                "name": "node",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "ArtworkVersion",
-                                    "kind": "LinkedField",
-                                    "name": "artworkVersion",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "Image",
-                                        "kind": "LinkedField",
-                                        "name": "image",
-                                        "plural": false,
-                                        "selections": (v6/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      (v5/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Artwork",
-                                    "kind": "LinkedField",
-                                    "name": "artwork",
-                                    "plural": false,
-                                    "selections": [
-                                      (v7/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "Partner",
-                                        "kind": "LinkedField",
-                                        "name": "partner",
-                                        "plural": false,
-                                        "selections": [
-                                          (v7/*: any*/),
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "initials",
-                                            "storageKey": null
-                                          },
-                                          (v0/*: any*/),
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "concreteType": "Profile",
-                                            "kind": "LinkedField",
-                                            "name": "profile",
-                                            "plural": false,
-                                            "selections": [
-                                              {
-                                                "alias": null,
-                                                "args": null,
-                                                "concreteType": "Image",
-                                                "kind": "LinkedField",
-                                                "name": "icon",
-                                                "plural": false,
-                                                "selections": (v6/*: any*/),
-                                                "storageKey": null
-                                              },
-                                              (v5/*: any*/)
-                                            ],
-                                            "storageKey": null
-                                          },
-                                          (v5/*: any*/)
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "shippingOrigin",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "title",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "artistNames",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "Artist",
-                                        "kind": "LinkedField",
-                                        "name": "artists",
-                                        "plural": true,
-                                        "selections": [
-                                          (v7/*: any*/),
-                                          (v5/*: any*/)
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      (v5/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": [
-                                      {
-                                        "kind": "Literal",
-                                        "name": "first",
-                                        "value": 1
-                                      }
-                                    ],
-                                    "concreteType": "CommerceFulfillmentConnection",
-                                    "kind": "LinkedField",
-                                    "name": "fulfillments",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "CommerceFulfillmentEdge",
-                                        "kind": "LinkedField",
-                                        "name": "edges",
-                                        "plural": true,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "concreteType": "CommerceFulfillment",
-                                            "kind": "LinkedField",
-                                            "name": "node",
-                                            "plural": false,
-                                            "selections": [
-                                              {
-                                                "alias": null,
-                                                "args": null,
-                                                "kind": "ScalarField",
-                                                "name": "trackingId",
-                                                "storageKey": null
-                                              },
-                                              (v5/*: any*/)
-                                            ],
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": "fulfillments(first:1)"
-                                  },
-                                  (v5/*: any*/)
-                                ],
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          }
+                          (v14/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v5/*: any*/)
+                      (v11/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -621,19 +736,19 @@ return {
             ],
             "storageKey": "orders(first:10,states:[\"APPROVED\",\"CANCELED\",\"FULFILLED\",\"REFUNDED\",\"SUBMITTED\",\"PROCESSING_APPROVAL\"])"
           },
-          (v5/*: any*/)
+          (v11/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "b9fe1dd8609b11d7f9d62d3551a0ec6e",
+    "cacheID": "2203769c1d6c56cc6417021f7e321ca7",
     "id": null,
     "metadata": {},
     "name": "settingsRoutes_PurchasesRouteQuery",
     "operationKind": "query",
-    "text": "query settingsRoutes_PurchasesRouteQuery {\n  me {\n    ...SettingsPurchasesRoute_me\n    id\n  }\n}\n\nfragment CommercePagination_pageCursors on CommercePageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SettingsPurchasesRoute_me on Me {\n  ...SettingsPurchases_me\n}\n\nfragment SettingsPurchasesRow_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  source\n  internalID\n  code\n  displayState\n  state\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      lastDigits\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  buyerTotal(precision: 2)\n  createdAt\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artworkVersion {\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          id\n        }\n        artwork {\n          href\n          partner {\n            href\n            initials\n            name\n            profile {\n              icon {\n                cropped(width: 45, height: 45) {\n                  src\n                  srcSet\n                }\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          title\n          artistNames\n          artists {\n            href\n            id\n          }\n          id\n        }\n        fulfillments(first: 1) {\n          edges {\n            node {\n              trackingId\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SettingsPurchases_me on Me {\n  name\n  orders(states: [APPROVED, CANCELED, FULFILLED, REFUNDED, SUBMITTED, PROCESSING_APPROVAL], first: 10) {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...CommercePagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        code\n        ...SettingsPurchasesRow_order\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query settingsRoutes_PurchasesRouteQuery {\n  me {\n    ...SettingsPurchasesRoute_me\n    id\n  }\n}\n\nfragment CommercePagination_pageCursors on CommercePageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SettingsPurchasesRoute_me on Me {\n  ...SettingsPurchases_me\n}\n\nfragment SettingsPurchasesRow_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  source\n  internalID\n  code\n  displayState\n  state\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      lastDigits\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  buyerTotal(precision: 2)\n  createdAt\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artworkVersion {\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          id\n        }\n        artwork {\n          href\n          partner {\n            href\n            initials\n            name\n            profile {\n              icon {\n                cropped(width: 45, height: 45) {\n                  src\n                  srcSet\n                }\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          title\n          artistNames\n          artists {\n            href\n            id\n          }\n          id\n        }\n        fulfillments(first: 1) {\n          edges {\n            node {\n              trackingId\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SettingsPurchases_me on Me {\n  name\n  pendingOrders: orders(states: [PENDING], first: 100) {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...CommercePagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        code\n        source\n        createdAt\n        lineItems {\n          nodes {\n            artworkId\n            editionSetId\n            id\n          }\n        }\n        ...SettingsPurchasesRow_order\n        id\n      }\n    }\n  }\n  orders(states: [APPROVED, CANCELED, FULFILLED, REFUNDED, SUBMITTED, PROCESSING_APPROVAL], first: 10) {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...CommercePagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        code\n        ...SettingsPurchasesRow_order\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **FUTURE FRIDAY**

### Description

This is a future friday spike to see what showing pending orders on the order history page could look like. The implementation is minimal. Other notes:

- As I am re-using our order history items which means some expected values do not appear.
- I think some orders may have a display state of pending already on because they are pending acceptance from the user's perspective. Things like this could be replaced in a list item specific to a pending orders section.
- private sales orders would need to be filtered based on whether the invoice is finalized.
- other 'action required' orders could also be included - for example failed payment so that artsy users can see that information front and center, but ideally this would use a query based on a failed payment state which does not exist today.
- we could use a similar query in the nav to show a dot on the nav item in the presence of any pending/action required orders. The dot could go away by canceling or allowing such orders to expire.
- currently i deduplicate these orders based on `artworkId-editionSetId`.
- We would probably want more nuanced querying and logic eventually showing recent abandoned orders along with pending ones and that sort of thing.

cc @artsy/emerald-devs 

![image](https://github.com/artsy/force/assets/9088720/98801f3f-7d69-4637-bbf5-e593c6fdb789)
