### PR TITLE
fix: auto-continue when no address change is suggested

### DIFF
--- a/src/Apps/Order/Components/AddressVerificationFlow.tsx
+++ b/src/Apps/Order/Components/AddressVerificationFlow.tsx
@@ -20,7 +20,7 @@ import { useAnalyticsContext } from "System/Analytics/AnalyticsContext"
 
 interface AddressVerificationFlowProps {
   verifiedAddressResult: AddressVerificationFlow_verifiedAddressResult$data
-  onChosenAddress: (address: AddressValues) => void
+  onChosenAddress: (address: AddressValues, saveAndContinue: boolean) => void
   onClose: () => void
 }
 
@@ -77,7 +77,7 @@ const AddressVerificationFlow: React.FC<AddressVerificationFlowProps> = ({
     )
     if (selectedAddress) {
       setModalType(null)
-      onChosenAddress(selectedAddress.address)
+      onChosenAddress(selectedAddress.address, false)
     }
   }, [addressOptions, onChosenAddress, selectedAddressKey])
 
@@ -154,7 +154,7 @@ const AddressVerificationFlow: React.FC<AddressVerificationFlowProps> = ({
     }
 
     if (verificationStatus === "VERIFIED_NO_CHANGE") {
-      onChosenAddress(inputOption.address as AddressValues)
+      onChosenAddress(inputOption.address as AddressValues, true)
     } else {
       if (verificationStatus === "VERIFIED_WITH_CHANGES") {
         setModalType(ModalType.SUGGESTIONS)
@@ -359,7 +359,7 @@ const AddressVerificationFlowFragmentContainer = createFragmentContainer(
 
 export const AddressVerificationFlowQueryRenderer: React.FC<{
   address: AddressValues
-  onChosenAddress: (address: AddressValues) => void
+  onChosenAddress: (address: AddressValues, saveAndContinue: boolean) => void
   onClose: () => void
 }> = ({ address, onChosenAddress, onClose }) => {
   return (

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -810,10 +810,11 @@ export const ShippingRoute: FC<ShippingProps> = props => {
                     setAddressNeedsVerification(false)
                     setAddressHasBeenVerified(true)
                   }}
-                  onChosenAddress={chosenAddress => {
+                  onChosenAddress={(chosenAddress, saveAndContinue) => {
                     setAddressNeedsVerification(false)
                     setAddressHasBeenVerified(true)
                     setAddress({ ...address, ...chosenAddress })
+                    saveAndContinue && finalizeFulfillment()
                   }}
                 />
               )}


### PR DESCRIPTION
The type of this PR is: **FIX**

https://artsyproduct.atlassian.net/browse/EMI-1358

### Description

In [this PR](https://github.com/artsy/force/pull/12673), we removed the logic of automatically proceeding with a verified address due to a persistence bug. However, we _should_ continue when there are no changes being suggested, otherwise the user is forced to click again on the "Save and Continue" button after getting no feedback from the site (we don't show anything in the case of the user entering a perfect address)
In an ideal world, we should find a way of overcoming the persistence bug and refactoring the shipping index file.

Before (2 clicks):

https://github.com/artsy/force/assets/7518671/ee5931a2-5bd9-4682-9275-0d2fcbbce730

After (1 click):


https://github.com/artsy/force/assets/7518671/56b29f4d-fd9a-4d9a-8f56-f84310f59f4f


