### PR TITLE
Migrate alerting for missing OwnerTypes into refactored AnalyticsContext

### DIFF
--- a/src/Server/__tests__/getContextPage.jest.ts
+++ b/src/Server/__tests__/getContextPage.jest.ts
@@ -1,8 +1,4 @@
-import {
-  formatOwnerTypes,
-  getContextPageFromClient,
-} from "Server/getContextPage"
-import { OwnerType } from "@artsy/cohesion"
+import { getContextPageFromClient } from "Server/getContextPage"
 
 jest.mock("sharify", () => ({
   data: {
@@ -43,17 +39,5 @@ describe("getContextPageFromClient", () => {
       pageType: "artistSeries",
       path: "/artist-series/test-artist-series",
     })
-  })
-})
-
-describe("formatOwnerTypes", () => {
-  it("handles article path types", () => {
-    expect(formatOwnerTypes("/news")).toBe(OwnerType.article)
-    expect(formatOwnerTypes("/series")).toBe(OwnerType.article)
-    expect(formatOwnerTypes("/video")).toBe(OwnerType.article)
-  })
-
-  it("handles auction page types", () => {
-    expect(formatOwnerTypes("/auction")).toBe(OwnerType.sale)
   })
 })

--- a/src/Server/getContextPage.ts
+++ b/src/Server/getContextPage.ts
@@ -1,5 +1,5 @@
-import { OwnerType, PageOwnerType } from "@artsy/cohesion"
-import { camelCase } from "lodash"
+import { PageOwnerType } from "@artsy/cohesion"
+import { pathToOwnerType } from "System/Analytics/AnalyticsContext"
 // eslint-disable-next-line no-restricted-imports
 import { data as sd } from "sharify"
 
@@ -23,7 +23,7 @@ export function getContextPageFromClient(): ClientContextPage | undefined {
   const { pathname } = window.location
   const pageParts = pathname.split("/")
   const pageSlug = pageParts[2]
-  const pageType = PAGE_TYPE || formatOwnerTypes(pathname)
+  const pageType = PAGE_TYPE || pathToOwnerType(pathname)
   const canonicalUrl = `${sd.APP_URL}${pathname}`
 
   return {
@@ -33,36 +33,4 @@ export function getContextPageFromClient(): ClientContextPage | undefined {
     pageType,
     path: pathname,
   }
-}
-
-/**
- * @deprecated: Use `pathToOwnerType` from `AnalyticsContext`
- */
-export const formatOwnerTypes = (path: string) => {
-  const type = path.split("/")[1]
-  // Remove '2' to ensure that show2/fair2/etc are schema compliant
-  let formattedType = camelCase(type).replace("2", "")
-
-  if (path === "/") {
-    formattedType = OwnerType.home
-  }
-
-  switch (type) {
-    case "auction":
-      formattedType = OwnerType.sale
-      break
-    case "news":
-    case "series":
-    case "video":
-      formattedType = OwnerType.article
-      break
-  }
-
-  if (!OwnerType[formattedType] && sd.SHOW_ANALYTICS_CALLS) {
-    console.warn(
-      `OwnerType ${formattedType} is not part of @artsy/cohesion's schema.`
-    )
-  }
-
-  return OwnerType[formattedType] || formattedType
 }

--- a/src/System/Analytics/AnalyticsContext.tsx
+++ b/src/System/Analytics/AnalyticsContext.tsx
@@ -1,6 +1,9 @@
 import { FC, ReactNode, createContext, useContext, useMemo } from "react"
 import { OwnerType, PageOwnerType } from "@artsy/cohesion"
 import { camelCase } from "lodash"
+import { getENV } from "Utils/getENV"
+
+const SHOW_ANALYTICS_CALLS = getENV("SHOW_ANALYTICS_CALLS")
 
 const AnalyticsContext = createContext<{
   contextPageOwnerId?: string
@@ -63,9 +66,16 @@ export const AnalyticsContextProvider: FC<AnalyticsContextProviderProps> = ({
   ])
 
   const contextPageOwnerType = useMemo(() => {
-    return (path
+    const ownerType = (path
       ? pathToOwnerType(path) || formatType(_type) // Fallback for unsupported routes
       : "Unknown") as PageOwnerType
+
+    if (!Object.values(OwnerType).includes(ownerType) && SHOW_ANALYTICS_CALLS) {
+      console.warn(
+        `OwnerType "${ownerType}" is not part of @artsy/cohesion's schema.`
+      )
+    }
+    return ownerType
   }, [_type, path])
 
   return (

--- a/src/System/useFeatureFlag.tsx
+++ b/src/System/useFeatureFlag.tsx
@@ -1,9 +1,9 @@
 import { ActionType } from "@artsy/cohesion"
-import { formatOwnerTypes } from "Server/getContextPage"
 import { useSystemContext } from "System/useSystemContext"
 import { Variant } from "unleash-client"
 import { getENV } from "Utils/getENV"
 import { useRouter } from "./Router/useRouter"
+import { pathToOwnerType } from "System/Analytics/AnalyticsContext"
 
 export type FeatureFlags = Record<string, FeatureFlagDetails>
 
@@ -85,7 +85,7 @@ export function useTrackFeatureVariant({
     const path = router.match.location.pathname
     const pageParts = path.split("/")
     const pageSlug = pageParts[2]
-    const pageType = formatOwnerTypes(path)
+    const pageType = pathToOwnerType(path)
 
     const trackFeatureView = shouldTrack(experimentName, variantName)
 


### PR DESCRIPTION
Paired on this with @TMcMeans, if we've missed some critical consideration or otherwise don't want to merge that it's totally ok.

The type of this PR is: **chore**

### Description
Following up on [https://github.com/artsy/force/pull/12776](https://github.com/artsy/force/pull/12776/files#diff-91d000540513622973ef9d699e2cfd5ae4444c21ef601128c970314655d42f5eR113-R117), which fixed and refactored a lot of our analytics context, this PR:

- migrates the `OwnerType orders was not part of @artsy/cohesion's schema` messaging to our `useMemo` hook where it is set
- removes references to a deprecated method that did an earlier version of the same thing
- fixes a bug in our alerting code which was testing the keys rather than the values of the OwnerType enum.