### PR TITLE
fix(onyx-158): Hide See all matching works button on alerts confirmation step when <= 10 artworks match criteria

### DIFF
--- a/src/Components/SavedSearchAlert/Components/ConfirmationStepFooter.tsx
+++ b/src/Components/SavedSearchAlert/Components/ConfirmationStepFooter.tsx
@@ -8,13 +8,16 @@ import {
 } from "__generated__/ConfirmationStepFooterQuery.graphql"
 import { useTranslation } from "react-i18next"
 import { RouterLink } from "System/Router/RouterLink"
+import { NUMBER_OF_ARTWORKS_TO_SHOW } from "Components/SavedSearchAlert/ConfirmationArtworksGrid"
 
 interface ConfirmationStepFooterProps {
+  artworksCount: number
   me: ConfirmationStepFooterQuery$data["me"]
   onClose: () => void
 }
 
 export const ConfirmationStepFooter: FC<ConfirmationStepFooterProps> = ({
+  artworksCount,
   me,
   onClose,
 }) => {
@@ -23,18 +26,20 @@ export const ConfirmationStepFooter: FC<ConfirmationStepFooterProps> = ({
 
   return (
     <Flex flexDirection={["column", "row"]} gap={1}>
-      <Button
-        width="100%"
-        // @ts-ignore
-        as={RouterLink}
-        to={savedSearch?.href!}
-        onClick={() => {
-          onClose()
-        }}
-        data-testid="seeAllMatchingWorksButton"
-      >
-        {t("createAlertModal.confirmationStep.seeAllMatchingWorks")}
-      </Button>
+      {artworksCount > NUMBER_OF_ARTWORKS_TO_SHOW && (
+        <Button
+          width="100%"
+          // @ts-ignore
+          as={RouterLink}
+          to={savedSearch?.href!}
+          onClick={() => {
+            onClose()
+          }}
+          data-testid="seeAllMatchingWorksButton"
+        >
+          {t("createAlertModal.confirmationStep.seeAllMatchingWorks")}
+        </Button>
+      )}
 
       <Button
         width="100%"
@@ -54,6 +59,7 @@ export const ConfirmationStepFooter: FC<ConfirmationStepFooterProps> = ({
 }
 
 interface ConfirmationStepFooterQueryRendererProps {
+  artworksCount: number
   searchCriteriaId: string
   onClose: () => void
 }
@@ -61,7 +67,7 @@ interface ConfirmationStepFooterQueryRendererProps {
 export const ConfirmationStepFooterQueryRenderer: FC<ConfirmationStepFooterQueryRendererProps> = props => {
   return (
     <SystemQueryRenderer<ConfirmationStepFooterQuery>
-      placeholder={<ContentPlaceholder />}
+      placeholder={<ConfirmationStepFooterContentPlaceholder />}
       // Temporary workaround internalID is requested because there is a bug in Metaphysics. If a user's field is not requested, the
       // query returns null for savedSearch.
       query={graphql`
@@ -84,7 +90,7 @@ export const ConfirmationStepFooterQueryRenderer: FC<ConfirmationStepFooterQuery
         }
 
         if (!relayProps?.me?.savedSearch) {
-          return <ContentPlaceholder />
+          return <ConfirmationStepFooterContentPlaceholder />
         }
 
         return <ConfirmationStepFooter me={relayProps.me} {...props} />
@@ -93,7 +99,7 @@ export const ConfirmationStepFooterQueryRenderer: FC<ConfirmationStepFooterQuery
   )
 }
 
-const ContentPlaceholder: FC = () => {
+export const ConfirmationStepFooterContentPlaceholder: FC = () => {
   const { t } = useTranslation()
 
   return (

--- a/src/Components/SavedSearchAlert/Components/__tests__/ConfirmationStepFooter.jest.tsx
+++ b/src/Components/SavedSearchAlert/Components/__tests__/ConfirmationStepFooter.jest.tsx
@@ -3,6 +3,7 @@ import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { graphql } from "react-relay"
 import { ConfirmationStepFooter_Test_Query } from "__generated__/ConfirmationStepFooter_Test_Query.graphql"
 import { screen } from "@testing-library/react"
+import { NUMBER_OF_ARTWORKS_TO_SHOW } from "Components/SavedSearchAlert/ConfirmationArtworksGrid"
 
 jest.unmock("react-relay")
 
@@ -24,35 +25,59 @@ describe("ConfirmationStepFooter", () => {
     `,
   })
 
-  const renderComponent = () => {
-    renderWithRelay({
-      Me: () => ({
-        internalID: "1234",
-        savedSearch: {
-          href:
-            "/artist/banksy?sort=-published_at&attribution_class%5B0%5D=unique&additional_gene_ids%5B0%5D=prints&for_sale=true&search_criteria_id=289e87de-97e7-4c36-87aa-9fcd479b46b7",
-        },
-      }),
-    })
+  const renderComponent = (artworksCount: number) => {
+    renderWithRelay(
+      {
+        Me: () => ({
+          internalID: "1234",
+          savedSearch: {
+            href:
+              "/artist/banksy?sort=-published_at&attribution_class%5B0%5D=unique&additional_gene_ids%5B0%5D=prints&for_sale=true&search_criteria_id=289e87de-97e7-4c36-87aa-9fcd479b46b7",
+          },
+        }),
+      },
+      false,
+      { artworksCount: artworksCount }
+    )
   }
 
-  it("renders buttons", () => {
-    renderComponent()
+  describe("buttons", () => {
+    describe("when there are no artworks", () => {
+      it("renders only manage your alerts button", () => {
+        renderComponent(0)
 
-    expect(screen.getByText("See all matching works")).toBeInTheDocument()
-    expect(screen.getByText("Manage your alerts")).toBeInTheDocument()
-  })
+        expect(screen.getByText("Manage your alerts")).toBeInTheDocument()
+      })
+    })
 
-  it("redirects to the alerts page", () => {
-    renderComponent()
+    describe("when there are <= 10 artworks", () => {
+      it("renders only manage your alerts button", () => {
+        renderComponent(NUMBER_OF_ARTWORKS_TO_SHOW)
 
-    expect(screen.getByTestId("seeAllMatchingWorksButton")).toHaveAttribute(
-      "href",
-      "/artist/banksy?sort=-published_at&attribution_class%5B0%5D=unique&additional_gene_ids%5B0%5D=prints&for_sale=true&search_criteria_id=289e87de-97e7-4c36-87aa-9fcd479b46b7"
-    )
-    expect(screen.getByTestId("manageYourAlertsButton")).toHaveAttribute(
-      "href",
-      "/settings/alerts"
-    )
+        expect(screen.getByText("Manage your alerts")).toBeInTheDocument()
+      })
+    })
+
+    describe("when there are > 10 artworks", () => {
+      it("renders both buttons", () => {
+        renderComponent(NUMBER_OF_ARTWORKS_TO_SHOW + 1)
+
+        expect(screen.getByText("See all matching works")).toBeInTheDocument()
+        expect(screen.getByText("Manage your alerts")).toBeInTheDocument()
+      })
+    })
+
+    it("buttons have correct redirect links", () => {
+      renderComponent(NUMBER_OF_ARTWORKS_TO_SHOW + 1)
+
+      expect(screen.getByTestId("seeAllMatchingWorksButton")).toHaveAttribute(
+        "href",
+        "/artist/banksy?sort=-published_at&attribution_class%5B0%5D=unique&additional_gene_ids%5B0%5D=prints&for_sale=true&search_criteria_id=289e87de-97e7-4c36-87aa-9fcd479b46b7"
+      )
+      expect(screen.getByTestId("manageYourAlertsButton")).toHaveAttribute(
+        "href",
+        "/settings/alerts"
+      )
+    })
   })
 })

--- a/src/Components/SavedSearchAlert/ConfirmationArtworksGrid.tsx
+++ b/src/Components/SavedSearchAlert/ConfirmationArtworksGrid.tsx
@@ -19,24 +19,40 @@ import ArtworkGrid, {
 import { SearchCriteriaAttributes } from "Components/SavedSearchAlert/types"
 import { useTranslation } from "react-i18next"
 import { ArtworkGridContextProvider } from "Components/ArtworkGrid/ArtworkGridContext"
+import {
+  ConfirmationStepFooterContentPlaceholder,
+  ConfirmationStepFooterQueryRenderer,
+} from "Components/SavedSearchAlert/Components/ConfirmationStepFooter"
 
 export const NUMBER_OF_ARTWORKS_TO_SHOW = 10
 
 interface ConfirmationArtworksProps {
   artworksConnection: ConfirmationArtworksGridQuery$data["artworksConnection"]
+  searchCriteriaId: string
+  onClose: () => void
 }
 
 export const ConfirmationArtworks: FC<ConfirmationArtworksProps> = ({
   artworksConnection,
+  searchCriteriaId,
+  onClose,
 }) => {
   const { t } = useTranslation()
-  const artworksCount = artworksConnection?.counts?.total
+  const artworksCount = artworksConnection?.counts?.total ?? 0
 
   if (artworksCount === 0) {
     return (
-      <Text mb={2} p={2} bg="black10" color="black60">
-        {t("createAlertModal.confirmationStep.noMatches")}
-      </Text>
+      <>
+        <Text mb={2} p={2} bg="black10" color="black60">
+          {t("createAlertModal.confirmationStep.noMatches")}
+        </Text>
+
+        <ConfirmationStepFooterQueryRenderer
+          artworksCount={artworksCount!}
+          searchCriteriaId={searchCriteriaId}
+          onClose={onClose}
+        />
+      </>
     )
   }
 
@@ -72,11 +88,27 @@ export const ConfirmationArtworks: FC<ConfirmationArtworksProps> = ({
           </Column>
         </GridColumns>
       </ArtworkGridContextProvider>
+
+      <Spacer y={2} />
+
+      <ConfirmationStepFooterQueryRenderer
+        artworksCount={artworksCount!}
+        searchCriteriaId={searchCriteriaId}
+        onClose={onClose}
+      />
     </Flex>
   )
 }
 
-export const ConfirmationArtworksGridQueryRenderer: FC<SearchCriteriaAttributes> = props => {
+interface ConfirmationArtworksGridQueryRendererProps
+  extends SearchCriteriaAttributes {
+  searchCriteriaId: string
+  onClose: () => void
+}
+
+export const ConfirmationArtworksGridQueryRenderer: FC<ConfirmationArtworksGridQueryRendererProps> = props => {
+  const { searchCriteriaId, onClose, ...inputProps } = props
+
   return (
     <SystemQueryRenderer<ConfirmationArtworksGridQuery>
       placeholder={<ContentPlaceholder />}
@@ -95,7 +127,7 @@ export const ConfirmationArtworksGridQueryRenderer: FC<SearchCriteriaAttributes>
           first: NUMBER_OF_ARTWORKS_TO_SHOW,
           sort: "-published_at",
           forSale: true,
-          ...props,
+          ...inputProps,
         },
       }}
       render={({ props: relayProps, error }) => {
@@ -139,6 +171,10 @@ const ContentPlaceholder: FC = () => {
         columnCount={2}
         amount={NUMBER_OF_ARTWORKS_TO_SHOW}
       />
+
+      <Spacer y={2} />
+
+      <ConfirmationStepFooterContentPlaceholder />
     </Flex>
   )
 }

--- a/src/Components/SavedSearchAlert/ConfirmationStepModal.tsx
+++ b/src/Components/SavedSearchAlert/ConfirmationStepModal.tsx
@@ -1,6 +1,5 @@
 import { Join, ModalDialog, Spacer } from "@artsy/palette"
 import { ConfirmationModalHeader } from "Components/SavedSearchAlert/Components/ConfirmationModalHeader"
-import { ConfirmationStepFooterQueryRenderer } from "Components/SavedSearchAlert/Components/ConfirmationStepFooter"
 import { ConfirmationArtworksGridQueryRenderer } from "Components/SavedSearchAlert/ConfirmationArtworksGrid"
 import { useSavedSearchAlertContext } from "Components/SavedSearchAlert/SavedSearchAlertContext"
 import { FC } from "react"
@@ -26,10 +25,10 @@ export const ConfirmationStepModal: FC<ConfirmationStepModalProps> = ({
     >
       <Join separator={<Spacer y={2} />}>
         <ConfirmationModalHeader />
-        <ConfirmationArtworksGridQueryRenderer {...criteria} />
-        <ConfirmationStepFooterQueryRenderer
+        <ConfirmationArtworksGridQueryRenderer
           searchCriteriaId={searchCriteriaId}
           onClose={onClose}
+          {...criteria}
         />
       </Join>
     </ModalDialog>


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [ONYX-158]

### Description

There is a little sense to display "See all matching works" button when all works are already on the screen. This PR hides this button when there are <= artworks that match criteria.

- [Review app](https://onyx-158.artsy.net/)

| No matches | Few matches | Many matches |
|---|---|---|
| ![No matches](https://github.com/artsy/force/assets/3934579/b7edbad9-45f7-43e0-b89b-d05e50748aee) | ![Few matches](https://github.com/artsy/force/assets/3934579/e324ae00-b6f3-4251-b885-2f65510810f3) | ![Many matches](https://github.com/artsy/force/assets/3934579/93753f75-a752-41e4-9038-ea219ac3066f) |


[ONYX-158]: https://artsyproduct.atlassian.net/browse/ONYX-158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ