### PR TITLE
Use different feature flags for US and international address verification

### DIFF
--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -105,8 +105,13 @@ export const ShippingRoute: FC<ShippingProps> = props => {
   const { trackEvent } = useTracking()
   const { relayEnvironment } = useSystemContext()
 
-  // true if we want to verify addresses for this order
-  const isAddressVerificationEnabled = useFeatureFlag("address_verification")
+  const addressVerificationUSEnabled = !!useFeatureFlag(
+    "address_verification_us"
+  )
+  const addressVerificationIntlEnabled = !!useFeatureFlag(
+    "address_verification_intl"
+  )
+
   // true if the current address needs to be verified
   const [addressNeedsVerification, setAddressNeedsVerification] = useState<
     boolean
@@ -217,8 +222,14 @@ export const ShippingRoute: FC<ShippingProps> = props => {
     )
   }
 
+  const isAddressVerificationEnabled = (): boolean => {
+    return address.country === "US"
+      ? addressVerificationUSEnabled
+      : addressVerificationIntlEnabled
+  }
+
   const onContinueButtonPressed = async () => {
-    if (isAddressVerificationEnabled && !addressHasBeenVerified) {
+    if (isAddressVerificationEnabled() && !addressHasBeenVerified) {
       /**
        * Setting verifyAddress to true will cause the address verification flow
        * to be initiated on this render.

--- a/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -1062,30 +1062,100 @@ describe("Shipping", () => {
       })
     })
 
-    // eslint-disable-next-line jest/no-focused-tests
-    describe.only("with address verification enabled", () => {
+    describe("with US address verification enabled and international disabled", () => {
       beforeAll(() => {
         ;(useFeatureFlag as jest.Mock).mockImplementation(
-          (featureName: string) => featureName === "address_verification"
+          (featureName: string) => featureName === "address_verification_us"
         )
       })
 
       describe("when the continue button is clicked", () => {
-        it("mounts the address verification flow", async () => {
-          const wrapper = getWrapper({
-            CommerceOrder: () => testOrder,
-            Me: () => emptyTestMe,
+        describe("with US address", () => {
+          it("mounts the address verification flow", async () => {
+            const wrapper = getWrapper({
+              CommerceOrder: () => testOrder,
+              Me: () => emptyTestMe,
+            })
+
+            const page = new ShippingTestPage(wrapper)
+
+            fillAddressForm(page.root, validAddress)
+
+            await page.clickSubmit()
+
+            expect(
+              page.find(`[data-testid="address-verification-flow"]`).exists()
+            ).toBe(true)
           })
+        })
 
-          const page = new ShippingTestPage(wrapper)
+        describe("with international address", () => {
+          it("does not mount the address verification flow", async () => {
+            const wrapper = getWrapper({
+              CommerceOrder: () => testOrder,
+              Me: () => emptyTestMe,
+            })
 
-          fillAddressForm(page.root, validAddress)
+            const page = new ShippingTestPage(wrapper)
 
-          await page.clickSubmit()
+            const address = Object.assign({}, validAddress, { country: "GB" })
+            fillAddressForm(page.root, address)
 
-          expect(
-            page.find(`[data-testid="address-verification-flow"]`).exists()
-          ).toBe(true)
+            await page.clickSubmit()
+
+            expect(
+              page.find(`[data-testid="address-verification-flow"]`).exists()
+            ).toBe(false)
+          })
+        })
+      })
+    })
+
+    describe("with US address verification disabled and international enabled", () => {
+      beforeAll(() => {
+        ;(useFeatureFlag as jest.Mock).mockImplementation(
+          (featureName: string) => featureName === "address_verification_intl"
+        )
+      })
+
+      describe("when the continue button is clicked", () => {
+        describe("with US address", () => {
+          it("does not mount the address verification flow", async () => {
+            const wrapper = getWrapper({
+              CommerceOrder: () => testOrder,
+              Me: () => emptyTestMe,
+            })
+
+            const page = new ShippingTestPage(wrapper)
+
+            fillAddressForm(page.root, validAddress)
+
+            await page.clickSubmit()
+
+            expect(
+              page.find(`[data-testid="address-verification-flow"]`).exists()
+            ).toBe(false)
+          })
+        })
+
+        describe("with international address", () => {
+          it("mounts the address verification flow", async () => {
+            const wrapper = getWrapper({
+              CommerceOrder: () => testOrder,
+              Me: () => emptyTestMe,
+            })
+
+            const page = new ShippingTestPage(wrapper)
+
+            const address = Object.assign({}, validAddress, { country: "GB" })
+            fillAddressForm(page.root, address)
+
+            await page.clickSubmit()
+
+            expect(
+              page.find(`[data-testid="address-verification-flow"]`).exists()
+            ).toBe(true)
+          })
         })
       })
     })


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [EMI-1312](https://artsyproduct.atlassian.net/browse/EMI-1312)

### Description

We want to release address verification for US address only in the first iteration. This checks the country entered in the address form against the corresponding feature flag to determine enabling address verification or not.

I've created 2 feature flags [address_verification_us](https://unleash.artsy.net/projects/default/features/address_verification_us) and [address_verification_intl](https://unleash.artsy.net/projects/default/features/address_verification_intl), and will archive [the old one](https://unleash.artsy.net/projects/default/features/address_verification) after this.


[EMI-1312]: https://artsyproduct.atlassian.net/browse/EMI-1312?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ