### PR TITLE
fix: Extra save & continue click investigation fix

### DIFF
--- a/src/Apps/Order/Components/AddressVerificationFlow.tsx
+++ b/src/Apps/Order/Components/AddressVerificationFlow.tsx
@@ -39,8 +39,7 @@ interface AddressVerificationFlowProps {
   verifyAddress: AddressVerificationFlow_verifyAddress$data
   onChosenAddress: (
     verifiedBy: AddressVerifiedBy,
-    address: AddressValues,
-    saveAndContinue: boolean
+    address: AddressValues
   ) => void
   onClose: () => void
   /* used only as a fallback if verification is unavailable */
@@ -131,7 +130,7 @@ const AddressVerificationFlow: React.FC<AddressVerificationFlowProps> = ({
 
     if (selectedAddress) {
       setModalType(null)
-      onChosenAddress(verifiedBy, selectedAddress.address, true)
+      onChosenAddress(verifiedBy, selectedAddress.address)
     }
   }, [addressOptions, onChosenAddress, selectedAddressKey])
 
@@ -210,11 +209,11 @@ const AddressVerificationFlow: React.FC<AddressVerificationFlowProps> = ({
     if (hasError) {
       const fallbackOption = fallbackFromFormValues(verificationInput)
       const verifiedBy = AddressVerifiedBy.USER
-      onChosenAddress(verifiedBy, fallbackOption.address, true)
+      onChosenAddress(verifiedBy, fallbackOption.address)
     } else {
       if (verificationStatus === "VERIFIED_NO_CHANGE") {
         const verifiedBy = AddressVerifiedBy.ARTSY
-        onChosenAddress(verifiedBy, inputOption.address, true)
+        onChosenAddress(verifiedBy, inputOption.address)
       } else {
         if (verificationStatus === "VERIFIED_WITH_CHANGES") {
           setModalType(ModalType.SUGGESTIONS)
@@ -449,8 +448,7 @@ export const AddressVerificationFlowQueryRenderer: React.FC<{
   address: AddressValues
   onChosenAddress: (
     verifiedBy: AddressVerifiedBy,
-    address: AddressValues,
-    saveAndContinue: boolean
+    address: AddressValues
   ) => void
   onClose: () => void
 }> = ({ address, onChosenAddress, onClose }) => {

--- a/src/Apps/Order/Components/AddressVerificationFlow.tsx
+++ b/src/Apps/Order/Components/AddressVerificationFlow.tsx
@@ -131,7 +131,7 @@ const AddressVerificationFlow: React.FC<AddressVerificationFlowProps> = ({
 
     if (selectedAddress) {
       setModalType(null)
-      onChosenAddress(verifiedBy, selectedAddress.address, false)
+      onChosenAddress(verifiedBy, selectedAddress.address, true)
     }
   }, [addressOptions, onChosenAddress, selectedAddressKey])
 

--- a/src/Apps/Order/Components/__tests__/AddressVerificationFlow.jest.tsx
+++ b/src/Apps/Order/Components/__tests__/AddressVerificationFlow.jest.tsx
@@ -112,11 +112,7 @@ describe("AddressVerificationFlow", () => {
 
       await screen.findByTestId("emptyAddressVerification")
       expect(mockOnChosenAddress).toHaveBeenCalledTimes(1)
-      expect(mockOnChosenAddress).toHaveBeenCalledWith(
-        "USER",
-        mockInputAddress,
-        true
-      )
+      expect(mockOnChosenAddress).toHaveBeenCalledWith("USER", mockInputAddress)
       expect(trackEvent).not.toHaveBeenCalled()
     })
   })
@@ -181,8 +177,7 @@ describe("AddressVerificationFlow", () => {
       expect(mockOnChosenAddress).toHaveBeenCalledTimes(1)
       expect(mockOnChosenAddress).toHaveBeenCalledWith(
         "USER",
-        mockResult.inputAddress.address,
-        false
+        mockResult.inputAddress.address
       )
 
       expect(trackEvent).toHaveBeenCalledTimes(2)
@@ -208,8 +203,7 @@ describe("AddressVerificationFlow", () => {
       expect(mockOnChosenAddress).toHaveBeenCalledTimes(1)
       expect(mockOnChosenAddress).toHaveBeenCalledWith(
         "ARTSY",
-        mockInputAddress,
-        true
+        mockInputAddress
       )
       expect(trackEvent).not.toHaveBeenCalled()
     })
@@ -292,8 +286,7 @@ describe("AddressVerificationFlow", () => {
       expect(mockOnChosenAddress).toHaveBeenCalledTimes(1)
       expect(mockOnChosenAddress).toHaveBeenCalledWith(
         "ARTSY",
-        mockResult.suggestedAddresses[0].address,
-        false
+        mockResult.suggestedAddresses[0].address
       )
     })
 
@@ -320,11 +313,7 @@ describe("AddressVerificationFlow", () => {
       })
 
       expect(mockOnChosenAddress).toHaveBeenCalledTimes(1)
-      expect(mockOnChosenAddress).toHaveBeenCalledWith(
-        "USER",
-        mockInputAddress,
-        false
-      )
+      expect(mockOnChosenAddress).toHaveBeenCalledWith("USER", mockInputAddress)
     })
 
     it("calls onClose and tracks the click with the user closes the modal", async () => {

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -850,7 +850,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
                     setAddress(address => {
                       return { ...address, ...chosenAddress }
                     })
-                    // trigger finalizeAddres() via useEffect
+                    // trigger finalizeFulfillment() via useEffect
                     setReadyToSaveVerifiedAddress(true)
                   }}
                 />

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -131,6 +131,10 @@ export const ShippingRoute: FC<ShippingProps> = props => {
     setAddressVerifiedBy,
   ] = useState<AddressVerifiedBy | null>(null)
 
+  const [readyToSaveVerifiedAddress, setReadyToSaveVerifiedAddress] = useState(
+    false
+  )
+
   const [shippingOption, setShippingOption] = useState<
     CommerceOrderFulfillmentTypeEnum
   >(getShippingOption(props.order.requestedFulfillment?.__typename))
@@ -241,7 +245,9 @@ export const ShippingRoute: FC<ShippingProps> = props => {
   // Save shipping info on the order. If it's Artsy shipping and a quote hasn't
   // been selected, this renders the quotes for user to select and finalize
   // again.
+  console.log({ renderCycle: address })
   const finalizeFulfillment = async () => {
+    console.log({ finalizeFulfillment: address })
     if (checkIfArtsyShipping() && !!shippingQuoteId) {
       selectShippingQuote()
     } else {
@@ -686,6 +692,12 @@ export const ShippingRoute: FC<ShippingProps> = props => {
     return false
   }
 
+  useEffect(() => {
+    if (readyToSaveVerifiedAddress) {
+      finalizeFulfillment()
+    }
+  }, [readyToSaveVerifiedAddress])
+
   const renderArtaErrorMessage = () => {
     return (
       <Text
@@ -838,8 +850,11 @@ export const ShippingRoute: FC<ShippingProps> = props => {
                   ) => {
                     setAddressNeedsVerification(false)
                     setAddressVerifiedBy(verifiedBy)
-                    setAddress({ ...address, ...chosenAddress })
-                    saveAndContinue && finalizeFulfillment()
+                    setAddress(address => {
+                      return { ...address, ...chosenAddress }
+                    })
+                    setReadyToSaveVerifiedAddress(true)
+                    // saveAndContinue && finalizeFulfillment()
                   }}
                 />
               )}

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -850,6 +850,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
                     setAddress(address => {
                       return { ...address, ...chosenAddress }
                     })
+                    // trigger finalizeAddres() via useEffect
                     setReadyToSaveVerifiedAddress(true)
                   }}
                 />

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -844,18 +844,13 @@ export const ShippingRoute: FC<ShippingProps> = props => {
                     setAddressNeedsVerification(false)
                     setAddressVerifiedBy(AddressVerifiedBy.USER)
                   }}
-                  onChosenAddress={(
-                    verifiedBy,
-                    chosenAddress,
-                    saveAndContinue
-                  ) => {
+                  onChosenAddress={(verifiedBy, chosenAddress) => {
                     setAddressNeedsVerification(false)
                     setAddressVerifiedBy(verifiedBy)
                     setAddress(address => {
                       return { ...address, ...chosenAddress }
                     })
                     setReadyToSaveVerifiedAddress(true)
-                    // saveAndContinue && finalizeFulfillment()
                   }}
                 />
               )}

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -245,9 +245,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
   // Save shipping info on the order. If it's Artsy shipping and a quote hasn't
   // been selected, this renders the quotes for user to select and finalize
   // again.
-  console.log({ renderCycle: address })
   const finalizeFulfillment = async () => {
-    console.log({ finalizeFulfillment: address })
     if (checkIfArtsyShipping() && !!shippingQuoteId) {
       selectShippingQuote()
     } else {
@@ -692,10 +690,13 @@ export const ShippingRoute: FC<ShippingProps> = props => {
     return false
   }
 
+  // Automatically proceed after address verification flow is completed.
   useEffect(() => {
     if (readyToSaveVerifiedAddress) {
       finalizeFulfillment()
     }
+    // disabled because we only want this to run when once when readyToSaveVerifiedAddress changes to true
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [readyToSaveVerifiedAddress])
 
   const renderArtaErrorMessage = () => {

--- a/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -206,7 +206,11 @@ class ShippingTestPage extends OrderAppTestPage {
   }
 }
 
-describe("Shipping", () => {
+describe("Shipping [testing-library]", () => {
+  describe("US address verification", () => {})
+})
+
+describe("Shipping [enzyme]", () => {
   const pushMock = jest.fn()
   let isCommittingMutation
 


### PR DESCRIPTION
The type of this PR is: **fix**

Resolves [EMI-1410] and _I think _ [EMI-1397] as well.
This PR solves a bug we currently hack around, creating a negative user experience. Paired with @damassi and @iskounen on it.
cc @artsy/emerald-devs 

### Description

In https://github.com/artsy/force/pull/12684 and #12673 we changed the behavior of our address verification and submission flow to require an additional button click. Initially the thought was that we had a race condition with numerous `useState` variable settings, causing an old address to be sent immediately after confirmation.

While that fix solved the problem, we think the problem was actually that the `onChosenAddress` prop, an anonymous arrow function, was closuring the `finalizeFulfillment()` function, which itself was closuring the `setShipping()` function, which at the time the component was mounted contained an old address.

Both fixes accomplish the same thing - not calling the stale `finalizeFulfillment` closured into the onChosenAddress prop. We initially fixed this by checking for presence of `addressVerifiedBy` (it is null until set by the flow), and sometimes this worked, but other times it triggered an error from simultaneous mutations. Thus to illustrate the problem and potential fix we created a new state variable.

Lacking tests at the shipping route level i think this reserves at least one more round of manual testing for variations on:
- ship vs arta ship
- perfect address vs suggestions vs no suggestions
<!-- Implementation description -->


[EMI-1410]: https://artsyproduct.atlassian.net/browse/EMI-1410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EMI-1397]: https://artsyproduct.atlassian.net/browse/EMI-1397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ