### PR TITLE
fix(ONYX-274): update copy for title and sugested artworks modal

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/ArtworkAuctionCreateAlertHeader.tsx
+++ b/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/ArtworkAuctionCreateAlertHeader.tsx
@@ -129,7 +129,7 @@ const ArtworkAuctionCreateAlertHeader: FC<ArtworkAuctionCreateAlertHeaderProps> 
             textAlign={["left", "center"]}
             textColor={["black60", "black100"]}
           >
-            Get notified when similar works become available.
+            Create an alert to get notified when similar works become available.
           </Text>
         </Column>
         <Column span={12}>

--- a/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/SuggestedArtworksModal.tsx
+++ b/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/SuggestedArtworksModal.tsx
@@ -1,8 +1,7 @@
-import { Join, ModalDialog, Separator, Spacer } from "@artsy/palette"
+import { Join, ModalDialog, Spacer } from "@artsy/palette"
 import { FC } from "react"
 import { SuggestedArtworksModalHeader } from "Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/SuggestedArtworksModalHeader"
 import { SuggestedArtworksModalGridQueryRenderer } from "Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/SuggestedArtworksModalGrid"
-import { useTranslation } from "react-i18next"
 import { useSavedSearchAlertContext } from "Components/SavedSearchAlert/SavedSearchAlertContext"
 
 interface SuggestedArtworksModalProps {
@@ -12,20 +11,17 @@ interface SuggestedArtworksModalProps {
 export const SuggestedArtworksModal: FC<SuggestedArtworksModalProps> = ({
   onClose,
 }) => {
-  const { t } = useTranslation()
-  const { criteria } = useSavedSearchAlertContext()
+  const { criteria, entity } = useSavedSearchAlertContext()
+  const artistName = entity.defaultCriteria?.artistIDs?.[0].displayValue ?? ""
 
   return (
     <ModalDialog
       width={["100%", 700]}
       onClose={onClose}
-      title={t(
-        "artworkPage.artworkAuctionCreateAlertHeader.suggestedArtworksModal.title"
-      )}
+      title={"Works by " + artistName}
     >
       <Join separator={<Spacer y={2} />}>
         <SuggestedArtworksModalHeader />
-        <Separator />
         <SuggestedArtworksModalGridQueryRenderer
           {...criteria}
           onClose={onClose}

--- a/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/SuggestedArtworksModalHeader.tsx
+++ b/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/SuggestedArtworksModalHeader.tsx
@@ -1,4 +1,4 @@
-import { Flex, Pill } from "@artsy/palette"
+import { Flex, Pill, Text } from "@artsy/palette"
 import { useSavedSearchAlertContext } from "Components/SavedSearchAlert/SavedSearchAlertContext"
 import { FC } from "react"
 
@@ -6,21 +6,28 @@ export const SuggestedArtworksModalHeader: FC = () => {
   const { pills } = useSavedSearchAlertContext()
 
   return (
-    <Flex flexDirection="column">
-      <Flex flexWrap="wrap" gap={1}>
-        {pills.map(pill => {
-          return (
-            <Pill
-              key={`filter-label-${pill.field}-${pill.value}`}
-              variant="filter"
-              mb={1}
-              disabled
-            >
-              {pill.displayValue}
-            </Pill>
-          )
-        })}
+    <>
+      <Flex flexDirection="column">
+        <Text variant="sm-display" textColor="black60" mb={2}>
+          Available works you may have missed based on similar filters listed
+          below.
+        </Text>
+
+        <Flex flexWrap="wrap" gap={1}>
+          {pills.map(pill => {
+            return (
+              <Pill
+                key={`filter-label-${pill.field}-${pill.value}`}
+                variant="filter"
+                mb={1}
+                disabled
+              >
+                {pill.displayValue}
+              </Pill>
+            )
+          })}
+        </Flex>
       </Flex>
-    </Flex>
+    </>
   )
 }

--- a/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/SuggestedArtworksModalHeader.tsx
+++ b/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/SuggestedArtworksModalHeader.tsx
@@ -6,28 +6,26 @@ export const SuggestedArtworksModalHeader: FC = () => {
   const { pills } = useSavedSearchAlertContext()
 
   return (
-    <>
-      <Flex flexDirection="column">
-        <Text variant="sm-display" textColor="black60" mb={2}>
-          Available works you may have missed based on similar filters listed
-          below.
-        </Text>
+    <Flex flexDirection="column">
+      <Text variant="sm-display" textColor="black60" mb={2}>
+        Available works you may have missed based on similar filters listed
+        below.
+      </Text>
 
-        <Flex flexWrap="wrap" gap={1}>
-          {pills.map(pill => {
-            return (
-              <Pill
-                key={`filter-label-${pill.field}-${pill.value}`}
-                variant="filter"
-                mb={1}
-                disabled
-              >
-                {pill.displayValue}
-              </Pill>
-            )
-          })}
-        </Flex>
+      <Flex flexWrap="wrap" gap={1}>
+        {pills.map(pill => {
+          return (
+            <Pill
+              key={`filter-label-${pill.field}-${pill.value}`}
+              variant="filter"
+              mb={1}
+              disabled
+            >
+              {pill.displayValue}
+            </Pill>
+          )
+        })}
       </Flex>
-    </>
+    </Flex>
   )
 }

--- a/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/__tests__/SuggestedArtworksModal.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/__tests__/SuggestedArtworksModal.jest.tsx
@@ -44,7 +44,12 @@ describe("SuggestedArtworksModal", () => {
   it("renders title and pills", () => {
     renderComponent()
 
-    expect(screen.getByText("Suggested Artworks")).toBeInTheDocument()
+    expect(screen.getByText("Works by Banksy")).toBeInTheDocument()
+    expect(
+      screen.getByText(
+        "Available works you may have missed based on similar filters listed below."
+      )
+    ).toBeInTheDocument()
     expect(screen.getByText("Banksy")).toBeInTheDocument()
     expect(screen.getByText("Prints")).toBeInTheDocument()
     expect(screen.getByText("Unique")).toBeInTheDocument()

--- a/src/System/i18n/locales/en-US/translation.json
+++ b/src/System/i18n/locales/en-US/translation.json
@@ -109,7 +109,7 @@
       "watchingLot": "Watching lot"
     },
     "artworkAuctionCreateAlertHeader": {
-      "suggestedArtworksButton": "Browse Similar Artworks",
+      "suggestedArtworksButton": "Browse Similar Works",
       "seeMoreButton": "See more",
       "suggestedArtworksModal": {
         "title": "Suggested Artworks",


### PR DESCRIPTION
The type of this PR is: FIX

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [ONYX-274](https://artsyproduct.atlassian.net/browse/ONYX-274)

### Description

Update copy and add artistName to the Suggested Artworks modal title.

<img width="825" alt="Screenshot 2023-08-31 at 09 49 22" src="https://github.com/artsy/force/assets/17580625/36aa15ef-1227-4bbc-9525-9b498888dca9">


<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-274]: https://artsyproduct.atlassian.net/browse/ONYX-274?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ