### PR TITLE
fix: prevents non url back links

### DIFF
--- a/src/Apps/Artist/Components/ArtistBackLink.tsx
+++ b/src/Apps/Artist/Components/ArtistBackLink.tsx
@@ -5,6 +5,7 @@ import { useTracking } from "react-tracking"
 import { ArtistBackLink_artist$data } from "__generated__/ArtistBackLink_artist.graphql"
 import { TopContextBar } from "Components/TopContextBar"
 import { useRouter } from "System/Router/useRouter"
+import { sanitizeURL } from "Utils/sanitizeURL"
 
 interface ArtistBackLinkProps {
   artist: ArtistBackLink_artist$data
@@ -17,7 +18,7 @@ const ArtistBackLink: React.FC<ArtistBackLinkProps> = ({ artist }) => {
 
   const returnTo = router.match?.location?.query?.returnTo
 
-  const href = returnTo || artist.href
+  const href = returnTo ? sanitizeURL(returnTo) : artist.href
 
   return (
     <TopContextBar

--- a/src/Apps/Show/Components/BackToFairBanner.tsx
+++ b/src/Apps/Show/Components/BackToFairBanner.tsx
@@ -3,6 +3,7 @@ import { BackToFairBanner_show$data } from "__generated__/BackToFairBanner_show.
 import { createFragmentContainer, graphql } from "react-relay"
 import { TopContextBar } from "Components/TopContextBar"
 import { useRouter } from "System/Router/useRouter"
+import { sanitizeURL } from "Utils/sanitizeURL"
 
 interface BackToFairBannerProps {
   show: BackToFairBanner_show$data
@@ -14,7 +15,8 @@ const BackToFairBanner: React.FC<BackToFairBannerProps & BoxProps> = ({
   const { match } = useRouter()
   const { back_to_fair_href } = match.location.query
   const { fair } = show
-  let link = back_to_fair_href ?? fair?.href
+
+  const link = back_to_fair_href ? sanitizeURL(back_to_fair_href) : fair?.href
 
   if (!fair?.name) {
     return null

--- a/src/Utils/__tests__/sanitizeURL.jest.ts
+++ b/src/Utils/__tests__/sanitizeURL.jest.ts
@@ -1,0 +1,37 @@
+import { sanitizeURL } from "Utils/sanitizeURL"
+
+describe("sanitizeURL", () => {
+  it("sanitizes unsafe urls", () => {
+    expect(sanitizeURL("javascript:alert(1)")).toEqual("/")
+  })
+
+  it("sanitizes URI encoded unsafe urls", () => {
+    expect(sanitizeURL(encodeURIComponent("javascript:alert(1)"))).toEqual("/")
+  })
+
+  it("sanitizes unsafe data urls", () => {
+    expect(
+      sanitizeURL(
+        `data:text/html;charset=utf-8,${encodeURIComponent(
+          "<script>alert(1)</script>"
+        )}`
+      )
+    ).toEqual("/")
+  })
+
+  it("lets through http urls", () => {
+    expect(sanitizeURL("http://artsy.net")).toEqual("http://artsy.net")
+  })
+
+  it("lets through https urls", () => {
+    expect(sanitizeURL("https://artsy.net")).toEqual("https://artsy.net")
+  })
+
+  it("lets through relative urls", () => {
+    expect(sanitizeURL("/foo/bar")).toEqual("/foo/bar")
+  })
+
+  it("lets through relative urls without a leading slash", () => {
+    expect(sanitizeURL("foo/bar")).toEqual("foo/bar")
+  })
+})

--- a/src/Utils/sanitizeURL.ts
+++ b/src/Utils/sanitizeURL.ts
@@ -1,0 +1,16 @@
+export const sanitizeURL = (path: string) => {
+  if (!path || typeof path !== "string") return ""
+
+  const _path = path.toLowerCase()
+
+  if (
+    _path.includes("script:") ||
+    _path.includes("data:") ||
+    _path.includes("script%3a") ||
+    _path.includes("data%3a")
+  ) {
+    return "/"
+  }
+
+  return path
+}


### PR DESCRIPTION
Closes [DIA-102](https://artsyproduct.atlassian.net/browse/DIA-102) — for real this time.

No more global changes from me this week. However we now need to remain aware that this may sneak in as a problem again whenever we are utilizing query params. 

[DIA-102]: https://artsyproduct.atlassian.net/browse/DIA-102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ