### PR TITLE
fix: only expose unpublished pages to admins

### DIFF
--- a/src/Apps/Page/PageApp.tsx
+++ b/src/Apps/Page/PageApp.tsx
@@ -12,6 +12,8 @@ import {
   TOP_LEVEL_PAGE_SLUG_ALLOWLIST,
   PAGE_SLUGS_WITH_AUTH_REQUIRED,
 } from "./pageRoutes"
+import { HttpError } from "found"
+import { userIsAdmin } from "Utils/user"
 
 interface PageAppProps {
   page: PageApp_page$data
@@ -19,6 +21,7 @@ interface PageAppProps {
 
 const PageApp: FC<PageAppProps> = ({ page }) => {
   const { user } = useSystemContext()
+  const isAdmin = userIsAdmin(user)
   const { showAuthDialog } = useAuthDialog()
   const { match } = useRouter()
 
@@ -58,6 +61,8 @@ const PageApp: FC<PageAppProps> = ({ page }) => {
     ? `/${match.params.id}`
     : `/page/${match.params.id}`
 
+  if (!page.published && !isAdmin) throw new HttpError(404)
+
   if (!page.content) return null
 
   if (PAGE_SLUGS_WITH_AUTH_REQUIRED.includes(page.internalID) && !user?.id)
@@ -86,8 +91,9 @@ export const PageAppFragmentContainer = createFragmentContainer(PageApp, {
   page: graphql`
     fragment PageApp_page on Page {
       internalID
-      name
       content(format: HTML)
+      name
+      published
     }
   `,
 })

--- a/src/Apps/Page/__tests__/PageApp.jest.tsx
+++ b/src/Apps/Page/__tests__/PageApp.jest.tsx
@@ -3,8 +3,12 @@ import { PageApp_Test_Query } from "__generated__/PageApp_Test_Query.graphql"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { PageAppFragmentContainer } from "Apps/Page/PageApp"
 import { screen } from "@testing-library/react"
+import { HttpError } from "found"
+import { userIsAdmin } from "Utils/user"
 
 jest.unmock("react-relay")
+jest.mock("found")
+jest.mock("Utils/user")
 jest.mock("System/Router/useRouter", () => ({
   useRouter: () => ({ match: { params: { id: "example" } } }),
 }))
@@ -28,9 +32,36 @@ describe("PageApp", () => {
     renderWithRelay({
       Page: () => ({
         content: "<p>Example content</p>",
+        published: true,
       }),
     })
 
     expect(screen.getByText("Example content")).toBeInTheDocument()
+  })
+
+  it("throws a 404 when a page is unpublished and the user isn't an admin", () => {
+    const mockHttpError = HttpError as jest.Mock
+
+    renderWithRelay({
+      Page: () => ({
+        content: "<p>Example content</p>",
+        published: false,
+      }),
+    })
+
+    expect(mockHttpError).toHaveBeenCalledWith(404)
+  })
+
+  it("renders unpublished pages for admins", () => {
+    ;(userIsAdmin as jest.Mock).mockImplementationOnce(() => true)
+
+    renderWithRelay({
+      Page: () => ({
+        content: "<p>Unpublished content</p>",
+        published: false,
+      }),
+    })
+
+    expect(screen.getByText("Unpublished content")).toBeInTheDocument()
   })
 })

--- a/src/__generated__/PageApp_Test_Query.graphql.ts
+++ b/src/__generated__/PageApp_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<adedd680beb46ca7e899ec3674839d6b>>
+ * @generated SignedSource<<e6415079de780a3d2ebb335861786810>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -85,13 +85,6 @@ return {
           },
           {
             "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "name",
-            "storageKey": null
-          },
-          {
-            "alias": null,
             "args": [
               {
                 "kind": "Literal",
@@ -107,6 +100,20 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "published",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "id",
             "storageKey": null
           }
@@ -116,7 +123,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ce1e321e59737765254acd134c8b3fa7",
+    "cacheID": "5f93d561466837d7b5cb526e2f0d4caf",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -139,12 +146,18 @@ return {
           "nullable": false,
           "plural": false,
           "type": "String"
+        },
+        "page.published": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "Boolean"
         }
       }
     },
     "name": "PageApp_Test_Query",
     "operationKind": "query",
-    "text": "query PageApp_Test_Query {\n  page(id: \"example\") {\n    ...PageApp_page\n    id\n  }\n}\n\nfragment PageApp_page on Page {\n  internalID\n  name\n  content(format: HTML)\n}\n"
+    "text": "query PageApp_Test_Query {\n  page(id: \"example\") {\n    ...PageApp_page\n    id\n  }\n}\n\nfragment PageApp_page on Page {\n  internalID\n  content(format: HTML)\n  name\n  published\n}\n"
   }
 };
 })();

--- a/src/__generated__/PageApp_page.graphql.ts
+++ b/src/__generated__/PageApp_page.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<02eddecf68822c4266ce51a98c6f843e>>
+ * @generated SignedSource<<7fcb7968ffa595576a0bc3f53bae4046>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -14,6 +14,7 @@ export type PageApp_page$data = {
   readonly content: string | null;
   readonly internalID: string;
   readonly name: string;
+  readonly published: boolean;
   readonly " $fragmentType": "PageApp_page";
 };
 export type PageApp_page$key = {
@@ -36,13 +37,6 @@ const node: ReaderFragment = {
     },
     {
       "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "name",
-      "storageKey": null
-    },
-    {
-      "alias": null,
       "args": [
         {
           "kind": "Literal",
@@ -53,12 +47,26 @@ const node: ReaderFragment = {
       "kind": "ScalarField",
       "name": "content",
       "storageKey": "content(format:\"HTML\")"
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "published",
+      "storageKey": null
     }
   ],
   "type": "Page",
   "abstractKey": null
 };
 
-(node as any).hash = "94845d296973a411f90edbe8aca444a5";
+(node as any).hash = "7f0f1470be702d44404830b317cffc00";
 
 export default node;

--- a/src/__generated__/pageRoutes_PageQuery.graphql.ts
+++ b/src/__generated__/pageRoutes_PageQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4f95f410cf2aabf97e3ceb69ea1101d8>>
+ * @generated SignedSource<<d38c8dba8f5c8bcc056a792de9fb6699>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -88,13 +88,6 @@ return {
           },
           {
             "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "name",
-            "storageKey": null
-          },
-          {
-            "alias": null,
             "args": [
               {
                 "kind": "Literal",
@@ -110,6 +103,20 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "published",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "id",
             "storageKey": null
           }
@@ -119,12 +126,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "bbce546c73c13350b02235445c92b516",
+    "cacheID": "f3e62a2ddb6575a2d04aaeba07a2eb55",
     "id": null,
     "metadata": {},
     "name": "pageRoutes_PageQuery",
     "operationKind": "query",
-    "text": "query pageRoutes_PageQuery(\n  $id: ID!\n) {\n  page(id: $id) @principalField {\n    ...PageApp_page\n    id\n  }\n}\n\nfragment PageApp_page on Page {\n  internalID\n  name\n  content(format: HTML)\n}\n"
+    "text": "query pageRoutes_PageQuery(\n  $id: ID!\n) {\n  page(id: $id) @principalField {\n    ...PageApp_page\n    id\n  }\n}\n\nfragment PageApp_page on Page {\n  internalID\n  content(format: HTML)\n  name\n  published\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: fix

### Description

While working with the Auctions team to create a new page to store the conditions of sale of closed auctions, I noticed we are not respecting the [published field](https://github.com/artsy/gravity/blob/93c9a0374724525580f50f615b83b484df8feebc/app/models/domain/page.rb#L52) on the `Page` model. For example, this draft page is [unpublished](https://tools.artsy.net/pages/conditions-of-sale-archive-draft), but [publicly available](https://www.artsy.net/page/conditions-of-sale-archive-draft). 

This PR adds a guard that throws a `404` if the page is `unpublished: true` and the `user` is _not_ an admin user. 
