### PR TITLE
feat(artist): feature flags new artwork filter layout

### DIFF
--- a/src/Components/ArtworkFilter/ArtworkFilterCreateAlert.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilterCreateAlert.tsx
@@ -1,6 +1,6 @@
 import { ContextModule, Intent } from "@artsy/cohesion"
 import BellStrokeIcon from "@artsy/icons/BellStrokeIcon"
-import { Button } from "@artsy/palette"
+import { Button, ButtonProps } from "@artsy/palette"
 import { useArtworkFilterContext } from "Components/ArtworkFilter/ArtworkFilterContext"
 import { usePrepareFiltersForPills } from "Components/ArtworkFilter/Utils/usePrepareFiltersForPills"
 import { ProgressiveOnboardingAlertCreate } from "Components/ProgressiveOnboarding/ProgressiveOnboardingAlertCreate"
@@ -12,7 +12,9 @@ import { DEFAULT_METRIC } from "Utils/metrics"
 import { isEmpty } from "lodash"
 import { FC } from "react"
 
-export const ArtworkFilterCreateAlert: FC = () => {
+interface ArtworkFilterCreateAlertProps extends ButtonProps {}
+
+export const ArtworkFilterCreateAlert: FC<ArtworkFilterCreateAlertProps> = props => {
   const { entity } = useSavedSearchAlertContext()
   const { aggregations } = useArtworkFilterContext()
   const filters = usePrepareFiltersForPills()
@@ -52,6 +54,7 @@ export const ArtworkFilterCreateAlert: FC = () => {
                   variant="secondaryBlack"
                   size="small"
                   Icon={BellStrokeIcon}
+                  {...props}
                   onClick={() => {
                     createSkip()
                     readySkip()

--- a/src/Components/ArtworkFilter/ArtworkFilterDrawer.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilterDrawer.tsx
@@ -1,0 +1,63 @@
+import FilterIcon from "@artsy/icons/FilterIcon"
+import {
+  Box,
+  Button,
+  Drawer,
+  Flex,
+  ModalClose,
+  Spacer,
+  Text,
+} from "@artsy/palette"
+import { Z } from "Apps/Components/constants"
+import { FC, ReactNode, useState } from "react"
+
+interface ArtworkFilterDrawerProps {
+  children: ReactNode
+}
+
+export const ArtworkFilterDrawer: FC<ArtworkFilterDrawerProps> = ({
+  children,
+}) => {
+  const [mode, setMode] = useState<"Idle" | "Open">("Idle")
+
+  return (
+    <>
+      <Button
+        variant="tertiary"
+        Icon={FilterIcon}
+        size="small"
+        onClick={() => {
+          setMode("Open")
+        }}
+      >
+        Sort and Filter
+      </Button>
+
+      <Drawer
+        zIndex={Z.dropdown}
+        open={mode === "Open"}
+        onClose={() => {
+          setMode("Idle")
+        }}
+      >
+        <Box p={2} minWidth={375} position="relative">
+          <Flex alignItems="center">
+            <Text variant="xs" flex={1}>
+              Sort & Filter
+            </Text>
+
+            <ModalClose
+              onClick={() => {
+                setMode("Idle")
+              }}
+            />
+          </Flex>
+
+          <Spacer y={4} />
+
+          {children}
+        </Box>
+      </Drawer>
+    </>
+  )
+}

--- a/src/Components/ArtworkFilter/ArtworkFilters/ArtworkSortFilter2.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/ArtworkSortFilter2.tsx
@@ -1,0 +1,32 @@
+import { useArtworkFilterContext } from "Components/ArtworkFilter/ArtworkFilterContext"
+import { Radio, RadioGroup, Spacer } from "@artsy/palette"
+import { FC } from "react"
+import { FilterExpandable } from "Components/ArtworkFilter/ArtworkFilters/FilterExpandable"
+
+export const ArtworkSortFilter2: FC = () => {
+  const { sortOptions, filters, setFilter } = useArtworkFilterContext()
+
+  return (
+    <FilterExpandable label="Sort" expanded>
+      <Spacer y={1} />
+
+      <RadioGroup
+        defaultValue={filters?.sort}
+        onSelect={option => {
+          setFilter("sort", option)
+        }}
+        gap={2}
+      >
+        {(sortOptions || []).map(option => {
+          return (
+            <Radio
+              key={option.value}
+              value={option.value}
+              label={option.text}
+            />
+          )
+        })}
+      </RadioGroup>
+    </FilterExpandable>
+  )
+}

--- a/src/Components/ArtworkFilter/__tests__/ArtworkFilter.jest.tsx
+++ b/src/Components/ArtworkFilter/__tests__/ArtworkFilter.jest.tsx
@@ -262,15 +262,15 @@ describe("ArtworkFilter", () => {
     describe("total count label", () => {
       it("computs total count correctly", () => {
         let label = getTotalCountLabel({ total: "0", isAuctionArtwork: false })
-        expect(label).toEqual("0 Artworks:")
+        expect(label).toEqual("0 Artworks")
         label = getTotalCountLabel({ total: "1", isAuctionArtwork: false })
-        expect(label).toEqual("1 Artwork:")
+        expect(label).toEqual("1 Artwork")
         label = getTotalCountLabel({ total: "10", isAuctionArtwork: false })
-        expect(label).toEqual("10 Artworks:")
+        expect(label).toEqual("10 Artworks")
         label = getTotalCountLabel({ total: "1", isAuctionArtwork: true })
-        expect(label).toEqual("1 Lot:")
+        expect(label).toEqual("1 Lot")
         label = getTotalCountLabel({ total: "10", isAuctionArtwork: true })
-        expect(label).toEqual("10 Lots:")
+        expect(label).toEqual("10 Lots")
       })
 
       it("renders total count", () => {


### PR DESCRIPTION
Closes [DIA-15](https://artsyproduct.atlassian.net/browse/DIA-15)

![](https://static.damonzucconi.com/_capture/jnyXQiSE.png)

This enables the new filter grid via the `diamond_revised-artwork-filters`. (You can enable `diamond_revised-artwork-filters`) for the full experience.

This winds up being easy once we got rid of [the props drilled alerts stuff](https://github.com/artsy/force/pull/12714).

[DIA-15]: https://artsyproduct.atlassian.net/browse/DIA-15?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ