### PR TITLE
feat: add sale end year filter

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -408,6 +408,9 @@ export const ArtistAuctionResultsRefetchContainer = createRefetchContainer(
           currency: { type: "String" }
           includeEstimateRange: { type: "Boolean" }
           includeUnknownPrices: { type: "Boolean" }
+          saleStartYear: { type: "Int" }
+          saleEndYear: { type: "Int" }
+          allowUnspecifiedSaleDates: { type: "Boolean" }
           categories: { type: "[String]" }
           sizes: { type: "[ArtworkSizes]" }
           createdAfterYear: { type: "Int" }
@@ -438,6 +441,9 @@ export const ArtistAuctionResultsRefetchContainer = createRefetchContainer(
           sizes: $sizes
           priceRange: $priceRange
           currency: $currency
+          saleStartYear: $saleStartYear
+          saleEndYear: $saleEndYear
+          allowUnspecifiedSaleDates: $allowUnspecifiedSaleDates
           includeEstimateRange: $includeEstimateRange
           includeUnknownPrices: $includeUnknownPrices
           earliestCreatedYear: $createdAfterYear
@@ -471,6 +477,10 @@ export const ArtistAuctionResultsRefetchContainer = createRefetchContainer(
           categories: $categories
           sizes: $sizes
           priceRange: $priceRange
+          currency: $currency
+          saleStartYear: $saleStartYear
+          saleEndYear: $saleEndYear
+          allowUnspecifiedSaleDates: $allowUnspecifiedSaleDates
           includeEstimateRange: $includeEstimateRange
           includeUnknownPrices: $includeUnknownPrices
           earliestCreatedYear: $createdAfterYear
@@ -486,6 +496,10 @@ export const ArtistAuctionResultsRefetchContainer = createRefetchContainer(
           categories: $categories
           sizes: $sizes
           priceRange: $priceRange
+          currency: $currency
+          saleStartYear: $saleStartYear
+          saleEndYear: $saleEndYear
+          allowUnspecifiedSaleDates: $allowUnspecifiedSaleDates
           includeEstimateRange: $includeEstimateRange
           includeUnknownPrices: $includeUnknownPrices
           earliestCreatedYear: $createdAfterYear
@@ -513,6 +527,9 @@ export const ArtistAuctionResultsRefetchContainer = createRefetchContainer(
       $sizes: [ArtworkSizes]
       $priceRange: String
       $currency: String
+      $saleStartYear: Int
+      $saleEndYear: Int
+      $allowUnspecifiedSaleDates: Boolean
       $includeEstimateRange: Boolean
       $includeUnknownPrices: Boolean
       $createdBeforeYear: Int
@@ -535,6 +552,9 @@ export const ArtistAuctionResultsRefetchContainer = createRefetchContainer(
             sizes: $sizes
             priceRange: $priceRange
             currency: $currency
+            saleStartYear: $saleStartYear
+            saleEndYear: $saleEndYear
+            allowUnspecifiedSaleDates: $allowUnspecifiedSaleDates
             includeEstimateRange: $includeEstimateRange
             includeUnknownPrices: $includeUnknownPrices
             createdAfterYear: $createdAfterYear

--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultsRoute.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResultsRoute.tsx
@@ -29,6 +29,9 @@ export const AuctionResultsRouteFragmentContainer = createFragmentContainer(
           sizes: { type: "[ArtworkSizes]" }
           priceRange: { type: "String" }
           currency: { type: "String" }
+          saleEndYear: { type: "Int" }
+          saleStartYear: { type: "Int" }
+          allowUnspecifiedSaleDates: { type: "Boolean" }
           includeEstimateRange: { type: "Boolean" }
           includeUnknownPrices: { type: "Boolean" }
           createdAfterYear: { type: "Int" }
@@ -44,6 +47,9 @@ export const AuctionResultsRouteFragmentContainer = createFragmentContainer(
             sizes: $sizes
             priceRange: $priceRange
             currency: $currency
+            saleEndYear: $saleEndYear
+            saleStartYear: $saleStartYear
+            allowUnspecifiedSaleDates: $allowUnspecifiedSaleDates
             includeEstimateRange: $includeEstimateRange
             includeUnknownPrices: $includeUnknownPrices
             createdAfterYear: $createdAfterYear
@@ -51,7 +57,11 @@ export const AuctionResultsRouteFragmentContainer = createFragmentContainer(
             allowEmptyCreatedDates: $allowEmptyCreatedDates
           )
         sidebarAggregations: auctionResultsConnection(
-          aggregations: [SIMPLE_PRICE_HISTOGRAM, CURRENCIES_COUNT]
+          aggregations: [
+            SIMPLE_PRICE_HISTOGRAM
+            CURRENCIES_COUNT
+            LOTS_BY_SALE_YEAR
+          ]
         ) {
           aggregations {
             slice

--- a/src/Apps/Artist/Routes/AuctionResults/AuctionResultsFilterContext.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/AuctionResultsFilterContext.tsx
@@ -23,9 +23,15 @@ export interface AuctionResultsFilters {
   currency?: string
   includeEstimateRange?: boolean
   includeUnknownPrices?: boolean
+  saleStartYear?: number | null
+  saleEndYear?: number | null
+  allowUnspecifiedSaleDates?: boolean
 }
 
-export type Slice = "SIMPLE_PRICE_HISTOGRAM" | "CURRENCIES_COUNT"
+export type Slice =
+  | "SIMPLE_PRICE_HISTOGRAM"
+  | "CURRENCIES_COUNT"
+  | "LOTS_BY_SALE_YEAR"
 
 /**
  * Possible aggregations that can be passed
@@ -70,6 +76,9 @@ export const initialAuctionResultsFilterState = ({
   currency: "",
   includeEstimateRange: false,
   includeUnknownPrices: true,
+  saleStartYear: null,
+  saleEndYear: null,
+  allowUnspecifiedSaleDates: true,
 })
 
 /**
@@ -324,6 +333,9 @@ const AuctionResultsFilterReducer = (
         "includeEstimateRange",
         "includeUnknownPrices",
         "currency",
+        "saleStartYear",
+        "saleEndYear",
+        "allowUnspecifiedSaleDates",
       ]
 
       primitiveFilterTypes.forEach(filter => {

--- a/src/Apps/Artist/Routes/AuctionResults/AuctionResultsFilterContext.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/AuctionResultsFilterContext.tsx
@@ -259,6 +259,8 @@ export const AuctionResultsFilterContextProvider: React.FC<
           earliestCreatedYear,
           latestCreatedYear,
           metric: userPreferredMetric,
+          saleStartYear: null,
+          saleEndYear: null,
         } as any,
       }
       dispatchOrStage(action)

--- a/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/SaleEndYearFilter.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/SaleEndYearFilter.tsx
@@ -24,15 +24,18 @@ export const SaleEndYearFilter: React.FC = () => {
     value: c?.name,
   }))
 
-  React.useEffect(() => {
-    if (saleEndYear === null) {
-      setFilter?.("saleEndYear", new Date().getFullYear())
-    }
-    if (saleStartYear === null && options.length > 0) {
-      setFilter?.("saleStartYear", parseInt(options[0].value))
-    }
-  }, [saleEndYear, saleStartYear]) // eslint-disable-line react-hooks/exhaustive-deps
+  // All options less than the end year
+  const startOptions = options.filter(
+    option =>
+      parseInt(option.value) <=
+      (saleEndYear || parseInt(options[options.length - 1]?.value))
+  )
 
+  // All options greater than the start year
+  const endOptions = options.filter(
+    option =>
+      parseInt(option.value) >= (saleStartYear || parseInt(options[0]?.value))
+  )
   return (
     <FilterExpandable label="Sale Date" expanded>
       <Flex flexDirection="column" alignItems="left">
@@ -40,18 +43,16 @@ export const SaleEndYearFilter: React.FC = () => {
           <Flex>
             <Select
               title="Start year"
-              options={options}
+              options={startOptions}
               onSelect={year => setFilter?.("saleStartYear", parseInt(year))}
               defaultValue={options[0]?.value}
-              selected={saleStartYear?.toString()}
             />
             <Spacer x={1} />
             <Select
               title="End year"
-              options={options}
+              options={endOptions}
               onSelect={year => setFilter?.("saleEndYear", parseInt(year))}
               defaultValue={new Date().getFullYear().toString()}
-              selected={saleEndYear?.toString()}
             />
           </Flex>
 

--- a/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/SaleEndYearFilter.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/SaleEndYearFilter.tsx
@@ -25,13 +25,13 @@ export const SaleEndYearFilter: React.FC = () => {
   }))
 
   React.useEffect(() => {
-    if (!saleEndYear) {
+    if (saleEndYear === null) {
       setFilter?.("saleEndYear", new Date().getFullYear())
     }
-    if (!saleStartYear && options.length > 0) {
+    if (saleStartYear === null && options.length > 0) {
       setFilter?.("saleStartYear", parseInt(options[0].value))
     }
-  }, [saleEndYear, saleStartYear, setFilter, options])
+  }, [saleEndYear, saleStartYear]) // eslint-disable-line react-hooks/exhaustive-deps
 
   return (
     <FilterExpandable label="Sale Date" expanded>
@@ -43,6 +43,7 @@ export const SaleEndYearFilter: React.FC = () => {
               options={options}
               onSelect={year => setFilter?.("saleStartYear", parseInt(year))}
               defaultValue={options[0]?.value}
+              selected={saleStartYear?.toString()}
             />
             <Spacer x={1} />
             <Select
@@ -50,6 +51,7 @@ export const SaleEndYearFilter: React.FC = () => {
               options={options}
               onSelect={year => setFilter?.("saleEndYear", parseInt(year))}
               defaultValue={new Date().getFullYear().toString()}
+              selected={saleEndYear?.toString()}
             />
           </Flex>
 

--- a/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/SaleEndYearFilter.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/SaleEndYearFilter.tsx
@@ -1,0 +1,70 @@
+import * as React from "react"
+import { Checkbox, Flex, Select, Spacer } from "@artsy/palette"
+import {
+  useAuctionResultsFilterContext,
+  useCurrentlySelectedFiltersForAuctionResults,
+} from "Apps/Artist/Routes/AuctionResults/AuctionResultsFilterContext"
+import { FilterExpandable } from "Components/ArtworkFilter/ArtworkFilters/FilterExpandable"
+import { ShowMore } from "Components/ArtworkFilter/ArtworkFilters/ShowMore"
+
+export const SaleEndYearFilter: React.FC = () => {
+  const { setFilter, aggregations } = useAuctionResultsFilterContext()
+  const {
+    saleEndYear,
+    saleStartYear,
+    allowUnspecifiedSaleDates,
+  } = useCurrentlySelectedFiltersForAuctionResults()
+
+  const options = (
+    aggregations
+      ?.find(aggregation => aggregation.slice === "LOTS_BY_SALE_YEAR")
+      ?.counts.filter(c => c !== null) || []
+  ).map(c => ({
+    text: c?.name,
+    value: c?.name,
+  }))
+
+  React.useEffect(() => {
+    if (!saleEndYear) {
+      setFilter?.("saleEndYear", new Date().getFullYear())
+    }
+    if (!saleStartYear && options.length > 0) {
+      setFilter?.("saleStartYear", parseInt(options[0].value))
+    }
+  }, [saleEndYear, saleStartYear, setFilter, options])
+
+  return (
+    <FilterExpandable label="Sale End Date" expanded>
+      <Flex flexDirection="column" alignItems="left">
+        <ShowMore>
+          <Flex>
+            <Select
+              title="Start year"
+              options={options}
+              onSelect={year => setFilter?.("saleStartYear", parseInt(year))}
+              defaultValue={options[0]?.value}
+            />
+            <Spacer x={1} />
+            <Select
+              title="End year"
+              options={options}
+              onSelect={year => setFilter?.("saleEndYear", parseInt(year))}
+              defaultValue={new Date().getFullYear().toString()}
+            />
+          </Flex>
+
+          <Spacer y={2} />
+
+          <Checkbox
+            selected={allowUnspecifiedSaleDates}
+            onSelect={unspecified =>
+              setFilter?.("allowUnspecifiedSaleDates", unspecified)
+            }
+          >
+            Include unspecified sale dates
+          </Checkbox>
+        </ShowMore>
+      </Flex>
+    </FilterExpandable>
+  )
+}

--- a/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/SaleEndYearFilter.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/SaleEndYearFilter.tsx
@@ -34,7 +34,7 @@ export const SaleEndYearFilter: React.FC = () => {
   }, [saleEndYear, saleStartYear, setFilter, options])
 
   return (
-    <FilterExpandable label="Sale End Date" expanded>
+    <FilterExpandable label="Sale Date" expanded>
       <Flex flexDirection="column" alignItems="left">
         <ShowMore>
           <Flex>

--- a/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/SaleEndYearFilter.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/SaleEndYearFilter.tsx
@@ -24,18 +24,17 @@ export const SaleEndYearFilter: React.FC = () => {
     value: c?.name,
   }))
 
-  // All options less than the end year
   const startOptions = options.filter(
     option =>
       parseInt(option.value) <=
       (saleEndYear || parseInt(options[options.length - 1]?.value))
   )
 
-  // All options greater than the start year
   const endOptions = options.filter(
     option =>
       parseInt(option.value) >= (saleStartYear || parseInt(options[0]?.value))
   )
+
   return (
     <FilterExpandable label="Sale Date" expanded>
       <Flex flexDirection="column" alignItems="left">
@@ -45,14 +44,16 @@ export const SaleEndYearFilter: React.FC = () => {
               title="Start year"
               options={startOptions}
               onSelect={year => setFilter?.("saleStartYear", parseInt(year))}
-              defaultValue={options[0]?.value}
+              selected={(saleStartYear || options[0]?.value).toString()}
             />
             <Spacer x={1} />
             <Select
               title="End year"
               options={endOptions}
               onSelect={year => setFilter?.("saleEndYear", parseInt(year))}
-              defaultValue={new Date().getFullYear().toString()}
+              selected={(
+                saleEndYear || options[options.length - 1]?.value
+              ).toString()}
             />
           </Flex>
 

--- a/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/index.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/index.tsx
@@ -8,6 +8,7 @@ import { SizeFilter } from "./SizeFilter"
 import { YearCreated } from "./YearCreated"
 import { CurrencyFilter } from "./CurrencyFilter"
 import { KeywordFilter } from "./KeywordFilter"
+import { SaleEndYearFilter } from "./SaleEndYearFilter"
 
 export const AuctionFilters: React.FC<{
   showUpcomingAuctionResults: boolean
@@ -26,8 +27,9 @@ export const AuctionFilters: React.FC<{
         <MediumFilter />
         <SizeFilter />
         <YearCreated />
-        <PriceRangeFilter />
         <CurrencyFilter />
+        <PriceRangeFilter />
+        <SaleEndYearFilter />
         <AuctionHouseFilter />
       </Join>
     </>

--- a/src/Apps/Artist/Routes/AuctionResults/__tests__/ArtistAuctionResults.jest.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/__tests__/ArtistAuctionResults.jest.tsx
@@ -561,7 +561,7 @@ const AuctionResultsFixture: ArtistAuctionResults_Test_Query$rawResponse = {
         },
         {
           slice: "LOTS_BY_SALE_YEAR",
-          counts: [],
+          counts: [{ name: "1880", value: "1880", count: 100 }],
         },
       ],
     },

--- a/src/Apps/Artist/Routes/AuctionResults/__tests__/ArtistAuctionResults.jest.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/__tests__/ArtistAuctionResults.jest.tsx
@@ -554,6 +554,10 @@ const AuctionResultsFixture: ArtistAuctionResults_Test_Query$rawResponse = {
           slice: "CURRENCIES_COUNT",
           counts: [{ name: "USD", value: "USD", count: 100 }],
         },
+        {
+          slice: "LOTS_BY_SALE_YEAR",
+          counts: [],
+        },
       ],
     },
     auctionResultsConnection: {

--- a/src/Apps/Artist/Routes/AuctionResults/__tests__/ArtistAuctionResults.jest.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/__tests__/ArtistAuctionResults.jest.tsx
@@ -235,7 +235,7 @@ describe("AuctionResults", () => {
           checked: true,
         })
 
-        expect(checkedCheckboxes).toHaveLength(9)
+        expect(checkedCheckboxes).toHaveLength(10)
         expect(checkedCheckboxes[0]).toHaveTextContent("Hide upcoming auctions")
         expect(checkedCheckboxes[1]).toHaveTextContent("Painting")
         expect(checkedCheckboxes[2]).toHaveTextContent("Small (under 40cm)")
@@ -246,9 +246,12 @@ describe("AuctionResults", () => {
         expect(checkedCheckboxes[5]).toHaveTextContent(
           "Include unknown and unavailable prices"
         )
-        expect(checkedCheckboxes[6]).toHaveTextContent("Phillips")
-        expect(checkedCheckboxes[7]).toHaveTextContent("Bonhams")
-        expect(checkedCheckboxes[8]).toHaveTextContent("Artsy Auction")
+        expect(checkedCheckboxes[6]).toHaveTextContent(
+          "Include unspecified sale dates"
+        )
+        expect(checkedCheckboxes[7]).toHaveTextContent("Phillips")
+        expect(checkedCheckboxes[8]).toHaveTextContent("Bonhams")
+        expect(checkedCheckboxes[9]).toHaveTextContent("Artsy Auction")
 
         expect(radioElements).toHaveLength(2)
         expect(radioElements[0]).toHaveTextContent("cm")
@@ -322,7 +325,7 @@ describe("AuctionResults", () => {
               })
             })
 
-            expect(trackEvent).toHaveBeenCalledTimes(3)
+            expect(trackEvent).toHaveBeenCalledTimes(5)
             expect(trackEvent.mock.calls[0][0]).toMatchObject({
               action_type: "Auction results filter params changed",
               context_page: "Artist Auction Results",
@@ -331,12 +334,13 @@ describe("AuctionResults", () => {
 
             const { changed, current } = trackEvent.mock.calls[0][0]
             expect(JSON.parse(changed)).toMatchObject({
-              categories: ["Work on Paper"],
+              saleEndYear: 2023,
             })
             expect(JSON.parse(current)).toMatchObject({
-              categories: ["Work on Paper"],
-              organizations: [],
-              sizes: [],
+              categories: ["Painting"],
+              organizations: ["Phillips", "Bonhams", "Artsy Auction"],
+              saleEndYear: 2023,
+              sizes: ["SMALL", "LARGE"],
               page: 1,
               sort: "DATE_DESC",
               allowEmptyCreatedDates: true,

--- a/src/Apps/Artist/Routes/AuctionResults/__tests__/ArtistAuctionResults.jest.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/__tests__/ArtistAuctionResults.jest.tsx
@@ -325,7 +325,7 @@ describe("AuctionResults", () => {
               })
             })
 
-            expect(trackEvent).toHaveBeenCalledTimes(5)
+            expect(trackEvent).toHaveBeenCalledTimes(3)
             expect(trackEvent.mock.calls[0][0]).toMatchObject({
               action_type: "Auction results filter params changed",
               context_page: "Artist Auction Results",
@@ -334,13 +334,14 @@ describe("AuctionResults", () => {
 
             const { changed, current } = trackEvent.mock.calls[0][0]
             expect(JSON.parse(changed)).toMatchObject({
-              saleEndYear: 2023,
+              categories: ["Work on Paper"],
             })
             expect(JSON.parse(current)).toMatchObject({
-              categories: ["Painting"],
-              organizations: ["Phillips", "Bonhams", "Artsy Auction"],
-              saleEndYear: 2023,
-              sizes: ["SMALL", "LARGE"],
+              categories: ["Work on Paper"],
+              organizations: [],
+              saleEndYear: null,
+              saleStartYear: null,
+              sizes: [],
               page: 1,
               sort: "DATE_DESC",
               allowEmptyCreatedDates: true,

--- a/src/Apps/Artist/Utils/allowedAuctionResultFilters.ts
+++ b/src/Apps/Artist/Utils/allowedAuctionResultFilters.ts
@@ -31,6 +31,7 @@ const BOOLEAN_INPUT_ARGS = [
   "hideUpcoming",
   "includeEstimateRange",
   "includeUnknownPrices",
+  "allowUnspecifiedSaleDates",
 ]
 const SUPPORTED_INPUT_ARGS = [
   "organizations",
@@ -44,4 +45,7 @@ const SUPPORTED_INPUT_ARGS = [
   "allowEmptyCreatedDates",
   "includeEstimateRange",
   "includeUnknownPrices",
+  "allowUnspecifiedSaleDates",
+  "saleEndYear",
+  "saleStartYear",
 ]

--- a/src/__generated__/ArtistAuctionResultsQuery.graphql.ts
+++ b/src/__generated__/ArtistAuctionResultsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<55e3f6dddd03797183dc2b1a8eced96a>>
+ * @generated SignedSource<<30dae49ed610daaf176435a61f11e9ca>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,6 +15,7 @@ export type AuctionResultSorts = "DATE_ASC" | "DATE_DESC" | "ESTIMATE_AND_DATE_D
 export type AuctionResultsState = "ALL" | "PAST" | "UPCOMING" | "%future added value";
 export type ArtistAuctionResultsQuery$variables = {
   allowEmptyCreatedDates?: boolean | null;
+  allowUnspecifiedSaleDates?: boolean | null;
   artistID: string;
   before?: string | null;
   categories?: ReadonlyArray<string | null> | null;
@@ -29,6 +30,8 @@ export type ArtistAuctionResultsQuery$variables = {
   organizations?: ReadonlyArray<string | null> | null;
   page?: number | null;
   priceRange?: string | null;
+  saleEndYear?: number | null;
+  saleStartYear?: number | null;
   size?: number | null;
   sizes?: ReadonlyArray<ArtworkSizes | null> | null;
   sort?: AuctionResultSorts | null;
@@ -53,228 +56,258 @@ var v0 = {
 v1 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "artistID"
+  "name": "allowUnspecifiedSaleDates"
 },
 v2 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "before"
+  "name": "artistID"
 },
 v3 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "categories"
+  "name": "before"
 },
 v4 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "createdAfterYear"
+  "name": "categories"
 },
 v5 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "createdBeforeYear"
+  "name": "createdAfterYear"
 },
 v6 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "currency"
+  "name": "createdBeforeYear"
 },
 v7 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "first"
+  "name": "currency"
 },
 v8 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "includeEstimateRange"
+  "name": "first"
 },
 v9 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "includeUnknownPrices"
+  "name": "includeEstimateRange"
 },
 v10 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "keyword"
+  "name": "includeUnknownPrices"
 },
 v11 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "last"
+  "name": "keyword"
 },
 v12 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "organizations"
+  "name": "last"
 },
 v13 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "page"
+  "name": "organizations"
 },
 v14 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "priceRange"
+  "name": "page"
 },
 v15 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "size"
+  "name": "priceRange"
 },
 v16 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "sizes"
+  "name": "saleEndYear"
 },
 v17 = {
   "defaultValue": null,
   "kind": "LocalArgument",
-  "name": "sort"
+  "name": "saleStartYear"
 },
 v18 = {
   "defaultValue": null,
   "kind": "LocalArgument",
+  "name": "size"
+},
+v19 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "sizes"
+},
+v20 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "sort"
+},
+v21 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
   "name": "state"
 },
-v19 = [
+v22 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "artistID"
   }
 ],
-v20 = {
+v23 = {
   "kind": "Variable",
   "name": "allowEmptyCreatedDates",
   "variableName": "allowEmptyCreatedDates"
 },
-v21 = {
+v24 = {
+  "kind": "Variable",
+  "name": "allowUnspecifiedSaleDates",
+  "variableName": "allowUnspecifiedSaleDates"
+},
+v25 = {
   "kind": "Variable",
   "name": "before",
   "variableName": "before"
 },
-v22 = {
+v26 = {
   "kind": "Variable",
   "name": "categories",
   "variableName": "categories"
 },
-v23 = {
+v27 = {
   "kind": "Variable",
   "name": "currency",
   "variableName": "currency"
 },
-v24 = {
+v28 = {
   "kind": "Variable",
   "name": "first",
   "variableName": "first"
 },
-v25 = {
+v29 = {
   "kind": "Variable",
   "name": "includeEstimateRange",
   "variableName": "includeEstimateRange"
 },
-v26 = {
+v30 = {
   "kind": "Variable",
   "name": "includeUnknownPrices",
   "variableName": "includeUnknownPrices"
 },
-v27 = {
+v31 = {
   "kind": "Variable",
   "name": "keyword",
   "variableName": "keyword"
 },
-v28 = {
+v32 = {
   "kind": "Variable",
   "name": "last",
   "variableName": "last"
 },
-v29 = {
+v33 = {
   "kind": "Variable",
   "name": "organizations",
   "variableName": "organizations"
 },
-v30 = {
+v34 = {
   "kind": "Variable",
   "name": "page",
   "variableName": "page"
 },
-v31 = {
+v35 = {
   "kind": "Variable",
   "name": "priceRange",
   "variableName": "priceRange"
 },
-v32 = {
+v36 = {
+  "kind": "Variable",
+  "name": "saleEndYear",
+  "variableName": "saleEndYear"
+},
+v37 = {
+  "kind": "Variable",
+  "name": "saleStartYear",
+  "variableName": "saleStartYear"
+},
+v38 = {
   "kind": "Variable",
   "name": "size",
   "variableName": "size"
 },
-v33 = {
+v39 = {
   "kind": "Variable",
   "name": "sizes",
   "variableName": "sizes"
 },
-v34 = {
+v40 = {
   "kind": "Variable",
   "name": "sort",
   "variableName": "sort"
 },
-v35 = {
+v41 = {
   "kind": "Variable",
   "name": "state",
   "variableName": "state"
 },
-v36 = {
+v42 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v37 = {
+v43 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v38 = {
+v44 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "title",
   "storageKey": null
 },
-v39 = {
+v45 = {
   "kind": "Variable",
   "name": "earliestCreatedYear",
   "variableName": "createdAfterYear"
 },
-v40 = {
+v46 = {
   "kind": "Variable",
   "name": "latestCreatedYear",
   "variableName": "createdBeforeYear"
 },
-v41 = {
+v47 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v42 = {
+v48 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "page",
   "storageKey": null
 },
-v43 = [
-  (v41/*: any*/),
-  (v42/*: any*/),
+v49 = [
+  (v47/*: any*/),
+  (v48/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -283,29 +316,29 @@ v43 = [
     "storageKey": null
   }
 ],
-v44 = {
+v50 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "totalCount",
   "storageKey": null
 },
-v45 = {
+v51 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v46 = {
+v52 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "display",
   "storageKey": null
 },
-v47 = [
-  (v44/*: any*/)
+v53 = [
+  (v50/*: any*/)
 ];
 return {
   "fragment": {
@@ -328,7 +361,10 @@ return {
       (v15/*: any*/),
       (v16/*: any*/),
       (v17/*: any*/),
-      (v18/*: any*/)
+      (v18/*: any*/),
+      (v19/*: any*/),
+      (v20/*: any*/),
+      (v21/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -336,7 +372,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v19/*: any*/),
+        "args": (v22/*: any*/),
         "concreteType": "Artist",
         "kind": "LinkedField",
         "name": "artist",
@@ -344,9 +380,10 @@ return {
         "selections": [
           {
             "args": [
-              (v20/*: any*/),
-              (v21/*: any*/),
-              (v22/*: any*/),
+              (v23/*: any*/),
+              (v24/*: any*/),
+              (v25/*: any*/),
+              (v26/*: any*/),
               {
                 "kind": "Variable",
                 "name": "createdAfterYear",
@@ -357,10 +394,6 @@ return {
                 "name": "createdBeforeYear",
                 "variableName": "createdBeforeYear"
               },
-              (v23/*: any*/),
-              (v24/*: any*/),
-              (v25/*: any*/),
-              (v26/*: any*/),
               (v27/*: any*/),
               (v28/*: any*/),
               (v29/*: any*/),
@@ -369,7 +402,13 @@ return {
               (v32/*: any*/),
               (v33/*: any*/),
               (v34/*: any*/),
-              (v35/*: any*/)
+              (v35/*: any*/),
+              (v36/*: any*/),
+              (v37/*: any*/),
+              (v38/*: any*/),
+              (v39/*: any*/),
+              (v40/*: any*/),
+              (v41/*: any*/)
             ],
             "kind": "FragmentSpread",
             "name": "ArtistAuctionResults_artist"
@@ -384,24 +423,27 @@ return {
   "kind": "Request",
   "operation": {
     "argumentDefinitions": [
-      (v7/*: any*/),
-      (v11/*: any*/),
-      (v13/*: any*/),
-      (v15/*: any*/),
-      (v2/*: any*/),
-      (v17/*: any*/),
-      (v18/*: any*/),
-      (v1/*: any*/),
-      (v12/*: any*/),
-      (v10/*: any*/),
-      (v3/*: any*/),
-      (v16/*: any*/),
-      (v14/*: any*/),
-      (v6/*: any*/),
       (v8/*: any*/),
-      (v9/*: any*/),
-      (v5/*: any*/),
+      (v12/*: any*/),
+      (v14/*: any*/),
+      (v18/*: any*/),
+      (v3/*: any*/),
+      (v20/*: any*/),
+      (v21/*: any*/),
+      (v2/*: any*/),
+      (v13/*: any*/),
+      (v11/*: any*/),
       (v4/*: any*/),
+      (v19/*: any*/),
+      (v15/*: any*/),
+      (v7/*: any*/),
+      (v17/*: any*/),
+      (v16/*: any*/),
+      (v1/*: any*/),
+      (v9/*: any*/),
+      (v10/*: any*/),
+      (v6/*: any*/),
+      (v5/*: any*/),
       (v0/*: any*/)
     ],
     "kind": "Operation",
@@ -409,7 +451,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v19/*: any*/),
+        "args": (v22/*: any*/),
         "concreteType": "Artist",
         "kind": "LinkedField",
         "name": "artist",
@@ -422,8 +464,8 @@ return {
             "name": "slug",
             "storageKey": null
           },
-          (v36/*: any*/),
-          (v37/*: any*/),
+          (v42/*: any*/),
+          (v43/*: any*/),
           {
             "alias": null,
             "args": [
@@ -445,7 +487,7 @@ return {
                 "name": "description",
                 "storageKey": null
               },
-              (v38/*: any*/)
+              (v44/*: any*/)
             ],
             "storageKey": "meta(page:\"AUCTION_RESULTS\")"
           },
@@ -470,24 +512,27 @@ return {
           {
             "alias": null,
             "args": [
-              (v20/*: any*/),
-              (v21/*: any*/),
-              (v22/*: any*/),
               (v23/*: any*/),
-              (v39/*: any*/),
               (v24/*: any*/),
               (v25/*: any*/),
               (v26/*: any*/),
               (v27/*: any*/),
+              (v45/*: any*/),
               (v28/*: any*/),
-              (v40/*: any*/),
               (v29/*: any*/),
               (v30/*: any*/),
               (v31/*: any*/),
               (v32/*: any*/),
+              (v46/*: any*/),
               (v33/*: any*/),
               (v34/*: any*/),
-              (v35/*: any*/)
+              (v35/*: any*/),
+              (v36/*: any*/),
+              (v37/*: any*/),
+              (v38/*: any*/),
+              (v39/*: any*/),
+              (v40/*: any*/),
+              (v41/*: any*/)
             ],
             "concreteType": "AuctionResultConnection",
             "kind": "LinkedField",
@@ -559,7 +604,7 @@ return {
                     "kind": "LinkedField",
                     "name": "around",
                     "plural": true,
-                    "selections": (v43/*: any*/),
+                    "selections": (v49/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -569,7 +614,7 @@ return {
                     "kind": "LinkedField",
                     "name": "first",
                     "plural": false,
-                    "selections": (v43/*: any*/),
+                    "selections": (v49/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -579,7 +624,7 @@ return {
                     "kind": "LinkedField",
                     "name": "last",
                     "plural": false,
-                    "selections": (v43/*: any*/),
+                    "selections": (v49/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -590,15 +635,15 @@ return {
                     "name": "previous",
                     "plural": false,
                     "selections": [
-                      (v41/*: any*/),
-                      (v42/*: any*/)
+                      (v47/*: any*/),
+                      (v48/*: any*/)
                     ],
                     "storageKey": null
                   }
                 ],
                 "storageKey": null
               },
-              (v44/*: any*/),
+              (v50/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -615,8 +660,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v36/*: any*/),
-                      (v38/*: any*/),
+                      (v42/*: any*/),
+                      (v44/*: any*/),
                       {
                         "alias": "dimension_text",
                         "args": null,
@@ -639,8 +684,8 @@ return {
                         "name": "artist",
                         "plural": false,
                         "selections": [
-                          (v37/*: any*/),
-                          (v45/*: any*/)
+                          (v43/*: any*/),
+                          (v51/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -773,7 +818,7 @@ return {
                         "name": "priceRealized",
                         "plural": false,
                         "selections": [
-                          (v46/*: any*/),
+                          (v52/*: any*/),
                           {
                             "alias": "display_usd",
                             "args": null,
@@ -817,7 +862,7 @@ return {
                         "name": "estimate",
                         "plural": false,
                         "selections": [
-                          (v46/*: any*/)
+                          (v52/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -849,7 +894,7 @@ return {
                         "name": "isUpcoming",
                         "storageKey": null
                       },
-                      (v45/*: any*/)
+                      (v51/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -862,16 +907,20 @@ return {
           {
             "alias": "pastAuctionResults",
             "args": [
-              (v20/*: any*/),
-              (v22/*: any*/),
-              (v39/*: any*/),
-              (v25/*: any*/),
+              (v23/*: any*/),
+              (v24/*: any*/),
               (v26/*: any*/),
               (v27/*: any*/),
-              (v40/*: any*/),
+              (v45/*: any*/),
               (v29/*: any*/),
+              (v30/*: any*/),
               (v31/*: any*/),
+              (v46/*: any*/),
               (v33/*: any*/),
+              (v35/*: any*/),
+              (v36/*: any*/),
+              (v37/*: any*/),
+              (v39/*: any*/),
               {
                 "kind": "Literal",
                 "name": "state",
@@ -882,22 +931,26 @@ return {
             "kind": "LinkedField",
             "name": "auctionResultsConnection",
             "plural": false,
-            "selections": (v47/*: any*/),
+            "selections": (v53/*: any*/),
             "storageKey": null
           },
           {
             "alias": "upcomingAuctionResults",
             "args": [
-              (v20/*: any*/),
-              (v22/*: any*/),
-              (v39/*: any*/),
-              (v25/*: any*/),
+              (v23/*: any*/),
+              (v24/*: any*/),
               (v26/*: any*/),
               (v27/*: any*/),
-              (v40/*: any*/),
+              (v45/*: any*/),
               (v29/*: any*/),
+              (v30/*: any*/),
               (v31/*: any*/),
+              (v46/*: any*/),
               (v33/*: any*/),
+              (v35/*: any*/),
+              (v36/*: any*/),
+              (v37/*: any*/),
+              (v39/*: any*/),
               {
                 "kind": "Literal",
                 "name": "state",
@@ -908,26 +961,26 @@ return {
             "kind": "LinkedField",
             "name": "auctionResultsConnection",
             "plural": false,
-            "selections": (v47/*: any*/),
+            "selections": (v53/*: any*/),
             "storageKey": null
           },
-          (v45/*: any*/)
+          (v51/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "273b7502744779d7c84efbd2a99e50dc",
+    "cacheID": "09ac5668a03772e8ca029d54b5ffe78a",
     "id": null,
     "metadata": {},
     "name": "ArtistAuctionResultsQuery",
     "operationKind": "query",
-    "text": "query ArtistAuctionResultsQuery(\n  $first: Int\n  $last: Int\n  $page: Int\n  $size: Int\n  $before: String\n  $sort: AuctionResultSorts\n  $state: AuctionResultsState\n  $artistID: String!\n  $organizations: [String]\n  $keyword: String\n  $categories: [String]\n  $sizes: [ArtworkSizes]\n  $priceRange: String\n  $currency: String\n  $includeEstimateRange: Boolean\n  $includeUnknownPrices: Boolean\n  $createdBeforeYear: Int\n  $createdAfterYear: Int\n  $allowEmptyCreatedDates: Boolean\n) {\n  artist(id: $artistID) {\n    ...ArtistAuctionResults_artist_49n5AX\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  internalID\n  title\n  dimension_text: dimensionText\n  organization\n  artist {\n    name\n    id\n  }\n  images {\n    thumbnail {\n      cropped(width: 130, height: 130, version: [\"square140\"]) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n  }\n  mediumText\n  categoryText\n  date_text: dateText\n  saleDate\n  boughtIn\n  currency\n  price_realized: priceRealized {\n    display\n    display_usd: displayUSD\n    cents_usd: centsUSD\n  }\n  performance {\n    mid\n  }\n  estimate {\n    display\n  }\n  location\n  lotNumber\n  saleTitle\n  isUpcoming\n}\n\nfragment ArtistAuctionResults_artist_49n5AX on Artist {\n  slug\n  internalID\n  name\n  meta(page: AUCTION_RESULTS) {\n    description\n    title\n  }\n  counts {\n    auctionResults\n  }\n  auctionResultsConnection(first: $first, page: $page, size: $size, before: $before, last: $last, sort: $sort, organizations: $organizations, keyword: $keyword, categories: $categories, sizes: $sizes, priceRange: $priceRange, currency: $currency, includeEstimateRange: $includeEstimateRange, includeUnknownPrices: $includeUnknownPrices, earliestCreatedYear: $createdAfterYear, latestCreatedYear: $createdBeforeYear, allowEmptyCreatedDates: $allowEmptyCreatedDates, state: $state) {\n    createdYearRange {\n      startAt\n      endAt\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        isUpcoming\n        id\n      }\n    }\n  }\n  pastAuctionResults: auctionResultsConnection(state: PAST, organizations: $organizations, keyword: $keyword, categories: $categories, sizes: $sizes, priceRange: $priceRange, includeEstimateRange: $includeEstimateRange, includeUnknownPrices: $includeUnknownPrices, earliestCreatedYear: $createdAfterYear, latestCreatedYear: $createdBeforeYear, allowEmptyCreatedDates: $allowEmptyCreatedDates) {\n    totalCount\n  }\n  upcomingAuctionResults: auctionResultsConnection(state: UPCOMING, organizations: $organizations, keyword: $keyword, categories: $categories, sizes: $sizes, priceRange: $priceRange, includeEstimateRange: $includeEstimateRange, includeUnknownPrices: $includeUnknownPrices, earliestCreatedYear: $createdAfterYear, latestCreatedYear: $createdBeforeYear, allowEmptyCreatedDates: $allowEmptyCreatedDates) {\n    totalCount\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
+    "text": "query ArtistAuctionResultsQuery(\n  $first: Int\n  $last: Int\n  $page: Int\n  $size: Int\n  $before: String\n  $sort: AuctionResultSorts\n  $state: AuctionResultsState\n  $artistID: String!\n  $organizations: [String]\n  $keyword: String\n  $categories: [String]\n  $sizes: [ArtworkSizes]\n  $priceRange: String\n  $currency: String\n  $saleStartYear: Int\n  $saleEndYear: Int\n  $allowUnspecifiedSaleDates: Boolean\n  $includeEstimateRange: Boolean\n  $includeUnknownPrices: Boolean\n  $createdBeforeYear: Int\n  $createdAfterYear: Int\n  $allowEmptyCreatedDates: Boolean\n) {\n  artist(id: $artistID) {\n    ...ArtistAuctionResults_artist_2gBCIO\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  internalID\n  title\n  dimension_text: dimensionText\n  organization\n  artist {\n    name\n    id\n  }\n  images {\n    thumbnail {\n      cropped(width: 130, height: 130, version: [\"square140\"]) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n  }\n  mediumText\n  categoryText\n  date_text: dateText\n  saleDate\n  boughtIn\n  currency\n  price_realized: priceRealized {\n    display\n    display_usd: displayUSD\n    cents_usd: centsUSD\n  }\n  performance {\n    mid\n  }\n  estimate {\n    display\n  }\n  location\n  lotNumber\n  saleTitle\n  isUpcoming\n}\n\nfragment ArtistAuctionResults_artist_2gBCIO on Artist {\n  slug\n  internalID\n  name\n  meta(page: AUCTION_RESULTS) {\n    description\n    title\n  }\n  counts {\n    auctionResults\n  }\n  auctionResultsConnection(first: $first, page: $page, size: $size, before: $before, last: $last, sort: $sort, organizations: $organizations, keyword: $keyword, categories: $categories, sizes: $sizes, priceRange: $priceRange, currency: $currency, saleStartYear: $saleStartYear, saleEndYear: $saleEndYear, allowUnspecifiedSaleDates: $allowUnspecifiedSaleDates, includeEstimateRange: $includeEstimateRange, includeUnknownPrices: $includeUnknownPrices, earliestCreatedYear: $createdAfterYear, latestCreatedYear: $createdBeforeYear, allowEmptyCreatedDates: $allowEmptyCreatedDates, state: $state) {\n    createdYearRange {\n      startAt\n      endAt\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        isUpcoming\n        id\n      }\n    }\n  }\n  pastAuctionResults: auctionResultsConnection(state: PAST, organizations: $organizations, keyword: $keyword, categories: $categories, sizes: $sizes, priceRange: $priceRange, currency: $currency, saleStartYear: $saleStartYear, saleEndYear: $saleEndYear, allowUnspecifiedSaleDates: $allowUnspecifiedSaleDates, includeEstimateRange: $includeEstimateRange, includeUnknownPrices: $includeUnknownPrices, earliestCreatedYear: $createdAfterYear, latestCreatedYear: $createdBeforeYear, allowEmptyCreatedDates: $allowEmptyCreatedDates) {\n    totalCount\n  }\n  upcomingAuctionResults: auctionResultsConnection(state: UPCOMING, organizations: $organizations, keyword: $keyword, categories: $categories, sizes: $sizes, priceRange: $priceRange, currency: $currency, saleStartYear: $saleStartYear, saleEndYear: $saleEndYear, allowUnspecifiedSaleDates: $allowUnspecifiedSaleDates, includeEstimateRange: $includeEstimateRange, includeUnknownPrices: $includeUnknownPrices, earliestCreatedYear: $createdAfterYear, latestCreatedYear: $createdBeforeYear, allowEmptyCreatedDates: $allowEmptyCreatedDates) {\n    totalCount\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "d3cd17f8bb9a89a5b6387d6444cb027a";
+(node as any).hash = "b75161a889263f8a40b911784f0cf526";
 
 export default node;

--- a/src/__generated__/ArtistAuctionResultsRoute_artist.graphql.ts
+++ b/src/__generated__/ArtistAuctionResultsRoute_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c8fe38c23c2f757725a0be0f1a8294d1>>
+ * @generated SignedSource<<17c742c2e5763032fc9c1ae4d16919a4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -36,6 +36,11 @@ const node: ReaderFragment = {
       "defaultValue": null,
       "kind": "LocalArgument",
       "name": "allowEmptyCreatedDates"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "allowUnspecifiedSaleDates"
     },
     {
       "defaultValue": null,
@@ -85,6 +90,16 @@ const node: ReaderFragment = {
     {
       "defaultValue": null,
       "kind": "LocalArgument",
+      "name": "saleEndYear"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "saleStartYear"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
       "name": "sizes"
     },
     {
@@ -103,6 +118,11 @@ const node: ReaderFragment = {
           "kind": "Variable",
           "name": "allowEmptyCreatedDates",
           "variableName": "allowEmptyCreatedDates"
+        },
+        {
+          "kind": "Variable",
+          "name": "allowUnspecifiedSaleDates",
+          "variableName": "allowUnspecifiedSaleDates"
         },
         {
           "kind": "Variable",
@@ -151,6 +171,16 @@ const node: ReaderFragment = {
         },
         {
           "kind": "Variable",
+          "name": "saleEndYear",
+          "variableName": "saleEndYear"
+        },
+        {
+          "kind": "Variable",
+          "name": "saleStartYear",
+          "variableName": "saleStartYear"
+        },
+        {
+          "kind": "Variable",
           "name": "sizes",
           "variableName": "sizes"
         },
@@ -171,7 +201,8 @@ const node: ReaderFragment = {
           "name": "aggregations",
           "value": [
             "SIMPLE_PRICE_HISTOGRAM",
-            "CURRENCIES_COUNT"
+            "CURRENCIES_COUNT",
+            "LOTS_BY_SALE_YEAR"
           ]
         }
       ],
@@ -231,13 +262,13 @@ const node: ReaderFragment = {
           "storageKey": null
         }
       ],
-      "storageKey": "auctionResultsConnection(aggregations:[\"SIMPLE_PRICE_HISTOGRAM\",\"CURRENCIES_COUNT\"])"
+      "storageKey": "auctionResultsConnection(aggregations:[\"SIMPLE_PRICE_HISTOGRAM\",\"CURRENCIES_COUNT\",\"LOTS_BY_SALE_YEAR\"])"
     }
   ],
   "type": "Artist",
   "abstractKey": null
 };
 
-(node as any).hash = "8a4aec5718ff9101680e9fa540c50c9c";
+(node as any).hash = "8cc699aeb92de8bbb29b0af6d247c650";
 
 export default node;

--- a/src/__generated__/ArtistAuctionResults_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistAuctionResults_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<63060713037b61d1426fca147659ea06>>
+ * @generated SignedSource<<de4adcec1d4f852b7d46b947f36b621d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -739,7 +739,8 @@ return {
                 "name": "aggregations",
                 "value": [
                   "SIMPLE_PRICE_HISTOGRAM",
-                  "CURRENCIES_COUNT"
+                  "CURRENCIES_COUNT",
+                  "LOTS_BY_SALE_YEAR"
                 ]
               }
             ],
@@ -793,7 +794,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "auctionResultsConnection(aggregations:[\"SIMPLE_PRICE_HISTOGRAM\",\"CURRENCIES_COUNT\"])"
+            "storageKey": "auctionResultsConnection(aggregations:[\"SIMPLE_PRICE_HISTOGRAM\",\"CURRENCIES_COUNT\",\"LOTS_BY_SALE_YEAR\"])"
           },
           (v9/*: any*/)
         ],
@@ -802,12 +803,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "127a89229afd4f69c84e691a642004a5",
+    "cacheID": "3a70765087e1c9bdf1c5c72b54072520",
     "id": null,
     "metadata": {},
     "name": "ArtistAuctionResults_Test_Query",
     "operationKind": "query",
-    "text": "query ArtistAuctionResults_Test_Query(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistAuctionResultsRoute_artist\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  internalID\n  title\n  dimension_text: dimensionText\n  organization\n  artist {\n    name\n    id\n  }\n  images {\n    thumbnail {\n      cropped(width: 130, height: 130, version: [\"square140\"]) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n  }\n  mediumText\n  categoryText\n  date_text: dateText\n  saleDate\n  boughtIn\n  currency\n  price_realized: priceRealized {\n    display\n    display_usd: displayUSD\n    cents_usd: centsUSD\n  }\n  performance {\n    mid\n  }\n  estimate {\n    display\n  }\n  location\n  lotNumber\n  saleTitle\n  isUpcoming\n}\n\nfragment ArtistAuctionResultsRoute_artist on Artist {\n  ...ArtistAuctionResults_artist_1twhiG\n  sidebarAggregations: auctionResultsConnection(aggregations: [SIMPLE_PRICE_HISTOGRAM, CURRENCIES_COUNT]) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n  }\n}\n\nfragment ArtistAuctionResults_artist_1twhiG on Artist {\n  slug\n  internalID\n  name\n  meta(page: AUCTION_RESULTS) {\n    description\n    title\n  }\n  counts {\n    auctionResults\n  }\n  auctionResultsConnection(first: 50, sort: DATE_DESC, state: ALL) {\n    createdYearRange {\n      startAt\n      endAt\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        isUpcoming\n        id\n      }\n    }\n  }\n  pastAuctionResults: auctionResultsConnection(state: PAST) {\n    totalCount\n  }\n  upcomingAuctionResults: auctionResultsConnection(state: UPCOMING) {\n    totalCount\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
+    "text": "query ArtistAuctionResults_Test_Query(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistAuctionResultsRoute_artist\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  internalID\n  title\n  dimension_text: dimensionText\n  organization\n  artist {\n    name\n    id\n  }\n  images {\n    thumbnail {\n      cropped(width: 130, height: 130, version: [\"square140\"]) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n  }\n  mediumText\n  categoryText\n  date_text: dateText\n  saleDate\n  boughtIn\n  currency\n  price_realized: priceRealized {\n    display\n    display_usd: displayUSD\n    cents_usd: centsUSD\n  }\n  performance {\n    mid\n  }\n  estimate {\n    display\n  }\n  location\n  lotNumber\n  saleTitle\n  isUpcoming\n}\n\nfragment ArtistAuctionResultsRoute_artist on Artist {\n  ...ArtistAuctionResults_artist_GM8aI\n  sidebarAggregations: auctionResultsConnection(aggregations: [SIMPLE_PRICE_HISTOGRAM, CURRENCIES_COUNT, LOTS_BY_SALE_YEAR]) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n  }\n}\n\nfragment ArtistAuctionResults_artist_GM8aI on Artist {\n  slug\n  internalID\n  name\n  meta(page: AUCTION_RESULTS) {\n    description\n    title\n  }\n  counts {\n    auctionResults\n  }\n  auctionResultsConnection(first: 50, sort: DATE_DESC, state: ALL) {\n    createdYearRange {\n      startAt\n      endAt\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        isUpcoming\n        id\n      }\n    }\n  }\n  pastAuctionResults: auctionResultsConnection(state: PAST) {\n    totalCount\n  }\n  upcomingAuctionResults: auctionResultsConnection(state: UPCOMING) {\n    totalCount\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistAuctionResults_artist.graphql.ts
+++ b/src/__generated__/ArtistAuctionResults_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f1bad9f26aedb903f25e903767f68ccb>>
+ * @generated SignedSource<<c475de5e0c1b604ac93790369fec3395>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -62,58 +62,78 @@ var v0 = {
 },
 v1 = {
   "kind": "Variable",
+  "name": "allowUnspecifiedSaleDates",
+  "variableName": "allowUnspecifiedSaleDates"
+},
+v2 = {
+  "kind": "Variable",
   "name": "categories",
   "variableName": "categories"
 },
-v2 = {
+v3 = {
+  "kind": "Variable",
+  "name": "currency",
+  "variableName": "currency"
+},
+v4 = {
   "kind": "Variable",
   "name": "earliestCreatedYear",
   "variableName": "createdAfterYear"
 },
-v3 = {
+v5 = {
   "kind": "Variable",
   "name": "includeEstimateRange",
   "variableName": "includeEstimateRange"
 },
-v4 = {
+v6 = {
   "kind": "Variable",
   "name": "includeUnknownPrices",
   "variableName": "includeUnknownPrices"
 },
-v5 = {
+v7 = {
   "kind": "Variable",
   "name": "keyword",
   "variableName": "keyword"
 },
-v6 = {
+v8 = {
   "kind": "Variable",
   "name": "latestCreatedYear",
   "variableName": "createdBeforeYear"
 },
-v7 = {
+v9 = {
   "kind": "Variable",
   "name": "organizations",
   "variableName": "organizations"
 },
-v8 = {
+v10 = {
   "kind": "Variable",
   "name": "priceRange",
   "variableName": "priceRange"
 },
-v9 = {
+v11 = {
+  "kind": "Variable",
+  "name": "saleEndYear",
+  "variableName": "saleEndYear"
+},
+v12 = {
+  "kind": "Variable",
+  "name": "saleStartYear",
+  "variableName": "saleStartYear"
+},
+v13 = {
   "kind": "Variable",
   "name": "sizes",
   "variableName": "sizes"
 },
-v10 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "totalCount",
   "storageKey": null
 },
-v11 = [
-  (v10/*: any*/)
+v15 = [
+  (v14/*: any*/)
 ];
 return {
   "argumentDefinitions": [
@@ -121,6 +141,11 @@ return {
       "defaultValue": null,
       "kind": "LocalArgument",
       "name": "allowEmptyCreatedDates"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "allowUnspecifiedSaleDates"
     },
     {
       "defaultValue": null,
@@ -186,6 +211,16 @@ return {
       "defaultValue": null,
       "kind": "LocalArgument",
       "name": "priceRange"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "saleEndYear"
+    },
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "saleStartYear"
     },
     {
       "defaultValue": null,
@@ -286,45 +321,44 @@ return {
       "alias": null,
       "args": [
         (v0/*: any*/),
+        (v1/*: any*/),
         {
           "kind": "Variable",
           "name": "before",
           "variableName": "before"
         },
-        (v1/*: any*/),
-        {
-          "kind": "Variable",
-          "name": "currency",
-          "variableName": "currency"
-        },
         (v2/*: any*/),
+        (v3/*: any*/),
+        (v4/*: any*/),
         {
           "kind": "Variable",
           "name": "first",
           "variableName": "first"
         },
-        (v3/*: any*/),
-        (v4/*: any*/),
         (v5/*: any*/),
+        (v6/*: any*/),
+        (v7/*: any*/),
         {
           "kind": "Variable",
           "name": "last",
           "variableName": "last"
         },
-        (v6/*: any*/),
-        (v7/*: any*/),
+        (v8/*: any*/),
+        (v9/*: any*/),
         {
           "kind": "Variable",
           "name": "page",
           "variableName": "page"
         },
-        (v8/*: any*/),
+        (v10/*: any*/),
+        (v11/*: any*/),
+        (v12/*: any*/),
         {
           "kind": "Variable",
           "name": "size",
           "variableName": "size"
         },
-        (v9/*: any*/),
+        (v13/*: any*/),
         {
           "kind": "Variable",
           "name": "sort",
@@ -407,7 +441,7 @@ return {
           ],
           "storageKey": null
         },
-        (v10/*: any*/),
+        (v14/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -458,6 +492,10 @@ return {
         (v7/*: any*/),
         (v8/*: any*/),
         (v9/*: any*/),
+        (v10/*: any*/),
+        (v11/*: any*/),
+        (v12/*: any*/),
+        (v13/*: any*/),
         {
           "kind": "Literal",
           "name": "state",
@@ -468,7 +506,7 @@ return {
       "kind": "LinkedField",
       "name": "auctionResultsConnection",
       "plural": false,
-      "selections": (v11/*: any*/),
+      "selections": (v15/*: any*/),
       "storageKey": null
     },
     {
@@ -484,6 +522,10 @@ return {
         (v7/*: any*/),
         (v8/*: any*/),
         (v9/*: any*/),
+        (v10/*: any*/),
+        (v11/*: any*/),
+        (v12/*: any*/),
+        (v13/*: any*/),
         {
           "kind": "Literal",
           "name": "state",
@@ -494,7 +536,7 @@ return {
       "kind": "LinkedField",
       "name": "auctionResultsConnection",
       "plural": false,
-      "selections": (v11/*: any*/),
+      "selections": (v15/*: any*/),
       "storageKey": null
     }
   ],
@@ -503,6 +545,6 @@ return {
 };
 })();
 
-(node as any).hash = "c1a7858c4f6f6e2ac8fee51f0912076d";
+(node as any).hash = "dc48479e9f666f2b17bb8fba344dd7a1";
 
 export default node;

--- a/src/__generated__/artistRoutes_AuctionResultsQuery.graphql.ts
+++ b/src/__generated__/artistRoutes_AuctionResultsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2f3a5bbf8e8f2641d698e4b4ab3cf27e>>
+ * @generated SignedSource<<52c597a64f1cfd10d5ce703164f2ce02>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -821,7 +821,8 @@ return {
                 "name": "aggregations",
                 "value": [
                   "SIMPLE_PRICE_HISTOGRAM",
-                  "CURRENCIES_COUNT"
+                  "CURRENCIES_COUNT",
+                  "LOTS_BY_SALE_YEAR"
                 ]
               }
             ],
@@ -875,7 +876,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "auctionResultsConnection(aggregations:[\"SIMPLE_PRICE_HISTOGRAM\",\"CURRENCIES_COUNT\"])"
+            "storageKey": "auctionResultsConnection(aggregations:[\"SIMPLE_PRICE_HISTOGRAM\",\"CURRENCIES_COUNT\",\"LOTS_BY_SALE_YEAR\"])"
           },
           (v31/*: any*/)
         ],
@@ -884,12 +885,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "dcd66435a06c9d223e1371f4d3c9a079",
+    "cacheID": "da984990715186f32e88aa8327eb5d3c",
     "id": null,
     "metadata": {},
     "name": "artistRoutes_AuctionResultsQuery",
     "operationKind": "query",
-    "text": "query artistRoutes_AuctionResultsQuery(\n  $page: Int\n  $state: AuctionResultsState\n  $artistID: String!\n  $organizations: [String]\n  $categories: [String]\n  $sizes: [ArtworkSizes]\n  $priceRange: String\n  $includeEstimateRange: Boolean\n  $includeUnknownPrices: Boolean\n  $createdAfterYear: Int\n  $createdBeforeYear: Int\n  $allowEmptyCreatedDates: Boolean\n) {\n  artist(id: $artistID) {\n    ...ArtistAuctionResultsRoute_artist_rukZa\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  internalID\n  title\n  dimension_text: dimensionText\n  organization\n  artist {\n    name\n    id\n  }\n  images {\n    thumbnail {\n      cropped(width: 130, height: 130, version: [\"square140\"]) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n  }\n  mediumText\n  categoryText\n  date_text: dateText\n  saleDate\n  boughtIn\n  currency\n  price_realized: priceRealized {\n    display\n    display_usd: displayUSD\n    cents_usd: centsUSD\n  }\n  performance {\n    mid\n  }\n  estimate {\n    display\n  }\n  location\n  lotNumber\n  saleTitle\n  isUpcoming\n}\n\nfragment ArtistAuctionResultsRoute_artist_rukZa on Artist {\n  ...ArtistAuctionResults_artist_Cngys\n  sidebarAggregations: auctionResultsConnection(aggregations: [SIMPLE_PRICE_HISTOGRAM, CURRENCIES_COUNT]) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n  }\n}\n\nfragment ArtistAuctionResults_artist_Cngys on Artist {\n  slug\n  internalID\n  name\n  meta(page: AUCTION_RESULTS) {\n    description\n    title\n  }\n  counts {\n    auctionResults\n  }\n  auctionResultsConnection(first: 50, page: $page, sort: DATE_DESC, organizations: $organizations, categories: $categories, sizes: $sizes, priceRange: $priceRange, includeEstimateRange: $includeEstimateRange, includeUnknownPrices: $includeUnknownPrices, earliestCreatedYear: $createdAfterYear, latestCreatedYear: $createdBeforeYear, allowEmptyCreatedDates: $allowEmptyCreatedDates, state: $state) {\n    createdYearRange {\n      startAt\n      endAt\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        isUpcoming\n        id\n      }\n    }\n  }\n  pastAuctionResults: auctionResultsConnection(state: PAST, organizations: $organizations, categories: $categories, sizes: $sizes, priceRange: $priceRange, includeEstimateRange: $includeEstimateRange, includeUnknownPrices: $includeUnknownPrices, earliestCreatedYear: $createdAfterYear, latestCreatedYear: $createdBeforeYear, allowEmptyCreatedDates: $allowEmptyCreatedDates) {\n    totalCount\n  }\n  upcomingAuctionResults: auctionResultsConnection(state: UPCOMING, organizations: $organizations, categories: $categories, sizes: $sizes, priceRange: $priceRange, includeEstimateRange: $includeEstimateRange, includeUnknownPrices: $includeUnknownPrices, earliestCreatedYear: $createdAfterYear, latestCreatedYear: $createdBeforeYear, allowEmptyCreatedDates: $allowEmptyCreatedDates) {\n    totalCount\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
+    "text": "query artistRoutes_AuctionResultsQuery(\n  $page: Int\n  $state: AuctionResultsState\n  $artistID: String!\n  $organizations: [String]\n  $categories: [String]\n  $sizes: [ArtworkSizes]\n  $priceRange: String\n  $includeEstimateRange: Boolean\n  $includeUnknownPrices: Boolean\n  $createdAfterYear: Int\n  $createdBeforeYear: Int\n  $allowEmptyCreatedDates: Boolean\n) {\n  artist(id: $artistID) {\n    ...ArtistAuctionResultsRoute_artist_rukZa\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  internalID\n  title\n  dimension_text: dimensionText\n  organization\n  artist {\n    name\n    id\n  }\n  images {\n    thumbnail {\n      cropped(width: 130, height: 130, version: [\"square140\"]) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n  }\n  mediumText\n  categoryText\n  date_text: dateText\n  saleDate\n  boughtIn\n  currency\n  price_realized: priceRealized {\n    display\n    display_usd: displayUSD\n    cents_usd: centsUSD\n  }\n  performance {\n    mid\n  }\n  estimate {\n    display\n  }\n  location\n  lotNumber\n  saleTitle\n  isUpcoming\n}\n\nfragment ArtistAuctionResultsRoute_artist_rukZa on Artist {\n  ...ArtistAuctionResults_artist_2rF1H1\n  sidebarAggregations: auctionResultsConnection(aggregations: [SIMPLE_PRICE_HISTOGRAM, CURRENCIES_COUNT, LOTS_BY_SALE_YEAR]) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n  }\n}\n\nfragment ArtistAuctionResults_artist_2rF1H1 on Artist {\n  slug\n  internalID\n  name\n  meta(page: AUCTION_RESULTS) {\n    description\n    title\n  }\n  counts {\n    auctionResults\n  }\n  auctionResultsConnection(first: 50, page: $page, sort: DATE_DESC, organizations: $organizations, categories: $categories, sizes: $sizes, priceRange: $priceRange, includeEstimateRange: $includeEstimateRange, includeUnknownPrices: $includeUnknownPrices, earliestCreatedYear: $createdAfterYear, latestCreatedYear: $createdBeforeYear, allowEmptyCreatedDates: $allowEmptyCreatedDates, state: $state) {\n    createdYearRange {\n      startAt\n      endAt\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    totalCount\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        isUpcoming\n        id\n      }\n    }\n  }\n  pastAuctionResults: auctionResultsConnection(state: PAST, organizations: $organizations, categories: $categories, sizes: $sizes, priceRange: $priceRange, includeEstimateRange: $includeEstimateRange, includeUnknownPrices: $includeUnknownPrices, earliestCreatedYear: $createdAfterYear, latestCreatedYear: $createdBeforeYear, allowEmptyCreatedDates: $allowEmptyCreatedDates) {\n    totalCount\n  }\n  upcomingAuctionResults: auctionResultsConnection(state: UPCOMING, organizations: $organizations, categories: $categories, sizes: $sizes, priceRange: $priceRange, includeEstimateRange: $includeEstimateRange, includeUnknownPrices: $includeUnknownPrices, earliestCreatedYear: $createdAfterYear, latestCreatedYear: $createdBeforeYear, allowEmptyCreatedDates: $allowEmptyCreatedDates) {\n    totalCount\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [DIA-99]

### Description

Adds Sale Year filter for Auction Results page.


cc @artsy/diamond-devs 
![image](https://github.com/artsy/force/assets/1176374/67ff2ff1-526f-4741-b061-2f38c8895cd1)

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DIA-99]: https://artsyproduct.atlassian.net/browse/DIA-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ