### PR TITLE
fix: Prevent Alert list item name text overflow

### DIFF
--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertListItem.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertListItem.tsx
@@ -61,7 +61,7 @@ export const SavedSearchAlertListItem: React.FC<SavedSearchAlertListItemProps> =
           flexDirection={["column", "row"]}
           alignItems={["stretch", "center"]}
           flex={1}
-          overflow={"hidden"}
+          overflow="hidden"
         >
           <Text
             variant={["md", "lg"]}

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertListItem.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertListItem.tsx
@@ -60,10 +60,13 @@ export const SavedSearchAlertListItem: React.FC<SavedSearchAlertListItemProps> =
           mr={2}
           flexDirection={["column", "row"]}
           alignItems={["stretch", "center"]}
+          flex={1}
+          overflow={"hidden"}
         >
           <Text
             variant={["md", "lg"]}
             color={variant === "active" ? "blue100" : "black100"}
+            style={{ overflowWrap: "break-word" }}
           >
             {isFallbackToGeneratedAlertNamesEnabled
               ? item.displayName


### PR DESCRIPTION
Addresses [ONYX-281]

## Description

Prevent Alert list item name text overflow.

| Before | After |
| --- | --- |
| <img width="396" alt="Screenshot 2023-09-01 at 10 05 55" src="https://github.com/artsy/force/assets/4691889/83d7ea69-5878-4be4-9edc-0f6d1353297c">| <img width="393" alt="Screenshot 2023-09-01 at 10 04 09" src="https://github.com/artsy/force/assets/4691889/6d3fe10f-1a68-4131-84d4-e6715449ad7d">|



[ONYX-281]: https://artsyproduct.atlassian.net/browse/ONYX-281?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ