### PR TITLE
feat: use two k8s deployments

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -7,7 +7,7 @@ metadata:
     layer: application
     component: web
     app.kubernetes.io/version: production
-  name: force-web1
+  name: force-web
 spec:
   replicas: 3
   strategy:
@@ -27,11 +27,11 @@ spec:
         layer: application
         component: web
         app.kubernetes.io/version: production
-      name: force-web1
+      name: force-web
       namespace: default
     spec:
       containers:
-      - name: force-web1
+      - name: force-web
         env:
         - name: PORT
           value: '5000'
@@ -97,7 +97,7 @@ metadata:
     layer: application
     component: web
     app.kubernetes.io/version: production
-  name: force-web2
+  name: force-web-spotty
 spec:
   strategy:
     rollingUpdate:
@@ -116,11 +116,11 @@ spec:
         layer: application
         component: web
         app.kubernetes.io/version: production
-      name: force-web2
+      name: force-web-spotty
       namespace: default
     spec:
       containers:
-      - name: force-web2
+      - name: force-web-spotty
         env:
         - name: PORT
           value: '5000'
@@ -195,13 +195,13 @@ spec:
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: force-web2
+  name: force-web-spotty
   namespace: default
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: force-web2
+    name: force-web-spotty
   minReplicas: 1
   maxReplicas: 17
   behavior:

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -6,7 +6,6 @@ metadata:
     app: force
     layer: application
     component: web
-    spot-allowed: false
     app.kubernetes.io/version: production
   name: force-web1
 spec:
@@ -21,14 +20,12 @@ spec:
       app: force
       layer: application
       component: web
-      spot-allowed: false
   template:
     metadata:
       labels:
         app: force
         layer: application
         component: web
-        spot-allowed: false
         app.kubernetes.io/version: production
       name: force-web1
       namespace: default
@@ -99,7 +96,6 @@ metadata:
     app: force
     layer: application
     component: web
-    spot-allowed: true
     app.kubernetes.io/version: production
   name: force-web2
 spec:
@@ -113,14 +109,12 @@ spec:
       app: force
       layer: application
       component: web
-      spot-allowed: true
   template:
     metadata:
       labels:
         app: force
         layer: application
         component: web
-        spot-allowed: true
         app.kubernetes.io/version: production
       name: force-web2
       namespace: default

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -1,3 +1,4 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -5,8 +6,102 @@ metadata:
     app: force
     layer: application
     component: web
+    spot-allowed: false
     app.kubernetes.io/version: production
-  name: force-web
+  name: force-web1
+spec:
+  replicas: 3
+  strategy:
+    rollingUpdate:
+      maxSurge: 2
+      maxUnavailable: 0
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: force
+      layer: application
+      component: web
+      spot-allowed: false
+  template:
+    metadata:
+      labels:
+        app: force
+        layer: application
+        component: web
+        spot-allowed: false
+        app.kubernetes.io/version: production
+      name: force-web1
+      namespace: default
+    spec:
+      containers:
+      - name: force-web1
+        env:
+        - name: PORT
+          value: '5000'
+        - name: DD_TRACE_AGENT_HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: DD_VERSION
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['app.kubernetes.io/version']
+        envFrom:
+        - configMapRef:
+            name: force-environment
+        image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/force:production
+        imagePullPolicy: Always
+        ports:
+        - name: force-http
+          containerPort: 5000
+        readinessProbe:
+          httpGet:
+            port: force-http
+            path: /system/up
+            httpHeaders:
+            - name: X-FORWARDED-PROTO
+              value: https
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 10
+        resources:
+          requests:
+            cpu: 1000m
+            memory: 1Gi
+          limits:
+            memory: 2Gi
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - sh
+              - -c
+              - sleep 10
+      dnsPolicy: ClusterFirst
+      dnsConfig:
+        options:
+        - name: ndots
+          value: '1'
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: tier
+                operator: In
+                values:
+                - foreground
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: force
+    layer: application
+    component: web
+    spot-allowed: true
+    app.kubernetes.io/version: production
+  name: force-web2
 spec:
   strategy:
     rollingUpdate:
@@ -18,18 +113,20 @@ spec:
       app: force
       layer: application
       component: web
+      spot-allowed: true
   template:
     metadata:
       labels:
         app: force
         layer: application
         component: web
+        spot-allowed: true
         app.kubernetes.io/version: production
-      name: force-web
+      name: force-web2
       namespace: default
     spec:
       containers:
-      - name: force-web
+      - name: force-web2
         env:
         - name: PORT
           value: '5000'
@@ -104,15 +201,15 @@ spec:
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: force-web
+  name: force-web2
   namespace: default
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: force-web
-  minReplicas: 3
-  maxReplicas: 20
+    name: force-web2
+  minReplicas: 1
+  maxReplicas: 17
   behavior:
     scaleDown:
       stabilizationWindowSeconds: 1800

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -7,7 +7,6 @@ metadata:
     app: force
     layer: application
     component: web
-    spot-allowed: false
     app.kubernetes.io/version: staging
 spec:
   replicas: 1
@@ -21,14 +20,12 @@ spec:
       app: force
       layer: application
       component: web
-      spot-allowed: false
   template:
     metadata:
       labels:
         app: force
         layer: application
         component: web
-        spot-allowed: false
         app.kubernetes.io/version: staging
       name: force-web1
       namespace: default
@@ -107,7 +104,6 @@ metadata:
     app: force
     layer: application
     component: web
-    spot-allowed: true
     app.kubernetes.io/version: staging
 spec:
   strategy:
@@ -120,14 +116,12 @@ spec:
       app: force
       layer: application
       component: web
-      spot-allowed: true
   template:
     metadata:
       labels:
         app: force
         layer: application
         component: web
-        spot-allowed: true
         app.kubernetes.io/version: staging
       name: force-web2
       namespace: default

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: force-web1
+  name: force-web
   labels:
     app: force
     layer: application
@@ -27,11 +27,11 @@ spec:
         layer: application
         component: web
         app.kubernetes.io/version: staging
-      name: force-web1
+      name: force-web
       namespace: default
     spec:
       containers:
-      - name: force-web1
+      - name: force-web
         env:
         - name: PORT
           value: '5000'
@@ -99,7 +99,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: force-web2
+  name: force-web-spotty
   labels:
     app: force
     layer: application
@@ -123,11 +123,11 @@ spec:
         layer: application
         component: web
         app.kubernetes.io/version: staging
-      name: force-web2
+      name: force-web-spotty
       namespace: default
     spec:
       containers:
-      - name: force-web2
+      - name: force-web-spotty
         env:
         - name: PORT
           value: '5000'
@@ -209,13 +209,13 @@ spec:
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: force-web2
+  name: force-web-spotty
   namespace: default
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: force-web2
+    name: force-web-spotty
   minReplicas: 1
   maxReplicas: 2
   behavior:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -1,13 +1,16 @@
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: force-web
+  name: force-web1
   labels:
     app: force
     layer: application
     component: web
+    spot-allowed: false
     app.kubernetes.io/version: staging
 spec:
+  replicas: 1
   strategy:
     rollingUpdate:
       maxSurge: 2
@@ -18,18 +21,20 @@ spec:
       app: force
       layer: application
       component: web
+      spot-allowed: false
   template:
     metadata:
       labels:
         app: force
         layer: application
         component: web
+        spot-allowed: false
         app.kubernetes.io/version: staging
-      name: force-web
+      name: force-web1
       namespace: default
     spec:
       containers:
-      - name: force-web
+      - name: force-web1
         env:
         - name: PORT
           value: '5000'
@@ -94,18 +99,131 @@ spec:
                 values:
                 - foreground
 ---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: force-web2
+  labels:
+    app: force
+    layer: application
+    component: web
+    spot-allowed: true
+    app.kubernetes.io/version: staging
+spec:
+  strategy:
+    rollingUpdate:
+      maxSurge: 2
+      maxUnavailable: 0
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: force
+      layer: application
+      component: web
+      spot-allowed: true
+  template:
+    metadata:
+      labels:
+        app: force
+        layer: application
+        component: web
+        spot-allowed: true
+        app.kubernetes.io/version: staging
+      name: force-web2
+      namespace: default
+    spec:
+      containers:
+      - name: force-web2
+        env:
+        - name: PORT
+          value: '5000'
+        - name: DD_TRACE_AGENT_HOSTNAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        - name: PAGE_CACHE_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: KEEPALIVE_TIMEOUT_SECONDS
+          value: '95'
+        - name: HEADERS_TIMEOUT_SECONDS
+          value: '105'
+        - name: DD_VERSION
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.labels['app.kubernetes.io/version']
+        envFrom:
+        - configMapRef:
+            name: force-environment
+        image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/force:staging
+        imagePullPolicy: Always
+        ports:
+        - name: force-http
+          containerPort: 5000
+        readinessProbe:
+          httpGet:
+            port: force-http
+            path: /system/up
+            httpHeaders:
+            - name: X-FORWARDED-PROTO
+              value: https
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        resources:
+          requests:
+            cpu: 100m
+            memory: 500Mi
+          limits:
+            memory: 1Gi
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - sh
+              - -c
+              - sleep 10
+      dnsPolicy: ClusterFirst
+      dnsConfig:
+        options:
+        - name: ndots
+          value: '1'
+      tolerations:
+        - key: reserved
+          operator: Equal
+          value: spot
+          effect: NoSchedule
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: tier
+                operator: In
+                values:
+                - foreground
+                - foreground-spot
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            preference:
+              matchExpressions:
+              - key: tier
+                operator: In
+                values:
+                - foreground-spot
+---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
 metadata:
-  name: force-web
+  name: force-web2
   namespace: default
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: force-web
-  minReplicas: 2
-  maxReplicas: 3
+    name: force-web2
+  minReplicas: 1
+  maxReplicas: 2
   behavior:
     scaleDown:
       stabilizationWindowSeconds: 1800


### PR DESCRIPTION
The type of this PR is: **Feat**

[PHIRE-111]

### Description

[We noticed](https://artsy.slack.com/archives/CA8SANW3W/p1689785076024629?thread_ts=1689359985.499589&cid=CA8SANW3W) a situation where 9 Spot instances were interrupted together, taking down most of prod `force-web` pods, causing elevated latency for ~5 minutes. This is not acceptable.

This PR is to try the idea of using two deployments: `force-web1`, `force-web2`.

`web1` runs on on-demand EC2 instances only, so its pods are guaranteed to exist.

`web2`, as the current single-deployment, can run on on-demand or Spot but prefers Spot. Its pods can be all on Spot and therefore can all go away.

With this setup, a baseline of pods (`web1`) is guaranteed, so the service may be degraded by Spot interruptions but it will never completely go down.

[PHIRE-88]: https://artsyproduct.atlassian.net/browse/PHIRE-88?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PHIRE-111]: https://artsyproduct.atlassian.net/browse/PHIRE-111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ