### PR TITLE
Revert "chore(deps): update dep typescript from 4.7.4 to v4.9.5"

### DIFF
--- a/package.json
+++ b/package.json
@@ -338,7 +338,7 @@
     "swc-loader": "^0.2.3",
     "terser-webpack-plugin": "5.1.3",
     "time-fix-plugin": "^2.0.7",
-    "typescript": "4.9.5",
+    "typescript": "4.7.4",
     "typescript-styled-plugin": "0.15.0",
     "webpack": "5.76.0",
     "webpack-bundle-analyzer": "4.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -21620,10 +21620,10 @@ typescript-template-language-service-decorator@^2.2.0:
   resolved "https://registry.yarnpkg.com/typescript-template-language-service-decorator/-/typescript-template-language-service-decorator-2.2.0.tgz#4ee6d580f307fb9239978e69626f2775b8a59b2a"
   integrity sha512-xiolqt1i7e22rpqMaprPgSFVgU64u3b9n6EJlAaUYE61jumipKAdI1+O5khPlWslpTUj80YzjUKjJ2jxT0D74w==
 
-typescript@4.9.5:
-  version "4.9.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@4.7.4:
+  version "4.7.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
+  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
 
 ua-parser-js@^0.7.30:
   version "0.7.33"


### PR DESCRIPTION
This reverts commit 173de9d7d21b41a61f0c95bf83e87110afd51695.

This got merged automatically but before CI happened to run (momentarily 🍏 ?), and did indeed break something.