### PR TITLE
fix(onyx-162): Fix pill navigation when it doesn’t remove the arrow button when scrolled all the way over to the right

### DIFF
--- a/src/Components/Search/NewSearch/NewSearchInputPills.tsx
+++ b/src/Components/Search/NewSearch/NewSearchInputPills.tsx
@@ -162,7 +162,9 @@ const NewSearchInputPills: FC<NewSearchInputPillsProps> = ({
         pillsRef.current.scrollWidth - pillsRef.current.clientWidth
 
       const isAtStart = currentPosition === 0
-      const isAtEnd = currentPosition === maxScroll
+      // currentPosition can vary a bit when user has browser zoomed in or out
+      // this is why we use a range instead of exact value
+      const isAtEnd = Math.abs(currentPosition - maxScroll) < 10
 
       setShowPreviousChevron(!isAtStart)
       setShowNextChevron(!isAtEnd)


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [ONYX-162]

### Description

| Before | After |
|---|---|
| <video src="https://github.com/artsy/force/assets/3934579/b46987fb-0e40-4b3a-bb38-3ad2b6514b3d" /> | <video src="https://github.com/artsy/force/assets/3934579/4a5c9ad9-fd1a-4a74-bc0d-62496189cba3" /> |


[ONYX-162]: https://artsyproduct.atlassian.net/browse/ONYX-162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ