### PR TITLE
fix(progressive-onboarding): ensures we return correct ready states

### DIFF
--- a/src/Components/ProgressiveOnboarding/withProgressiveOnboardingCounts.tsx
+++ b/src/Components/ProgressiveOnboarding/withProgressiveOnboardingCounts.tsx
@@ -14,7 +14,6 @@ export interface WithProgressiveOnboardingCountsProps {
 }
 
 const INITIAL_COUNTS = {
-  isReady: false,
   followedArtists: 0,
   savedArtworks: 0,
   savedSearches: 0,
@@ -37,7 +36,12 @@ export const withProgressiveOnboardingCounts = <
     return (
       <SystemQueryRenderer<withProgressiveOnboardingCountsQuery>
         lazyLoad
-        placeholder={<Component {...props} counts={INITIAL_COUNTS} />}
+        placeholder={
+          <Component
+            {...props}
+            counts={{ ...INITIAL_COUNTS, isReady: false }}
+          />
+        }
         query={graphql`
           query withProgressiveOnboardingCountsQuery {
             me {
@@ -50,9 +54,23 @@ export const withProgressiveOnboardingCounts = <
           }
         `}
         render={({ props: renderProps, error }) => {
-          if (error || !renderProps?.me) {
+          if (error) {
             console.error(error)
-            return <Component {...props} counts={INITIAL_COUNTS} />
+            return (
+              <Component
+                {...props}
+                counts={{ ...INITIAL_COUNTS, isReady: true }}
+              />
+            )
+          }
+
+          if (!renderProps?.me) {
+            return (
+              <Component
+                {...props}
+                counts={{ ...INITIAL_COUNTS, isReady: false }}
+              />
+            )
           }
 
           const counts = renderProps.me.counts || INITIAL_COUNTS


### PR DESCRIPTION
Currently Integrity is failing due to errors in onboarding which are strange, to say the least. As you're moving through the onboarding flow, it 'resets'. Sometimes there's what appear to be CSS errors indicative of an SSR mismatch. A little tricky to debug.

I'm not entirely sure how this would be causing the behavior we're seeing in staging. But this is 'correct' now and does appear to fix. Will continue to investigate/come up with a spec.