### PR TITLE
fix: remove sale year params

### DIFF
--- a/src/Apps/Artist/Utils/allowedAuctionResultFilters.ts
+++ b/src/Apps/Artist/Utils/allowedAuctionResultFilters.ts
@@ -46,6 +46,4 @@ const SUPPORTED_INPUT_ARGS = [
   "includeEstimateRange",
   "includeUnknownPrices",
   "allowUnspecifiedSaleDates",
-  "saleEndYear",
-  "saleStartYear",
 ]


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->


### Description

I noticed when including `saleEndYear` and `saleStartYear` as url params, that we were sending  to Metaphysics string as parameter from these variables.
This PR remove the argument support

