### PR TITLE
fix: add spacing for Market Stats for mobile view

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -240,7 +240,7 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
 
       <Jump id="marketSignalsTop" />
 
-      <Spacer y={2} />
+      <Spacer y={[2, 0]} />
 
       <MarketStatsQueryRenderer
         id={artist.internalID}

--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -240,6 +240,8 @@ const AuctionResultsContainer: React.FC<AuctionResultsProps> = ({
 
       <Jump id="marketSignalsTop" />
 
+      <Spacer y={2} />
+
       <MarketStatsQueryRenderer
         id={artist.internalID}
         onRendered={handleMarketStatsRendered}

--- a/src/Apps/Artist/Routes/AuctionResults/Components/MarketStats.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/MarketStats.tsx
@@ -65,7 +65,6 @@ export const MarketStats: FC<MarketStatsProps> = ({
 
   return (
     <>
-      <Spacer y={30} />
       <Text
         variant={["sm-display", "lg-display"]}
         display="flex"

--- a/src/Apps/Artist/Routes/AuctionResults/Components/MarketStats.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/MarketStats.tsx
@@ -65,6 +65,7 @@ export const MarketStats: FC<MarketStatsProps> = ({
 
   return (
     <>
+      <Spacer y={30} />
       <Text
         variant={["sm-display", "lg-display"]}
         display="flex"

--- a/src/Apps/Artist/Routes/Overview/ArtistOverviewRoute.tsx
+++ b/src/Apps/Artist/Routes/Overview/ArtistOverviewRoute.tsx
@@ -1,4 +1,4 @@
-import { Flex } from "@artsy/palette"
+import { Flex, Spacer } from "@artsy/palette"
 import * as React from "react"
 import { Title, Meta } from "react-head"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -44,6 +44,8 @@ const ArtistOverviewRoute: React.FC<ArtistOverviewRouteProps> = ({
       <Title>{title}</Title>
       <Meta name="title" content={title} />
       <Meta name="description" content={description} />
+
+      <Spacer y={[2, 0]} />
 
       <Flex flexDirection="column" gap={6}>
         <ArtistCareerHighlightsQueryRenderer id={artist.internalID} />


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

I noticed Market Stats needs a bit spacing for mobile view

![Screenshot 2023-08-17 at 12 39 31](https://github.com/artsy/force/assets/1176374/36a831cf-f70a-43d9-a297-c954fbebe943)

![Screenshot 2023-08-17 at 12 39 36](https://github.com/artsy/force/assets/1176374/f9378807-891c-4e17-8771-3df225eb5035)


<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ