### PR TITLE
feat: report currency not supported (EMI-1328)

### DIFF
--- a/src/Apps/Order/Dialogs.tsx
+++ b/src/Apps/Order/Dialogs.tsx
@@ -26,6 +26,8 @@ interface DialogState {
   onForceClose: () => Promise<void>
 }
 
+const defaultErrorDialogCopy = getErrorDialogCopy()
+
 export class DialogContainer extends Container<DialogState> {
   state: DialogState = {
     props: {
@@ -116,15 +118,13 @@ export class DialogContainer extends Container<DialogState> {
     })
   }
 
-  defaultErrorDialogCopy = getErrorDialogCopy()
-
   /**
    * returns a promise that resolves to `true` if the user clicked the
    * continue button, and `false` if the modal was dismissed through other means.
    */
   showErrorDialog = ({
-    title = this.defaultErrorDialogCopy.title,
-    message = this.defaultErrorDialogCopy.message,
+    title = defaultErrorDialogCopy.title,
+    message = defaultErrorDialogCopy.formattedMessage,
     continueButtonText = "Continue",
     width = undefined,
   }: {

--- a/src/Apps/Order/Dialogs.tsx
+++ b/src/Apps/Order/Dialogs.tsx
@@ -1,7 +1,7 @@
 import { Button, Text } from "@artsy/palette"
 import { ModalDialog } from "@artsy/palette"
+import { getErrorDialogCopy } from "Apps/Order/Utils/getErrorDialogCopy"
 import * as React from "react"
-import { RouterLink } from "System/Router/RouterLink"
 // TODO: Replace with normal React state
 // eslint-disable-next-line no-restricted-imports
 import { Container, Subscribe } from "unstated"
@@ -116,22 +116,15 @@ export class DialogContainer extends Container<DialogState> {
     })
   }
 
+  defaultErrorDialogCopy = getErrorDialogCopy()
+
   /**
    * returns a promise that resolves to `true` if the user clicked the
    * continue button, and `false` if the modal was dismissed through other means.
    */
   showErrorDialog = ({
-    title = "An error occurred",
-    supportEmail = "orders@artsy.net",
-    message = (
-      <>
-        Something went wrong. Please try again or contact{" "}
-        <RouterLink inline to={`mailto:${supportEmail}}`}>
-          {supportEmail}
-        </RouterLink>
-        .
-      </>
-    ),
+    title = this.defaultErrorDialogCopy.title,
+    message = this.defaultErrorDialogCopy.message,
     continueButtonText = "Continue",
     width = undefined,
   }: {

--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -36,6 +36,7 @@ import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
 import { extractNodes } from "Utils/extractNodes"
 import { useTracking } from "react-tracking"
 import { OrderRouteContainer } from "Apps/Order/Components/OrderRouteContainer"
+
 export interface ReviewProps extends SystemContextProps {
   stripe: Stripe
   elements: StripeElements
@@ -339,6 +340,17 @@ export const ReviewRoute: FC<ReviewProps> = props => {
           const title = "Insufficient funds"
           const message =
             "There aren't enough funds available on the payment methods you provided. Please contact your card provider or try another card."
+
+          trackErrorMessageEvent(title, message, data.decline_code)
+
+          await props.dialog.showErrorDialog({
+            title: title,
+            message: message,
+          })
+        } else if (data.decline_code === "currency_not_supported") {
+          const title = "Payment declined"
+          const message =
+            "This card is not compatible with the currency for this artwork. Please confirm with your card issuer if this currency can be supported, try a different payment method or contact orders@artsy.net."
 
           trackErrorMessageEvent(title, message, data.decline_code)
 

--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -36,6 +36,10 @@ import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
 import { extractNodes } from "Utils/extractNodes"
 import { useTracking } from "react-tracking"
 import { OrderRouteContainer } from "Apps/Order/Components/OrderRouteContainer"
+import {
+  ErrorDialogs,
+  getErrorDialogCopy,
+} from "Apps/Order/Utils/getErrorDialogCopy"
 
 export interface ReviewProps extends SystemContextProps {
   stripe: Stripe
@@ -348,11 +352,11 @@ export const ReviewRoute: FC<ReviewProps> = props => {
             message: message,
           })
         } else if (data.decline_code === "currency_not_supported") {
-          const title = "Payment declined"
-          const message =
-            "This card is not compatible with the currency for this artwork. Please confirm with your card issuer if this currency can be supported, try a different payment method or contact orders@artsy.net."
+          const { title, message, messagePlain } = getErrorDialogCopy(
+            ErrorDialogs.CurrencyNotSupported
+          )
 
-          trackErrorMessageEvent(title, message, data.decline_code)
+          trackErrorMessageEvent(title, messagePlain, data.decline_code)
 
           await props.dialog.showErrorDialog({
             title: title,

--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -352,15 +352,15 @@ export const ReviewRoute: FC<ReviewProps> = props => {
             message: message,
           })
         } else if (data.decline_code === "currency_not_supported") {
-          const { title, message, messagePlain } = getErrorDialogCopy(
+          const { title, message, formattedMessage } = getErrorDialogCopy(
             ErrorDialogs.CurrencyNotSupported
           )
 
-          trackErrorMessageEvent(title, messagePlain, data.decline_code)
+          trackErrorMessageEvent(title, message, data.decline_code)
 
           await props.dialog.showErrorDialog({
             title: title,
-            message: message,
+            message: formattedMessage,
           })
         } else {
           const title = "Charge failed"
@@ -417,9 +417,7 @@ export const ReviewRoute: FC<ReviewProps> = props => {
         break
       }
       default: {
-        const title = "An error occurred"
-        const message =
-          "Something went wrong. Please try again or contact orders@artsy.net"
+        const { title, message } = getErrorDialogCopy()
         const errorCode = error.code || ""
 
         trackErrorMessageEvent(title, message, errorCode)

--- a/src/Apps/Order/Routes/__fixtures__/MutationResults/submitOrder.ts
+++ b/src/Apps/Order/Routes/__fixtures__/MutationResults/submitOrder.ts
@@ -41,6 +41,20 @@ export const submitOrderWithFailureInsufficientFunds = {
   },
 }
 
+export const submitOrderWithFailureCurrencyNotSupported = {
+  commerceSubmitOrder: {
+    orderOrError: {
+      __typename: "CommerceOrderWithMutationFailure",
+      error: {
+        type: "processing",
+        code: "charge_authorization_failed",
+        data:
+          '{"id":null,"failure_code":"card_declined","failure_message":"Your card is not supported for this currency.","decline_code":"currency_not_supported"}',
+      },
+    },
+  },
+}
+
 export const submitOrderWithVersionMismatchFailure = {
   commerceSubmitOrder: {
     orderOrError: {

--- a/src/Apps/Order/Routes/__tests__/Review.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Review.jest.tsx
@@ -44,6 +44,10 @@ import {
   submitOrderWithFailureCurrencyNotSupported,
 } from "Apps/Order/Routes/__fixtures__/MutationResults/submitOrder"
 import { CommercePaymentMethodEnum } from "__generated__/Payment_order.graphql"
+import {
+  ErrorDialogs,
+  getErrorDialogCopy,
+} from "Apps/Order/Utils/getErrorDialogCopy"
 
 jest.unmock("react-relay")
 
@@ -282,10 +286,14 @@ describe("Review", () => {
       const page = new ReviewTestPage(wrapper)
       await page.clickSubmit()
 
+      const {
+        title: expectedTitle,
+        message: expectedMessage,
+      } = getErrorDialogCopy(ErrorDialogs.CurrencyNotSupported)
+
       expect(mockShowErrorDialog).toHaveBeenCalledWith({
-        title: "Payment declined",
-        message:
-          "This card is not compatible with the currency for this artwork. Please confirm with your card issuer if this currency can be supported, try a different payment method or contact orders@artsy.net.",
+        title: expectedTitle,
+        message: expectedMessage,
       })
     })
 

--- a/src/Apps/Order/Routes/__tests__/Review.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Review.jest.tsx
@@ -288,12 +288,12 @@ describe("Review", () => {
 
       const {
         title: expectedTitle,
-        message: expectedMessage,
+        formattedMessage: expectedFormattedMessage,
       } = getErrorDialogCopy(ErrorDialogs.CurrencyNotSupported)
 
       expect(mockShowErrorDialog).toHaveBeenCalledWith({
         title: expectedTitle,
-        message: expectedMessage,
+        message: expectedFormattedMessage,
       })
     })
 

--- a/src/Apps/Order/Routes/__tests__/Review.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Review.jest.tsx
@@ -41,6 +41,7 @@ import {
   submitOrderWithFailureInsufficientFunds,
   submitOrderWithNoInventoryFailure,
   submitOrderWithActionRequired,
+  submitOrderWithFailureCurrencyNotSupported,
 } from "Apps/Order/Routes/__fixtures__/MutationResults/submitOrder"
 import { CommercePaymentMethodEnum } from "__generated__/Payment_order.graphql"
 
@@ -268,6 +269,23 @@ describe("Review", () => {
         title: "Insufficient funds",
         message:
           "There aren't enough funds available on the payment methods you provided. Please contact your card provider or try another card.",
+      })
+    })
+
+    it("shows a modal with a helpful error message if the user's card is declined due to currency not supported", async () => {
+      mockCommitMutation.mockResolvedValue(
+        submitOrderWithFailureCurrencyNotSupported
+      )
+      const wrapper = getWrapper({
+        CommerceOrder: () => testOrder,
+      })
+      const page = new ReviewTestPage(wrapper)
+      await page.clickSubmit()
+
+      expect(mockShowErrorDialog).toHaveBeenCalledWith({
+        title: "Payment declined",
+        message:
+          "This card is not compatible with the currency for this artwork. Please confirm with your card issuer if this currency can be supported, try a different payment method or contact orders@artsy.net.",
       })
     })
 

--- a/src/Apps/Order/Utils/__tests__/getErrorDialogCopy.jest.tsx
+++ b/src/Apps/Order/Utils/__tests__/getErrorDialogCopy.jest.tsx
@@ -1,25 +1,26 @@
 import { render, screen } from "@testing-library/react"
 import {
   ErrorDialogs,
+  formatErrorDialogMessage,
   getErrorDialogCopy,
 } from "Apps/Order/Utils/getErrorDialogCopy"
 
 describe("getErrorDialogCopy", () => {
   describe("dialog is CurrencyNotSupported", () => {
     it("returns the expected title and message", () => {
-      const { title, message, messagePlain } = getErrorDialogCopy(
+      const { title, message, formattedMessage } = getErrorDialogCopy(
         ErrorDialogs.CurrencyNotSupported
       )
 
       expect(title).toBe("Payment declined")
-      expect(messagePlain).toBe(
+      expect(message).toBe(
         "This card is not compatible with the currency for this artwork. Please confirm with your card issuer if this currency can be supported, try a different payment method or contact orders@artsy.net."
       )
 
-      render(<>{message}</>)
+      render(<>{formattedMessage}</>)
 
       expect(screen.queryByTestId("formatted-message")).toHaveTextContent(
-        "This card is not compatible with the currency for this artwork. Please confirm with your card issuer if this currency can be supported, try a different payment method or contact"
+        "This card is not compatible with the currency for this artwork. Please confirm with your card issuer if this currency can be supported, try a different payment method or contact orders@artsy.net."
       )
       expect(screen.queryByTestId("support-email-link")).toHaveAttribute(
         "href",
@@ -30,21 +31,93 @@ describe("getErrorDialogCopy", () => {
 
   describe("dialog is not provided", () => {
     it("returns the default title and message", () => {
-      const { title, message, messagePlain } = getErrorDialogCopy()
+      const { title, message, formattedMessage } = getErrorDialogCopy()
 
       expect(title).toBe("An error occurred")
-      expect(messagePlain).toBe(
+      expect(message).toBe(
         "Something went wrong. Please try again or contact orders@artsy.net."
       )
 
-      render(<>{message}</>)
+      render(<>{formattedMessage}</>)
 
       expect(screen.queryByTestId("formatted-message")).toHaveTextContent(
-        "Something went wrong. Please try again or contact"
+        "Something went wrong. Please try again or contact orders@artsy.net."
       )
       expect(screen.queryByTestId("support-email-link")).toHaveAttribute(
         "href",
         "mailto:orders@artsy.net"
+      )
+    })
+  })
+})
+
+describe("formatErrorDialogMessage", () => {
+  describe("message contains one support email address", () => {
+    it("replaces it with a mailto link", () => {
+      const message = "Foo orders@artsy.net."
+
+      render(<>{formatErrorDialogMessage(message)}</>)
+
+      expect(screen.queryByTestId("support-email-link")).toHaveAttribute(
+        "href",
+        "mailto:orders@artsy.net"
+      )
+      expect(screen.queryByTestId("formatted-message")).toHaveTextContent(
+        "Foo orders@artsy.net."
+      )
+    })
+  })
+
+  describe("message contains multiple support email addresses", () => {
+    it("replaces every instance with mailto links", () => {
+      const message =
+        "Foo orders@artsy.net bar orders@artsy.net baz orders@artsy.net."
+
+      render(<>{formatErrorDialogMessage(message)}</>)
+
+      expect(screen.queryByTestId("support-email-link-0")).toHaveAttribute(
+        "href",
+        "mailto:orders@artsy.net"
+      )
+      expect(screen.queryByTestId("support-email-link-1")).toHaveAttribute(
+        "href",
+        "mailto:orders@artsy.net"
+      )
+      expect(screen.queryByTestId("support-email-link-2")).toHaveAttribute(
+        "href",
+        "mailto:orders@artsy.net"
+      )
+      expect(screen.queryByTestId("formatted-message")).toHaveTextContent(
+        "Foo orders@artsy.net bar orders@artsy.net baz orders@artsy.net."
+      )
+    })
+  })
+
+  describe("message only contains a support email address", () => {
+    it("replaces it with a mailto link", () => {
+      const message = "orders@artsy.net"
+
+      render(<>{formatErrorDialogMessage(message)}</>)
+
+      expect(screen.queryByTestId("support-email-link")).toHaveAttribute(
+        "href",
+        "mailto:orders@artsy.net"
+      )
+      expect(screen.queryByTestId("formatted-message")).toHaveTextContent(
+        "orders@artsy.net"
+      )
+    })
+  })
+
+  describe("message does not contains a support email address", () => {
+    it("returns the message", () => {
+      const message = "Foo bar baz."
+
+      render(<>{formatErrorDialogMessage(message)}</>)
+
+      expect(screen.queryByTestId("support-email-link")).not.toBeInTheDocument()
+      expect(screen.queryByTestId("formatted-message")).toHaveTextContent(
+        "Foo bar baz."
       )
     })
   })

--- a/src/Apps/Order/Utils/__tests__/getErrorDialogCopy.jest.tsx
+++ b/src/Apps/Order/Utils/__tests__/getErrorDialogCopy.jest.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from "@testing-library/react"
 import {
   ErrorDialogs,
-  formatErrorDialogMessage,
+  ErrorDialogMessage,
   getErrorDialogCopy,
 } from "Apps/Order/Utils/getErrorDialogCopy"
 
@@ -51,12 +51,12 @@ describe("getErrorDialogCopy", () => {
   })
 })
 
-describe("formatErrorDialogMessage", () => {
+describe("ErrorDialogMessage", () => {
   describe("message contains one support email address", () => {
     it("replaces it with a mailto link", () => {
       const message = "Foo orders@artsy.net."
 
-      render(<>{formatErrorDialogMessage(message)}</>)
+      render(<ErrorDialogMessage message={message} />)
 
       expect(screen.queryByTestId("support-email-link")).toHaveAttribute(
         "href",
@@ -73,7 +73,7 @@ describe("formatErrorDialogMessage", () => {
       const message =
         "Foo orders@artsy.net bar orders@artsy.net baz orders@artsy.net."
 
-      render(<>{formatErrorDialogMessage(message)}</>)
+      render(<ErrorDialogMessage message={message} />)
 
       expect(screen.queryByTestId("support-email-link-0")).toHaveAttribute(
         "href",
@@ -97,7 +97,7 @@ describe("formatErrorDialogMessage", () => {
     it("replaces it with a mailto link", () => {
       const message = "orders@artsy.net"
 
-      render(<>{formatErrorDialogMessage(message)}</>)
+      render(<ErrorDialogMessage message={message} />)
 
       expect(screen.queryByTestId("support-email-link")).toHaveAttribute(
         "href",
@@ -113,7 +113,7 @@ describe("formatErrorDialogMessage", () => {
     it("returns the message", () => {
       const message = "Foo bar baz."
 
-      render(<>{formatErrorDialogMessage(message)}</>)
+      render(<ErrorDialogMessage message={message} />)
 
       expect(screen.queryByTestId("support-email-link")).not.toBeInTheDocument()
       expect(screen.queryByTestId("formatted-message")).toHaveTextContent(

--- a/src/Apps/Order/Utils/__tests__/getErrorDialogCopy.jest.tsx
+++ b/src/Apps/Order/Utils/__tests__/getErrorDialogCopy.jest.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react"
+import {
+  ErrorDialogs,
+  getErrorDialogCopy,
+} from "Apps/Order/Utils/getErrorDialogCopy"
+
+describe("getErrorDialogCopy", () => {
+  describe("dialog is CurrencyNotSupported", () => {
+    it("returns the expected title and message", () => {
+      const { title, message, messagePlain } = getErrorDialogCopy(
+        ErrorDialogs.CurrencyNotSupported
+      )
+
+      expect(title).toBe("Payment declined")
+      expect(messagePlain).toBe(
+        "This card is not compatible with the currency for this artwork. Please confirm with your card issuer if this currency can be supported, try a different payment method or contact orders@artsy.net."
+      )
+
+      render(<>{message}</>)
+
+      expect(screen.queryByTestId("formatted-message")).toHaveTextContent(
+        "This card is not compatible with the currency for this artwork. Please confirm with your card issuer if this currency can be supported, try a different payment method or contact"
+      )
+      expect(screen.queryByTestId("support-email-link")).toHaveAttribute(
+        "href",
+        "mailto:orders@artsy.net"
+      )
+    })
+  })
+
+  describe("dialog is not provided", () => {
+    it("returns the default title and message", () => {
+      const { title, message, messagePlain } = getErrorDialogCopy()
+
+      expect(title).toBe("An error occurred")
+      expect(messagePlain).toBe(
+        "Something went wrong. Please try again or contact orders@artsy.net."
+      )
+
+      render(<>{message}</>)
+
+      expect(screen.queryByTestId("formatted-message")).toHaveTextContent(
+        "Something went wrong. Please try again or contact"
+      )
+      expect(screen.queryByTestId("support-email-link")).toHaveAttribute(
+        "href",
+        "mailto:orders@artsy.net"
+      )
+    })
+  })
+})

--- a/src/Apps/Order/Utils/getErrorDialogCopy.tsx
+++ b/src/Apps/Order/Utils/getErrorDialogCopy.tsx
@@ -1,57 +1,80 @@
 import { RouterLink } from "System/Router/RouterLink"
 import React from "react"
 
+const SUPPORT_EMAIL = "orders@artsy.net"
+
 export enum ErrorDialogs {
   CurrencyNotSupported = "currency_not_supported",
 }
 
-export const getErrorDialogCopy = (
-  dialog?: ErrorDialogs
-): {
+interface ErrorDialogCopy {
   title: string
-  message: React.ReactNode
-  messagePlain: string
-} => {
-  const supportEmail = "orders@artsy.net"
+  message: string
+  formattedMessage: React.ReactNode
+}
 
+export const getErrorDialogCopy = (dialog?: ErrorDialogs): ErrorDialogCopy => {
   switch (dialog) {
     case ErrorDialogs.CurrencyNotSupported:
-      return {
-        title: "Payment declined",
-        message: (
-          <div data-testid="formatted-message">
-            This card is not compatible with the currency for this artwork.
-            Please confirm with your card issuer if this currency can be
-            supported, try a different payment method or contact{" "}
-            <RouterLink
-              data-testid="support-email-link"
-              inline
-              to={`mailto:${supportEmail}`}
-            >
-              {supportEmail}
-            </RouterLink>
-            .
-          </div>
-        ),
-        messagePlain: `This card is not compatible with the currency for this artwork. Please confirm with your card issuer if this currency can be supported, try a different payment method or contact ${supportEmail}.`,
-      }
+      return currencyNotSupportedErrorDialogCopy()
     default:
-      return {
-        title: "An error occurred",
-        message: (
-          <div data-testid="formatted-message">
-            Something went wrong. Please try again or contact{" "}
-            <RouterLink
-              data-testid="support-email-link"
-              inline
-              to={`mailto:${supportEmail}`}
-            >
-              {supportEmail}
-            </RouterLink>
-            .
-          </div>
-        ),
-        messagePlain: `Something went wrong. Please try again or contact ${supportEmail}.`,
-      }
+      return defaultErrorDialogCopy()
   }
+}
+
+const currencyNotSupportedErrorDialogCopy = () => {
+  const title = "Payment declined"
+  const message = `This card is not compatible with the currency for this artwork. Please confirm with your card issuer if this currency can be supported, try a different payment method or contact ${SUPPORT_EMAIL}.`
+
+  return errorDialogCopy(title, message)
+}
+
+const defaultErrorDialogCopy = () => {
+  const title = "An error occurred"
+  const message = `Something went wrong. Please try again or contact ${SUPPORT_EMAIL}.`
+
+  return errorDialogCopy(title, message)
+}
+
+const errorDialogCopy = (title: string, message: string): ErrorDialogCopy => {
+  return {
+    title,
+    message,
+    formattedMessage: formatErrorDialogMessage(message),
+  }
+}
+
+export const formatErrorDialogMessage = (message: string) => {
+  return (
+    <div data-testid="formatted-message">
+      {replaceSupportEmailWithMailtoLinks(message)}
+    </div>
+  )
+}
+
+const replaceSupportEmailWithMailtoLinks = (message: string) => {
+  const substrings = message.split(SUPPORT_EMAIL)
+
+  return substrings.map((substring, index) => {
+    // prevents a mailto link being added after the last substring
+    const isLastSubstring = index === substrings.length - 1
+
+    // prevents an index being added to the link if there is only one instance
+    const testidSuffix = substrings.length > 2 ? `-${index}` : ""
+
+    return (
+      <>
+        {substring}
+        {!isLastSubstring && (
+          <RouterLink
+            data-testid={`support-email-link${testidSuffix}`}
+            inline
+            to={`mailto:${SUPPORT_EMAIL}`}
+          >
+            {SUPPORT_EMAIL}
+          </RouterLink>
+        )}
+      </>
+    )
+  })
 }

--- a/src/Apps/Order/Utils/getErrorDialogCopy.tsx
+++ b/src/Apps/Order/Utils/getErrorDialogCopy.tsx
@@ -40,22 +40,20 @@ const errorDialogCopy = (title: string, message: string): ErrorDialogCopy => {
   return {
     title,
     message,
-    formattedMessage: formatErrorDialogMessage(message),
+    formattedMessage: <ErrorDialogMessage message={message} />,
   }
 }
 
-export const formatErrorDialogMessage = (message: string) => {
-  return (
-    <div data-testid="formatted-message">
-      {replaceSupportEmailWithMailtoLinks(message)}
-    </div>
-  )
+interface ErrorDialogMessageProps {
+  message: string
 }
 
-const replaceSupportEmailWithMailtoLinks = (message: string) => {
+export const ErrorDialogMessage = (props: ErrorDialogMessageProps) => {
+  const { message } = props
   const substrings = message.split(SUPPORT_EMAIL)
 
-  return substrings.map((substring, index) => {
+  // replaces all support emails with mailto links
+  const formattedMessage = substrings.map((substring, index) => {
     // prevents a mailto link being added after the last substring
     const isLastSubstring = index === substrings.length - 1
 
@@ -77,4 +75,6 @@ const replaceSupportEmailWithMailtoLinks = (message: string) => {
       </>
     )
   })
+
+  return <div data-testid="formatted-message">{formattedMessage}</div>
 }

--- a/src/Apps/Order/Utils/getErrorDialogCopy.tsx
+++ b/src/Apps/Order/Utils/getErrorDialogCopy.tsx
@@ -1,0 +1,57 @@
+import { RouterLink } from "System/Router/RouterLink"
+import React from "react"
+
+export enum ErrorDialogs {
+  CurrencyNotSupported = "currency_not_supported",
+}
+
+export const getErrorDialogCopy = (
+  dialog?: ErrorDialogs
+): {
+  title: string
+  message: React.ReactNode
+  messagePlain: string
+} => {
+  const supportEmail = "orders@artsy.net"
+
+  switch (dialog) {
+    case ErrorDialogs.CurrencyNotSupported:
+      return {
+        title: "Payment declined",
+        message: (
+          <div data-testid="formatted-message">
+            This card is not compatible with the currency for this artwork.
+            Please confirm with your card issuer if this currency can be
+            supported, try a different payment method or contact{" "}
+            <RouterLink
+              data-testid="support-email-link"
+              inline
+              to={`mailto:${supportEmail}`}
+            >
+              {supportEmail}
+            </RouterLink>
+            .
+          </div>
+        ),
+        messagePlain: `This card is not compatible with the currency for this artwork. Please confirm with your card issuer if this currency can be supported, try a different payment method or contact ${supportEmail}.`,
+      }
+    default:
+      return {
+        title: "An error occurred",
+        message: (
+          <div data-testid="formatted-message">
+            Something went wrong. Please try again or contact{" "}
+            <RouterLink
+              data-testid="support-email-link"
+              inline
+              to={`mailto:${supportEmail}`}
+            >
+              {supportEmail}
+            </RouterLink>
+            .
+          </div>
+        ),
+        messagePlain: `Something went wrong. Please try again or contact ${supportEmail}.`,
+      }
+  }
+}


### PR DESCRIPTION
The type of this PR is: feat

This PR solves [EMI-1328] by adding a special error handler for `currency_not_supported` decline codes when a hold fails on order submission so that we can show a better error message. Previously we were showing users the following error message in this scenario:

> **Charge failed** Payment has been declined. Please contact your card provider or bank institution, then press “Submit” again. Alternatively, use another payment method.

Now we will show:

> **Payment declined** This card is not compatible with the currency for this artwork. Please confirm with your card issuer if this currency can be supported, try a different payment method or contact [orders@artsy.net](mailto:orders@artsy.net).

---

This PR also adds a new utility method `getErrorDialogCopy` that can be used in the many places where custom error dialogs are displayed throughout the orders app. The goal of this method is to:

1. Centralize the copy for the various error dialogs so that they can be extracted from components
2. Reduce duplication between the copy that is shown to users and the copy that is tracked in events
3. Allow error dialogs to link users to mailto:orders@artsy.net

[EMI-1328]: https://artsyproduct.atlassian.net/browse/EMI-1328?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ