### PR TITLE
fix(auth): threads through analytics options after social login/sign up

### DIFF
--- a/src/Components/AuthDialog/AuthDialogContext.tsx
+++ b/src/Components/AuthDialog/AuthDialogContext.tsx
@@ -42,7 +42,7 @@ export type AuthDialogOptions = {
   onSuccess?: () => void
 }
 
-type AuthDialogAnalytics = {
+export type AuthDialogAnalytics = {
   contextModule: AuthContextModule
   intent?: AuthIntent
   trigger?: AuthTrigger

--- a/src/Components/AuthDialog/Components/AuthDialogSocial.tsx
+++ b/src/Components/AuthDialog/Components/AuthDialogSocial.tsx
@@ -40,6 +40,7 @@ export const AuthDialogSocial: FC = () => {
   const handleClick = (service: "facebook" | "apple" | "google") => () => {
     setSocialAuthTracking({
       action: { Login: "loggedIn", SignUp: "signedUp" }[mode],
+      analytics,
       service,
     })
   }

--- a/src/Components/AuthDialog/Hooks/__tests__/useSocialAuthTracking.jest.ts
+++ b/src/Components/AuthDialog/Hooks/__tests__/useSocialAuthTracking.jest.ts
@@ -37,12 +37,23 @@ describe("useSocialAuthTracking", () => {
     mockCookiesExpire.mockImplementation(jest.fn())
 
     mockCookiesGet.mockImplementation(() =>
-      JSON.stringify({ action: "loggedIn", service: "google" })
+      JSON.stringify({
+        action: "loggedIn",
+        service: "google",
+        analytics: {
+          contextModule: "header",
+        },
+      })
     )
 
     renderHook(useSocialAuthTracking)
 
-    expect(loggedIn).toBeCalledWith({ service: "google", userId: "example" })
+    expect(loggedIn).toBeCalledWith({
+      contextModule: "header",
+      service: "google",
+      userId: "example",
+    })
+
     expect(mockCookiesExpire).toBeCalledWith("useSocialAuthTracking")
   })
 
@@ -67,7 +78,13 @@ describe("useSocialAuthTracking", () => {
     mockCookiesExpire.mockImplementation(jest.fn())
 
     mockCookiesGet.mockImplementation(() =>
-      JSON.stringify({ action: "loggedIn", service: "google" })
+      JSON.stringify({
+        action: "loggedIn",
+        service: "google",
+        analytics: {
+          contextModule: "header",
+        },
+      })
     )
 
     mockUseRouter.mockImplementation(() => ({

--- a/src/Components/AuthDialog/Hooks/useAuthDialogTracking.ts
+++ b/src/Components/AuthDialog/Hooks/useAuthDialogTracking.ts
@@ -42,11 +42,13 @@ export const useAuthDialogTracking = () => {
     },
 
     loggedIn: ({
+      contextModule = analytics.contextModule,
       service = "email",
       userId,
       intent = analytics.intent || Intent.login,
       trigger = analytics.trigger || "click",
     }: {
+      contextModule?: SuccessfullyLoggedIn["context_module"]
       service: SuccessfullyLoggedIn["service"]
       userId: SuccessfullyLoggedIn["user_id"]
       intent?: SuccessfullyLoggedIn["intent"]
@@ -55,7 +57,7 @@ export const useAuthDialogTracking = () => {
       const payload: SuccessfullyLoggedIn = {
         action: ActionType.successfullyLoggedIn,
         auth_redirect: redirectUrl,
-        context_module: analytics.contextModule,
+        context_module: contextModule,
         intent,
         service,
         trigger,
@@ -67,11 +69,13 @@ export const useAuthDialogTracking = () => {
     },
 
     signedUp: ({
+      contextModule = analytics.contextModule,
       service = "email",
       userId,
       intent = analytics.intent || Intent.signup,
       trigger = analytics.trigger || "click",
     }: {
+      contextModule?: CreatedAccount["context_module"]
       service: CreatedAccount["service"]
       userId: CreatedAccount["user_id"]
       intent?: CreatedAccount["intent"]
@@ -80,7 +84,7 @@ export const useAuthDialogTracking = () => {
       const payload: CreatedAccount = {
         action: ActionType.createdAccount,
         auth_redirect: redirectUrl,
-        context_module: analytics.contextModule,
+        context_module: contextModule,
         intent,
         onboarding: isElligibleForOnboarding,
         service,

--- a/src/Components/AuthDialog/Hooks/useSocialAuthTracking.ts
+++ b/src/Components/AuthDialog/Hooks/useSocialAuthTracking.ts
@@ -4,6 +4,7 @@ import { useAuthDialogTracking } from "Components/AuthDialog/Hooks/useAuthDialog
 import { useEffect } from "react"
 import { useSystemContext } from "System/useSystemContext"
 import { useRouter } from "System/Router/useRouter"
+import { AuthDialogAnalytics } from "Components/AuthDialog/AuthDialogContext"
 
 const USE_SOCIAL_AUTH_TRACKING_KEY = "useSocialAuthTracking"
 
@@ -35,6 +36,7 @@ export const useSocialAuthTracking = () => {
     if (!value) {
       // Expire the cookie so we don't keep trying to parse it
       Cookies.expire(USE_SOCIAL_AUTH_TRACKING_KEY)
+      console.warn('Invalid cookie found for "useSocialAuthTracking"')
 
       return
     }
@@ -48,7 +50,11 @@ export const useSocialAuthTracking = () => {
       return
     }
 
-    track[value.action]({ service: value.service, userId: user.id })
+    track[value.action]({
+      service: value.service,
+      userId: user.id,
+      ...value.analytics,
+    })
 
     Cookies.expire(USE_SOCIAL_AUTH_TRACKING_KEY)
   }, [location.pathname, track, user])
@@ -56,10 +62,19 @@ export const useSocialAuthTracking = () => {
 
 const schema = Yup.object({
   action: Yup.string().oneOf(["loggedIn", "signedUp"]).required(),
+  analytics: Yup.object({
+    contextModule: Yup.string().required(),
+    intent: Yup.string(),
+    trigger: Yup.string(),
+  }),
   service: Yup.string().oneOf(["apple", "google", "facebook"]).required(),
 })
 
-type Payload = Yup.InferType<typeof schema>
+type Payload = Omit<Yup.InferType<typeof schema>, "analytics"> & {
+  // We assume that the unions are valid because it would
+  // be difficult to get the runtime values from Cohesion
+  analytics: AuthDialogAnalytics
+}
 
 const isValid = (value: any): value is Payload => {
   return schema.isValidSync(value)


### PR DESCRIPTION
Closes [DIA-45](https://artsyproduct.atlassian.net/browse/DIA-45)

We lose the auth context once there's a full page load so we need to store the analytics options in the cookie that the social tracking picks up on then just pass those through to the tracking call.

[DIA-45]: https://artsyproduct.atlassian.net/browse/DIA-45?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ