### PR TITLE
chore: add deadend breadcrumbs to review route

### DIFF
--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -418,7 +418,24 @@ export const ReviewRoute: FC<ReviewProps> = props => {
       }
       default: {
         const { title, message } = getErrorDialogCopy()
-        const errorCode = error.code || ""
+        let errorCode = error.code || ""
+
+        /**
+         * Our tracking events show that many users are still seeing the generic
+         * error message when they attempt to submit an order. However, we are
+         * not receiving any error codes with these tracking events, so it has
+         * been difficult to further investigate them.
+         *
+         * This is an attempt to serialize the errors that lead users to this
+         * code path so that we can better understand what is happening.
+         */
+        if (errorCode === "") {
+          try {
+            errorCode = error.toString()
+          } catch (e) {
+            // do nothing
+          }
+        }
 
         trackErrorMessageEvent(title, message, errorCode)
 


### PR DESCRIPTION
Our tracking data shows that users are seeing the generic "Something went wrong..." error message while attempting to submit orders. We have been able to map some occurrences of these to errors raised in Exchange, but there is still a fair number of occurrences that do not correspond to any logged errors in Exchange.

This PR aims to give us some more breadcrumbs when investigating these occurrences by logging the error that causes them inside the tracking event. Previously we had hoped that an error code would be available, but these have mostly been blank.