### PR TITLE
fix(EMI-1383): style error modal background color

### DIFF
--- a/src/Apps/Order/Components/AddressVerificationFlow.tsx
+++ b/src/Apps/Order/Components/AddressVerificationFlow.tsx
@@ -359,7 +359,12 @@ const AddressVerificationFlow: React.FC<AddressVerificationFlowProps> = ({
           <Spacer y={4} />
           <Text fontWeight="bold">What you entered</Text>
           <Spacer y={1} />
-          <Box border="1px solid" borderColor="black30" p={2}>
+          <Box
+            border="1px solid"
+            borderColor="black5"
+            p={2}
+            backgroundColor="black5"
+          >
             {addressOptions[0]!.lines!.map((line: string) => (
               <Text key={line}>{line}</Text>
             ))}


### PR DESCRIPTION
The type of this PR is: **fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-1383]

### Description

<!-- Implementation description -->
The goal of this pr is to make a quick fix to the generic error modal in the address verification flow to have a light grey background, to make it look less editable based on feedback from QA. Here's the figma design for reference: https://www.figma.com/file/TainZ4UB7crFHJuYzhhx7d/Address-Verification?type=design&node-id=1-12&mode=design&t=emanoboiinbjD2Cn-0

![Screenshot 2023-08-11 at 2 08 34 PM](https://github.com/artsy/force/assets/23108927/9cdc1198-21d4-4c1a-9445-55f850357ca1)




[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EMI-1383]: https://artsyproduct.atlassian.net/browse/EMI-1383?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ