### PR TITLE
fix(dia-103): ensures top context bar only links to internal routes

### DIFF
--- a/src/Apps/Consign/Routes/ConsignmentInquiry/ConsignmentInquiry.tsx
+++ b/src/Apps/Consign/Routes/ConsignmentInquiry/ConsignmentInquiry.tsx
@@ -203,7 +203,6 @@ export const ConsignmentInquiry: React.FC<ConsignmentInquiryProps> = ({
               onClick={() => {
                 handleBack(dirty)
               }}
-              redirectTo="/sell"
             >
               Back
             </TopContextBar>

--- a/src/Apps/Consign/Routes/ConsignmentInquiry/__tests__/ConsignmentInquiry.jest.tsx
+++ b/src/Apps/Consign/Routes/ConsignmentInquiry/__tests__/ConsignmentInquiry.jest.tsx
@@ -90,7 +90,7 @@ describe("ConsignmentInquiry", () => {
     expect(screen.getByText("Contact a specialist")).toBeInTheDocument()
 
     expect(
-      screen.getAllByRole("link").find(c => c.textContent?.includes("Back"))
+      screen.getAllByRole("button").find(c => c.textContent?.includes("Back"))
     ).toBeInTheDocument()
 
     expect(getSubmitButton()).toBeInTheDocument()

--- a/src/Apps/Consign/Routes/SubmissionFlow/ContactInformation/ContactInformation.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ContactInformation/ContactInformation.tsx
@@ -208,15 +208,16 @@ export const ContactInformation: React.FC<ContactInformationProps> = ({
   return (
     <>
       {isFirstStep && !artworkId ? (
+        // FIXME: Inappropriate component for this; don't replicate browser back button
         <TopContextBar
           displayBackArrow
           hideSeparator
           onClick={() => router.go(-1)}
-          redirectTo="/sell"
         >
           Back
         </TopContextBar>
       ) : (
+        // FIXME: Should not have a generic "Back" label that links to a specific location
         <TopContextBar displayBackArrow hideSeparator href={backTo}>
           Back
         </TopContextBar>

--- a/src/Components/TopContextBar.tsx
+++ b/src/Components/TopContextBar.tsx
@@ -1,5 +1,13 @@
 import * as React from "react"
-import { Box, Flex, FullBleed, Separator, Text, Image } from "@artsy/palette"
+import {
+  Box,
+  Flex,
+  FullBleed,
+  Separator,
+  Text,
+  Image,
+  Clickable,
+} from "@artsy/palette"
 import { RouterLink } from "System/Router/RouterLink"
 import { cropped } from "Utils/resized"
 import ChevronLeftIcon from "@artsy/icons/ChevronLeftIcon"
@@ -7,7 +15,6 @@ import ChevronLeftIcon from "@artsy/icons/ChevronLeftIcon"
 export interface TopContextBarProps {
   displayBackArrow?: boolean
   href?: string | null
-  redirectTo?: string | undefined
   /** Should the biggest size image available */
   src?: string | null
   rightContent?: React.ReactNode
@@ -19,7 +26,6 @@ export const TopContextBar: React.FC<TopContextBarProps> = ({
   children,
   displayBackArrow = false,
   href,
-  redirectTo,
   src,
   rightContent,
   onClick,
@@ -39,14 +45,14 @@ export const TopContextBar: React.FC<TopContextBarProps> = ({
               textDecoration: "none",
               onClick,
             }
-          : {})}
-        {...(redirectTo
-          ? {
-              as: RouterLink,
-              textDecoration: "none",
-              onClick,
-            }
-          : {})}
+          : {
+              ...(onClick
+                ? {
+                    as: Clickable,
+                    onClick,
+                  }
+                : {}),
+            })}
       >
         <Flex flex={1} flexDirection="row" alignItems="center">
           {displayBackArrow && (

--- a/src/Components/TopContextBar.tsx
+++ b/src/Components/TopContextBar.tsx
@@ -11,6 +11,7 @@ import {
 import { RouterLink } from "System/Router/RouterLink"
 import { cropped } from "Utils/resized"
 import ChevronLeftIcon from "@artsy/icons/ChevronLeftIcon"
+import { sanitizeURL } from "Utils/sanitizeURL"
 
 export interface TopContextBarProps {
   displayBackArrow?: boolean
@@ -25,13 +26,14 @@ export interface TopContextBarProps {
 export const TopContextBar: React.FC<TopContextBarProps> = ({
   children,
   displayBackArrow = false,
-  href,
+  href: _href,
   src,
   rightContent,
   onClick,
   hideSeparator = false,
 }) => {
   const image = src ? cropped(src, { width: 60, height: 60 }) : null
+  const href = _href ? sanitizeURL(_href, { enforceInternal: true }) : null
 
   return (
     <>

--- a/src/Utils/__tests__/sanitizeURL.jest.ts
+++ b/src/Utils/__tests__/sanitizeURL.jest.ts
@@ -34,4 +34,10 @@ describe("sanitizeURL", () => {
   it("lets through relative urls without a leading slash", () => {
     expect(sanitizeURL("foo/bar")).toEqual("foo/bar")
   })
+
+  it("optionally enforces internal urls", () => {
+    expect(
+      sanitizeURL("http://example.com", { enforceInternal: true })
+    ).toEqual("/")
+  })
 })

--- a/src/Utils/sanitizeURL.ts
+++ b/src/Utils/sanitizeURL.ts
@@ -1,4 +1,7 @@
-export const sanitizeURL = (path: string) => {
+export const sanitizeURL = (
+  path: string,
+  options = { enforceInternal: false }
+) => {
   if (!path || typeof path !== "string") return ""
 
   const _path = path.toLowerCase()
@@ -8,6 +11,13 @@ export const sanitizeURL = (path: string) => {
     _path.includes("data:") ||
     _path.includes("script%3a") ||
     _path.includes("data%3a")
+  ) {
+    return "/"
+  }
+
+  if (
+    options.enforceInternal &&
+    (_path.startsWith("http://") || _path.startsWith("https://"))
   ) {
     return "/"
   }


### PR DESCRIPTION
Closes [DIA-103](https://artsyproduct.atlassian.net/browse/DIA-103)

This is just a minor clean up related to the ticket wherein one could alter the query string to execute a script on click. This also now prevents someone from linking to an external site.

In the process I noticed some code that didn't actually work and uncovered some bugs in the consignment flow.

[DIA-103]: https://artsyproduct.atlassian.net/browse/DIA-103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ