### PR TITLE
refactor: support passing in a relay env to `renderWithRelay` test helper

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/SingleAuctionResultPage/__tests__/AuctionResult.jest.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/SingleAuctionResultPage/__tests__/AuctionResult.jest.tsx
@@ -28,7 +28,7 @@ describe("AuctionResult", () => {
   describe("Auction result data", () => {
     describe("when it's a past auction", () => {
       it("renders the auction result data", () => {
-        renderWithRelay({ AuctionResult: () => mockAuctionResult }, false)
+        renderWithRelay({ AuctionResult: () => mockAuctionResult })
 
         expect(screen.getByText("Carrie Mae Weems")).toBeInTheDocument()
         expect(
@@ -71,19 +71,16 @@ describe("AuctionResult", () => {
       })
 
       it("renders the auction result data with non-USD currency", () => {
-        renderWithRelay(
-          {
-            AuctionResult: () => ({
-              ...mockAuctionResult,
-              currency: "EUR",
-              priceRealized: {
-                display: "€35,280",
-                displayUSD: "US$35,280",
-              },
-            }),
-          },
-          false
-        )
+        renderWithRelay({
+          AuctionResult: () => ({
+            ...mockAuctionResult,
+            currency: "EUR",
+            priceRealized: {
+              display: "€35,280",
+              displayUSD: "US$35,280",
+            },
+          }),
+        })
 
         expect(screen.getByText("Carrie Mae Weems")).toBeInTheDocument()
         expect(
@@ -99,15 +96,12 @@ describe("AuctionResult", () => {
       })
 
       it("renders the auction result data with no sale price", () => {
-        renderWithRelay(
-          {
-            AuctionResult: () => ({
-              ...mockAuctionResult,
-              priceRealized: null,
-            }),
-          },
-          false
-        )
+        renderWithRelay({
+          AuctionResult: () => ({
+            ...mockAuctionResult,
+            priceRealized: null,
+          }),
+        })
 
         expect(screen.getByText("Carrie Mae Weems")).toBeInTheDocument()
         expect(
@@ -121,16 +115,13 @@ describe("AuctionResult", () => {
       })
 
       it("renders the auction result data when bought in", () => {
-        renderWithRelay(
-          {
-            AuctionResult: () => ({
-              ...mockAuctionResult,
-              priceRealized: null,
-              boughtIn: true,
-            }),
-          },
-          false
-        )
+        renderWithRelay({
+          AuctionResult: () => ({
+            ...mockAuctionResult,
+            priceRealized: null,
+            boughtIn: true,
+          }),
+        })
 
         expect(screen.getByText("Carrie Mae Weems")).toBeInTheDocument()
         expect(
@@ -147,16 +138,13 @@ describe("AuctionResult", () => {
         const lastMonth = new Date().setDate(new Date().getDate() - 1)
         const lastMonthISO = new Date(lastMonth).toISOString()
 
-        renderWithRelay(
-          {
-            AuctionResult: () => ({
-              ...mockAuctionResult,
-              saleDate: lastMonthISO,
-              priceRealized: null,
-            }),
-          },
-          false
-        )
+        renderWithRelay({
+          AuctionResult: () => ({
+            ...mockAuctionResult,
+            saleDate: lastMonthISO,
+            priceRealized: null,
+          }),
+        })
 
         expect(screen.getByText("Carrie Mae Weems")).toBeInTheDocument()
         expect(
@@ -172,10 +160,9 @@ describe("AuctionResult", () => {
 
     describe("when it's an upcoming auction", () => {
       it("renders the auction result data with estimate when available", () => {
-        renderWithRelay(
-          { AuctionResult: () => ({ ...mockAuctionResult, isUpcoming: true }) },
-          false
-        )
+        renderWithRelay({
+          AuctionResult: () => ({ ...mockAuctionResult, isUpcoming: true }),
+        })
 
         expect(screen.getByText("Carrie Mae Weems")).toBeInTheDocument()
         expect(
@@ -216,16 +203,13 @@ describe("AuctionResult", () => {
       })
 
       it("renders the auction result data without estimate when not available", () => {
-        renderWithRelay(
-          {
-            AuctionResult: () => ({
-              ...mockAuctionResult,
-              isUpcoming: true,
-              estimate: null,
-            }),
-          },
-          false
-        )
+        renderWithRelay({
+          AuctionResult: () => ({
+            ...mockAuctionResult,
+            isUpcoming: true,
+            estimate: null,
+          }),
+        })
 
         expect(screen.queryByText("Sale Price")).not.toBeInTheDocument()
 

--- a/src/Apps/Artist/Routes/AuctionResults/__tests__/ArtistAuctionResultItem.jest.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/__tests__/ArtistAuctionResultItem.jest.tsx
@@ -43,7 +43,7 @@ describe("ArtistAuctionResultItem", () => {
   })
 
   it("renders the auction result data", () => {
-    renderWithRelay(mockResolver, false)
+    renderWithRelay(mockResolver)
 
     expect(
       screen.getByText("Neuschwanstein (Feldmann & Schellmann 372), 1987")
@@ -67,7 +67,7 @@ describe("ArtistAuctionResultItem", () => {
       user: { name: "Logged In", email: "loggedin@example.com" },
     }))
 
-    renderWithRelay(mockResolver, false)
+    renderWithRelay(mockResolver)
 
     const auctioResultLink = screen.getByRole("link")
 
@@ -79,7 +79,7 @@ describe("ArtistAuctionResultItem", () => {
 
   describe("when showArtistName is true", () => {
     it("renders artist name with the auction result data", () => {
-      renderWithRelay(mockResolver, false, { showArtistName: true })
+      renderWithRelay(mockResolver, { showArtistName: true })
 
       expect(screen.getAllByText("Andy Warhol").length).toBe(2)
       expect(
@@ -110,10 +110,9 @@ describe("ArtistAuctionResultItem", () => {
       const lastMonth = new Date().setDate(new Date().getDate() - 1)
       const lastMonthISO = new Date(lastMonth).toISOString()
 
-      renderWithRelay(
-        { AuctionResult: () => ({ ...auctionResult, saleDate: lastMonthISO }) },
-        false
-      )
+      renderWithRelay({
+        AuctionResult: () => ({ ...auctionResult, saleDate: lastMonthISO }),
+      })
 
       expect(screen.getAllByText("Awaiting results")).toHaveLength(2)
     })
@@ -122,23 +121,20 @@ describe("ArtistAuctionResultItem", () => {
       const lastMonth = new Date().setDate(new Date().getDate() - 1)
       const lastMonthISO = new Date(lastMonth).toISOString()
 
-      renderWithRelay(
-        {
-          AuctionResult: () => ({
-            ...auctionResult,
-            saleDate: lastMonthISO,
-            boughtIn: true,
-          }),
-        },
-        false
-      )
+      renderWithRelay({
+        AuctionResult: () => ({
+          ...auctionResult,
+          saleDate: lastMonthISO,
+          boughtIn: true,
+        }),
+      })
 
       expect(screen.getAllByText("Bought In")).toHaveLength(2)
       expect(screen.queryByText("Awaiting results")).not.toBeInTheDocument()
     })
 
     it("renders price not available when the auction result is over a month with no price", () => {
-      renderWithRelay(mockResolver, false)
+      renderWithRelay(mockResolver)
 
       expect(screen.getAllByText("Price not available")).toHaveLength(2)
     })

--- a/src/Apps/Artist/Routes/AuctionResults/__tests__/ArtistAuctionResults.jest.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/__tests__/ArtistAuctionResults.jest.tsx
@@ -102,13 +102,7 @@ describe("AuctionResults", () => {
       mockUseAuthDialog.mockImplementation(() => ({ showAuthDialog }))
 
       let operationVariables
-      const { env } = renderWithRelay(mockedResolver, true)
-
-      act(() => {
-        env.mock.resolveMostRecentOperation(operation => {
-          return MockPayloadGenerator.generate(operation, mockedResolver)
-        })
-      })
+      const { env } = renderWithRelay(mockedResolver)
 
       const checkboxes = screen.getAllByRole("checkbox")
       fireEvent.click(checkboxes[2])
@@ -260,14 +254,8 @@ describe("AuctionResults", () => {
       describe("pagination", () => {
         // FIXME: SWC_COMPILER_MIGRATION
         it.skip("triggers relay refetch with after, and re-shows sign up to see price", async () => {
-          const { env } = renderWithRelay(mockedResolver, true)
+          const { env } = renderWithRelay(mockedResolver)
           let operationVariables
-
-          act(() => {
-            env.mock.resolveMostRecentOperation(operation => {
-              return MockPayloadGenerator.generate(operation, mockedResolver)
-            })
-          })
 
           const navigation = screen.getByRole("navigation")
           const checkboxes = screen.getAllByRole("checkbox")
@@ -292,13 +280,7 @@ describe("AuctionResults", () => {
       describe("filters", () => {
         describe("medium filter", () => {
           it("triggers relay refetch with medium list, and re-shows sign up to see price", () => {
-            const { env } = renderWithRelay(mockedResolver, true)
-
-            act(() => {
-              env.mock.resolveMostRecentOperation(operation => {
-                return MockPayloadGenerator.generate(operation, mockedResolver)
-              })
-            })
+            const { env } = renderWithRelay(mockedResolver)
 
             const checkboxes = screen.getAllByRole("checkbox")
             fireEvent.click(checkboxes[2])
@@ -361,13 +343,7 @@ describe("AuctionResults", () => {
         describe("auction house filter", () => {
           it("triggers relay refetch with organization list, and re-shows sign up to see price", () => {
             let operationVariables
-            const { env } = renderWithRelay(mockedResolver, true)
-
-            act(() => {
-              env.mock.resolveMostRecentOperation(operation => {
-                return MockPayloadGenerator.generate(operation, mockedResolver)
-              })
-            })
+            const { env } = renderWithRelay(mockedResolver)
 
             fireEvent.click(
               screen.getAllByText("Christie's", { exact: false })[0]
@@ -407,13 +383,7 @@ describe("AuctionResults", () => {
         describe("size filter", () => {
           it("triggers relay refetch with size list and tracks events, and re-shows sign up to see price", () => {
             let operationVariables
-            const { env } = renderWithRelay(mockedResolver, true)
-
-            act(() => {
-              env.mock.resolveMostRecentOperation(operation => {
-                return MockPayloadGenerator.generate(operation, mockedResolver)
-              })
-            })
+            const { env } = renderWithRelay(mockedResolver)
 
             fireEvent.click(screen.getByText("Medium (40 – 100cm)"))
             act(() => {
@@ -449,13 +419,7 @@ describe("AuctionResults", () => {
         describe("year created filter", () => {
           it("triggers relay refetch with created years and tracks events, and re-shows sign up to see price", () => {
             let operationVariables
-            const { env } = renderWithRelay(mockedResolver, true)
-
-            act(() => {
-              env.mock.resolveMostRecentOperation(operation => {
-                return MockPayloadGenerator.generate(operation, mockedResolver)
-              })
-            })
+            const { env } = renderWithRelay(mockedResolver)
 
             const comboboxes = screen.getAllByRole("combobox")
             fireEvent.change(comboboxes[1], { target: { value: "1900" } })
@@ -475,13 +439,7 @@ describe("AuctionResults", () => {
         describe("hide upcoming filter", () => {
           it("triggers relay refetch with state", () => {
             let operationVariables
-            const { env } = renderWithRelay(mockedResolver, true)
-
-            act(() => {
-              env.mock.resolveMostRecentOperation(operation => {
-                return MockPayloadGenerator.generate(operation, mockedResolver)
-              })
-            })
+            const { env } = renderWithRelay(mockedResolver)
 
             const checkboxes = screen.getAllByRole("checkbox")
             fireEvent.click(checkboxes[0])
@@ -500,13 +458,7 @@ describe("AuctionResults", () => {
       describe("sort", () => {
         it("triggers relay refetch with correct params, and re-shows sign up to see price", () => {
           let operationVariables
-          const { env } = renderWithRelay(mockedResolver, true)
-
-          act(() => {
-            env.mock.resolveMostRecentOperation(operation => {
-              return MockPayloadGenerator.generate(operation, mockedResolver)
-            })
-          })
+          const { env } = renderWithRelay(mockedResolver)
 
           const comboboxes = screen.getAllByRole("combobox")
           fireEvent.change(comboboxes[0], {

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkAuctionRegistrationPanel.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkAuctionRegistrationPanel.jest.tsx
@@ -22,16 +22,13 @@ const { renderWithRelay } = setupTestWrapperTL<
 
 describe("ArtworkAuctionRegistrationPanel", () => {
   it("renders countdown timer and button", () => {
-    renderWithRelay(
-      {
-        Artwork: () => ({
-          sale: {
-            registrationEndsAt: DateTime.local().plus({ days: 1 }).toString(),
-          },
-        }),
-      },
-      false
-    )
+    renderWithRelay({
+      Artwork: () => ({
+        sale: {
+          registrationEndsAt: DateTime.local().plus({ days: 1 }).toString(),
+        },
+      }),
+    })
 
     const timer = screen.getByText("Registration for this auction ends:")
     const button = screen.getByText("Register to Bid")
@@ -41,16 +38,13 @@ describe("ArtworkAuctionRegistrationPanel", () => {
   })
 
   it("renders only button", () => {
-    renderWithRelay(
-      {
-        Artwork: () => ({
-          sale: {
-            registrationEndsAt: null,
-          },
-        }),
-      },
-      false
-    )
+    renderWithRelay({
+      Artwork: () => ({
+        sale: {
+          registrationEndsAt: null,
+        },
+      }),
+    })
 
     const timer = screen.queryByText("Registration for this auction ends:")
     const button = screen.getByText("Register to Bid")

--- a/src/Apps/CollectorProfile/Components/CollectorProfileHeader/Components/__tests__/CollectorProfileHeaderAvatar.jest.tsx
+++ b/src/Apps/CollectorProfile/Components/CollectorProfileHeader/Components/__tests__/CollectorProfileHeaderAvatar.jest.tsx
@@ -23,13 +23,13 @@ describe("CollectorProfileHeaderAvatar", () => {
   })
 
   it("renders the avatar when there is a picture", () => {
-    renderWithRelay(dataMockResolvers, false)
+    renderWithRelay(dataMockResolvers)
 
     expect(screen.getByRole("img")).toBeInTheDocument()
   })
 
   it("does not render the image when there is no picture", () => {
-    renderWithRelay({ Me: () => ({ icon: null }) }, false)
+    renderWithRelay({ Me: () => ({ icon: null }) })
 
     expect(screen.queryByRole("img")).not.toBeInTheDocument()
   })

--- a/src/Apps/CollectorProfile/Components/CollectorProfileHeader/Components/__tests__/CollectorProfileHeaderInfo.jest.tsx
+++ b/src/Apps/CollectorProfile/Components/CollectorProfileHeader/Components/__tests__/CollectorProfileHeaderInfo.jest.tsx
@@ -23,7 +23,7 @@ describe("CollectorProfileHeaderInfo", () => {
   })
 
   it("renders all the info fields when all data is available", () => {
-    renderWithRelay(mockResolversAllFields, false)
+    renderWithRelay(mockResolversAllFields)
 
     expect(screen.getByText("New York, NY, USA")).toBeInTheDocument()
     expect(screen.getByText("Collector")).toBeInTheDocument()
@@ -31,7 +31,7 @@ describe("CollectorProfileHeaderInfo", () => {
   })
 
   it("renders the info field when some data is available", () => {
-    renderWithRelay(mockResolversSomeFields, false)
+    renderWithRelay(mockResolversSomeFields)
 
     expect(screen.getByText("Berlin, Germany")).toBeInTheDocument()
     expect(screen.getByText("Gallery")).toBeInTheDocument()

--- a/src/Apps/CollectorProfile/Components/CollectorProfileHeader/__tests__/CollectorProfileHeader.jest.tsx
+++ b/src/Apps/CollectorProfile/Components/CollectorProfileHeader/__tests__/CollectorProfileHeader.jest.tsx
@@ -28,7 +28,7 @@ describe("CollectorProfileHeader", () => {
   it("renders the name, bio, and member since", () => {
     const { renderWithRelay } = getWrapper()
 
-    renderWithRelay(mockResolvers, false)
+    renderWithRelay(mockResolvers)
 
     expect(screen.getByText("Darth Vader")).toBeInTheDocument()
     expect(screen.getByText("Member since 1987")).toBeInTheDocument()
@@ -39,14 +39,14 @@ describe("CollectorProfileHeader", () => {
     it("renders the settings button in Desktop", () => {
       const { renderWithRelay } = getWrapper()
 
-      renderWithRelay(mockResolvers, false)
+      renderWithRelay(mockResolvers)
 
       expect(screen.getByText("Settings")).toBeInTheDocument()
     })
 
     it("navigates when the settings button is pressed", () => {
       const { renderWithRelay } = getWrapper()
-      renderWithRelay(mockResolvers, false)
+      renderWithRelay(mockResolvers)
 
       expect(
         screen
@@ -58,14 +58,14 @@ describe("CollectorProfileHeader", () => {
     it("renders the settings icon in Mobile", () => {
       const { renderWithRelay } = getWrapper("xs")
 
-      renderWithRelay(mockResolvers, false)
+      renderWithRelay(mockResolvers)
 
       expect(screen.getByLabelText("Settings")).toBeInTheDocument()
     })
 
     it("navigates when the the settings icon in Mobile is pressed", () => {
       const { renderWithRelay } = getWrapper("xs")
-      renderWithRelay(mockResolvers, false)
+      renderWithRelay(mockResolvers)
 
       expect(screen.getByLabelText("Settings")).toHaveAttribute(
         "href",

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkImageBrowser/__tests__/MyCollectionArtworkImageBrowser.jest.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkImageBrowser/__tests__/MyCollectionArtworkImageBrowser.jest.tsx
@@ -36,22 +36,19 @@ describe("MyCollectionArtworkImageBrowser", () => {
       }
     })
     it("renders correctly", () => {
-      renderWithRelay(
-        {
-          Artwork: () => ({
-            images: [{ width: 800, height: 600 }],
-            figures: [{ __typename: "Image" }],
-          }),
-          Image: () => ({ isDefault: true }),
-          ResizedImageUrl: () => ({
-            width: 800,
-            height: 600,
-            src: "image.jpg",
-            srcSet: "image.jpg 1x",
-          }),
-        },
-        false
-      )
+      renderWithRelay({
+        Artwork: () => ({
+          images: [{ width: 800, height: 600 }],
+          figures: [{ __typename: "Image" }],
+        }),
+        Image: () => ({ isDefault: true }),
+        ResizedImageUrl: () => ({
+          width: 800,
+          height: 600,
+          src: "image.jpg",
+          srcSet: "image.jpg 1x",
+        }),
+      })
 
       expect(screen.getByTestId("artwork-lightbox-box")).toHaveStyle(
         "max-width: 800px"
@@ -79,7 +76,6 @@ describe("MyCollectionArtworkImageBrowser", () => {
               internalID: "artwork-x",
             }),
           },
-          false,
           { isMyCollectionArtwork: true }
         )
 
@@ -93,7 +89,7 @@ describe("MyCollectionArtworkImageBrowser", () => {
 
     describe("when the artwork is a normal artwork", () => {
       it("renders the empty state correctly", () => {
-        renderWithRelay({ Artwork: () => ({ images: [], figures: [] }) }, false)
+        renderWithRelay({ Artwork: () => ({ images: [], figures: [] }) })
 
         expect(
           screen.getByTestId("artwork-browser-no-image-box")

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/__tests__/MyCollectionArtworkSidebar.jest.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/__tests__/MyCollectionArtworkSidebar.jest.tsx
@@ -30,7 +30,7 @@ describe("MyCollectionArtworkSidebar", () => {
 
   describe("for artwork with metadata", () => {
     beforeEach(() => {
-      renderWithRelay({ Artwork: () => mockResolversWithData }, false)
+      renderWithRelay({ Artwork: () => mockResolversWithData })
     })
 
     it("displays artists names and title with the artist url", () => {
@@ -67,32 +67,26 @@ describe("MyCollectionArtworkSidebar", () => {
     })
 
     it("includes Notes when notes are present", () => {
-      renderWithRelay(
-        {
-          Artwork: () => ({
-            ...mockResolversWithData,
-            confidentialNotes: "A short text",
-          }),
-        },
-        false
-      )
+      renderWithRelay({
+        Artwork: () => ({
+          ...mockResolversWithData,
+          confidentialNotes: "A short text",
+        }),
+      })
       expect(screen.getByText("A short text")).toBeInTheDocument()
     })
 
     describe("when the artwork is part of limited edition", () => {
       beforeEach(() => {
-        renderWithRelay(
-          {
-            Artwork: () => ({
-              ...mockResolversWithData,
-              attributionClass: {
-                shortDescription: "Part of a limited edition set",
-              },
-              editionOf: "Edition 7/11",
-            }),
-          },
-          false
-        )
+        renderWithRelay({
+          Artwork: () => ({
+            ...mockResolversWithData,
+            attributionClass: {
+              shortDescription: "Part of a limited edition set",
+            },
+            editionOf: "Edition 7/11",
+          }),
+        })
       })
 
       it("displays edition info", () => {
@@ -106,10 +100,9 @@ describe("MyCollectionArtworkSidebar", () => {
 
     describe("when metric is set to 'cm'", () => {
       beforeEach(() => {
-        renderWithRelay(
-          { Artwork: () => ({ ...mockResolversWithData, metric: "cm" }) },
-          false
-        )
+        renderWithRelay({
+          Artwork: () => ({ ...mockResolversWithData, metric: "cm" }),
+        })
       })
 
       it("displays dimensions in cm", () => {
@@ -124,7 +117,7 @@ describe("MyCollectionArtworkSidebar", () => {
 
   describe("for artwork with minimal metadata", () => {
     beforeEach(() => {
-      renderWithRelay({ Artwork: () => emptyMockResolvers }, false)
+      renderWithRelay({ Artwork: () => emptyMockResolvers })
     })
 
     it("displays artists names and title", () => {

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/__tests__/MyCollectionArtworkArtistMarket.jest.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/__tests__/MyCollectionArtworkArtistMarket.jest.tsx
@@ -32,7 +32,7 @@ describe("MyCollectionArtworkArtistMarket", () => {
   })
 
   it("renders the market price insights for an artwork", () => {
-    renderWithRelay(mockResolvers, false)
+    renderWithRelay(mockResolvers)
 
     expect(screen.getByText("Annual Value Sold")).toBeInTheDocument()
     expect(screen.getByText("$13B")).toBeInTheDocument()

--- a/src/Apps/Order/Components/__tests__/AddressVerificationFlow.jest.tsx
+++ b/src/Apps/Order/Components/__tests__/AddressVerificationFlow.jest.tsx
@@ -90,7 +90,6 @@ describe("AddressVerificationFlow", () => {
       {
         VerifyAddressMutationType: () => result,
       },
-      undefined,
       componentProps
     )
   }

--- a/src/Apps/Settings/Routes/Insights/Components/CareerHighlights/CareerHighlightsModal/Components/__tests__/CareerHighlightModalStep.jest.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/CareerHighlights/CareerHighlightsModal/Components/__tests__/CareerHighlightModalStep.jest.tsx
@@ -35,7 +35,7 @@ describe("CareerHighlightModalStep", () => {
   })
 
   it("renders the career highlights data", () => {
-    renderWithRelay(mockResolver, false)
+    renderWithRelay(mockResolver)
 
     expect(screen.getByText("3")).toBeInTheDocument()
     expect(

--- a/src/Apps/Settings/Routes/Insights/Components/CareerHighlights/__tests__/InsightsCareerHighlightRail.jest.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/CareerHighlights/__tests__/InsightsCareerHighlightRail.jest.tsx
@@ -24,7 +24,7 @@ describe("InsightsCareerHighlightRail", () => {
 
   describe("when a user collection has career highlights", () => {
     it("renders career highlights", () => {
-      renderWithRelay(mockResolverData, false)
+      renderWithRelay(mockResolverData)
 
       // singular
       expect(
@@ -55,7 +55,7 @@ describe("InsightsCareerHighlightRail", () => {
 
   describe("when a user collection has no career highlights", () => {
     it("doesn't render career highlights or promo card", () => {
-      renderWithRelay(mockResolverNoData, false)
+      renderWithRelay(mockResolverNoData)
 
       expect(
         screen.queryByText("Artist had a solo show at a major institution.")

--- a/src/Apps/Settings/Routes/Insights/Components/__tests__/InsightsMedianSalePrice.jest.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/__tests__/InsightsMedianSalePrice.jest.tsx
@@ -45,7 +45,7 @@ describe("InsightsMedianSalePrice", () => {
   describe("when there are market price insights data", () => {
     describe("Median auction price in the last 3 years", () => {
       it("renders the median auction price in the last 3 years", () => {
-        renderWithRelay(mockResolver, false)
+        renderWithRelay(mockResolver)
 
         expect(
           screen.getByText("Median Auction Price in the Last 3 Years")
@@ -72,7 +72,7 @@ describe("InsightsMedianSalePrice", () => {
         },
       }))
 
-      renderWithRelay(mockResolver, false)
+      renderWithRelay(mockResolver)
 
       const artistRow = screen.getByText("Takashi Murakami")
 
@@ -92,7 +92,7 @@ describe("InsightsMedianSalePrice", () => {
         },
       }))
 
-      renderWithRelay(mockResolver, false)
+      renderWithRelay(mockResolver)
 
       const artistRow = screen.getByText("Takashi Murakami")
 
@@ -106,7 +106,7 @@ describe("InsightsMedianSalePrice", () => {
 
   describe("when there are no market price insights data", () => {
     it("renders nothing", () => {
-      renderWithRelay(mockEmptyResolver, false)
+      renderWithRelay(mockEmptyResolver)
 
       expect(
         screen.queryByText("Median Auction Price in the Last 3 Years")

--- a/src/Apps/Settings/Routes/Insights/Components/__tests__/InsightsOverview.jest.tsx
+++ b/src/Apps/Settings/Routes/Insights/Components/__tests__/InsightsOverview.jest.tsx
@@ -30,10 +30,9 @@ describe("InsightsOverview", () => {
   })
 
   it("renders My Collection info properly", () => {
-    renderWithRelay(
-      { MyCollectionInfo: () => ({ artistsCount: 7, artworksCount: 21 }) },
-      false
-    )
+    renderWithRelay({
+      MyCollectionInfo: () => ({ artistsCount: 7, artworksCount: 21 }),
+    })
 
     expect(screen.getByText("Total Artists")).toBeInTheDocument()
     expect(screen.getByText("7")).toBeInTheDocument()

--- a/src/Components/Artwork/__tests__/GridItem.jest.tsx
+++ b/src/Components/Artwork/__tests__/GridItem.jest.tsx
@@ -2,8 +2,8 @@ import { screen } from "@testing-library/react"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { graphql } from "react-relay"
 
-import { GridItem_Test_Query } from "../../../__generated__/GridItem_Test_Query.graphql"
-import ArtworkGridItemFragmentContainer from "../GridItem"
+import { GridItem_Test_Query } from "__generated__/GridItem_Test_Query.graphql"
+import ArtworkGridItemFragmentContainer from "Components/Artwork/GridItem"
 
 jest.unmock("react-relay")
 describe("GridItem", () => {
@@ -24,7 +24,7 @@ describe("GridItem", () => {
   })
 
   it("navigates to the standard artwork page for standard artworks", async () => {
-    renderWithRelay(mockResolvers, false)
+    renderWithRelay(mockResolvers)
 
     expect(screen.getByText("artwork-title")).toBeInTheDocument()
 
@@ -35,7 +35,7 @@ describe("GridItem", () => {
   })
 
   it("navigates to my collection artwork page for my collection artworks", async () => {
-    renderWithRelay(mockResolvers, false, {
+    renderWithRelay(mockResolvers, {
       to: "/my-collection/artwork/artwork-id",
     })
 

--- a/src/Components/Artwork/__tests__/Metadata.jest.tsx
+++ b/src/Components/Artwork/__tests__/Metadata.jest.tsx
@@ -24,7 +24,7 @@ describe("Metadata", () => {
   })
 
   it("navigates to artwork page when clicking on a normal artwork", () => {
-    renderWithRelay(mockResolver, false)
+    renderWithRelay(mockResolver)
 
     expect(screen.getByText("artwork title")).toBeInTheDocument()
 
@@ -35,7 +35,7 @@ describe("Metadata", () => {
   })
 
   it("navigates to my collection artwork page when clicking on a my collection artwork", () => {
-    renderWithRelay(mockResolver, false, {
+    renderWithRelay(mockResolver, {
       to: "/my-collection/artwork/artwork-id",
     })
 
@@ -48,7 +48,7 @@ describe("Metadata", () => {
   })
 
   it("navigates to my collection artwork page when clicking on a my collection artwork when ff enabled", () => {
-    renderWithRelay(mockResolver, false, {
+    renderWithRelay(mockResolver, {
       to: "/collector-profile/my-collection/artwork/artwork-id",
     })
 

--- a/src/Components/SavedSearchAlert/Components/__tests__/ConfirmationStepFooter.jest.tsx
+++ b/src/Components/SavedSearchAlert/Components/__tests__/ConfirmationStepFooter.jest.tsx
@@ -36,7 +36,6 @@ describe("ConfirmationStepFooter", () => {
           },
         }),
       },
-      false,
       { artworksCount: artworksCount }
     )
   }

--- a/src/DevTools/setupTestWrapper.tsx
+++ b/src/DevTools/setupTestWrapper.tsx
@@ -85,10 +85,10 @@ export const setupTestWrapperTL = <T extends OperationType>({
 }: SetupTestWrapper<T>) => {
   const renderWithRelay = (
     mockResolvers: MockResolvers = {},
-    manualEnvControl?: boolean,
-    componentProps?: {}
+    componentProps?: {},
+    mockedEnv?: ReturnType<typeof createMockEnvironment>
   ): RenderWithRelay => {
-    const env = createMockEnvironment()
+    const env = mockedEnv ?? createMockEnvironment()
     const TestRenderer = () => (
       <QueryRenderer<T>
         environment={env}
@@ -106,11 +106,9 @@ export const setupTestWrapperTL = <T extends OperationType>({
 
     const view = render(<TestRenderer />)
 
-    if (!manualEnvControl) {
-      env.mock.resolveMostRecentOperation(operation => {
-        return MockPayloadGenerator.generate(operation, mockResolvers)
-      })
-    }
+    env.mock.resolveMostRecentOperation(operation => {
+      return MockPayloadGenerator.generate(operation, mockResolvers)
+    })
 
     return { ...view, env }
   }


### PR DESCRIPTION
The type of this PR is: **Test**

This PR solves [EMI-1413](https://artsyproduct.atlassian.net/browse/EMI-1413)

### Description

Inspired by @erikdstock's [spike](https://github.com/artsy/force/compare/erik.SPIKE-shipping-react-testing-library-spike), I realized a need, while working on [EMI-1413](https://artsyproduct.atlassian.net/browse/EMI-1413), to support passing in a relay environment to the [`renderWithRelay`](https://github.com/artsy/force/blob/68a4a6139e1e666818b6581b29e4abdd8ffb6ffb/src/DevTools/setupTestWrapper.tsx#L86-L90) helper, to avoid handling multiple relay environments in tests. The existing [`manualEnvControl`](https://github.com/artsy/force/blob/68a4a6139e1e666818b6581b29e4abdd8ffb6ffb/src/DevTools/setupTestWrapper.tsx#L88) boolean is not able to support this.

This PR replaces the `manualEnvControl` boolean with an optional  `mockedEnv` argument. By default, the helper creates a mock relay environment. If the caller passes in one, the helper uses it instead.

The function signature is also more aligned with the [enzyme counterpart](https://github.com/artsy/force/blob/68a4a6139e1e666818b6581b29e4abdd8ffb6ffb/src/DevTools/setupTestWrapper.tsx#L129-L133).


[EMI-1413]: https://artsyproduct.atlassian.net/browse/EMI-1413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EMI-1413]: https://artsyproduct.atlassian.net/browse/EMI-1413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ