### PR TITLE
feat: add follower count for galleries

### DIFF
--- a/src/Apps/Artist/Components/ArtistHeader/ArtistHeader.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/ArtistHeader.tsx
@@ -17,6 +17,7 @@ import { RouterLink } from "System/Router/RouterLink"
 import { useTranslation } from "react-i18next"
 import { HeaderIcon } from "Components/HeaderIcon"
 import { ProgressiveOnboardingFollowArtist } from "Components/ProgressiveOnboarding/ProgressiveOnboardingFollowArtist"
+import { formatFollowerCount } from "Utils/formatFollowerCount"
 
 interface ArtistHeaderProps {
   artist: ArtistHeader_artist$data
@@ -162,16 +163,3 @@ export const ArtistHeaderFragmentContainer = createFragmentContainer(
     `,
   }
 )
-
-const formatFollowerCount = (n: number) => {
-  try {
-    const formatter = Intl.NumberFormat("en-US", {
-      notation: "compact",
-      compactDisplay: "short",
-    })
-
-    return formatter.format(n).toLocaleLowerCase()
-  } catch (error) {
-    return n
-  }
-}

--- a/src/Apps/Artist/Components/ArtistHeader/ArtistHeader2.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/ArtistHeader2.tsx
@@ -29,6 +29,7 @@ import {
   isValidImage,
 } from "Apps/Artist/Components/ArtistHeader/ArtistHeaderImage"
 import { ProgressiveOnboardingFollowArtist } from "Components/ProgressiveOnboarding/ProgressiveOnboardingFollowArtist"
+import { formatFollowerCount } from "Utils/formatFollowerCount"
 
 interface ArtistHeaderProps {
   artist: ArtistHeader2_artist$data
@@ -317,18 +318,5 @@ const CV = styled(RouterLink)`
     color: currentColor;
   }
 `
-
-const formatFollowerCount = (n: number) => {
-  try {
-    const formatter = Intl.NumberFormat("en-US", {
-      notation: "compact",
-      compactDisplay: "short",
-    })
-
-    return formatter.format(n).toLocaleLowerCase()
-  } catch (error) {
-    return n
-  }
-}
 
 export const ARTIST_HEADER_NUMBER_OF_INSIGHTS = 6

--- a/src/Apps/Partner/Components/NavigationTabs/index.tsx
+++ b/src/Apps/Partner/Components/NavigationTabs/index.tsx
@@ -83,7 +83,12 @@ export const NavigationTabs: React.FC<NavigationTabsProps> = ({ partner }) => {
   const tabs = routes
     .filter(route => !route.hidden)
     .map(route => (
-      <RouteTab to={route.href} exact={route.exact} onClick={handleClick}>
+      <RouteTab
+        to={route.href}
+        exact={route.exact}
+        onClick={handleClick}
+        key={route.name}
+      >
         {route.name}
       </RouteTab>
     ))

--- a/src/Apps/Partner/Components/PartnerHeader/index.tsx
+++ b/src/Apps/Partner/Components/PartnerHeader/index.tsx
@@ -9,6 +9,7 @@ import { RouterLink } from "System/Router/RouterLink"
 import { PartnerHeader_partner$data } from "__generated__/PartnerHeader_partner.graphql"
 import { themeGet } from "@styled-system/theme-get"
 import { Jump } from "Utils/Hooks/useJump"
+import { formatFollowerCount } from "Utils/formatFollowerCount"
 
 export interface PartnerHeaderProps {
   partner: PartnerHeader_partner$data
@@ -26,6 +27,8 @@ export const PartnerHeader: React.FC<PartnerHeaderProps> = ({ partner }) => {
   const partnerUrl = `/partner/${partner.slug}`
   const canFollow =
     partner && partner.type !== "Auction House" && !!partner.profile
+
+  const hasFollows = partner.profile?.counts?.follows >= 500
 
   return (
     <>
@@ -77,6 +80,19 @@ export const PartnerHeader: React.FC<PartnerHeaderProps> = ({ partner }) => {
               contextModule={ContextModule.partnerHeader}
               width="100%"
             />
+            {hasFollows && (
+              <Text
+                variant="xs"
+                color="black60"
+                textAlign="center"
+                flexShrink={0}
+                paddingTop={0.5}
+              >
+                {formatFollowerCount(partner?.profile?.counts?.follows)}{" "}
+                Follower
+                {partner?.profile?.counts?.follows === 1 ? "" : "s"}
+              </Text>
+            )}
           </Column>
         )}
       </GridColumns>
@@ -93,6 +109,9 @@ export const PartnerHeaderFragmentContainer = createFragmentContainer(
         type
         slug
         profile {
+          counts {
+            follows
+          }
           internalID
           icon {
             resized(width: 80, height: 80, version: "square140") {

--- a/src/Apps/Partner/Components/__tests__/PartnerHeader.jest.tsx
+++ b/src/Apps/Partner/Components/__tests__/PartnerHeader.jest.tsx
@@ -229,4 +229,34 @@ describe("PartnerHeader", () => {
 
     expect(wrapper.find(FollowProfileButtonQueryRenderer).length).toEqual(0)
   })
+
+  it("doesn't display the follow count", () => {
+    const wrapper = getWrapper({
+      Partner: () => ({
+        name: "White cube",
+        profile: {
+          counts: {
+            follows: 100,
+          },
+        },
+      }),
+    })
+
+    expect(wrapper.text()).not.toContain("100 Followers")
+  })
+
+  it("displays the follow count", () => {
+    const wrapper = getWrapper({
+      Partner: () => ({
+        name: "White cube",
+        profile: {
+          counts: {
+            follows: 500,
+          },
+        },
+      }),
+    })
+
+    expect(wrapper.text()).toContain("500 Followers")
+  })
 })

--- a/src/Utils/__tests__/formatFollowerCount.jest.ts
+++ b/src/Utils/__tests__/formatFollowerCount.jest.ts
@@ -1,0 +1,15 @@
+import { formatFollowerCount } from "Utils/formatFollowerCount"
+
+describe("formatFollowerCount", () => {
+  it("should format a large number to compact notation", () => {
+    const largeNumber = 10000
+    const formattedNumber = formatFollowerCount(largeNumber)
+    expect(formattedNumber).toEqual("10k")
+  })
+
+  it("should format a small number to compact notation", () => {
+    const smallNumber = 150
+    const result = formatFollowerCount(smallNumber)
+    expect(result).toEqual("150")
+  })
+})

--- a/src/Utils/formatFollowerCount.ts
+++ b/src/Utils/formatFollowerCount.ts
@@ -1,0 +1,12 @@
+export const formatFollowerCount = (n: number) => {
+  try {
+    const formatter = Intl.NumberFormat("en-US", {
+      notation: "compact",
+      compactDisplay: "short",
+    })
+
+    return formatter.format(n).toLocaleLowerCase()
+  } catch (error) {
+    return n
+  }
+}

--- a/src/__generated__/PartnerApp_Test_Query.graphql.ts
+++ b/src/__generated__/PartnerApp_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b062329106cc4a0effdd5cbad93dfd31>>
+ * @generated SignedSource<<b7c3882000511857a74b79d04b134875>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -260,6 +260,24 @@ return {
                 "storageKey": null
               },
               (v2/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ProfileCounts",
+                "kind": "LinkedField",
+                "name": "counts",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "follows",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
               (v1/*: any*/),
               {
                 "alias": null,
@@ -628,7 +646,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "3f7791274863aef3fa38e7a14d05f8a4",
+    "cacheID": "fea283663a63fb134e8c219e40a2b2dc",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -712,6 +730,13 @@ return {
           "plural": false,
           "type": "Profile"
         },
+        "partner.profile.counts": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ProfileCounts"
+        },
+        "partner.profile.counts.follows": (v11/*: any*/),
         "partner.profile.icon": (v18/*: any*/),
         "partner.profile.icon.resized": {
           "enumValues": null,
@@ -740,7 +765,7 @@ return {
     },
     "name": "PartnerApp_Test_Query",
     "operationKind": "query",
-    "text": "query PartnerApp_Test_Query {\n  partner(id: \"example\") {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n  partnerType\n  displayArtistsSection\n  displayWorksSection\n  counts {\n    eligibleArtworks\n    displayableShows\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n  }\n  articles: articlesConnection {\n    totalCount\n  }\n  representedArtists: artistsConnection(representedBy: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  notRepresentedArtists: artistsConnection(representedBy: false, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  viewingRooms: viewingRoomsConnection(statuses: [live, closed, scheduled]) {\n    totalCount\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  internalID\n  partnerType\n  displayFullPartnerPage\n  partnerPageEligible\n  isDefaultProfilePublic\n  categories {\n    id\n    name\n  }\n  profile {\n    ...PartnerHeaderImage_profile\n    id\n  }\n  ...PartnerMeta_partner\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeaderImage_profile on Profile {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  profile {\n    internalID\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMeta_partner on Partner {\n  locationsConnection(first: 1) {\n    edges {\n      node {\n        address\n        address2\n        city\n        coordinates {\n          lat\n          lng\n        }\n        country\n        phone\n        postalCode\n        state\n        id\n      }\n    }\n  }\n  meta {\n    image\n    title\n    description\n  }\n  name\n  slug\n}\n"
+    "text": "query PartnerApp_Test_Query {\n  partner(id: \"example\") {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n  partnerType\n  displayArtistsSection\n  displayWorksSection\n  counts {\n    eligibleArtworks\n    displayableShows\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n  }\n  articles: articlesConnection {\n    totalCount\n  }\n  representedArtists: artistsConnection(representedBy: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  notRepresentedArtists: artistsConnection(representedBy: false, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  viewingRooms: viewingRoomsConnection(statuses: [live, closed, scheduled]) {\n    totalCount\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  internalID\n  partnerType\n  displayFullPartnerPage\n  partnerPageEligible\n  isDefaultProfilePublic\n  categories {\n    id\n    name\n  }\n  profile {\n    ...PartnerHeaderImage_profile\n    id\n  }\n  ...PartnerMeta_partner\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeaderImage_profile on Profile {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  profile {\n    counts {\n      follows\n    }\n    internalID\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMeta_partner on Partner {\n  locationsConnection(first: 1) {\n    edges {\n      node {\n        address\n        address2\n        city\n        coordinates {\n          lat\n          lng\n        }\n        country\n        phone\n        postalCode\n        state\n        id\n      }\n    }\n  }\n  meta {\n    image\n    title\n    description\n  }\n  name\n  slug\n}\n"
   }
 };
 })();

--- a/src/__generated__/PartnerHeader_Test_Query.graphql.ts
+++ b/src/__generated__/PartnerHeader_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<55000f2161f4ff2f575e7389a49c0f34>>
+ * @generated SignedSource<<a0f90cd823c76a6a51ab9181dbf101ff>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -30,6 +30,9 @@ export type PartnerHeader_Test_Query$rawResponse = {
     } | null;
     readonly name: string | null;
     readonly profile: {
+      readonly counts: {
+        readonly follows: any | null;
+      } | null;
       readonly icon: {
         readonly resized: {
           readonly src: string;
@@ -155,6 +158,24 @@ return {
               {
                 "alias": null,
                 "args": null,
+                "concreteType": "ProfileCounts",
+                "kind": "LinkedField",
+                "name": "counts",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "follows",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
                 "kind": "ScalarField",
                 "name": "internalID",
                 "storageKey": null
@@ -276,7 +297,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "795f99676da85f6dcccaacde39350304",
+    "cacheID": "524ed91e14607eab719c86e65873356c",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -320,6 +341,18 @@ return {
           "plural": false,
           "type": "Profile"
         },
+        "partner.profile.counts": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ProfileCounts"
+        },
+        "partner.profile.counts.follows": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "FormattedNumber"
+        },
         "partner.profile.icon": {
           "enumValues": null,
           "nullable": true,
@@ -342,7 +375,7 @@ return {
     },
     "name": "PartnerHeader_Test_Query",
     "operationKind": "query",
-    "text": "query PartnerHeader_Test_Query {\n  partner(id: \"white-cube\") {\n    ...PartnerHeader_partner\n    id\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  profile {\n    internalID\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query PartnerHeader_Test_Query {\n  partner(id: \"white-cube\") {\n    ...PartnerHeader_partner\n    id\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  profile {\n    counts {\n      follows\n    }\n    internalID\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/PartnerHeader_partner.graphql.ts
+++ b/src/__generated__/PartnerHeader_partner.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<197b3082ed6a8648e1bd60add001d25e>>
+ * @generated SignedSource<<7307a26122e715cc3f94da877089e90f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -21,6 +21,9 @@ export type PartnerHeader_partner$data = {
   } | null;
   readonly name: string | null;
   readonly profile: {
+    readonly counts: {
+      readonly follows: any | null;
+    } | null;
     readonly icon: {
       readonly resized: {
         readonly src: string;
@@ -73,6 +76,24 @@ const node: ReaderFragment = {
       "name": "profile",
       "plural": false,
       "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ProfileCounts",
+          "kind": "LinkedField",
+          "name": "counts",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "follows",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
         {
           "alias": null,
           "args": null,
@@ -193,6 +214,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "7f0a97c890f8c512b9cf5a8e7837424a";
+(node as any).hash = "52e0a19ddfaa94155e29ee5d2212443e";
 
 export default node;

--- a/src/__generated__/partnerRoutes_PartnerQuery.graphql.ts
+++ b/src/__generated__/partnerRoutes_PartnerQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<eb560659537294d5daaccdd2320582b7>>
+ * @generated SignedSource<<be46c24d03989049513411805de2e48e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -203,6 +203,24 @@ return {
                 "storageKey": null
               },
               (v5/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ProfileCounts",
+                "kind": "LinkedField",
+                "name": "counts",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "follows",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
               (v4/*: any*/),
               {
                 "alias": null,
@@ -571,12 +589,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "0839c6b683cac74abd2d628ec994c890",
+    "cacheID": "8c5dc8f698478d6fd10ef03b4ae83957",
     "id": null,
     "metadata": {},
     "name": "partnerRoutes_PartnerQuery",
     "operationKind": "query",
-    "text": "query partnerRoutes_PartnerQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    partnerType\n    displayFullPartnerPage\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n  partnerType\n  displayArtistsSection\n  displayWorksSection\n  counts {\n    eligibleArtworks\n    displayableShows\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n  }\n  articles: articlesConnection {\n    totalCount\n  }\n  representedArtists: artistsConnection(representedBy: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  notRepresentedArtists: artistsConnection(representedBy: false, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  viewingRooms: viewingRoomsConnection(statuses: [live, closed, scheduled]) {\n    totalCount\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  internalID\n  partnerType\n  displayFullPartnerPage\n  partnerPageEligible\n  isDefaultProfilePublic\n  categories {\n    id\n    name\n  }\n  profile {\n    ...PartnerHeaderImage_profile\n    id\n  }\n  ...PartnerMeta_partner\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeaderImage_profile on Profile {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  profile {\n    internalID\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMeta_partner on Partner {\n  locationsConnection(first: 1) {\n    edges {\n      node {\n        address\n        address2\n        city\n        coordinates {\n          lat\n          lng\n        }\n        country\n        phone\n        postalCode\n        state\n        id\n      }\n    }\n  }\n  meta {\n    image\n    title\n    description\n  }\n  name\n  slug\n}\n"
+    "text": "query partnerRoutes_PartnerQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    partnerType\n    displayFullPartnerPage\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n  partnerType\n  displayArtistsSection\n  displayWorksSection\n  counts {\n    eligibleArtworks\n    displayableShows\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n  }\n  articles: articlesConnection {\n    totalCount\n  }\n  representedArtists: artistsConnection(representedBy: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  notRepresentedArtists: artistsConnection(representedBy: false, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  viewingRooms: viewingRoomsConnection(statuses: [live, closed, scheduled]) {\n    totalCount\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  internalID\n  partnerType\n  displayFullPartnerPage\n  partnerPageEligible\n  isDefaultProfilePublic\n  categories {\n    id\n    name\n  }\n  profile {\n    ...PartnerHeaderImage_profile\n    id\n  }\n  ...PartnerMeta_partner\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeaderImage_profile on Profile {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  profile {\n    counts {\n      follows\n    }\n    internalID\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMeta_partner on Partner {\n  locationsConnection(first: 1) {\n    edges {\n      node {\n        address\n        address2\n        city\n        coordinates {\n          lat\n          lng\n        }\n        country\n        phone\n        postalCode\n        state\n        id\n      }\n    }\n  }\n  meta {\n    image\n    title\n    description\n  }\n  name\n  slug\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [DIA-130]

### Description
- It adds the follower count to partner's page.
- Removed duplicated code on couple of places for `formatFollowerCount` and moved to `utils`.
- It adds `key={route.name}` to Route to fix annoying key warnings in the console.

<img width="512" alt="Screenshot 2023-09-13 at 14 58 07" src="https://github.com/artsy/force/assets/1176374/6227a68d-ffca-4c14-a8c3-249ddb894554">
<img width="939" alt="Screenshot 2023-09-13 at 14 57 58" src="https://github.com/artsy/force/assets/1176374/c7f250cd-c14e-4cd3-bfc9-5f34ff539e97">
<img width="939" alt="Screenshot 2023-09-13 at 14 57 58" src="https://github.com/artsy/force/assets/1176374/dd744d99-2822-4584-8b2b-01aee8f52202">





<!-- Implementation description -->
