### PR TITLE
fix: display the price filter for all users

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/index.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/index.tsx
@@ -2,7 +2,6 @@ import { Join, Spacer } from "@artsy/palette"
 import { HideUpcomingFilter } from "Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/HideUpcomingFilter"
 import { PriceRangeFilter } from "./PriceRangeFilter"
 import * as React from "react"
-import { useSystemContext } from "System/SystemContext"
 import { AuctionHouseFilter } from "./AuctionHouseFilter"
 import { MediumFilter } from "./MediumFilter"
 import { SizeFilter } from "./SizeFilter"
@@ -11,7 +10,6 @@ import { YearCreated } from "./YearCreated"
 export const AuctionFilters: React.FC<{
   showUpcomingAuctionResults: boolean
 }> = ({ showUpcomingAuctionResults }) => {
-  const { isLoggedIn } = useSystemContext()
   return (
     <>
       {showUpcomingAuctionResults && (
@@ -25,7 +23,7 @@ export const AuctionFilters: React.FC<{
         <MediumFilter />
         <SizeFilter />
         <YearCreated />
-        {isLoggedIn && <PriceRangeFilter />}
+        <PriceRangeFilter />
         <AuctionHouseFilter />
       </Join>
     </>

--- a/src/Apps/Artist/Routes/AuctionResults/__tests__/ArtistAuctionResults.jest.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/__tests__/ArtistAuctionResults.jest.tsx
@@ -230,7 +230,7 @@ describe("AuctionResults", () => {
           checked: true,
         })
 
-        expect(checkedCheckboxes).toHaveLength(8)
+        expect(checkedCheckboxes).toHaveLength(9)
         expect(checkedCheckboxes[0]).toHaveTextContent("Hide upcoming auctions")
         expect(checkedCheckboxes[1]).toHaveTextContent("Painting")
         expect(checkedCheckboxes[2]).toHaveTextContent("Small (under 40cm)")
@@ -238,9 +238,12 @@ describe("AuctionResults", () => {
         expect(checkedCheckboxes[4]).toHaveTextContent(
           "Include unspecified dates"
         )
-        expect(checkedCheckboxes[5]).toHaveTextContent("Phillips")
-        expect(checkedCheckboxes[6]).toHaveTextContent("Bonhams")
-        expect(checkedCheckboxes[7]).toHaveTextContent("Artsy Auction")
+        expect(checkedCheckboxes[5]).toHaveTextContent(
+          "Include unknown and unavailable prices"
+        )
+        expect(checkedCheckboxes[6]).toHaveTextContent("Phillips")
+        expect(checkedCheckboxes[7]).toHaveTextContent("Bonhams")
+        expect(checkedCheckboxes[8]).toHaveTextContent("Artsy Auction")
       })
     })
 


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR reverts back display the price filter for all users.

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ