### PR TITLE
fix(analyticscontext): ensures updated context on route changes

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -229,7 +229,7 @@
         "filename": "src/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx",
         "hashed_secret": "d7fc89e39d93a3ec26b311594abff287d01b2ace",
         "is_verified": false,
-        "line_number": 359
+        "line_number": 360
       }
     ],
     "src/Apps/__tests__/Fixtures/Artwork/ArtworkRelatedArtists.fixture.ts": [
@@ -565,5 +565,5 @@
       }
     ]
   },
-  "generated_at": "2023-05-31T18:20:50Z"
+  "generated_at": "2023-08-18T16:21:53Z"
 }

--- a/docs/best_practices.md
+++ b/docs/best_practices.md
@@ -294,3 +294,11 @@ const MyApp = () => {
   )
 }
 ```
+
+If you are building an entity route (/example/:slug) — be sure to wrap your app in the `AnalyticsContextProvider` and provide the corresponding `internalID`.
+
+```tsx
+<AnalyticsContextProvider contextPageOwnerId={artist.internalID}>
+  {...}
+</AnalyticsContextProvider>
+```

--- a/docs/best_practices.md
+++ b/docs/best_practices.md
@@ -295,10 +295,10 @@ const MyApp = () => {
 }
 ```
 
-If you are building an entity route (/example/:slug) — be sure to wrap your app in the `AnalyticsContextProvider` and provide the corresponding `internalID`.
+If you are building an entity route (/example/:slug) — be sure to wrap your app in the `Analytics` and provide the corresponding `internalID`.
 
 ```tsx
-<AnalyticsContextProvider contextPageOwnerId={artist.internalID}>
+<Analytics contextPageOwnerId={artist.internalID}>
   {...}
-</AnalyticsContextProvider>
+</Analytics>
 ```

--- a/src/Apps/Article/Components/ArticleBody.tsx
+++ b/src/Apps/Article/Components/ArticleBody.tsx
@@ -25,8 +25,7 @@ import { ArticleAd } from "./ArticleAd/ArticleAd"
 import { ArticleSectionFragmentContainer } from "./ArticleSection"
 import { ArticleSectionAdFragmentContainer } from "./ArticleSectionAd"
 import { OPTIMAL_READING_WIDTH } from "./Sections/ArticleSectionText"
-import { AnalyticsContext } from "System/Analytics/AnalyticsContext"
-import { OwnerType } from "@artsy/cohesion"
+import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
 import { ArticleNewsSourceFragmentContainer } from "./ArticleNewsSource"
 import { TopContextBar } from "Components/TopContextBar"
 
@@ -38,13 +37,7 @@ const ArticleBody: FC<ArticleBodyProps> = ({ article }) => {
   const centered = article.layout === "FEATURE" || article.layout === "NEWS"
 
   return (
-    <AnalyticsContext.Provider
-      value={{
-        contextPageOwnerId: article.internalID,
-        contextPageOwnerSlug: article.slug!,
-        contextPageOwnerType: OwnerType.article,
-      }}
-    >
+    <AnalyticsContextProvider contextPageOwnerId={article.internalID}>
       <ArticleContextProvider articleId={article.internalID}>
         {article.layout === "STANDARD" && (
           <FullBleed bg="black5" p={1}>
@@ -223,7 +216,7 @@ const ArticleBody: FC<ArticleBodyProps> = ({ article }) => {
           )}
         </GridColumns>
       </ArticleContextProvider>
-    </AnalyticsContext.Provider>
+    </AnalyticsContextProvider>
   )
 }
 

--- a/src/Apps/Article/Components/ArticleBody.tsx
+++ b/src/Apps/Article/Components/ArticleBody.tsx
@@ -25,7 +25,7 @@ import { ArticleAd } from "./ArticleAd/ArticleAd"
 import { ArticleSectionFragmentContainer } from "./ArticleSection"
 import { ArticleSectionAdFragmentContainer } from "./ArticleSectionAd"
 import { OPTIMAL_READING_WIDTH } from "./Sections/ArticleSectionText"
-import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
+import { Analytics } from "System/Analytics/AnalyticsContext"
 import { ArticleNewsSourceFragmentContainer } from "./ArticleNewsSource"
 import { TopContextBar } from "Components/TopContextBar"
 
@@ -37,7 +37,7 @@ const ArticleBody: FC<ArticleBodyProps> = ({ article }) => {
   const centered = article.layout === "FEATURE" || article.layout === "NEWS"
 
   return (
-    <AnalyticsContextProvider contextPageOwnerId={article.internalID}>
+    <Analytics contextPageOwnerId={article.internalID}>
       <ArticleContextProvider articleId={article.internalID}>
         {article.layout === "STANDARD" && (
           <FullBleed bg="black5" p={1}>
@@ -216,7 +216,7 @@ const ArticleBody: FC<ArticleBodyProps> = ({ article }) => {
           )}
         </GridColumns>
       </ArticleContextProvider>
-    </AnalyticsContextProvider>
+    </Analytics>
   )
 }
 

--- a/src/Apps/Artist/ArtistApp.tsx
+++ b/src/Apps/Artist/ArtistApp.tsx
@@ -1,7 +1,7 @@
 import { Spacer } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ArtistApp_artist$data } from "__generated__/ArtistApp_artist.graphql"
-import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
+import { Analytics } from "System/Analytics/AnalyticsContext"
 import { ArtistHeaderFragmentContainer } from "./Components/ArtistHeader/ArtistHeader"
 import { ArtistHeaderFragmentContainer as ArtistHeader2FragmentContainer } from "./Components/ArtistHeader/ArtistHeader2"
 import { RouteTab, RouteTabs } from "Components/RouteTabs"
@@ -23,7 +23,7 @@ const ArtistApp: React.FC<ArtistAppProps> = ({ artist, children }) => {
     <>
       <ArtistMetaFragmentContainer artist={artist} />
 
-      <AnalyticsContextProvider contextPageOwnerId={artist.internalID}>
+      <Analytics contextPageOwnerId={artist.internalID}>
         <Spacer y={[2, 4]} />
 
         {isRevisedArtistHeader ? (
@@ -57,7 +57,7 @@ const ArtistApp: React.FC<ArtistAppProps> = ({ artist, children }) => {
         <Spacer y={[0, 4]} />
 
         {children}
-      </AnalyticsContextProvider>
+      </Analytics>
     </>
   )
 }

--- a/src/Apps/Artist/ArtistApp.tsx
+++ b/src/Apps/Artist/ArtistApp.tsx
@@ -1,10 +1,7 @@
 import { Spacer } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ArtistApp_artist$data } from "__generated__/ArtistApp_artist.graphql"
-import {
-  AnalyticsContext,
-  useAnalyticsContext,
-} from "System/Analytics/AnalyticsContext"
+import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
 import { ArtistHeaderFragmentContainer } from "./Components/ArtistHeader/ArtistHeader"
 import { ArtistHeaderFragmentContainer as ArtistHeader2FragmentContainer } from "./Components/ArtistHeader/ArtistHeader2"
 import { RouteTab, RouteTabs } from "Components/RouteTabs"
@@ -18,8 +15,6 @@ interface ArtistAppProps {
 }
 
 const ArtistApp: React.FC<ArtistAppProps> = ({ artist, children }) => {
-  const { contextPageOwnerType, contextPageOwnerSlug } = useAnalyticsContext()
-
   useScrollToOpenArtistAuthModal()
 
   const isRevisedArtistHeader = useFeatureFlag("diamond_revised-artist-header")
@@ -28,13 +23,7 @@ const ArtistApp: React.FC<ArtistAppProps> = ({ artist, children }) => {
     <>
       <ArtistMetaFragmentContainer artist={artist} />
 
-      <AnalyticsContext.Provider
-        value={{
-          contextPageOwnerId: artist.internalID,
-          contextPageOwnerSlug,
-          contextPageOwnerType,
-        }}
-      >
+      <AnalyticsContextProvider contextPageOwnerId={artist.internalID}>
         <Spacer y={[2, 4]} />
 
         {isRevisedArtistHeader ? (
@@ -68,7 +57,7 @@ const ArtistApp: React.FC<ArtistAppProps> = ({ artist, children }) => {
         <Spacer y={[0, 4]} />
 
         {children}
-      </AnalyticsContext.Provider>
+      </AnalyticsContextProvider>
     </>
   )
 }

--- a/src/Apps/Artist/ArtistSubApp.tsx
+++ b/src/Apps/Artist/ArtistSubApp.tsx
@@ -2,7 +2,7 @@ import { Spacer } from "@artsy/palette"
 import { Match } from "found"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ArtistSubApp_artist$data } from "__generated__/ArtistSubApp_artist.graphql"
-import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
+import { Analytics } from "System/Analytics/AnalyticsContext"
 import { ArtistBackLinkFragmentContainer } from "./Components/ArtistBackLink"
 import { ArtistMetaFragmentContainer } from "./Components/ArtistMeta/ArtistMeta"
 import { useScrollToOpenArtistAuthModal } from "Utils/Hooks/useScrollToOpenArtistAuthModal"
@@ -26,13 +26,13 @@ const ArtistSubApp: React.FC<ArtistSubAppProps> = ({
     <>
       <ArtistMetaFragmentContainer artist={artist} />
 
-      <AnalyticsContextProvider contextPageOwnerId={artist.internalID}>
+      <Analytics contextPageOwnerId={artist.internalID}>
         {!isEigen && <ArtistBackLinkFragmentContainer artist={artist} />}
 
         <Spacer y={[2, 4]} />
 
         {children}
-      </AnalyticsContextProvider>
+      </Analytics>
     </>
   )
 }

--- a/src/Apps/Artist/ArtistSubApp.tsx
+++ b/src/Apps/Artist/ArtistSubApp.tsx
@@ -2,10 +2,7 @@ import { Spacer } from "@artsy/palette"
 import { Match } from "found"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ArtistSubApp_artist$data } from "__generated__/ArtistSubApp_artist.graphql"
-import {
-  AnalyticsContext,
-  useAnalyticsContext,
-} from "System/Analytics/AnalyticsContext"
+import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
 import { ArtistBackLinkFragmentContainer } from "./Components/ArtistBackLink"
 import { ArtistMetaFragmentContainer } from "./Components/ArtistMeta/ArtistMeta"
 import { useScrollToOpenArtistAuthModal } from "Utils/Hooks/useScrollToOpenArtistAuthModal"
@@ -22,7 +19,6 @@ const ArtistSubApp: React.FC<ArtistSubAppProps> = ({
   match,
 }) => {
   const { isEigen } = useSystemContext()
-  const { contextPageOwnerType, contextPageOwnerSlug } = useAnalyticsContext()
 
   useScrollToOpenArtistAuthModal()
 
@@ -30,19 +26,13 @@ const ArtistSubApp: React.FC<ArtistSubAppProps> = ({
     <>
       <ArtistMetaFragmentContainer artist={artist} />
 
-      <AnalyticsContext.Provider
-        value={{
-          contextPageOwnerId: artist.internalID,
-          contextPageOwnerSlug,
-          contextPageOwnerType,
-        }}
-      >
+      <AnalyticsContextProvider contextPageOwnerId={artist.internalID}>
         {!isEigen && <ArtistBackLinkFragmentContainer artist={artist} />}
 
         <Spacer y={[2, 4]} />
 
         {children}
-      </AnalyticsContext.Provider>
+      </AnalyticsContextProvider>
     </>
   )
 }

--- a/src/Apps/ArtistSeries/ArtistSeriesApp.tsx
+++ b/src/Apps/ArtistSeries/ArtistSeriesApp.tsx
@@ -6,10 +6,7 @@ import { ArtistSeriesArtworksFilterRefetchContainer as ArtistSeriesArtworksFilte
 import { ArtistSeriesRailFragmentContainer as OtherArtistSeriesRail } from "Components/ArtistSeriesRail/ArtistSeriesRail"
 import { ArtistSeriesMetaFragmentContainer as ArtistSeriesMeta } from "./Components/ArtistSeriesMeta"
 import { ContextModule } from "@artsy/cohesion"
-import {
-  AnalyticsContext,
-  useAnalyticsContext,
-} from "System/Analytics/AnalyticsContext"
+import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
 import { SharedArtworkFilterContextProps } from "Components/ArtworkFilter/ArtworkFilterContext"
 import { Spacer } from "@artsy/palette"
 
@@ -18,45 +15,35 @@ interface ArtistSeriesAppProps {
 }
 
 const ArtistSeriesApp: React.FC<ArtistSeriesAppProps> = ({ artistSeries }) => {
-  const { contextPageOwnerType, contextPageOwnerSlug } = useAnalyticsContext()
-
   const { railArtist, internalID, sidebarAggregations } = artistSeries
 
   return (
-    <AnalyticsContext.Provider
-      value={{
-        contextPageOwnerId: internalID,
-        contextPageOwnerSlug,
-        contextPageOwnerType,
-      }}
-    >
-      <>
-        <ArtistSeriesMeta artistSeries={artistSeries} />
+    <AnalyticsContextProvider contextPageOwnerId={internalID}>
+      <ArtistSeriesMeta artistSeries={artistSeries} />
 
-        <ArtistSeriesHeader artistSeries={artistSeries} />
+      <ArtistSeriesHeader artistSeries={artistSeries} />
 
-        <Spacer y={6} />
+      <Spacer y={6} />
 
-        <ArtistSeriesArtworksFilter
-          artistSeries={artistSeries}
-          aggregations={
-            sidebarAggregations?.aggregations as SharedArtworkFilterContextProps["aggregations"]
-          }
-        />
+      <ArtistSeriesArtworksFilter
+        artistSeries={artistSeries}
+        aggregations={
+          sidebarAggregations?.aggregations as SharedArtworkFilterContextProps["aggregations"]
+        }
+      />
 
-        {(railArtist?.length ?? 0) > 0 && (
-          <>
-            <Spacer y={6} />
+      {(railArtist?.length ?? 0) > 0 && (
+        <>
+          <Spacer y={6} />
 
-            <OtherArtistSeriesRail
-              artist={(railArtist ?? [])[0]!}
-              title="Series by this artist"
-              contextModule={ContextModule.moreSeriesByThisArtist}
-            />
-          </>
-        )}
-      </>
-    </AnalyticsContext.Provider>
+          <OtherArtistSeriesRail
+            artist={(railArtist ?? [])[0]!}
+            title="Series by this artist"
+            contextModule={ContextModule.moreSeriesByThisArtist}
+          />
+        </>
+      )}
+    </AnalyticsContextProvider>
   )
 }
 

--- a/src/Apps/ArtistSeries/ArtistSeriesApp.tsx
+++ b/src/Apps/ArtistSeries/ArtistSeriesApp.tsx
@@ -6,7 +6,7 @@ import { ArtistSeriesArtworksFilterRefetchContainer as ArtistSeriesArtworksFilte
 import { ArtistSeriesRailFragmentContainer as OtherArtistSeriesRail } from "Components/ArtistSeriesRail/ArtistSeriesRail"
 import { ArtistSeriesMetaFragmentContainer as ArtistSeriesMeta } from "./Components/ArtistSeriesMeta"
 import { ContextModule } from "@artsy/cohesion"
-import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
+import { Analytics } from "System/Analytics/AnalyticsContext"
 import { SharedArtworkFilterContextProps } from "Components/ArtworkFilter/ArtworkFilterContext"
 import { Spacer } from "@artsy/palette"
 
@@ -18,7 +18,7 @@ const ArtistSeriesApp: React.FC<ArtistSeriesAppProps> = ({ artistSeries }) => {
   const { railArtist, internalID, sidebarAggregations } = artistSeries
 
   return (
-    <AnalyticsContextProvider contextPageOwnerId={internalID}>
+    <Analytics contextPageOwnerId={internalID}>
       <ArtistSeriesMeta artistSeries={artistSeries} />
 
       <ArtistSeriesHeader artistSeries={artistSeries} />
@@ -43,7 +43,7 @@ const ArtistSeriesApp: React.FC<ArtistSeriesAppProps> = ({ artistSeries }) => {
           />
         </>
       )}
-    </AnalyticsContextProvider>
+    </Analytics>
   )
 }
 

--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -27,7 +27,7 @@ import * as DeprecatedSchema from "@artsy/cohesion/dist/DeprecatedSchema"
 import { RecentlyViewed } from "Components/RecentlyViewed"
 import { useRouter } from "System/Router/useRouter"
 import { TrackingProp } from "react-tracking"
-import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
+import { Analytics } from "System/Analytics/AnalyticsContext"
 import { useRouteComplete } from "Utils/Hooks/useRouteComplete"
 import { Media } from "Utils/Responsive"
 import { UseRecordArtworkView } from "./useRecordArtworkView"
@@ -296,7 +296,7 @@ const TrackingWrappedArtworkApp: React.FC<Props> = props => {
   const websocketEnabled = !!sale?.extendedBiddingIntervalMinutes
 
   return (
-    <AnalyticsContextProvider contextPageOwnerId={internalID}>
+    <Analytics contextPageOwnerId={internalID}>
       <WebsocketContextProvider
         channelInfo={{
           channel: "SalesChannel",
@@ -311,7 +311,7 @@ const TrackingWrappedArtworkApp: React.FC<Props> = props => {
           shouldTrackPageView={isComplete}
         />
       </WebsocketContextProvider>
-    </AnalyticsContextProvider>
+    </Analytics>
   )
 }
 

--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -27,10 +27,7 @@ import * as DeprecatedSchema from "@artsy/cohesion/dist/DeprecatedSchema"
 import { RecentlyViewed } from "Components/RecentlyViewed"
 import { useRouter } from "System/Router/useRouter"
 import { TrackingProp } from "react-tracking"
-import {
-  AnalyticsContext,
-  useAnalyticsContext,
-} from "System/Analytics/AnalyticsContext"
+import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
 import { useRouteComplete } from "Utils/Hooks/useRouteComplete"
 import { Media } from "Utils/Responsive"
 import { UseRecordArtworkView } from "./useRecordArtworkView"
@@ -290,7 +287,7 @@ const TrackingWrappedArtworkApp: React.FC<Props> = props => {
       location: { pathname, state },
     },
   } = useRouter()
-  const { contextPageOwnerSlug, contextPageOwnerType } = useAnalyticsContext()
+
   // Check to see if referrer comes from link interception.
   // @see interceptLinks.ts
   const referrer = state && state.previousHref
@@ -299,13 +296,7 @@ const TrackingWrappedArtworkApp: React.FC<Props> = props => {
   const websocketEnabled = !!sale?.extendedBiddingIntervalMinutes
 
   return (
-    <AnalyticsContext.Provider
-      value={{
-        contextPageOwnerId: internalID,
-        contextPageOwnerSlug,
-        contextPageOwnerType,
-      }}
-    >
+    <AnalyticsContextProvider contextPageOwnerId={internalID}>
       <WebsocketContextProvider
         channelInfo={{
           channel: "SalesChannel",
@@ -320,7 +311,7 @@ const TrackingWrappedArtworkApp: React.FC<Props> = props => {
           shouldTrackPageView={isComplete}
         />
       </WebsocketContextProvider>
-    </AnalyticsContext.Provider>
+    </AnalyticsContextProvider>
   )
 }
 

--- a/src/Apps/Artwork/Components/ArtworkDetails/__tests__/ArtworkDetailsAdditionalInfo.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/__tests__/ArtworkDetailsAdditionalInfo.jest.tsx
@@ -3,8 +3,7 @@ import { graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import { MockBoot } from "DevTools/MockBoot"
 import { ArtworkDetailsAdditionalInfo_Test_Query } from "__generated__/ArtworkDetailsAdditionalInfo_Test_Query.graphql"
-import { AnalyticsContext } from "System/Analytics/AnalyticsContext"
-import { OwnerType } from "@artsy/cohesion"
+import { AnalyticsCombinedContextProvider } from "System/Analytics/AnalyticsContext"
 import { ArtworkDetailsAdditionalInfoFragmentContainer } from "Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAdditionalInfo"
 import { fireEvent, screen } from "@testing-library/react"
 
@@ -18,16 +17,13 @@ const { renderWithRelay } = setupTestWrapperTL<
   Component: props => {
     return (
       <MockBoot>
-        <AnalyticsContext.Provider
-          value={{
-            contextPageOwnerId: "example-artwork-id",
-            contextPageOwnerSlug: "example-artwork-slug",
-            contextPageOwnerType: OwnerType.artwork,
-          }}
+        <AnalyticsCombinedContextProvider
+          contextPageOwnerId="example-artwork-id"
+          path="/artwork/example-artwork-slug"
         >
           {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
           <ArtworkDetailsAdditionalInfoFragmentContainer {...props} />
-        </AnalyticsContext.Provider>
+        </AnalyticsCombinedContextProvider>
       </MockBoot>
     )
   },

--- a/src/Apps/Auction/AuctionApp.tsx
+++ b/src/Apps/Auction/AuctionApp.tsx
@@ -1,7 +1,7 @@
 import { Box, Join, Message, Spacer, Tab, Tabs, Text } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { FullBleedHeader } from "Components/FullBleedHeader/FullBleedHeader"
-import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
+import { Analytics } from "System/Analytics/AnalyticsContext"
 import { AuctionApp_me$data } from "__generated__/AuctionApp_me.graphql"
 import { AuctionApp_sale$data } from "__generated__/AuctionApp_sale.graphql"
 import { AuctionApp_viewer$data } from "__generated__/AuctionApp_viewer.graphql"
@@ -64,7 +64,7 @@ export const AuctionApp: React.FC<AuctionAppProps> = ({
 
   return (
     <>
-      <AnalyticsContextProvider contextPageOwnerId={sale.internalID}>
+      <Analytics contextPageOwnerId={sale.internalID}>
         <WebsocketContextProvider
           channelInfo={{
             channel: "SalesChannel",
@@ -143,7 +143,7 @@ export const AuctionApp: React.FC<AuctionAppProps> = ({
             <Box>{children}</Box>
           </Join>
         </WebsocketContextProvider>
-      </AnalyticsContextProvider>
+      </Analytics>
     </>
   )
 }

--- a/src/Apps/Auction/AuctionApp.tsx
+++ b/src/Apps/Auction/AuctionApp.tsx
@@ -1,10 +1,7 @@
 import { Box, Join, Message, Spacer, Tab, Tabs, Text } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { FullBleedHeader } from "Components/FullBleedHeader/FullBleedHeader"
-import {
-  AnalyticsContext,
-  useAnalyticsContext,
-} from "System/Analytics/AnalyticsContext"
+import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
 import { AuctionApp_me$data } from "__generated__/AuctionApp_me.graphql"
 import { AuctionApp_sale$data } from "__generated__/AuctionApp_sale.graphql"
 import { AuctionApp_viewer$data } from "__generated__/AuctionApp_viewer.graphql"
@@ -33,7 +30,6 @@ export const AuctionApp: React.FC<AuctionAppProps> = ({
   sale,
   viewer,
 }) => {
-  const { contextPageOwnerType, contextPageOwnerSlug } = useAnalyticsContext()
   const { tracking } = useAuctionTracking()
 
   const showActiveBids = me?.showActiveBids?.length && !sale.isClosed
@@ -68,13 +64,7 @@ export const AuctionApp: React.FC<AuctionAppProps> = ({
 
   return (
     <>
-      <AnalyticsContext.Provider
-        value={{
-          contextPageOwnerId: sale.internalID,
-          contextPageOwnerSlug,
-          contextPageOwnerType,
-        }}
-      >
+      <AnalyticsContextProvider contextPageOwnerId={sale.internalID}>
         <WebsocketContextProvider
           channelInfo={{
             channel: "SalesChannel",
@@ -153,7 +143,7 @@ export const AuctionApp: React.FC<AuctionAppProps> = ({
             <Box>{children}</Box>
           </Join>
         </WebsocketContextProvider>
-      </AnalyticsContext.Provider>
+      </AnalyticsContextProvider>
     </>
   )
 }

--- a/src/Apps/Auctions/Components/MyBids/MyBids.tsx
+++ b/src/Apps/Auctions/Components/MyBids/MyBids.tsx
@@ -88,7 +88,6 @@ const MyBids: React.FC<MyBidsProps> = props => {
                           trackEvent(
                             clickedEntityGroup({
                               contextModule: ContextModule.yourActiveBids,
-                              // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                               contextPageOwnerType,
                               destinationPageOwnerType: OwnerType.sale,
                               type: "thumbnail",

--- a/src/Apps/Auctions/Components/MyBids/MyBidsBidHeader.tsx
+++ b/src/Apps/Auctions/Components/MyBids/MyBidsBidHeader.tsx
@@ -27,7 +27,6 @@ export const MyBidsBidHeader: React.FC<MyBidsBidHeaderProps> = ({ sale }) => {
         trackEvent(
           clickedEntityGroup({
             contextModule: ContextModule.yourActiveBids,
-            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             contextPageOwnerType,
             destinationPageOwnerType: OwnerType.sale,
             type: "thumbnail",

--- a/src/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/__tests__/ArtistSeriesEntity.jest.tsx
+++ b/src/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/__tests__/ArtistSeriesEntity.jest.tsx
@@ -1,9 +1,8 @@
 import { CollectionsHubLinkedCollections } from "Apps/__tests__/Fixtures/Collections"
 import { useTracking } from "react-tracking"
 import { mount } from "enzyme"
-import { ArtistSeriesEntity } from "../ArtistSeriesEntity"
-import { OwnerType } from "@artsy/cohesion"
-import { AnalyticsContext } from "System/Analytics/AnalyticsContext"
+import { ArtistSeriesEntity } from "Apps/Collect/Routes/Collection/Components/CollectionsHubRails/ArtistSeriesRail/ArtistSeriesEntity"
+import { AnalyticsCombinedContextProvider } from "System/Analytics/AnalyticsContext"
 import { Image } from "@artsy/palette"
 import { RouterLink } from "System/Router/RouterLink"
 
@@ -32,15 +31,12 @@ describe.skip("ArtistSeriesEntity", () => {
 
   const getWrapper = (passedProps = props) => {
     return mount(
-      <AnalyticsContext.Provider
-        value={{
-          contextPageOwnerId: "1234",
-          contextPageOwnerSlug: "slug",
-          contextPageOwnerType: OwnerType.collection,
-        }}
+      <AnalyticsCombinedContextProvider
+        contextPageOwnerId="1234"
+        path="/collection/slug"
       >
         <ArtistSeriesEntity {...passedProps} />
-      </AnalyticsContext.Provider>
+      </AnalyticsCombinedContextProvider>
     )
   }
 

--- a/src/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/__tests__/FeaturedCollectionsRails.jest.tsx
+++ b/src/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/__tests__/FeaturedCollectionsRails.jest.tsx
@@ -4,8 +4,7 @@ import { mount } from "enzyme"
 import "jest-styled-components"
 import { FeaturedCollectionsRails } from "Apps/Collect/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/index"
 import { paginateCarousel } from "@artsy/palette"
-import { OwnerType } from "@artsy/cohesion"
-import { AnalyticsContext } from "System/Analytics/AnalyticsContext"
+import { AnalyticsCombinedContextProvider } from "System/Analytics/AnalyticsContext"
 import { FeaturedCollectionRailEntityFragmentContainer } from "Apps/Collect/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/FeaturedCollectionRailEntity"
 
 jest.mock("@artsy/palette/dist/elements/Carousel/paginate")
@@ -21,15 +20,12 @@ describe("FeaturedCollectionsRails", () => {
   const trackEvent = jest.fn()
   const getWrapper = (passedProps = props) => {
     return mount(
-      <AnalyticsContext.Provider
-        value={{
-          contextPageOwnerId: "1234",
-          contextPageOwnerSlug: "slug",
-          contextPageOwnerType: OwnerType.collection,
-        }}
+      <AnalyticsCombinedContextProvider
+        contextPageOwnerId="1234"
+        path="/collection/slug"
       >
         <FeaturedCollectionsRails {...passedProps} />
-      </AnalyticsContext.Provider>
+      </AnalyticsCombinedContextProvider>
     )
   }
 

--- a/src/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/OtherCollectionEntity.tsx
+++ b/src/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/OtherCollectionEntity.tsx
@@ -30,7 +30,6 @@ export const OtherCollectionEntity: React.FC<CollectionProps> = ({
         contextModule: ContextModule.otherCollectionsRail,
         contextPageOwnerId,
         contextPageOwnerSlug,
-        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         contextPageOwnerType,
         destinationPageOwnerId: id,
         destinationPageOwnerSlug: slug,

--- a/src/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/__tests__/OtherCollectionEntity.jest.tsx
+++ b/src/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/__tests__/OtherCollectionEntity.jest.tsx
@@ -1,9 +1,8 @@
 import { CollectionHubFixture } from "Apps/__tests__/Fixtures/Collections"
 import { useTracking } from "react-tracking"
 import { mount } from "enzyme"
-import { OtherCollectionEntity } from "../OtherCollectionEntity"
-import { OwnerType } from "@artsy/cohesion"
-import { AnalyticsContext } from "System/Analytics/AnalyticsContext"
+import { OtherCollectionEntity } from "Apps/Collect/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/OtherCollectionEntity"
+import { AnalyticsCombinedContextProvider } from "System/Analytics/AnalyticsContext"
 import { Image } from "@artsy/palette"
 import { RouterLink } from "System/Router/RouterLink"
 
@@ -31,15 +30,12 @@ describe.skip("OtherCollectionEntity", () => {
 
   const getWrapper = (passedProps = props) => {
     return mount(
-      <AnalyticsContext.Provider
-        value={{
-          contextPageOwnerId: "1234",
-          contextPageOwnerSlug: "slug",
-          contextPageOwnerType: OwnerType.collection,
-        }}
+      <AnalyticsCombinedContextProvider
+        contextPageOwnerId="1234"
+        path="/collection/slug"
       >
         <OtherCollectionEntity {...passedProps} />
-      </AnalyticsContext.Provider>
+      </AnalyticsCombinedContextProvider>
     )
   }
 

--- a/src/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/__tests__/OtherCollectionsRail.jest.tsx
+++ b/src/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/__tests__/OtherCollectionsRail.jest.tsx
@@ -2,10 +2,9 @@ import { CollectionHubFixture } from "Apps/__tests__/Fixtures/Collections"
 import { useTracking } from "react-tracking"
 import { mount } from "enzyme"
 import "jest-styled-components"
-import { OtherCollectionsRail } from "../index"
+import { OtherCollectionsRail } from "Apps/Collect/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/index"
 import { paginateCarousel } from "@artsy/palette"
-import { OwnerType } from "@artsy/cohesion"
-import { AnalyticsContext } from "System/Analytics/AnalyticsContext"
+import { AnalyticsCombinedContextProvider } from "System/Analytics/AnalyticsContext"
 
 jest.mock("@artsy/palette/dist/elements/Carousel/paginate")
 jest.mock("@artsy/palette", () => {
@@ -41,15 +40,12 @@ describe("CollectionsRail", () => {
 
   const getWrapper = (passedProps = props) => {
     return mount(
-      <AnalyticsContext.Provider
-        value={{
-          contextPageOwnerId: "1234",
-          contextPageOwnerSlug: "slug",
-          contextPageOwnerType: OwnerType.collection,
-        }}
+      <AnalyticsCombinedContextProvider
+        contextPageOwnerId="1234"
+        path="/collection/slug"
       >
         <OtherCollectionsRail {...passedProps} />
-      </AnalyticsContext.Provider>
+      </AnalyticsCombinedContextProvider>
     )
   }
 

--- a/src/Apps/Collect/Routes/Collection/index.tsx
+++ b/src/Apps/Collect/Routes/Collection/index.tsx
@@ -11,7 +11,7 @@ import * as React from "react"
 import { RelayRefetchProp, graphql, createFragmentContainer } from "react-relay"
 import { truncate } from "lodash"
 import { CollectionsHubRailsContainer as CollectionsHubRails } from "./Components/CollectionsHubRails"
-import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
+import { Analytics } from "System/Analytics/AnalyticsContext"
 import { TrackingProp } from "react-tracking"
 import { ErrorPage } from "Components/ErrorPage"
 import { CollectionArtworksFilterRefetchContainer } from "./Components/CollectionArtworksFilter"
@@ -139,9 +139,9 @@ const TrackingWrappedCollectionApp: React.FC<CollectionAppProps> = props => {
     collection: { id },
   } = props
   return (
-    <AnalyticsContextProvider contextPageOwnerId={id}>
+    <Analytics contextPageOwnerId={id}>
       <CollectionApp {...props} />
-    </AnalyticsContextProvider>
+    </Analytics>
   )
 }
 

--- a/src/Apps/Collect/Routes/Collection/index.tsx
+++ b/src/Apps/Collect/Routes/Collection/index.tsx
@@ -11,11 +11,7 @@ import * as React from "react"
 import { RelayRefetchProp, graphql, createFragmentContainer } from "react-relay"
 import { truncate } from "lodash"
 import { CollectionsHubRailsContainer as CollectionsHubRails } from "./Components/CollectionsHubRails"
-import {
-  AnalyticsContext,
-  AnalyticsContextProps,
-  useAnalyticsContext,
-} from "System/Analytics/AnalyticsContext"
+import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
 import { TrackingProp } from "react-tracking"
 import { ErrorPage } from "Components/ErrorPage"
 import { CollectionArtworksFilterRefetchContainer } from "./Components/CollectionArtworksFilter"
@@ -26,7 +22,7 @@ import {
 import { MetaTags } from "Components/MetaTags"
 import { getENV } from "Utils/getENV"
 
-interface CollectionAppProps extends SystemContextProps, AnalyticsContextProps {
+interface CollectionAppProps extends SystemContextProps {
   collection: Collection_collection$data
   relay: RelayRefetchProp
   tracking: TrackingProp
@@ -142,17 +138,10 @@ const TrackingWrappedCollectionApp: React.FC<CollectionAppProps> = props => {
   const {
     collection: { id },
   } = props
-  const { contextPageOwnerSlug, contextPageOwnerType } = useAnalyticsContext()
   return (
-    <AnalyticsContext.Provider
-      value={{
-        contextPageOwnerId: id,
-        contextPageOwnerSlug,
-        contextPageOwnerType,
-      }}
-    >
+    <AnalyticsContextProvider contextPageOwnerId={id}>
       <CollectionApp {...props} />
-    </AnalyticsContext.Provider>
+    </AnalyticsContextProvider>
   )
 }
 

--- a/src/Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2Route.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2Route.tsx
@@ -9,7 +9,7 @@ import { extractNodes } from "Utils/extractNodes"
 import { CollectorProfileSaves2Route_me$data } from "__generated__/CollectorProfileSaves2Route_me.graphql"
 import { useTracking } from "react-tracking"
 import { ActionType, OwnerType, ViewedArtworkList } from "@artsy/cohesion"
-import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
+import { Analytics } from "System/Analytics/AnalyticsContext"
 import { HttpError } from "found"
 import { MetaTags } from "Components/MetaTags"
 import { Jump } from "Utils/Hooks/useJump"
@@ -123,9 +123,9 @@ const PageWrapper: FC<CollectorProfileSaves2RouteProps> = props => {
   const { match } = useRouter()
 
   return (
-    <AnalyticsContextProvider contextPageOwnerId={match.params.id}>
+    <Analytics contextPageOwnerId={match.params.id}>
       <CollectorProfileSaves2Route {...props} />
-    </AnalyticsContextProvider>
+    </Analytics>
   )
 }
 

--- a/src/Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2Route.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/CollectorProfileSaves2Route.tsx
@@ -9,7 +9,7 @@ import { extractNodes } from "Utils/extractNodes"
 import { CollectorProfileSaves2Route_me$data } from "__generated__/CollectorProfileSaves2Route_me.graphql"
 import { useTracking } from "react-tracking"
 import { ActionType, OwnerType, ViewedArtworkList } from "@artsy/cohesion"
-import { AnalyticsContext } from "System/Analytics/AnalyticsContext"
+import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
 import { HttpError } from "found"
 import { MetaTags } from "Components/MetaTags"
 import { Jump } from "Utils/Hooks/useJump"
@@ -123,14 +123,9 @@ const PageWrapper: FC<CollectorProfileSaves2RouteProps> = props => {
   const { match } = useRouter()
 
   return (
-    <AnalyticsContext.Provider
-      value={{
-        contextPageOwnerId: match.params.id,
-        contextPageOwnerType: OwnerType.saves,
-      }}
-    >
+    <AnalyticsContextProvider contextPageOwnerId={match.params.id}>
       <CollectorProfileSaves2Route {...props} />
-    </AnalyticsContext.Provider>
+    </AnalyticsContextProvider>
   )
 }
 

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/__tests__/CreateNewListModal.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/__tests__/CreateNewListModal.jest.tsx
@@ -1,10 +1,9 @@
-import { OwnerType } from "@artsy/cohesion"
 import { render, screen, fireEvent, waitFor } from "@testing-library/react"
 import {
   CreateNewListModalContainer,
   CreateNewListModalContainerProps,
 } from "Apps/CollectorProfile/Routes/Saves2/Components/CreateNewListModal/CreateNewListModal"
-import { AnalyticsContext } from "System/Analytics/AnalyticsContext"
+import { AnalyticsCombinedContextProvider } from "System/Analytics/AnalyticsContext"
 import { useMutation } from "Utils/Hooks/useMutation"
 import { useTracking } from "react-tracking"
 
@@ -34,12 +33,9 @@ describe("CreateNewListModal", () => {
 
   const TestComponent = (props: Partial<CreateNewListModalContainerProps>) => {
     return (
-      <AnalyticsContext.Provider
-        value={{
-          contextPageOwnerId: "page-owner-id",
-          contextPageOwnerSlug: "page-owner-slug",
-          contextPageOwnerType: OwnerType.saves,
-        }}
+      <AnalyticsCombinedContextProvider
+        contextPageOwnerId="page-owner-id"
+        path="/saves/page-owner-slug"
       >
         <CreateNewListModalContainer
           {...props}
@@ -47,7 +43,7 @@ describe("CreateNewListModal", () => {
           onClose={props.onClose ?? onCloseMock}
           onComplete={props.onComplete ?? onCompleteMock}
         />
-      </AnalyticsContext.Provider>
+      </AnalyticsCombinedContextProvider>
     )
   }
 

--- a/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectArtworkListsModal/__tests__/SelectArtworkListsModal.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves2/Components/SelectArtworkListsModal/__tests__/SelectArtworkListsModal.jest.tsx
@@ -12,8 +12,7 @@ import {
 } from "Components/Artwork/ManageArtworkForSaves"
 import { useTracking } from "react-tracking"
 import { useMutation } from "Utils/Hooks/useMutation"
-import { AnalyticsContext } from "System/Analytics/AnalyticsContext"
-import { OwnerType } from "@artsy/cohesion"
+import { AnalyticsCombinedContextProvider } from "System/Analytics/AnalyticsContext"
 import { FC } from "react"
 import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
 
@@ -40,17 +39,14 @@ const { renderWithRelay } = setupTestWrapperTL<
     }
 
     return (
-      <AnalyticsContext.Provider
-        value={{
-          contextPageOwnerId: "page-owner-id",
-          contextPageOwnerSlug: "page-owner-slug",
-          contextPageOwnerType: OwnerType.artist,
-        }}
+      <AnalyticsCombinedContextProvider
+        contextPageOwnerId="page-owner-id"
+        path="/artist/page-owner-slug"
       >
         <ManageArtworkForSavesProvider artwork={artwork}>
           <TestComponent {...props} />
         </ManageArtworkForSavesProvider>
-      </AnalyticsContext.Provider>
+      </AnalyticsCombinedContextProvider>
     )
   },
   query: graphql`

--- a/src/Apps/Components/AppShell.tsx
+++ b/src/Apps/Components/AppShell.tsx
@@ -9,7 +9,7 @@ import { useProductionEnvironmentWarning } from "Utils/Hooks/useProductionEnviro
 import { useOnboardingModal } from "Utils/Hooks/useOnboardingModal"
 import { Layout } from "Apps/Components/Layouts"
 import { useSetupAuth } from "Utils/Hooks/useSetupAuth"
-import { AnalyticsInferredContextProvider } from "System/Analytics/AnalyticsContext"
+import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
 
 const logger = createLogger("Apps/Components/AppShell")
 interface AppShellProps {
@@ -48,10 +48,10 @@ export const AppShell: React.FC<AppShellProps> = props => {
   useProductionEnvironmentWarning()
 
   return (
-    <AnalyticsInferredContextProvider path={match?.location?.pathname}>
+    <AnalyticsContextProvider path={match?.location?.pathname}>
       <Layout variant={routeConfig?.layout}>{children}</Layout>
 
       {onboardingComponent}
-    </AnalyticsInferredContextProvider>
+    </AnalyticsContextProvider>
   )
 }

--- a/src/Apps/Components/AppShell.tsx
+++ b/src/Apps/Components/AppShell.tsx
@@ -9,6 +9,7 @@ import { useProductionEnvironmentWarning } from "Utils/Hooks/useProductionEnviro
 import { useOnboardingModal } from "Utils/Hooks/useOnboardingModal"
 import { Layout } from "Apps/Components/Layouts"
 import { useSetupAuth } from "Utils/Hooks/useSetupAuth"
+import { AnalyticsInferredContextProvider } from "System/Analytics/AnalyticsContext"
 
 const logger = createLogger("Apps/Components/AppShell")
 interface AppShellProps {
@@ -47,10 +48,10 @@ export const AppShell: React.FC<AppShellProps> = props => {
   useProductionEnvironmentWarning()
 
   return (
-    <>
+    <AnalyticsInferredContextProvider path={match?.location?.pathname}>
       <Layout variant={routeConfig?.layout}>{children}</Layout>
 
       {onboardingComponent}
-    </>
+    </AnalyticsInferredContextProvider>
   )
 }

--- a/src/Apps/Example/Routes/Artist/ExampleArtistRoute.tsx
+++ b/src/Apps/Example/Routes/Artist/ExampleArtistRoute.tsx
@@ -3,10 +3,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { ExampleArtistRoute_artist$data } from "__generated__/ExampleArtistRoute_artist.graphql"
 import { Box, Text } from "@artsy/palette"
 import { Title } from "react-head"
-import {
-  AnalyticsContext,
-  useAnalyticsContext,
-} from "System/Analytics/AnalyticsContext"
+import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
 import { FollowArtistButtonQueryRenderer } from "Components/FollowButton/FollowArtistButton"
 import { ContextModule } from "@artsy/cohesion"
 
@@ -36,26 +33,17 @@ const ExampleArtistRoute: React.FC<ExampleArtistAppProps> = ({ artist }) => {
 }
 
 /**
- * Routes with /:id require an additional AnalyticsContext.Provider
- * declaration to add slug and id, extending the context provided by <Boot>
+ * Routes with :slugs require AnalyticsContextProvider to provide the corresponding internalID
  */
 const TrackingWrappedExampleArtistRoute: React.FC<ExampleArtistAppProps> = props => {
   const {
-    artist: { internalID, slug },
+    artist: { internalID },
   } = props
 
-  const { contextPageOwnerType } = useAnalyticsContext()
-
   return (
-    <AnalyticsContext.Provider
-      value={{
-        contextPageOwnerId: internalID,
-        contextPageOwnerSlug: slug,
-        contextPageOwnerType,
-      }}
-    >
+    <AnalyticsContextProvider contextPageOwnerId={internalID}>
       <ExampleArtistRoute {...props} />
-    </AnalyticsContext.Provider>
+    </AnalyticsContextProvider>
   )
 }
 
@@ -67,7 +55,6 @@ export const ExampleArtistRouteFragmentContainer = createFragmentContainer(
         name
         bio
         internalID
-        slug
       }
     `,
   }

--- a/src/Apps/Example/Routes/Artist/ExampleArtistRoute.tsx
+++ b/src/Apps/Example/Routes/Artist/ExampleArtistRoute.tsx
@@ -3,7 +3,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { ExampleArtistRoute_artist$data } from "__generated__/ExampleArtistRoute_artist.graphql"
 import { Box, Text } from "@artsy/palette"
 import { Title } from "react-head"
-import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
+import { Analytics } from "System/Analytics/AnalyticsContext"
 import { FollowArtistButtonQueryRenderer } from "Components/FollowButton/FollowArtistButton"
 import { ContextModule } from "@artsy/cohesion"
 
@@ -33,7 +33,7 @@ const ExampleArtistRoute: React.FC<ExampleArtistAppProps> = ({ artist }) => {
 }
 
 /**
- * Routes with :slugs require AnalyticsContextProvider to provide the corresponding internalID
+ * Routes with :slugs require Analytics to provide the corresponding internalID
  */
 const TrackingWrappedExampleArtistRoute: React.FC<ExampleArtistAppProps> = props => {
   const {
@@ -41,9 +41,9 @@ const TrackingWrappedExampleArtistRoute: React.FC<ExampleArtistAppProps> = props
   } = props
 
   return (
-    <AnalyticsContextProvider contextPageOwnerId={internalID}>
+    <Analytics contextPageOwnerId={internalID}>
       <ExampleArtistRoute {...props} />
-    </AnalyticsContextProvider>
+    </Analytics>
   )
 }
 

--- a/src/Apps/Example/Routes/Artwork/ExampleArtworkRoute.tsx
+++ b/src/Apps/Example/Routes/Artwork/ExampleArtworkRoute.tsx
@@ -1,7 +1,7 @@
 import { Box, Flex, Image, Text } from "@artsy/palette"
 import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
+import { Analytics } from "System/Analytics/AnalyticsContext"
 import { ExampleArtworkRoute_artwork$data } from "__generated__/ExampleArtworkRoute_artwork.graphql"
 import { EntityHeaderArtistFragmentContainer } from "Components/EntityHeaders/EntityHeaderArtist"
 import { MetaTags } from "Components/MetaTags"
@@ -49,7 +49,7 @@ const ExampleArtworkRoute: React.FC<ExampleArtworkRouteProps> = ({
 }
 
 /**
- * Routes with :slugs require AnalyticsContextProvider to provide the corresponding internalID
+ * Routes with :slugs require Analytics to provide the corresponding internalID
  */
 const TrackingWrappedExampleArtworkRoute: React.FC<ExampleArtworkRouteProps> = props => {
   const {
@@ -57,9 +57,9 @@ const TrackingWrappedExampleArtworkRoute: React.FC<ExampleArtworkRouteProps> = p
   } = props
 
   return (
-    <AnalyticsContextProvider contextPageOwnerId={internalID}>
+    <Analytics contextPageOwnerId={internalID}>
       <ExampleArtworkRoute {...props} />
-    </AnalyticsContextProvider>
+    </Analytics>
   )
 }
 

--- a/src/Apps/Example/Routes/Welcome/WelcomeRoute.tsx
+++ b/src/Apps/Example/Routes/Welcome/WelcomeRoute.tsx
@@ -21,7 +21,6 @@ export const WelcomeRoute: React.FC = () => {
     trackEvent(
       clickedShowMore({
         context_module: ContextModule.promoSpace,
-        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         context_page_owner_type: contextPageOwnerType,
         context_page_owner_slug: contextPageOwnerSlug,
         context_page_owner_id: contextPageOwnerId,

--- a/src/Apps/Fair/Components/FairCollections/FairCollection.tsx
+++ b/src/Apps/Fair/Components/FairCollections/FairCollection.tsx
@@ -43,7 +43,6 @@ export const FairCollection: React.FC<FairCollectionProps> = ({
 
   const collectionTrackingData: ClickedCollectionGroup = {
     context_module: ContextModule.curatedHighlightsRail,
-    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
     context_page_owner_type: contextPageOwnerType,
     context_page_owner_id: contextPageOwnerId,
     context_page_owner_slug: contextPageOwnerSlug,

--- a/src/Apps/Fair/Components/__tests__/FairBoothRail.jest.tsx
+++ b/src/Apps/Fair/Components/__tests__/FairBoothRail.jest.tsx
@@ -4,8 +4,7 @@ import { graphql } from "react-relay"
 import { FairBoothRail_Test_Query } from "__generated__/FairBoothRail_Test_Query.graphql"
 import { BoothFilterContextProvider } from "Apps/Fair/Components/BoothFilterContext"
 import { fireEvent, screen } from "@testing-library/react"
-import { AnalyticsContext } from "System/Analytics/AnalyticsContext"
-import { OwnerType } from "@artsy/cohesion"
+import { AnalyticsCombinedContextProvider } from "System/Analytics/AnalyticsContext"
 import { useTracking } from "react-tracking"
 import { useRouter } from "System/Router/useRouter"
 
@@ -17,17 +16,14 @@ const { renderWithRelay } = setupTestWrapperTL<FairBoothRail_Test_Query>({
   Component: props => {
     if (props.show) {
       return (
-        <AnalyticsContext.Provider
-          value={{
-            contextPageOwnerId: "context-page-owner-id",
-            contextPageOwnerSlug: "context-page-owner-slug",
-            contextPageOwnerType: OwnerType.show,
-          }}
+        <AnalyticsCombinedContextProvider
+          contextPageOwnerId="context-page-owner-id"
+          path="/show/context-page-owner-slug"
         >
           <BoothFilterContextProvider filters={{ sort: "NAME_ASC", page: 2 }}>
             <FairBoothRailFragmentContainer show={props.show} />
           </BoothFilterContextProvider>
-        </AnalyticsContext.Provider>
+        </AnalyticsCombinedContextProvider>
       )
     }
 

--- a/src/Apps/Fair/Components/__tests__/FairCollection.jest.tsx
+++ b/src/Apps/Fair/Components/__tests__/FairCollection.jest.tsx
@@ -4,8 +4,7 @@ import { FairCollectionFragmentContainer } from "Apps/Fair/Components/FairCollec
 import { FairCollection_Query$rawResponse } from "__generated__/FairCollection_Query.graphql"
 import { useTracking } from "react-tracking"
 import { RouterLink } from "System/Router/RouterLink"
-import { OwnerType } from "@artsy/cohesion"
-import { AnalyticsContext } from "System/Analytics/AnalyticsContext"
+import { AnalyticsCombinedContextProvider } from "System/Analytics/AnalyticsContext"
 
 jest.unmock("react-relay")
 jest.mock("react-tracking")
@@ -19,18 +18,15 @@ describe("FairCollection", () => {
     return renderRelayTree({
       Component: ({ marketingCollection: collection }) => {
         return (
-          <AnalyticsContext.Provider
-            value={{
-              contextPageOwnerId: "abc1234",
-              contextPageOwnerSlug: "miart-2020",
-              contextPageOwnerType: OwnerType.fair,
-            }}
+          <AnalyticsCombinedContextProvider
+            contextPageOwnerId="abc1234"
+            path="/fair/miart-2020"
           >
             <FairCollectionFragmentContainer
               collection={collection}
               carouselIndex={2}
             />
-          </AnalyticsContext.Provider>
+          </AnalyticsCombinedContextProvider>
         )
       },
       query: graphql`

--- a/src/Apps/Fair/Components/__tests__/FairFollowedArtists.jest.tsx
+++ b/src/Apps/Fair/Components/__tests__/FairFollowedArtists.jest.tsx
@@ -1,8 +1,7 @@
 import { FairFollowedArtists } from "Apps/Fair/Components/FairOverview/FairFollowedArtists"
 import { useTracking } from "react-tracking"
-import { AnalyticsContext } from "System/Analytics/AnalyticsContext"
+import { AnalyticsCombinedContextProvider } from "System/Analytics/AnalyticsContext"
 import { mount } from "enzyme"
-import { OwnerType } from "@artsy/cohesion"
 
 jest.mock("react-tracking")
 jest.mock("Components/Artwork/ShelfArtwork", () => {
@@ -43,15 +42,12 @@ describe("FairFollowedArtists", () => {
 
   const getWrapper = () => {
     return mount(
-      <AnalyticsContext.Provider
-        value={{
-          contextPageOwnerId: "example-fair-id",
-          contextPageOwnerSlug: "example-fair-slug",
-          contextPageOwnerType: OwnerType.fair,
-        }}
+      <AnalyticsCombinedContextProvider
+        contextPageOwnerId="example-fair-id"
+        path="/fair/example-fair-slug"
       >
         <FairFollowedArtists fair={FAIR_FOLLOWED_ARTISTS_FIXTURE as any} />
-      </AnalyticsContext.Provider>
+      </AnalyticsCombinedContextProvider>
     )
   }
 

--- a/src/Apps/Fair/FairApp.tsx
+++ b/src/Apps/Fair/FairApp.tsx
@@ -4,10 +4,7 @@ import { FairApp_fair$data } from "__generated__/FairApp_fair.graphql"
 import { DROP_SHADOW, FullBleed, Spacer } from "@artsy/palette"
 import { FairMetaFragmentContainer } from "./Components/FairMeta"
 import { useSystemContext } from "System/useSystemContext"
-import {
-  AnalyticsContext,
-  useAnalyticsContext,
-} from "System/Analytics/AnalyticsContext"
+import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
 import { HttpError } from "found"
 import { useRouter } from "System/Router/useRouter"
 import { userIsAdmin } from "Utils/user"
@@ -81,10 +78,8 @@ const FairApp: React.FC<FairAppProps> = ({ children, fair }) => {
 
 const TrackingWrappedFairApp: React.FC<FairAppProps> = props => {
   const {
-    fair: { internalID, profile, slug },
+    fair: { internalID, profile },
   } = props
-
-  const { contextPageOwnerType } = useAnalyticsContext()
 
   const { user } = useSystemContext()
 
@@ -95,15 +90,9 @@ const TrackingWrappedFairApp: React.FC<FairAppProps> = props => {
   }
 
   return (
-    <AnalyticsContext.Provider
-      value={{
-        contextPageOwnerId: internalID,
-        contextPageOwnerSlug: slug,
-        contextPageOwnerType,
-      }}
-    >
+    <AnalyticsContextProvider contextPageOwnerId={internalID}>
       <FairApp {...props} />
-    </AnalyticsContext.Provider>
+    </AnalyticsContextProvider>
   )
 }
 
@@ -119,7 +108,6 @@ export const FairAppFragmentContainer = createFragmentContainer(
         ...FairHeaderImage_fair
         ...ExhibitorsLetterNav_fair
         internalID
-        slug
         profile {
           id
         }

--- a/src/Apps/Fair/FairApp.tsx
+++ b/src/Apps/Fair/FairApp.tsx
@@ -4,7 +4,7 @@ import { FairApp_fair$data } from "__generated__/FairApp_fair.graphql"
 import { DROP_SHADOW, FullBleed, Spacer } from "@artsy/palette"
 import { FairMetaFragmentContainer } from "./Components/FairMeta"
 import { useSystemContext } from "System/useSystemContext"
-import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
+import { Analytics } from "System/Analytics/AnalyticsContext"
 import { HttpError } from "found"
 import { useRouter } from "System/Router/useRouter"
 import { userIsAdmin } from "Utils/user"
@@ -90,9 +90,9 @@ const TrackingWrappedFairApp: React.FC<FairAppProps> = props => {
   }
 
   return (
-    <AnalyticsContextProvider contextPageOwnerId={internalID}>
+    <Analytics contextPageOwnerId={internalID}>
       <FairApp {...props} />
-    </AnalyticsContextProvider>
+    </Analytics>
   )
 }
 

--- a/src/Apps/Fair/__tests__/FairApp.jest.tsx
+++ b/src/Apps/Fair/__tests__/FairApp.jest.tsx
@@ -3,10 +3,10 @@ import { FairAppFragmentContainer } from "Apps/Fair/FairApp"
 import { graphql } from "react-relay"
 import { FairApp_Test_Query } from "__generated__/FairApp_Test_Query.graphql"
 import { useTracking } from "react-tracking"
-import { OwnerType } from "@artsy/cohesion"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { useRouter } from "System/Router/useRouter"
 import { fireEvent, screen } from "@testing-library/react"
+import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
 
 const mockJumpTo = jest.fn()
 
@@ -29,16 +29,10 @@ const { renderWithRelay } = setupTestWrapperTL<FairApp_Test_Query>({
     if (!props.fair) return null
 
     return (
-      <MockBoot
-        context={{
-          analytics: {
-            contextPageOwnerId: "bson-fair",
-            contextPageOwnerSlug: "miart-2020",
-            contextPageOwnerType: OwnerType.fair,
-          },
-        }}
-      >
-        <FairAppFragmentContainer fair={props.fair} />
+      <MockBoot>
+        <AnalyticsContextProvider contextPageOwnerId="bson-fair">
+          <FairAppFragmentContainer fair={props.fair} />
+        </AnalyticsContextProvider>
       </MockBoot>
     )
   },
@@ -60,7 +54,7 @@ describe("FairApp", () => {
     mockUseRouter.mockImplementation(() => ({
       match: {
         location: {
-          pathname: "anything",
+          pathname: "fair/miart-2020",
         },
       },
     }))

--- a/src/Apps/Fair/__tests__/FairApp.jest.tsx
+++ b/src/Apps/Fair/__tests__/FairApp.jest.tsx
@@ -6,7 +6,7 @@ import { useTracking } from "react-tracking"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { useRouter } from "System/Router/useRouter"
 import { fireEvent, screen } from "@testing-library/react"
-import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
+import { AnalyticsCombinedContextProvider } from "System/Analytics/AnalyticsContext"
 
 const mockJumpTo = jest.fn()
 
@@ -30,9 +30,12 @@ const { renderWithRelay } = setupTestWrapperTL<FairApp_Test_Query>({
 
     return (
       <MockBoot>
-        <AnalyticsContextProvider contextPageOwnerId="bson-fair">
+        <AnalyticsCombinedContextProvider
+          path="/fair/miart-2020"
+          contextPageOwnerId="bson-fair"
+        >
           <FairAppFragmentContainer fair={props.fair} />
-        </AnalyticsContextProvider>
+        </AnalyticsCombinedContextProvider>
       </MockBoot>
     )
   },

--- a/src/Apps/Partner/PartnerApp.tsx
+++ b/src/Apps/Partner/PartnerApp.tsx
@@ -8,6 +8,7 @@ import { PartnerHeaderImageFragmentContainer as PartnerHeaderImage } from "./Com
 import { PartnerMetaFragmentContainer } from "./Components/PartnerMeta"
 import { PartnerArtistsLoadingContextProvider } from "./Utils/PartnerArtistsLoadingContext"
 import { HttpError } from "found"
+import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
 
 export interface PartnerAppProps {
   partner: PartnerApp_partner$data
@@ -41,38 +42,41 @@ export const PartnerApp: React.FC<PartnerAppProps> = ({
   )
 
   return (
-    <PartnerArtistsLoadingContextProvider>
-      {profile && displayFullPartnerPage && (
-        <PartnerHeaderImage profile={profile} />
-      )}
-
-      <PartnerMetaFragmentContainer partner={partner} />
-
-      <PartnerHeader partner={partner} />
-
-      <FullBleed mb={[2, 4]}>
-        {firstEligibleBadgeName ? (
-          <Marquee
-            speed="static"
-            marqueeText={firstEligibleBadgeName.replace(" ", "-")} // hypenate gallery badges
-          />
-        ) : (
-          <Separator />
+    <AnalyticsContextProvider contextPageOwnerId={partner.internalID}>
+      <PartnerArtistsLoadingContextProvider>
+        {profile && displayFullPartnerPage && (
+          <PartnerHeaderImage profile={profile} />
         )}
-      </FullBleed>
 
-      {(displayFullPartnerPage || partnerType === "Brand") && (
-        <NavigationTabs partner={partner} />
-      )}
+        <PartnerMetaFragmentContainer partner={partner} />
 
-      {children}
-    </PartnerArtistsLoadingContextProvider>
+        <PartnerHeader partner={partner} />
+
+        <FullBleed mb={[2, 4]}>
+          {firstEligibleBadgeName ? (
+            <Marquee
+              speed="static"
+              marqueeText={firstEligibleBadgeName.replace(" ", "-")} // hypenate gallery badges
+            />
+          ) : (
+            <Separator />
+          )}
+        </FullBleed>
+
+        {(displayFullPartnerPage || partnerType === "Brand") && (
+          <NavigationTabs partner={partner} />
+        )}
+
+        {children}
+      </PartnerArtistsLoadingContextProvider>
+    </AnalyticsContextProvider>
   )
 }
 
 export const PartnerAppFragmentContainer = createFragmentContainer(PartnerApp, {
   partner: graphql`
     fragment PartnerApp_partner on Partner {
+      internalID
       partnerType
       displayFullPartnerPage
       partnerPageEligible

--- a/src/Apps/Partner/PartnerApp.tsx
+++ b/src/Apps/Partner/PartnerApp.tsx
@@ -8,7 +8,7 @@ import { PartnerHeaderImageFragmentContainer as PartnerHeaderImage } from "./Com
 import { PartnerMetaFragmentContainer } from "./Components/PartnerMeta"
 import { PartnerArtistsLoadingContextProvider } from "./Utils/PartnerArtistsLoadingContext"
 import { HttpError } from "found"
-import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
+import { Analytics } from "System/Analytics/AnalyticsContext"
 
 export interface PartnerAppProps {
   partner: PartnerApp_partner$data
@@ -42,7 +42,7 @@ export const PartnerApp: React.FC<PartnerAppProps> = ({
   )
 
   return (
-    <AnalyticsContextProvider contextPageOwnerId={partner.internalID}>
+    <Analytics contextPageOwnerId={partner.internalID}>
       <PartnerArtistsLoadingContextProvider>
         {profile && displayFullPartnerPage && (
           <PartnerHeaderImage profile={profile} />
@@ -69,7 +69,7 @@ export const PartnerApp: React.FC<PartnerAppProps> = ({
 
         {children}
       </PartnerArtistsLoadingContextProvider>
-    </AnalyticsContextProvider>
+    </Analytics>
   )
 }
 

--- a/src/Apps/Partner/__tests__/PartnerApp.jest.tsx
+++ b/src/Apps/Partner/__tests__/PartnerApp.jest.tsx
@@ -8,7 +8,7 @@ import { HeadProvider } from "react-head"
 jest.unmock("react-relay")
 jest.mock("react-tracking")
 jest.mock("System/Analytics/AnalyticsContext", () => ({
-  AnalyticsContextProvider: ({ children }) => children,
+  Analytics: ({ children }) => children,
 }))
 jest.mock("System/Router/useRouter", () => ({
   useRouter: () => ({

--- a/src/Apps/Partner/__tests__/PartnerApp.jest.tsx
+++ b/src/Apps/Partner/__tests__/PartnerApp.jest.tsx
@@ -1,12 +1,15 @@
 import { graphql } from "react-relay"
 import { PartnerApp_Test_Query } from "__generated__/PartnerApp_Test_Query.graphql"
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
-import { PartnerAppFragmentContainer } from "../PartnerApp"
-import { PartnerHeaderImageFragmentContainer as PartnerHeaderImage } from "../Components/PartnerHeader/PartnerHeaderImage"
+import { PartnerAppFragmentContainer } from "Apps/Partner/PartnerApp"
+import { PartnerHeaderImageFragmentContainer } from "Apps/Partner/Components/PartnerHeader/PartnerHeaderImage"
 import { HeadProvider } from "react-head"
 
 jest.unmock("react-relay")
 jest.mock("react-tracking")
+jest.mock("System/Analytics/AnalyticsContext", () => ({
+  AnalyticsContextProvider: ({ children }) => children,
+}))
 jest.mock("System/Router/useRouter", () => ({
   useRouter: () => ({
     match: {
@@ -94,7 +97,7 @@ describe("PartnerApp", () => {
       }),
     })
 
-    expect(wrapper.find(PartnerHeaderImage).length).toEqual(1)
+    expect(wrapper.find(PartnerHeaderImageFragmentContainer).length).toEqual(1)
   })
 
   it("doesn't display profile image if there is no info", () => {
@@ -105,7 +108,7 @@ describe("PartnerApp", () => {
         },
       }),
     })
-    expect(wrapper.find(PartnerHeaderImage).length).toBe(0)
+    expect(wrapper.find(PartnerHeaderImageFragmentContainer).length).toBe(0)
   })
 
   it("doesn't display profile image if the partner isn't eligible for a full profile", () => {
@@ -115,6 +118,6 @@ describe("PartnerApp", () => {
       }),
     })
 
-    expect(wrapper.find(PartnerHeaderImage)).toHaveLength(0)
+    expect(wrapper.find(PartnerHeaderImageFragmentContainer)).toHaveLength(0)
   })
 })

--- a/src/Apps/Search/Routes/SearchResultsArtworks.tsx
+++ b/src/Apps/Search/Routes/SearchResultsArtworks.tsx
@@ -11,8 +11,6 @@ import {
 } from "Components/ArtworkFilter/ArtworkFilterContext"
 import { useSystemContext } from "System/useSystemContext"
 import { SearchResultsArtworksFilters } from "Apps/Search/Components/SearchResultsArtworksFilters"
-import { AnalyticsContext } from "System/Analytics/AnalyticsContext"
-import { OwnerType } from "@artsy/cohesion"
 
 interface SearchResultsRouteProps {
   viewer: SearchResultsArtworks_viewer$data
@@ -25,34 +23,28 @@ export const SearchResultsArtworksRoute: React.FC<SearchResultsRouteProps> = pro
   const { sidebar } = viewer
 
   return (
-    <AnalyticsContext.Provider
-      value={{
-        contextPageOwnerType: OwnerType.search,
-      }}
-    >
-      <ArtworkFilter
-        mt={4}
-        viewer={viewer}
-        filters={match.location.query}
-        onChange={updateUrl}
-        ZeroState={ZeroState}
-        aggregations={
-          sidebar?.aggregations as SharedArtworkFilterContextProps["aggregations"]
-        }
-        counts={sidebar?.counts as Counts}
-        sortOptions={[
-          { value: "-decayed_merch", text: "Recommended" },
-          { value: "-has_price,-prices", text: "Price (High to Low)" },
-          { value: "-has_price,prices", text: "Price (Low to High)" },
-          { value: "-partner_updated_at", text: "Recently Updated" },
-          { value: "-published_at", text: "Recently Added" },
-          { value: "-year", text: "Artwork Year (Descending)" },
-          { value: "year", text: "Artwork Year (Ascending)" },
-        ]}
-        Filters={<SearchResultsArtworksFilters />}
-        userPreferredMetric={userPreferences?.metric}
-      />
-    </AnalyticsContext.Provider>
+    <ArtworkFilter
+      mt={4}
+      viewer={viewer}
+      filters={match.location.query}
+      onChange={updateUrl}
+      ZeroState={ZeroState}
+      aggregations={
+        sidebar?.aggregations as SharedArtworkFilterContextProps["aggregations"]
+      }
+      counts={sidebar?.counts as Counts}
+      sortOptions={[
+        { value: "-decayed_merch", text: "Recommended" },
+        { value: "-has_price,-prices", text: "Price (High to Low)" },
+        { value: "-has_price,prices", text: "Price (Low to High)" },
+        { value: "-partner_updated_at", text: "Recently Updated" },
+        { value: "-published_at", text: "Recently Added" },
+        { value: "-year", text: "Artwork Year (Descending)" },
+        { value: "year", text: "Artwork Year (Ascending)" },
+      ]}
+      Filters={<SearchResultsArtworksFilters />}
+      userPreferredMetric={userPreferences?.metric}
+    />
   )
 }
 

--- a/src/Apps/Show/Components/ShowContextCard.tsx
+++ b/src/Apps/Show/Components/ShowContextCard.tsx
@@ -55,7 +55,6 @@ export const ShowContextCard: React.FC<Props> = ({ show }) => {
       const payload: ClickedFairCard = {
         action: ActionType.clickedFairCard,
         context_module: ContextModule.presentingFair,
-        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         context_page_owner_type: contextPageOwnerType,
         context_page_owner_id: contextPageOwnerId,
         context_page_owner_slug: contextPageOwnerSlug,
@@ -70,31 +69,27 @@ export const ShowContextCard: React.FC<Props> = ({ show }) => {
       tracking.trackEvent(payload)
     }
 
+    if (!fair) return null
+
     return (
       <GridColumns>
-        {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         {fair.isActive && (
           <Column span={6}>
-            {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
             <Text variant="lg-display">Part of {fair.name}</Text>
           </Column>
         )}
         <Column span={6}>
           <StyledLink
-            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             to={fair.href}
             textDecoration="none"
             onClick={handleClick}
           >
-            {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
             <FairCard fair={fair} />
 
             <Spacer y={2} />
             <Box>
-              {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
               <Text variant="xl">{fair.name}</Text>
 
-              {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
               <FairTiming fair={fair} />
             </Box>
           </StyledLink>
@@ -126,7 +121,6 @@ export const ShowContextCard: React.FC<Props> = ({ show }) => {
       const payload: ClickedPartnerCard = {
         action: ActionType.clickedPartnerCard,
         context_module: ContextModule.presentingPartner,
-        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         context_page_owner_type: contextPageOwnerType,
         context_page_owner_id: contextPageOwnerId,
         context_page_owner_slug: contextPageOwnerSlug,

--- a/src/Apps/Show/Components/ShowViewingRoom.tsx
+++ b/src/Apps/Show/Components/ShowViewingRoom.tsx
@@ -41,7 +41,6 @@ export const ShowViewingRoom: React.FC<ShowViewingRoomProps> = ({
     const payload: ClickedViewingRoomCard = {
       action: ActionType.clickedViewingRoomCard,
       context_module: ContextModule.associatedViewingRoom,
-      // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
       context_page_owner_type: contextPageOwnerType,
       context_page_owner_id: contextPageOwnerId,
       context_page_owner_slug: contextPageOwnerSlug,

--- a/src/Apps/Show/ShowApp.tsx
+++ b/src/Apps/Show/ShowApp.tsx
@@ -16,10 +16,7 @@ import { ShowViewingRoomFragmentContainer as ShowViewingRoom } from "./Component
 import { ShowApp_show$data } from "__generated__/ShowApp_show.graphql"
 import { ShowArtworksRefetchContainer as ShowArtworksFilter } from "./Components/ShowArtworks"
 import { ShowContextCardFragmentContainer as ShowContextCard } from "./Components/ShowContextCard"
-import {
-  AnalyticsContext,
-  useAnalyticsContext,
-} from "System/Analytics/AnalyticsContext"
+import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
 import { ShowArtworksEmptyStateFragmentContainer as ShowArtworksEmptyState } from "./Components/ShowArtworksEmptyState"
 import {
   Counts,
@@ -33,8 +30,6 @@ interface ShowAppProps {
 }
 
 export const ShowApp: React.FC<ShowAppProps> = ({ show }) => {
-  const { contextPageOwnerSlug, contextPageOwnerType } = useAnalyticsContext()
-
   const hasViewingRoom = (show.viewingRoomsConnection?.edges?.length ?? 0) > 0
   const hasAbout = !!show.about
   const hasWideHeader =
@@ -46,13 +41,7 @@ export const ShowApp: React.FC<ShowAppProps> = ({ show }) => {
       <ShowMeta show={show} />
 
       <>
-        <AnalyticsContext.Provider
-          value={{
-            contextPageOwnerId: show.internalID,
-            contextPageOwnerSlug,
-            contextPageOwnerType,
-          }}
-        >
+        <AnalyticsContextProvider contextPageOwnerId={show.internalID}>
           {show.fair?.hasFullFeature && isFairBooth && (
             <BackToFairBanner show={show} />
           )}
@@ -125,7 +114,7 @@ export const ShowApp: React.FC<ShowAppProps> = ({ show }) => {
               </>
             )}
           </Join>
-        </AnalyticsContext.Provider>
+        </AnalyticsContextProvider>
       </>
     </>
   )

--- a/src/Apps/Show/ShowApp.tsx
+++ b/src/Apps/Show/ShowApp.tsx
@@ -16,7 +16,7 @@ import { ShowViewingRoomFragmentContainer as ShowViewingRoom } from "./Component
 import { ShowApp_show$data } from "__generated__/ShowApp_show.graphql"
 import { ShowArtworksRefetchContainer as ShowArtworksFilter } from "./Components/ShowArtworks"
 import { ShowContextCardFragmentContainer as ShowContextCard } from "./Components/ShowContextCard"
-import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
+import { Analytics } from "System/Analytics/AnalyticsContext"
 import { ShowArtworksEmptyStateFragmentContainer as ShowArtworksEmptyState } from "./Components/ShowArtworksEmptyState"
 import {
   Counts,
@@ -41,7 +41,7 @@ export const ShowApp: React.FC<ShowAppProps> = ({ show }) => {
       <ShowMeta show={show} />
 
       <>
-        <AnalyticsContextProvider contextPageOwnerId={show.internalID}>
+        <Analytics contextPageOwnerId={show.internalID}>
           {show.fair?.hasFullFeature && isFairBooth && (
             <BackToFairBanner show={show} />
           )}
@@ -114,7 +114,7 @@ export const ShowApp: React.FC<ShowAppProps> = ({ show }) => {
               </>
             )}
           </Join>
-        </AnalyticsContextProvider>
+        </Analytics>
       </>
     </>
   )

--- a/src/Apps/Show/ShowSubApp.tsx
+++ b/src/Apps/Show/ShowSubApp.tsx
@@ -3,7 +3,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { Box } from "@artsy/palette"
 import { ShowSubApp_show$data } from "__generated__/ShowSubApp_show.graphql"
 import { ShowMetaFragmentContainer as ShowMeta } from "./Components/ShowMeta"
-import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
+import { Analytics } from "System/Analytics/AnalyticsContext"
 import { TopContextBar } from "Components/TopContextBar"
 
 interface ShowAppProps {
@@ -15,7 +15,7 @@ const ShowApp: React.FC<ShowAppProps> = ({ children, show }) => {
     <>
       <ShowMeta show={show} />
 
-      <AnalyticsContextProvider contextPageOwnerId={show.internalID}>
+      <Analytics contextPageOwnerId={show.internalID}>
         <TopContextBar displayBackArrow href={show.href}>
           Back to {show.name}
           {!show.isFairBooth && show.partner?.name && (
@@ -24,7 +24,7 @@ const ShowApp: React.FC<ShowAppProps> = ({ children, show }) => {
         </TopContextBar>
 
         <Box minHeight="50vh">{children}</Box>
-      </AnalyticsContextProvider>
+      </Analytics>
     </>
   )
 }

--- a/src/Apps/Show/ShowSubApp.tsx
+++ b/src/Apps/Show/ShowSubApp.tsx
@@ -3,10 +3,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { Box } from "@artsy/palette"
 import { ShowSubApp_show$data } from "__generated__/ShowSubApp_show.graphql"
 import { ShowMetaFragmentContainer as ShowMeta } from "./Components/ShowMeta"
-import {
-  AnalyticsContext,
-  useAnalyticsContext,
-} from "System/Analytics/AnalyticsContext"
+import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
 import { TopContextBar } from "Components/TopContextBar"
 
 interface ShowAppProps {
@@ -14,19 +11,11 @@ interface ShowAppProps {
 }
 
 const ShowApp: React.FC<ShowAppProps> = ({ children, show }) => {
-  const { contextPageOwnerSlug, contextPageOwnerType } = useAnalyticsContext()
-
   return (
     <>
       <ShowMeta show={show} />
 
-      <AnalyticsContext.Provider
-        value={{
-          contextPageOwnerId: show.internalID,
-          contextPageOwnerSlug,
-          contextPageOwnerType,
-        }}
-      >
+      <AnalyticsContextProvider contextPageOwnerId={show.internalID}>
         <TopContextBar displayBackArrow href={show.href}>
           Back to {show.name}
           {!show.isFairBooth && show.partner?.name && (
@@ -35,7 +24,7 @@ const ShowApp: React.FC<ShowAppProps> = ({ children, show }) => {
         </TopContextBar>
 
         <Box minHeight="50vh">{children}</Box>
-      </AnalyticsContext.Provider>
+      </AnalyticsContextProvider>
     </>
   )
 }

--- a/src/Apps/Show/__tests__/ShowContextCard.jest.tsx
+++ b/src/Apps/Show/__tests__/ShowContextCard.jest.tsx
@@ -1,8 +1,7 @@
-import { ShowContextCardFragmentContainer } from "../Components/ShowContextCard"
+import { ShowContextCardFragmentContainer } from "Apps/Show/Components/ShowContextCard"
 import { graphql } from "react-relay"
 import { ShowContextCard_Test_Query } from "__generated__/ShowContextCard_Test_Query.graphql"
-import { AnalyticsContext } from "System/Analytics/AnalyticsContext"
-import { OwnerType } from "@artsy/cohesion"
+import { AnalyticsCombinedContextProvider } from "System/Analytics/AnalyticsContext"
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
 import { useTracking } from "react-tracking"
 
@@ -11,16 +10,13 @@ jest.mock("react-tracking")
 
 const { getWrapper } = setupTestWrapper<ShowContextCard_Test_Query>({
   Component: props => (
-    <AnalyticsContext.Provider
-      value={{
-        contextPageOwnerId: "example-show-id",
-        contextPageOwnerSlug: "example-show-slug",
-        contextPageOwnerType: OwnerType.show,
-      }}
+    <AnalyticsCombinedContextProvider
+      contextPageOwnerId="example-show-id"
+      path="/show/example-show-slug"
     >
       {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
       <ShowContextCardFragmentContainer {...props} />
-    </AnalyticsContext.Provider>
+    </AnalyticsCombinedContextProvider>
   ),
   query: graphql`
     query ShowContextCard_Test_Query @relay_test_operation {

--- a/src/Apps/Show/__tests__/ShowViewingRoom.jest.tsx
+++ b/src/Apps/Show/__tests__/ShowViewingRoom.jest.tsx
@@ -1,10 +1,9 @@
 import { graphql } from "react-relay"
-import { ShowViewingRoomFragmentContainer as ShowViewingRoom } from "../Components/ShowViewingRoom"
+import { ShowViewingRoomFragmentContainer as ShowViewingRoom } from "Apps/Show/Components/ShowViewingRoom"
 import { ShowViewingRoom_Test_Query } from "__generated__/ShowViewingRoom_Test_Query.graphql"
 import { useTracking } from "react-tracking"
-import { AnalyticsContext } from "System/Analytics/AnalyticsContext"
-import { OwnerType } from "@artsy/cohesion"
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
+import { AnalyticsCombinedContextProvider } from "System/Analytics/AnalyticsContext"
 
 jest.mock("react-tracking")
 jest.unmock("react-relay")
@@ -12,16 +11,13 @@ jest.unmock("react-relay")
 const { getWrapper } = setupTestWrapper<ShowViewingRoom_Test_Query>({
   Component: props => {
     return (
-      <AnalyticsContext.Provider
-        value={{
-          contextPageOwnerId: "example-show-id",
-          contextPageOwnerSlug: "example-show-slug",
-          contextPageOwnerType: OwnerType.show,
-        }}
+      <AnalyticsCombinedContextProvider
+        contextPageOwnerId="example-show-id"
+        path="/show/example-show-slug"
       >
         {/* @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION */}
         <ShowViewingRoom {...props} />
-      </AnalyticsContext.Provider>
+      </AnalyticsCombinedContextProvider>
     )
   },
   query: graphql`

--- a/src/Apps/ViewingRoom/ViewingRoomApp.tsx
+++ b/src/Apps/ViewingRoom/ViewingRoomApp.tsx
@@ -11,6 +11,7 @@ import { SystemContext } from "System/SystemContext"
 import { userHasAccessToPartner } from "Utils/user"
 import { FullBleedBanner } from "Components/FullBleedBanner"
 import HideIcon from "@artsy/icons/HideIcon"
+import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
 
 interface ViewingRoomAppProps {
   children: React.ReactNode
@@ -29,7 +30,7 @@ const ViewingRoomApp: React.FC<ViewingRoomAppProps> = ({
     (viewingRoom.status === "draft" || viewingRoom.status === "scheduled")
 
   return (
-    <>
+    <AnalyticsContextProvider contextPageOwnerId={viewingRoom.internalID}>
       <ViewingRoomMeta viewingRoom={viewingRoom} />
 
       {isPreviewable && (
@@ -52,7 +53,7 @@ const ViewingRoomApp: React.FC<ViewingRoomAppProps> = ({
           <ViewingRoomContentNotAccessible viewingRoom={viewingRoom} />
         )}
       </Join>
-    </>
+    </AnalyticsContextProvider>
   )
 }
 
@@ -65,10 +66,11 @@ export const ViewingRoomAppFragmentContainer = createFragmentContainer(
         ...ViewingRoomMeta_viewingRoom
         ...ViewingRoomHeader_viewingRoom
         ...ViewingRoomContentNotAccessible_viewingRoom
+        internalID
+        status
         partner {
           internalID
         }
-        status
       }
     `,
   }

--- a/src/Apps/ViewingRoom/ViewingRoomApp.tsx
+++ b/src/Apps/ViewingRoom/ViewingRoomApp.tsx
@@ -11,7 +11,7 @@ import { SystemContext } from "System/SystemContext"
 import { userHasAccessToPartner } from "Utils/user"
 import { FullBleedBanner } from "Components/FullBleedBanner"
 import HideIcon from "@artsy/icons/HideIcon"
-import { AnalyticsContextProvider } from "System/Analytics/AnalyticsContext"
+import { Analytics } from "System/Analytics/AnalyticsContext"
 
 interface ViewingRoomAppProps {
   children: React.ReactNode
@@ -30,7 +30,7 @@ const ViewingRoomApp: React.FC<ViewingRoomAppProps> = ({
     (viewingRoom.status === "draft" || viewingRoom.status === "scheduled")
 
   return (
-    <AnalyticsContextProvider contextPageOwnerId={viewingRoom.internalID}>
+    <Analytics contextPageOwnerId={viewingRoom.internalID}>
       <ViewingRoomMeta viewingRoom={viewingRoom} />
 
       {isPreviewable && (
@@ -53,7 +53,7 @@ const ViewingRoomApp: React.FC<ViewingRoomAppProps> = ({
           <ViewingRoomContentNotAccessible viewingRoom={viewingRoom} />
         )}
       </Join>
-    </AnalyticsContextProvider>
+    </Analytics>
   )
 }
 

--- a/src/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx
+++ b/src/Apps/ViewingRoom/__tests__/ViewingRoomApp.jest.tsx
@@ -344,6 +344,7 @@ describe("ViewingRoomApp", () => {
 
 const DraftViewingRoomAppFixture: ViewingRoomApp_DraftTest_Query$rawResponse = {
   viewingRoom: {
+    internalID: "example",
     href: "/viewing-room/example",
     pullQuote: "Example pull quote",
     distanceToClose: null,
@@ -367,6 +368,7 @@ const DraftViewingRoomAppFixture: ViewingRoomApp_DraftTest_Query$rawResponse = {
 
 const ScheduledViewingRoomAppFixture: ViewingRoomApp_ScheduledTest_Query$rawResponse = {
   viewingRoom: {
+    internalID: "example",
     href: "/viewing-room/example",
     pullQuote: "Example pull quote",
     distanceToClose: null,
@@ -390,6 +392,7 @@ const ScheduledViewingRoomAppFixture: ViewingRoomApp_ScheduledTest_Query$rawResp
 
 const OpenViewingRoomAppFixture: ViewingRoomApp_OpenTest_Query$rawResponse = {
   viewingRoom: {
+    internalID: "example",
     href: "/viewing-room/example",
     pullQuote: "Example pull quote",
     distanceToClose: "1 month",
@@ -413,6 +416,7 @@ const OpenViewingRoomAppFixture: ViewingRoomApp_OpenTest_Query$rawResponse = {
 
 const ClosedViewingRoomAppFixture: ViewingRoomApp_ClosedTest_Query$rawResponse = {
   viewingRoom: {
+    internalID: "example",
     href: "/viewing-room/example",
     pullQuote: "Example pull quote",
     distanceToClose: null,
@@ -436,6 +440,7 @@ const ClosedViewingRoomAppFixture: ViewingRoomApp_ClosedTest_Query$rawResponse =
 
 const LoggedOutViewingRoomAppFixture: ViewingRoomApp_LoggedOutTest_Query$rawResponse = {
   viewingRoom: {
+    internalID: "example",
     href: "/viewing-room/example",
     pullQuote: "Example pull quote",
     distanceToClose: "1 month",

--- a/src/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
@@ -67,7 +67,6 @@ const ArtworkFilterArtworkGrid: React.FC<ArtworkFilterArtworkGridProps> = props 
           onBrickClick={(artwork, artworkIndex) => {
             trackEvent(
               clickedMainArtworkGrid({
-                // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
                 contextPageOwnerType,
                 contextPageOwnerSlug,
                 contextPageOwnerId,

--- a/src/Components/ArtworkFilter/__tests__/ArtworkFilter.jest.tsx
+++ b/src/Components/ArtworkFilter/__tests__/ArtworkFilter.jest.tsx
@@ -92,9 +92,6 @@ describe("ArtworkFilter", () => {
         expect.objectContaining({
           action: "commercialFilterParamsChanged",
           context_module: "artworkGrid",
-          context_owner_id: undefined,
-          context_owner_slug: undefined,
-          context_owner_type: "home",
           // `current` and `changed` are sent as
           // JSON blobs, and verified below
         })
@@ -167,9 +164,6 @@ describe("ArtworkFilter", () => {
         expect.objectContaining({
           action: "clickedChangePage",
           context_module: "artworkGrid",
-          context_page_owner_id: undefined,
-          context_page_owner_slug: undefined,
-          context_page_owner_type: "home",
           page_current: 1,
           page_changed: 3,
         })
@@ -216,9 +210,6 @@ describe("ArtworkFilter", () => {
       expect(trackEvent).toHaveBeenCalledWith({
         action: "clickedMainArtworkGrid",
         context_module: "artworkGrid",
-        context_page_owner_id: undefined,
-        context_page_owner_slug: undefined,
-        context_page_owner_type: "home",
         destination_page_owner_id: "5d041931e607c200127ef3c1",
         destination_page_owner_slug: "andy-warhol-kenny-burrell",
         destination_page_owner_type: "artwork",

--- a/src/Components/RelatedCollectionsRail/RelatedCollectionEntity.tsx
+++ b/src/Components/RelatedCollectionsRail/RelatedCollectionEntity.tsx
@@ -8,6 +8,7 @@ import { ContextModule, clickedCollectionGroup } from "@artsy/cohesion"
 import { useAnalyticsContext } from "System/Analytics/AnalyticsContext"
 import { RouterLink } from "System/Router/RouterLink"
 import { cropped } from "Utils/resized"
+import { extractNodes } from "Utils/extractNodes"
 
 export interface RelatedCollectionEntityProps {
   collection: RelatedCollectionEntity_collection$data
@@ -28,8 +29,8 @@ export const RelatedCollectionEntity: React.FC<RelatedCollectionEntityProps> = (
     slug,
     title,
   } = collection
-  // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-  const artworks = artworksConnection.edges.map(({ node }) => node)
+
+  const artworks = extractNodes(artworksConnection)
 
   const { trackEvent } = useTracking()
   const {
@@ -44,7 +45,6 @@ export const RelatedCollectionEntity: React.FC<RelatedCollectionEntityProps> = (
         contextModule: ContextModule.relatedCollectionsRail,
         contextPageOwnerId,
         contextPageOwnerSlug,
-        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
         contextPageOwnerType,
         destinationPageOwnerId: id,
         destinationPageOwnerSlug: slug,
@@ -67,6 +67,8 @@ export const RelatedCollectionEntity: React.FC<RelatedCollectionEntityProps> = (
 
               const { resized } = artwork.image
 
+              if (!resized) return null
+
               return (
                 <Box key={index} ml={index === 0 ? 0 : -2}>
                   <Image
@@ -74,7 +76,7 @@ export const RelatedCollectionEntity: React.FC<RelatedCollectionEntityProps> = (
                     srcSet={resized.srcSet}
                     width={resized.width}
                     height={resized.height}
-                    alt={artwork.title}
+                    alt=""
                     lazyLoad
                   />
                 </Box>

--- a/src/Components/RelatedCollectionsRail/__tests__/RelatedCollectionEntity.jest.tsx
+++ b/src/Components/RelatedCollectionsRail/__tests__/RelatedCollectionEntity.jest.tsx
@@ -1,9 +1,8 @@
 import { CollectionsRailFixture } from "Apps/__tests__/Fixtures/Collections"
 import { mount } from "enzyme"
-import { RelatedCollectionEntity } from "../RelatedCollectionEntity"
+import { RelatedCollectionEntity } from "Components/RelatedCollectionsRail/RelatedCollectionEntity"
 import { useTracking } from "react-tracking"
-import { OwnerType } from "@artsy/cohesion"
-import { AnalyticsContext } from "System/Analytics/AnalyticsContext"
+import { AnalyticsCombinedContextProvider } from "System/Analytics/AnalyticsContext"
 import { RouterLink } from "System/Router/RouterLink"
 
 jest.mock("react-tracking")
@@ -26,15 +25,12 @@ describe.skip("RelatedCollectionEntity", () => {
 
   const getWrapper = (passedProps = props) => {
     return mount(
-      <AnalyticsContext.Provider
-        value={{
-          contextPageOwnerId: "1234",
-          contextPageOwnerSlug: "slug",
-          contextPageOwnerType: OwnerType.collection,
-        }}
+      <AnalyticsCombinedContextProvider
+        contextPageOwnerId="1234"
+        path="/collection/slug"
       >
         <RelatedCollectionEntity {...passedProps} />
-      </AnalyticsContext.Provider>
+      </AnalyticsCombinedContextProvider>
     )
   }
 

--- a/src/Components/RelatedCollectionsRail/__tests__/RelatedCollectionsRail.jest.tsx
+++ b/src/Components/RelatedCollectionsRail/__tests__/RelatedCollectionsRail.jest.tsx
@@ -2,13 +2,13 @@ import { CollectionsRailFixture } from "Apps/__tests__/Fixtures/Collections"
 import { mount } from "enzyme"
 import "jest-styled-components"
 import { clone, drop } from "lodash"
+// eslint-disable-next-line no-restricted-imports
 import Waypoint from "react-waypoint"
-import { RelatedCollectionEntity } from "../RelatedCollectionEntity"
-import { RelatedCollectionsRail } from "../RelatedCollectionsRail"
+import { RelatedCollectionEntity } from "Components/RelatedCollectionsRail/RelatedCollectionEntity"
+import { RelatedCollectionsRail } from "Components/RelatedCollectionsRail/RelatedCollectionsRail"
 import { paginateCarousel } from "@artsy/palette"
-import { OwnerType } from "@artsy/cohesion"
 import { useTracking } from "react-tracking"
-import { AnalyticsContext } from "System/Analytics/AnalyticsContext"
+import { AnalyticsCombinedContextProvider } from "System/Analytics/AnalyticsContext"
 
 jest.mock("react-tracking")
 jest.mock("@artsy/palette/dist/elements/Carousel/paginate")
@@ -20,15 +20,12 @@ describe.skip("CollectionsRail", () => {
 
   const getWrapper = (passedProps = props) => {
     return mount(
-      <AnalyticsContext.Provider
-        value={{
-          contextPageOwnerId: "1234",
-          contextPageOwnerSlug: "slug",
-          contextPageOwnerType: OwnerType.collection,
-        }}
+      <AnalyticsCombinedContextProvider
+        contextPageOwnerId="1234"
+        path="/collection/slug"
       >
         <RelatedCollectionsRail {...passedProps} />
-      </AnalyticsContext.Provider>
+      </AnalyticsCombinedContextProvider>
     )
   }
 

--- a/src/Server/__tests__/getContextPage.jest.ts
+++ b/src/Server/__tests__/getContextPage.jest.ts
@@ -1,9 +1,7 @@
 import {
   formatOwnerTypes,
   getContextPageFromClient,
-  getContextPageFromReq,
 } from "Server/getContextPage"
-import { Request } from "express"
 import { OwnerType } from "@artsy/cohesion"
 
 jest.mock("sharify", () => ({
@@ -11,36 +9,6 @@ jest.mock("sharify", () => ({
     APP_URL: "https://artsy.net",
   },
 }))
-
-describe("getContextPageFromReq", () => {
-  it("returns expected values", () => {
-    const page = getContextPageFromReq({
-      path: "/artist/test-artist",
-    } as Request)
-
-    expect(page).toEqual({
-      canonicalUrl: "https://artsy.net/artist/test-artist",
-      pageParts: ["", "artist", "test-artist"],
-      pageSlug: "test-artist",
-      pageType: "artist",
-      path: "/artist/test-artist",
-    })
-  })
-
-  it("handles camelcasing", () => {
-    const page = getContextPageFromReq({
-      path: "/artist-series/test-artist-series",
-    } as Request)
-
-    expect(page).toEqual({
-      canonicalUrl: "https://artsy.net/artist-series/test-artist-series",
-      pageParts: ["", "artist-series", "test-artist-series"],
-      pageSlug: "test-artist-series",
-      pageType: "artistSeries",
-      path: "/artist-series/test-artist-series",
-    })
-  })
-})
 
 describe("getContextPageFromClient", () => {
   it("returns correct props", () => {

--- a/src/Server/getContextPage.ts
+++ b/src/Server/getContextPage.ts
@@ -1,30 +1,7 @@
-import { Request } from "express"
 import { OwnerType, PageOwnerType } from "@artsy/cohesion"
 import { camelCase } from "lodash"
+// eslint-disable-next-line no-restricted-imports
 import { data as sd } from "sharify"
-
-export function getContextPageFromReq({
-  path,
-}: Request): {
-  canonicalUrl: string
-  pageParts: string[]
-  pageType: PageOwnerType
-  pageSlug: string
-  path: string
-} {
-  const pageParts = path.split("/")
-  const pageSlug = pageParts[2]
-  const pageType = formatOwnerTypes(path)
-  const canonicalUrl = `${sd.APP_URL}${path}`
-
-  return {
-    canonicalUrl,
-    pageParts,
-    pageSlug,
-    pageType,
-    path,
-  }
-}
 
 interface ClientContextPage {
   canonicalUrl: string
@@ -34,6 +11,9 @@ interface ClientContextPage {
   path: string
 }
 
+/**
+ * @deprecated: See `AnalyticsContext`
+ */
 export function getContextPageFromClient(): ClientContextPage | undefined {
   if (!window) {
     return
@@ -55,6 +35,9 @@ export function getContextPageFromClient(): ClientContextPage | undefined {
   }
 }
 
+/**
+ * @deprecated: Use `pathToOwnerType` from `AnalyticsContext`
+ */
 export const formatOwnerTypes = (path: string) => {
   const type = path.split("/")[1]
   // Remove '2' to ensure that show2/fair2/etc are schema compliant

--- a/src/System/Analytics/AnalyticsContext.tsx
+++ b/src/System/Analytics/AnalyticsContext.tsx
@@ -26,7 +26,7 @@ export const useAnalyticsContext = () => {
   }
 }
 
-interface AnalyticsContextProviderProps {
+interface AnalyticsProps {
   children: ReactNode
   contextPageOwnerId: string
 }
@@ -34,7 +34,7 @@ interface AnalyticsContextProviderProps {
 /**
  * Wrap entity pages (/example/:slug) with this component to provide the internalID
  */
-export const AnalyticsContextProvider: FC<AnalyticsContextProviderProps> = ({
+export const Analytics: FC<AnalyticsProps> = ({
   contextPageOwnerId,
   children,
 }) => {
@@ -45,7 +45,7 @@ export const AnalyticsContextProvider: FC<AnalyticsContextProviderProps> = ({
   )
 }
 
-interface AnalyticsInferredContextProviderProps {
+interface AnalyticsContextProviderProps {
   children: ReactNode
   path?: string
 }
@@ -54,7 +54,7 @@ interface AnalyticsInferredContextProviderProps {
  * Wraps `AppShell` and updates on route changes.
  * Pulls out the `contextPageOwnerType` and `contextPageOwnerSlug` from the route.
  */
-export const AnalyticsInferredContextProvider: FC<AnalyticsInferredContextProviderProps> = ({
+export const AnalyticsContextProvider: FC<AnalyticsContextProviderProps> = ({
   children,
   path,
 }) => {
@@ -78,14 +78,14 @@ export const AnalyticsInferredContextProvider: FC<AnalyticsInferredContextProvid
 }
 
 export const AnalyticsCombinedContextProvider: FC<
-  AnalyticsContextProviderProps & AnalyticsInferredContextProviderProps
+  AnalyticsProps & AnalyticsContextProviderProps
 > = ({ children, contextPageOwnerId, path }) => {
   return (
-    <AnalyticsContextProvider contextPageOwnerId={contextPageOwnerId}>
-      <AnalyticsInferredContextProvider path={path}>
+    <Analytics contextPageOwnerId={contextPageOwnerId}>
+      <AnalyticsContextProvider path={path}>
         {children}
-      </AnalyticsInferredContextProvider>
-    </AnalyticsContextProvider>
+      </AnalyticsContextProvider>
+    </Analytics>
   )
 }
 

--- a/src/System/Analytics/AnalyticsContext.tsx
+++ b/src/System/Analytics/AnalyticsContext.tsx
@@ -1,20 +1,137 @@
-import { createContext, useContext } from "react"
-import { PageOwnerType } from "@artsy/cohesion"
+import { FC, ReactNode, createContext, useContext, useMemo } from "react"
+import { OwnerType, PageOwnerType } from "@artsy/cohesion"
+import { camelCase } from "lodash"
 
-export interface AnalyticsContextProps {
+const AnalyticsContext = createContext<{
   contextPageOwnerId?: string
-  contextPageOwnerSlug?: string
-  contextPageOwnerType?: PageOwnerType
-}
-
-export const AnalyticsContext = createContext<{
-  contextPageOwnerId?: string
-  contextPageOwnerSlug?: string
-  contextPageOwnerType?: PageOwnerType
-  children?: any
 }>({})
 
+const AnalyticsInferredContext = createContext<{
+  contextPageOwnerType: PageOwnerType
+  contextPageOwnerSlug?: string
+}>({
+  contextPageOwnerType: (undefined as any) as PageOwnerType,
+})
+
+/**
+ * Pull out the contextPageOwner props for use in shared components
+ */
 export const useAnalyticsContext = () => {
-  const analyticsContext = useContext(AnalyticsContext)
-  return analyticsContext
+  const context = useContext(AnalyticsContext)
+  const inferredContext = useContext(AnalyticsInferredContext)
+
+  return {
+    ...context,
+    ...inferredContext,
+  }
+}
+
+interface AnalyticsContextProviderProps {
+  children: ReactNode
+  contextPageOwnerId: string
+}
+
+/**
+ * Wrap entity pages (/example/:slug) with this component to provide the internalID
+ */
+export const AnalyticsContextProvider: FC<AnalyticsContextProviderProps> = ({
+  contextPageOwnerId,
+  children,
+}) => {
+  return (
+    <AnalyticsContext.Provider value={{ contextPageOwnerId }}>
+      {children}
+    </AnalyticsContext.Provider>
+  )
+}
+
+interface AnalyticsInferredContextProviderProps {
+  children: ReactNode
+  path?: string
+}
+
+/**
+ * Wraps `AppShell` and updates on route changes.
+ * Pulls out the `contextPageOwnerType` and `contextPageOwnerSlug` from the route.
+ */
+export const AnalyticsInferredContextProvider: FC<AnalyticsInferredContextProviderProps> = ({
+  children,
+  path,
+}) => {
+  const [_type, contextPageOwnerSlug] = useMemo(() => tokenize(path ?? ""), [
+    path,
+  ])
+
+  const contextPageOwnerType = useMemo(() => {
+    return (path
+      ? pathToOwnerType(path) || formatType(_type) // Fallback for unsupported routes
+      : "Unknown") as PageOwnerType
+  }, [_type, path])
+
+  return (
+    <AnalyticsInferredContext.Provider
+      value={{ contextPageOwnerType, contextPageOwnerSlug }}
+    >
+      {children}
+    </AnalyticsInferredContext.Provider>
+  )
+}
+
+export const AnalyticsCombinedContextProvider: FC<
+  AnalyticsContextProviderProps & AnalyticsInferredContextProviderProps
+> = ({ children, contextPageOwnerId, path }) => {
+  return (
+    <AnalyticsContextProvider contextPageOwnerId={contextPageOwnerId}>
+      <AnalyticsInferredContextProvider path={path}>
+        {children}
+      </AnalyticsInferredContextProvider>
+    </AnalyticsContextProvider>
+  )
+}
+
+export const tokenize = (path: string) => {
+  const slice = path.startsWith("/") ? 1 : 0
+  return path.slice(slice).split("/")
+}
+
+export const formatType = (part: string): string => {
+  return camelCase(part).replace("2", "")
+}
+
+export const pathToOwnerType = (path: string): PageOwnerType => {
+  if (path === "/") {
+    return OwnerType.home
+  }
+
+  const [_type, slug, tab] = tokenize(path)
+
+  // Remove '2' to ensure that show2/fair2/etc are schema compliant
+  const type = formatType(_type)
+
+  switch (true) {
+    // Handle special cases
+    case type === "orders" && tab === "shipping":
+      return OwnerType.ordersShipping
+    case type === "orders" && tab === "payment":
+      return OwnerType.ordersPayment
+    case type === "orders" && tab === "review":
+      return OwnerType.ordersReview
+    case type === "collectorProfile" && slug === "saves":
+      // Why is this somehow different from OwnerType.savesAndFollows?
+      // Why aren't there other cases for collector-profile routes?
+      return OwnerType.saves
+    case type === "auction":
+      return OwnerType.sale
+    case type === "news":
+    case type === "series":
+    case type === "video":
+      return OwnerType.article
+    case type === "artFairs":
+      return OwnerType.fairs
+    case type === "settings":
+    case type === "collectorProfile":
+      return OwnerType.editProfile
+    default:
+      return OwnerType[type]
+  }
 }

--- a/src/System/Router/Boot.tsx
+++ b/src/System/Router/Boot.tsx
@@ -23,7 +23,6 @@ import {
   MediaContextProvider,
   ResponsiveProvider,
 } from "Utils/Responsive"
-import { AnalyticsContext } from "System/Analytics/AnalyticsContext"
 import { ClientContext } from "System/Router/buildClientAppContext"
 import { SiftContainer } from "Utils/SiftContainer"
 import { setupSentryClient } from "Server/setupSentryClient"
@@ -82,33 +81,31 @@ export const Boot = track(undefined, {
       <HeadProvider headTags={headTags}>
         <StateProvider>
           <SystemContextProvider {...contextProps}>
-            <AnalyticsContext.Provider value={context?.analytics}>
-              <ErrorBoundary>
-                <MediaContextProvider onlyMatch={onlyMatchMediaQueries}>
-                  <ResponsiveProvider
-                    mediaQueries={THEME.mediaQueries}
-                    initialMatchingMediaQueries={onlyMatchMediaQueries as any}
-                  >
-                    <ToastsProvider>
-                      <StickyProvider>
-                        <AuthIntentProvider>
-                          <AuthDialogProvider>
-                            <ProgressiveOnboardingProvider>
-                              <CookieConsentManager>
-                                <FocusVisible />
-                                <SiftContainer />
+            <ErrorBoundary>
+              <MediaContextProvider onlyMatch={onlyMatchMediaQueries}>
+                <ResponsiveProvider
+                  mediaQueries={THEME.mediaQueries}
+                  initialMatchingMediaQueries={onlyMatchMediaQueries as any}
+                >
+                  <ToastsProvider>
+                    <StickyProvider>
+                      <AuthIntentProvider>
+                        <AuthDialogProvider>
+                          <ProgressiveOnboardingProvider>
+                            <CookieConsentManager>
+                              <FocusVisible />
+                              <SiftContainer />
 
-                                {children}
-                              </CookieConsentManager>
-                            </ProgressiveOnboardingProvider>
-                          </AuthDialogProvider>
-                        </AuthIntentProvider>
-                      </StickyProvider>
-                    </ToastsProvider>
-                  </ResponsiveProvider>
-                </MediaContextProvider>
-              </ErrorBoundary>
-            </AnalyticsContext.Provider>
+                              {children}
+                            </CookieConsentManager>
+                          </ProgressiveOnboardingProvider>
+                        </AuthDialogProvider>
+                      </AuthIntentProvider>
+                    </StickyProvider>
+                  </ToastsProvider>
+                </ResponsiveProvider>
+              </MediaContextProvider>
+            </ErrorBoundary>
           </SystemContextProvider>
         </StateProvider>
       </HeadProvider>

--- a/src/System/Router/__tests__/buildClientApp.jest.tsx
+++ b/src/System/Router/__tests__/buildClientApp.jest.tsx
@@ -109,7 +109,6 @@ describe("buildClientApp", () => {
         <SystemContextConsumer>
           {context => {
             expect(Object.keys(context).sort()).toEqual([
-              "analytics",
               "featureFlags",
               "isEigen",
               "isFetching",

--- a/src/System/Router/__tests__/buildServerApp.jest.tsx
+++ b/src/System/Router/__tests__/buildServerApp.jest.tsx
@@ -167,7 +167,6 @@ describe("buildServerApp", () => {
         <SystemContextConsumer>
           {context => {
             expect(Object.keys(context).sort()).toEqual([
-              "analytics",
               "featureFlags",
               "initialMatchingMediaQueries",
               "isEigen",

--- a/src/System/Router/buildClientAppContext.ts
+++ b/src/System/Router/buildClientAppContext.ts
@@ -1,34 +1,21 @@
-import { getContextPageFromClient } from "Server/getContextPage"
 // eslint-disable-next-line no-restricted-imports
 import { data as sd } from "sharify"
-import { AnalyticsContextProps } from "System/Analytics/AnalyticsContext"
 import { FeatureFlags } from "System/useFeatureFlag"
 import { UserPreferences } from "Server/middleware/userPreferencesMiddleware"
 
 export interface ClientContext {
   user: User
-  analytics: AnalyticsContextProps
   featureFlags: FeatureFlags
   userPreferences: UserPreferences
 }
 
 export const buildClientAppContext = (
   context: { injectedData?: object } = {}
-) => {
-  const contextPage = getContextPageFromClient()
-
-  if (contextPage) {
-    const { pageSlug, pageType } = contextPage
-
-    return {
-      analytics: {
-        contextPageOwnerSlug: pageSlug,
-        contextPageOwnerType: pageType,
-      },
-      user: sd.CURRENT_USER,
-      featureFlags: sd.FEATURE_FLAGS,
-      userPreferences: sd.USER_PREFERENCES,
-      ...context,
-    }
+): ClientContext | undefined => {
+  return {
+    user: sd.CURRENT_USER,
+    featureFlags: sd.FEATURE_FLAGS,
+    userPreferences: sd.USER_PREFERENCES,
+    ...context,
   }
 }

--- a/src/System/Router/buildServerAppContext.ts
+++ b/src/System/Router/buildServerAppContext.ts
@@ -2,7 +2,6 @@ import type {
   ArtsyRequest,
   ArtsyResponse,
 } from "Server/middleware/artsyExpress"
-import { getContextPageFromReq } from "Server/getContextPage"
 
 /**
  * Builds initial context for Reaction components from server load. Put commonly
@@ -17,15 +16,10 @@ export const buildServerAppContext = (
   res: ArtsyResponse,
   context: { injectedData?: object } = {}
 ) => {
-  const { pageType, pageSlug } = getContextPageFromReq(req)
   return {
     initialMatchingMediaQueries: res.locals.sd.IS_MOBILE ? ["xs"] : undefined,
     user: req.user,
     isEigen: req.header("User-Agent")?.match("Artsy-Mobile") != null,
-    analytics: {
-      contextPageOwnerType: pageType,
-      contextPageOwnerSlug: pageSlug,
-    },
     featureFlags: res.locals.sd.FEATURE_FLAGS,
     userPreferences: res.locals.sd.USER_PREFERENCES,
     ...context,

--- a/src/__generated__/ExampleArtistRoute_artist.graphql.ts
+++ b/src/__generated__/ExampleArtistRoute_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<55a9a38a78b2875619b8e79ec515bed6>>
+ * @generated SignedSource<<5a40b9ef7338b67a608f933302434209>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -14,7 +14,6 @@ export type ExampleArtistRoute_artist$data = {
   readonly bio: string | null;
   readonly internalID: string;
   readonly name: string | null;
-  readonly slug: string;
   readonly " $fragmentType": "ExampleArtistRoute_artist";
 };
 export type ExampleArtistRoute_artist$key = {
@@ -48,19 +47,12 @@ const node: ReaderFragment = {
       "kind": "ScalarField",
       "name": "internalID",
       "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "slug",
-      "storageKey": null
     }
   ],
   "type": "Artist",
   "abstractKey": null
 };
 
-(node as any).hash = "c3e11e91b699af66a2aeadf0fc2222b3";
+(node as any).hash = "9f949ee70f6a716caf42c982adc9270a";
 
 export default node;

--- a/src/__generated__/ExampleArtworkRoute_artwork.graphql.ts
+++ b/src/__generated__/ExampleArtworkRoute_artwork.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e4927562baaf41e144b12990e05dcb44>>
+ * @generated SignedSource<<eded007f50df18e8c41a92ad389d5de6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,6 +16,7 @@ export type ExampleArtworkRoute_artwork$data = {
       readonly artistsConnection: {
         readonly edges: ReadonlyArray<{
           readonly node: {
+            readonly internalID: string;
             readonly " $fragmentSpreads": FragmentRefs<"EntityHeaderArtist_artist">;
           } | null;
         } | null> | null;
@@ -36,7 +37,15 @@ export type ExampleArtworkRoute_artwork$key = {
   readonly " $fragmentSpreads": FragmentRefs<"ExampleArtworkRoute_artwork">;
 };
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+};
+return {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": {
@@ -90,13 +99,7 @@ const node: ReaderFragment = {
       "name": "date",
       "storageKey": null
     },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "internalID",
-      "storageKey": null
-    },
+    (v0/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -155,6 +158,7 @@ const node: ReaderFragment = {
                           "kind": "FragmentSpread",
                           "name": "EntityHeaderArtist_artist"
                         },
+                        (v0/*: any*/),
                         {
                           "alias": null,
                           "args": null,
@@ -213,7 +217,8 @@ const node: ReaderFragment = {
   "type": "Artwork",
   "abstractKey": null
 };
+})();
 
-(node as any).hash = "48e949f2d2071b986181176ba9fde9d6";
+(node as any).hash = "8b51a28c607092606cfb37e6a8700831";
 
 export default node;

--- a/src/__generated__/FairApp_Test_Query.graphql.ts
+++ b/src/__generated__/FairApp_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<21eefa9d47d41323298a4cf955228452>>
+ * @generated SignedSource<<6ef2673021922a5f93f58cabc2152d4a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -268,7 +268,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "df1378df77df69320a1323aba4f2f8f6",
+    "cacheID": "b08d17b25c77374037b4b8d7c9d43067",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -321,7 +321,7 @@ return {
     },
     "name": "FairApp_Test_Query",
     "operationKind": "query",
-    "text": "query FairApp_Test_Query {\n  fair(id: \"example\") {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment ExhibitorsLetterNav_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n  }\n}\n\nfragment FairApp_fair on Fair {\n  ...FairTabs_fair\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairHeaderImage_fair\n  ...ExhibitorsLetterNav_fair\n  internalID\n  slug\n  profile {\n    id\n  }\n}\n\nfragment FairHeaderImage_fair on Fair {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  name\n  exhibitionPeriod\n  profile {\n    icon {\n      url(version: [\"large\", \"square\", \"square140\"])\n    }\n    id\n  }\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n\nfragment FairTabs_fair on Fair {\n  href\n  counts {\n    artworks\n  }\n}\n"
+    "text": "query FairApp_Test_Query {\n  fair(id: \"example\") {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment ExhibitorsLetterNav_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n  }\n}\n\nfragment FairApp_fair on Fair {\n  ...FairTabs_fair\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairHeaderImage_fair\n  ...ExhibitorsLetterNav_fair\n  internalID\n  profile {\n    id\n  }\n}\n\nfragment FairHeaderImage_fair on Fair {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  name\n  exhibitionPeriod\n  profile {\n    icon {\n      url(version: [\"large\", \"square\", \"square140\"])\n    }\n    id\n  }\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n\nfragment FairTabs_fair on Fair {\n  href\n  counts {\n    artworks\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/FairApp_fair.graphql.ts
+++ b/src/__generated__/FairApp_fair.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<69356b771541fff73f0478875a32e083>>
+ * @generated SignedSource<<a5f7272a7f85e8f3c25668a7db22512d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,7 +15,6 @@ export type FairApp_fair$data = {
   readonly profile: {
     readonly id: string;
   } | null;
-  readonly slug: string;
   readonly " $fragmentSpreads": FragmentRefs<"ExhibitorsLetterNav_fair" | "FairHeaderImage_fair" | "FairHeader_fair" | "FairMeta_fair" | "FairTabs_fair">;
   readonly " $fragmentType": "FairApp_fair";
 };
@@ -65,13 +64,6 @@ const node: ReaderFragment = {
     {
       "alias": null,
       "args": null,
-      "kind": "ScalarField",
-      "name": "slug",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
       "concreteType": "Profile",
       "kind": "LinkedField",
       "name": "profile",
@@ -92,6 +84,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "80f839ebe021f81e3d289987060a9f2b";
+(node as any).hash = "0eb1702e4a331569aee3578c3d71af36";
 
 export default node;

--- a/src/__generated__/PartnerApp_Test_Query.graphql.ts
+++ b/src/__generated__/PartnerApp_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f2eb197462adc8e86ea9789a9a5982e7>>
+ * @generated SignedSource<<b062329106cc4a0effdd5cbad93dfd31>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -33,105 +33,112 @@ v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "internalID",
   "storageKey": null
 },
 v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "id",
   "storageKey": null
 },
 v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "city",
+  "name": "name",
   "storageKey": null
 },
 v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "city",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "totalCount",
   "storageKey": null
 },
-v5 = [
-  (v4/*: any*/)
+v6 = [
+  (v5/*: any*/)
 ],
-v6 = {
+v7 = {
   "kind": "Literal",
   "name": "displayOnPartnerProfile",
   "value": true
 },
-v7 = {
+v8 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v8 = {
+v9 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v9 = {
+v10 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v10 = {
+v11 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FormattedNumber"
 },
-v11 = {
+v12 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Boolean"
 },
-v12 = {
+v13 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "LocationConnection"
 },
-v13 = {
+v14 = {
   "enumValues": null,
   "nullable": true,
   "plural": true,
   "type": "LocationEdge"
 },
-v14 = {
+v15 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Location"
 },
-v15 = {
+v16 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Float"
 },
-v16 = {
+v17 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "ArtistPartnerConnection"
 },
-v17 = {
+v18 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Image"
 },
-v18 = {
+v19 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
@@ -178,6 +185,7 @@ return {
         "name": "partner",
         "plural": false,
         "selections": [
+          (v1/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -214,8 +222,8 @@ return {
             "name": "categories",
             "plural": true,
             "selections": [
-              (v1/*: any*/),
-              (v2/*: any*/)
+              (v2/*: any*/),
+              (v3/*: any*/)
             ],
             "storageKey": null
           },
@@ -251,14 +259,8 @@ return {
                 ],
                 "storageKey": null
               },
+              (v2/*: any*/),
               (v1/*: any*/),
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "internalID",
-                "storageKey": null
-              },
               {
                 "alias": null,
                 "args": null,
@@ -358,7 +360,7 @@ return {
                         "name": "address2",
                         "storageKey": null
                       },
-                      (v3/*: any*/),
+                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -412,7 +414,7 @@ return {
                         "name": "state",
                         "storageKey": null
                       },
-                      (v1/*: any*/)
+                      (v2/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -454,7 +456,7 @@ return {
             ],
             "storageKey": null
           },
-          (v2/*: any*/),
+          (v3/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -483,7 +485,7 @@ return {
             "name": "locationsConnection",
             "plural": false,
             "selections": [
-              (v4/*: any*/),
+              (v5/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -500,8 +502,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v3/*: any*/),
-                      (v1/*: any*/)
+                      (v4/*: any*/),
+                      (v2/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -557,13 +559,13 @@ return {
             "kind": "LinkedField",
             "name": "articlesConnection",
             "plural": false,
-            "selections": (v5/*: any*/),
+            "selections": (v6/*: any*/),
             "storageKey": null
           },
           {
             "alias": "representedArtists",
             "args": [
-              (v6/*: any*/),
+              (v7/*: any*/),
               {
                 "kind": "Literal",
                 "name": "representedBy",
@@ -574,13 +576,13 @@ return {
             "kind": "LinkedField",
             "name": "artistsConnection",
             "plural": false,
-            "selections": (v5/*: any*/),
+            "selections": (v6/*: any*/),
             "storageKey": "artistsConnection(displayOnPartnerProfile:true,representedBy:true)"
           },
           {
             "alias": "notRepresentedArtists",
             "args": [
-              (v6/*: any*/),
+              (v7/*: any*/),
               {
                 "kind": "Literal",
                 "name": "hasPublishedArtworks",
@@ -596,7 +598,7 @@ return {
             "kind": "LinkedField",
             "name": "artistsConnection",
             "plural": false,
-            "selections": (v5/*: any*/),
+            "selections": (v6/*: any*/),
             "storageKey": "artistsConnection(displayOnPartnerProfile:true,hasPublishedArtworks:true,representedBy:false)"
           },
           {
@@ -616,17 +618,17 @@ return {
             "kind": "LinkedField",
             "name": "viewingRoomsConnection",
             "plural": false,
-            "selections": (v5/*: any*/),
+            "selections": (v6/*: any*/),
             "storageKey": "viewingRoomsConnection(statuses:[\"live\",\"closed\",\"scheduled\"])"
           },
-          (v1/*: any*/)
+          (v2/*: any*/)
         ],
         "storageKey": "partner(id:\"example\")"
       }
     ]
   },
   "params": {
-    "cacheID": "020c5f23aa7521e1003f6d194684c590",
+    "cacheID": "3f7791274863aef3fa38e7a14d05f8a4",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -642,102 +644,103 @@ return {
           "plural": false,
           "type": "ArticleConnection"
         },
-        "partner.articles.totalCount": (v7/*: any*/),
+        "partner.articles.totalCount": (v8/*: any*/),
         "partner.categories": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "PartnerCategory"
         },
-        "partner.categories.id": (v8/*: any*/),
-        "partner.categories.name": (v9/*: any*/),
+        "partner.categories.id": (v9/*: any*/),
+        "partner.categories.name": (v10/*: any*/),
         "partner.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "PartnerCounts"
         },
-        "partner.counts.displayableShows": (v10/*: any*/),
-        "partner.counts.eligibleArtworks": (v10/*: any*/),
-        "partner.displayArtistsSection": (v11/*: any*/),
-        "partner.displayFullPartnerPage": (v11/*: any*/),
-        "partner.displayWorksSection": (v11/*: any*/),
-        "partner.id": (v8/*: any*/),
-        "partner.isDefaultProfilePublic": (v11/*: any*/),
-        "partner.locations": (v12/*: any*/),
-        "partner.locations.edges": (v13/*: any*/),
-        "partner.locations.edges.node": (v14/*: any*/),
-        "partner.locations.edges.node.city": (v9/*: any*/),
-        "partner.locations.edges.node.id": (v8/*: any*/),
-        "partner.locations.totalCount": (v7/*: any*/),
-        "partner.locationsConnection": (v12/*: any*/),
-        "partner.locationsConnection.edges": (v13/*: any*/),
-        "partner.locationsConnection.edges.node": (v14/*: any*/),
-        "partner.locationsConnection.edges.node.address": (v9/*: any*/),
-        "partner.locationsConnection.edges.node.address2": (v9/*: any*/),
-        "partner.locationsConnection.edges.node.city": (v9/*: any*/),
+        "partner.counts.displayableShows": (v11/*: any*/),
+        "partner.counts.eligibleArtworks": (v11/*: any*/),
+        "partner.displayArtistsSection": (v12/*: any*/),
+        "partner.displayFullPartnerPage": (v12/*: any*/),
+        "partner.displayWorksSection": (v12/*: any*/),
+        "partner.id": (v9/*: any*/),
+        "partner.internalID": (v9/*: any*/),
+        "partner.isDefaultProfilePublic": (v12/*: any*/),
+        "partner.locations": (v13/*: any*/),
+        "partner.locations.edges": (v14/*: any*/),
+        "partner.locations.edges.node": (v15/*: any*/),
+        "partner.locations.edges.node.city": (v10/*: any*/),
+        "partner.locations.edges.node.id": (v9/*: any*/),
+        "partner.locations.totalCount": (v8/*: any*/),
+        "partner.locationsConnection": (v13/*: any*/),
+        "partner.locationsConnection.edges": (v14/*: any*/),
+        "partner.locationsConnection.edges.node": (v15/*: any*/),
+        "partner.locationsConnection.edges.node.address": (v10/*: any*/),
+        "partner.locationsConnection.edges.node.address2": (v10/*: any*/),
+        "partner.locationsConnection.edges.node.city": (v10/*: any*/),
         "partner.locationsConnection.edges.node.coordinates": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "LatLng"
         },
-        "partner.locationsConnection.edges.node.coordinates.lat": (v15/*: any*/),
-        "partner.locationsConnection.edges.node.coordinates.lng": (v15/*: any*/),
-        "partner.locationsConnection.edges.node.country": (v9/*: any*/),
-        "partner.locationsConnection.edges.node.id": (v8/*: any*/),
-        "partner.locationsConnection.edges.node.phone": (v9/*: any*/),
-        "partner.locationsConnection.edges.node.postalCode": (v9/*: any*/),
-        "partner.locationsConnection.edges.node.state": (v9/*: any*/),
+        "partner.locationsConnection.edges.node.coordinates.lat": (v16/*: any*/),
+        "partner.locationsConnection.edges.node.coordinates.lng": (v16/*: any*/),
+        "partner.locationsConnection.edges.node.country": (v10/*: any*/),
+        "partner.locationsConnection.edges.node.id": (v9/*: any*/),
+        "partner.locationsConnection.edges.node.phone": (v10/*: any*/),
+        "partner.locationsConnection.edges.node.postalCode": (v10/*: any*/),
+        "partner.locationsConnection.edges.node.state": (v10/*: any*/),
         "partner.meta": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "PartnerMeta"
         },
-        "partner.meta.description": (v9/*: any*/),
-        "partner.meta.image": (v9/*: any*/),
-        "partner.meta.title": (v9/*: any*/),
-        "partner.name": (v9/*: any*/),
-        "partner.notRepresentedArtists": (v16/*: any*/),
-        "partner.notRepresentedArtists.totalCount": (v7/*: any*/),
-        "partner.partnerPageEligible": (v11/*: any*/),
-        "partner.partnerType": (v9/*: any*/),
+        "partner.meta.description": (v10/*: any*/),
+        "partner.meta.image": (v10/*: any*/),
+        "partner.meta.title": (v10/*: any*/),
+        "partner.name": (v10/*: any*/),
+        "partner.notRepresentedArtists": (v17/*: any*/),
+        "partner.notRepresentedArtists.totalCount": (v8/*: any*/),
+        "partner.partnerPageEligible": (v12/*: any*/),
+        "partner.partnerType": (v10/*: any*/),
         "partner.profile": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Profile"
         },
-        "partner.profile.icon": (v17/*: any*/),
+        "partner.profile.icon": (v18/*: any*/),
         "partner.profile.icon.resized": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ResizedImageUrl"
         },
-        "partner.profile.icon.resized.src": (v18/*: any*/),
-        "partner.profile.icon.resized.srcSet": (v18/*: any*/),
-        "partner.profile.id": (v8/*: any*/),
-        "partner.profile.image": (v17/*: any*/),
-        "partner.profile.image.url": (v9/*: any*/),
-        "partner.profile.internalID": (v8/*: any*/),
-        "partner.representedArtists": (v16/*: any*/),
-        "partner.representedArtists.totalCount": (v7/*: any*/),
-        "partner.slug": (v8/*: any*/),
-        "partner.type": (v9/*: any*/),
+        "partner.profile.icon.resized.src": (v19/*: any*/),
+        "partner.profile.icon.resized.srcSet": (v19/*: any*/),
+        "partner.profile.id": (v9/*: any*/),
+        "partner.profile.image": (v18/*: any*/),
+        "partner.profile.image.url": (v10/*: any*/),
+        "partner.profile.internalID": (v9/*: any*/),
+        "partner.representedArtists": (v17/*: any*/),
+        "partner.representedArtists.totalCount": (v8/*: any*/),
+        "partner.slug": (v9/*: any*/),
+        "partner.type": (v10/*: any*/),
         "partner.viewingRooms": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ViewingRoomsConnection"
         },
-        "partner.viewingRooms.totalCount": (v7/*: any*/)
+        "partner.viewingRooms.totalCount": (v8/*: any*/)
       }
     },
     "name": "PartnerApp_Test_Query",
     "operationKind": "query",
-    "text": "query PartnerApp_Test_Query {\n  partner(id: \"example\") {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n  partnerType\n  displayArtistsSection\n  displayWorksSection\n  counts {\n    eligibleArtworks\n    displayableShows\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n  }\n  articles: articlesConnection {\n    totalCount\n  }\n  representedArtists: artistsConnection(representedBy: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  notRepresentedArtists: artistsConnection(representedBy: false, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  viewingRooms: viewingRoomsConnection(statuses: [live, closed, scheduled]) {\n    totalCount\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  partnerType\n  displayFullPartnerPage\n  partnerPageEligible\n  isDefaultProfilePublic\n  categories {\n    id\n    name\n  }\n  profile {\n    ...PartnerHeaderImage_profile\n    id\n  }\n  ...PartnerMeta_partner\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeaderImage_profile on Profile {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  profile {\n    internalID\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMeta_partner on Partner {\n  locationsConnection(first: 1) {\n    edges {\n      node {\n        address\n        address2\n        city\n        coordinates {\n          lat\n          lng\n        }\n        country\n        phone\n        postalCode\n        state\n        id\n      }\n    }\n  }\n  meta {\n    image\n    title\n    description\n  }\n  name\n  slug\n}\n"
+    "text": "query PartnerApp_Test_Query {\n  partner(id: \"example\") {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n  partnerType\n  displayArtistsSection\n  displayWorksSection\n  counts {\n    eligibleArtworks\n    displayableShows\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n  }\n  articles: articlesConnection {\n    totalCount\n  }\n  representedArtists: artistsConnection(representedBy: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  notRepresentedArtists: artistsConnection(representedBy: false, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  viewingRooms: viewingRoomsConnection(statuses: [live, closed, scheduled]) {\n    totalCount\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  internalID\n  partnerType\n  displayFullPartnerPage\n  partnerPageEligible\n  isDefaultProfilePublic\n  categories {\n    id\n    name\n  }\n  profile {\n    ...PartnerHeaderImage_profile\n    id\n  }\n  ...PartnerMeta_partner\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeaderImage_profile on Profile {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  profile {\n    internalID\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMeta_partner on Partner {\n  locationsConnection(first: 1) {\n    edges {\n      node {\n        address\n        address2\n        city\n        coordinates {\n          lat\n          lng\n        }\n        country\n        phone\n        postalCode\n        state\n        id\n      }\n    }\n  }\n  meta {\n    image\n    title\n    description\n  }\n  name\n  slug\n}\n"
   }
 };
 })();

--- a/src/__generated__/PartnerApp_partner.graphql.ts
+++ b/src/__generated__/PartnerApp_partner.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0acecd7ca27e37f9bf0a8d6ba93cd8a5>>
+ * @generated SignedSource<<65e33742be706f950351f5bc53e589ac>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,6 +16,7 @@ export type PartnerApp_partner$data = {
     readonly name: string | null;
   } | null> | null;
   readonly displayFullPartnerPage: boolean | null;
+  readonly internalID: string;
   readonly isDefaultProfilePublic: boolean | null;
   readonly partnerPageEligible: boolean | null;
   readonly partnerType: string | null;
@@ -36,6 +37,13 @@ const node: ReaderFragment = {
   "metadata": null,
   "name": "PartnerApp_partner",
   "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "internalID",
+      "storageKey": null
+    },
     {
       "alias": null,
       "args": null,
@@ -125,6 +133,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "9ab19f514efb71031e2ccf955bc30515";
+(node as any).hash = "9db7bc7d8ab75e3488b5d16ad875d4f7";
 
 export default node;

--- a/src/__generated__/ViewingRoomApp_ClosedTest_Query.graphql.ts
+++ b/src/__generated__/ViewingRoomApp_ClosedTest_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d7dda7bbe47f30989103bf93fde545c1>>
+ * @generated SignedSource<<f27c910e03c85efb9ffd28e44ec66ef1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -28,6 +28,7 @@ export type ViewingRoomApp_ClosedTest_Query$rawResponse = {
         readonly normalized: string | null;
       } | null;
     } | null;
+    readonly internalID: string;
     readonly partner: {
       readonly href: string | null;
       readonly id: string;
@@ -68,18 +69,25 @@ v2 = {
   "storageKey": null
 },
 v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v4 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v4 = {
+v5 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v5 = {
+v6 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
@@ -193,13 +201,7 @@ return {
                 "name": "id",
                 "storageKey": null
               },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "internalID",
-                "storageKey": null
-              }
+              (v3/*: any*/)
             ],
             "storageKey": null
           },
@@ -223,14 +225,15 @@ return {
             "kind": "ScalarField",
             "name": "status",
             "storageKey": null
-          }
+          },
+          (v3/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "1fd50573ca945b9f3bcdf76ad516089d",
+    "cacheID": "c5456c81f756c13731c3f6b26e60ec8c",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -240,9 +243,9 @@ return {
           "plural": false,
           "type": "ViewingRoom"
         },
-        "viewingRoom.distanceToClose": (v3/*: any*/),
-        "viewingRoom.distanceToOpen": (v3/*: any*/),
-        "viewingRoom.href": (v3/*: any*/),
+        "viewingRoom.distanceToClose": (v4/*: any*/),
+        "viewingRoom.distanceToOpen": (v4/*: any*/),
+        "viewingRoom.href": (v4/*: any*/),
         "viewingRoom.image": {
           "enumValues": null,
           "nullable": true,
@@ -255,25 +258,26 @@ return {
           "plural": false,
           "type": "ImageURLs"
         },
-        "viewingRoom.image.imageURLs.normalized": (v3/*: any*/),
+        "viewingRoom.image.imageURLs.normalized": (v4/*: any*/),
+        "viewingRoom.internalID": (v5/*: any*/),
         "viewingRoom.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "viewingRoom.partner.href": (v3/*: any*/),
-        "viewingRoom.partner.id": (v4/*: any*/),
-        "viewingRoom.partner.internalID": (v4/*: any*/),
-        "viewingRoom.partner.name": (v3/*: any*/),
-        "viewingRoom.pullQuote": (v3/*: any*/),
-        "viewingRoom.status": (v5/*: any*/),
-        "viewingRoom.title": (v5/*: any*/)
+        "viewingRoom.partner.href": (v4/*: any*/),
+        "viewingRoom.partner.id": (v5/*: any*/),
+        "viewingRoom.partner.internalID": (v5/*: any*/),
+        "viewingRoom.partner.name": (v4/*: any*/),
+        "viewingRoom.pullQuote": (v4/*: any*/),
+        "viewingRoom.status": (v6/*: any*/),
+        "viewingRoom.title": (v6/*: any*/)
       }
     },
     "name": "ViewingRoomApp_ClosedTest_Query",
     "operationKind": "query",
-    "text": "query ViewingRoomApp_ClosedTest_Query(\n  $slug: ID!\n) {\n  viewingRoom(id: $slug) {\n    ...ViewingRoomApp_viewingRoom\n  }\n}\n\nfragment ViewingRoomApp_viewingRoom on ViewingRoom {\n  ...ViewingRoomMeta_viewingRoom\n  ...ViewingRoomHeader_viewingRoom\n  ...ViewingRoomContentNotAccessible_viewingRoom\n  partner {\n    internalID\n    id\n  }\n  status\n}\n\nfragment ViewingRoomContentNotAccessible_viewingRoom on ViewingRoom {\n  status\n  partner {\n    href\n    id\n  }\n}\n\nfragment ViewingRoomHeader_viewingRoom on ViewingRoom {\n  image {\n    imageURLs {\n      normalized\n    }\n  }\n  title\n  partner {\n    name\n    href\n    id\n  }\n  distanceToOpen\n  distanceToClose\n  status\n}\n\nfragment ViewingRoomMeta_viewingRoom on ViewingRoom {\n  title\n  href\n  pullQuote\n  image {\n    imageURLs {\n      normalized\n    }\n  }\n}\n"
+    "text": "query ViewingRoomApp_ClosedTest_Query(\n  $slug: ID!\n) {\n  viewingRoom(id: $slug) {\n    ...ViewingRoomApp_viewingRoom\n  }\n}\n\nfragment ViewingRoomApp_viewingRoom on ViewingRoom {\n  ...ViewingRoomMeta_viewingRoom\n  ...ViewingRoomHeader_viewingRoom\n  ...ViewingRoomContentNotAccessible_viewingRoom\n  internalID\n  status\n  partner {\n    internalID\n    id\n  }\n}\n\nfragment ViewingRoomContentNotAccessible_viewingRoom on ViewingRoom {\n  status\n  partner {\n    href\n    id\n  }\n}\n\nfragment ViewingRoomHeader_viewingRoom on ViewingRoom {\n  image {\n    imageURLs {\n      normalized\n    }\n  }\n  title\n  partner {\n    name\n    href\n    id\n  }\n  distanceToOpen\n  distanceToClose\n  status\n}\n\nfragment ViewingRoomMeta_viewingRoom on ViewingRoom {\n  title\n  href\n  pullQuote\n  image {\n    imageURLs {\n      normalized\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ViewingRoomApp_DraftTest_Query.graphql.ts
+++ b/src/__generated__/ViewingRoomApp_DraftTest_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<119fb6bf385d66e58765912e6f72c1ea>>
+ * @generated SignedSource<<2e04ac1bb7ee417c2c27afb702af4d7a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -28,6 +28,7 @@ export type ViewingRoomApp_DraftTest_Query$rawResponse = {
         readonly normalized: string | null;
       } | null;
     } | null;
+    readonly internalID: string;
     readonly partner: {
       readonly href: string | null;
       readonly id: string;
@@ -68,18 +69,25 @@ v2 = {
   "storageKey": null
 },
 v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v4 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v4 = {
+v5 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v5 = {
+v6 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
@@ -193,13 +201,7 @@ return {
                 "name": "id",
                 "storageKey": null
               },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "internalID",
-                "storageKey": null
-              }
+              (v3/*: any*/)
             ],
             "storageKey": null
           },
@@ -223,14 +225,15 @@ return {
             "kind": "ScalarField",
             "name": "status",
             "storageKey": null
-          }
+          },
+          (v3/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "c5e3086bd3eca566d87148fe165d18e4",
+    "cacheID": "5ea02d04692fe4d66eefc6baafe460d8",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -240,9 +243,9 @@ return {
           "plural": false,
           "type": "ViewingRoom"
         },
-        "viewingRoom.distanceToClose": (v3/*: any*/),
-        "viewingRoom.distanceToOpen": (v3/*: any*/),
-        "viewingRoom.href": (v3/*: any*/),
+        "viewingRoom.distanceToClose": (v4/*: any*/),
+        "viewingRoom.distanceToOpen": (v4/*: any*/),
+        "viewingRoom.href": (v4/*: any*/),
         "viewingRoom.image": {
           "enumValues": null,
           "nullable": true,
@@ -255,25 +258,26 @@ return {
           "plural": false,
           "type": "ImageURLs"
         },
-        "viewingRoom.image.imageURLs.normalized": (v3/*: any*/),
+        "viewingRoom.image.imageURLs.normalized": (v4/*: any*/),
+        "viewingRoom.internalID": (v5/*: any*/),
         "viewingRoom.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "viewingRoom.partner.href": (v3/*: any*/),
-        "viewingRoom.partner.id": (v4/*: any*/),
-        "viewingRoom.partner.internalID": (v4/*: any*/),
-        "viewingRoom.partner.name": (v3/*: any*/),
-        "viewingRoom.pullQuote": (v3/*: any*/),
-        "viewingRoom.status": (v5/*: any*/),
-        "viewingRoom.title": (v5/*: any*/)
+        "viewingRoom.partner.href": (v4/*: any*/),
+        "viewingRoom.partner.id": (v5/*: any*/),
+        "viewingRoom.partner.internalID": (v5/*: any*/),
+        "viewingRoom.partner.name": (v4/*: any*/),
+        "viewingRoom.pullQuote": (v4/*: any*/),
+        "viewingRoom.status": (v6/*: any*/),
+        "viewingRoom.title": (v6/*: any*/)
       }
     },
     "name": "ViewingRoomApp_DraftTest_Query",
     "operationKind": "query",
-    "text": "query ViewingRoomApp_DraftTest_Query(\n  $slug: ID!\n) {\n  viewingRoom(id: $slug) {\n    ...ViewingRoomApp_viewingRoom\n  }\n}\n\nfragment ViewingRoomApp_viewingRoom on ViewingRoom {\n  ...ViewingRoomMeta_viewingRoom\n  ...ViewingRoomHeader_viewingRoom\n  ...ViewingRoomContentNotAccessible_viewingRoom\n  partner {\n    internalID\n    id\n  }\n  status\n}\n\nfragment ViewingRoomContentNotAccessible_viewingRoom on ViewingRoom {\n  status\n  partner {\n    href\n    id\n  }\n}\n\nfragment ViewingRoomHeader_viewingRoom on ViewingRoom {\n  image {\n    imageURLs {\n      normalized\n    }\n  }\n  title\n  partner {\n    name\n    href\n    id\n  }\n  distanceToOpen\n  distanceToClose\n  status\n}\n\nfragment ViewingRoomMeta_viewingRoom on ViewingRoom {\n  title\n  href\n  pullQuote\n  image {\n    imageURLs {\n      normalized\n    }\n  }\n}\n"
+    "text": "query ViewingRoomApp_DraftTest_Query(\n  $slug: ID!\n) {\n  viewingRoom(id: $slug) {\n    ...ViewingRoomApp_viewingRoom\n  }\n}\n\nfragment ViewingRoomApp_viewingRoom on ViewingRoom {\n  ...ViewingRoomMeta_viewingRoom\n  ...ViewingRoomHeader_viewingRoom\n  ...ViewingRoomContentNotAccessible_viewingRoom\n  internalID\n  status\n  partner {\n    internalID\n    id\n  }\n}\n\nfragment ViewingRoomContentNotAccessible_viewingRoom on ViewingRoom {\n  status\n  partner {\n    href\n    id\n  }\n}\n\nfragment ViewingRoomHeader_viewingRoom on ViewingRoom {\n  image {\n    imageURLs {\n      normalized\n    }\n  }\n  title\n  partner {\n    name\n    href\n    id\n  }\n  distanceToOpen\n  distanceToClose\n  status\n}\n\nfragment ViewingRoomMeta_viewingRoom on ViewingRoom {\n  title\n  href\n  pullQuote\n  image {\n    imageURLs {\n      normalized\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ViewingRoomApp_LoggedOutTest_Query.graphql.ts
+++ b/src/__generated__/ViewingRoomApp_LoggedOutTest_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<69f4a3c4d2f83afeec88bdea728a111b>>
+ * @generated SignedSource<<df86f781040c873a45ddc5bd232f1335>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -28,6 +28,7 @@ export type ViewingRoomApp_LoggedOutTest_Query$rawResponse = {
         readonly normalized: string | null;
       } | null;
     } | null;
+    readonly internalID: string;
     readonly partner: {
       readonly href: string | null;
       readonly id: string;
@@ -68,18 +69,25 @@ v2 = {
   "storageKey": null
 },
 v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v4 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v4 = {
+v5 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v5 = {
+v6 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
@@ -193,13 +201,7 @@ return {
                 "name": "id",
                 "storageKey": null
               },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "internalID",
-                "storageKey": null
-              }
+              (v3/*: any*/)
             ],
             "storageKey": null
           },
@@ -223,14 +225,15 @@ return {
             "kind": "ScalarField",
             "name": "status",
             "storageKey": null
-          }
+          },
+          (v3/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "3bc19c4b7478804f3f452abf86302d5f",
+    "cacheID": "482643c3b8877411f9351552be8b68dd",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -240,9 +243,9 @@ return {
           "plural": false,
           "type": "ViewingRoom"
         },
-        "viewingRoom.distanceToClose": (v3/*: any*/),
-        "viewingRoom.distanceToOpen": (v3/*: any*/),
-        "viewingRoom.href": (v3/*: any*/),
+        "viewingRoom.distanceToClose": (v4/*: any*/),
+        "viewingRoom.distanceToOpen": (v4/*: any*/),
+        "viewingRoom.href": (v4/*: any*/),
         "viewingRoom.image": {
           "enumValues": null,
           "nullable": true,
@@ -255,25 +258,26 @@ return {
           "plural": false,
           "type": "ImageURLs"
         },
-        "viewingRoom.image.imageURLs.normalized": (v3/*: any*/),
+        "viewingRoom.image.imageURLs.normalized": (v4/*: any*/),
+        "viewingRoom.internalID": (v5/*: any*/),
         "viewingRoom.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "viewingRoom.partner.href": (v3/*: any*/),
-        "viewingRoom.partner.id": (v4/*: any*/),
-        "viewingRoom.partner.internalID": (v4/*: any*/),
-        "viewingRoom.partner.name": (v3/*: any*/),
-        "viewingRoom.pullQuote": (v3/*: any*/),
-        "viewingRoom.status": (v5/*: any*/),
-        "viewingRoom.title": (v5/*: any*/)
+        "viewingRoom.partner.href": (v4/*: any*/),
+        "viewingRoom.partner.id": (v5/*: any*/),
+        "viewingRoom.partner.internalID": (v5/*: any*/),
+        "viewingRoom.partner.name": (v4/*: any*/),
+        "viewingRoom.pullQuote": (v4/*: any*/),
+        "viewingRoom.status": (v6/*: any*/),
+        "viewingRoom.title": (v6/*: any*/)
       }
     },
     "name": "ViewingRoomApp_LoggedOutTest_Query",
     "operationKind": "query",
-    "text": "query ViewingRoomApp_LoggedOutTest_Query(\n  $slug: ID!\n) {\n  viewingRoom(id: $slug) {\n    ...ViewingRoomApp_viewingRoom\n  }\n}\n\nfragment ViewingRoomApp_viewingRoom on ViewingRoom {\n  ...ViewingRoomMeta_viewingRoom\n  ...ViewingRoomHeader_viewingRoom\n  ...ViewingRoomContentNotAccessible_viewingRoom\n  partner {\n    internalID\n    id\n  }\n  status\n}\n\nfragment ViewingRoomContentNotAccessible_viewingRoom on ViewingRoom {\n  status\n  partner {\n    href\n    id\n  }\n}\n\nfragment ViewingRoomHeader_viewingRoom on ViewingRoom {\n  image {\n    imageURLs {\n      normalized\n    }\n  }\n  title\n  partner {\n    name\n    href\n    id\n  }\n  distanceToOpen\n  distanceToClose\n  status\n}\n\nfragment ViewingRoomMeta_viewingRoom on ViewingRoom {\n  title\n  href\n  pullQuote\n  image {\n    imageURLs {\n      normalized\n    }\n  }\n}\n"
+    "text": "query ViewingRoomApp_LoggedOutTest_Query(\n  $slug: ID!\n) {\n  viewingRoom(id: $slug) {\n    ...ViewingRoomApp_viewingRoom\n  }\n}\n\nfragment ViewingRoomApp_viewingRoom on ViewingRoom {\n  ...ViewingRoomMeta_viewingRoom\n  ...ViewingRoomHeader_viewingRoom\n  ...ViewingRoomContentNotAccessible_viewingRoom\n  internalID\n  status\n  partner {\n    internalID\n    id\n  }\n}\n\nfragment ViewingRoomContentNotAccessible_viewingRoom on ViewingRoom {\n  status\n  partner {\n    href\n    id\n  }\n}\n\nfragment ViewingRoomHeader_viewingRoom on ViewingRoom {\n  image {\n    imageURLs {\n      normalized\n    }\n  }\n  title\n  partner {\n    name\n    href\n    id\n  }\n  distanceToOpen\n  distanceToClose\n  status\n}\n\nfragment ViewingRoomMeta_viewingRoom on ViewingRoom {\n  title\n  href\n  pullQuote\n  image {\n    imageURLs {\n      normalized\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ViewingRoomApp_OpenTest_Query.graphql.ts
+++ b/src/__generated__/ViewingRoomApp_OpenTest_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<abd551b43a8ffa7a7a1e69c85a81ac5d>>
+ * @generated SignedSource<<e0cedc1d331c8deee5cf6a6d79bdf595>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -28,6 +28,7 @@ export type ViewingRoomApp_OpenTest_Query$rawResponse = {
         readonly normalized: string | null;
       } | null;
     } | null;
+    readonly internalID: string;
     readonly partner: {
       readonly href: string | null;
       readonly id: string;
@@ -68,18 +69,25 @@ v2 = {
   "storageKey": null
 },
 v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v4 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v4 = {
+v5 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v5 = {
+v6 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
@@ -193,13 +201,7 @@ return {
                 "name": "id",
                 "storageKey": null
               },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "internalID",
-                "storageKey": null
-              }
+              (v3/*: any*/)
             ],
             "storageKey": null
           },
@@ -223,14 +225,15 @@ return {
             "kind": "ScalarField",
             "name": "status",
             "storageKey": null
-          }
+          },
+          (v3/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "ebf4f17bc9839eca2aa62c7b8136f755",
+    "cacheID": "0126ae86d0195d21bc75b26fd5049eda",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -240,9 +243,9 @@ return {
           "plural": false,
           "type": "ViewingRoom"
         },
-        "viewingRoom.distanceToClose": (v3/*: any*/),
-        "viewingRoom.distanceToOpen": (v3/*: any*/),
-        "viewingRoom.href": (v3/*: any*/),
+        "viewingRoom.distanceToClose": (v4/*: any*/),
+        "viewingRoom.distanceToOpen": (v4/*: any*/),
+        "viewingRoom.href": (v4/*: any*/),
         "viewingRoom.image": {
           "enumValues": null,
           "nullable": true,
@@ -255,25 +258,26 @@ return {
           "plural": false,
           "type": "ImageURLs"
         },
-        "viewingRoom.image.imageURLs.normalized": (v3/*: any*/),
+        "viewingRoom.image.imageURLs.normalized": (v4/*: any*/),
+        "viewingRoom.internalID": (v5/*: any*/),
         "viewingRoom.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "viewingRoom.partner.href": (v3/*: any*/),
-        "viewingRoom.partner.id": (v4/*: any*/),
-        "viewingRoom.partner.internalID": (v4/*: any*/),
-        "viewingRoom.partner.name": (v3/*: any*/),
-        "viewingRoom.pullQuote": (v3/*: any*/),
-        "viewingRoom.status": (v5/*: any*/),
-        "viewingRoom.title": (v5/*: any*/)
+        "viewingRoom.partner.href": (v4/*: any*/),
+        "viewingRoom.partner.id": (v5/*: any*/),
+        "viewingRoom.partner.internalID": (v5/*: any*/),
+        "viewingRoom.partner.name": (v4/*: any*/),
+        "viewingRoom.pullQuote": (v4/*: any*/),
+        "viewingRoom.status": (v6/*: any*/),
+        "viewingRoom.title": (v6/*: any*/)
       }
     },
     "name": "ViewingRoomApp_OpenTest_Query",
     "operationKind": "query",
-    "text": "query ViewingRoomApp_OpenTest_Query(\n  $slug: ID!\n) {\n  viewingRoom(id: $slug) {\n    ...ViewingRoomApp_viewingRoom\n  }\n}\n\nfragment ViewingRoomApp_viewingRoom on ViewingRoom {\n  ...ViewingRoomMeta_viewingRoom\n  ...ViewingRoomHeader_viewingRoom\n  ...ViewingRoomContentNotAccessible_viewingRoom\n  partner {\n    internalID\n    id\n  }\n  status\n}\n\nfragment ViewingRoomContentNotAccessible_viewingRoom on ViewingRoom {\n  status\n  partner {\n    href\n    id\n  }\n}\n\nfragment ViewingRoomHeader_viewingRoom on ViewingRoom {\n  image {\n    imageURLs {\n      normalized\n    }\n  }\n  title\n  partner {\n    name\n    href\n    id\n  }\n  distanceToOpen\n  distanceToClose\n  status\n}\n\nfragment ViewingRoomMeta_viewingRoom on ViewingRoom {\n  title\n  href\n  pullQuote\n  image {\n    imageURLs {\n      normalized\n    }\n  }\n}\n"
+    "text": "query ViewingRoomApp_OpenTest_Query(\n  $slug: ID!\n) {\n  viewingRoom(id: $slug) {\n    ...ViewingRoomApp_viewingRoom\n  }\n}\n\nfragment ViewingRoomApp_viewingRoom on ViewingRoom {\n  ...ViewingRoomMeta_viewingRoom\n  ...ViewingRoomHeader_viewingRoom\n  ...ViewingRoomContentNotAccessible_viewingRoom\n  internalID\n  status\n  partner {\n    internalID\n    id\n  }\n}\n\nfragment ViewingRoomContentNotAccessible_viewingRoom on ViewingRoom {\n  status\n  partner {\n    href\n    id\n  }\n}\n\nfragment ViewingRoomHeader_viewingRoom on ViewingRoom {\n  image {\n    imageURLs {\n      normalized\n    }\n  }\n  title\n  partner {\n    name\n    href\n    id\n  }\n  distanceToOpen\n  distanceToClose\n  status\n}\n\nfragment ViewingRoomMeta_viewingRoom on ViewingRoom {\n  title\n  href\n  pullQuote\n  image {\n    imageURLs {\n      normalized\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ViewingRoomApp_ScheduledTest_Query.graphql.ts
+++ b/src/__generated__/ViewingRoomApp_ScheduledTest_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8385fabcd3b2ff6ba2697ae8718bb2f3>>
+ * @generated SignedSource<<013097b127508cdde0d1116f9ca614af>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -28,6 +28,7 @@ export type ViewingRoomApp_ScheduledTest_Query$rawResponse = {
         readonly normalized: string | null;
       } | null;
     } | null;
+    readonly internalID: string;
     readonly partner: {
       readonly href: string | null;
       readonly id: string;
@@ -68,18 +69,25 @@ v2 = {
   "storageKey": null
 },
 v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v4 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v4 = {
+v5 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v5 = {
+v6 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
@@ -193,13 +201,7 @@ return {
                 "name": "id",
                 "storageKey": null
               },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "internalID",
-                "storageKey": null
-              }
+              (v3/*: any*/)
             ],
             "storageKey": null
           },
@@ -223,14 +225,15 @@ return {
             "kind": "ScalarField",
             "name": "status",
             "storageKey": null
-          }
+          },
+          (v3/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "8e55ad76766571c76959d338b77eb60c",
+    "cacheID": "8a97c70297faaffd0289d44eb4b3000b",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -240,9 +243,9 @@ return {
           "plural": false,
           "type": "ViewingRoom"
         },
-        "viewingRoom.distanceToClose": (v3/*: any*/),
-        "viewingRoom.distanceToOpen": (v3/*: any*/),
-        "viewingRoom.href": (v3/*: any*/),
+        "viewingRoom.distanceToClose": (v4/*: any*/),
+        "viewingRoom.distanceToOpen": (v4/*: any*/),
+        "viewingRoom.href": (v4/*: any*/),
         "viewingRoom.image": {
           "enumValues": null,
           "nullable": true,
@@ -255,25 +258,26 @@ return {
           "plural": false,
           "type": "ImageURLs"
         },
-        "viewingRoom.image.imageURLs.normalized": (v3/*: any*/),
+        "viewingRoom.image.imageURLs.normalized": (v4/*: any*/),
+        "viewingRoom.internalID": (v5/*: any*/),
         "viewingRoom.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "viewingRoom.partner.href": (v3/*: any*/),
-        "viewingRoom.partner.id": (v4/*: any*/),
-        "viewingRoom.partner.internalID": (v4/*: any*/),
-        "viewingRoom.partner.name": (v3/*: any*/),
-        "viewingRoom.pullQuote": (v3/*: any*/),
-        "viewingRoom.status": (v5/*: any*/),
-        "viewingRoom.title": (v5/*: any*/)
+        "viewingRoom.partner.href": (v4/*: any*/),
+        "viewingRoom.partner.id": (v5/*: any*/),
+        "viewingRoom.partner.internalID": (v5/*: any*/),
+        "viewingRoom.partner.name": (v4/*: any*/),
+        "viewingRoom.pullQuote": (v4/*: any*/),
+        "viewingRoom.status": (v6/*: any*/),
+        "viewingRoom.title": (v6/*: any*/)
       }
     },
     "name": "ViewingRoomApp_ScheduledTest_Query",
     "operationKind": "query",
-    "text": "query ViewingRoomApp_ScheduledTest_Query(\n  $slug: ID!\n) {\n  viewingRoom(id: $slug) {\n    ...ViewingRoomApp_viewingRoom\n  }\n}\n\nfragment ViewingRoomApp_viewingRoom on ViewingRoom {\n  ...ViewingRoomMeta_viewingRoom\n  ...ViewingRoomHeader_viewingRoom\n  ...ViewingRoomContentNotAccessible_viewingRoom\n  partner {\n    internalID\n    id\n  }\n  status\n}\n\nfragment ViewingRoomContentNotAccessible_viewingRoom on ViewingRoom {\n  status\n  partner {\n    href\n    id\n  }\n}\n\nfragment ViewingRoomHeader_viewingRoom on ViewingRoom {\n  image {\n    imageURLs {\n      normalized\n    }\n  }\n  title\n  partner {\n    name\n    href\n    id\n  }\n  distanceToOpen\n  distanceToClose\n  status\n}\n\nfragment ViewingRoomMeta_viewingRoom on ViewingRoom {\n  title\n  href\n  pullQuote\n  image {\n    imageURLs {\n      normalized\n    }\n  }\n}\n"
+    "text": "query ViewingRoomApp_ScheduledTest_Query(\n  $slug: ID!\n) {\n  viewingRoom(id: $slug) {\n    ...ViewingRoomApp_viewingRoom\n  }\n}\n\nfragment ViewingRoomApp_viewingRoom on ViewingRoom {\n  ...ViewingRoomMeta_viewingRoom\n  ...ViewingRoomHeader_viewingRoom\n  ...ViewingRoomContentNotAccessible_viewingRoom\n  internalID\n  status\n  partner {\n    internalID\n    id\n  }\n}\n\nfragment ViewingRoomContentNotAccessible_viewingRoom on ViewingRoom {\n  status\n  partner {\n    href\n    id\n  }\n}\n\nfragment ViewingRoomHeader_viewingRoom on ViewingRoom {\n  image {\n    imageURLs {\n      normalized\n    }\n  }\n  title\n  partner {\n    name\n    href\n    id\n  }\n  distanceToOpen\n  distanceToClose\n  status\n}\n\nfragment ViewingRoomMeta_viewingRoom on ViewingRoom {\n  title\n  href\n  pullQuote\n  image {\n    imageURLs {\n      normalized\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ViewingRoomApp_viewingRoom.graphql.ts
+++ b/src/__generated__/ViewingRoomApp_viewingRoom.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<57685ff19f1920eb636289cab73e90c6>>
+ * @generated SignedSource<<9114c0a1b4bcdac1847580799cab8aaa>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,6 +11,7 @@
 import { Fragment, ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type ViewingRoomApp_viewingRoom$data = {
+  readonly internalID: string;
   readonly partner: {
     readonly internalID: string;
   } | null;
@@ -23,7 +24,15 @@ export type ViewingRoomApp_viewingRoom$key = {
   readonly " $fragmentSpreads": FragmentRefs<"ViewingRoomApp_viewingRoom">;
 };
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+};
+return {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
@@ -44,6 +53,14 @@ const node: ReaderFragment = {
       "kind": "FragmentSpread",
       "name": "ViewingRoomContentNotAccessible_viewingRoom"
     },
+    (v0/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "status",
+      "storageKey": null
+    },
     {
       "alias": null,
       "args": null,
@@ -52,28 +69,16 @@ const node: ReaderFragment = {
       "name": "partner",
       "plural": false,
       "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "internalID",
-          "storageKey": null
-        }
+        (v0/*: any*/)
       ],
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "status",
       "storageKey": null
     }
   ],
   "type": "ViewingRoom",
   "abstractKey": null
 };
+})();
 
-(node as any).hash = "42b4a4acd26b4325cfef0fefd73552d6";
+(node as any).hash = "2d21bb76bccd60f41b8510ed547e84cd";
 
 export default node;

--- a/src/__generated__/exampleRoutes_ArtistQuery.graphql.ts
+++ b/src/__generated__/exampleRoutes_ArtistQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fa1ff612eef6bf97e8bf8a269bfb3867>>
+ * @generated SignedSource<<45a58708b37983188608af996e206a95>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -109,13 +109,6 @@ return {
             "kind": "ScalarField",
             "name": "internalID",
             "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "slug",
-            "storageKey": null
           }
         ],
         "storageKey": null
@@ -123,12 +116,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "8f7d15cd5f0d3bb3949bd45c16f88738",
+    "cacheID": "f4b3a80c97fa58b6055b7bff5ba53caf",
     "id": null,
     "metadata": {},
     "name": "exampleRoutes_ArtistQuery",
     "operationKind": "query",
-    "text": "query exampleRoutes_ArtistQuery(\n  $slug: String!\n) {\n  artist(id: $slug) @principalField {\n    id\n    ...ExampleArtistRoute_artist\n  }\n}\n\nfragment ExampleArtistRoute_artist on Artist {\n  name\n  bio\n  internalID\n  slug\n}\n"
+    "text": "query exampleRoutes_ArtistQuery(\n  $slug: String!\n) {\n  artist(id: $slug) @principalField {\n    id\n    ...ExampleArtistRoute_artist\n  }\n}\n\nfragment ExampleArtistRoute_artist on Artist {\n  name\n  bio\n  internalID\n}\n"
   }
 };
 })();

--- a/src/__generated__/exampleRoutes_ArtworkQuery.graphql.ts
+++ b/src/__generated__/exampleRoutes_ArtworkQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4ff2baba0d511a1dd1bc8bba0511f398>>
+ * @generated SignedSource<<c2026c2d75409a20f8cecfff003210e4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -367,12 +367,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "961537e94655194c36c733dfe736e9be",
+    "cacheID": "58fef622bf0480e368cf463046e2970b",
     "id": null,
     "metadata": {},
     "name": "exampleRoutes_ArtworkQuery",
     "operationKind": "query",
-    "text": "query exampleRoutes_ArtworkQuery(\n  $slug: String!\n) {\n  artwork(id: $slug) @principalField {\n    id\n    ...ExampleArtworkRoute_artwork\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ExampleArtworkRoute_artwork on Artwork {\n  title\n  artistNames\n  medium\n  imageUrl\n  date\n  internalID\n  slug\n  artist {\n    related {\n      artistsConnection(kind: MAIN, first: 4) {\n        edges {\n          node {\n            ...EntityHeaderArtist_artist\n            id\n            __typename\n          }\n          cursor\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query exampleRoutes_ArtworkQuery(\n  $slug: String!\n) {\n  artwork(id: $slug) @principalField {\n    id\n    ...ExampleArtworkRoute_artwork\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  avatar: image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ExampleArtworkRoute_artwork on Artwork {\n  title\n  artistNames\n  medium\n  imageUrl\n  date\n  internalID\n  slug\n  artist {\n    related {\n      artistsConnection(kind: MAIN, first: 4) {\n        edges {\n          node {\n            ...EntityHeaderArtist_artist\n            internalID\n            id\n            __typename\n          }\n          cursor\n        }\n        pageInfo {\n          endCursor\n          hasNextPage\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/fairRoutes_FairQuery.graphql.ts
+++ b/src/__generated__/fairRoutes_FairQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e3a6d59caa10de6023c3530873efec36>>
+ * @generated SignedSource<<8729143e2627cb48858bd4ddf9850068>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -259,12 +259,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d83c347fdab16413cf9ae94b7c990fe5",
+    "cacheID": "ed515a6dbbc77cd8f2573030ad52a543",
     "id": null,
     "metadata": {},
     "name": "fairRoutes_FairQuery",
     "operationKind": "query",
-    "text": "query fairRoutes_FairQuery(\n  $slug: String!\n) {\n  fair(id: $slug) @principalField {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment ExhibitorsLetterNav_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n  }\n}\n\nfragment FairApp_fair on Fair {\n  ...FairTabs_fair\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairHeaderImage_fair\n  ...ExhibitorsLetterNav_fair\n  internalID\n  slug\n  profile {\n    id\n  }\n}\n\nfragment FairHeaderImage_fair on Fair {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  name\n  exhibitionPeriod\n  profile {\n    icon {\n      url(version: [\"large\", \"square\", \"square140\"])\n    }\n    id\n  }\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n\nfragment FairTabs_fair on Fair {\n  href\n  counts {\n    artworks\n  }\n}\n"
+    "text": "query fairRoutes_FairQuery(\n  $slug: String!\n) {\n  fair(id: $slug) @principalField {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment ExhibitorsLetterNav_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n  }\n}\n\nfragment FairApp_fair on Fair {\n  ...FairTabs_fair\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairHeaderImage_fair\n  ...ExhibitorsLetterNav_fair\n  internalID\n  profile {\n    id\n  }\n}\n\nfragment FairHeaderImage_fair on Fair {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  name\n  exhibitionPeriod\n  profile {\n    icon {\n      url(version: [\"large\", \"square\", \"square140\"])\n    }\n    id\n  }\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n\nfragment FairTabs_fair on Fair {\n  href\n  counts {\n    artworks\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/partnerRoutes_PartnerQuery.graphql.ts
+++ b/src/__generated__/partnerRoutes_PartnerQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6724bc37979660027913a9138e512389>>
+ * @generated SignedSource<<eb560659537294d5daaccdd2320582b7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -58,34 +58,41 @@ v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "internalID",
   "storageKey": null
 },
 v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "id",
   "storageKey": null
 },
 v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "city",
+  "name": "name",
   "storageKey": null
 },
 v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "city",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "totalCount",
   "storageKey": null
 },
-v8 = [
-  (v7/*: any*/)
+v9 = [
+  (v8/*: any*/)
 ],
-v9 = {
+v10 = {
   "kind": "Literal",
   "name": "displayOnPartnerProfile",
   "value": true
@@ -135,6 +142,7 @@ return {
         "selections": [
           (v2/*: any*/),
           (v3/*: any*/),
+          (v4/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -157,8 +165,8 @@ return {
             "name": "categories",
             "plural": true,
             "selections": [
-              (v4/*: any*/),
-              (v5/*: any*/)
+              (v5/*: any*/),
+              (v6/*: any*/)
             ],
             "storageKey": null
           },
@@ -194,14 +202,8 @@ return {
                 ],
                 "storageKey": null
               },
+              (v5/*: any*/),
               (v4/*: any*/),
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "internalID",
-                "storageKey": null
-              },
               {
                 "alias": null,
                 "args": null,
@@ -301,7 +303,7 @@ return {
                         "name": "address2",
                         "storageKey": null
                       },
-                      (v6/*: any*/),
+                      (v7/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -355,7 +357,7 @@ return {
                         "name": "state",
                         "storageKey": null
                       },
-                      (v4/*: any*/)
+                      (v5/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -397,7 +399,7 @@ return {
             ],
             "storageKey": null
           },
-          (v5/*: any*/),
+          (v6/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -426,7 +428,7 @@ return {
             "name": "locationsConnection",
             "plural": false,
             "selections": [
-              (v7/*: any*/),
+              (v8/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -443,8 +445,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/),
-                      (v4/*: any*/)
+                      (v7/*: any*/),
+                      (v5/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -500,13 +502,13 @@ return {
             "kind": "LinkedField",
             "name": "articlesConnection",
             "plural": false,
-            "selections": (v8/*: any*/),
+            "selections": (v9/*: any*/),
             "storageKey": null
           },
           {
             "alias": "representedArtists",
             "args": [
-              (v9/*: any*/),
+              (v10/*: any*/),
               {
                 "kind": "Literal",
                 "name": "representedBy",
@@ -517,13 +519,13 @@ return {
             "kind": "LinkedField",
             "name": "artistsConnection",
             "plural": false,
-            "selections": (v8/*: any*/),
+            "selections": (v9/*: any*/),
             "storageKey": "artistsConnection(displayOnPartnerProfile:true,representedBy:true)"
           },
           {
             "alias": "notRepresentedArtists",
             "args": [
-              (v9/*: any*/),
+              (v10/*: any*/),
               {
                 "kind": "Literal",
                 "name": "hasPublishedArtworks",
@@ -539,7 +541,7 @@ return {
             "kind": "LinkedField",
             "name": "artistsConnection",
             "plural": false,
-            "selections": (v8/*: any*/),
+            "selections": (v9/*: any*/),
             "storageKey": "artistsConnection(displayOnPartnerProfile:true,hasPublishedArtworks:true,representedBy:false)"
           },
           {
@@ -559,22 +561,22 @@ return {
             "kind": "LinkedField",
             "name": "viewingRoomsConnection",
             "plural": false,
-            "selections": (v8/*: any*/),
+            "selections": (v9/*: any*/),
             "storageKey": "viewingRoomsConnection(statuses:[\"live\",\"closed\",\"scheduled\"])"
           },
-          (v4/*: any*/)
+          (v5/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "13cb661c53d084d6e396b6619d17f93d",
+    "cacheID": "0839c6b683cac74abd2d628ec994c890",
     "id": null,
     "metadata": {},
     "name": "partnerRoutes_PartnerQuery",
     "operationKind": "query",
-    "text": "query partnerRoutes_PartnerQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    partnerType\n    displayFullPartnerPage\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n  partnerType\n  displayArtistsSection\n  displayWorksSection\n  counts {\n    eligibleArtworks\n    displayableShows\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n  }\n  articles: articlesConnection {\n    totalCount\n  }\n  representedArtists: artistsConnection(representedBy: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  notRepresentedArtists: artistsConnection(representedBy: false, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  viewingRooms: viewingRoomsConnection(statuses: [live, closed, scheduled]) {\n    totalCount\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  partnerType\n  displayFullPartnerPage\n  partnerPageEligible\n  isDefaultProfilePublic\n  categories {\n    id\n    name\n  }\n  profile {\n    ...PartnerHeaderImage_profile\n    id\n  }\n  ...PartnerMeta_partner\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeaderImage_profile on Profile {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  profile {\n    internalID\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMeta_partner on Partner {\n  locationsConnection(first: 1) {\n    edges {\n      node {\n        address\n        address2\n        city\n        coordinates {\n          lat\n          lng\n        }\n        country\n        phone\n        postalCode\n        state\n        id\n      }\n    }\n  }\n  meta {\n    image\n    title\n    description\n  }\n  name\n  slug\n}\n"
+    "text": "query partnerRoutes_PartnerQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    partnerType\n    displayFullPartnerPage\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n  partnerType\n  displayArtistsSection\n  displayWorksSection\n  counts {\n    eligibleArtworks\n    displayableShows\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n  }\n  articles: articlesConnection {\n    totalCount\n  }\n  representedArtists: artistsConnection(representedBy: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  notRepresentedArtists: artistsConnection(representedBy: false, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  viewingRooms: viewingRoomsConnection(statuses: [live, closed, scheduled]) {\n    totalCount\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  internalID\n  partnerType\n  displayFullPartnerPage\n  partnerPageEligible\n  isDefaultProfilePublic\n  categories {\n    id\n    name\n  }\n  profile {\n    ...PartnerHeaderImage_profile\n    id\n  }\n  ...PartnerMeta_partner\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeaderImage_profile on Profile {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  profile {\n    internalID\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMeta_partner on Partner {\n  locationsConnection(first: 1) {\n    edges {\n      node {\n        address\n        address2\n        city\n        coordinates {\n          lat\n          lng\n        }\n        country\n        phone\n        postalCode\n        state\n        id\n      }\n    }\n  }\n  meta {\n    image\n    title\n    description\n  }\n  name\n  slug\n}\n"
   }
 };
 })();

--- a/src/__generated__/viewingRoomRoutes_ViewingRoomQuery.graphql.ts
+++ b/src/__generated__/viewingRoomRoutes_ViewingRoomQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fd3335ee33f347e0f1d21774f9f71065>>
+ * @generated SignedSource<<bb18df288f74daf44011fa079de413d4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -43,6 +43,13 @@ v2 = {
   "args": null,
   "kind": "ScalarField",
   "name": "href",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
   "storageKey": null
 };
 return {
@@ -153,13 +160,7 @@ return {
                 "name": "id",
                 "storageKey": null
               },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "internalID",
-                "storageKey": null
-              }
+              (v3/*: any*/)
             ],
             "storageKey": null
           },
@@ -183,19 +184,20 @@ return {
             "kind": "ScalarField",
             "name": "status",
             "storageKey": null
-          }
+          },
+          (v3/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "2b2d6535cf5d6e660247079c3b4ca96a",
+    "cacheID": "e75d71d95e16fb9a7350b6f19115a139",
     "id": null,
     "metadata": {},
     "name": "viewingRoomRoutes_ViewingRoomQuery",
     "operationKind": "query",
-    "text": "query viewingRoomRoutes_ViewingRoomQuery(\n  $slug: ID!\n) {\n  viewingRoom(id: $slug) @principalField {\n    ...ViewingRoomApp_viewingRoom\n  }\n}\n\nfragment ViewingRoomApp_viewingRoom on ViewingRoom {\n  ...ViewingRoomMeta_viewingRoom\n  ...ViewingRoomHeader_viewingRoom\n  ...ViewingRoomContentNotAccessible_viewingRoom\n  partner {\n    internalID\n    id\n  }\n  status\n}\n\nfragment ViewingRoomContentNotAccessible_viewingRoom on ViewingRoom {\n  status\n  partner {\n    href\n    id\n  }\n}\n\nfragment ViewingRoomHeader_viewingRoom on ViewingRoom {\n  image {\n    imageURLs {\n      normalized\n    }\n  }\n  title\n  partner {\n    name\n    href\n    id\n  }\n  distanceToOpen\n  distanceToClose\n  status\n}\n\nfragment ViewingRoomMeta_viewingRoom on ViewingRoom {\n  title\n  href\n  pullQuote\n  image {\n    imageURLs {\n      normalized\n    }\n  }\n}\n"
+    "text": "query viewingRoomRoutes_ViewingRoomQuery(\n  $slug: ID!\n) {\n  viewingRoom(id: $slug) @principalField {\n    ...ViewingRoomApp_viewingRoom\n  }\n}\n\nfragment ViewingRoomApp_viewingRoom on ViewingRoom {\n  ...ViewingRoomMeta_viewingRoom\n  ...ViewingRoomHeader_viewingRoom\n  ...ViewingRoomContentNotAccessible_viewingRoom\n  internalID\n  status\n  partner {\n    internalID\n    id\n  }\n}\n\nfragment ViewingRoomContentNotAccessible_viewingRoom on ViewingRoom {\n  status\n  partner {\n    href\n    id\n  }\n}\n\nfragment ViewingRoomHeader_viewingRoom on ViewingRoom {\n  image {\n    imageURLs {\n      normalized\n    }\n  }\n  title\n  partner {\n    name\n    href\n    id\n  }\n  distanceToOpen\n  distanceToClose\n  status\n}\n\nfragment ViewingRoomMeta_viewingRoom on ViewingRoom {\n  title\n  href\n  pullQuote\n  image {\n    imageURLs {\n      normalized\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
OK — what do we think about this. Basically: solve the same problem but without state or effects.

The problem is two-fold: we need to update the analytics context on route changes and we need to merge in a value lower in the tree. So instead of a single context that listens to the route change: two separate contexts that just accept props and a single hook that merges them.

Ultimately you don't need to know anything new as a dev: just pull in `AnalyticsContextProvider` in your app on entity pages and provide the `internalID`. And where needed use the `useAnalayticsContext` hook to pull out the values.

This shouldn't have any issues with Integrity because it is essentially the same as before: a static context.