### PR TITLE
feat(onyx): search pills chevron improvements

### DIFF
--- a/src/Components/Search/NewSearch/NewSearchInputPills.tsx
+++ b/src/Components/Search/NewSearch/NewSearchInputPills.tsx
@@ -169,6 +169,25 @@ const NewSearchInputPills: FC<NewSearchInputPillsProps> = ({
     }
   }
 
+  const handlePillClick = (pill: PillType) => {
+    onPillClick(pill)
+
+    // If user clicks on the leftmost or the rightmost pill, scroll to the left or to the right
+    // so that the pill is not hidden behind the chevron
+    const pillsContainer = pillsRef.current
+    if (pill == PILLS[0]) {
+      pillsContainer?.scrollBy({
+        left: -150, // Can be any number smaller than a pill width, 120 is the width of the current widest pill
+        behavior: "smooth",
+      })
+    } else if (pill == PILLS[PILLS.length - 1]) {
+      pillsContainer?.scrollBy({
+        left: 150, // Can be any number bigger than a pill width, 120 is the width of the current widest pill
+        behavior: "smooth",
+      })
+    }
+  }
+
   return (
     <Flex alignItems="center" bg="white">
       {enableChevronNavigation && (
@@ -177,6 +196,7 @@ const NewSearchInputPills: FC<NewSearchInputPillsProps> = ({
           left={0}
           opacity={showPreviousChevron ? 1 : 0}
           zIndex={showPreviousChevron ? 1 : -1}
+          style={{ pointerEvents: "none" }}
         >
           <PreviousChevron onClick={scrollToLeft} left={2} />
           <GradientBg placement="left" />
@@ -200,7 +220,7 @@ const NewSearchInputPills: FC<NewSearchInputPillsProps> = ({
               mr={1}
               selected={selected}
               disabled={disabled}
-              onClick={() => onPillClick(pill)}
+              onClick={() => handlePillClick(pill)}
             >
               {displayName}
             </Pill>
@@ -214,6 +234,7 @@ const NewSearchInputPills: FC<NewSearchInputPillsProps> = ({
           right={0}
           opacity={showNextChevron ? 1 : 0}
           zIndex={showNextChevron ? 1 : -1}
+          style={{ pointerEvents: "none" }}
         >
           <NextChevron onClick={scrollToRight} right={2} />
           <GradientBg placement="right" />


### PR DESCRIPTION
The type of this PR is: **Feat**

### Description

This is a tiny improvement for the search pills navigation. When user almost reaches the rightmost pill - shadow covers it and it is not possible to click on the pill. This PR fixes this bug. Also when clicking on the rightmost pill we scroll to the very right and hide the chevron.

| Before | After |
|---|---|
| <video src="https://github.com/artsy/force/assets/3934579/681342eb-5e9e-4c37-b68f-fe7f051f721b" /> | <video src="https://github.com/artsy/force/assets/3934579/aa831b57-3166-4dc2-91b8-3bb401883175" /> |

