### PR TITLE
feat(emi-1286): handle errors using the orError approach

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -106,15 +106,6 @@ type addOrderedSetItemSuccess {
   setItem: OrderedSetItem
 }
 
-input AddressInput {
-  addressLine1: String!
-  addressLine2: String
-  city: String
-  country: String!
-  postalCode: String!
-  region: String
-}
-
 type addUserRoleFailure {
   mutationError: GravityMutationError
 }
@@ -1356,9 +1347,6 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
   auctionResultsConnection(
     after: String
 
-    # Lits of aggregations fot auction results
-    aggregations: [AuctionResultsAggregation]
-
     # Allow auction results with empty created date values
     allowEmptyCreatedDates: Boolean = true
     before: String
@@ -1370,12 +1358,6 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     earliestCreatedYear: Int
     first: Int
 
-    # Includes auction results with suitable estimate ranges
-    includeEstimateRange: Boolean = false
-
-    # Includes auction results without price
-    includeUnknownPrices: Boolean = true
-
     # Filter by artwork title or description keyword search
     keyword: String
     last: Int
@@ -1386,9 +1368,6 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
     # Filter auction results by organizations
     organizations: [String]
     page: Int
-
-    # Filter auction results by price
-    priceRange: String
 
     # When true, will only return records for allowed artists.
     recordsTrusted: Boolean = false
@@ -1536,10 +1515,7 @@ type Artist implements EntityWithFilterArtworksConnectionInterface & Node & Sear
       HIGH_AUCTION_RECORD
       ACTIVE_SECONDARY_MARKET
       CRITICALLY_ACCLAIMED
-      RECENT_CAREER_EVENT
       ARTSY_VANGUARD_YEAR
-      CURATORS_PICK_EMERGING
-      TRENDING_NOW
       GAINING_FOLLOWERS
       SOLO_SHOW
       GROUP_SHOW
@@ -1769,16 +1745,13 @@ enum ArtistInsightKind {
   BIENNIAL
   COLLECTED
   CRITICALLY_ACCLAIMED
-  CURATORS_PICK_EMERGING
   GAINING_FOLLOWERS
   GROUP_SHOW
   HIGH_AUCTION_RECORD
   PRIVATE_COLLECTIONS
-  RECENT_CAREER_EVENT
   RESIDENCIES
   REVIEWED
   SOLO_SHOW
-  TRENDING_NOW
 }
 
 type ArtistInsightsCount {
@@ -2828,7 +2801,6 @@ type AuctionResult implements Node {
 
 # A connection to a list of items.
 type AuctionResultConnection {
-  aggregations: [AuctionResultsAggregationType]
   createdYearRange: YearRange
 
   # A list of edges.
@@ -2860,16 +2832,6 @@ type AuctionResultPriceRealized {
     # Passes in to numeral, such as `'0.00'`
     format: String = ""
   ): String
-}
-
-enum AuctionResultsAggregation {
-  SIMPLE_PRICE_HISTOGRAM
-}
-
-# The results for one of the requested aggregations
-type AuctionResultsAggregationType {
-  counts: [AggregationCount]
-  slice: AuctionResultsAggregation
 }
 
 # An auction lot result
@@ -12896,7 +12858,6 @@ type MyCollectionConnection {
     size: Int
     sort: ArtistSorts
   ): ArtistConnection
-    @deprecated(reason: "Please use `me.userInterestsConnection` instead")
   default: Boolean!
   description: String!
 
@@ -12993,7 +12954,6 @@ type MyCollectionInfo {
     size: Int
     sort: ArtistSorts
   ): ArtistConnection
-    @deprecated(reason: "Please use `me.userInterestsConnection` instead")
   default: Boolean!
   description: String!
   includesPurchasedArtworks: Boolean!
@@ -14091,9 +14051,6 @@ type PhoneNumberType {
 }
 
 type PreviewSavedSearch {
-  # A suggestion for a name that describes a set of saved search criteria in a conventional format
-  displayName: String!
-
   # Human-friendly labels that are added by Metaphysics to the upstream SearchCriteria type coming from Gravity
   labels: [SearchCriteriaLabel]!
 }
@@ -15745,7 +15702,7 @@ type Query {
   ): VanityURLEntityType
 
   # Verify a given address.
-  verifyAddress(address: AddressInput!): VerifyAddressType
+  verifyAddress(input: VerifyAddressInput!): VerifyAddressPayload
 
   # A wildcard used to support complex root queries in Relay
   viewer: Viewer
@@ -19279,6 +19236,27 @@ enum VerificationStatuses {
   VERIFIED_WITH_CHANGES
 }
 
+type VerifyAddressFailureType {
+  mutationError: GravityMutationError
+}
+
+input VerifyAddressInput {
+  addressLine1: String!
+  addressLine2: String
+  city: String
+  clientMutationId: String
+  country: String!
+  postalCode: String!
+  region: String
+}
+
+union VerifyAddressMutationType = VerifyAddressFailureType | VerifyAddressType
+
+type VerifyAddressPayload {
+  clientMutationId: String
+  verifyAddressOrError: VerifyAddressMutationType
+}
+
 type VerifyAddressType {
   inputAddress: InputAddressFields!
   suggestedAddresses: [SuggestedAddressFields]!
@@ -20198,7 +20176,7 @@ type Viewer {
   ): VanityURLEntityType
 
   # Verify a given address.
-  verifyAddress(address: AddressInput!): VerifyAddressType
+  verifyAddress(input: VerifyAddressInput!): VerifyAddressPayload
   viewingRoomsConnection(
     after: String
     first: Int

--- a/src/Apps/Order/Components/AddressVerificationFlow.tsx
+++ b/src/Apps/Order/Components/AddressVerificationFlow.tsx
@@ -135,15 +135,23 @@ const AddressVerificationFlow: React.FC<AddressVerificationFlowProps> = ({
 
   // Handling possibly incorrectly (by MP) possible null values
   const suggestedAddresses =
-    verifiedAddressResult.suggestedAddresses ||
+    verifiedAddressResult.verifyAddressOrError?.suggestedAddresses ||
     ([] as NonNullable<
-      NonNullable<AddressVerificationFlow_verifiedAddressResult$data>
+      NonNullable<
+        NonNullable<AddressVerificationFlow_verifiedAddressResult$data>
+      >["verifyAddressOrError"]
     >["suggestedAddresses"])
-  const inputAddress = verifiedAddressResult.inputAddress as NonNullable<
-    NonNullable<AddressVerificationFlow_verifiedAddressResult$data>
+  const inputAddress = verifiedAddressResult.verifyAddressOrError
+    ?.inputAddress as NonNullable<
+    NonNullable<
+      NonNullable<AddressVerificationFlow_verifiedAddressResult$data>
+    >["verifyAddressOrError"]
   >["inputAddress"]
-  const verificationStatus = verifiedAddressResult.verificationStatus as NonNullable<
-    AddressVerificationFlow_verifiedAddressResult$data
+  const verificationStatus = verifiedAddressResult.verifyAddressOrError
+    ?.verificationStatus as NonNullable<
+    NonNullable<
+      AddressVerificationFlow_verifiedAddressResult$data
+    >["verifyAddressOrError"]
   >["verificationStatus"]
 
   useEffect(() => {
@@ -328,30 +336,34 @@ const AddressVerificationFlowFragmentContainer = createFragmentContainer(
   AddressVerificationFlow,
   {
     verifiedAddressResult: graphql`
-      fragment AddressVerificationFlow_verifiedAddressResult on VerifyAddressType {
-        inputAddress {
-          lines
-          address {
-            addressLine1
-            addressLine2
-            city
-            country
-            postalCode
-            region
+      fragment AddressVerificationFlow_verifiedAddressResult on VerifyAddressPayload {
+        verifyAddressOrError {
+          ... on VerifyAddressType {
+            inputAddress {
+              lines
+              address {
+                addressLine1
+                addressLine2
+                city
+                country
+                postalCode
+                region
+              }
+            }
+            suggestedAddresses {
+              lines
+              address {
+                addressLine1
+                addressLine2
+                city
+                country
+                postalCode
+                region
+              }
+            }
+            verificationStatus
           }
         }
-        suggestedAddresses {
-          lines
-          address {
-            addressLine1
-            addressLine2
-            city
-            country
-            postalCode
-            region
-          }
-        }
-        verificationStatus
       }
     `,
   }
@@ -385,8 +397,8 @@ export const AddressVerificationFlowQueryRenderer: React.FC<{
         )
       }}
       query={graphql`
-        query AddressVerificationFlowQuery($address: AddressInput!) {
-          verifyAddress(address: $address) {
+        query AddressVerificationFlowQuery($address: VerifyAddressInput!) {
+          verifyAddress(input: $address) {
             ...AddressVerificationFlow_verifiedAddressResult
           }
         }

--- a/src/__generated__/AddressVerificationFlowQuery.graphql.ts
+++ b/src/__generated__/AddressVerificationFlowQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<583724a2c34ac790a82e71bc348115cf>>
+ * @generated SignedSource<<ba0f8a4c443e5281f987de6d5d1ffee6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -211,6 +211,45 @@ return {
                 ],
                 "type": "VerifyAddressType",
                 "abstractKey": null
+              },
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "GravityMutationError",
+                    "kind": "LinkedField",
+                    "name": "mutationError",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "type",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "message",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "statusCode",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "VerifyAddressFailureType",
+                "abstractKey": null
               }
             ],
             "storageKey": null
@@ -221,12 +260,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "cb46a34eb42d272a530f24a979312c71",
+    "cacheID": "4015ec1428f40530a71a7784417c18af",
     "id": null,
     "metadata": {},
     "name": "AddressVerificationFlowQuery",
     "operationKind": "query",
-    "text": "query AddressVerificationFlowQuery(\n  $address: VerifyAddressInput!\n) {\n  verifyAddress(input: $address) {\n    ...AddressVerificationFlow_verifiedAddressResult\n  }\n}\n\nfragment AddressVerificationFlow_verifiedAddressResult on VerifyAddressPayload {\n  verifyAddressOrError {\n    __typename\n    ... on VerifyAddressType {\n      inputAddress {\n        lines\n        address {\n          addressLine1\n          addressLine2\n          city\n          country\n          postalCode\n          region\n        }\n      }\n      suggestedAddresses {\n        lines\n        address {\n          addressLine1\n          addressLine2\n          city\n          country\n          postalCode\n          region\n        }\n      }\n      verificationStatus\n    }\n  }\n}\n"
+    "text": "query AddressVerificationFlowQuery(\n  $address: VerifyAddressInput!\n) {\n  verifyAddress(input: $address) {\n    ...AddressVerificationFlow_verifiedAddressResult\n  }\n}\n\nfragment AddressVerificationFlow_verifiedAddressResult on VerifyAddressPayload {\n  verifyAddressOrError {\n    __typename\n    ... on VerifyAddressType {\n      inputAddress {\n        lines\n        address {\n          addressLine1\n          addressLine2\n          city\n          country\n          postalCode\n          region\n        }\n      }\n      suggestedAddresses {\n        lines\n        address {\n          addressLine1\n          addressLine2\n          city\n          country\n          postalCode\n          region\n        }\n      }\n      verificationStatus\n    }\n    ... on VerifyAddressFailureType {\n      mutationError {\n        type\n        message\n        statusCode\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/AddressVerificationFlowQuery.graphql.ts
+++ b/src/__generated__/AddressVerificationFlowQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b6764c3f8857351e0034a8273abeea46>>
+ * @generated SignedSource<<583724a2c34ac790a82e71bc348115cf>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,16 +10,17 @@
 
 import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type AddressInput = {
+export type VerifyAddressInput = {
   addressLine1: string;
   addressLine2?: string | null;
   city?: string | null;
+  clientMutationId?: string | null;
   country: string;
   postalCode: string;
   region?: string | null;
 };
 export type AddressVerificationFlowQuery$variables = {
-  address: AddressInput;
+  address: VerifyAddressInput;
 };
 export type AddressVerificationFlowQuery$data = {
   readonly verifyAddress: {
@@ -42,7 +43,7 @@ var v0 = [
 v1 = [
   {
     "kind": "Variable",
-    "name": "address",
+    "name": "input",
     "variableName": "address"
   }
 ],
@@ -107,7 +108,7 @@ return {
       {
         "alias": null,
         "args": (v1/*: any*/),
-        "concreteType": "VerifyAddressType",
+        "concreteType": "VerifyAddressPayload",
         "kind": "LinkedField",
         "name": "verifyAddress",
         "plural": false,
@@ -133,7 +134,7 @@ return {
       {
         "alias": null,
         "args": (v1/*: any*/),
-        "concreteType": "VerifyAddressType",
+        "concreteType": "VerifyAddressPayload",
         "kind": "LinkedField",
         "name": "verifyAddress",
         "plural": false,
@@ -141,52 +142,77 @@ return {
           {
             "alias": null,
             "args": null,
-            "concreteType": "InputAddressFields",
+            "concreteType": null,
             "kind": "LinkedField",
-            "name": "inputAddress",
+            "name": "verifyAddressOrError",
             "plural": false,
             "selections": [
-              (v2/*: any*/),
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "InputAddress",
-                "kind": "LinkedField",
-                "name": "address",
-                "plural": false,
-                "selections": (v3/*: any*/),
+                "kind": "ScalarField",
+                "name": "__typename",
                 "storageKey": null
-              }
-            ],
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "SuggestedAddressFields",
-            "kind": "LinkedField",
-            "name": "suggestedAddresses",
-            "plural": true,
-            "selections": [
-              (v2/*: any*/),
+              },
               {
-                "alias": null,
-                "args": null,
-                "concreteType": "SuggestedAddress",
-                "kind": "LinkedField",
-                "name": "address",
-                "plural": false,
-                "selections": (v3/*: any*/),
-                "storageKey": null
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "InputAddressFields",
+                    "kind": "LinkedField",
+                    "name": "inputAddress",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "InputAddress",
+                        "kind": "LinkedField",
+                        "name": "address",
+                        "plural": false,
+                        "selections": (v3/*: any*/),
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "SuggestedAddressFields",
+                    "kind": "LinkedField",
+                    "name": "suggestedAddresses",
+                    "plural": true,
+                    "selections": [
+                      (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "SuggestedAddress",
+                        "kind": "LinkedField",
+                        "name": "address",
+                        "plural": false,
+                        "selections": (v3/*: any*/),
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "verificationStatus",
+                    "storageKey": null
+                  }
+                ],
+                "type": "VerifyAddressType",
+                "abstractKey": null
               }
             ],
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "verificationStatus",
             "storageKey": null
           }
         ],
@@ -195,16 +221,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "242e36573eba93a6afcaef3208233de4",
+    "cacheID": "cb46a34eb42d272a530f24a979312c71",
     "id": null,
     "metadata": {},
     "name": "AddressVerificationFlowQuery",
     "operationKind": "query",
-    "text": "query AddressVerificationFlowQuery(\n  $address: AddressInput!\n) {\n  verifyAddress(address: $address) {\n    ...AddressVerificationFlow_verifiedAddressResult\n  }\n}\n\nfragment AddressVerificationFlow_verifiedAddressResult on VerifyAddressType {\n  inputAddress {\n    lines\n    address {\n      addressLine1\n      addressLine2\n      city\n      country\n      postalCode\n      region\n    }\n  }\n  suggestedAddresses {\n    lines\n    address {\n      addressLine1\n      addressLine2\n      city\n      country\n      postalCode\n      region\n    }\n  }\n  verificationStatus\n}\n"
+    "text": "query AddressVerificationFlowQuery(\n  $address: VerifyAddressInput!\n) {\n  verifyAddress(input: $address) {\n    ...AddressVerificationFlow_verifiedAddressResult\n  }\n}\n\nfragment AddressVerificationFlow_verifiedAddressResult on VerifyAddressPayload {\n  verifyAddressOrError {\n    __typename\n    ... on VerifyAddressType {\n      inputAddress {\n        lines\n        address {\n          addressLine1\n          addressLine2\n          city\n          country\n          postalCode\n          region\n        }\n      }\n      suggestedAddresses {\n        lines\n        address {\n          addressLine1\n          addressLine2\n          city\n          country\n          postalCode\n          region\n        }\n      }\n      verificationStatus\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "fc3f5b41165706d036f0f408dc3ddba2";
+(node as any).hash = "9cd92a98345e3a667a62caa83c9f94e6";
 
 export default node;

--- a/src/__generated__/AddressVerificationFlow_verifiedAddressResult.graphql.ts
+++ b/src/__generated__/AddressVerificationFlow_verifiedAddressResult.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9229996d1999538586f837aa2f75483a>>
+ * @generated SignedSource<<d9f5cb888d482f9e420f50c4ff805e4b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,29 +12,31 @@ import { Fragment, ReaderFragment } from 'relay-runtime';
 export type VerificationStatuses = "NOT_FOUND" | "NOT_PERFORMED" | "VERIFICATION_UNAVAILABLE" | "VERIFIED_NO_CHANGE" | "VERIFIED_WITH_CHANGES" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type AddressVerificationFlow_verifiedAddressResult$data = {
-  readonly inputAddress: {
-    readonly address: {
-      readonly addressLine1: string;
-      readonly addressLine2: string | null;
-      readonly city: string;
-      readonly country: string;
-      readonly postalCode: string;
-      readonly region: string | null;
-    } | null;
-    readonly lines: ReadonlyArray<string | null> | null;
-  };
-  readonly suggestedAddresses: ReadonlyArray<{
-    readonly address: {
-      readonly addressLine1: string;
-      readonly addressLine2: string | null;
-      readonly city: string;
-      readonly country: string;
-      readonly postalCode: string;
-      readonly region: string | null;
-    } | null;
-    readonly lines: ReadonlyArray<string | null> | null;
-  } | null>;
-  readonly verificationStatus: VerificationStatuses;
+  readonly verifyAddressOrError: {
+    readonly inputAddress?: {
+      readonly address: {
+        readonly addressLine1: string;
+        readonly addressLine2: string | null;
+        readonly city: string;
+        readonly country: string;
+        readonly postalCode: string;
+        readonly region: string | null;
+      } | null;
+      readonly lines: ReadonlyArray<string | null> | null;
+    };
+    readonly suggestedAddresses?: ReadonlyArray<{
+      readonly address: {
+        readonly addressLine1: string;
+        readonly addressLine2: string | null;
+        readonly city: string;
+        readonly country: string;
+        readonly postalCode: string;
+        readonly region: string | null;
+      } | null;
+      readonly lines: ReadonlyArray<string | null> | null;
+    } | null>;
+    readonly verificationStatus?: VerificationStatuses;
+  } | null;
   readonly " $fragmentType": "AddressVerificationFlow_verifiedAddressResult";
 };
 export type AddressVerificationFlow_verifiedAddressResult$key = {
@@ -103,60 +105,78 @@ return {
     {
       "alias": null,
       "args": null,
-      "concreteType": "InputAddressFields",
+      "concreteType": null,
       "kind": "LinkedField",
-      "name": "inputAddress",
+      "name": "verifyAddressOrError",
       "plural": false,
       "selections": [
-        (v0/*: any*/),
         {
-          "alias": null,
-          "args": null,
-          "concreteType": "InputAddress",
-          "kind": "LinkedField",
-          "name": "address",
-          "plural": false,
-          "selections": (v1/*: any*/),
-          "storageKey": null
+          "kind": "InlineFragment",
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "InputAddressFields",
+              "kind": "LinkedField",
+              "name": "inputAddress",
+              "plural": false,
+              "selections": [
+                (v0/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "InputAddress",
+                  "kind": "LinkedField",
+                  "name": "address",
+                  "plural": false,
+                  "selections": (v1/*: any*/),
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "SuggestedAddressFields",
+              "kind": "LinkedField",
+              "name": "suggestedAddresses",
+              "plural": true,
+              "selections": [
+                (v0/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "SuggestedAddress",
+                  "kind": "LinkedField",
+                  "name": "address",
+                  "plural": false,
+                  "selections": (v1/*: any*/),
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "verificationStatus",
+              "storageKey": null
+            }
+          ],
+          "type": "VerifyAddressType",
+          "abstractKey": null
         }
       ],
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "SuggestedAddressFields",
-      "kind": "LinkedField",
-      "name": "suggestedAddresses",
-      "plural": true,
-      "selections": [
-        (v0/*: any*/),
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": "SuggestedAddress",
-          "kind": "LinkedField",
-          "name": "address",
-          "plural": false,
-          "selections": (v1/*: any*/),
-          "storageKey": null
-        }
-      ],
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "verificationStatus",
       "storageKey": null
     }
   ],
-  "type": "VerifyAddressType",
+  "type": "VerifyAddressPayload",
   "abstractKey": null
 };
 })();
 
-(node as any).hash = "815aeb0ffb99d2d138f2e502d7a31139";
+(node as any).hash = "782ba37c562bfd5c8e3127fd3d95e16e";
 
 export default node;

--- a/src/__generated__/AddressVerificationFlow_verifiedAddressResult.graphql.ts
+++ b/src/__generated__/AddressVerificationFlow_verifiedAddressResult.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d9f5cb888d482f9e420f50c4ff805e4b>>
+ * @generated SignedSource<<79e77fcc92ba39e316a45872597ea7d2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -24,6 +24,11 @@ export type AddressVerificationFlow_verifiedAddressResult$data = {
       } | null;
       readonly lines: ReadonlyArray<string | null> | null;
     };
+    readonly mutationError?: {
+      readonly message: string;
+      readonly statusCode: number | null;
+      readonly type: string | null;
+    } | null;
     readonly suggestedAddresses?: ReadonlyArray<{
       readonly address: {
         readonly addressLine1: string;
@@ -167,6 +172,45 @@ return {
           ],
           "type": "VerifyAddressType",
           "abstractKey": null
+        },
+        {
+          "kind": "InlineFragment",
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "GravityMutationError",
+              "kind": "LinkedField",
+              "name": "mutationError",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "type",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "message",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "statusCode",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "type": "VerifyAddressFailureType",
+          "abstractKey": null
         }
       ],
       "storageKey": null
@@ -177,6 +221,6 @@ return {
 };
 })();
 
-(node as any).hash = "782ba37c562bfd5c8e3127fd3d95e16e";
+(node as any).hash = "6795615167f6d70f9f083443550debb8";
 
 export default node;

--- a/src/__generated__/ArtistApp_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistApp_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<47302d10b8dd1e2f39b5c8113faf1c2c>>
+ * @generated SignedSource<<28e611e65619bc8ce535fa8e54be0553>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -941,16 +941,13 @@ return {
             "BIENNIAL",
             "COLLECTED",
             "CRITICALLY_ACCLAIMED",
-            "CURATORS_PICK_EMERGING",
             "GAINING_FOLLOWERS",
             "GROUP_SHOW",
             "HIGH_AUCTION_RECORD",
             "PRIVATE_COLLECTIONS",
-            "RECENT_CAREER_EVENT",
             "RESIDENCIES",
             "REVIEWED",
-            "SOLO_SHOW",
-            "TRENDING_NOW"
+            "SOLO_SHOW"
           ],
           "nullable": true,
           "plural": false,

--- a/src/__generated__/ArtistCareerHighlights_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistCareerHighlights_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d27f572da73134a4941657628475d497>>
+ * @generated SignedSource<<5a9b0b63a4e762e13a15509c09c7ea8c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -180,16 +180,13 @@ return {
             "BIENNIAL",
             "COLLECTED",
             "CRITICALLY_ACCLAIMED",
-            "CURATORS_PICK_EMERGING",
             "GAINING_FOLLOWERS",
             "GROUP_SHOW",
             "HIGH_AUCTION_RECORD",
             "PRIVATE_COLLECTIONS",
-            "RECENT_CAREER_EVENT",
             "RESIDENCIES",
             "REVIEWED",
-            "SOLO_SHOW",
-            "TRENDING_NOW"
+            "SOLO_SHOW"
           ],
           "nullable": true,
           "plural": false,

--- a/src/__generated__/ArtistCareerHighlights_artist.graphql.ts
+++ b/src/__generated__/ArtistCareerHighlights_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e8ed304b90d90af57db75c62df75579e>>
+ * @generated SignedSource<<69e77aa81ed68f318ea608cdb9d42635>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,7 +9,7 @@
 // @ts-nocheck
 
 import { Fragment, ReaderFragment } from 'relay-runtime';
-export type ArtistInsightKind = "ACTIVE_SECONDARY_MARKET" | "ARTSY_VANGUARD_YEAR" | "AWARDS" | "BIENNIAL" | "COLLECTED" | "CRITICALLY_ACCLAIMED" | "CURATORS_PICK_EMERGING" | "GAINING_FOLLOWERS" | "GROUP_SHOW" | "HIGH_AUCTION_RECORD" | "PRIVATE_COLLECTIONS" | "RECENT_CAREER_EVENT" | "RESIDENCIES" | "REVIEWED" | "SOLO_SHOW" | "TRENDING_NOW" | "%future added value";
+export type ArtistInsightKind = "ACTIVE_SECONDARY_MARKET" | "ARTSY_VANGUARD_YEAR" | "AWARDS" | "BIENNIAL" | "COLLECTED" | "CRITICALLY_ACCLAIMED" | "GAINING_FOLLOWERS" | "GROUP_SHOW" | "HIGH_AUCTION_RECORD" | "PRIVATE_COLLECTIONS" | "RESIDENCIES" | "REVIEWED" | "SOLO_SHOW" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type ArtistCareerHighlights_artist$data = {
   readonly href: string | null;

--- a/src/__generated__/ArtistHeader2_artist.graphql.ts
+++ b/src/__generated__/ArtistHeader2_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d2108c40a2add3119b4a1f8dc2e7fa58>>
+ * @generated SignedSource<<9980bc17eba753a801fba2a817787364>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,7 +9,7 @@
 // @ts-nocheck
 
 import { Fragment, ReaderFragment } from 'relay-runtime';
-export type ArtistInsightKind = "ACTIVE_SECONDARY_MARKET" | "ARTSY_VANGUARD_YEAR" | "AWARDS" | "BIENNIAL" | "COLLECTED" | "CRITICALLY_ACCLAIMED" | "CURATORS_PICK_EMERGING" | "GAINING_FOLLOWERS" | "GROUP_SHOW" | "HIGH_AUCTION_RECORD" | "PRIVATE_COLLECTIONS" | "RECENT_CAREER_EVENT" | "RESIDENCIES" | "REVIEWED" | "SOLO_SHOW" | "TRENDING_NOW" | "%future added value";
+export type ArtistInsightKind = "ACTIVE_SECONDARY_MARKET" | "ARTSY_VANGUARD_YEAR" | "AWARDS" | "BIENNIAL" | "COLLECTED" | "CRITICALLY_ACCLAIMED" | "GAINING_FOLLOWERS" | "GROUP_SHOW" | "HIGH_AUCTION_RECORD" | "PRIVATE_COLLECTIONS" | "RESIDENCIES" | "REVIEWED" | "SOLO_SHOW" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type ArtistHeader2_artist$data = {
   readonly biographyBlurb: {

--- a/src/__generated__/ArtistInsightBadges_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistInsightBadges_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2630574f4ac916510cc2672129df338e>>
+ * @generated SignedSource<<4f256cd08ae19d2585f75af5dbf8112c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -162,16 +162,13 @@ return {
             "BIENNIAL",
             "COLLECTED",
             "CRITICALLY_ACCLAIMED",
-            "CURATORS_PICK_EMERGING",
             "GAINING_FOLLOWERS",
             "GROUP_SHOW",
             "HIGH_AUCTION_RECORD",
             "PRIVATE_COLLECTIONS",
-            "RECENT_CAREER_EVENT",
             "RESIDENCIES",
             "REVIEWED",
-            "SOLO_SHOW",
-            "TRENDING_NOW"
+            "SOLO_SHOW"
           ],
           "nullable": true,
           "plural": false,

--- a/src/__generated__/ArtistInsightBadges_artist.graphql.ts
+++ b/src/__generated__/ArtistInsightBadges_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7a39f4187c8d2519fb5c13e8601e2688>>
+ * @generated SignedSource<<115bcb8d7b6d8dba0233aea1aaebec2e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,7 +9,7 @@
 // @ts-nocheck
 
 import { Fragment, ReaderFragment } from 'relay-runtime';
-export type ArtistInsightKind = "ACTIVE_SECONDARY_MARKET" | "ARTSY_VANGUARD_YEAR" | "AWARDS" | "BIENNIAL" | "COLLECTED" | "CRITICALLY_ACCLAIMED" | "CURATORS_PICK_EMERGING" | "GAINING_FOLLOWERS" | "GROUP_SHOW" | "HIGH_AUCTION_RECORD" | "PRIVATE_COLLECTIONS" | "RECENT_CAREER_EVENT" | "RESIDENCIES" | "REVIEWED" | "SOLO_SHOW" | "TRENDING_NOW" | "%future added value";
+export type ArtistInsightKind = "ACTIVE_SECONDARY_MARKET" | "ARTSY_VANGUARD_YEAR" | "AWARDS" | "BIENNIAL" | "COLLECTED" | "CRITICALLY_ACCLAIMED" | "GAINING_FOLLOWERS" | "GROUP_SHOW" | "HIGH_AUCTION_RECORD" | "PRIVATE_COLLECTIONS" | "RESIDENCIES" | "REVIEWED" | "SOLO_SHOW" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type ArtistInsightBadges_artist$data = {
   readonly insightBadges: ReadonlyArray<{


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-1286]

### Description

This is a followup of https://github.com/artsy/metaphysics/pull/5179.
The goal here is to update the code to use the `...orError` response format in order to handle errors more easily.

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EMI-1286]: https://artsyproduct.atlassian.net/browse/EMI-1286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ