### PR TITLE
feat: use generated displayName for alerts without a custom name 

### DIFF
--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditForm.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditForm.tsx
@@ -44,6 +44,7 @@ import { RouterLink } from "System/Router/RouterLink"
 import { DEFAULT_FREQUENCY } from "Components/SavedSearchAlert/constants"
 import { FrequenceRadioButtons } from "Components/SavedSearchAlert/Components/FrequencyRadioButtons"
 import { PriceRangeFilter } from "Components/SavedSearchAlert/Components/PriceRangeFilter"
+import { useFeatureFlag } from "System/useFeatureFlag"
 
 const logger = createLogger(
   "Apps/SavedSearchAlerts/Components/SavedSearchAlertEditForm"
@@ -101,12 +102,17 @@ const SavedSearchAlertEditForm: React.FC<SavedSearchAlertEditFormProps> = ({
   )
   const userAllowsEmails = isCustomAlertsNotificationsEnabled ?? false
   const shouldShowEmailWarning = !!initialValues.email && !userAllowsEmails
+  const isFallbackToGeneratedAlertNamesEnabled = useFeatureFlag(
+    "onyx_force-fallback-to-generated-alert-names"
+  )
 
   const handleSubmit = async (values: SavedSearchAleftFormValues) => {
     try {
       const updatedAlertSettings: SavedSearchAleftFormValues = {
         ...values,
-        name: values.name || entity.placeholder,
+        name:
+          values.name ||
+          (isFallbackToGeneratedAlertNamesEnabled ? "" : entity.placeholder),
         frequency: values.push ? values.frequency : DEFAULT_FREQUENCY,
       }
 
@@ -160,7 +166,11 @@ const SavedSearchAlertEditForm: React.FC<SavedSearchAlertEditFormProps> = ({
               <Input
                 title="Alert Name"
                 name="name"
-                placeholder={entity.placeholder}
+                placeholder={
+                  isFallbackToGeneratedAlertNamesEnabled
+                    ? undefined
+                    : entity.placeholder
+                }
                 value={values.name}
                 onChange={handleChange("name")}
                 onBlur={handleBlur("name")}
@@ -312,7 +322,7 @@ const SavedSearchAlertEditFormContainer: React.FC<SavedSearchAlertEditFormProps>
       id: savedSearch?.internalID!,
       // alert doesn't have a slug, for this reason we pass internalID
       slug: savedSearch?.internalID!,
-      name: savedSearch?.userAlertSettings.name ?? "",
+      name: savedSearch?.userAlertSettings.name ?? undefined,
     },
   }
 

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditForm.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditForm.tsx
@@ -30,7 +30,7 @@ import {
   useSavedSearchAlertContext,
 } from "Components/SavedSearchAlert/SavedSearchAlertContext"
 import {
-  SavedSearchAleftFormValues,
+  SavedSearchAlertFormValues,
   SavedSearchEntity,
   SavedSearchEntityCriteria,
   SavedSearchFrequency,
@@ -85,7 +85,7 @@ const SavedSearchAlertEditForm: React.FC<SavedSearchAlertEditFormProps> = ({
     removePill,
   } = useSavedSearchAlertContext()
 
-  const initialValues: SavedSearchAleftFormValues = {
+  const initialValues: SavedSearchAlertFormValues = {
     name: userAlertSettings.name ?? "",
     push: userAlertSettings.push,
     email: userAlertSettings.email,
@@ -106,9 +106,9 @@ const SavedSearchAlertEditForm: React.FC<SavedSearchAlertEditFormProps> = ({
     "onyx_force-fallback-to-generated-alert-names"
   )
 
-  const handleSubmit = async (values: SavedSearchAleftFormValues) => {
+  const handleSubmit = async (values: SavedSearchAlertFormValues) => {
     try {
-      const updatedAlertSettings: SavedSearchAleftFormValues = {
+      const updatedAlertSettings: SavedSearchAlertFormValues = {
         ...values,
         name:
           values.name ||

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditFormDesktop.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditFormDesktop.tsx
@@ -2,6 +2,7 @@ import { Box, Clickable, Flex, Spacer, Text } from "@artsy/palette"
 import { EditAlertFormBase } from "Apps/Settings/Routes/SavedSearchAlerts/types"
 import { SavedSearchAlertEditFormQueryRenderer } from "./SavedSearchAlertEditForm"
 import CloseIcon from "@artsy/icons/CloseIcon"
+import { useFeatureFlag } from "System/useFeatureFlag"
 
 export const SavedSearchAlertEditFormDesktop: React.FC<EditAlertFormBase> = ({
   editAlertEntity,
@@ -9,11 +10,18 @@ export const SavedSearchAlertEditFormDesktop: React.FC<EditAlertFormBase> = ({
   onDeleteClick,
   onCompleted,
 }) => {
+  const isFallbackToGeneratedAlertNamesEnabled = useFeatureFlag(
+    "onyx_force-fallback-to-generated-alert-names"
+  )
+
   return (
     <Box flex={1} p={4}>
       <Flex justifyContent="space-between" alignItems="center">
         <Text variant={["md", "lg"]} flex={1} mr={1}>
-          Edit {editAlertEntity.name}
+          Edit{" "}
+          {isFallbackToGeneratedAlertNamesEnabled
+            ? "Alert"
+            : editAlertEntity.name}
         </Text>
         <Clickable onClick={onCloseClick}>
           <CloseIcon display="flex" />

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditFormMobile.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditFormMobile.tsx
@@ -1,6 +1,7 @@
 import { ModalDialog, Spacer } from "@artsy/palette"
-import { EditAlertFormBase } from "../types"
+import { EditAlertFormBase } from "Apps/Settings/Routes/SavedSearchAlerts/types"
 import { SavedSearchAlertEditFormQueryRenderer } from "./SavedSearchAlertEditForm"
+import { useFeatureFlag } from "System/useFeatureFlag"
 
 export const SavedSearchAlertEditFormMobile: React.FC<EditAlertFormBase> = ({
   editAlertEntity,
@@ -8,9 +9,15 @@ export const SavedSearchAlertEditFormMobile: React.FC<EditAlertFormBase> = ({
   onDeleteClick,
   onCompleted,
 }) => {
+  const isFallbackToGeneratedAlertNamesEnabled = useFeatureFlag(
+    "onyx_force-fallback-to-generated-alert-names"
+  )
+
   return (
     <ModalDialog
-      title={`Edit ${editAlertEntity.name}`}
+      title={`Edit ${
+        isFallbackToGeneratedAlertNamesEnabled ? "Alert" : editAlertEntity.name
+      }`}
       m={0}
       dialogProps={{
         width: "100%",

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertListItem.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertListItem.tsx
@@ -15,6 +15,7 @@ import { SavedSearchAlertListItem_item$data } from "__generated__/SavedSearchAle
 import { EditAlertEntity } from "Apps/Settings/Routes/SavedSearchAlerts/types"
 import ChevronUpIcon from "@artsy/icons/ChevronUpIcon"
 import ChevronDownIcon from "@artsy/icons/ChevronDownIcon"
+import { useFeatureFlag } from "System/useFeatureFlag"
 
 export type SavedSearchAlertListItemVariant = "active" | "inactive"
 
@@ -34,6 +35,9 @@ export const SavedSearchAlertListItem: React.FC<SavedSearchAlertListItemProps> =
   const Icon = isExpanded ? ChevronUpIcon : ChevronDownIcon
 
   const toggleExpandFilters = () => setIsExpanded(isExpanded => !isExpanded)
+  const isFallbackToGeneratedAlertNamesEnabled = useFeatureFlag(
+    "onyx_force-fallback-to-generated-alert-names"
+  )
 
   const toggleExpandFiltersText = isExpanded
     ? "Close all filters"
@@ -61,7 +65,9 @@ export const SavedSearchAlertListItem: React.FC<SavedSearchAlertListItemProps> =
             variant={["md", "lg"]}
             color={variant === "active" ? "blue100" : "black100"}
           >
-            {item.userAlertSettings.name}
+            {isFallbackToGeneratedAlertNamesEnabled
+              ? item.displayName
+              : item.userAlertSettings.name}
           </Text>
           <Spacer x={2} y={2} />
           <Clickable textDecoration="underline" onClick={toggleExpandFilters}>
@@ -77,7 +83,7 @@ export const SavedSearchAlertListItem: React.FC<SavedSearchAlertListItemProps> =
             onClick={() => {
               onEditAlertClick({
                 id: item.internalID,
-                name: item.userAlertSettings.name!,
+                name: item.userAlertSettings.name ?? undefined,
                 artistIds: item.artistIDs as string[],
               })
             }}
@@ -117,6 +123,7 @@ export const SavedSearchAlertListItemFragmentContainer = createFragmentContainer
     item: graphql`
       fragment SavedSearchAlertListItem_item on SearchCriteria {
         internalID
+        displayName
         artistIDs
         href
         labels {

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/types.ts
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/types.ts
@@ -1,6 +1,6 @@
 export interface EditAlertEntity {
   id: string
-  name: string
+  name: string | undefined
   artistIds: string[]
 }
 

--- a/src/Components/SavedSearchAlert/Mutations/createSavedSearchAlert.ts
+++ b/src/Components/SavedSearchAlert/Mutations/createSavedSearchAlert.ts
@@ -4,13 +4,13 @@ import {
 } from "__generated__/createSavedSearchAlertMutation.graphql"
 import { commitMutation, Environment, graphql } from "relay-runtime"
 import {
-  SavedSearchAleftFormValues,
+  SavedSearchAlertFormValues,
   SearchCriteriaAttributes,
 } from "Components/SavedSearchAlert/types"
 
 export const createSavedSearchAlert = (
   environment: Environment,
-  userAlertSettings: SavedSearchAleftFormValues,
+  userAlertSettings: SavedSearchAlertFormValues,
   attributes: SearchCriteriaAttributes
 ): Promise<createSavedSearchAlertMutation$data> => {
   return new Promise((resolve, reject) => {

--- a/src/Components/SavedSearchAlert/SavedSearchAlertModal.tsx
+++ b/src/Components/SavedSearchAlert/SavedSearchAlertModal.tsx
@@ -22,7 +22,7 @@ import {
 } from "./SavedSearchAlertContext"
 import {
   FilterPill,
-  SavedSearchAleftFormValues,
+  SavedSearchAlertFormValues,
   SavedSearchAlertMutationResult,
   SavedSearchEntity,
   SearchCriteriaAttributeKeys,
@@ -38,7 +38,7 @@ import { useFeatureFlag } from "System/useFeatureFlag"
 
 interface SavedSearchAlertFormProps {
   entity: SavedSearchEntity
-  initialValues: SavedSearchAleftFormValues
+  initialValues: SavedSearchAlertFormValues
   onClose: () => void
   onCreateAlert?: (result: SavedSearchAlertMutationResult) => void
 }
@@ -74,12 +74,12 @@ export const SavedSearchAlertModal: FC<SavedSearchAlertFormProps> = ({
     removeCriteriaValue(pill.field as SearchCriteriaAttributeKeys, pill.value)
   }
 
-  const handleSubmit = async (values: SavedSearchAleftFormValues) => {
+  const handleSubmit = async (values: SavedSearchAlertFormValues) => {
     if (!relayEnvironment) {
       return null
     }
 
-    const userAlertSettings: SavedSearchAleftFormValues = {
+    const userAlertSettings: SavedSearchAlertFormValues = {
       name:
         values.name ||
         (isFallbackToGeneratedAlertNamesEnabled ? "" : entity.placeholder),
@@ -104,7 +104,7 @@ export const SavedSearchAlertModal: FC<SavedSearchAlertFormProps> = ({
   }
 
   return (
-    <Formik<SavedSearchAleftFormValues>
+    <Formik<SavedSearchAlertFormValues>
       initialValues={initialValues}
       onSubmit={handleSubmit}
     >

--- a/src/Components/SavedSearchAlert/SavedSearchAlertModal.tsx
+++ b/src/Components/SavedSearchAlert/SavedSearchAlertModal.tsx
@@ -34,6 +34,7 @@ import { DEFAULT_FREQUENCY } from "./constants"
 import { FrequenceRadioButtons } from "./Components/FrequencyRadioButtons"
 import { PriceRangeFilter } from "Components/SavedSearchAlert/Components/PriceRangeFilter"
 import { ConfirmationStepModal } from "Components/SavedSearchAlert/ConfirmationStepModal"
+import { useFeatureFlag } from "System/useFeatureFlag"
 
 interface SavedSearchAlertFormProps {
   entity: SavedSearchEntity
@@ -61,6 +62,9 @@ export const SavedSearchAlertModal: FC<SavedSearchAlertFormProps> = ({
 }) => {
   const { relayEnvironment } = useSystemContext()
   const { pills, criteria, removeCriteriaValue } = useSavedSearchAlertContext()
+  const isFallbackToGeneratedAlertNamesEnabled = useFeatureFlag(
+    "onyx_force-fallback-to-generated-alert-names"
+  )
 
   const handleRemovePillPress = (pill: FilterPill) => {
     if (pill.isDefault) {
@@ -76,7 +80,9 @@ export const SavedSearchAlertModal: FC<SavedSearchAlertFormProps> = ({
     }
 
     const userAlertSettings: SavedSearchAleftFormValues = {
-      name: values.name || entity.placeholder,
+      name:
+        values.name ||
+        (isFallbackToGeneratedAlertNamesEnabled ? "" : entity.placeholder),
       email: values.email,
       push: values.push,
       frequency: values.push ? values.frequency : DEFAULT_FREQUENCY,
@@ -133,7 +139,11 @@ export const SavedSearchAlertModal: FC<SavedSearchAlertFormProps> = ({
               <Input
                 title="Alert Name"
                 name="name"
-                placeholder={entity.placeholder}
+                placeholder={
+                  isFallbackToGeneratedAlertNamesEnabled
+                    ? undefined
+                    : entity.placeholder
+                }
                 value={values.name}
                 onChange={handleChange("name")}
                 onBlur={handleBlur("name")}

--- a/src/Components/SavedSearchAlert/__tests__/SavedSearchAlertModal.jest.tsx
+++ b/src/Components/SavedSearchAlert/__tests__/SavedSearchAlertModal.jest.tsx
@@ -8,12 +8,12 @@ import {
   SavedSearchAlertFormContainerProps,
 } from "Components/SavedSearchAlert/SavedSearchAlertModal"
 import {
-  SavedSearchAleftFormValues,
+  SavedSearchAlertFormValues,
   SavedSearchEntity,
   SearchCriteriaAttributes,
 } from "Components/SavedSearchAlert/types"
 
-const formInitialValues: SavedSearchAleftFormValues = {
+const formInitialValues: SavedSearchAlertFormValues = {
   name: "",
   email: true,
   push: false,

--- a/src/Components/SavedSearchAlert/types.ts
+++ b/src/Components/SavedSearchAlert/types.ts
@@ -27,7 +27,7 @@ export interface SavedSearchEntityOwner {
   type: PageOwnerType
   slug: string
   id: string
-  name: string
+  name: string | undefined
 }
 
 export interface SavedSearchEntityCriteria {
@@ -56,7 +56,7 @@ export type FilterPill = {
 
 export type SavedSearchFrequency = "daily" | "instant"
 
-export interface SavedSearchAleftFormValues {
+export interface SavedSearchAlerfFormValues {
   name: string
   email: boolean
   push: boolean

--- a/src/Components/SavedSearchAlert/types.ts
+++ b/src/Components/SavedSearchAlert/types.ts
@@ -56,7 +56,7 @@ export type FilterPill = {
 
 export type SavedSearchFrequency = "daily" | "instant"
 
-export interface SavedSearchAlerfFormValues {
+export interface SavedSearchAlertFormValues {
   name: string
   email: boolean
   push: boolean

--- a/src/__generated__/SavedSearchAlertListItem_item.graphql.ts
+++ b/src/__generated__/SavedSearchAlertListItem_item.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<13aea50abff22cb6c2adb8fb12b10633>>
+ * @generated SignedSource<<464f26f97ae76054bc76b4de49846409>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,7 @@ import { Fragment, ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type SavedSearchAlertListItem_item$data = {
   readonly artistIDs: ReadonlyArray<string> | null;
+  readonly displayName: string;
   readonly href: string;
   readonly internalID: string;
   readonly labels: ReadonlyArray<{
@@ -38,6 +39,13 @@ const node: ReaderFragment = {
       "args": null,
       "kind": "ScalarField",
       "name": "internalID",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "displayName",
       "storageKey": null
     },
     {
@@ -95,6 +103,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "fe0b5b2fbd78d012e3bbf601026a5ece";
+(node as any).hash = "35f469c2e286278b9cbf0d109224ba46";
 
 export default node;

--- a/src/__generated__/SavedSearchAlertsAppRefetchQuery.graphql.ts
+++ b/src/__generated__/SavedSearchAlertsAppRefetchQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f4983c80fb076b6f566fb697870c2799>>
+ * @generated SignedSource<<21d96207d2ae30c3acc25756e4bc9ab8>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -147,6 +147,13 @@ return {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
+                        "name": "displayName",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
                         "name": "artistIDs",
                         "storageKey": null
                       },
@@ -265,12 +272,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f22322436464e7d3f0d87b7696464add",
+    "cacheID": "12d104300be0d38d10a463fb2ddb5ae0",
     "id": null,
     "metadata": {},
     "name": "SavedSearchAlertsAppRefetchQuery",
     "operationKind": "query",
-    "text": "query SavedSearchAlertsAppRefetchQuery(\n  $after: String\n  $count: Int!\n  $sort: SavedSearchesSortEnum\n) {\n  me {\n    ...SavedSearchAlertsApp_me_3P8D4U\n    id\n  }\n}\n\nfragment SavedSearchAlertListItem_item on SearchCriteria {\n  internalID\n  artistIDs\n  href\n  labels {\n    displayValue\n  }\n  userAlertSettings {\n    name\n  }\n}\n\nfragment SavedSearchAlertsApp_me_3P8D4U on Me {\n  savedSearchesConnection(first: $count, after: $after, sort: $sort) {\n    edges {\n      node {\n        internalID\n        ...SavedSearchAlertListItem_item\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query SavedSearchAlertsAppRefetchQuery(\n  $after: String\n  $count: Int!\n  $sort: SavedSearchesSortEnum\n) {\n  me {\n    ...SavedSearchAlertsApp_me_3P8D4U\n    id\n  }\n}\n\nfragment SavedSearchAlertListItem_item on SearchCriteria {\n  internalID\n  displayName\n  artistIDs\n  href\n  labels {\n    displayValue\n  }\n  userAlertSettings {\n    name\n  }\n}\n\nfragment SavedSearchAlertsApp_me_3P8D4U on Me {\n  savedSearchesConnection(first: $count, after: $after, sort: $sort) {\n    edges {\n      node {\n        internalID\n        ...SavedSearchAlertListItem_item\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SavedSearchAlertsApp_Test_Query.graphql.ts
+++ b/src/__generated__/SavedSearchAlertsApp_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7e95b2ff723175497a174201c568d0a9>>
+ * @generated SignedSource<<1c73f70a5b8d33e149b01a6768654a2c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -25,6 +25,7 @@ export type SavedSearchAlertsApp_Test_Query$rawResponse = {
         readonly node: {
           readonly __typename: "SearchCriteria";
           readonly artistIDs: ReadonlyArray<string> | null;
+          readonly displayName: string;
           readonly href: string;
           readonly internalID: string;
           readonly labels: ReadonlyArray<{
@@ -131,6 +132,13 @@ return {
                         "args": null,
                         "kind": "ScalarField",
                         "name": "internalID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "displayName",
                         "storageKey": null
                       },
                       {
@@ -255,12 +263,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "fd3ebff13beb53901ec6c118e7c25673",
+    "cacheID": "311347d5e26fc42d8939f30dfae7a938",
     "id": null,
     "metadata": {},
     "name": "SavedSearchAlertsApp_Test_Query",
     "operationKind": "query",
-    "text": "query SavedSearchAlertsApp_Test_Query {\n  me {\n    ...SavedSearchAlertsApp_me\n    id\n  }\n}\n\nfragment SavedSearchAlertListItem_item on SearchCriteria {\n  internalID\n  artistIDs\n  href\n  labels {\n    displayValue\n  }\n  userAlertSettings {\n    name\n  }\n}\n\nfragment SavedSearchAlertsApp_me on Me {\n  savedSearchesConnection(first: 10, sort: CREATED_AT_DESC) {\n    edges {\n      node {\n        internalID\n        ...SavedSearchAlertListItem_item\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query SavedSearchAlertsApp_Test_Query {\n  me {\n    ...SavedSearchAlertsApp_me\n    id\n  }\n}\n\nfragment SavedSearchAlertListItem_item on SearchCriteria {\n  internalID\n  displayName\n  artistIDs\n  href\n  labels {\n    displayValue\n  }\n  userAlertSettings {\n    name\n  }\n}\n\nfragment SavedSearchAlertsApp_me on Me {\n  savedSearchesConnection(first: 10, sort: CREATED_AT_DESC) {\n    edges {\n      node {\n        internalID\n        ...SavedSearchAlertListItem_item\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/settingsRoutes_SavedSearchAlertsAppQuery.graphql.ts
+++ b/src/__generated__/settingsRoutes_SavedSearchAlertsAppQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f24bb08f1d82bea92b8e3ef1c548b8b0>>
+ * @generated SignedSource<<666173dc04961ad80cbe259bf32ce701>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -104,6 +104,13 @@ return {
                         "args": null,
                         "kind": "ScalarField",
                         "name": "internalID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "displayName",
                         "storageKey": null
                       },
                       {
@@ -228,12 +235,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "377bf13459cdc949ba875c39b58b06a9",
+    "cacheID": "0389c3e1e12508ff0de66abf30690fe0",
     "id": null,
     "metadata": {},
     "name": "settingsRoutes_SavedSearchAlertsAppQuery",
     "operationKind": "query",
-    "text": "query settingsRoutes_SavedSearchAlertsAppQuery {\n  me {\n    ...SavedSearchAlertsApp_me\n    id\n  }\n}\n\nfragment SavedSearchAlertListItem_item on SearchCriteria {\n  internalID\n  artistIDs\n  href\n  labels {\n    displayValue\n  }\n  userAlertSettings {\n    name\n  }\n}\n\nfragment SavedSearchAlertsApp_me on Me {\n  savedSearchesConnection(first: 10, sort: CREATED_AT_DESC) {\n    edges {\n      node {\n        internalID\n        ...SavedSearchAlertListItem_item\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query settingsRoutes_SavedSearchAlertsAppQuery {\n  me {\n    ...SavedSearchAlertsApp_me\n    id\n  }\n}\n\nfragment SavedSearchAlertListItem_item on SearchCriteria {\n  internalID\n  displayName\n  artistIDs\n  href\n  labels {\n    displayValue\n  }\n  userAlertSettings {\n    name\n  }\n}\n\nfragment SavedSearchAlertsApp_me on Me {\n  savedSearchesConnection(first: 10, sort: CREATED_AT_DESC) {\n    edges {\n      node {\n        internalID\n        ...SavedSearchAlertListItem_item\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/settingsRoutes_SavedSearchAlertsQuery.graphql.ts
+++ b/src/__generated__/settingsRoutes_SavedSearchAlertsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e98f0e398880e0bdd19199c1d191b47f>>
+ * @generated SignedSource<<efc386b45ef6de08b01af5188b764627>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -104,6 +104,13 @@ return {
                         "args": null,
                         "kind": "ScalarField",
                         "name": "internalID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "displayName",
                         "storageKey": null
                       },
                       {
@@ -228,12 +235,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "fd78c190ef06f0813046fe24aa9bd691",
+    "cacheID": "55fe6f4969e6c79f3a96d91abf35cbb9",
     "id": null,
     "metadata": {},
     "name": "settingsRoutes_SavedSearchAlertsQuery",
     "operationKind": "query",
-    "text": "query settingsRoutes_SavedSearchAlertsQuery {\n  me {\n    ...SavedSearchAlertsApp_me\n    id\n  }\n}\n\nfragment SavedSearchAlertListItem_item on SearchCriteria {\n  internalID\n  artistIDs\n  href\n  labels {\n    displayValue\n  }\n  userAlertSettings {\n    name\n  }\n}\n\nfragment SavedSearchAlertsApp_me on Me {\n  savedSearchesConnection(first: 10, sort: CREATED_AT_DESC) {\n    edges {\n      node {\n        internalID\n        ...SavedSearchAlertListItem_item\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query settingsRoutes_SavedSearchAlertsQuery {\n  me {\n    ...SavedSearchAlertsApp_me\n    id\n  }\n}\n\nfragment SavedSearchAlertListItem_item on SearchCriteria {\n  internalID\n  displayName\n  artistIDs\n  href\n  labels {\n    displayValue\n  }\n  userAlertSettings {\n    name\n  }\n}\n\nfragment SavedSearchAlertsApp_me on Me {\n  savedSearchesConnection(first: 10, sort: CREATED_AT_DESC) {\n    edges {\n      node {\n        internalID\n        ...SavedSearchAlertListItem_item\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Feat**

Jira: [ONYX-227](https://artsyproduct.atlassian.net/browse/ONYX-227)

### Description

Allow collectors to create an alert without specifying a custom name and fallback to our generated display name which automatically displays the most relevant criteria at a glance.

With the feature flag enabled, the "Alert Name" input placeholder will be empty, and creating/updating an alert with no custom name will trigger the new generated default/fallback name.

**Next Steps**
- Open a similar PR for the app/eigen
- Update the create/edit flows to utilize the previewSavedSearch query field in Metaphysics so we can preview the generated name and formatted pills without formatting client-side.

### Screen Recording

https://www.loom.com/share/6ccad310d13248e5a66e9b0aff289eb9?sid=aa946cc3-ac57-490c-91b0-af74962d6747





[ONYX-227]: https://artsyproduct.atlassian.net/browse/ONYX-227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ