### PR TITLE
fix: only perform address verification once

### DIFF
--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -107,10 +107,14 @@ export const ShippingRoute: FC<ShippingProps> = props => {
 
   // true if we want to verify addresses for this order
   const isAddressVerificationEnabled = useFeatureFlag("address_verification")
-  // true if the current address has been verified
-  const [addressVerified, setAddressVerified] = useState<boolean>(false)
   // true if the current address needs to be verified
-  const [verifyAddress, setVerifyAddress] = useState<boolean>(false)
+  const [addressNeedsVerification, setAddressNeedsVerification] = useState<
+    boolean
+  >(false)
+  // true if the current address has been verified
+  const [addressHasBeenVerified, setAddressHasBeenVerified] = useState<boolean>(
+    false
+  )
 
   const [shippingOption, setShippingOption] = useState<
     CommerceOrderFulfillmentTypeEnum
@@ -214,12 +218,12 @@ export const ShippingRoute: FC<ShippingProps> = props => {
   }
 
   const onContinueButtonPressed = async () => {
-    if (isAddressVerificationEnabled && !addressVerified) {
+    if (isAddressVerificationEnabled && !addressHasBeenVerified) {
       /**
        * Setting verifyAddress to true will cause the address verification flow
        * to be initiated on this render.
        */
-      setVerifyAddress(true)
+      setAddressNeedsVerification(true)
       return
     }
 
@@ -755,7 +759,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
               <Text variant="lg-display" mb="2">
                 Delivery address
               </Text>
-              {verifyAddress && (
+              {addressNeedsVerification && (
                 <AddressVerificationFlowQueryRenderer
                   data-testid="address-verification-flow"
                   address={{
@@ -767,12 +771,12 @@ export const ShippingRoute: FC<ShippingProps> = props => {
                     postalCode: address.postalCode,
                   }}
                   onClose={() => {
-                    setVerifyAddress(false)
-                    setAddressVerified(true)
+                    setAddressNeedsVerification(false)
+                    setAddressHasBeenVerified(true)
                   }}
                   onChosenAddress={chosenAddress => {
-                    setVerifyAddress(false)
-                    setAddressVerified(true)
+                    setAddressNeedsVerification(false)
+                    setAddressHasBeenVerified(true)
                     setAddress({ ...address, ...chosenAddress })
                     onContinueButtonPressed()
                   }}

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -768,6 +768,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
                   }}
                   onClose={() => {
                     setVerifyAddress(false)
+                    setAddressVerified(true)
                   }}
                   onChosenAddress={chosenAddress => {
                     setVerifyAddress(false)


### PR DESCRIPTION
The type of this PR is: Fix
This PR solves [EMI-1302]

### Description

This PR updates the address verification flow to only happen once. Previously, users could close the address verification modal and try again with a modified address. However, that creates a lot of noise and racks up additional usage charges from Smarty, so we are limiting it to 1 address verification per visit to the Shipping step of the checkout flow.

**Note:** If the user proceeds to the Payment step and returns to the Shipping step to edit their address, verification will be performed again.


[EMI-1302]: https://artsyproduct.atlassian.net/browse/EMI-1302?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ