### PR TITLE
feat: report destination_could_not_be_geocoded error (EMI-1332)

### DIFF
--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -95,6 +95,10 @@ import {
   AddressVerifiedBy,
 } from "Apps/Order/Components/AddressVerificationFlow"
 import { Analytics } from "System/Analytics/AnalyticsContext"
+import {
+  ErrorDialogs,
+  getErrorDialogCopy,
+} from "Apps/Order/Utils/getErrorDialogCopy"
 
 const logger = createLogger("Order/Routes/Shipping/index.tsx")
 
@@ -528,6 +532,25 @@ export const ShippingRoute: FC<ShippingProps> = props => {
       props.dialog.showErrorDialog({
         title: "Can't ship to that address",
         message: "This work can only be shipped domestically.",
+      })
+    } else if (error.code === "destination_could_not_be_geocoded") {
+      const { title, message, formattedMessage } = getErrorDialogCopy(
+        ErrorDialogs.DestinationCouldNotBeGeocoded
+      )
+
+      trackEvent({
+        action: ActionType.errorMessageViewed,
+        context_owner_type: OwnerType.ordersShipping,
+        context_owner_id: props.order.internalID,
+        title,
+        message,
+        error_code: error.code,
+        flow: "user submits a shipping option",
+      })
+
+      props.dialog.showErrorDialog({
+        title,
+        message: formattedMessage,
       })
     } else if (checkIfArtsyShipping() && shippingQuoteId) {
       trackEvent({

--- a/src/Apps/Order/Routes/__fixtures__/MutationResults/setOrderShipping.ts
+++ b/src/Apps/Order/Routes/__fixtures__/MutationResults/setOrderShipping.ts
@@ -49,6 +49,19 @@ export const settingOrderShipmentSuccess = {
   },
 }
 
+export const settingOrderArtaShipmentDestinationCouldNotBeGeocodedFailure = {
+  commerceSetShipping: {
+    orderOrError: {
+      error: {
+        type: "arta",
+        code: "destination_could_not_be_geocoded",
+        data:
+          '{"status":422,"errors":{"destination":["could not be geocoded"]}}',
+      },
+    },
+  },
+}
+
 export const settingOrderArtaShipmentSuccess = {
   commerceSetShipping: {
     orderOrError: {

--- a/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -38,8 +38,13 @@ import {
   settingOrderShipmentMissingRegionFailure,
   settingOrderArtaShipmentSuccess,
   selectShippingQuoteSuccess,
+  settingOrderArtaShipmentDestinationCouldNotBeGeocodedFailure,
 } from "Apps/Order/Routes/__fixtures__/MutationResults/setOrderShipping"
 import { useFeatureFlag } from "System/useFeatureFlag"
+import {
+  ErrorDialogs,
+  getErrorDialogCopy,
+} from "Apps/Order/Utils/getErrorDialogCopy"
 
 jest.unmock("react-relay")
 jest.mock("react-tracking")
@@ -538,6 +543,30 @@ describe("Shipping", () => {
           title: "Invalid address",
           message:
             "There was an error processing your address. Please review and try again.",
+        })
+      })
+
+      it("shows a validation error modal when there is a destination_could_not_be_geocoded error from the server", async () => {
+        mockCommitMutation.mockResolvedValueOnce(
+          settingOrderArtaShipmentDestinationCouldNotBeGeocodedFailure
+        )
+        const wrapper = getWrapper({
+          CommerceOrder: () => testOrder,
+          Me: () => emptyTestMe,
+        })
+        const page = new ShippingTestPage(wrapper)
+
+        fillAddressForm(page.root, validAddress)
+        await page.clickSubmit()
+
+        const {
+          title: expectedTitle,
+          formattedMessage: expectedMessage,
+        } = getErrorDialogCopy(ErrorDialogs.DestinationCouldNotBeGeocoded)
+
+        expect(mockShowErrorDialog).toHaveBeenCalledWith({
+          title: expectedTitle,
+          message: expectedMessage,
         })
       })
     })

--- a/src/Apps/Order/Utils/getErrorDialogCopy.tsx
+++ b/src/Apps/Order/Utils/getErrorDialogCopy.tsx
@@ -4,6 +4,7 @@ import React from "react"
 const SUPPORT_EMAIL = "orders@artsy.net"
 
 export enum ErrorDialogs {
+  DestinationCouldNotBeGeocoded = "destination_could_not_be_geocoded",
   CurrencyNotSupported = "currency_not_supported",
 }
 
@@ -15,11 +16,20 @@ interface ErrorDialogCopy {
 
 export const getErrorDialogCopy = (dialog?: ErrorDialogs): ErrorDialogCopy => {
   switch (dialog) {
+    case ErrorDialogs.DestinationCouldNotBeGeocoded:
+      return destinationCouldNotBeGeocodedErrorDialogCopy()
     case ErrorDialogs.CurrencyNotSupported:
       return currencyNotSupportedErrorDialogCopy()
     default:
       return defaultErrorDialogCopy()
   }
+}
+
+const destinationCouldNotBeGeocodedErrorDialogCopy = () => {
+  const title = "Cannot calculate shipping"
+  const message = `Please confirm that your address details are correct and try again. If the issue continues contact ${SUPPORT_EMAIL}.`
+
+  return errorDialogCopy(title, message)
 }
 
 const currencyNotSupportedErrorDialogCopy = () => {


### PR DESCRIPTION
The type of this PR is: Feat
This PR solves [EMI-1332]

This PR is a follow-up to artsy/exchange#1763 that displays an error message for the error that is newly being returned from Exchange when a user submits a non-existing shipping address.

It also makes use of the new `getErrorDialogCopy` function created in #12803 to house the new copy. That function is still being tested out as I work on checkout dead-ends so any feedback on it is appreciated.

[EMI-1332]: https://artsyproduct.atlassian.net/browse/EMI-1332?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ