### PR TITLE
chore(analytics): add contextModule to ShelfArtwork used in closed lot header

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/SuggestedArtworksShelf.tsx
+++ b/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/SuggestedArtworksShelf.tsx
@@ -1,3 +1,4 @@
+import { ContextModule } from "@artsy/cohesion"
 import { Flex, Skeleton } from "@artsy/palette"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { FC } from "react"
@@ -37,6 +38,7 @@ export const SuggestedArtworksShelf: FC<SuggestedArtworksShelfProps> = ({
       {artworks.map(artwork => (
         <ShelfArtworkFragmentContainer
           artwork={artwork}
+          contextModule={ContextModule.artworkClosedLotHeader}
           key={artwork.internalID}
           data-testid="ShelfSuggestedArtworks"
         />


### PR DESCRIPTION

The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

Follow-up to #12817 ([ONYX-278](https://artsyproduct.atlassian.net/browse/ONYX-278))

### Description

<!-- Implementation description -->

Adds a contextModule analytics attribute to the ShelfArtwork component used in the new closed lot create alert header.

cc/ @tam-kis 

<img width="1327" alt="Screenshot 2023-08-31 at 13 49 02" src="https://github.com/artsy/force/assets/123595/cc616b35-ae2d-4816-8933-d1ffa8307336">


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-278]: https://artsyproduct.atlassian.net/browse/ONYX-278?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ