### PR TITLE
fix: remove broken auction support chat until it's properly implemented

### DIFF
--- a/src/Apps/Auction/AuctionApp.tsx
+++ b/src/Apps/Auction/AuctionApp.tsx
@@ -20,9 +20,6 @@ import { useAuctionTracking } from "./Hooks/useAuctionTracking"
 import { AuctionCurrentAuctionsRailFragmentContainer } from "./Components/AuctionCurrentAuctionsRail"
 import { WebsocketContextProvider } from "System/WebsocketContext"
 import { CascadingEndTimesBannerFragmentContainer } from "Components/CascadingEndTimesBanner"
-import { getENV } from "Utils/getENV"
-import { SalesforceWrapper } from "Components/SalesforceWrapper"
-import { Media } from "Utils/Responsive"
 
 export interface AuctionAppProps {
   me: AuctionApp_me$data
@@ -157,12 +154,6 @@ export const AuctionApp: React.FC<AuctionAppProps> = ({
           </Join>
         </WebsocketContextProvider>
       </AnalyticsContext.Provider>
-
-      {getENV("SALESFORCE_CHAT_ENABLED") ? (
-        <Media greaterThan="xs">
-          <SalesforceWrapper isInAuction={true} />
-        </Media>
-      ) : null}
     </>
   )
 }

--- a/src/Apps/Auction/__tests__/AuctionApp.jest.tsx
+++ b/src/Apps/Auction/__tests__/AuctionApp.jest.tsx
@@ -107,7 +107,7 @@ describe("AuctionApp", () => {
   it("embeds Salesforce widget", () => {
     mockGetENV.mockImplementation(() => ({ SALESFORCE_CHAT_ENABLED: true }))
     const wrapper = getWrapper()
-    expect(wrapper.find("SalesforceWrapper").exists()).toBeTruthy()
+    expect(wrapper.find("SalesforceWrapper").exists()).toBeFalsy()
   })
 
   it("does not embed Salesforce widget on mobile", () => {


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

See [Slack thread](https://artsy.slack.com/archives/C02JHHHKP5K/p1692814936087279) for more details.

The auction support chat was not ready to launch and it's currently broken in production. This quickly removes it for now until it's properly implemented.