### PR TITLE
feat: do not use spot in staging

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -84,11 +84,6 @@ spec:
         options:
         - name: ndots
           value: '1'
-      tolerations:
-        - key: reserved
-          operator: Equal
-          value: spot
-          effect: NoSchedule
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -98,15 +93,6 @@ spec:
                 operator: In
                 values:
                 - foreground
-                - foreground-spot
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            preference:
-              matchExpressions:
-              - key: tier
-                operator: In
-                values:
-                - foreground-spot
 ---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [PHIRE-102]

### Description

Prevent staging pods from running on Spot instances.

[PHIRE-102]: https://artsyproduct.atlassian.net/browse/PHIRE-102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ