### PR TITLE
feat(alerts): use generated displayName in create and edit forms

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,5 +28,8 @@
   ],
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
-  "typescript.preferences.importModuleSpecifier": "non-relative"
+  "typescript.preferences.importModuleSpecifier": "non-relative",
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "vscode.typescript-language-features"
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,8 +28,5 @@
   ],
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
-  "typescript.preferences.importModuleSpecifier": "non-relative",
-  "[typescriptreact]": {
-    "editor.defaultFormatter": "vscode.typescript-language-features"
-  }
+  "typescript.preferences.importModuleSpecifier": "non-relative"
 }

--- a/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCreateArtworkAlert.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCreateArtworkAlert.jest.tsx
@@ -40,17 +40,6 @@ describe("ArtworkSidebarCreateArtworkAlert", () => {
     })
   })
 
-  it("should correctly render placeholder", () => {
-    const placeholder = "Artworks like: Some artwork title"
-    renderWithRelay({
-      Artwork: () => Artwork,
-    })
-
-    fireEvent.click(screen.getByText("Create Alert"))
-
-    expect(screen.getByPlaceholderText(placeholder)).toBeInTheDocument()
-  })
-
   it("should correctly render pills", () => {
     renderWithRelay({
       Artwork: () => Artwork,

--- a/src/Components/SavedSearchAlert/Components/SavedSearchAlertNameInput.tsx
+++ b/src/Components/SavedSearchAlert/Components/SavedSearchAlertNameInput.tsx
@@ -18,22 +18,21 @@ export const SavedSearchAlertNameInputQueryRenderer: FC = () => {
 
   const debouncedSetCriteriaState = useMemo(
     () => debounce(setCriteriaState, 200),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   )
 
   useEffect(() => {
     debouncedSetCriteriaState(criteria)
-  }, [criteria])
+  }, [criteria, debouncedSetCriteriaState])
 
   return (
     <SystemQueryRenderer<SavedSearchAlertNameInputQuery>
       lazyLoad
       query={graphql`
-        query SavedSearchAlertNameInputQuery($attributes: PreviewSavedSearchAttributes!) {
-          previewSavedSearch(
-            attributes: $attributes
-          ) {
+        query SavedSearchAlertNameInputQuery(
+          $attributes: PreviewSavedSearchAttributes!
+        ) {
+          previewSavedSearch(attributes: $attributes) {
             displayName
           }
         }
@@ -61,7 +60,6 @@ export const SavedSearchAlertNameInput: FC<SavedSavedAlertNameInputProps> = ({
   const { values, errors, handleChange, handleBlur } = useFormikContext<
     SavedSearchAlertFormValues
   >()
-
 
   useEffect(() => {
     if (placeholder) {

--- a/src/Components/SavedSearchAlert/Components/SavedSearchAlertNameInput.tsx
+++ b/src/Components/SavedSearchAlert/Components/SavedSearchAlertNameInput.tsx
@@ -1,0 +1,66 @@
+import { Input, Text } from "@artsy/palette"
+import { SavedSearchAlertFormValues } from "Components/SavedSearchAlert/types"
+import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
+import { useFormikContext } from "formik"
+import { FC } from "react"
+import { graphql } from "react-relay"
+import { SavedSearchAlertNameInputQuery } from "__generated__/SavedSearchAlertNameInputQuery.graphql"
+
+interface SavedSavedAlertNameInputProps {
+  placeholder?: string
+}
+
+export const SavedSearchAlertNameInputQueryRenderer: FC = () => {
+  return (
+    <SystemQueryRenderer<SavedSearchAlertNameInputQuery>
+      lazyLoad
+      // placeholder={}
+      query={graphql`
+        query SavedSearchAlertNameInputQuery {
+          previewSavedSearch(
+            attributes: { artistIDs: ["andy-warhol"], priceRange: "*-35000" }
+          ) {
+            displayName
+          }
+        }
+      `}
+      render={({ props, error }) => {
+        if (error) {
+          console.error(error)
+          return null
+        }
+
+        if (!props) {
+          return <Text>Loading...</Text>
+        }
+
+        return (
+          <SavedSearchAlertNameInput
+            placeholder={props?.previewSavedSearch?.displayName}
+          />
+        )
+      }}
+    />
+  )
+}
+
+export const SavedSearchAlertNameInput: FC<SavedSavedAlertNameInputProps> = ({
+  placeholder,
+}) => {
+  const { values, errors, handleChange, handleBlur } = useFormikContext<
+    SavedSearchAlertFormValues
+  >()
+
+  return (
+    <Input
+      title="Alert Name"
+      name="name"
+      placeholder={placeholder}
+      value={values.name}
+      onChange={handleChange("name")}
+      onBlur={handleBlur("name")}
+      error={errors.name}
+      maxLength={75}
+    />
+  )
+}

--- a/src/Components/SavedSearchAlert/Components/SavedSearchAlertNameInput.tsx
+++ b/src/Components/SavedSearchAlert/Components/SavedSearchAlertNameInput.tsx
@@ -1,29 +1,28 @@
 import { Input } from "@artsy/palette"
+import { useSavedSearchAlertContext } from "Components/SavedSearchAlert/SavedSearchAlertContext"
 import { SavedSearchAlertFormValues } from "Components/SavedSearchAlert/types"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
-import { useFormikContext } from "formik"
-import { FC, useEffect, useMemo, useState } from "react"
-import { createFragmentContainer, graphql } from "react-relay"
+import { useSystemContext } from "System/SystemContext"
+import { useDebouncedValue } from "Utils/Hooks/useDebounce"
 import { SavedSearchAlertNameInputQuery } from "__generated__/SavedSearchAlertNameInputQuery.graphql"
-import { useSavedSearchAlertContext } from "Components/SavedSearchAlert/SavedSearchAlertContext"
-import { debounce } from "lodash"
 import { SavedSearchAlertNameInput_previewSavedSearch$data } from "__generated__/SavedSearchAlertNameInput_previewSavedSearch.graphql"
+import { useFormikContext } from "formik"
+import { FC, useEffect, useState } from "react"
+import { createFragmentContainer, graphql } from "react-relay"
 
 export const SavedSearchAlertNameInputQueryRenderer: FC = () => {
+  const { relayEnvironment } = useSystemContext()
+
   const { criteria } = useSavedSearchAlertContext()
-  const [criteriaState, setCriteriaState] = useState({})
 
-  const debouncedSetCriteriaState = useMemo(
-    () => debounce(setCriteriaState, 200),
-    []
-  )
-
-  useEffect(() => {
-    debouncedSetCriteriaState(criteria)
-  }, [criteria, debouncedSetCriteriaState])
+  const { debouncedValue: criteriaState } = useDebouncedValue({
+    value: criteria,
+    delay: 200,
+  })
 
   return (
     <SystemQueryRenderer<SavedSearchAlertNameInputQuery>
+      environment={relayEnvironment}
       query={graphql`
         query SavedSearchAlertNameInputQuery(
           $attributes: PreviewSavedSearchAttributes!
@@ -43,8 +42,7 @@ export const SavedSearchAlertNameInputQueryRenderer: FC = () => {
 
         return (
           <SavedSearchAlertNameInputFragmentContainer
-            // @ts-expect-error "No overload matches this call" TODO: why??
-            previewSavedSearch={props?.viewer?.previewSavedSearch}
+            previewSavedSearch={(props?.viewer?.previewSavedSearch ?? null)!}
           />
         )
       }}

--- a/src/Components/SavedSearchAlert/Components/SavedSearchAlertNameInput.tsx
+++ b/src/Components/SavedSearchAlert/Components/SavedSearchAlertNameInput.tsx
@@ -83,7 +83,7 @@ const SavedSearchAlertNameInput: FC<SavedSavedAlertNameInputProps> = props => {
   )
 }
 
-const SavedSearchAlertNameInputFragmentContainer = createFragmentContainer(
+export const SavedSearchAlertNameInputFragmentContainer = createFragmentContainer(
   SavedSearchAlertNameInput,
   {
     previewSavedSearch: graphql`

--- a/src/Components/SavedSearchAlert/Components/SavedSearchAlertNameInput.tsx
+++ b/src/Components/SavedSearchAlert/Components/SavedSearchAlertNameInput.tsx
@@ -27,7 +27,6 @@ export const SavedSearchAlertNameInputQueryRenderer: FC = () => {
 
   return (
     <SystemQueryRenderer<SavedSearchAlertNameInputQuery>
-      lazyLoad
       query={graphql`
         query SavedSearchAlertNameInputQuery(
           $attributes: PreviewSavedSearchAttributes!

--- a/src/Components/SavedSearchAlert/Components/__tests__/SavedSearchAlertNameInput.jest.tsx
+++ b/src/Components/SavedSearchAlert/Components/__tests__/SavedSearchAlertNameInput.jest.tsx
@@ -1,0 +1,55 @@
+import { SavedSearchAlertNameInputFragmentContainer } from "Components/SavedSearchAlert/Components/SavedSearchAlertNameInput"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
+import { screen } from "@testing-library/react"
+import { graphql } from "react-relay"
+
+jest.unmock("react-relay")
+
+// Because of the component's use of useFormikContext
+jest.mock("formik", () => ({
+  useFormikContext: () => ({
+    values: {},
+    errors: {},
+    handleChange: jest.fn(),
+    handleBlur: jest.fn(),
+  }),
+}))
+
+describe("SavedSearchAlertNameInputFragmentContainer", () => {
+  it("renders the generated display name as placeholder", () => {
+    const { renderWithRelay } = setupTestWrapperTL({
+      Component: (props: any) => {
+        return (
+          <SavedSearchAlertNameInputFragmentContainer
+            previewSavedSearch={props?.viewer?.previewSavedSearch}
+          />
+        )
+      },
+      query: graphql`
+        query SavedSearchAlertNameInput_Test_Query(
+          $attributes: PreviewSavedSearchAttributes!
+        ) {
+          viewer {
+            previewSavedSearch(attributes: $attributes) {
+              displayName
+            }
+          }
+        }
+      `,
+      variables: {
+        attributes: {
+          artistIDs: ["kaws"],
+          attributionClass: ["unique"],
+        },
+      },
+    })
+
+    renderWithRelay({
+      PreviewSavedSearch: () => ({
+        displayName: "Kaws — Unique",
+      }),
+    })
+
+    expect(screen.queryByPlaceholderText("Kaws — Unique")).toBeInTheDocument()
+  })
+})

--- a/src/Components/SavedSearchAlert/Components/__tests__/SavedSearchAlertNameInput.jest.tsx
+++ b/src/Components/SavedSearchAlert/Components/__tests__/SavedSearchAlertNameInput.jest.tsx
@@ -1,6 +1,6 @@
+import { screen } from "@testing-library/react"
 import { SavedSearchAlertNameInputFragmentContainer } from "Components/SavedSearchAlert/Components/SavedSearchAlertNameInput"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
-import { screen } from "@testing-library/react"
 import { graphql } from "react-relay"
 
 jest.unmock("react-relay")

--- a/src/Components/SavedSearchAlert/SavedSearchAlertModal.tsx
+++ b/src/Components/SavedSearchAlert/SavedSearchAlertModal.tsx
@@ -5,7 +5,6 @@ import {
   Button,
   Checkbox,
   Flex,
-  Input,
   Join,
   ModalDialog,
   Separator,
@@ -35,6 +34,7 @@ import { FrequenceRadioButtons } from "./Components/FrequencyRadioButtons"
 import { PriceRangeFilter } from "Components/SavedSearchAlert/Components/PriceRangeFilter"
 import { ConfirmationStepModal } from "Components/SavedSearchAlert/ConfirmationStepModal"
 import { useFeatureFlag } from "System/useFeatureFlag"
+import { SavedSearchAlertNameInputQueryRenderer } from "Components/SavedSearchAlert/Components/SavedSearchAlertNameInput"
 
 interface SavedSearchAlertFormProps {
   entity: SavedSearchEntity
@@ -136,21 +136,7 @@ export const SavedSearchAlertModal: FC<SavedSearchAlertFormProps> = ({
             }
           >
             <Join separator={<Spacer y={2} />}>
-              <Input
-                title="Alert Name"
-                name="name"
-                placeholder={
-                  isFallbackToGeneratedAlertNamesEnabled
-                    ? undefined
-                    : entity.placeholder
-                }
-                value={values.name}
-                onChange={handleChange("name")}
-                onBlur={handleBlur("name")}
-                error={errors.name}
-                maxLength={75}
-              />
-
+              <SavedSearchAlertNameInputQueryRenderer />
               <Box>
                 <Text variant="xs">Filters</Text>
                 <Spacer y={2} />

--- a/src/Components/SavedSearchAlert/__tests__/SavedSearchAlertModal.jest.tsx
+++ b/src/Components/SavedSearchAlert/__tests__/SavedSearchAlertModal.jest.tsx
@@ -98,7 +98,6 @@ describe("SavedSearchAlertModal", () => {
 
   it("renders correctly", () => {
     render(<TestComponent />)
-    expect(screen.getByText("Alert Name")).toBeInTheDocument()
     expect(screen.getByText("Filters")).toBeInTheDocument()
     expect(screen.getByText("Test Artist")).toBeInTheDocument()
     expect(screen.getByText("Open Edition")).toBeInTheDocument()
@@ -106,17 +105,8 @@ describe("SavedSearchAlertModal", () => {
     expect(screen.getByText("Email Alerts")).toBeInTheDocument()
     expect(screen.getByText("Mobile Alerts")).toBeInTheDocument()
     expect(screen.getByText("Save Alert")).toBeInTheDocument()
-    expect(screen.getByRole("textbox")).toHaveValue("")
     expect(screen.getAllByRole("checkbox")[0]).toBeChecked()
     expect(screen.getAllByRole("checkbox")[1]).not.toBeChecked()
-  })
-
-  it("alert name generated correctly", () => {
-    render(<TestComponent />)
-    expect(screen.getByRole("textbox")).toHaveAttribute(
-      "placeholder",
-      "Test Artist"
-    )
   })
 
   it("email value changes correctly", () => {
@@ -151,22 +141,15 @@ describe("SavedSearchAlertModal", () => {
   it("clear entered data when modal is closed", () => {
     const { rerender } = render(<TestComponent />)
 
-    fireEvent.change(screen.getByRole("textbox"), {
-      target: {
-        value: "New Name",
-      },
-    })
     fireEvent.click(screen.getAllByRole("checkbox")[0])
     fireEvent.click(screen.getAllByRole("checkbox")[1])
 
-    expect(screen.getByRole("textbox")).toHaveValue("New Name")
     expect(screen.getAllByRole("checkbox")[0]).not.toBeChecked()
     expect(screen.getAllByRole("checkbox")[1]).toBeChecked()
 
     rerender(<TestComponent visible={false} />)
     rerender(<TestComponent visible={true} />)
 
-    expect(screen.getByRole("textbox")).toHaveValue("")
     expect(screen.getAllByRole("checkbox")[0]).toBeChecked()
     expect(screen.getAllByRole("checkbox")[1]).not.toBeChecked()
   })

--- a/src/__generated__/SavedSearchAlertNameInputQuery.graphql.ts
+++ b/src/__generated__/SavedSearchAlertNameInputQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<cfa79b8d68f6b8ea2d47057c2e4aa270>>
+ * @generated SignedSource<<62e1597db72a9a15e87057020914d96a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,7 +9,28 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Query } from 'relay-runtime';
-export type SavedSearchAlertNameInputQuery$variables = {};
+export type ArtworkSizes = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
+export type PreviewSavedSearchAttributes = {
+  acquireable?: boolean | null;
+  additionalGeneIDs?: ReadonlyArray<string | null> | null;
+  artistIDs?: ReadonlyArray<string | null> | null;
+  atAuction?: boolean | null;
+  attributionClass?: ReadonlyArray<string | null> | null;
+  colors?: ReadonlyArray<string | null> | null;
+  height?: string | null;
+  inquireableOnly?: boolean | null;
+  locationCities?: ReadonlyArray<string | null> | null;
+  majorPeriods?: ReadonlyArray<string | null> | null;
+  materialsTerms?: ReadonlyArray<string | null> | null;
+  offerable?: boolean | null;
+  partnerIDs?: ReadonlyArray<string | null> | null;
+  priceRange?: string | null;
+  sizes?: ReadonlyArray<ArtworkSizes | null> | null;
+  width?: string | null;
+};
+export type SavedSearchAlertNameInputQuery$variables = {
+  attributes: PreviewSavedSearchAttributes;
+};
 export type SavedSearchAlertNameInputQuery$data = {
   readonly previewSavedSearch: {
     readonly displayName: string;
@@ -23,17 +44,19 @@ export type SavedSearchAlertNameInputQuery = {
 const node: ConcreteRequest = (function(){
 var v0 = [
   {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "attributes"
+  }
+],
+v1 = [
+  {
     "alias": null,
     "args": [
       {
-        "kind": "Literal",
+        "kind": "Variable",
         "name": "attributes",
-        "value": {
-          "artistIDs": [
-            "andy-warhol"
-          ],
-          "priceRange": "*-35000"
-        }
+        "variableName": "attributes"
       }
     ],
     "concreteType": "PreviewSavedSearch",
@@ -49,37 +72,37 @@ var v0 = [
         "storageKey": null
       }
     ],
-    "storageKey": "previewSavedSearch(attributes:{\"artistIDs\":[\"andy-warhol\"],\"priceRange\":\"*-35000\"})"
+    "storageKey": null
   }
 ];
 return {
   "fragment": {
-    "argumentDefinitions": [],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "SavedSearchAlertNameInputQuery",
-    "selections": (v0/*: any*/),
+    "selections": (v1/*: any*/),
     "type": "Query",
     "abstractKey": null
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": [],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "SavedSearchAlertNameInputQuery",
-    "selections": (v0/*: any*/)
+    "selections": (v1/*: any*/)
   },
   "params": {
-    "cacheID": "20d4554c6a9ed0a6ff366f2b0110c68a",
+    "cacheID": "de53c207480e7620a54434f8120b3596",
     "id": null,
     "metadata": {},
     "name": "SavedSearchAlertNameInputQuery",
     "operationKind": "query",
-    "text": "query SavedSearchAlertNameInputQuery {\n  previewSavedSearch(attributes: {artistIDs: [\"andy-warhol\"], priceRange: \"*-35000\"}) {\n    displayName\n  }\n}\n"
+    "text": "query SavedSearchAlertNameInputQuery(\n  $attributes: PreviewSavedSearchAttributes!\n) {\n  previewSavedSearch(attributes: $attributes) {\n    displayName\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "20a485d1303bf39e85fe79ba570a0fa4";
+(node as any).hash = "1fff36175ac490e3c795e516f2f2c5b2";
 
 export default node;

--- a/src/__generated__/SavedSearchAlertNameInputQuery.graphql.ts
+++ b/src/__generated__/SavedSearchAlertNameInputQuery.graphql.ts
@@ -1,0 +1,85 @@
+/**
+ * @generated SignedSource<<cfa79b8d68f6b8ea2d47057c2e4aa270>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+export type SavedSearchAlertNameInputQuery$variables = {};
+export type SavedSearchAlertNameInputQuery$data = {
+  readonly previewSavedSearch: {
+    readonly displayName: string;
+  } | null;
+};
+export type SavedSearchAlertNameInputQuery = {
+  response: SavedSearchAlertNameInputQuery$data;
+  variables: SavedSearchAlertNameInputQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Literal",
+        "name": "attributes",
+        "value": {
+          "artistIDs": [
+            "andy-warhol"
+          ],
+          "priceRange": "*-35000"
+        }
+      }
+    ],
+    "concreteType": "PreviewSavedSearch",
+    "kind": "LinkedField",
+    "name": "previewSavedSearch",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "displayName",
+        "storageKey": null
+      }
+    ],
+    "storageKey": "previewSavedSearch(attributes:{\"artistIDs\":[\"andy-warhol\"],\"priceRange\":\"*-35000\"})"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SavedSearchAlertNameInputQuery",
+    "selections": (v0/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "SavedSearchAlertNameInputQuery",
+    "selections": (v0/*: any*/)
+  },
+  "params": {
+    "cacheID": "20d4554c6a9ed0a6ff366f2b0110c68a",
+    "id": null,
+    "metadata": {},
+    "name": "SavedSearchAlertNameInputQuery",
+    "operationKind": "query",
+    "text": "query SavedSearchAlertNameInputQuery {\n  previewSavedSearch(attributes: {artistIDs: [\"andy-warhol\"], priceRange: \"*-35000\"}) {\n    displayName\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "20a485d1303bf39e85fe79ba570a0fa4";
+
+export default node;

--- a/src/__generated__/SavedSearchAlertNameInputQuery.graphql.ts
+++ b/src/__generated__/SavedSearchAlertNameInputQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<62e1597db72a9a15e87057020914d96a>>
+ * @generated SignedSource<<1421321f86349da4506cac136ea65894>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,6 +9,7 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
 export type ArtworkSizes = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
 export type PreviewSavedSearchAttributes = {
   acquireable?: boolean | null;
@@ -32,8 +33,10 @@ export type SavedSearchAlertNameInputQuery$variables = {
   attributes: PreviewSavedSearchAttributes;
 };
 export type SavedSearchAlertNameInputQuery$data = {
-  readonly previewSavedSearch: {
-    readonly displayName: string;
+  readonly viewer: {
+    readonly previewSavedSearch: {
+      readonly " $fragmentSpreads": FragmentRefs<"SavedSearchAlertNameInput_previewSavedSearch">;
+    } | null;
   } | null;
 };
 export type SavedSearchAlertNameInputQuery = {
@@ -51,28 +54,9 @@ var v0 = [
 ],
 v1 = [
   {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "attributes",
-        "variableName": "attributes"
-      }
-    ],
-    "concreteType": "PreviewSavedSearch",
-    "kind": "LinkedField",
-    "name": "previewSavedSearch",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "kind": "ScalarField",
-        "name": "displayName",
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
+    "kind": "Variable",
+    "name": "attributes",
+    "variableName": "attributes"
   }
 ];
 return {
@@ -81,7 +65,35 @@ return {
     "kind": "Fragment",
     "metadata": null,
     "name": "SavedSearchAlertNameInputQuery",
-    "selections": (v1/*: any*/),
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": (v1/*: any*/),
+            "concreteType": "PreviewSavedSearch",
+            "kind": "LinkedField",
+            "name": "previewSavedSearch",
+            "plural": false,
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "SavedSearchAlertNameInput_previewSavedSearch"
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
     "type": "Query",
     "abstractKey": null
   },
@@ -90,19 +102,49 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "SavedSearchAlertNameInputQuery",
-    "selections": (v1/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": (v1/*: any*/),
+            "concreteType": "PreviewSavedSearch",
+            "kind": "LinkedField",
+            "name": "previewSavedSearch",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "displayName",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
-    "cacheID": "de53c207480e7620a54434f8120b3596",
+    "cacheID": "77f96e974094f5bcc19f2294877ad861",
     "id": null,
     "metadata": {},
     "name": "SavedSearchAlertNameInputQuery",
     "operationKind": "query",
-    "text": "query SavedSearchAlertNameInputQuery(\n  $attributes: PreviewSavedSearchAttributes!\n) {\n  previewSavedSearch(attributes: $attributes) {\n    displayName\n  }\n}\n"
+    "text": "query SavedSearchAlertNameInputQuery(\n  $attributes: PreviewSavedSearchAttributes!\n) {\n  viewer {\n    previewSavedSearch(attributes: $attributes) {\n      ...SavedSearchAlertNameInput_previewSavedSearch\n    }\n  }\n}\n\nfragment SavedSearchAlertNameInput_previewSavedSearch on PreviewSavedSearch {\n  displayName\n}\n"
   }
 };
 })();
 
-(node as any).hash = "1fff36175ac490e3c795e516f2f2c5b2";
+(node as any).hash = "55f1e043586d42fa286585a27e62a01e";
 
 export default node;

--- a/src/__generated__/SavedSearchAlertNameInput_Test_Query.graphql.ts
+++ b/src/__generated__/SavedSearchAlertNameInput_Test_Query.graphql.ts
@@ -1,0 +1,121 @@
+/**
+ * @generated SignedSource<<2b311936e60b7d0fcd3da45e8bc1dd1a>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+export type ArtworkSizes = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
+export type PreviewSavedSearchAttributes = {
+  acquireable?: boolean | null;
+  additionalGeneIDs?: ReadonlyArray<string | null> | null;
+  artistIDs?: ReadonlyArray<string | null> | null;
+  atAuction?: boolean | null;
+  attributionClass?: ReadonlyArray<string | null> | null;
+  colors?: ReadonlyArray<string | null> | null;
+  height?: string | null;
+  inquireableOnly?: boolean | null;
+  locationCities?: ReadonlyArray<string | null> | null;
+  majorPeriods?: ReadonlyArray<string | null> | null;
+  materialsTerms?: ReadonlyArray<string | null> | null;
+  offerable?: boolean | null;
+  partnerIDs?: ReadonlyArray<string | null> | null;
+  priceRange?: string | null;
+  sizes?: ReadonlyArray<ArtworkSizes | null> | null;
+  width?: string | null;
+};
+export type SavedSearchAlertNameInput_Test_Query$variables = {
+  attributes: PreviewSavedSearchAttributes;
+};
+export type SavedSearchAlertNameInput_Test_Query$data = {
+  readonly viewer: {
+    readonly previewSavedSearch: {
+      readonly displayName: string;
+    } | null;
+  } | null;
+};
+export type SavedSearchAlertNameInput_Test_Query = {
+  response: SavedSearchAlertNameInput_Test_Query$data;
+  variables: SavedSearchAlertNameInput_Test_Query$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "attributes"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": null,
+    "concreteType": "Viewer",
+    "kind": "LinkedField",
+    "name": "viewer",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": [
+          {
+            "kind": "Variable",
+            "name": "attributes",
+            "variableName": "attributes"
+          }
+        ],
+        "concreteType": "PreviewSavedSearch",
+        "kind": "LinkedField",
+        "name": "previewSavedSearch",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "displayName",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SavedSearchAlertNameInput_Test_Query",
+    "selections": (v1/*: any*/),
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SavedSearchAlertNameInput_Test_Query",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "6256da5b9e01982d8f7ae0d745076923",
+    "id": null,
+    "metadata": {},
+    "name": "SavedSearchAlertNameInput_Test_Query",
+    "operationKind": "query",
+    "text": "query SavedSearchAlertNameInput_Test_Query(\n  $attributes: PreviewSavedSearchAttributes!\n) {\n  viewer {\n    previewSavedSearch(attributes: $attributes) {\n      displayName\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "cfbfeb2a6a52be89399b432ce61b72bc";
+
+export default node;

--- a/src/__generated__/SavedSearchAlertNameInput_previewSavedSearch.graphql.ts
+++ b/src/__generated__/SavedSearchAlertNameInput_previewSavedSearch.graphql.ts
@@ -1,0 +1,42 @@
+/**
+ * @generated SignedSource<<c402ac6995afabdfd499e067792b3edc>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { Fragment, ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type SavedSearchAlertNameInput_previewSavedSearch$data = {
+  readonly displayName: string;
+  readonly " $fragmentType": "SavedSearchAlertNameInput_previewSavedSearch";
+};
+export type SavedSearchAlertNameInput_previewSavedSearch$key = {
+  readonly " $data"?: SavedSearchAlertNameInput_previewSavedSearch$data;
+  readonly " $fragmentSpreads": FragmentRefs<"SavedSearchAlertNameInput_previewSavedSearch">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "SavedSearchAlertNameInput_previewSavedSearch",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "displayName",
+      "storageKey": null
+    }
+  ],
+  "type": "PreviewSavedSearch",
+  "abstractKey": null
+};
+
+(node as any).hash = "f6012e331da9a867f56c20d9a2c01653";
+
+export default node;


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [ONYX-241]

Co-authored-by: @dblandin 

## Description

Wires up the new `previewSavedSearch.displayName` field from https://github.com/artsy/metaphysics/pull/5186 into the Alert creating and editing flows.

This feature is guarded by the [`onyx_force-fallback-to-generated-alert-names`](https://unleash.artsy.net/projects/default/features/onyx_force-fallback-to-generated-alert-names) feature flag, which is based on a user id strategy, so you might have to opt in to see these changes.


---

### When the feature flag is enabled

The MP-backed display name is shown (and updated realtime) as the placeholder in the alert form:

|Artist|Artwork|
|---|---|
|<video src="https://github.com/artsy/force/assets/140521/64c43a1c-c1f8-4cb2-abb7-cecd0a252602" />|<video src="https://github.com/artsy/force/assets/140521/0b4362b4-fb38-44af-b946-a8fb2a0bfe69" />|


---

### When the feature flag is disabled

Functions as before, i.e. the old-style placeholder is shown:

|Artist|Artwork|
|---|---|
|<video src="https://github.com/artsy/force/assets/140521/fc70c391-6259-44e2-be2f-84aa9673e215" />|<video src="https://github.com/artsy/force/assets/140521/62cc686c-8bab-44fe-acef-7bcf59492948" />|





















[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-241]: https://artsyproduct.atlassian.net/browse/ONYX-241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ