### PR TITLE
chore: do not render sale end year filter when no options available

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/SaleEndYearFilter.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/SaleEndYearFilter.tsx
@@ -24,6 +24,10 @@ export const SaleEndYearFilter: React.FC = () => {
     value: c?.name,
   }))
 
+  if (options.length === 0) {
+    return null
+  }
+
   const startOptions = options.filter(
     option =>
       parseInt(option.value) <=

--- a/src/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResultsFilterContext.jest.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/__tests__/AuctionResultsFilterContext.jest.tsx
@@ -34,6 +34,10 @@ describe("AuctionResultsFilterContext", () => {
     // Sets year filters to a wide range in case the data is not provided
     expect(context.filters?.["createdAfterYear"]).toEqual(0)
     expect(context.filters?.["createdBeforeYear"]).toEqual(10000)
+    expect(context.filters?.["allowEmptyCreatedDates"]).toEqual(true)
+    expect(context.filters?.["saleEndYear"]).toEqual(null)
+    expect(context.filters?.["saleStartYear"]).toEqual(null)
+    expect(context.aggregations).toEqual([])
   })
 
   describe("behaviors", () => {


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->


### Description
I noticed in the [datadog](https://app.datadoghq.com/apm/services/force/operations/express.request/resources?env=production&graphType=flamegraph&resources=qson%3A%28data%3A%28visible%3A%21t%2Chits%3A%28selected%3Atotal%29%2Cerrors%3A%28selected%3Atotal%29%2Clatency%3A%28selected%3Aavg%29%2CtopN%3Aall%2CselectedResourceID%3A109c96c4c4c2f7%29%2Cversion%3A%210%29&shouldShowLegend=true&sort=time&spanID=8951849862372371502&summary=qson%3A%28data%3A%28visible%3A%21t%2Cerrors%3A%28selected%3Acount%29%2Chits%3A%28selected%3Acount%29%2Clatency%3A%28selected%3Alatency%2Cslot%3A%28agg%3A75%29%2Cdistribution%3A%28isLogScale%3A%21f%29%29%2Csublayer%3A%28slot%3A%28layers%3Aservice%29%2Cselected%3Apercentage%29%29%2Cversion%3A%211%29&timeHint=1693570959744&topGraphs=latency%3Alatency%2Chits%3Aversion_count%2Cerrors%3Acount%2CbreakdownAs%3Apercentage&trace=AgAAAYpQsgmAsQpWJAAAAAAAAAAYAAAAAEFZcFFzaG1iQUFCU25PZzhWQ1E5U1R0OAAAACQAAAAAMDE4YTUwZTItMTQ4Ni00OTg5LWI2YjItYzQxNDFmZjRhMjQx&traceID=8951849862372371502&start=1693569400540&end=1693573000540&paused=true) that from _time to time_ this issue happens because we are not able to fetch options.


<!-- Implementation description -->

@artsy/diamond-devs 
