### PR TITLE
feat: show error message when setting payment by setup intent fails (EMI-1284)

### DIFF
--- a/src/Apps/Order/Dialogs.tsx
+++ b/src/Apps/Order/Dialogs.tsx
@@ -13,6 +13,7 @@ interface CtaProps {
 
 interface ModalDialogProps {
   show?: boolean
+  width?: number
   heading?: string
   detail?: React.ReactNode
   primaryCta: CtaProps
@@ -132,11 +133,13 @@ export class DialogContainer extends Container<DialogState> {
       </>
     ),
     continueButtonText = "Continue",
+    width = undefined,
   }: {
     title?: string
     message?: React.ReactNode
     supportEmail?: string
     continueButtonText?: string
+    width?: number
   } = {}): Promise<boolean> => {
     return new Promise<boolean>(resolve => {
       const onContinue = () => {
@@ -152,6 +155,7 @@ export class DialogContainer extends Container<DialogState> {
       this.show({
         props: {
           show: true,
+          width,
           heading: title,
           detail: message,
           primaryCta: {
@@ -209,6 +213,8 @@ export const ConnectedModalDialog = () => (
         <ModalDialog
           title={props.heading}
           onClose={props.onClose}
+          width={props.width ? "fit-content" : undefined}
+          maxWidth={props.width}
           footer={
             <Button width="100%" onClick={props.primaryCta.action}>
               {props.primaryCta.text}

--- a/src/Apps/Order/Hooks/__tests__/useStripePaymentBySetupIntentId.jest.tsx
+++ b/src/Apps/Order/Hooks/__tests__/useStripePaymentBySetupIntentId.jest.tsx
@@ -1,0 +1,95 @@
+import { renderHook } from "@testing-library/react-hooks"
+import { useStripePaymentBySetupIntentId } from "Apps/Order/Hooks/useStripePaymentBySetupIntentId"
+import { useRouter } from "System/Router/useRouter"
+import { useSetPaymentByStripeIntent } from "Apps/Order/Mutations/useSetPaymentByStripeIntentMutation"
+import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
+
+jest.mock("System/Router/useRouter")
+jest.mock("Apps/Order/Mutations/useSetPaymentByStripeIntentMutation")
+
+describe("useStripePaymentBySetupIntentId", () => {
+  const mockUseRouter = useRouter as jest.Mock
+  const mockUseSetPaymentByStripeIntent = useSetPaymentByStripeIntent as jest.Mock
+
+  let mockOrderOrError
+
+  beforeAll(() => {
+    mockUseRouter.mockImplementation(() => ({
+      match: {
+        location: {
+          query: {
+            save_account: false,
+            setup_intent: "setup-intent-id",
+            setup_intent_client_secret: "client-secret",
+            redirect_status: "succeeded",
+          },
+        },
+      },
+    }))
+
+    mockUseSetPaymentByStripeIntent.mockImplementation(() => ({
+      submitMutation: jest.fn().mockImplementation(() => ({
+        commerceSetPaymentByStripeIntent: {
+          orderOrError: mockOrderOrError,
+        },
+      })),
+    }))
+  })
+
+  afterEach(() => jest.clearAllMocks())
+
+  describe("when useSetPaymentByStripeIntent returns successfully", () => {
+    beforeAll(() => {
+      // the mutation is considered successful if there is no error object
+      mockOrderOrError = {}
+    })
+
+    it("requests the useSetPaymentByStripeIntent mutation", async () => {
+      renderHook(() => useStripePaymentBySetupIntentId("order-id"))
+
+      await flushPromiseQueue()
+
+      expect(mockUseSetPaymentByStripeIntent).toHaveBeenCalled()
+    })
+
+    it("returns a result object", async () => {
+      const { result } = renderHook(() =>
+        useStripePaymentBySetupIntentId("order-id")
+      )
+
+      await flushPromiseQueue()
+
+      expect(result.current).toEqual({
+        isProcessingRedirect: false,
+        stripeSetupIntentId: "setup-intent-id",
+        isPaymentSetupSuccessful: true,
+        paymentSetupErrorCode: null,
+      })
+    })
+  })
+
+  describe("when useSetPaymentByStripeIntent returns an error", () => {
+    beforeAll(() => {
+      mockOrderOrError = {
+        error: {
+          code: "error-code",
+        },
+      }
+    })
+
+    it("returns a result object", async () => {
+      const { result } = renderHook(() =>
+        useStripePaymentBySetupIntentId("order-id")
+      )
+
+      await flushPromiseQueue()
+
+      expect(result.current).toEqual({
+        isProcessingRedirect: false,
+        stripeSetupIntentId: "setup-intent-id",
+        isPaymentSetupSuccessful: false,
+        paymentSetupErrorCode: "error-code",
+      })
+    })
+  })
+})

--- a/src/Apps/Order/Hooks/__tests__/useStripePaymentBySetupIntentId.jest.tsx
+++ b/src/Apps/Order/Hooks/__tests__/useStripePaymentBySetupIntentId.jest.tsx
@@ -63,7 +63,7 @@ describe("useStripePaymentBySetupIntentId", () => {
         isProcessingRedirect: false,
         stripeSetupIntentId: "setup-intent-id",
         isPaymentSetupSuccessful: true,
-        paymentSetupErrorCode: null,
+        paymentSetupError: null,
       })
     })
   })
@@ -88,7 +88,7 @@ describe("useStripePaymentBySetupIntentId", () => {
         isProcessingRedirect: false,
         stripeSetupIntentId: "setup-intent-id",
         isPaymentSetupSuccessful: false,
-        paymentSetupErrorCode: "error-code",
+        paymentSetupError: { code: "error-code" },
       })
     })
   })

--- a/src/Apps/Order/Hooks/useStripePaymentBySetupIntentId.tsx
+++ b/src/Apps/Order/Hooks/useStripePaymentBySetupIntentId.tsx
@@ -19,9 +19,9 @@ export function useStripePaymentBySetupIntentId(orderId: string) {
   const [isPaymentSetupSuccessful, setIsPaymentSetupSuccessful] = useState(
     false
   )
-  const [paymentSetupErrorCode, setPaymentSetupErrorCode] = useState<
-    null | string
-  >(null)
+  const [paymentSetupError, setPaymentSetupError] = useState<null | object>(
+    null
+  )
 
   useEffect(() => {
     // pull necessary params from Stripe redirect URL
@@ -77,7 +77,7 @@ export function useStripePaymentBySetupIntentId(orderId: string) {
       setIsPaymentSetupSuccessful(true)
     } catch (error) {
       setIsPaymentSetupSuccessful(false)
-      setPaymentSetupErrorCode(error.code)
+      setPaymentSetupError(error)
     }
   }
 
@@ -85,6 +85,6 @@ export function useStripePaymentBySetupIntentId(orderId: string) {
     isProcessingRedirect,
     stripeSetupIntentId,
     isPaymentSetupSuccessful,
-    paymentSetupErrorCode,
+    paymentSetupError,
   }
 }

--- a/src/Apps/Order/Hooks/useStripePaymentBySetupIntentId.tsx
+++ b/src/Apps/Order/Hooks/useStripePaymentBySetupIntentId.tsx
@@ -19,6 +19,9 @@ export function useStripePaymentBySetupIntentId(orderId: string) {
   const [isPaymentSetupSuccessful, setIsPaymentSetupSuccessful] = useState(
     false
   )
+  const [paymentSetupErrorCode, setPaymentSetupErrorCode] = useState<
+    null | string
+  >(null)
 
   useEffect(() => {
     // pull necessary params from Stripe redirect URL
@@ -74,6 +77,7 @@ export function useStripePaymentBySetupIntentId(orderId: string) {
       setIsPaymentSetupSuccessful(true)
     } catch (error) {
       setIsPaymentSetupSuccessful(false)
+      setPaymentSetupErrorCode(error.code)
     }
   }
 
@@ -81,5 +85,6 @@ export function useStripePaymentBySetupIntentId(orderId: string) {
     isProcessingRedirect,
     stripeSetupIntentId,
     isPaymentSetupSuccessful,
+    paymentSetupErrorCode,
   }
 }

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -136,7 +136,9 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
   const displayLoading =
     isProcessingRedirect ||
     isSavingPayment ||
-    (!!match?.location?.query?.setup_intent && !bankAccountHasInsufficientFunds)
+    (!!match?.location?.query?.setup_intent &&
+      !bankAccountHasInsufficientFunds &&
+      !paymentSetupErrorCode)
 
   let routeSteps
   if (order.mode === "OFFER") {
@@ -341,12 +343,12 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
     ) {
       handlePaymentStepComplete()
     } else if (paymentSetupErrorCode && !isPaymentSetupSuccessful) {
-      setIsSavingPayment(false)
-      props.router.push(`/orders/${props.order.internalID}/payment`)
+      // setIsSavingPayment(false)
+      // props.router.push(`/orders/${props.order.internalID}/payment`)
 
-      const title = "Unsupported country"
+      const title = "Choose another payment method"
       const message =
-        "We are unable to process payments from SEPA accounts in your country at the moment."
+        "The bank account you entered is not denominated in EUR. Please select another payment method and try again."
       const error_code = paymentSetupErrorCode
 
       trackEvent({

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -343,13 +343,9 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
     ) {
       handlePaymentStepComplete()
     } else if (paymentSetupErrorCode && !isPaymentSetupSuccessful) {
-      // setIsSavingPayment(false)
-      // props.router.push(`/orders/${props.order.internalID}/payment`)
-
       const title = "Choose another payment method"
       const message =
         "The bank account you entered is not denominated in EUR. Please select another payment method and try again."
-      const error_code = paymentSetupErrorCode
 
       trackEvent({
         action: ActionType.errorMessageViewed,
@@ -357,13 +353,14 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
         context_owner_id: props.order.internalID,
         title: title,
         message: message,
-        error_code: error_code,
+        error_code: paymentSetupErrorCode,
         flow: "user sets payment by setup intent",
       })
 
       props.dialog.showErrorDialog({
         title: title,
         message: message,
+        width: 500,
       })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -129,7 +129,7 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
     isProcessingRedirect,
     stripeSetupIntentId,
     isPaymentSetupSuccessful,
-    paymentSetupErrorCode,
+    paymentSetupError,
   } = useStripePaymentBySetupIntentId(order.internalID)
 
   // SavingPaymentSpinner is rendered and PaymentContent is hidden when true
@@ -138,7 +138,7 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
     isSavingPayment ||
     (!!match?.location?.query?.setup_intent &&
       !bankAccountHasInsufficientFunds &&
-      !paymentSetupErrorCode)
+      !paymentSetupError)
 
   let routeSteps
   if (order.mode === "OFFER") {
@@ -342,13 +342,15 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
         selectedPaymentMethod === "SEPA_DEBIT")
     ) {
       handlePaymentStepComplete()
-    } else if (!isPaymentSetupSuccessful) {
+    } else if (paymentSetupError) {
       let title = "An error occurred"
       let message =
         "Something went wrong. Please try again or contact orders@artsy.net"
       let width: undefined | number = undefined
 
-      if (paymentSetupErrorCode === "unsupported_sepa_country") {
+      const errorCode = (paymentSetupError as any).code
+
+      if (errorCode === "unsupported_sepa_country") {
         title = "Choose another payment method"
         message =
           "The bank account you entered is not denominated in EUR. Please select another payment method and try again."
@@ -361,7 +363,7 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
         context_owner_id: props.order.internalID,
         title: title,
         message: message,
-        error_code: paymentSetupErrorCode,
+        error_code: errorCode,
         flow: "user sets payment by setup intent",
       })
 
@@ -377,7 +379,7 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
     selectedBankAccountId,
     balanceCheckEnabled,
     selectedPaymentMethod,
-    paymentSetupErrorCode,
+    paymentSetupError,
   ])
 
   const setOrderPayment = (

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -343,9 +343,17 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
     ) {
       handlePaymentStepComplete()
     } else if (paymentSetupErrorCode && !isPaymentSetupSuccessful) {
-      const title = "Choose another payment method"
-      const message =
-        "The bank account you entered is not denominated in EUR. Please select another payment method and try again."
+      let title = "An error occurred"
+      let message =
+        "Something went wrong. Please try again or contact orders@artsy.net"
+      let width: undefined | number = undefined
+
+      if (paymentSetupErrorCode === "unsupported_sepa_country") {
+        title = "Choose another payment method"
+        message =
+          "The bank account you entered is not denominated in EUR. Please select another payment method and try again."
+        width = 500
+      }
 
       trackEvent({
         action: ActionType.errorMessageViewed,
@@ -358,9 +366,9 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
       })
 
       props.dialog.showErrorDialog({
-        title: title,
-        message: message,
-        width: 500,
+        title,
+        message,
+        width,
       })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -342,7 +342,18 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
         selectedPaymentMethod === "SEPA_DEBIT")
     ) {
       handlePaymentStepComplete()
-    } else if (paymentSetupError) {
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    isPaymentSetupSuccessful,
+    selectedBankAccountId,
+    balanceCheckEnabled,
+    selectedPaymentMethod,
+  ])
+
+  // show error modal when payment setup error is set
+  useEffect(() => {
+    if (paymentSetupError) {
       let title = "An error occurred"
       let message =
         "Something went wrong. Please try again or contact orders@artsy.net"
@@ -374,13 +385,7 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
       })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    isPaymentSetupSuccessful,
-    selectedBankAccountId,
-    balanceCheckEnabled,
-    selectedPaymentMethod,
-    paymentSetupError,
-  ])
+  }, [paymentSetupError])
 
   const setOrderPayment = (
     variables: PaymentRouteSetOrderPaymentMutation["variables"]

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -342,7 +342,7 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
         selectedPaymentMethod === "SEPA_DEBIT")
     ) {
       handlePaymentStepComplete()
-    } else if (paymentSetupErrorCode && !isPaymentSetupSuccessful) {
+    } else if (!isPaymentSetupSuccessful) {
       let title = "An error occurred"
       let message =
         "Something went wrong. Please try again or contact orders@artsy.net"


### PR DESCRIPTION
The type of this PR is: Feat
This PR solves [EMI-1284]

### Description

This is a companion PR to artsy/exchange#1733 that displays an error message to users if it doesn't pass backend validation in Exchange. (See the companion PR in Exchange for more context.)

[EMI-1284]: https://artsyproduct.atlassian.net/browse/EMI-1284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ