### PR TITLE
feat(ONYX-130): add shelf for suggested artworks

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/ArtworkAuctionCreateAlertHeader.tsx
+++ b/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/ArtworkAuctionCreateAlertHeader.tsx
@@ -20,6 +20,7 @@ import { OwnerType } from "@artsy/cohesion"
 import { getAllowedSearchCriteria } from "Components/SavedSearchAlert/Utils/savedSearchCriteria"
 import { Media } from "Utils/Responsive"
 import { ArtworkAuctionCreateAlertTooltip } from "Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/ArtworkAuctionCreateAlertTooltip"
+import { SuggestedArtworksShelfQueryRenderer } from "Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/SuggestedArtworksShelf"
 
 interface ArtworkAuctionCreateAlertHeaderProps {
   artwork: ArtworkAuctionCreateAlertHeader_artwork$data
@@ -123,6 +124,10 @@ const ArtworkAuctionCreateAlertHeader: FC<ArtworkAuctionCreateAlertHeaderProps> 
             <Spacer y={4} />
             <ArtworkAuctionCreateAlertTooltip />
           </Media>
+        </Column>
+
+        <Column span={12}>
+          <SuggestedArtworksShelfQueryRenderer {...criteria} />
         </Column>
 
         <Column span={2} start={6}>

--- a/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/ArtworkAuctionCreateAlertHeader.tsx
+++ b/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/ArtworkAuctionCreateAlertHeader.tsx
@@ -127,7 +127,9 @@ const ArtworkAuctionCreateAlertHeader: FC<ArtworkAuctionCreateAlertHeaderProps> 
         </Column>
 
         <Column span={12}>
-          <SuggestedArtworksShelfQueryRenderer {...criteria} />
+          <Media greaterThan="xs">
+            <SuggestedArtworksShelfQueryRenderer {...criteria} />
+          </Media>
         </Column>
 
         <Column span={2} start={6}>

--- a/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/SuggestedArtworksShelf.tsx
+++ b/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/SuggestedArtworksShelf.tsx
@@ -31,7 +31,7 @@ export const SuggestedArtworksShelf: FC<SuggestedArtworksShelfProps> = ({
         <Flex
           flexDirection="row"
           flexWrap="wrap"
-          gap={1}
+          gap={2}
           justifyContent="center"
         >
           {artworks.map(artwork => (

--- a/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/SuggestedArtworksShelf.tsx
+++ b/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/SuggestedArtworksShelf.tsx
@@ -6,7 +6,7 @@ import {
   SuggestedArtworksShelfQuery,
   SuggestedArtworksShelfQuery$data,
 } from "__generated__/SuggestedArtworksShelfQuery.graphql"
-import { Media } from "Utils/Responsive"
+
 import {
   ShelfArtworkFragmentContainer,
   ShelfArtworkPlaceholder,
@@ -26,24 +26,15 @@ export const SuggestedArtworksShelf: FC<SuggestedArtworksShelfProps> = ({
   const artworks = extractNodes(artworksConnection)
 
   return (
-    <>
-      <Media greaterThan="xs">
-        <Flex
-          flexDirection="row"
-          flexWrap="wrap"
-          gap={2}
-          justifyContent="center"
-        >
-          {artworks.map(artwork => (
-            <ShelfArtworkFragmentContainer
-              artwork={artwork}
-              key={artwork.internalID}
-              data-testid="ShelfSuggestedArtworks"
-            />
-          ))}
-        </Flex>
-      </Media>
-    </>
+    <Flex flexDirection="row" flexWrap="wrap" gap={2} justifyContent="center">
+      {artworks.map(artwork => (
+        <ShelfArtworkFragmentContainer
+          artwork={artwork}
+          key={artwork.internalID}
+          data-testid="ShelfSuggestedArtworks"
+        />
+      ))}
+    </Flex>
   )
 }
 

--- a/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/SuggestedArtworksShelf.tsx
+++ b/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/SuggestedArtworksShelf.tsx
@@ -1,0 +1,107 @@
+import { Flex, Skeleton } from "@artsy/palette"
+import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
+import { FC } from "react"
+import { graphql } from "react-relay"
+import {
+  SuggestedArtworksShelfQuery,
+  SuggestedArtworksShelfQuery$data,
+} from "__generated__/SuggestedArtworksShelfQuery.graphql"
+import { Media } from "Utils/Responsive"
+import {
+  ShelfArtworkFragmentContainer,
+  ShelfArtworkPlaceholder,
+} from "Components/Artwork/ShelfArtwork"
+import { SearchCriteriaAttributes } from "Components/SavedSearchAlert/types"
+import { extractNodes } from "Utils/extractNodes"
+
+export const NUMBER_OF_ARTWORKS_TO_SHOW = 5
+
+interface SuggestedArtworksShelfProps {
+  artworksConnection: SuggestedArtworksShelfQuery$data["artworksConnection"]
+}
+
+export const SuggestedArtworksShelf: FC<SuggestedArtworksShelfProps> = ({
+  artworksConnection,
+}) => {
+  const artworks = extractNodes(artworksConnection)
+
+  return (
+    <>
+      <Media greaterThan="xs">
+        <Flex
+          flexDirection="row"
+          flexWrap="wrap"
+          gap={1}
+          justifyContent="center"
+        >
+          {artworks.map(artwork => (
+            <ShelfArtworkFragmentContainer
+              artwork={artwork}
+              key={artwork.internalID}
+              data-testid="ShelfSuggestedArtworks"
+            />
+          ))}
+        </Flex>
+      </Media>
+    </>
+  )
+}
+
+export const SuggestedArtworksShelfQueryRenderer: FC<SearchCriteriaAttributes> = props => {
+  return (
+    <SystemQueryRenderer<SuggestedArtworksShelfQuery>
+      placeholder={<ContentPlaceholder />}
+      query={graphql`
+        query SuggestedArtworksShelfQuery($input: FilterArtworksInput) {
+          artworksConnection(input: $input) {
+            counts {
+              total
+            }
+            edges {
+              node {
+                ...ShelfArtwork_artwork
+                internalID
+              }
+            }
+          }
+        }
+      `}
+      variables={{
+        input: {
+          first: NUMBER_OF_ARTWORKS_TO_SHOW,
+          sort: "-published_at",
+          forSale: true,
+          ...props,
+        },
+      }}
+      render={({ props: relayProps, error }) => {
+        if (error) {
+          console.error(error)
+          return null
+        }
+
+        if (!relayProps?.artworksConnection) {
+          return <ContentPlaceholder />
+        }
+
+        return (
+          <SuggestedArtworksShelf
+            artworksConnection={relayProps.artworksConnection}
+          />
+        )
+      }}
+    />
+  )
+}
+
+const ContentPlaceholder: FC = () => {
+  return (
+    <Skeleton>
+      <Flex flexDirection="row" flexWrap="wrap" gap={1} justifyContent="center">
+        {[...new Array(5)].map((_, i) => {
+          return <ShelfArtworkPlaceholder key={i} index={i} />
+        })}
+      </Flex>
+    </Skeleton>
+  )
+}

--- a/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/__tests__/SuggestedArtworksShelf.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/__tests__/SuggestedArtworksShelf.jest.tsx
@@ -1,0 +1,90 @@
+import { OwnerType } from "@artsy/cohesion"
+import { SuggestedArtworksShelf } from "Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/SuggestedArtworksShelf"
+import { SavedSearchAlertContextProvider } from "Components/SavedSearchAlert/SavedSearchAlertContext"
+import { SavedSearchEntity } from "Components/SavedSearchAlert/types"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
+import { graphql } from "react-relay"
+import { screen } from "@testing-library/react"
+import { SuggestedArtworksShelf_Test_Query } from "__generated__/SuggestedArtworksShelf_Test_Query.graphql"
+
+jest.unmock("react-relay")
+
+describe("SuggestedArtworksShelf", () => {
+  const savedSearchEntity: SavedSearchEntity = {
+    placeholder: "Test Artist",
+    defaultCriteria: {
+      artistIDs: [
+        {
+          displayValue: "Banksy",
+          value: "4dd1584de0091e000100207c",
+        },
+      ],
+    },
+    owner: {
+      type: OwnerType.artwork,
+      id: "owner-id",
+      slug: "owner-slug",
+      name: "Owner Name",
+    },
+  }
+
+  const criteria = {
+    additionalGeneIDs: ["prints"],
+    artistIDs: ["4dd1584de0091e000100207c"],
+    attributionClass: ["unique"],
+  }
+
+  const { renderWithRelay } = setupTestWrapperTL<
+    SuggestedArtworksShelf_Test_Query
+  >({
+    Component: props => {
+      return (
+        <SavedSearchAlertContextProvider
+          entity={savedSearchEntity}
+          criteria={criteria}
+          aggregations={[]}
+          artistSlug="bansky"
+        >
+          <SuggestedArtworksShelf
+            artworksConnection={props.artworksConnection}
+          />
+        </SavedSearchAlertContextProvider>
+      )
+    },
+    query: graphql`
+      query SuggestedArtworksShelf_Test_Query @relay_test_operation {
+        artworksConnection(first: 5, sort: "-published_at", forSale: true) {
+          counts {
+            total
+          }
+          edges {
+            node {
+              ...ShelfArtwork_artwork
+              internalID
+            }
+          }
+        }
+      }
+    `,
+  })
+
+  it("renders SuggestedArtworkShelf", async () => {
+    renderWithRelay({
+      FilterArtworksConnection: () => ({
+        counts: { total: 11 },
+      }),
+    })
+    expect(screen.queryByTestId("ShelfSuggestedArtworks")).toBeInTheDocument()
+  })
+
+  it("renders nothing if there are no related artworks", () => {
+    renderWithRelay({
+      FilterArtworksConnection: () => ({
+        edges: [],
+      }),
+    })
+    expect(
+      screen.queryByTestId("ShelfSuggestedArtworks")
+    ).not.toBeInTheDocument()
+  })
+})

--- a/src/__generated__/SuggestedArtworksShelfQuery.graphql.ts
+++ b/src/__generated__/SuggestedArtworksShelfQuery.graphql.ts
@@ -1,0 +1,673 @@
+/**
+ * @generated SignedSource<<36896b48bfa8eae491288bd29fe5951b>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "LOCATION_CITY" | "MAJOR_PERIOD" | "MATERIALS_TERMS" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "SIMPLE_PRICE_HISTOGRAM" | "TOTAL" | "%future added value";
+export type ArtworkSizes = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
+export type FilterArtworksInput = {
+  acquireable?: boolean | null;
+  additionalGeneIDs?: ReadonlyArray<string | null> | null;
+  after?: string | null;
+  aggregationPartnerCities?: ReadonlyArray<string | null> | null;
+  aggregations?: ReadonlyArray<ArtworkAggregation | null> | null;
+  artistID?: string | null;
+  artistIDs?: ReadonlyArray<string | null> | null;
+  artistNationalities?: ReadonlyArray<string | null> | null;
+  artistSeriesID?: string | null;
+  atAuction?: boolean | null;
+  attributionClass?: ReadonlyArray<string | null> | null;
+  before?: string | null;
+  color?: string | null;
+  colors?: ReadonlyArray<string | null> | null;
+  dimensionRange?: string | null;
+  excludeArtworkIDs?: ReadonlyArray<string | null> | null;
+  extraAggregationGeneIDs?: ReadonlyArray<string | null> | null;
+  first?: number | null;
+  forSale?: boolean | null;
+  geneID?: string | null;
+  geneIDs?: ReadonlyArray<string | null> | null;
+  height?: string | null;
+  includeArtworksByFollowedArtists?: boolean | null;
+  includeMediumFilterInAggregation?: boolean | null;
+  inquireableOnly?: boolean | null;
+  keyword?: string | null;
+  keywordMatchExact?: boolean | null;
+  last?: number | null;
+  locationCities?: ReadonlyArray<string | null> | null;
+  majorPeriods?: ReadonlyArray<string | null> | null;
+  marketable?: boolean | null;
+  marketingCollectionID?: string | null;
+  materialsTerms?: ReadonlyArray<string | null> | null;
+  medium?: string | null;
+  offerable?: boolean | null;
+  page?: number | null;
+  partnerCities?: ReadonlyArray<string | null> | null;
+  partnerID?: string | null;
+  partnerIDs?: ReadonlyArray<string | null> | null;
+  period?: string | null;
+  periods?: ReadonlyArray<string | null> | null;
+  priceRange?: string | null;
+  saleID?: string | null;
+  size?: number | null;
+  sizes?: ReadonlyArray<ArtworkSizes | null> | null;
+  sort?: string | null;
+  tagID?: string | null;
+  width?: string | null;
+};
+export type SuggestedArtworksShelfQuery$variables = {
+  input?: FilterArtworksInput | null;
+};
+export type SuggestedArtworksShelfQuery$data = {
+  readonly artworksConnection: {
+    readonly counts: {
+      readonly total: any | null;
+    } | null;
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly internalID: string;
+        readonly " $fragmentSpreads": FragmentRefs<"ShelfArtwork_artwork">;
+      } | null;
+    } | null> | null;
+  } | null;
+};
+export type SuggestedArtworksShelfQuery = {
+  response: SuggestedArtworksShelfQuery$data;
+  variables: SuggestedArtworksShelfQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "FilterArtworksCounts",
+  "kind": "LinkedField",
+  "name": "counts",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "total",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v6 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true
+  }
+],
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "endAt",
+  "storageKey": null
+},
+v9 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+],
+v10 = [
+  (v7/*: any*/),
+  (v5/*: any*/)
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SuggestedArtworksShelfQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "FilterArtworksConnection",
+        "kind": "LinkedField",
+        "name": "artworksConnection",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "FilterArtworksEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Artwork",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  {
+                    "args": null,
+                    "kind": "FragmentSpread",
+                    "name": "ShelfArtwork_artwork"
+                  },
+                  (v3/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SuggestedArtworksShelfQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "FilterArtworksConnection",
+        "kind": "LinkedField",
+        "name": "artworksConnection",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "FilterArtworksEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Artwork",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v3/*: any*/),
+                  (v4/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "title",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "date",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "sale_message",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "saleMessage",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "cultural_maker",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "culturalMaker",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artist",
+                    "kind": "LinkedField",
+                    "name": "artist",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ArtistTargetSupply",
+                        "kind": "LinkedField",
+                        "name": "targetSupply",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isP1",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      (v5/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "ArtworkPriceInsights",
+                    "kind": "LinkedField",
+                    "name": "marketPriceInsights",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "demandRank",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": (v6/*: any*/),
+                    "concreteType": "Artist",
+                    "kind": "LinkedField",
+                    "name": "artists",
+                    "plural": true,
+                    "selections": [
+                      (v5/*: any*/),
+                      (v4/*: any*/),
+                      (v7/*: any*/)
+                    ],
+                    "storageKey": "artists(shallow:true)"
+                  },
+                  {
+                    "alias": "collecting_institution",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "collectingInstitution",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": (v6/*: any*/),
+                    "concreteType": "Partner",
+                    "kind": "LinkedField",
+                    "name": "partner",
+                    "plural": false,
+                    "selections": [
+                      (v7/*: any*/),
+                      (v4/*: any*/),
+                      (v5/*: any*/)
+                    ],
+                    "storageKey": "partner(shallow:true)"
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Sale",
+                    "kind": "LinkedField",
+                    "name": "sale",
+                    "plural": false,
+                    "selections": [
+                      (v8/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "cascadingEndTimeIntervalMinutes",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "extendedBiddingIntervalMinutes",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "startAt",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_auction",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isAuction",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_closed",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isClosed",
+                        "storageKey": null
+                      },
+                      (v5/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "sale_artwork",
+                    "args": null,
+                    "concreteType": "SaleArtwork",
+                    "kind": "LinkedField",
+                    "name": "saleArtwork",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "lotID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "lotLabel",
+                        "storageKey": null
+                      },
+                      (v8/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "extendedBiddingEndAt",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "formattedEndDateTime",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "SaleArtworkCounts",
+                        "kind": "LinkedField",
+                        "name": "counts",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "bidder_positions",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "bidderPositions",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "highest_bid",
+                        "args": null,
+                        "concreteType": "SaleArtworkHighestBid",
+                        "kind": "LinkedField",
+                        "name": "highestBid",
+                        "plural": false,
+                        "selections": (v9/*: any*/),
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "opening_bid",
+                        "args": null,
+                        "concreteType": "SaleArtworkOpeningBid",
+                        "kind": "LinkedField",
+                        "name": "openingBid",
+                        "plural": false,
+                        "selections": (v9/*: any*/),
+                        "storageKey": null
+                      },
+                      (v5/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  (v5/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "slug",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "isSaved",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "artistNames",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "preview",
+                    "args": null,
+                    "concreteType": "Image",
+                    "kind": "LinkedField",
+                    "name": "image",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "version",
+                            "value": "square"
+                          }
+                        ],
+                        "kind": "ScalarField",
+                        "name": "url",
+                        "storageKey": "url(version:\"square\")"
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "customCollections",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "default",
+                        "value": false
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "first",
+                        "value": 0
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "saves",
+                        "value": true
+                      }
+                    ],
+                    "concreteType": "CollectionsConnection",
+                    "kind": "LinkedField",
+                    "name": "collectionsConnection",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "totalCount",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": "collectionsConnection(default:false,first:0,saves:true)"
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AttributionClass",
+                    "kind": "LinkedField",
+                    "name": "attributionClass",
+                    "plural": false,
+                    "selections": (v10/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "ArtworkMedium",
+                    "kind": "LinkedField",
+                    "name": "mediumType",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Gene",
+                        "kind": "LinkedField",
+                        "name": "filterGene",
+                        "plural": false,
+                        "selections": (v10/*: any*/),
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Image",
+                    "kind": "LinkedField",
+                    "name": "image",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": "src",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "version",
+                            "value": [
+                              "larger",
+                              "large"
+                            ]
+                          }
+                        ],
+                        "kind": "ScalarField",
+                        "name": "url",
+                        "storageKey": "url(version:[\"larger\",\"large\"])"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "width",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "height",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          (v5/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "7c6b7449e83095ed1274aa41c4aa457e",
+    "id": null,
+    "metadata": {},
+    "name": "SuggestedArtworksShelfQuery",
+    "operationKind": "query",
+    "text": "query SuggestedArtworksShelfQuery(\n  $input: FilterArtworksInput\n) {\n  artworksConnection(input: $input) {\n    counts {\n      total\n    }\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  customCollections: collectionsConnection(first: 0, default: false, saves: true) {\n    totalCount\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "ed2824d5582f2da1d37b4df0343a3884";
+
+export default node;

--- a/src/__generated__/SuggestedArtworksShelf_Test_Query.graphql.ts
+++ b/src/__generated__/SuggestedArtworksShelf_Test_Query.graphql.ts
@@ -1,0 +1,823 @@
+/**
+ * @generated SignedSource<<82f0e0d42dd750dc3657da52f6c59876>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type SuggestedArtworksShelf_Test_Query$variables = {};
+export type SuggestedArtworksShelf_Test_Query$data = {
+  readonly artworksConnection: {
+    readonly counts: {
+      readonly total: any | null;
+    } | null;
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly internalID: string;
+        readonly " $fragmentSpreads": FragmentRefs<"ShelfArtwork_artwork">;
+      } | null;
+    } | null> | null;
+  } | null;
+};
+export type SuggestedArtworksShelf_Test_Query = {
+  response: SuggestedArtworksShelf_Test_Query$data;
+  variables: SuggestedArtworksShelf_Test_Query$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 5
+  },
+  {
+    "kind": "Literal",
+    "name": "forSale",
+    "value": true
+  },
+  {
+    "kind": "Literal",
+    "name": "sort",
+    "value": "-published_at"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "FilterArtworksCounts",
+  "kind": "LinkedField",
+  "name": "counts",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "total",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v5 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true
+  }
+],
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "endAt",
+  "storageKey": null
+},
+v8 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+],
+v9 = [
+  (v6/*: any*/),
+  (v4/*: any*/)
+],
+v10 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "FormattedNumber"
+},
+v11 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v12 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Boolean"
+},
+v13 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v14 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Int"
+},
+v15 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Image"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SuggestedArtworksShelf_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "FilterArtworksConnection",
+        "kind": "LinkedField",
+        "name": "artworksConnection",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "FilterArtworksEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Artwork",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  {
+                    "args": null,
+                    "kind": "FragmentSpread",
+                    "name": "ShelfArtwork_artwork"
+                  },
+                  (v2/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": "artworksConnection(first:5,forSale:true,sort:\"-published_at\")"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "SuggestedArtworksShelf_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "FilterArtworksConnection",
+        "kind": "LinkedField",
+        "name": "artworksConnection",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "FilterArtworksEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Artwork",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v2/*: any*/),
+                  (v3/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "title",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "date",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "sale_message",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "saleMessage",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "cultural_maker",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "culturalMaker",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artist",
+                    "kind": "LinkedField",
+                    "name": "artist",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ArtistTargetSupply",
+                        "kind": "LinkedField",
+                        "name": "targetSupply",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isP1",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      (v4/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "ArtworkPriceInsights",
+                    "kind": "LinkedField",
+                    "name": "marketPriceInsights",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "demandRank",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": (v5/*: any*/),
+                    "concreteType": "Artist",
+                    "kind": "LinkedField",
+                    "name": "artists",
+                    "plural": true,
+                    "selections": [
+                      (v4/*: any*/),
+                      (v3/*: any*/),
+                      (v6/*: any*/)
+                    ],
+                    "storageKey": "artists(shallow:true)"
+                  },
+                  {
+                    "alias": "collecting_institution",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "collectingInstitution",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": (v5/*: any*/),
+                    "concreteType": "Partner",
+                    "kind": "LinkedField",
+                    "name": "partner",
+                    "plural": false,
+                    "selections": [
+                      (v6/*: any*/),
+                      (v3/*: any*/),
+                      (v4/*: any*/)
+                    ],
+                    "storageKey": "partner(shallow:true)"
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Sale",
+                    "kind": "LinkedField",
+                    "name": "sale",
+                    "plural": false,
+                    "selections": [
+                      (v7/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "cascadingEndTimeIntervalMinutes",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "extendedBiddingIntervalMinutes",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "startAt",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_auction",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isAuction",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "is_closed",
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isClosed",
+                        "storageKey": null
+                      },
+                      (v4/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "sale_artwork",
+                    "args": null,
+                    "concreteType": "SaleArtwork",
+                    "kind": "LinkedField",
+                    "name": "saleArtwork",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "lotID",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "lotLabel",
+                        "storageKey": null
+                      },
+                      (v7/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "extendedBiddingEndAt",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "formattedEndDateTime",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "SaleArtworkCounts",
+                        "kind": "LinkedField",
+                        "name": "counts",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "bidder_positions",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "bidderPositions",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "highest_bid",
+                        "args": null,
+                        "concreteType": "SaleArtworkHighestBid",
+                        "kind": "LinkedField",
+                        "name": "highestBid",
+                        "plural": false,
+                        "selections": (v8/*: any*/),
+                        "storageKey": null
+                      },
+                      {
+                        "alias": "opening_bid",
+                        "args": null,
+                        "concreteType": "SaleArtworkOpeningBid",
+                        "kind": "LinkedField",
+                        "name": "openingBid",
+                        "plural": false,
+                        "selections": (v8/*: any*/),
+                        "storageKey": null
+                      },
+                      (v4/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  (v4/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "slug",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "isSaved",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "artistNames",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "preview",
+                    "args": null,
+                    "concreteType": "Image",
+                    "kind": "LinkedField",
+                    "name": "image",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "version",
+                            "value": "square"
+                          }
+                        ],
+                        "kind": "ScalarField",
+                        "name": "url",
+                        "storageKey": "url(version:\"square\")"
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "customCollections",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "default",
+                        "value": false
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "first",
+                        "value": 0
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "saves",
+                        "value": true
+                      }
+                    ],
+                    "concreteType": "CollectionsConnection",
+                    "kind": "LinkedField",
+                    "name": "collectionsConnection",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "totalCount",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": "collectionsConnection(default:false,first:0,saves:true)"
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "AttributionClass",
+                    "kind": "LinkedField",
+                    "name": "attributionClass",
+                    "plural": false,
+                    "selections": (v9/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "ArtworkMedium",
+                    "kind": "LinkedField",
+                    "name": "mediumType",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Gene",
+                        "kind": "LinkedField",
+                        "name": "filterGene",
+                        "plural": false,
+                        "selections": (v9/*: any*/),
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Image",
+                    "kind": "LinkedField",
+                    "name": "image",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": "src",
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "version",
+                            "value": [
+                              "larger",
+                              "large"
+                            ]
+                          }
+                        ],
+                        "kind": "ScalarField",
+                        "name": "url",
+                        "storageKey": "url(version:[\"larger\",\"large\"])"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "width",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "height",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          (v4/*: any*/)
+        ],
+        "storageKey": "artworksConnection(first:5,forSale:true,sort:\"-published_at\")"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "dbb5a87397ef00d67e5db91898eba6e5",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "artworksConnection": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "FilterArtworksConnection"
+        },
+        "artworksConnection.counts": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "FilterArtworksCounts"
+        },
+        "artworksConnection.counts.total": (v10/*: any*/),
+        "artworksConnection.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "FilterArtworksEdge"
+        },
+        "artworksConnection.edges.node": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artwork"
+        },
+        "artworksConnection.edges.node.artist": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artist"
+        },
+        "artworksConnection.edges.node.artist.id": (v11/*: any*/),
+        "artworksConnection.edges.node.artist.targetSupply": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtistTargetSupply"
+        },
+        "artworksConnection.edges.node.artist.targetSupply.isP1": (v12/*: any*/),
+        "artworksConnection.edges.node.artistNames": (v13/*: any*/),
+        "artworksConnection.edges.node.artists": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "Artist"
+        },
+        "artworksConnection.edges.node.artists.href": (v13/*: any*/),
+        "artworksConnection.edges.node.artists.id": (v11/*: any*/),
+        "artworksConnection.edges.node.artists.name": (v13/*: any*/),
+        "artworksConnection.edges.node.attributionClass": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "AttributionClass"
+        },
+        "artworksConnection.edges.node.attributionClass.id": (v11/*: any*/),
+        "artworksConnection.edges.node.attributionClass.name": (v13/*: any*/),
+        "artworksConnection.edges.node.collecting_institution": (v13/*: any*/),
+        "artworksConnection.edges.node.cultural_maker": (v13/*: any*/),
+        "artworksConnection.edges.node.customCollections": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "CollectionsConnection"
+        },
+        "artworksConnection.edges.node.customCollections.totalCount": (v14/*: any*/),
+        "artworksConnection.edges.node.date": (v13/*: any*/),
+        "artworksConnection.edges.node.href": (v13/*: any*/),
+        "artworksConnection.edges.node.id": (v11/*: any*/),
+        "artworksConnection.edges.node.image": (v15/*: any*/),
+        "artworksConnection.edges.node.image.height": (v14/*: any*/),
+        "artworksConnection.edges.node.image.src": (v13/*: any*/),
+        "artworksConnection.edges.node.image.width": (v14/*: any*/),
+        "artworksConnection.edges.node.internalID": (v11/*: any*/),
+        "artworksConnection.edges.node.isSaved": (v12/*: any*/),
+        "artworksConnection.edges.node.marketPriceInsights": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtworkPriceInsights"
+        },
+        "artworksConnection.edges.node.marketPriceInsights.demandRank": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Float"
+        },
+        "artworksConnection.edges.node.mediumType": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtworkMedium"
+        },
+        "artworksConnection.edges.node.mediumType.filterGene": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Gene"
+        },
+        "artworksConnection.edges.node.mediumType.filterGene.id": (v11/*: any*/),
+        "artworksConnection.edges.node.mediumType.filterGene.name": (v13/*: any*/),
+        "artworksConnection.edges.node.partner": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Partner"
+        },
+        "artworksConnection.edges.node.partner.href": (v13/*: any*/),
+        "artworksConnection.edges.node.partner.id": (v11/*: any*/),
+        "artworksConnection.edges.node.partner.name": (v13/*: any*/),
+        "artworksConnection.edges.node.preview": (v15/*: any*/),
+        "artworksConnection.edges.node.preview.url": (v13/*: any*/),
+        "artworksConnection.edges.node.sale": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Sale"
+        },
+        "artworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v14/*: any*/),
+        "artworksConnection.edges.node.sale.endAt": (v13/*: any*/),
+        "artworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v14/*: any*/),
+        "artworksConnection.edges.node.sale.id": (v11/*: any*/),
+        "artworksConnection.edges.node.sale.is_auction": (v12/*: any*/),
+        "artworksConnection.edges.node.sale.is_closed": (v12/*: any*/),
+        "artworksConnection.edges.node.sale.startAt": (v13/*: any*/),
+        "artworksConnection.edges.node.sale_artwork": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtwork"
+        },
+        "artworksConnection.edges.node.sale_artwork.counts": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkCounts"
+        },
+        "artworksConnection.edges.node.sale_artwork.counts.bidder_positions": (v10/*: any*/),
+        "artworksConnection.edges.node.sale_artwork.endAt": (v13/*: any*/),
+        "artworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v13/*: any*/),
+        "artworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v13/*: any*/),
+        "artworksConnection.edges.node.sale_artwork.highest_bid": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkHighestBid"
+        },
+        "artworksConnection.edges.node.sale_artwork.highest_bid.display": (v13/*: any*/),
+        "artworksConnection.edges.node.sale_artwork.id": (v11/*: any*/),
+        "artworksConnection.edges.node.sale_artwork.lotID": (v13/*: any*/),
+        "artworksConnection.edges.node.sale_artwork.lotLabel": (v13/*: any*/),
+        "artworksConnection.edges.node.sale_artwork.opening_bid": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkOpeningBid"
+        },
+        "artworksConnection.edges.node.sale_artwork.opening_bid.display": (v13/*: any*/),
+        "artworksConnection.edges.node.sale_message": (v13/*: any*/),
+        "artworksConnection.edges.node.slug": (v11/*: any*/),
+        "artworksConnection.edges.node.title": (v13/*: any*/),
+        "artworksConnection.id": (v11/*: any*/)
+      }
+    },
+    "name": "SuggestedArtworksShelf_Test_Query",
+    "operationKind": "query",
+    "text": "query SuggestedArtworksShelf_Test_Query {\n  artworksConnection(first: 5, sort: \"-published_at\", forSale: true) {\n    counts {\n      total\n    }\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  customCollections: collectionsConnection(first: 0, default: false, saves: true) {\n    totalCount\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "c99f60106facd47a5f06c626b5e7c139";
+
+export default node;


### PR DESCRIPTION
The type of this PR is: Feat

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [ONYX-130](https://artsyproduct.atlassian.net/browse/ONYX-130)

### Description

Adds Shelf for suggested artworks based on criteria.

<img width="1406" alt="Screenshot 2023-08-18 at 13 11 55" src="https://github.com/artsy/force/assets/17580625/6c65d3d0-5a77-4ebd-81c2-6da8fce4c39c">



<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-130]: https://artsyproduct.atlassian.net/browse/ONYX-130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ