### PR TITLE
fix: Alert edit form scroll bug

### DIFF
--- a/src/Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp.tsx
@@ -27,7 +27,6 @@ import { MetaTags } from "Components/MetaTags"
 import { SavedSearchAlertsEmptyResults } from "./Components/SavedSearchAlertsEmptyResults"
 import { SavedSearchAlertEditFormDesktop } from "./Components/SavedSearchAlertEditFormDesktop"
 import { Sticky } from "Components/Sticky"
-import { useNavBarHeight } from "Components/NavBar/useNavBarHeight"
 import { SavedSearchAlertEditFormMobile } from "./Components/SavedSearchAlertEditFormMobile"
 import { useTracking } from "react-tracking"
 import { ActionType } from "@artsy/cohesion"
@@ -45,7 +44,6 @@ export const SavedSearchAlertsApp: React.FC<SavedSearchAlertsAppProps> = ({
   me,
   relay,
 }) => {
-  const { desktop } = useNavBarHeight()
   const [
     editAlertEntity,
     setEditAlertEntity,
@@ -186,17 +184,12 @@ export const SavedSearchAlertsApp: React.FC<SavedSearchAlertsAppProps> = ({
                     borderLeftColor="black15"
                   >
                     <Sticky bottomBoundary="#content-end">
-                      <Box
-                        overflowY="auto"
-                        maxHeight={`calc(100vh - ${desktop}px)`}
-                      >
-                        <SavedSearchAlertEditFormDesktop
-                          editAlertEntity={editAlertEntity}
-                          onCloseClick={closeEditForm}
-                          onCompleted={handleCompleted}
-                          onDeleteClick={handleDeleteClick}
-                        />
-                      </Box>
+                      <SavedSearchAlertEditFormDesktop
+                        editAlertEntity={editAlertEntity}
+                        onCloseClick={closeEditForm}
+                        onCompleted={handleCompleted}
+                        onDeleteClick={handleDeleteClick}
+                      />
                     </Sticky>
                   </Column>
                 )}


### PR DESCRIPTION
Addresses [ONYX-283]

## Description

This fixes the scroll bug in the Saved Search Alert edit form. There are two nested scroll views. The issue is that the user cannot scroll to the end of the form component when focusing on the form scroll view.

<img width="807" alt="Screenshot 2023-08-31 at 13 40 58" src="https://github.com/artsy/force/assets/4691889/d65c90a7-db64-47a4-945e-142fec707679">


[ONYX-283]: https://artsyproduct.atlassian.net/browse/ONYX-283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ