### PR TITLE
fix: Add padding to Alert list header on mobile

### DIFF
--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertHeader.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertHeader.tsx
@@ -21,6 +21,7 @@ export const SavedSearchAlertHeader: FC<SavedSearchAlertHeaderProps> = ({
       alignItems={["stretch", "center"]}
       justifyContent="space-between"
       mb={4}
+      mx={[2, 0]}
     >
       <Text variant={["md", "lg"]} mb={[4, 0]} mr={[0, 2]}>
         Alerts


### PR DESCRIPTION

## Description

This PR adds missing padding to Alert list header on mobile.

| Before | After |
| --- | --- |
|<img width="479" alt="Screenshot 2023-08-31 at 16 20 39" src="https://github.com/artsy/force/assets/4691889/d46077c7-c72a-44e0-a6b2-228385cf9b24"> | <img width="477" alt="Screenshot 2023-08-31 at 16 20 20" src="https://github.com/artsy/force/assets/4691889/82c7f235-e072-4e6c-a3bf-751ac83988c4">|





Add padding to Alert list header on mobile.