### PR TITLE
fix: Adjust `New Works from Galleries you follow` artwork grid details

### DIFF
--- a/src/Apps/NewWorksFromGalleriesYouFollow/NewWorksFromGalleriesYouFollowApp.tsx
+++ b/src/Apps/NewWorksFromGalleriesYouFollow/NewWorksFromGalleriesYouFollowApp.tsx
@@ -61,13 +61,8 @@ const NewWorksFromGalleriesYouFollowApp: FC<NewWorksFromGalleriesYouFollowAppPro
         <>
           <ArtworkGrid
             artworks={artworksConnection}
-            columnCount={[2, 3, 4, 4]}
-            showHoverDetails={false}
-            showArtworksWithoutImages
-            hideSaleInfo
+            columnCount={[2, 3, 3, 4]}
             to={artwork => `/artwork/${artwork.internalID}`}
-            showHighDemandIcon
-            showSaveButton={false}
             onLoadMore={handleLoadMore}
           />
 


### PR DESCRIPTION
Jira Ticket: [ONYX-45]
More Context: https://artsy.slack.com/archives/C05EQL4R5N0/p1694165141999769?thread_ts=1694095496.316869&cid=C05EQL4R5N0

## Description

This PR adjusts the artwork grid details for "New Works from Galleries You Follow" to match other artwork grids. I accidentally copy-pasted the props from the My Collection artwork grid, which doesn't display all the details.

| Before | After |
| --- | --- |
|<img width="893" alt="Screenshot 2023-09-13 at 11 46 55" src="https://github.com/artsy/force/assets/4691889/20e5d597-c2ca-4ce2-9885-bcd9ae37dbd2"> |<img width="897" alt="Screenshot 2023-09-13 at 11 46 47" src="https://github.com/artsy/force/assets/4691889/e8af72d8-c356-4784-8efe-be14458790fc"> |





[ONYX-45]: https://artsyproduct.atlassian.net/browse/ONYX-45?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ