### PR TITLE
feat(ONYX-144): hide search pills on mWeb until user has started typing

### DIFF
--- a/src/Components/Search/NewSearch/Mobile/Overlay.tsx
+++ b/src/Components/Search/NewSearch/Mobile/Overlay.tsx
@@ -120,13 +120,15 @@ export const Overlay: FC<OverlayProps> = ({ viewer, relay, onClose }) => {
             />
           </Box>
 
-          <NewSearchInputPillsFragmentContainer
-            onPillClick={handlePillClick}
-            viewer={viewer}
-            selectedPill={selectedPill}
-            enableChevronNavigation={false}
-            forceDisabled={disablePills}
-          />
+          {shouldStartSearching(inputValue) && (
+            <NewSearchInputPillsFragmentContainer
+              onPillClick={handlePillClick}
+              viewer={viewer}
+              selectedPill={selectedPill}
+              enableChevronNavigation={false}
+              forceDisabled={disablePills}
+            />
+          )}
         </>
       }
     >


### PR DESCRIPTION
The type of this PR is: **FEAT**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [ONYX-144]

### Description

<!-- Implementation description -->
Hide search pills on mWeb until the user has started typing.
We use the `shouldStartSearching` function to show/hide the search results list. I used the same function to show/hide the pills. 

| before | after with unsatisfactory input value | after with satisfactory input value|
| --- | --- | --- |
| <img width="444" alt="image" src="https://github.com/artsy/force/assets/36167539/9ccb3d8a-7b51-4a5c-aff4-a883f8d62b73"> | <img width="464" alt="image" src="https://github.com/artsy/force/assets/36167539/c8aa8c02-d212-4fba-b33a-0b63385e3768"> | <img width="442" alt="image" src="https://github.com/artsy/force/assets/36167539/f8d629e0-4a55-456a-b199-9f184ea245cc"> |