### PR TITLE
fix(partner): Ensure represented artists are always aat the top

### DIFF
--- a/src/Apps/Partner/Components/PartnerArtists/PartnerArtistList/PartnerArtistList.tsx
+++ b/src/Apps/Partner/Components/PartnerArtists/PartnerArtistList/PartnerArtistList.tsx
@@ -35,7 +35,7 @@ export const PartnerArtistList: React.FC<PartnerArtistListProps> = ({
         ...(worksAvailableBy.length === 0
           ? []
           : [{ name: "Works Available by", edges: worksAvailableBy }]),
-      ].sort((a, b) => b.edges.length - a.edges.length)
+      ]
     : [{ name: null, edges }]
 
   return (
@@ -45,7 +45,9 @@ export const PartnerArtistList: React.FC<PartnerArtistListProps> = ({
           <Box key={name ?? i}>
             {name && (
               <>
-                <Text variant="sm-display">{name}</Text>
+                <Text variant="sm-display" fontWeight="bold">
+                  {name}
+                </Text>
 
                 <Spacer y={2} />
               </>


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Fixes an issue a partner noticed around how we were organizing the partner artists page. Before we were dynamically sorting, but now we're ensuring that Represented Artists is always at the top 

