### PR TITLE
fix(alerts): prevent artwork alert creation when there are no artists

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCreateArtworkAlert.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCreateArtworkAlert.tsx
@@ -28,6 +28,7 @@ const ArtworkSidebarCreateArtworkAlert: React.FC<ArtworkSidebarCreateArtworkAler
   const attributionClass = compact([artwork.attributionClass?.internalID])
   const artistIDs = artists.map(artist => artist.internalID)
   const placeholder = `Artworks like: ${artwork.title!}`
+  const hasArtists = !!artwork.artists?.length
 
   const defaultArtistsCriteria: SavedSearchEntityCriteria[] = artists.map(
     artist => ({
@@ -74,6 +75,8 @@ const ArtworkSidebarCreateArtworkAlert: React.FC<ArtworkSidebarCreateArtworkAler
     additionalGeneIDs,
   }
   const allowedCriteria = getAllowedSearchCriteria(criteria)
+
+  if (!hasArtists) return null
 
   return (
     <>

--- a/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCreateArtworkAlert.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCreateArtworkAlert.jest.tsx
@@ -40,6 +40,14 @@ describe("ArtworkSidebarCreateArtworkAlert", () => {
     })
   })
 
+  it("should not render when an artwork has no artists", () => {
+    renderWithRelay({
+      Artwork: () => ({ ...Artwork, artists: [] }),
+    })
+
+    expect(screen.queryByText("Create Alert")).not.toBeInTheDocument()
+  })
+
   it("should correctly render pills", () => {
     renderWithRelay({
       Artwork: () => Artwork,


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [ONYX-275]

### Description

Prevents the creation of alerts from artwork pages when the artwork has no associated artists.

Auction artworks were [already doing](https://github.com/artsy/force/blob/156b302c328600c704360e4998168c1a72186d44/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarBiddingClosedMessage.tsx#L24) the right thing. So this addresses the non-auction case, which solves this issue for other susceptible works, such as museums‘ permanent collection artworks —

|Before|After|
|---|---|
|<img width="1392" alt="before" src="https://github.com/artsy/force/assets/140521/71d37862-40ca-4c49-a4d9-6f9505de47bb">|<img width="1392" alt="after" src="https://github.com/artsy/force/assets/140521/40ee5b2c-eabd-4202-90e1-a6caaa1cc4d2">|


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-275]: https://artsyproduct.atlassian.net/browse/ONYX-275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ