### PR TITLE
fix: use the correct back href for the lot page

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/SingleAuctionResultPage/AuctionResult.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/SingleAuctionResultPage/AuctionResult.tsx
@@ -9,7 +9,6 @@ import { MetaTags } from "Components/MetaTags"
 import { createFragmentContainer, graphql } from "react-relay"
 import { extractNodes } from "Utils/extractNodes"
 import { TopContextBar } from "Components/TopContextBar"
-import { useRouter } from "System/Router/useRouter"
 
 interface AuctionResultProps {
   auctionResult: AuctionResult_auctionResult$data
@@ -18,10 +17,10 @@ interface AuctionResultProps {
 export const AuctionResult: React.FC<AuctionResultProps> = ({
   auctionResult,
 }) => {
-  const { router } = useRouter()
   const { comparableAuctionResults, title, artist, internalID } = auctionResult
 
   const results = extractNodes(comparableAuctionResults)
+  const href = artist?.href + "/auction-results"
 
   return (
     <>
@@ -32,12 +31,7 @@ export const AuctionResult: React.FC<AuctionResultProps> = ({
         pathname={`/auction-result/${internalID}`}
       />
 
-      <TopContextBar
-        onClick={() => router.go(-1)}
-        redirectTo={artist?.href!}
-        displayBackArrow
-        hideSeparator
-      >
+      <TopContextBar href={href} displayBackArrow hideSeparator>
         Back
       </TopContextBar>
 


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [DIA-74]

### Description
When landing to the lot page it should go back to parent auction-results tab.

<!-- Implementation description -->

cc @artsy/diamond-devs 
