### PR TITLE
fix: perform basic form validation before address verification

### DIFF
--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -239,7 +239,42 @@ export const ShippingRoute: FC<ShippingProps> = props => {
     }
   }
 
+  /**
+   * Perform basic form validation for address and phone number.
+   *
+   * @returns true if both are valid; false, otherwise
+   */
+  const validateAddressAndPhoneNumber = () => {
+    const {
+      errors: addressErrors,
+      hasErrors: invalidAddress,
+    } = validateAddress(address)
+    const {
+      error: phoneNumberError,
+      hasError: invalidPhoneNumber,
+    } = validatePhoneNumber(phoneNumber)
+
+    if (invalidAddress) {
+      setAddressErrors(addressErrors!)
+      setAddressTouched(touchedAddress)
+    }
+    if (invalidPhoneNumber) {
+      setPhoneNumberError(phoneNumberError!)
+      setPhoneNumberTouched(true)
+    }
+
+    return !invalidAddress && !invalidPhoneNumber
+  }
+
   const onContinueButtonPressed = async () => {
+    if (
+      shippingOption === "SHIP" &&
+      isCreateNewAddress() &&
+      !validateAddressAndPhoneNumber()
+    ) {
+      return
+    }
+
     if (
       isAddressVerificationEnabled() &&
       !addressHasBeenVerified &&
@@ -257,28 +292,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
   }
 
   const selectShipping = async (editedAddress?: MutationAddressResponse) => {
-    if (shippingOption === "SHIP") {
-      if (isCreateNewAddress()) {
-        // validate when order is not pickup and the address is new
-        const { errors, hasErrors } = validateAddress(address)
-        const { error, hasError } = validatePhoneNumber(phoneNumber)
-        if (hasErrors && hasError) {
-          setAddressErrors(errors!)
-          setAddressTouched(touchedAddress)
-          setPhoneNumberError(error!)
-          setPhoneNumberTouched(true)
-          return
-        } else if (hasErrors) {
-          setAddressErrors(errors!)
-          setAddressTouched(touchedAddress)
-          return
-        } else if (hasError) {
-          setPhoneNumberError(error!)
-          setPhoneNumberTouched(true)
-          return
-        }
-      }
-    } else {
+    if (shippingOption === "PICKUP") {
       const { error, hasError } = validatePhoneNumber(phoneNumber)
       if (hasError) {
         setPhoneNumberError(error!)

--- a/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -1029,6 +1029,38 @@ describe("Shipping", () => {
 
           expect(mockCommitMutation).toHaveBeenCalled()
         })
+
+        describe("with address verfication enabled", () => {
+          beforeAll(() => {
+            ;(useFeatureFlag as jest.Mock).mockImplementation(
+              (featureName: string) => featureName === "address_verification_us"
+            )
+          })
+
+          afterAll(() => {
+            ;(useFeatureFlag as jest.Mock).mockReset()
+          })
+
+          it("triggers basic form validation first", async () => {
+            const wrapper = getWrapper({
+              CommerceOrder: () => testOrder,
+              Me: () => emptyTestMe,
+            })
+
+            const page = new ShippingTestPage(wrapper)
+
+            await page.clickSubmit()
+
+            const input = page
+              .find(Input)
+              .filterWhere(wrapper => wrapper.props().title === "Full name")
+            expect(input.props().error).toEqual("This field is required")
+
+            expect(
+              page.find(`[data-testid="address-verification-flow"]`).exists()
+            ).toBe(false)
+          })
+        })
       })
 
       it("does submit the mutation with a non-ship order", async () => {

--- a/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -1658,9 +1658,10 @@ describe("Shipping", () => {
             )
             const wrapper = getWrapper({
               CommerceOrder: () => UntouchedBuyOrderWithShippingQuotes,
-              Me: () => emptyTestMe,
+              Me: () => testMe,
             })
             const page = new ShippingTestPage(wrapper)
+            await page.update()
 
             page.find(`[data-test="shipping-quotes"]`).last().simulate("click")
 


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [EMI-1316](https://artsyproduct.atlassian.net/browse/EMI-1316)

### Description

Basic form validation (e.g. required fields) should be performed before the address verification (e.g. calling Smarty API for suggestions). This changes the order to perform basic form validation first.

### Before and after
<details><summary>Before</summary>
<p>

![form-validation-first](https://github.com/artsy/force/assets/796573/cc3af34f-87ec-4e87-94e1-b77cd92754f8)

</p>
</details> 

<details><summary>After</summary>
<p>

![form-validation-first-after](https://github.com/artsy/force/assets/796573/da7faace-d655-4ae8-ad59-5690f07864ad)


</p>
</details> 

[EMI-1316]: https://artsyproduct.atlassian.net/browse/EMI-1316?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ