### PR TITLE
fix(EMI-1459) use throttle instead of debounce for address autocomplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,7 +143,7 @@
     "jsdom": "20.0.0",
     "jwt-decode": "2.2.0",
     "localforage": "^1.10.0",
-    "lodash": "4.17.21",
+    "lodash": "^4.17.21",
     "luxon": "^3.2.1",
     "map-cursor-to-max": "^1.0.0",
     "memoize-one": "^5.2.1",

--- a/src/Components/Address/__tests__/useAddressAutocomplete.jest.ts
+++ b/src/Components/Address/__tests__/useAddressAutocomplete.jest.ts
@@ -6,10 +6,13 @@ import {
 import { useFeatureFlag } from "System/useFeatureFlag"
 import { getENV } from "Utils/getENV"
 import { waitFor } from "@testing-library/react"
+import { throttle } from "lodash"
 
 jest.mock("react-tracking")
 jest.mock("System/useFeatureFlag")
 jest.mock("Utils/getENV")
+
+jest.mock("lodash/throttle", () => jest.fn(fn => fn))
 
 let mockFetch: jest.Mock
 
@@ -195,6 +198,20 @@ describe("useAddressAutocomplete", () => {
 
         expect(result.current.autocompleteOptions).toEqual([])
         expect(mockFetch).not.toHaveBeenCalled()
+      })
+
+      it("throttles calls to the Smarty API", async () => {
+        const { result } = setupHook({ country: "US" })
+
+        act(() => {
+          result.current.fetchForAutocomplete({ search: "401 Broadway" })
+        })
+
+        expect(throttle).toHaveBeenCalledTimes(1)
+        expect(throttle).toHaveBeenCalledWith(expect.any(Function), 500, {
+          leading: true,
+          trailing: true,
+        })
       })
     })
 


### PR DESCRIPTION
The type of this PR is: **fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-1459]

### Description

<!-- Implementation description -->
The goal of this PR is to change the usage of debounce to implementing Lodash's throttle function in the `useAddressAutocomplete` hook to stagger multiple query requests to the Smarty API on user key press.

Note: Thoroughly testing the throttle's behavior was challenging. Although Lodash's throttle can use `setTimeout`, it also employs timestamps for finer control over function execution. This makes it less straightforward to mock using Jest's timer mocks, which are primarily designed to work with `setInterval()` and `setTimeout()`.

@artsy/emerald-devs 

![Sep-15-2023 12-21-21](https://github.com/artsy/force/assets/23108927/14d38aec-8ef6-4063-ad6f-f89cc427611d)


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[EMI-1459]: https://artsyproduct.atlassian.net/browse/EMI-1459?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ