### PR TITLE
fix: avoid double triggering address verification modal

### DIFF
--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -228,6 +228,17 @@ export const ShippingRoute: FC<ShippingProps> = props => {
       : addressVerificationIntlEnabled
   }
 
+  // Save shipping info on the order. If it's Artsy shipping and a quote hasn't
+  // been selected, this renders the quotes for user to select and finalize
+  // again.
+  const finalizeFulfillment = async () => {
+    if (checkIfArtsyShipping() && !!shippingQuoteId) {
+      selectShippingQuote()
+    } else {
+      selectShipping()
+    }
+  }
+
   const onContinueButtonPressed = async () => {
     if (
       isAddressVerificationEnabled() &&
@@ -242,11 +253,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
       return
     }
 
-    if (checkIfArtsyShipping() && !!shippingQuoteId) {
-      selectShippingQuote()
-    } else {
-      selectShipping()
-    }
+    finalizeFulfillment()
   }
 
   const selectShipping = async (editedAddress?: MutationAddressResponse) => {
@@ -793,7 +800,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
                     setAddressNeedsVerification(false)
                     setAddressHasBeenVerified(true)
                     setAddress({ ...address, ...chosenAddress })
-                    onContinueButtonPressed()
+                    finalizeFulfillment()
                   }}
                 />
               )}

--- a/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -1069,6 +1069,10 @@ describe("Shipping", () => {
         )
       })
 
+      afterAll(() => {
+        ;(useFeatureFlag as jest.Mock).mockReset()
+      })
+
       describe("when the continue button is clicked", () => {
         describe("with US address", () => {
           it("mounts the address verification flow", async () => {
@@ -1116,6 +1120,10 @@ describe("Shipping", () => {
         ;(useFeatureFlag as jest.Mock).mockImplementation(
           (featureName: string) => featureName === "address_verification_intl"
         )
+      })
+
+      afterAll(() => {
+        ;(useFeatureFlag as jest.Mock).mockReset()
       })
 
       describe("when the continue button is clicked", () => {
@@ -1315,8 +1323,12 @@ describe("Shipping", () => {
     describe("with address verification enabled", () => {
       beforeAll(() => {
         ;(useFeatureFlag as jest.Mock).mockImplementation(
-          (featureName: string) => featureName === "address_verification"
+          (featureName: string) => featureName === "address_verification_us"
         )
+      })
+
+      afterAll(() => {
+        ;(useFeatureFlag as jest.Mock).mockReset()
       })
 
       describe("when the continue button is clicked", () => {


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [EMI-1311](https://artsyproduct.atlassian.net/browse/EMI-1311)

### Description

The address verification modal gets triggered again after user choosing an address from it. Setting states is async. Checking if the verification needs to run right after the async set states will get the old value of the states, which triggers the address verification again.

Since on choosing an address we are ready to proceed to the next step, this directly move on to finalizing fulfillment, instead of checking again if address verification needs to run.

#### Before

![double-modal-before](https://github.com/artsy/force/assets/796573/542abd86-20a0-4b74-a285-24b7e77c893c)

#### After

![double-modal](https://github.com/artsy/force/assets/796573/3a3bcaa7-a9d3-4c7a-9491-09201adfbcd9)


[EMI-1311]: https://artsyproduct.atlassian.net/browse/EMI-1311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ