### PR TITLE
fix: fixes no results message on search page

### DIFF
--- a/src/Apps/Search/Components/ZeroState.tsx
+++ b/src/Apps/Search/Components/ZeroState.tsx
@@ -21,7 +21,8 @@ export const ZeroState: FC<ZeroStateProps> = ({ term }) => {
           <>
             {t(`searchApp.resultsCount`, { count: 0 })}
             <Box as="span" color="blue100">
-              “ {filters?.term ?? term}”
+              {" "}
+              “{filters?.term ?? term}”
             </Box>
           </>
         )}


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Fixes "No results found for" message on the search page. Before it had an extra space between search term's quotation marks.

| Before | After |
|---|---|
| ![Screenshot 2023-09-18 at 13 11 09](https://github.com/artsy/force/assets/3934579/01d443d1-3058-4b97-980f-45a768d76db7) | ![Screenshot 2023-09-18 at 13 11 16](https://github.com/artsy/force/assets/3934579/e5ad9b68-8046-401a-852a-620e37ea7d67) |