### PR TITLE
feat(progressive-onboarding): displays follow tip to logged out users

### DIFF
--- a/src/Apps/Artist/Components/ArtistHeader/__tests__/ArtistHeader.jest.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/__tests__/ArtistHeader.jest.tsx
@@ -11,6 +11,13 @@ jest.mock("react-head", () => ({
   Link: () => null,
 }))
 
+jest.mock(
+  "Components/ProgressiveOnboarding/ProgressiveOnboardingFollowArtist",
+  () => ({
+    ProgressiveOnboardingFollowArtist: ({ children }) => children,
+  })
+)
+
 const mockuseTracking = useTracking as jest.Mock
 const trackingSpy = jest.fn()
 

--- a/src/Components/ProgressiveOnboarding/ProgressiveOnboardingContext.tsx
+++ b/src/Components/ProgressiveOnboarding/ProgressiveOnboardingContext.tsx
@@ -27,16 +27,18 @@ const ProgressiveOnboardingContext = createContext<{
     key: ProgressiveOnboardingKey | readonly ProgressiveOnboardingKey[]
   ) => void
   isDismissed: (key: ProgressiveOnboardingKey) => DismissedKeyStatus
+  syncFromLoggedOutUser: () => void
 }>({
   dismissed: [],
   dismiss: () => {},
   isDismissed: _key => ({ status: false, timestamp: 0 }),
+  syncFromLoggedOutUser: () => {},
 })
 
 export const ProgressiveOnboardingProvider: FC = ({ children }) => {
   const { user } = useSystemContext()
 
-  const id = user?.id ?? "user"
+  const id = user?.id ?? PROGRESSIVE_ONBOARDING_LOGGED_OUT_USER_ID
 
   const [dismissed, setDismissed] = useState<DismissedKey[]>([])
 
@@ -76,6 +78,29 @@ export const ProgressiveOnboardingProvider: FC = ({ children }) => {
     [dismissed, mounted]
   )
 
+  /**
+   * If the user is logged out, and performs some action which causes them
+   * to login, we need to sync up the dismissed state from the logged out user
+   */
+  const syncFromLoggedOutUser = useCallback(() => {
+    if (id === PROGRESSIVE_ONBOARDING_LOGGED_OUT_USER_ID) return
+
+    const loggedOutDismissals = get(PROGRESSIVE_ONBOARDING_LOGGED_OUT_USER_ID)
+    const loggedInDismissals = get(id)
+
+    const dismissals = uniqBy(
+      [...loggedOutDismissals, ...loggedInDismissals],
+      d => d.key
+    )
+
+    setDismissed(dismissals)
+
+    localStorage.setItem(localStorageKey(id), JSON.stringify(dismissals))
+    localStorage.removeItem(
+      localStorageKey(PROGRESSIVE_ONBOARDING_LOGGED_OUT_USER_ID)
+    )
+  }, [id])
+
   // Ensure that the dismissed state stays in sync incase the user
   // has multiple tabs open.
   useEffect(() => {
@@ -92,7 +117,7 @@ export const ProgressiveOnboardingProvider: FC = ({ children }) => {
 
   return (
     <ProgressiveOnboardingContext.Provider
-      value={{ dismissed, dismiss, isDismissed }}
+      value={{ dismissed, dismiss, isDismissed, syncFromLoggedOutUser }}
     >
       {children}
     </ProgressiveOnboardingContext.Provider>
@@ -100,16 +125,10 @@ export const ProgressiveOnboardingProvider: FC = ({ children }) => {
 }
 
 export const useProgressiveOnboarding = () => {
-  const { dismiss, dismissed, isDismissed } = useContext(
-    ProgressiveOnboardingContext
-  )
-
-  return {
-    dismiss,
-    dismissed,
-    isDismissed,
-  }
+  return useContext(ProgressiveOnboardingContext)
 }
+
+export const PROGRESSIVE_ONBOARDING_LOGGED_OUT_USER_ID = "user" as const
 
 export const localStorageKey = (id: string) => {
   return `progressive-onboarding.dismissed.${id}`

--- a/src/Components/ProgressiveOnboarding/ProgressiveOnboardingFollowArtist.tsx
+++ b/src/Components/ProgressiveOnboarding/ProgressiveOnboardingFollowArtist.tsx
@@ -13,7 +13,6 @@ import {
 } from "Components/ProgressiveOnboarding/withProgressiveOnboardingCounts"
 import { useRouter } from "System/Router/useRouter"
 import { pathToRegexp } from "path-to-regexp"
-import { useSystemContext } from "System/SystemContext"
 
 interface ProgressiveOnboardingFollowArtistProps
   extends WithProgressiveOnboardingCountsProps {}
@@ -22,14 +21,11 @@ export const __ProgressiveOnboardingFollowArtist__: FC<ProgressiveOnboardingFoll
   counts,
   children,
 }) => {
-  const { isLoggedIn } = useSystemContext()
-
   const router = useRouter()
 
   const { dismiss, isDismissed } = useProgressiveOnboarding()
 
   const isDisplayable =
-    isLoggedIn &&
     // Hasn't dismissed the follow artist onboarding.
     !isDismissed(PROGRESSIVE_ONBOARDING_FOLLOW_ARTIST).status &&
     // Hasn't followed an artist yet.

--- a/src/Components/ProgressiveOnboarding/__tests__/ProgressiveOnboardingContext.jest.tsx
+++ b/src/Components/ProgressiveOnboarding/__tests__/ProgressiveOnboardingContext.jest.tsx
@@ -1,5 +1,6 @@
 import { renderHook } from "@testing-library/react-hooks"
 import {
+  PROGRESSIVE_ONBOARDING_LOGGED_OUT_USER_ID,
   ProgressiveOnboardingProvider,
   __dismiss__,
   get,
@@ -9,8 +10,14 @@ import {
   useProgressiveOnboarding,
 } from "Components/ProgressiveOnboarding/ProgressiveOnboardingContext"
 
+jest.mock("System/SystemContext", () => ({
+  useSystemContext: jest.fn().mockReturnValue({
+    user: { id: "example-id" },
+  }),
+}))
+
 describe("ProgressiveOnboardingContext", () => {
-  const id = "user"
+  const id = "example-id"
 
   describe("get", () => {
     afterEach(() => reset(id))
@@ -202,6 +209,53 @@ describe("ProgressiveOnboardingContext", () => {
         { key: "follow-find", timestamp: expect.any(Number) },
         { key: "follow-highlight", timestamp: expect.any(Number) },
       ])
+    })
+  })
+
+  describe("syncFromLoggedOutUser", () => {
+    it("does nothing if the user is logged out", () => {
+      const { result } = renderHook(useProgressiveOnboarding, {
+        wrapper: ({ children }) => (
+          <ProgressiveOnboardingProvider>
+            {children}
+          </ProgressiveOnboardingProvider>
+        ),
+      })
+
+      result.current.syncFromLoggedOutUser()
+
+      expect(get(id)).toEqual([])
+    })
+
+    describe("logged in", () => {
+      it("syncs the dismissed state from the logged out user", () => {
+        const loggedOutUserId = PROGRESSIVE_ONBOARDING_LOGGED_OUT_USER_ID
+
+        const loggedOutDismissals = [
+          { key: "follow-artist", timestamp: 555 },
+          { key: "follow-find", timestamp: 555 },
+        ]
+
+        localStorage.setItem(
+          localStorageKey(loggedOutUserId),
+          JSON.stringify(loggedOutDismissals)
+        )
+
+        expect(get(id)).toEqual([])
+
+        const { result } = renderHook(useProgressiveOnboarding, {
+          initialProps: { id: loggedOutUserId },
+          wrapper: ({ children }) => (
+            <ProgressiveOnboardingProvider>
+              {children}
+            </ProgressiveOnboardingProvider>
+          ),
+        })
+
+        result.current.syncFromLoggedOutUser()
+
+        expect(get(id)).toEqual(loggedOutDismissals)
+      })
     })
   })
 })

--- a/src/Components/ProgressiveOnboarding/withProgressiveOnboardingCounts.tsx
+++ b/src/Components/ProgressiveOnboarding/withProgressiveOnboardingCounts.tsx
@@ -29,7 +29,9 @@ export const withProgressiveOnboardingCounts = <
     const { isLoggedIn } = useSystemContext()
 
     if (!isLoggedIn) {
-      return <Component {...props} counts={INITIAL_COUNTS} />
+      return (
+        <Component {...props} counts={{ ...INITIAL_COUNTS, isReady: true }} />
+      )
     }
 
     return (


### PR DESCRIPTION
Closes [DIA-7](https://artsyproduct.atlassian.net/browse/DIA-7)

[DIA-7]: https://artsyproduct.atlassian.net/browse/DIA-7?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

This PR displays the follow artist progressive onboarding tip to logged out users. Once the user is logged in it will also sync up the dismissal status with the logged out statuses and reset those. (Statuses are keyed to user IDs)