### PR TITLE
feat: handle gravity errors in metaphysics verify address query resolver

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -106,15 +106,6 @@ type addOrderedSetItemSuccess {
   setItem: OrderedSetItem
 }
 
-input AddressInput {
-  addressLine1: String!
-  addressLine2: String
-  city: String
-  country: String!
-  postalCode: String!
-  region: String
-}
-
 type addUserRoleFailure {
   mutationError: GravityMutationError
 }
@@ -15749,7 +15740,7 @@ type Query {
   ): VanityURLEntityType
 
   # Verify a given address.
-  verifyAddress(address: AddressInput!): VerifyAddressType
+  verifyAddress(input: VerifyAddressInput!): VerifyAddressPayload
 
   # A wildcard used to support complex root queries in Relay
   viewer: Viewer
@@ -19284,6 +19275,27 @@ enum VerificationStatuses {
   VERIFIED_WITH_CHANGES
 }
 
+type VerifyAddressFailureType {
+  mutationError: GravityMutationError
+}
+
+input VerifyAddressInput {
+  addressLine1: String!
+  addressLine2: String
+  city: String
+  clientMutationId: String
+  country: String!
+  postalCode: String!
+  region: String
+}
+
+union VerifyAddressMutationType = VerifyAddressFailureType | VerifyAddressType
+
+type VerifyAddressPayload {
+  clientMutationId: String
+  verifyAddressOrError: VerifyAddressMutationType
+}
+
 type VerifyAddressType {
   inputAddress: InputAddressFields!
   suggestedAddresses: [SuggestedAddressFields]!
@@ -20203,7 +20215,7 @@ type Viewer {
   ): VanityURLEntityType
 
   # Verify a given address.
-  verifyAddress(address: AddressInput!): VerifyAddressType
+  verifyAddress(input: VerifyAddressInput!): VerifyAddressPayload
   viewingRoomsConnection(
     after: String
     first: Int

--- a/src/Apps/Order/Components/AddressVerificationFlow.tsx
+++ b/src/Apps/Order/Components/AddressVerificationFlow.tsx
@@ -218,7 +218,7 @@ const AddressVerificationFlow: React.FC<AddressVerificationFlowProps> = ({
         context_page_owner_id: contextPageOwnerSlug,
         user_id: userId,
         flow: "user adding shipping address",
-        subject: "Check your delivery address",
+        subject: "Check your delivery address (error)",
         option: "review and confirm",
       })
     } else {

--- a/src/Apps/Order/Components/AddressVerificationFlow.tsx
+++ b/src/Apps/Order/Components/AddressVerificationFlow.tsx
@@ -176,13 +176,16 @@ const AddressVerificationFlow: React.FC<AddressVerificationFlowProps> = ({
 
   const error = (verifyAddress.verifyAddressOrError as VerifyAddressErrorType)
     ?.mutationError
-  const suggestedAddresses =
-    (verifyAddress.verifyAddressOrError as VerifyAddressSuccessType)
-      ?.suggestedAddresses || []
+  const suggestedAddresses = (verifyAddress.verifyAddressOrError as VerifyAddressSuccessType)
+    ?.suggestedAddresses
   const inputAddress = (verifyAddress.verifyAddressOrError as VerifyAddressSuccessType)
     ?.inputAddress
   const verificationStatus = (verifyAddress.verifyAddressOrError as VerifyAddressSuccessType)
     ?.verificationStatus
+
+  const userId = user?.id
+
+  const hasError = Boolean(error)
 
   useEffect(() => {
     const inputOption: AddressOption = {
@@ -198,7 +201,7 @@ const AddressVerificationFlow: React.FC<AddressVerificationFlowProps> = ({
       lines: [formValues],
     }
 
-    if (error) {
+    if (hasError) {
       setAddressOptions([formInput])
       setModalType(ModalType.REVIEW_AND_CONFIRM)
     } else {
@@ -213,13 +216,13 @@ const AddressVerificationFlow: React.FC<AddressVerificationFlowProps> = ({
             context_module: ContextModule.ordersShipping,
             context_page_owner_type: OwnerType.ordersShipping,
             context_page_owner_id: contextPageOwnerSlug,
-            user_id: user?.id,
+            user_id: userId,
             flow: "user adding shipping address",
             subject: "Confirm your delivery address",
             option: "suggestions",
           })
 
-          const suggestedOptions = suggestedAddresses!
+          const suggestedOptions = (suggestedAddresses || [])
             .slice(0, 1)
             .map(({ address, lines }: any, index) => ({
               key: `suggestedAddress-${index}`,
@@ -236,7 +239,7 @@ const AddressVerificationFlow: React.FC<AddressVerificationFlowProps> = ({
             context_module: ContextModule.ordersShipping,
             context_page_owner_type: OwnerType.ordersShipping,
             context_page_owner_id: contextPageOwnerSlug,
-            user_id: user?.id,
+            user_id: userId,
             flow: "user adding shipping address",
             subject: "Check your delivery address",
             option: "review and confirm",
@@ -250,9 +253,9 @@ const AddressVerificationFlow: React.FC<AddressVerificationFlowProps> = ({
     suggestedAddresses,
     verificationStatus,
     trackEvent,
-    user,
+    userId,
     contextPageOwnerSlug,
-    error,
+    hasError,
   ])
 
   if (verificationStatus === "VERIFIED_NO_CHANGE")

--- a/src/Apps/Order/Components/AddressVerificationFlow.tsx
+++ b/src/Apps/Order/Components/AddressVerificationFlow.tsx
@@ -209,18 +209,8 @@ const AddressVerificationFlow: React.FC<AddressVerificationFlowProps> = ({
 
     if (hasError) {
       const fallbackOption = fallbackFromFormValues(verificationInput)
-      setAddressOptions([fallbackOption])
-      setModalType(ModalType.REVIEW_AND_CONFIRM)
-      trackEvent({
-        action_type: "validationAddressViewed",
-        context_module: ContextModule.ordersShipping,
-        context_page_owner_type: OwnerType.ordersShipping,
-        context_page_owner_id: contextPageOwnerSlug,
-        user_id: userId,
-        flow: "user adding shipping address",
-        subject: "Check your delivery address (error)",
-        option: "review and confirm",
-      })
+      const verifiedBy = AddressVerifiedBy.USER
+      onChosenAddress(verifiedBy, fallbackOption.address, true)
     } else {
       if (verificationStatus === "VERIFIED_NO_CHANGE") {
         const verifiedBy = AddressVerifiedBy.ARTSY
@@ -276,7 +266,7 @@ const AddressVerificationFlow: React.FC<AddressVerificationFlowProps> = ({
     verificationInput,
   ])
 
-  if (verificationStatus === "VERIFIED_NO_CHANGE")
+  if (verificationStatus === "VERIFIED_NO_CHANGE" || hasError)
     return <div data-testid="emptyAddressVerification"></div>
 
   if (!modalType || addressOptions.length === 0) return null

--- a/src/Apps/Order/Components/AddressVerificationFlow.tsx
+++ b/src/Apps/Order/Components/AddressVerificationFlow.tsx
@@ -446,7 +446,7 @@ export const AddressVerificationFlowQueryRenderer: React.FC<{
       variables={{ address }}
       render={({ props }) => {
         if (!props?.verifyAddress) {
-          return <div>... loading ... </div>
+          return null
         }
 
         return (

--- a/src/Apps/Order/Components/__tests__/AddressVerificationFlow.jest.tsx
+++ b/src/Apps/Order/Components/__tests__/AddressVerificationFlow.jest.tsx
@@ -83,8 +83,7 @@ describe("AddressVerificationFlow", () => {
         fieldErrors: [{ message: "oh no", name: "Errorik" }],
       },
     }
-
-    it("displays the 'check your address modal similar to NOT_FOUND'", async () => {
+    it("calls onChosenAddress, verified by USER without displaying a modal or tracking", async () => {
       renderWithRelay(
         {
           VerifyAddressMutationType: () => mockError,
@@ -93,67 +92,14 @@ describe("AddressVerificationFlow", () => {
         componentProps
       )
 
-      await screen.findByText("Check your delivery address")
-      const body =
-        "The address you entered may be incorrect or incomplete. Please check it and make any changes necessary."
-      expect(screen.getByText(body)).toBeInTheDocument()
-      expect(screen.getByText("What you entered")).toBeInTheDocument()
-      expect(screen.getByText("Use This Address")).toBeInTheDocument()
-      expect(screen.getByText("Edit Address")).toBeInTheDocument()
-
-      // These values come from the input address, not the verification result
-      // and are constructed locally
-      expect(screen.getByText("401 Broadway")).toBeInTheDocument()
-      expect(screen.getByText("Suite 25")).toBeInTheDocument()
-      expect(screen.getByText("New York, NY 10013")).toBeInTheDocument()
-      expect(screen.getByText("US")).toBeInTheDocument()
-
-      await screen.findByText("Check your delivery address")
-
-      expect(trackEvent).toHaveBeenCalledTimes(1)
-      expect(trackEvent).toHaveBeenCalledWith({
-        action_type: "validationAddressViewed",
-        context_module: "ordersShipping",
-        context_page_owner_id: undefined,
-        context_page_owner_type: "orders-shipping",
-        flow: "user adding shipping address",
-        option: "review and confirm",
-        subject: "Check your delivery address (error)",
-        user_id: undefined,
-      })
-    })
-
-    it("can be selected similar to NOT_FOUND", async () => {
-      renderWithRelay(
-        {
-          VerifyAddressMutationType: () => mockError,
-        },
-        undefined,
-        componentProps
-      )
-
-      await screen.findByText("Check your delivery address")
-
-      const button = screen.getByText("Use This Address")
-      button.click()
-
+      await screen.findByTestId("emptyAddressVerification")
       expect(mockOnChosenAddress).toHaveBeenCalledTimes(1)
       expect(mockOnChosenAddress).toHaveBeenCalledWith(
         "USER",
         mockInputAddress,
-        false
+        true
       )
-
-      expect(trackEvent).toHaveBeenCalledTimes(2)
-      expect(trackEvent).toHaveBeenNthCalledWith(2, {
-        action_type: "clickedValidationAddress",
-        context_module: "ordersShipping",
-        context_page_owner_id: undefined,
-        context_page_owner_type: "orders-shipping",
-        label: "Use This Address",
-        subject: "Check your delivery address",
-        user_id: undefined,
-      })
+      expect(trackEvent).not.toHaveBeenCalled()
     })
   })
 
@@ -254,7 +200,7 @@ describe("AddressVerificationFlow", () => {
   describe("when the verification status is VERIFIED_NO_CHANGE", () => {
     const verificationStatus = "VERIFIED_NO_CHANGE"
 
-    it("calls onChosenAddress without displaying a modal", async () => {
+    it("calls onChosenAddress, verified by ARTSY without displaying a modal", async () => {
       renderWithRelay(
         {
           VerifyAddressMutationType: () => ({

--- a/src/Apps/Order/Components/__tests__/AddressVerificationFlow.jest.tsx
+++ b/src/Apps/Order/Components/__tests__/AddressVerificationFlow.jest.tsx
@@ -118,7 +118,7 @@ describe("AddressVerificationFlow", () => {
         context_page_owner_type: "orders-shipping",
         flow: "user adding shipping address",
         option: "review and confirm",
-        subject: "Check your delivery address",
+        subject: "Check your delivery address (error)",
         user_id: undefined,
       })
     })

--- a/src/Apps/Order/Components/__tests__/AddressVerificationFlow.jest.tsx
+++ b/src/Apps/Order/Components/__tests__/AddressVerificationFlow.jest.tsx
@@ -30,9 +30,9 @@ const { renderWithRelay } = setupTestWrapperTL<
 >({
   Component: AddressVerificationFlowFragmentContainer,
   query: graphql`
-    query AddressVerificationFlow_Test_Query($address: AddressInput!)
+    query AddressVerificationFlow_Test_Query($address: VerifyAddressInput!)
       @relay_test_operation {
-      verifyAddress(address: $address) {
+      verifyAddress(input: $address) {
         ...AddressVerificationFlow_verifyAddress
       }
     }

--- a/src/__generated__/AddressVerificationFlowQuery.graphql.ts
+++ b/src/__generated__/AddressVerificationFlowQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e122403e61456c1c2272093675069b67>>
+ * @generated SignedSource<<4f576ee528ba3ed8e219f5965a24ae9c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,16 +10,17 @@
 
 import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type AddressInput = {
+export type VerifyAddressInput = {
   addressLine1: string;
   addressLine2?: string | null;
   city?: string | null;
+  clientMutationId?: string | null;
   country: string;
   postalCode: string;
   region?: string | null;
 };
 export type AddressVerificationFlowQuery$variables = {
-  address: AddressInput;
+  address: VerifyAddressInput;
 };
 export type AddressVerificationFlowQuery$data = {
   readonly verifyAddress: {
@@ -42,7 +43,7 @@ var v0 = [
 v1 = [
   {
     "kind": "Variable",
-    "name": "address",
+    "name": "input",
     "variableName": "address"
   }
 ],
@@ -107,7 +108,7 @@ return {
       {
         "alias": null,
         "args": (v1/*: any*/),
-        "concreteType": "VerifyAddressType",
+        "concreteType": "VerifyAddressPayload",
         "kind": "LinkedField",
         "name": "verifyAddress",
         "plural": false,
@@ -133,7 +134,7 @@ return {
       {
         "alias": null,
         "args": (v1/*: any*/),
-        "concreteType": "VerifyAddressType",
+        "concreteType": "VerifyAddressPayload",
         "kind": "LinkedField",
         "name": "verifyAddress",
         "plural": false,
@@ -141,52 +142,116 @@ return {
           {
             "alias": null,
             "args": null,
-            "concreteType": "InputAddressFields",
+            "concreteType": null,
             "kind": "LinkedField",
-            "name": "inputAddress",
+            "name": "verifyAddressOrError",
             "plural": false,
             "selections": [
-              (v2/*: any*/),
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "InputAddress",
-                "kind": "LinkedField",
-                "name": "address",
-                "plural": false,
-                "selections": (v3/*: any*/),
+                "kind": "ScalarField",
+                "name": "__typename",
                 "storageKey": null
-              }
-            ],
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "SuggestedAddressFields",
-            "kind": "LinkedField",
-            "name": "suggestedAddresses",
-            "plural": true,
-            "selections": [
-              (v2/*: any*/),
+              },
               {
-                "alias": null,
-                "args": null,
-                "concreteType": "SuggestedAddress",
-                "kind": "LinkedField",
-                "name": "address",
-                "plural": false,
-                "selections": (v3/*: any*/),
-                "storageKey": null
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "InputAddressFields",
+                    "kind": "LinkedField",
+                    "name": "inputAddress",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "InputAddress",
+                        "kind": "LinkedField",
+                        "name": "address",
+                        "plural": false,
+                        "selections": (v3/*: any*/),
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "SuggestedAddressFields",
+                    "kind": "LinkedField",
+                    "name": "suggestedAddresses",
+                    "plural": true,
+                    "selections": [
+                      (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "SuggestedAddress",
+                        "kind": "LinkedField",
+                        "name": "address",
+                        "plural": false,
+                        "selections": (v3/*: any*/),
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "verificationStatus",
+                    "storageKey": null
+                  }
+                ],
+                "type": "VerifyAddressType",
+                "abstractKey": null
+              },
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "GravityMutationError",
+                    "kind": "LinkedField",
+                    "name": "mutationError",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "type",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "message",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "statusCode",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "VerifyAddressFailureType",
+                "abstractKey": null
               }
             ],
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "verificationStatus",
             "storageKey": null
           }
         ],
@@ -195,16 +260,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "01f44d47aa39b335ffa23007d00cd289",
+    "cacheID": "fd4afe0d503bcde5e5bf5b0b6decdb60",
     "id": null,
     "metadata": {},
     "name": "AddressVerificationFlowQuery",
     "operationKind": "query",
-    "text": "query AddressVerificationFlowQuery(\n  $address: AddressInput!\n) {\n  verifyAddress(address: $address) {\n    ...AddressVerificationFlow_verifyAddress\n  }\n}\n\nfragment AddressVerificationFlow_verifyAddress on VerifyAddressType {\n  inputAddress {\n    lines\n    address {\n      addressLine1\n      addressLine2\n      city\n      country\n      postalCode\n      region\n    }\n  }\n  suggestedAddresses {\n    lines\n    address {\n      addressLine1\n      addressLine2\n      city\n      country\n      postalCode\n      region\n    }\n  }\n  verificationStatus\n}\n"
+    "text": "query AddressVerificationFlowQuery(\n  $address: VerifyAddressInput!\n) {\n  verifyAddress(input: $address) {\n    ...AddressVerificationFlow_verifyAddress\n  }\n}\n\nfragment AddressVerificationFlow_verifyAddress on VerifyAddressPayload {\n  verifyAddressOrError {\n    __typename\n    ... on VerifyAddressType {\n      inputAddress {\n        lines\n        address {\n          addressLine1\n          addressLine2\n          city\n          country\n          postalCode\n          region\n        }\n      }\n      suggestedAddresses {\n        lines\n        address {\n          addressLine1\n          addressLine2\n          city\n          country\n          postalCode\n          region\n        }\n      }\n      verificationStatus\n    }\n    ... on VerifyAddressFailureType {\n      mutationError {\n        type\n        message\n        statusCode\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "2cc68455d9f5588f2331a3dc8bdc6942";
+(node as any).hash = "31cd5f4d8f169b96f099ac32b701be30";
 
 export default node;

--- a/src/__generated__/AddressVerificationFlow_Test_Query.graphql.ts
+++ b/src/__generated__/AddressVerificationFlow_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1a1825afd5694c1de007ac661b194cfe>>
+ * @generated SignedSource<<75a1e8ee116c9c32e49e7c4d4968bf52>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,16 +10,17 @@
 
 import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type AddressInput = {
+export type VerifyAddressInput = {
   addressLine1: string;
   addressLine2?: string | null;
   city?: string | null;
+  clientMutationId?: string | null;
   country: string;
   postalCode: string;
   region?: string | null;
 };
 export type AddressVerificationFlow_Test_Query$variables = {
-  address: AddressInput;
+  address: VerifyAddressInput;
 };
 export type AddressVerificationFlow_Test_Query$data = {
   readonly verifyAddress: {
@@ -42,7 +43,7 @@ var v0 = [
 v1 = [
   {
     "kind": "Variable",
-    "name": "address",
+    "name": "input",
     "variableName": "address"
   }
 ],
@@ -125,7 +126,7 @@ return {
       {
         "alias": null,
         "args": (v1/*: any*/),
-        "concreteType": "VerifyAddressType",
+        "concreteType": "VerifyAddressPayload",
         "kind": "LinkedField",
         "name": "verifyAddress",
         "plural": false,
@@ -151,7 +152,7 @@ return {
       {
         "alias": null,
         "args": (v1/*: any*/),
-        "concreteType": "VerifyAddressType",
+        "concreteType": "VerifyAddressPayload",
         "kind": "LinkedField",
         "name": "verifyAddress",
         "plural": false,
@@ -159,52 +160,116 @@ return {
           {
             "alias": null,
             "args": null,
-            "concreteType": "InputAddressFields",
+            "concreteType": null,
             "kind": "LinkedField",
-            "name": "inputAddress",
+            "name": "verifyAddressOrError",
             "plural": false,
             "selections": [
-              (v2/*: any*/),
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "InputAddress",
-                "kind": "LinkedField",
-                "name": "address",
-                "plural": false,
-                "selections": (v3/*: any*/),
+                "kind": "ScalarField",
+                "name": "__typename",
                 "storageKey": null
-              }
-            ],
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "SuggestedAddressFields",
-            "kind": "LinkedField",
-            "name": "suggestedAddresses",
-            "plural": true,
-            "selections": [
-              (v2/*: any*/),
+              },
               {
-                "alias": null,
-                "args": null,
-                "concreteType": "SuggestedAddress",
-                "kind": "LinkedField",
-                "name": "address",
-                "plural": false,
-                "selections": (v3/*: any*/),
-                "storageKey": null
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "InputAddressFields",
+                    "kind": "LinkedField",
+                    "name": "inputAddress",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "InputAddress",
+                        "kind": "LinkedField",
+                        "name": "address",
+                        "plural": false,
+                        "selections": (v3/*: any*/),
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "SuggestedAddressFields",
+                    "kind": "LinkedField",
+                    "name": "suggestedAddresses",
+                    "plural": true,
+                    "selections": [
+                      (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "SuggestedAddress",
+                        "kind": "LinkedField",
+                        "name": "address",
+                        "plural": false,
+                        "selections": (v3/*: any*/),
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "verificationStatus",
+                    "storageKey": null
+                  }
+                ],
+                "type": "VerifyAddressType",
+                "abstractKey": null
+              },
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "GravityMutationError",
+                    "kind": "LinkedField",
+                    "name": "mutationError",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "type",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "message",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "statusCode",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "VerifyAddressFailureType",
+                "abstractKey": null
               }
             ],
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "verificationStatus",
             "storageKey": null
           }
         ],
@@ -213,7 +278,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "24e425ce3f99ac0b06d0e2522e50c45d",
+    "cacheID": "74290259e39657f12c9d0bcc8e0ac38f",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -221,47 +286,68 @@ return {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "VerifyAddressType"
+          "type": "VerifyAddressPayload"
         },
-        "verifyAddress.inputAddress": {
+        "verifyAddress.verifyAddressOrError": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "VerifyAddressMutationType"
+        },
+        "verifyAddress.verifyAddressOrError.__typename": (v4/*: any*/),
+        "verifyAddress.verifyAddressOrError.inputAddress": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "InputAddressFields"
         },
-        "verifyAddress.inputAddress.address": {
+        "verifyAddress.verifyAddressOrError.inputAddress.address": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "InputAddress"
         },
-        "verifyAddress.inputAddress.address.addressLine1": (v4/*: any*/),
-        "verifyAddress.inputAddress.address.addressLine2": (v5/*: any*/),
-        "verifyAddress.inputAddress.address.city": (v4/*: any*/),
-        "verifyAddress.inputAddress.address.country": (v4/*: any*/),
-        "verifyAddress.inputAddress.address.postalCode": (v4/*: any*/),
-        "verifyAddress.inputAddress.address.region": (v5/*: any*/),
-        "verifyAddress.inputAddress.lines": (v6/*: any*/),
-        "verifyAddress.suggestedAddresses": {
+        "verifyAddress.verifyAddressOrError.inputAddress.address.addressLine1": (v4/*: any*/),
+        "verifyAddress.verifyAddressOrError.inputAddress.address.addressLine2": (v5/*: any*/),
+        "verifyAddress.verifyAddressOrError.inputAddress.address.city": (v4/*: any*/),
+        "verifyAddress.verifyAddressOrError.inputAddress.address.country": (v4/*: any*/),
+        "verifyAddress.verifyAddressOrError.inputAddress.address.postalCode": (v4/*: any*/),
+        "verifyAddress.verifyAddressOrError.inputAddress.address.region": (v5/*: any*/),
+        "verifyAddress.verifyAddressOrError.inputAddress.lines": (v6/*: any*/),
+        "verifyAddress.verifyAddressOrError.mutationError": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "GravityMutationError"
+        },
+        "verifyAddress.verifyAddressOrError.mutationError.message": (v4/*: any*/),
+        "verifyAddress.verifyAddressOrError.mutationError.statusCode": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Int"
+        },
+        "verifyAddress.verifyAddressOrError.mutationError.type": (v5/*: any*/),
+        "verifyAddress.verifyAddressOrError.suggestedAddresses": {
           "enumValues": null,
           "nullable": false,
           "plural": true,
           "type": "SuggestedAddressFields"
         },
-        "verifyAddress.suggestedAddresses.address": {
+        "verifyAddress.verifyAddressOrError.suggestedAddresses.address": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SuggestedAddress"
         },
-        "verifyAddress.suggestedAddresses.address.addressLine1": (v4/*: any*/),
-        "verifyAddress.suggestedAddresses.address.addressLine2": (v5/*: any*/),
-        "verifyAddress.suggestedAddresses.address.city": (v4/*: any*/),
-        "verifyAddress.suggestedAddresses.address.country": (v4/*: any*/),
-        "verifyAddress.suggestedAddresses.address.postalCode": (v4/*: any*/),
-        "verifyAddress.suggestedAddresses.address.region": (v5/*: any*/),
-        "verifyAddress.suggestedAddresses.lines": (v6/*: any*/),
-        "verifyAddress.verificationStatus": {
+        "verifyAddress.verifyAddressOrError.suggestedAddresses.address.addressLine1": (v4/*: any*/),
+        "verifyAddress.verifyAddressOrError.suggestedAddresses.address.addressLine2": (v5/*: any*/),
+        "verifyAddress.verifyAddressOrError.suggestedAddresses.address.city": (v4/*: any*/),
+        "verifyAddress.verifyAddressOrError.suggestedAddresses.address.country": (v4/*: any*/),
+        "verifyAddress.verifyAddressOrError.suggestedAddresses.address.postalCode": (v4/*: any*/),
+        "verifyAddress.verifyAddressOrError.suggestedAddresses.address.region": (v5/*: any*/),
+        "verifyAddress.verifyAddressOrError.suggestedAddresses.lines": (v6/*: any*/),
+        "verifyAddress.verifyAddressOrError.verificationStatus": {
           "enumValues": [
             "NOT_FOUND",
             "NOT_PERFORMED",
@@ -277,11 +363,11 @@ return {
     },
     "name": "AddressVerificationFlow_Test_Query",
     "operationKind": "query",
-    "text": "query AddressVerificationFlow_Test_Query(\n  $address: AddressInput!\n) {\n  verifyAddress(address: $address) {\n    ...AddressVerificationFlow_verifyAddress\n  }\n}\n\nfragment AddressVerificationFlow_verifyAddress on VerifyAddressType {\n  inputAddress {\n    lines\n    address {\n      addressLine1\n      addressLine2\n      city\n      country\n      postalCode\n      region\n    }\n  }\n  suggestedAddresses {\n    lines\n    address {\n      addressLine1\n      addressLine2\n      city\n      country\n      postalCode\n      region\n    }\n  }\n  verificationStatus\n}\n"
+    "text": "query AddressVerificationFlow_Test_Query(\n  $address: VerifyAddressInput!\n) {\n  verifyAddress(input: $address) {\n    ...AddressVerificationFlow_verifyAddress\n  }\n}\n\nfragment AddressVerificationFlow_verifyAddress on VerifyAddressPayload {\n  verifyAddressOrError {\n    __typename\n    ... on VerifyAddressType {\n      inputAddress {\n        lines\n        address {\n          addressLine1\n          addressLine2\n          city\n          country\n          postalCode\n          region\n        }\n      }\n      suggestedAddresses {\n        lines\n        address {\n          addressLine1\n          addressLine2\n          city\n          country\n          postalCode\n          region\n        }\n      }\n      verificationStatus\n    }\n    ... on VerifyAddressFailureType {\n      mutationError {\n        type\n        message\n        statusCode\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "f9ed0de239e1632f8b2c4a3fa40f8d63";
+(node as any).hash = "33002f652097a89ebf5cc1ee9262fe9e";
 
 export default node;

--- a/src/__generated__/AddressVerificationFlow_verifyAddress.graphql.ts
+++ b/src/__generated__/AddressVerificationFlow_verifyAddress.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d6410b273f262533be6f588a51fe144c>>
+ * @generated SignedSource<<fda14fac03ad195d14bbf0c11a98629a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,7 +13,15 @@ export type VerificationStatuses = "NOT_FOUND" | "NOT_PERFORMED" | "VERIFICATION
 import { FragmentRefs } from "relay-runtime";
 export type AddressVerificationFlow_verifyAddress$data = {
   readonly verifyAddressOrError: {
-    readonly inputAddress?: {
+    readonly __typename: "VerifyAddressFailureType";
+    readonly mutationError: {
+      readonly message: string;
+      readonly statusCode: number | null;
+      readonly type: string | null;
+    } | null;
+  } | {
+    readonly __typename: "VerifyAddressType";
+    readonly inputAddress: {
       readonly address: {
         readonly addressLine1: string;
         readonly addressLine2: string | null;
@@ -24,12 +32,7 @@ export type AddressVerificationFlow_verifyAddress$data = {
       } | null;
       readonly lines: ReadonlyArray<string | null> | null;
     };
-    readonly mutationError?: {
-      readonly message: string;
-      readonly statusCode: number | null;
-      readonly type: string | null;
-    } | null;
-    readonly suggestedAddresses?: ReadonlyArray<{
+    readonly suggestedAddresses: ReadonlyArray<{
       readonly address: {
         readonly addressLine1: string;
         readonly addressLine2: string | null;
@@ -40,7 +43,11 @@ export type AddressVerificationFlow_verifyAddress$data = {
       } | null;
       readonly lines: ReadonlyArray<string | null> | null;
     } | null>;
-    readonly verificationStatus?: VerificationStatuses;
+    readonly verificationStatus: VerificationStatuses;
+  } | {
+    // This will never be '%other', but we need some
+    // value in case none of the concrete values match.
+    readonly __typename: "%other";
   } | null;
   readonly " $fragmentType": "AddressVerificationFlow_verifyAddress";
 };
@@ -115,6 +122,13 @@ return {
       "name": "verifyAddressOrError",
       "plural": false,
       "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "__typename",
+          "storageKey": null
+        },
         {
           "kind": "InlineFragment",
           "selections": [
@@ -221,6 +235,6 @@ return {
 };
 })();
 
-(node as any).hash = "cb5608ca3f58c8a79579d1caa0e349ba";
+(node as any).hash = "b8978b3664eccfdd5cb181d5a78e78aa";
 
 export default node;

--- a/src/__generated__/AddressVerificationFlow_verifyAddress.graphql.ts
+++ b/src/__generated__/AddressVerificationFlow_verifyAddress.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c83c0b305bfafb03d2471b403942050e>>
+ * @generated SignedSource<<d6410b273f262533be6f588a51fe144c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,29 +12,36 @@ import { Fragment, ReaderFragment } from 'relay-runtime';
 export type VerificationStatuses = "NOT_FOUND" | "NOT_PERFORMED" | "VERIFICATION_UNAVAILABLE" | "VERIFIED_NO_CHANGE" | "VERIFIED_WITH_CHANGES" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type AddressVerificationFlow_verifyAddress$data = {
-  readonly inputAddress: {
-    readonly address: {
-      readonly addressLine1: string;
-      readonly addressLine2: string | null;
-      readonly city: string;
-      readonly country: string;
-      readonly postalCode: string;
-      readonly region: string | null;
+  readonly verifyAddressOrError: {
+    readonly inputAddress?: {
+      readonly address: {
+        readonly addressLine1: string;
+        readonly addressLine2: string | null;
+        readonly city: string;
+        readonly country: string;
+        readonly postalCode: string;
+        readonly region: string | null;
+      } | null;
+      readonly lines: ReadonlyArray<string | null> | null;
+    };
+    readonly mutationError?: {
+      readonly message: string;
+      readonly statusCode: number | null;
+      readonly type: string | null;
     } | null;
-    readonly lines: ReadonlyArray<string | null> | null;
-  };
-  readonly suggestedAddresses: ReadonlyArray<{
-    readonly address: {
-      readonly addressLine1: string;
-      readonly addressLine2: string | null;
-      readonly city: string;
-      readonly country: string;
-      readonly postalCode: string;
-      readonly region: string | null;
-    } | null;
-    readonly lines: ReadonlyArray<string | null> | null;
-  } | null>;
-  readonly verificationStatus: VerificationStatuses;
+    readonly suggestedAddresses?: ReadonlyArray<{
+      readonly address: {
+        readonly addressLine1: string;
+        readonly addressLine2: string | null;
+        readonly city: string;
+        readonly country: string;
+        readonly postalCode: string;
+        readonly region: string | null;
+      } | null;
+      readonly lines: ReadonlyArray<string | null> | null;
+    } | null>;
+    readonly verificationStatus?: VerificationStatuses;
+  } | null;
   readonly " $fragmentType": "AddressVerificationFlow_verifyAddress";
 };
 export type AddressVerificationFlow_verifyAddress$key = {
@@ -103,60 +110,117 @@ return {
     {
       "alias": null,
       "args": null,
-      "concreteType": "InputAddressFields",
+      "concreteType": null,
       "kind": "LinkedField",
-      "name": "inputAddress",
+      "name": "verifyAddressOrError",
       "plural": false,
       "selections": [
-        (v0/*: any*/),
         {
-          "alias": null,
-          "args": null,
-          "concreteType": "InputAddress",
-          "kind": "LinkedField",
-          "name": "address",
-          "plural": false,
-          "selections": (v1/*: any*/),
-          "storageKey": null
+          "kind": "InlineFragment",
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "InputAddressFields",
+              "kind": "LinkedField",
+              "name": "inputAddress",
+              "plural": false,
+              "selections": [
+                (v0/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "InputAddress",
+                  "kind": "LinkedField",
+                  "name": "address",
+                  "plural": false,
+                  "selections": (v1/*: any*/),
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "SuggestedAddressFields",
+              "kind": "LinkedField",
+              "name": "suggestedAddresses",
+              "plural": true,
+              "selections": [
+                (v0/*: any*/),
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "SuggestedAddress",
+                  "kind": "LinkedField",
+                  "name": "address",
+                  "plural": false,
+                  "selections": (v1/*: any*/),
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "verificationStatus",
+              "storageKey": null
+            }
+          ],
+          "type": "VerifyAddressType",
+          "abstractKey": null
+        },
+        {
+          "kind": "InlineFragment",
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "GravityMutationError",
+              "kind": "LinkedField",
+              "name": "mutationError",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "type",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "message",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "statusCode",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "type": "VerifyAddressFailureType",
+          "abstractKey": null
         }
       ],
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "SuggestedAddressFields",
-      "kind": "LinkedField",
-      "name": "suggestedAddresses",
-      "plural": true,
-      "selections": [
-        (v0/*: any*/),
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": "SuggestedAddress",
-          "kind": "LinkedField",
-          "name": "address",
-          "plural": false,
-          "selections": (v1/*: any*/),
-          "storageKey": null
-        }
-      ],
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "verificationStatus",
       "storageKey": null
     }
   ],
-  "type": "VerifyAddressType",
+  "type": "VerifyAddressPayload",
   "abstractKey": null
 };
 })();
 
-(node as any).hash = "1cc5e84c3a0a61d8f92bba7d7efbf3a8";
+(node as any).hash = "cb5608ca3f58c8a79579d1caa0e349ba";
 
 export default node;


### PR DESCRIPTION
Must be merged with https://github.com/artsy/metaphysics/pull/5179
Completes [EMI-1286]


This is a rebase of #12703. I put it in a separate PR for comparison in case i missed anything in the rebase to avoid force pushing over that work. The functionality is to handle an error from our address verification service and fall back to our confirmation modal without suggestions. Must be tested against https://github.com/artsy/metaphysics/pull/5179 locally and merged together, as it includes a major schema change used only by this component.

<details><summary>Summary of changes from #12703 </summary>

- rebased the @fladson's branch off of `main`, doing my best to fix merge conflicts
- added tests for the new behavior
- removed a `...loading...` message used in development
- added functionality to fall back to an address based on the user's input in case a gravity error meant that the formatted `inputAddress` lines were not available.

</details> 

Questions:
- Do we want to track viewing this kind of modal differently? Currently it is tracked as any other verification without suggested addresses.
- Tracking code is becoming duplicative. We could move this out into a hook that runs only when the modal renders and eliminate the large `useEffect()` hook which adds a lot of complexity - but that could be a followup.
- The Query Renderer passes an `error` prop that we aren't handling which is different from our schema error. I want to understand how that works so that if it ever pops up we don't block address selection completely.


[EMI-1286]: https://artsyproduct.atlassian.net/browse/EMI-1286?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ