### PR TITLE
feat(alerts): update confirmation messages for various cases

### DIFF
--- a/src/Components/SavedSearchAlert/Components/__tests__/ConfirmationModalHeader.jest.tsx
+++ b/src/Components/SavedSearchAlert/Components/__tests__/ConfirmationModalHeader.jest.tsx
@@ -41,7 +41,9 @@ describe("ConfirmationModalHeader", () => {
     )
 
     expect(
-      screen.getByText("We will notify you when new works get added to Artsy.")
+      screen.getByText(
+        "We’ll let you know when matching works are added to Artsy."
+      )
     ).toBeInTheDocument()
     expect(screen.getByText("Prints")).toBeInTheDocument()
     expect(screen.getByText("Unique")).toBeInTheDocument()

--- a/src/Components/SavedSearchAlert/ConfirmationArtworksGrid.tsx
+++ b/src/Components/SavedSearchAlert/ConfirmationArtworksGrid.tsx
@@ -20,6 +20,8 @@ import { SearchCriteriaAttributes } from "Components/SavedSearchAlert/types"
 import { useTranslation } from "react-i18next"
 import { ArtworkGridContextProvider } from "Components/ArtworkGrid/ArtworkGridContext"
 
+export const NUMBER_OF_ARTWORKS_TO_SHOW = 10
+
 interface ConfirmationArtworksProps {
   artworksConnection: ConfirmationArtworksGridQuery$data["artworksConnection"]
 }
@@ -40,7 +42,7 @@ export const ConfirmationArtworks: FC<ConfirmationArtworksProps> = ({
 
   return (
     <Flex flexDirection="column">
-      {artworksCount > 10 ? (
+      {artworksCount > NUMBER_OF_ARTWORKS_TO_SHOW ? (
         <>
           <Text variant="sm-display" color="black60">
             {t("createAlertModal.confirmationStep.manyMatchingArtworks", {
@@ -90,7 +92,7 @@ export const ConfirmationArtworksGridQueryRenderer: FC<SearchCriteriaAttributes>
       `}
       variables={{
         input: {
-          first: 10,
+          first: NUMBER_OF_ARTWORKS_TO_SHOW,
           sort: "-published_at",
           forSale: true,
           ...props,
@@ -133,7 +135,10 @@ const ContentPlaceholder: FC = () => {
 
       <Spacer y={2} />
 
-      <ArtworkGridPlaceholder columnCount={2} amount={10} />
+      <ArtworkGridPlaceholder
+        columnCount={2}
+        amount={NUMBER_OF_ARTWORKS_TO_SHOW}
+      />
     </Flex>
   )
 }

--- a/src/Components/SavedSearchAlert/ConfirmationArtworksGrid.tsx
+++ b/src/Components/SavedSearchAlert/ConfirmationArtworksGrid.tsx
@@ -30,16 +30,36 @@ export const ConfirmationArtworks: FC<ConfirmationArtworksProps> = ({
   const { t } = useTranslation()
   const artworksCount = artworksConnection?.counts?.total
 
+  if (artworksCount === 0) {
+    return (
+      <Text mb={2} p={2} bg="black10" color="black60">
+        {t("createAlertModal.confirmationStep.noMatches")}
+      </Text>
+    )
+  }
+
   return (
     <Flex flexDirection="column">
-      <Text variant="sm-display" color="black60">
-        {t("createAlertModal.confirmationStep.artworksMatchCriteria", {
-          count: artworksCount,
-        })}
-      </Text>
-      <Text variant="sm-display" color="black60">
-        {t("createAlertModal.confirmationStep.seeOurTopPicks")}
-      </Text>
+      {artworksCount > 10 ? (
+        <>
+          <Text variant="sm-display" color="black60">
+            {t("createAlertModal.confirmationStep.manyMatchingArtworks", {
+              count: artworksCount,
+            })}
+          </Text>
+          <Text variant="sm-display" color="black60">
+            {t("createAlertModal.confirmationStep.seeOurTopPicks")}
+          </Text>
+        </>
+      ) : (
+        <>
+          <Text variant="sm-display" color="black60">
+            {t("createAlertModal.confirmationStep.fewMatchingArtworks", {
+              count: artworksCount,
+            })}
+          </Text>
+        </>
+      )}
 
       <Spacer y={2} />
 

--- a/src/Components/SavedSearchAlert/__tests__/ConfirmationArtworksGrid.jest.tsx
+++ b/src/Components/SavedSearchAlert/__tests__/ConfirmationArtworksGrid.jest.tsx
@@ -24,7 +24,7 @@ describe("ConfirmationArtworksGrid", () => {
     `,
   })
 
-  it("renders aworks count and artworks grid", () => {
+  it("renders artworks count and artworks grid", () => {
     renderWithRelay({
       FilterArtworksConnection: () => ({
         counts: {
@@ -38,6 +38,73 @@ describe("ConfirmationArtworksGrid", () => {
       screen.getByText("300 works currently on Artsy match your criteria.")
     ).toBeInTheDocument()
     expect(screen.getByText("See our top picks for you:")).toBeInTheDocument()
+  })
+
+  it("displays the correct message when there are many matches", async () => {
+    renderWithRelay({
+      FilterArtworksConnection: () => ({
+        counts: {
+          total: 11,
+        },
+        edges: artworks,
+      }),
+    })
+
+    expect(
+      screen.getByText("11 works currently on Artsy match your criteria.")
+    ).toBeInTheDocument()
+    expect(screen.getByText("See our top picks for you:")).toBeInTheDocument()
+  })
+
+  it("displays the correct message when there are few matches", async () => {
+    renderWithRelay({
+      FilterArtworksConnection: () => ({
+        counts: {
+          total: 9,
+        },
+        edges: artworks,
+      }),
+    })
+
+    expect(
+      screen.getByText(
+        "You might like these 9 works currently on Artsy that match your criteria:"
+      )
+    ).toBeInTheDocument()
+  })
+
+  it("displays the correct message when there are is one match", async () => {
+    renderWithRelay({
+      FilterArtworksConnection: () => ({
+        counts: {
+          total: 1,
+        },
+        edges: artworks,
+      }),
+    })
+
+    expect(
+      screen.getByText(
+        "You might like this 1 work currently on Artsy that matches your criteria:"
+      )
+    ).toBeInTheDocument()
+  })
+
+  it("displays the correct message when there are no matches", async () => {
+    renderWithRelay({
+      FilterArtworksConnection: () => ({
+        counts: {
+          total: 0,
+        },
+        edges: artworks,
+      }),
+    })
+
+    expect(
+      screen.getByText(
+        "There aren’t any works available that meet the criteria at this time."
+      )
+    ).toBeInTheDocument()
   })
 })
 

--- a/src/Components/SavedSearchAlert/__tests__/ConfirmationArtworksGrid.jest.tsx
+++ b/src/Components/SavedSearchAlert/__tests__/ConfirmationArtworksGrid.jest.tsx
@@ -1,7 +1,10 @@
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { graphql } from "react-relay"
 import { screen } from "@testing-library/react"
-import { ConfirmationArtworks } from "Components/SavedSearchAlert/ConfirmationArtworksGrid"
+import {
+  ConfirmationArtworks,
+  NUMBER_OF_ARTWORKS_TO_SHOW,
+} from "Components/SavedSearchAlert/ConfirmationArtworksGrid"
 import { ConfirmationArtworksGrid_Test_Query } from "__generated__/ConfirmationArtworksGrid_Test_Query.graphql"
 
 jest.unmock("react-relay")
@@ -44,7 +47,7 @@ describe("ConfirmationArtworksGrid", () => {
     renderWithRelay({
       FilterArtworksConnection: () => ({
         counts: {
-          total: 11,
+          total: NUMBER_OF_ARTWORKS_TO_SHOW + 1,
         },
         edges: artworks,
       }),
@@ -60,7 +63,7 @@ describe("ConfirmationArtworksGrid", () => {
     renderWithRelay({
       FilterArtworksConnection: () => ({
         counts: {
-          total: 9,
+          total: NUMBER_OF_ARTWORKS_TO_SHOW - 1,
         },
         edges: artworks,
       }),

--- a/src/System/i18n/locales/en-US/translation.json
+++ b/src/System/i18n/locales/en-US/translation.json
@@ -269,9 +269,11 @@
     "setPriceRange": "Set price range you are interested in",
     "confirmationStep": {
       "saved": "Your alert has been saved.",
-      "weWillNotifyYou": "We will notify you when new works get added to Artsy.",
-      "artworksMatchCriteria_one": "1 work currently on Artsy matches your criteria.",
-      "artworksMatchCriteria_other": "{{count}} works currently on Artsy match your criteria.",
+      "weWillNotifyYou": "We’ll let you know when matching works are added to Artsy.",
+      "manyMatchingArtworks": "{{count}} works currently on Artsy match your criteria.",
+      "fewMatchingArtworks_one": "You might like this 1 work currently on Artsy that matches your criteria:",
+      "fewMatchingArtworks_other": "You might like these {{count}} works currently on Artsy that match your criteria:",
+      "noMatches": "There aren’t any works available that meet the criteria at this time.",
       "seeOurTopPicks": "See our top picks for you:",
       "seeAllMatchingWorks": "See all matching works",
       "manageYourAlerts": "Manage your alerts"


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [ONYX-148]

### Description

Per the discussion on ONYX-15 this updates the copy for the various cases that might be encountered in the Alert confirmation modal: many matches, few matches, one match, no matches.

|Many|Few|One|None|
|---|---|---|---|
|<img width="679" alt="many" src="https://github.com/artsy/force/assets/140521/5b8d5259-dc4a-4e2f-b7e2-5d2d55f40301">|<img width="683" alt="few" src="https://github.com/artsy/force/assets/140521/7b1e53dc-73d2-4936-8ad4-34472bb4836d">|<img width="683" alt="one" src="https://github.com/artsy/force/assets/140521/5d383a0a-0f50-4db2-a58c-74ba7c5e1082">|<img width="684" alt="0" src="https://github.com/artsy/force/assets/140521/ad2d374a-6050-42d3-8f96-d7d7a3a8b61c">|




[ONYX-148]: https://artsyproduct.atlassian.net/browse/ONYX-148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ