### PR TITLE
fix(onyx): update copy and placeholder for Auction create alert header

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/ArtworkAuctionCreateAlertHeader.tsx
+++ b/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/ArtworkAuctionCreateAlertHeader.tsx
@@ -109,9 +109,16 @@ const ArtworkAuctionCreateAlertHeader: FC<ArtworkAuctionCreateAlertHeaderProps> 
     >
       <GridColumns py={6}>
         <Column span={12}>
-          <Text variant="lg" textAlign="center">
+          <Text variant="lg" textAlign={["left", "center"]}>
             Bidding for <i>{artwork.title?.trim()}</i>
             {artistName} has ended.
+          </Text>
+          <Text
+            variant={["sm-display", "lg"]}
+            textAlign={["left", "center"]}
+            textColor={["black60", "black100"]}
+          >
+            Get notified when similar works become available.
           </Text>
         </Column>
 

--- a/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/ArtworkAuctionCreateAlertTooltip.tsx
+++ b/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/ArtworkAuctionCreateAlertTooltip.tsx
@@ -15,8 +15,7 @@ export const ArtworkAuctionCreateAlertTooltip: FC = () => {
   return (
     <Flex justifyContent="center" alignItems="center">
       <Text variant="sm">
-        Available works by {artistName} based on similar tags and auction
-        activity.
+        You may be interested in these similar works by {artistName}.
       </Text>
       <Tooltip
         width="auto"

--- a/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/SuggestedArtworksShelf.tsx
+++ b/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/SuggestedArtworksShelf.tsx
@@ -41,7 +41,7 @@ export const SuggestedArtworksShelf: FC<SuggestedArtworksShelfProps> = ({
 export const SuggestedArtworksShelfQueryRenderer: FC<SearchCriteriaAttributes> = props => {
   return (
     <SystemQueryRenderer<SuggestedArtworksShelfQuery>
-      placeholder={<ContentPlaceholder />}
+      placeholder={<SuggestedArtworksShelfPlaceholder />}
       query={graphql`
         query SuggestedArtworksShelfQuery($input: FilterArtworksInput) {
           artworksConnection(input: $input) {
@@ -72,7 +72,7 @@ export const SuggestedArtworksShelfQueryRenderer: FC<SearchCriteriaAttributes> =
         }
 
         if (!relayProps?.artworksConnection) {
-          return <ContentPlaceholder />
+          return <SuggestedArtworksShelfPlaceholder />
         }
 
         return (
@@ -85,10 +85,10 @@ export const SuggestedArtworksShelfQueryRenderer: FC<SearchCriteriaAttributes> =
   )
 }
 
-const ContentPlaceholder: FC = () => {
+const SuggestedArtworksShelfPlaceholder: FC = () => {
   return (
     <Skeleton>
-      <Flex flexDirection="row" flexWrap="wrap" gap={1} justifyContent="center">
+      <Flex flexDirection="row" flexWrap="wrap" gap={2} justifyContent="center">
         {[...new Array(5)].map((_, i) => {
           return <ShelfArtworkPlaceholder key={i} index={i} />
         })}

--- a/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/__tests__/ArtworkAuctionCreateAlertTooltip.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/__tests__/ArtworkAuctionCreateAlertTooltip.jest.tsx
@@ -46,7 +46,7 @@ describe("ArtworkAuctionCreateAlertTooltip", () => {
 
     expect(
       screen.getByText(
-        "Available works by Andy Warhol based on similar tags and auction activity."
+        "You may be interested in these similar works by Andy Warhol."
       )
     ).toBeInTheDocument()
     expect(screen.getByText("Andy Warhol")).toBeInTheDocument()

--- a/src/System/i18n/locales/en-US/translation.json
+++ b/src/System/i18n/locales/en-US/translation.json
@@ -109,7 +109,7 @@
       "watchingLot": "Watching lot"
     },
     "artworkAuctionCreateAlertHeader": {
-      "suggestedArtworksButton": "Suggested Artworks",
+      "suggestedArtworksButton": "Browse Similar Artworks",
       "seeMoreButton": "See more",
       "suggestedArtworksModal": {
         "title": "Suggested Artworks",


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

Update placeholder and copy for `ArtworkAuctionsCreateAlertHeader` feature.


<img width="751" alt="Screenshot 2023-08-23 at 16 33 34" src="https://github.com/artsy/force/assets/17580625/8ac59c4c-236a-49ca-9d18-cb79b418ea02">


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ