### PR TITLE
chore: EM-1355 - send address verified by

### DIFF
--- a/src/Apps/Order/Components/AddressVerificationFlow.tsx
+++ b/src/Apps/Order/Components/AddressVerificationFlow.tsx
@@ -217,6 +217,8 @@ const AddressVerificationFlow: React.FC<AddressVerificationFlowProps> = ({
   if (verificationStatus === "VERIFIED_NO_CHANGE")
     return <div data-testid="emptyAddressVerification"></div>
 
+  if (addressOptions.length === 0) return null
+
   if (modalType === ModalType.SUGGESTIONS) {
     return (
       <ModalDialog title="Confirm your delivery address" onClose={handleClose}>

--- a/src/Apps/Order/Components/AddressVerificationFlow.tsx
+++ b/src/Apps/Order/Components/AddressVerificationFlow.tsx
@@ -18,7 +18,10 @@ import { useSystemContext } from "System/SystemContext"
 import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { useAnalyticsContext } from "System/Analytics/AnalyticsContext"
 
-export type AddressVerifiedBy = "USER" | "ARTSY"
+export enum AddressVerifiedBy {
+  USER = "USER",
+  ARTSY = "ARTSY",
+}
 type AddressOptionKey = "userInput" | string
 
 interface AddressVerificationFlowProps {
@@ -80,7 +83,10 @@ const AddressVerificationFlow: React.FC<AddressVerificationFlowProps> = ({
       option => option.key === selectedAddressKey
     )
 
-    const verifiedBy = selectedAddressKey === "userInput" ? "USER" : "ARTSY"
+    const verifiedBy =
+      selectedAddressKey === "userInput"
+        ? AddressVerifiedBy.USER
+        : AddressVerifiedBy.ARTSY
 
     if (selectedAddress) {
       setModalType(null)
@@ -156,7 +162,7 @@ const AddressVerificationFlow: React.FC<AddressVerificationFlowProps> = ({
     }
 
     if (verificationStatus === "VERIFIED_NO_CHANGE") {
-      const verifiedBy = "ARTSY"
+      const verifiedBy = AddressVerifiedBy.ARTSY
       onChosenAddress(verifiedBy, inputOption.address as AddressValues, true)
     } else {
       if (verificationStatus === "VERIFIED_WITH_CHANGES") {

--- a/src/Apps/Order/Components/AddressVerificationFlow.tsx
+++ b/src/Apps/Order/Components/AddressVerificationFlow.tsx
@@ -57,9 +57,10 @@ const AddressVerificationFlow: React.FC<AddressVerificationFlowProps> = ({
 }) => {
   const [modalType, setModalType] = useState<ModalType | null>(null)
   const [addressOptions, setAddressOptions] = useState<AddressOption[]>([])
-  const [selectedAddressKey, setSelectedAddressKey] = useState<AddressOptionKey | null>(
-    null
-  )
+  const [
+    selectedAddressKey,
+    setSelectedAddressKey,
+  ] = useState<AddressOptionKey | null>(null)
 
   const { trackEvent } = useTracking()
   const { user } = useSystemContext()
@@ -129,18 +130,13 @@ const AddressVerificationFlow: React.FC<AddressVerificationFlowProps> = ({
     }
   }, [addressOptions])
 
-  // Handling possibly incorrectly (by MP) possible null values
   const suggestedAddresses =
     verifiedAddressResult.suggestedAddresses ||
     ([] as NonNullable<
-      NonNullable<AddressVerificationFlow_verifiedAddressResult$data>
+      AddressVerificationFlow_verifiedAddressResult$data
     >["suggestedAddresses"])
-  const inputAddress = verifiedAddressResult.inputAddress as NonNullable<
-    NonNullable<AddressVerificationFlow_verifiedAddressResult$data>
-  >["inputAddress"]
-  const verificationStatus = verifiedAddressResult.verificationStatus as NonNullable<
-    AddressVerificationFlow_verifiedAddressResult$data
-  >["verificationStatus"]
+  const inputAddress = verifiedAddressResult.inputAddress as AddressVerificationFlow_verifiedAddressResult$data["inputAddress"]
+  const verificationStatus = verifiedAddressResult.verificationStatus as AddressVerificationFlow_verifiedAddressResult$data["verificationStatus"]
 
   useEffect(() => {
     const inputOption: AddressOption = {

--- a/src/Apps/Order/Components/AddressVerificationFlow.tsx
+++ b/src/Apps/Order/Components/AddressVerificationFlow.tsx
@@ -189,7 +189,6 @@ const AddressVerificationFlow: React.FC<AddressVerificationFlowProps> = ({
           }))
         setAddressOptions([...suggestedOptions, inputOption])
       } else {
-        console.warn("ELSE address could not be verified")
         setAddressOptions([inputOption])
         setModalType(ModalType.REVIEW_AND_CONFIRM)
         trackEvent({

--- a/src/Apps/Order/Components/AddressVerificationFlow.tsx
+++ b/src/Apps/Order/Components/AddressVerificationFlow.tsx
@@ -57,17 +57,13 @@ const AddressVerificationFlow: React.FC<AddressVerificationFlowProps> = ({
 }) => {
   const [modalType, setModalType] = useState<ModalType | null>(null)
   const [addressOptions, setAddressOptions] = useState<AddressOption[]>([])
-  const [selectedAddressKey, setSelectedAddressKey2] = useState<string | null>(
+  const [selectedAddressKey, setSelectedAddressKey] = useState<AddressOptionKey | null>(
     null
   )
 
   const { trackEvent } = useTracking()
   const { user } = useSystemContext()
   const { contextPageOwnerSlug } = useAnalyticsContext()
-
-  const setSelectedAddressKey = (key: string) => {
-    setSelectedAddressKey2(key)
-  }
 
   const chooseAddress = useCallback(() => {
     if (!selectedAddressKey) return

--- a/src/Apps/Order/Components/__tests__/AddressVerificationFlow.jest.tsx
+++ b/src/Apps/Order/Components/__tests__/AddressVerificationFlow.jest.tsx
@@ -1,0 +1,160 @@
+import { screen, waitFor } from "@testing-library/react"
+import { AddressVerificationFlowFragmentContainer } from "Apps/Order/Components/AddressVerificationFlow"
+import { AddressVerificationFlow_Test_Query } from "__generated__/AddressVerificationFlow_Test_Query.graphql"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
+import { graphql } from "react-relay"
+import { AddressVerificationFlow_verifyAddress$data } from "__generated__/AddressVerificationFlow_verifyAddress.graphql"
+import { useTracking } from "react-tracking"
+
+// const mockOnChosenAddress = jest.fn()
+// const mockOnClose = jest.fn()
+const mockInputAddress = {
+  addressLine1: "401 Broadway",
+  addressLine2: "Suite 25",
+  city: "New York",
+  region: "NY",
+  postalCode: "10013",
+  country: "US",
+}
+
+jest.unmock("react-relay")
+
+jest.mock("react-tracking")
+
+const { renderWithRelay } = setupTestWrapperTL<
+  AddressVerificationFlow_Test_Query
+>({
+  Component: AddressVerificationFlowFragmentContainer,
+  query: graphql`
+    query AddressVerificationFlow_Test_Query($address: AddressInput!)
+      @relay_test_operation {
+      verifyAddress(address: $address) {
+        ...AddressVerificationFlow_verifyAddress
+      }
+    }
+  `,
+  variables: { address: mockInputAddress },
+})
+
+let defaultResult: Omit<
+  AddressVerificationFlow_verifyAddress$data,
+  " $fragmentType"
+>
+
+beforeEach(() => {
+  defaultResult = {
+    verificationStatus: "NOT_FOUND",
+    suggestedAddresses: [],
+    inputAddress: {
+      lines: ["401 Broadway", "Suite 25", "New York, NY 10013", "USA"],
+      address: mockInputAddress,
+    },
+  }
+})
+
+const trackEvent = jest.fn()
+beforeAll(() => {
+  ;(useTracking as jest.Mock).mockImplementation(() => {
+    return {
+      trackEvent,
+    }
+  })
+})
+
+describe("AddressVerificationFlow", () => {
+  describe("when the verification status is NOT_FOUND", () => {
+    const verificationStatus = "NOT_FOUND"
+
+    it("displays the correct content", async () => {
+      renderWithRelay({
+        VerifyAddressType: () => ({
+          ...defaultResult,
+          verificationStatus,
+          inputAddress: {
+            lines: ["401 Broadway", "Suite 25", "New York, NY 10013", "USA"],
+            address: {
+              addressLine1: "401 Broadway",
+              addressLine2: "Suite 25",
+              city: "New York",
+              region: "NY",
+              postalCode: "10013",
+              country: "US",
+            },
+          },
+          suggestedAddresses: [],
+        }),
+      })
+
+      await screen.findByText("Check your delivery address")
+
+      const body =
+        "The address you entered may be incorrect or incomplete. Please check it and make any changes necessary."
+      expect(screen.getByText(body)).toBeInTheDocument()
+      expect(screen.getByText("What you entered")).toBeInTheDocument()
+      expect(screen.getByText("Use This Address")).toBeInTheDocument()
+      expect(screen.getByText("Edit Address")).toBeInTheDocument()
+    })
+  })
+
+  describe("when the verification status is VERIFIED_NO_CHANGE", () => {
+    const verificationStatus = "VERIFIED_NO_CHANGE"
+
+    it("calls onChosenAddress without displaying a modal", async () => {
+      const mockOnChosenAddress = jest.fn()
+
+      renderWithRelay(
+        {
+          VerifyAddressType: () => ({ ...defaultResult, verificationStatus }),
+        },
+        undefined,
+        {
+          onChosenAddress: mockOnChosenAddress,
+        }
+      )
+
+      await screen.findByTestId("emptyAddressVerification")
+      await waitFor(() => {
+        expect(mockOnChosenAddress).toHaveBeenCalledTimes(1)
+        expect(mockOnChosenAddress).toHaveBeenCalledWith(
+          "ARTSY",
+          mockInputAddress,
+          true
+        )
+      })
+    })
+  })
+
+  describe("when the verification status is VERIFIED_WITH_CHANGES", () => {
+    it("displays the correct content", async () => {
+      const mockResolver = {
+        ...defaultResult,
+        verificationStatus: "VERIFIED_WITH_CHANGES",
+        suggestedAddresses: [
+          {
+            lines: ["401 Broadway Suite 25", "New York, NY 10013", "USA"],
+            address: {
+              addressLine1: "401 Broadway Suite 25",
+              city: "New York",
+              region: "NY",
+              postalCode: "10013",
+              country: "US",
+            },
+          },
+        ],
+      }
+      renderWithRelay({
+        VerifyAddressType: () => mockResolver,
+      })
+
+      await screen.findByText("Confirm your delivery address")
+
+      const body =
+        "To ensure prompt and accurate delivery, we suggest a modified shipping address."
+      expect(screen.getByText(body)).toBeInTheDocument()
+      expect(screen.getByText("Recommended")).toBeInTheDocument()
+      expect(screen.getByText("What you entered")).toBeInTheDocument()
+      expect(screen.getByText("Use This Address")).toBeInTheDocument()
+      expect(screen.getByText("Back to Edit")).toBeInTheDocument()
+    })
+  })
+})

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -116,10 +116,13 @@ export const ShippingRoute: FC<ShippingProps> = props => {
   )
 
   // true if the current address needs to be verified
+  // TODO: Is this necessary, or can it just use the checks above?
   const [addressNeedsVerification, setAddressNeedsVerification] = useState<
     boolean
   >(false)
-  // true if the current address has been verified
+
+  // Presence of addressVerifiedBy indicates that the address has been verified
+  // via the address verification flow.
   const [
     addressVerifiedBy,
     setAddressVerifiedBy,
@@ -574,7 +577,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
     // If the address has already been verified and the user is editing the form,
     // consider this a user-verified address (perform verification only once).
     if (addressVerifiedBy) {
-      setAddressVerifiedBy("USER")
+      setAddressVerifiedBy(AddressVerifiedBy.USER)
     }
   }
 
@@ -819,7 +822,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
                   }}
                   onClose={() => {
                     setAddressNeedsVerification(false)
-                    setAddressVerifiedBy("USER")
+                    setAddressVerifiedBy(AddressVerifiedBy.USER)
                   }}
                   onChosenAddress={(
                     verifiedBy,

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -12,7 +12,10 @@ import {
 import { useSystemContext } from "System/useSystemContext"
 import { RouterLink } from "System/Router/RouterLink"
 import { Shipping_order$data } from "__generated__/Shipping_order.graphql"
-import { CommerceOrderFulfillmentTypeEnum } from "__generated__/SetShippingMutation.graphql"
+import {
+  CommerceOrderFulfillmentTypeEnum,
+  CommerceSetShippingInput,
+} from "__generated__/SetShippingMutation.graphql"
 import { ArtworkSummaryItemFragmentContainer as ArtworkSummaryItem } from "Apps/Order/Components/ArtworkSummaryItem"
 import {
   buyNowFlowSteps,
@@ -331,15 +334,19 @@ export const ShippingRoute: FC<ShippingProps> = props => {
 
       const isArtsyShipping = checkIfArtsyShipping()
 
+      const mutationInput: CommerceSetShippingInput = {
+        id: props.order.internalID,
+        fulfillmentType: isArtsyShipping ? "SHIP_ARTA" : shippingOption,
+        shipping: shipToAddress,
+        phoneNumber: shipToPhoneNumber,
+      }
+      if (addressVerifiedBy) {
+        mutationInput.addressVerifiedBy = addressVerifiedBy
+      }
+
       const orderOrError = (
         await setShipping(props.commitMutation, {
-          input: {
-            id: props.order.internalID,
-            fulfillmentType: isArtsyShipping ? "SHIP_ARTA" : shippingOption,
-            addressVerifiedBy,
-            shipping: shipToAddress,
-            phoneNumber: shipToPhoneNumber,
-          },
+          input: mutationInput,
         })
       ).commerceSetShipping?.orderOrError
 

--- a/src/__generated__/AddressVerificationFlow_Test_Query.graphql.ts
+++ b/src/__generated__/AddressVerificationFlow_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e122403e61456c1c2272093675069b67>>
+ * @generated SignedSource<<1a1825afd5694c1de007ac661b194cfe>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,17 +18,17 @@ export type AddressInput = {
   postalCode: string;
   region?: string | null;
 };
-export type AddressVerificationFlowQuery$variables = {
+export type AddressVerificationFlow_Test_Query$variables = {
   address: AddressInput;
 };
-export type AddressVerificationFlowQuery$data = {
+export type AddressVerificationFlow_Test_Query$data = {
   readonly verifyAddress: {
     readonly " $fragmentSpreads": FragmentRefs<"AddressVerificationFlow_verifyAddress">;
   } | null;
 };
-export type AddressVerificationFlowQuery = {
-  response: AddressVerificationFlowQuery$data;
-  variables: AddressVerificationFlowQuery$variables;
+export type AddressVerificationFlow_Test_Query = {
+  response: AddressVerificationFlow_Test_Query$data;
+  variables: AddressVerificationFlow_Test_Query$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -96,13 +96,31 @@ v3 = [
     "name": "region",
     "storageKey": null
   }
-];
+],
+v4 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "String"
+},
+v5 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v6 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": true,
+  "type": "String"
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
-    "name": "AddressVerificationFlowQuery",
+    "name": "AddressVerificationFlow_Test_Query",
     "selections": [
       {
         "alias": null,
@@ -128,7 +146,7 @@ return {
   "operation": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
-    "name": "AddressVerificationFlowQuery",
+    "name": "AddressVerificationFlow_Test_Query",
     "selections": [
       {
         "alias": null,
@@ -195,16 +213,75 @@ return {
     ]
   },
   "params": {
-    "cacheID": "01f44d47aa39b335ffa23007d00cd289",
+    "cacheID": "24e425ce3f99ac0b06d0e2522e50c45d",
     "id": null,
-    "metadata": {},
-    "name": "AddressVerificationFlowQuery",
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "verifyAddress": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "VerifyAddressType"
+        },
+        "verifyAddress.inputAddress": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "InputAddressFields"
+        },
+        "verifyAddress.inputAddress.address": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "InputAddress"
+        },
+        "verifyAddress.inputAddress.address.addressLine1": (v4/*: any*/),
+        "verifyAddress.inputAddress.address.addressLine2": (v5/*: any*/),
+        "verifyAddress.inputAddress.address.city": (v4/*: any*/),
+        "verifyAddress.inputAddress.address.country": (v4/*: any*/),
+        "verifyAddress.inputAddress.address.postalCode": (v4/*: any*/),
+        "verifyAddress.inputAddress.address.region": (v5/*: any*/),
+        "verifyAddress.inputAddress.lines": (v6/*: any*/),
+        "verifyAddress.suggestedAddresses": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": true,
+          "type": "SuggestedAddressFields"
+        },
+        "verifyAddress.suggestedAddresses.address": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SuggestedAddress"
+        },
+        "verifyAddress.suggestedAddresses.address.addressLine1": (v4/*: any*/),
+        "verifyAddress.suggestedAddresses.address.addressLine2": (v5/*: any*/),
+        "verifyAddress.suggestedAddresses.address.city": (v4/*: any*/),
+        "verifyAddress.suggestedAddresses.address.country": (v4/*: any*/),
+        "verifyAddress.suggestedAddresses.address.postalCode": (v4/*: any*/),
+        "verifyAddress.suggestedAddresses.address.region": (v5/*: any*/),
+        "verifyAddress.suggestedAddresses.lines": (v6/*: any*/),
+        "verifyAddress.verificationStatus": {
+          "enumValues": [
+            "NOT_FOUND",
+            "NOT_PERFORMED",
+            "VERIFICATION_UNAVAILABLE",
+            "VERIFIED_NO_CHANGE",
+            "VERIFIED_WITH_CHANGES"
+          ],
+          "nullable": false,
+          "plural": false,
+          "type": "VerificationStatuses"
+        }
+      }
+    },
+    "name": "AddressVerificationFlow_Test_Query",
     "operationKind": "query",
-    "text": "query AddressVerificationFlowQuery(\n  $address: AddressInput!\n) {\n  verifyAddress(address: $address) {\n    ...AddressVerificationFlow_verifyAddress\n  }\n}\n\nfragment AddressVerificationFlow_verifyAddress on VerifyAddressType {\n  inputAddress {\n    lines\n    address {\n      addressLine1\n      addressLine2\n      city\n      country\n      postalCode\n      region\n    }\n  }\n  suggestedAddresses {\n    lines\n    address {\n      addressLine1\n      addressLine2\n      city\n      country\n      postalCode\n      region\n    }\n  }\n  verificationStatus\n}\n"
+    "text": "query AddressVerificationFlow_Test_Query(\n  $address: AddressInput!\n) {\n  verifyAddress(address: $address) {\n    ...AddressVerificationFlow_verifyAddress\n  }\n}\n\nfragment AddressVerificationFlow_verifyAddress on VerifyAddressType {\n  inputAddress {\n    lines\n    address {\n      addressLine1\n      addressLine2\n      city\n      country\n      postalCode\n      region\n    }\n  }\n  suggestedAddresses {\n    lines\n    address {\n      addressLine1\n      addressLine2\n      city\n      country\n      postalCode\n      region\n    }\n  }\n  verificationStatus\n}\n"
   }
 };
 })();
 
-(node as any).hash = "2cc68455d9f5588f2331a3dc8bdc6942";
+(node as any).hash = "f9ed0de239e1632f8b2c4a3fa40f8d63";
 
 export default node;

--- a/src/__generated__/AddressVerificationFlow_verifyAddress.graphql.ts
+++ b/src/__generated__/AddressVerificationFlow_verifyAddress.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9229996d1999538586f837aa2f75483a>>
+ * @generated SignedSource<<c83c0b305bfafb03d2471b403942050e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,7 +11,7 @@
 import { Fragment, ReaderFragment } from 'relay-runtime';
 export type VerificationStatuses = "NOT_FOUND" | "NOT_PERFORMED" | "VERIFICATION_UNAVAILABLE" | "VERIFIED_NO_CHANGE" | "VERIFIED_WITH_CHANGES" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
-export type AddressVerificationFlow_verifiedAddressResult$data = {
+export type AddressVerificationFlow_verifyAddress$data = {
   readonly inputAddress: {
     readonly address: {
       readonly addressLine1: string;
@@ -35,11 +35,11 @@ export type AddressVerificationFlow_verifiedAddressResult$data = {
     readonly lines: ReadonlyArray<string | null> | null;
   } | null>;
   readonly verificationStatus: VerificationStatuses;
-  readonly " $fragmentType": "AddressVerificationFlow_verifiedAddressResult";
+  readonly " $fragmentType": "AddressVerificationFlow_verifyAddress";
 };
-export type AddressVerificationFlow_verifiedAddressResult$key = {
-  readonly " $data"?: AddressVerificationFlow_verifiedAddressResult$data;
-  readonly " $fragmentSpreads": FragmentRefs<"AddressVerificationFlow_verifiedAddressResult">;
+export type AddressVerificationFlow_verifyAddress$key = {
+  readonly " $data"?: AddressVerificationFlow_verifyAddress$data;
+  readonly " $fragmentSpreads": FragmentRefs<"AddressVerificationFlow_verifyAddress">;
 };
 
 const node: ReaderFragment = (function(){
@@ -98,7 +98,7 @@ return {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
-  "name": "AddressVerificationFlow_verifiedAddressResult",
+  "name": "AddressVerificationFlow_verifyAddress",
   "selections": [
     {
       "alias": null,
@@ -157,6 +157,6 @@ return {
 };
 })();
 
-(node as any).hash = "815aeb0ffb99d2d138f2e502d7a31139";
+(node as any).hash = "1cc5e84c3a0a61d8f92bba7d7efbf3a8";
 
 export default node;


### PR DESCRIPTION
The type of this PR is: **Chore**

cc @artsy/emerald-devs 
This PR solves [EM-1295] and mostly completes  [EM-1355]. It includes an update of the changes in https://github.com/artsy/force/pull/12636

### Description

With this change the `address_verified_by` argument is sent to [exchange's `setShipping` mutation](https://github.com/artsy/exchange/blob/b9079eb9d9bb5b157fb55f8d67b950e9f3ab2a73/app/graphql/mutations/set_shipping.rb#L30), triggering the backend address verification job.

It also fixes some types and cleans up some development code.

<!-- Implementation description -->
To accomplish this I updated our boolean `addressHasBeenVerified` state variable to be a `null | "ARTSY" | "USER"` `addressVerifiedBy` variable - its presence means that it has been verified, and editing the form after saving sets the address as verified by the user (since we don't perform verification more than once without a reload).

**Note/followup:** After the address has a verified-by value in exchange, it [will not be re-set](https://github.com/artsy/exchange/blob/b9079eb9d9bb5b157fb55f8d67b950e9f3ab2a73/app/services/shipping/verify_address.rb#L6). Thus if a user goes back and edits their address neither this nor the payload will be updated. Fixed in https://github.com/artsy/exchange/pull/1735

### Steps to test manually
1. Have an exchange staging console open
2. Begin an order checkout, removing all saved addresses
3. Enter a completely wrong US address for the delivery address and see the address verification modal - the version with no choices.
4. Click to keep the address
5. Click save & continue: 

**Find the order in the exchange staging console, see that the shipping address has been set along with `shipping_address_verified_by: "USER"` but no `shipping_address_verified_payload`.**

6. Reload the page
7. Enter a new address that will get suggestions, (401 broadway, 26th floor, new york, NY 10013 with the floor number on line 2 usually works).
8. Select the suggested address ['use this address']
9. Click save & continue again

**Reload the order in the exchange staging console, see that the shipping address has been updated along with `shipping_address_verified_by: "ARTSY"` and a `shipping_address_verified_payload`.**

10. On the shipping page with an address that has already been saved as verified by ARTSY (e.g. an Arta order that has not had its shipping option selected yet), edit the form to change something and save it again.

**Reload the order in exchange once more and see that the address has updated and is again verified by USER.**

Other expected behavior:
- User closes either modal without actively clicking the primary address select button: `address_verified_by USER`
- address verification not enabled: `address_verified_by: nil`

<details><summary>Saved address verification payload in exchange for an ARTSY-verified address</summary>

![image](https://github.com/artsy/force/assets/9088720/76be301a-5d16-4aa9-a88c-16f355f33cae)

</details> 
