### PR TITLE
feat(EMI-151): handle 3DS flow consistently

### DIFF
--- a/src/Apps/Order/Routes/Accept/index.tsx
+++ b/src/Apps/Order/Routes/Accept/index.tsx
@@ -79,6 +79,11 @@ export const Accept: FC<AcceptProps & StripeProps> = props => {
                   data
                 }
               }
+              ... on CommerceOrderRequiresAction {
+                actionData {
+                  clientSecret
+                }
+              }
             }
           }
         }
@@ -91,6 +96,22 @@ export const Accept: FC<AcceptProps & StripeProps> = props => {
       const orderOrError = (await acceptOffer()).commerceBuyerAcceptOffer
         ?.orderOrError
 
+      if (orderOrError?.actionData?.clientSecret) {
+        const scaResult = await stripe.handleCardAction(
+          orderOrError.actionData.clientSecret
+        )
+
+        if (scaResult.error) {
+          return dialog.showErrorDialog({
+            title: "An error occurred",
+            message: scaResult.error.message,
+          })
+        }
+
+        onSubmit()
+        return
+      }
+
       if (!orderOrError?.error) {
         router.push(`/orders/${order.internalID}/status`)
         return
@@ -101,6 +122,7 @@ export const Accept: FC<AcceptProps & StripeProps> = props => {
         return
       }
 
+      // TODO: Remove below fixedOrderOrError logic and fixFailedPayment once Exchange mutation is updated
       const fixedOrderOrError = (
         await fixFailedPayment({
           input: {

--- a/src/__generated__/AcceptOfferMutation.graphql.ts
+++ b/src/__generated__/AcceptOfferMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<edea735cee6f1d24f346dbca38db616d>>
+ * @generated SignedSource<<f6fef22aa97f7a272985b4ae81428e04>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -21,6 +21,9 @@ export type AcceptOfferMutation$data = {
   readonly commerceBuyerAcceptOffer: {
     readonly orderOrError: {
       readonly __typename: "CommerceOrderWithMutationSuccess";
+      readonly actionData?: {
+        readonly clientSecret: string;
+      };
       readonly error?: {
         readonly code: string;
         readonly data: string | null;
@@ -119,6 +122,31 @@ v5 = {
   ],
   "type": "CommerceOrderWithMutationFailure",
   "abstractKey": null
+},
+v6 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "CommerceOrderActionData",
+      "kind": "LinkedField",
+      "name": "actionData",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "clientSecret",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "CommerceOrderRequiresAction",
+  "abstractKey": null
 };
 return {
   "fragment": {
@@ -164,7 +192,8 @@ return {
                 "type": "CommerceOrderWithMutationSuccess",
                 "abstractKey": null
               },
-              (v5/*: any*/)
+              (v5/*: any*/),
+              (v6/*: any*/)
             ],
             "storageKey": null
           }
@@ -226,7 +255,8 @@ return {
                 "type": "CommerceOrderWithMutationSuccess",
                 "abstractKey": null
               },
-              (v5/*: any*/)
+              (v5/*: any*/),
+              (v6/*: any*/)
             ],
             "storageKey": null
           }
@@ -236,16 +266,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "5bd6cad2fd4cf41037248759d2390452",
+    "cacheID": "55e9e1f8671cbc9aeb21b346effafcbd",
     "id": null,
     "metadata": {},
     "name": "AcceptOfferMutation",
     "operationKind": "mutation",
-    "text": "mutation AcceptOfferMutation(\n  $input: CommerceBuyerAcceptOfferInput!\n) {\n  commerceBuyerAcceptOffer(input: $input) {\n    orderOrError {\n      __typename\n      ... on CommerceOrderWithMutationSuccess {\n        __typename\n        order {\n          __typename\n          internalID\n          ... on CommerceOfferOrder {\n            awaitingResponseFrom\n          }\n          id\n        }\n      }\n      ... on CommerceOrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n    }\n  }\n}\n"
+    "text": "mutation AcceptOfferMutation(\n  $input: CommerceBuyerAcceptOfferInput!\n) {\n  commerceBuyerAcceptOffer(input: $input) {\n    orderOrError {\n      __typename\n      ... on CommerceOrderWithMutationSuccess {\n        __typename\n        order {\n          __typename\n          internalID\n          ... on CommerceOfferOrder {\n            awaitingResponseFrom\n          }\n          id\n        }\n      }\n      ... on CommerceOrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n      ... on CommerceOrderRequiresAction {\n        actionData {\n          clientSecret\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "a72db42fb4cf493527dad1d4d6aa1cdc";
+(node as any).hash = "6f7ba402365c2ec78fee134be9bb8355";
 
 export default node;


### PR DESCRIPTION

The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-151]

### Description
This is part 1 of handling Stripe's 3DS flow consistently. For more context, please see https://artsyproduct.atlassian.net/browse/EMI-151

[Part two](https://github.com/artsy/exchange/pull/1787) will allow us to remove the unnecessary code in a followup PR.

<!-- Implementation description -->

Relates to https://github.com/artsy/force/pull/12744

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EMI-151]: https://artsyproduct.atlassian.net/browse/EMI-151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ