### PR TITLE
fix: preserve suggested address after editing

### DIFF
--- a/src/Components/AddressForm.tsx
+++ b/src/Components/AddressForm.tsx
@@ -2,6 +2,7 @@ import { Column, GridColumns, Text, Spacer, Input } from "@artsy/palette"
 import { CountrySelect } from "Components/CountrySelect"
 import * as React from "react"
 import { CreateTokenCardData } from "@stripe/stripe-js"
+import { isEqual } from "lodash"
 
 export interface Address {
   name: string
@@ -69,7 +70,15 @@ export const AddressForm: React.FC<AddressFormProps> = ({
   touched,
   tabIndex,
 }) => {
-  const [address, setAddress] = React.useState({ ...emptyAddress, ...value })
+  const addressFromProp = { ...emptyAddress, ...value }
+  const [address, setAddress] = React.useState(addressFromProp)
+  const [prevValue, setPrevValue] = React.useState(value)
+
+  if (!isEqual(value, prevValue)) {
+    setPrevValue(value)
+    setAddress(addressFromProp)
+  }
+
   const [key, setKey] = React.useState<keyof Address>()
 
   const changeEventHandler = (key: keyof Address) => (

--- a/src/Components/__tests__/AddressForm.jest.tsx
+++ b/src/Components/__tests__/AddressForm.jest.tsx
@@ -1,0 +1,42 @@
+import { screen, render, fireEvent } from "@testing-library/react"
+import { AddressForm } from "Components/AddressForm"
+import { FC, useState } from "react"
+
+describe("AddressForm", () => {
+  it("preserves updated value from props after user input", () => {
+    const Page: FC = () => {
+      const [address, setAddress] = useState({ addressLine1: "Before update" })
+      const updateAddress = () => {
+        setAddress({ addressLine1: "After update" })
+      }
+
+      return (
+        <>
+          <AddressForm
+            value={address}
+            errors={{}}
+            touched={{}}
+            onChange={address => {
+              setAddress(address)
+            }}
+          />
+          <button onClick={updateAddress}>Update</button>
+        </>
+      )
+    }
+
+    render(<Page />)
+
+    const line1 = screen.getByPlaceholderText(
+      "Street address"
+    ) as HTMLInputElement
+    expect(line1.value).toBe("Before update")
+
+    fireEvent.click(screen.getByText("Update"))
+    expect(line1.value).toBe("After update")
+
+    const city = screen.getByPlaceholderText("City")
+    fireEvent.change(city, { target: { value: "New York" } })
+    expect(line1.value).toBe("After update")
+  })
+})


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [EMI-1388](https://artsyproduct.atlassian.net/browse/EMI-1388)

### Description

Editing address after accepting suggested address resets form with original user inputs. This was due to the `initialState` in `useState` is only used in the initial render and ignored in re-render. This PR also adds a test to cover this scenario. More details in thread.

<details><summary>Before</summary>
<p>
![persist-address-old](https://github.com/artsy/force/assets/796573/99d50d6b-ab7f-4e71-958f-bc02235b6435)


</p>
</details> 

<details><summary>After</summary>
<p>

![persist-address-new](https://github.com/artsy/force/assets/796573/f88fe30d-0c78-45fe-a5b4-048e265b41be)


</p>
</details> 

[EMI-1388]: https://artsyproduct.atlassian.net/browse/EMI-1388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ