### PR TITLE
fix(DIA-102): sanitize back hrefs

### DIFF
--- a/src/Apps/Auction/Components/RegisterButton.tsx
+++ b/src/Apps/Auction/Components/RegisterButton.tsx
@@ -223,11 +223,14 @@ const ButtonAction: React.FC<{
   return (
     <Flex flexDirection="column" data-testid="RegisterButton">
       <Button
-        // @ts-ignore
-        as={RouterLink}
-        to={to}
         onClick={onClick}
         disabled={disabled}
+        {...(to
+          ? {
+              as: RouterLink,
+              to,
+            }
+          : {})}
       >
         {title}
       </Button>

--- a/src/System/Router/RouterLink.tsx
+++ b/src/System/Router/RouterLink.tsx
@@ -6,6 +6,7 @@ import styled from "styled-components"
 import { compose, ResponsiveValue, system } from "styled-system"
 import { useMemo } from "react"
 import { themeGet } from "@styled-system/theme-get"
+import { sanitizeURL } from "Utils/sanitizeURL"
 
 /**
  * Wrapper component around found's <Link> component with a fallback to a normal
@@ -35,11 +36,18 @@ export const RouterLink: React.FC<RouterLinkProps> = React.forwardRef(
       [matcher, routes, to]
     )
 
+    // Sanitize the URL as it may come from a query param
+    const safeTo = useMemo(() => {
+      return sanitizeURL(to ?? "")
+    }, [to])
+
     if (isSupportedInRouter) {
-      return <RouterAwareLink inline={inline} to={to ?? ""} {...rest} />
+      return <RouterAwareLink ref={ref} inline={inline} to={safeTo} {...rest} />
     }
 
-    return <RouterUnawareLink inline={inline} href={to ?? ""} {...rest} />
+    return (
+      <RouterUnawareLink ref={ref} inline={inline} href={safeTo} {...rest} />
+    )
   }
 )
 

--- a/src/System/Router/__tests__/RouterLink.jest.tsx
+++ b/src/System/Router/__tests__/RouterLink.jest.tsx
@@ -48,4 +48,14 @@ describe("RouterLink", () => {
     expect(wrapper.find(Link).length).toEqual(0)
     expect(wrapper.find("a").length).toEqual(1)
   })
+
+  it("sanitizes unsafe URLs", () => {
+    const wrapper = mount(<RouterLink to="javascript:alert(1)">Foo</RouterLink>)
+    expect(wrapper.find("a").prop("href")).toEqual("/")
+  })
+
+  it("allows empty hrefs", () => {
+    const wrapper = mount(<RouterLink to="">Foo</RouterLink>)
+    expect(wrapper.find("a").prop("href")).toEqual("")
+  })
 })

--- a/src/Utils/__tests__/sanitizeURL.jest.ts
+++ b/src/Utils/__tests__/sanitizeURL.jest.ts
@@ -1,0 +1,37 @@
+import { sanitizeURL } from "Utils/sanitizeURL"
+
+describe("sanitizeURL", () => {
+  it("sanitizes unsafe urls", () => {
+    expect(sanitizeURL("javascript:alert(1)")).toEqual("/")
+  })
+
+  it("sanitizes URI encoded unsafe urls", () => {
+    expect(sanitizeURL(encodeURIComponent("javascript:alert(1)"))).toEqual("/")
+  })
+
+  it("sanitizes unsafe data urls", () => {
+    expect(
+      sanitizeURL(
+        `data:text/html;charset=utf-8,${encodeURIComponent(
+          "<script>alert(1)</script>"
+        )}`
+      )
+    ).toEqual("/")
+  })
+
+  it("lets through http urls", () => {
+    expect(sanitizeURL("http://artsy.net")).toEqual("http://artsy.net")
+  })
+
+  it("lets through https urls", () => {
+    expect(sanitizeURL("https://artsy.net")).toEqual("https://artsy.net")
+  })
+
+  it("lets through relative urls", () => {
+    expect(sanitizeURL("/foo/bar")).toEqual("/foo/bar")
+  })
+
+  it("lets through relative urls without a leading slash", () => {
+    expect(sanitizeURL("foo/bar")).toEqual("foo/bar")
+  })
+})

--- a/src/Utils/sanitizeURL.ts
+++ b/src/Utils/sanitizeURL.ts
@@ -1,0 +1,16 @@
+export const sanitizeURL = (path: string) => {
+  if (!path || typeof path !== "string") return ""
+
+  const _path = path.toLowerCase()
+
+  if (
+    _path.includes("script:") ||
+    _path.includes("data:") ||
+    _path.includes("script%3a") ||
+    _path.includes("data%3a")
+  ) {
+    return "/"
+  }
+
+  return path
+}


### PR DESCRIPTION
Closes [DIA-102](https://artsyproduct.atlassian.net/browse/DIA-102)

Round Two

Here we return empty string if the function is passed empty string. Which — makes fine sense.

[DIA-102]: https://artsyproduct.atlassian.net/browse/DIA-102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ