### PR TITLE
fix(EMI-1321): address verify only on create

### DIFF
--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -224,8 +224,8 @@ export const ShippingRoute: FC<ShippingProps> = props => {
       isCreateNewAddress()
     ) {
       /**
-       * Setting verifyAddress to true will cause the address verification flow
-       * to be initiated on this render.
+       * Setting addressNeedsVerification to true will cause the address
+       * verification flow to be initiated on this render.
        */
       setAddressNeedsVerification(true)
       return

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -113,7 +113,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
   >(false)
   // true if the current address has been verified
   const [addressHasBeenVerified, setAddressHasBeenVerified] = useState<boolean>(
-    true
+    false
   )
 
   const [shippingOption, setShippingOption] = useState<
@@ -218,7 +218,11 @@ export const ShippingRoute: FC<ShippingProps> = props => {
   }
 
   const onContinueButtonPressed = async () => {
-    if (isAddressVerificationEnabled && !addressHasBeenVerified) {
+    if (
+      isAddressVerificationEnabled &&
+      !addressHasBeenVerified &&
+      isCreateNewAddress()
+    ) {
       /**
        * Setting verifyAddress to true will cause the address verification flow
        * to be initiated on this render.
@@ -617,7 +621,6 @@ export const ShippingRoute: FC<ShippingProps> = props => {
     createdAddress: CreateUserAddressMutation$data["createUserAddress"]
   ) => {
     if (createdAddress?.userAddressOrErrors?.internalID) {
-      setAddressHasBeenVerified(false)
       selectSavedAddress(createdAddress.userAddressOrErrors.internalID)
     }
   }

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -113,7 +113,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
   >(false)
   // true if the current address has been verified
   const [addressHasBeenVerified, setAddressHasBeenVerified] = useState<boolean>(
-    false
+    true
   )
 
   const [shippingOption, setShippingOption] = useState<
@@ -617,6 +617,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
     createdAddress: CreateUserAddressMutation$data["createUserAddress"]
   ) => {
     if (createdAddress?.userAddressOrErrors?.internalID) {
+      setAddressHasBeenVerified(false)
       selectSavedAddress(createdAddress.userAddressOrErrors.internalID)
     }
   }


### PR DESCRIPTION
The type of this PR is: **FIX**

https://artsyproduct.atlassian.net/browse/EMI-1321

### Description

As a first step in the address verification flow, we should only verify addresses when the user has none and they are creating their first one. If the user already has at least an address in our system, we won't validate existing or new ones they create.
