### PR TITLE
fix(EMI-1342): jumping issue on iPhones in Offer page

### DIFF
--- a/src/Apps/Order/Components/PriceOptions.tsx
+++ b/src/Apps/Order/Components/PriceOptions.tsx
@@ -12,6 +12,7 @@ import { PriceOptions_order$data } from "__generated__/PriceOptions_order.graphq
 import { appendCurrencySymbol } from "Apps/Order/Utils/currencyUtils"
 import { useTracking } from "react-tracking"
 import { Jump, useJump } from "Utils/Hooks/useJump"
+import { Device, useDeviceDetection } from "Utils/Hooks/useDeviceDetection"
 
 export interface PriceOptionsProps {
   onChange: (value: number) => void
@@ -33,6 +34,7 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
   const [customValue, setCustomValue] = useState<number>()
   const [toggle, setToggle] = useState(false)
   const [selectedRadio, setSelectedRadio] = useState<string>()
+  const { device } = useDeviceDetection()
   const listPrice = artwork?.listPrice
 
   useEffect(() => {
@@ -185,7 +187,8 @@ export const PriceOptions: React.FC<PriceOptionsProps> = ({
                     onChange={setCustomValue}
                     onFocus={() => {
                       onFocus()
-                      jumpTo("price-option-custom")
+                      if (device !== Device.iPhone)
+                        jumpTo("price-option-custom")
                     }}
                     noTitle
                   />


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-1342]

### Description
This PR fixes the double-jumping that happens in the offer screen in Safari iOS (tested with Safari mobile view and it works fine)

### Videos
| Before | After |
|---|---|
| <video src="https://github.com/artsy/force/assets/20655703/552c60aa-7492-41c4-8e1d-0b17dd56b089" /> | <video src="https://github.com/artsy/force/assets/20655703/3a6a69e8-8edd-4d1a-a416-2f3e4d7c6532" />	 | 















<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EMI-1342]: https://artsyproduct.atlassian.net/browse/EMI-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ