### PR TITLE
chore(ONYX-137): Remove "Recommended" artwork grid sort on show/booth pages

### DIFF
--- a/src/Apps/Show/Components/ShowArtworks.tsx
+++ b/src/Apps/Show/Components/ShowArtworks.tsx
@@ -44,7 +44,6 @@ const ShowArtworksFilter: React.FC<ShowArtworksFilterProps> = props => {
       filters={filters}
       sortOptions={[
         { text: "Gallery Curated", value: "partner_show_position" },
-        { text: "Recommended", value: "-decayed_merch" },
         { text: "Price (High to Low)", value: "-has_price,-prices" },
         { text: "Price (Low to High)", value: "-has_price,prices" },
         { text: "Recently Updated", value: "-partner_updated_at" },


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [ONYX-137]

### Description

<!-- Implementation description -->
| Before | After |
| --- | --- |
| <img width="988" alt="image" src="https://github.com/artsy/force/assets/36167539/95acec73-22c8-4db0-9f20-e7df9c4cbf93"> | <img width="979" alt="image" src="https://github.com/artsy/force/assets/36167539/1010caa3-3eb4-44ef-bac2-bb6a571c278d"> |

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-137]: https://artsyproduct.atlassian.net/browse/ONYX-137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ