### PR TITLE
fix(artist): triggers 2x2 layout at a wider breakpoint

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/Components/MarketStats.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/MarketStats.tsx
@@ -217,7 +217,7 @@ const MarketStatsFigure: FC<MarketStatsFigureProps> = ({
 
   return (
     <Column
-      span={[6, 3]}
+      span={[6, 6, 3]}
       justifyContent="flex-end"
       display="flex"
       flexDirection="column"


### PR DESCRIPTION
Closes [DIA-60](https://artsyproduct.atlassian.net/browse/DIA-60)

At some breakpoints the figures would get truncated. We simply move to a layout that gives them more space, at a wider breakpoint.

[DIA-60]: https://artsyproduct.atlassian.net/browse/DIA-60?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ