### PR TITLE
chore: add deadend breadcrumbs to payment route

### DIFF
--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -281,6 +281,25 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
       setIsSavingPayment(false)
       handlePaymentError(error)
 
+      let errorCode = error.code || ""
+
+      /**
+       * Our tracking events show that many users are still seeing the generic
+       * error message when they attempt to submit this step. However, we are
+       * not receiving any error codes with these tracking events, so it has
+       * been difficult to further investigate them.
+       *
+       * This is an attempt to serialize the errors that lead users to this
+       * code path so that we can better understand what is happening.
+       */
+      if (errorCode === "") {
+        try {
+          errorCode = error.toString()
+        } catch (e) {
+          // do nothing
+        }
+      }
+
       trackEvent({
         action: ActionType.errorMessageViewed,
         context_owner_type: OwnerType.ordersPayment,
@@ -288,7 +307,7 @@ export const PaymentRoute: FC<PaymentRouteProps> = props => {
         title: "An error occurred",
         message:
           "Something went wrong. Please try again or contact orders@artsy.net",
-        error_code: null,
+        error_code: errorCode,
         flow: "user sets credit card as payment method",
       })
 


### PR DESCRIPTION
This PR is related to #12870.

Our tracking data shows that users are seeing the generic "Something went wrong..." error message while attempting to submit the Payment step. We have been able to map some occurrences of these to errors raised in Exchange, but there is still a fair number of occurrences that do not correspond to any logged errors in Exchange.

This PR aims to give us some more breadcrumbs when investigating these occurrences by logging the error that causes them inside the tracking event. Previously we had hoped that an error code would be available, but these have mostly been blank.