### PR TITLE
Fix: EMI-1457 - show autocomplete input by default so hidden element styles are applied properly

### DIFF
--- a/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -47,6 +47,12 @@ jest.mock("Utils/Hooks/useMatchMedia", () => ({
   __internal__useMatchMedia: () => ({}),
 }))
 
+// TODO: Turning this on causes 1 test to fail expectedly and another to also fail. What is going on here?
+const TRIGGER_LEAKY_FAILURES = false
+const triggerLeakyFailure = () => {
+  expect(TRIGGER_LEAKY_FAILURES).toBe(false)
+}
+
 jest.mock("@artsy/palette", () => {
   return {
     ...jest.requireActual("@artsy/palette"),
@@ -277,8 +283,8 @@ describe("Shipping", () => {
           Me: () => meWithoutAddress,
         })
 
-        expect(screen.getByRole("combobox")).toHaveValue("US")
-        expect(screen.getByRole("combobox")).toBeDisabled()
+        expect(screen.getByTestId("AddressForm_country")).toHaveValue("US")
+        expect(screen.getByTestId("AddressForm_country")).toBeDisabled()
       })
 
       it("sets and enables country select if artwork only ships domestically and is in the EU", async () => {
@@ -296,8 +302,8 @@ describe("Shipping", () => {
           Me: () => meWithoutAddress,
         })
 
-        expect(screen.getByRole("combobox")).toHaveValue("IT")
-        expect(screen.getByRole("combobox")).toBeEnabled()
+        expect(screen.getByTestId("AddressForm_country")).toHaveValue("IT")
+        expect(screen.getByTestId("AddressForm_country")).toBeEnabled()
       })
 
       it("sets shipping on order and saves address on user", async () => {
@@ -307,7 +313,7 @@ describe("Shipping", () => {
           Me: () => meWithoutAddress,
         })
 
-        fillAddressForm(validAddress)
+        await fillAddressForm(validAddress)
         await saveAndContinue()
 
         expect(mockCommitMutation).toHaveBeenCalledTimes(2)
@@ -346,7 +352,7 @@ describe("Shipping", () => {
           Me: () => meWithoutAddress,
         })
 
-        fillAddressForm(validAddress)
+        await fillAddressForm(validAddress)
         userEvent.click(
           screen.getByRole("checkbox", { name: /Save shipping address/ })
         )
@@ -378,7 +384,7 @@ describe("Shipping", () => {
           Me: () => meWithoutAddress,
         })
 
-        fillAddressForm(validAddress)
+        await fillAddressForm(validAddress)
         await saveAndContinue()
 
         expect(mockCommitMutation).toHaveBeenCalledTimes(2)
@@ -403,7 +409,7 @@ describe("Shipping", () => {
           Me: () => meWithoutAddress,
         })
 
-        fillAddressForm(validAddress)
+        await fillAddressForm(validAddress)
         await saveAndContinue()
 
         expect(mockShowErrorDialog).toHaveBeenCalledWith()
@@ -416,7 +422,7 @@ describe("Shipping", () => {
           Me: () => meWithoutAddress,
         })
 
-        fillAddressForm(validAddress)
+        await fillAddressForm(validAddress)
         await saveAndContinue()
 
         expect(mockShowErrorDialog).toHaveBeenCalledWith()
@@ -431,7 +437,7 @@ describe("Shipping", () => {
           Me: () => meWithoutAddress,
         })
 
-        fillAddressForm(validAddress)
+        await fillAddressForm(validAddress)
         await saveAndContinue()
 
         expect(mockShowErrorDialog).toHaveBeenCalledWith({
@@ -450,7 +456,7 @@ describe("Shipping", () => {
           Me: () => meWithoutAddress,
         })
 
-        fillAddressForm(validAddress)
+        await fillAddressForm(validAddress)
         await saveAndContinue()
 
         expect(mockShowErrorDialog).toHaveBeenCalledWith({
@@ -469,7 +475,7 @@ describe("Shipping", () => {
           Me: () => meWithoutAddress,
         })
 
-        fillAddressForm(validAddress)
+        await fillAddressForm(validAddress)
         await saveAndContinue()
 
         expect(mockShowErrorDialog).toHaveBeenCalledWith({
@@ -573,7 +579,7 @@ describe("Shipping", () => {
             Me: () => meWithoutAddress,
           })
 
-          fillAddressForm({
+          await fillAddressForm({
             name: "Erik David",
             addressLine1: "401 Broadway",
             addressLine2: "",
@@ -596,7 +602,7 @@ describe("Shipping", () => {
             Me: () => meWithoutAddress,
           })
 
-          fillAddressForm({
+          await fillAddressForm({
             name: "Erik David",
             addressLine1: "401 Broadway",
             addressLine2: "",
@@ -672,7 +678,7 @@ describe("Shipping", () => {
               screen.queryByText("This field is required")
             ).not.toBeInTheDocument()
 
-            fillAddressForm(validAddress)
+            await fillAddressForm(validAddress)
             userEvent.clear(screen.getByPlaceholderText("Street address"))
 
             await userEvent.click(screen.getByText("Save and Continue"))
@@ -718,7 +724,7 @@ describe("Shipping", () => {
               relayEnv
             )
 
-            fillAddressForm(validAddress)
+            await fillAddressForm(validAddress)
             await userEvent.click(screen.getByText("Save and Continue"))
 
             const mutation = env.mock.getMostRecentOperation()
@@ -756,8 +762,10 @@ describe("Shipping", () => {
               relayEnv
             )
 
-            fillAddressForm(validAddress)
-            userEvent.selectOptions(screen.getByRole("combobox"), ["TW"])
+            await fillAddressForm(validAddress)
+            userEvent.selectOptions(screen.getByTestId("AddressForm_country"), [
+              "TW",
+            ])
             await userEvent.click(screen.getByText("Save and Continue"))
 
             expect(env.mock.getAllOperations()).toHaveLength(0)
@@ -778,7 +786,7 @@ describe("Shipping", () => {
             relayEnv = undefined
           })
 
-          it("does not triggers tthe flow for US address after clicking continue", async () => {
+          it("does not trigger the flow for US address after clicking continue", async () => {
             const { env } = renderWithRelay(
               {
                 CommerceOrder: () => order,
@@ -788,7 +796,7 @@ describe("Shipping", () => {
               relayEnv
             )
 
-            fillAddressForm(validAddress)
+            await fillAddressForm(validAddress)
             await userEvent.click(screen.getByText("Save and Continue"))
 
             expect(env.mock.getAllOperations()).toHaveLength(0)
@@ -804,8 +812,10 @@ describe("Shipping", () => {
               relayEnv
             )
 
-            fillAddressForm(validAddress)
-            userEvent.selectOptions(screen.getByRole("combobox"), ["TW"])
+            await fillAddressForm(validAddress)
+            userEvent.selectOptions(screen.getByTestId("AddressForm_country"), [
+              "TW",
+            ])
             await userEvent.click(screen.getByText("Save and Continue"))
 
             const mutation = env.mock.getMostRecentOperation()
@@ -1081,7 +1091,7 @@ describe("Shipping", () => {
           Me: () => meWithoutAddress,
         })
 
-        fillAddressForm(validAddress)
+        await fillAddressForm(validAddress)
         await saveAndContinue()
 
         // FIXME: `getByRole` can be slow and cause test to time out.
@@ -1091,7 +1101,7 @@ describe("Shipping", () => {
         // expect(screen.getByRole("radio", { name: /White Glove/ })).toBeVisible()
         // expect(screen.getByRole("radio", { name: /Rush/ })).toBeVisible()
         // expect(screen.getByRole("radio", { name: /Premium/ })).toBeVisible()
-
+        triggerLeakyFailure()
         expect(mockCommitMutation).toHaveBeenCalledTimes(2)
 
         let mutationArg = mockCommitMutation.mock.calls[0][0]
@@ -1163,7 +1173,7 @@ describe("Shipping", () => {
           Me: () => meWithoutAddress,
         })
 
-        fillAddressForm(validAddress)
+        await fillAddressForm(validAddress)
         await saveAndContinue()
 
         expect(
@@ -1190,7 +1200,7 @@ describe("Shipping", () => {
           Me: () => meWithoutAddress,
         })
 
-        fillAddressForm(validAddress)
+        await fillAddressForm(validAddress)
         await saveAndContinue()
 
         // FIXME: `getByRole` can be slow and cause test to time out.

--- a/src/Components/Address/AddressForm.tsx
+++ b/src/Components/Address/AddressForm.tsx
@@ -160,7 +160,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
           value={value?.name}
           onChange={changeEventHandler("name")}
           error={getError("name")}
-          data-test="AddressForm_name"
+          data-testid="AddressForm_name"
         />
       </Column>
 
@@ -179,7 +179,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
           onSelect={changeValueHandler("country")}
           disabled={lockCountryToOrigin}
           euShippingOnly={lockCountriesToEU}
-          data-test="AddressForm_country"
+          data-testid="AddressForm_country"
         />
         {(lockCountryToOrigin || lockCountriesToEU) && (
           <>
@@ -226,7 +226,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
               }
             }}
             error={getError("addressLine1")}
-            data-test="AddressForm_addressLine1"
+            data-testid="AddressForm_addressLine1"
             forwardRef={autocompleteRef}
           />
         ) : (
@@ -238,7 +238,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
             value={value?.addressLine1}
             onChange={changeEventHandler("addressLine1")}
             error={getError("addressLine1")}
-            data-test="AddressForm_addressLine1"
+            data-testid="AddressForm_addressLine1"
           />
         )}
       </Column>
@@ -251,7 +251,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
           value={value?.addressLine2 || ""}
           onChange={changeEventHandler("addressLine2")}
           error={getError("addressLine2")}
-          data-test="AddressForm_addressLine2"
+          data-testid="AddressForm_addressLine2"
         />
       </Column>
       <Column span={12}>
@@ -263,7 +263,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
           value={value?.city}
           onChange={changeEventHandler("city")}
           error={getError("city")}
-          data-test="AddressForm_city"
+          data-testid="AddressForm_city"
         />
       </Column>
       <Column span={6}>
@@ -276,7 +276,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
           value={value?.region}
           onChange={changeEventHandler("region")}
           error={getError("region")}
-          data-test="AddressForm_region"
+          data-testid="AddressForm_region"
         />
       </Column>
       <Column span={6}>
@@ -290,7 +290,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
           value={value?.postalCode}
           onChange={changeEventHandler("postalCode")}
           error={getError("postalCode")}
-          data-test="AddressForm_postalCode"
+          data-testid="AddressForm_postalCode"
         />
       </Column>
 
@@ -308,7 +308,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
               value={value?.phoneNumber}
               onChange={changeEventHandler("phoneNumber")}
               error={getError("phoneNumber")}
-              data-test="AddressForm_phoneNumber"
+              data-testid="AddressForm_phoneNumber"
             />
           </Column>
           <Spacer y={2} />

--- a/src/Components/Address/AddressForm.tsx
+++ b/src/Components/Address/AddressForm.tsx
@@ -88,8 +88,8 @@ export const AddressForm: React.FC<AddressFormProps> = ({
   const {
     autocompleteOptions,
     fetchForAutocomplete,
-    isAddressAutocompleteEnabled,
     fetchSecondarySuggestions,
+    ...autocomplete
   } = useAddressAutocomplete(address)
 
   if (!isEqual(value, prevValue)) {
@@ -102,7 +102,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
   const changeEventHandler = (key: keyof Address) => (
     ev: React.FormEvent<HTMLInputElement>
   ) => {
-    const shouldFetch = isAddressAutocompleteEnabled && key === "addressLine1"
+    const shouldFetch = autocomplete.enabled && key === "addressLine1"
     if (shouldFetch) {
       fetchForAutocomplete({ search: ev.currentTarget.value })
     }
@@ -193,9 +193,11 @@ export const AddressForm: React.FC<AddressFormProps> = ({
         )}
       </Column>
       <Column span={12}>
-        {isAddressAutocompleteEnabled ? (
+        {/* Render the autocomplete input optimistically on the server to make sure we send applicable styles to the client */}
+        {!autocomplete.loaded || autocomplete.enabled ? (
           <AutocompleteInput<AddressAutocompleteSuggestion>
             tabIndex={tabIndex}
+            disabled={!autocomplete.loaded}
             id="AddressForm_addressLine1"
             placeholder="Street address"
             title="Address line 1"

--- a/src/Components/Address/AddressForm.tsx
+++ b/src/Components/Address/AddressForm.tsx
@@ -193,7 +193,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
         )}
       </Column>
       <Column span={12}>
-        {/* Render the autocomplete input optimistically on the server to make sure we send applicable styles to the client */}
+        {/* Render the autocomplete optimistically to avoid an SSR mismatch */}
         {!autocomplete.loaded || autocomplete.enabled ? (
           <AutocompleteInput<AddressAutocompleteSuggestion>
             tabIndex={tabIndex}

--- a/src/Components/Address/__tests__/useAddressAutocomplete.jest.ts
+++ b/src/Components/Address/__tests__/useAddressAutocomplete.jest.ts
@@ -299,7 +299,7 @@ describe("useAddressAutocomplete", () => {
     })
   })
 
-  describe("isAddressAutocompleteEnabled", () => {
+  describe("enabled", () => {
     describe("feature flag is enabled", () => {
       beforeAll(() => {
         ;(useFeatureFlag as jest.Mock).mockImplementation(
@@ -319,14 +319,14 @@ describe("useAddressAutocomplete", () => {
         describe("selected country is US", () => {
           it("returns true", () => {
             const { result } = setupHook({ country: "US" })
-            expect(result.current.isAddressAutocompleteEnabled).toBe(true)
+            expect(result.current.enabled).toBe(true)
           })
         })
 
         describe("selected country is not US", () => {
           it("returns false", () => {
             const { result } = setupHook({ country: "AF" })
-            expect(result.current.isAddressAutocompleteEnabled).toBe(false)
+            expect(result.current.enabled).toBe(false)
           })
         })
       })
@@ -339,14 +339,14 @@ describe("useAddressAutocomplete", () => {
         describe("selected country is US", () => {
           it("returns false", () => {
             const { result } = setupHook({ country: "US" })
-            expect(result.current.isAddressAutocompleteEnabled).toBe(false)
+            expect(result.current.enabled).toBe(false)
           })
         })
 
         describe("selected country is not US", () => {
           it("returns false", () => {
             const { result } = setupHook({ country: "AF" })
-            expect(result.current.isAddressAutocompleteEnabled).toBe(false)
+            expect(result.current.enabled).toBe(false)
           })
         })
       })
@@ -369,14 +369,14 @@ describe("useAddressAutocomplete", () => {
         describe("selected country is US", () => {
           it("returns false", () => {
             const { result } = setupHook({ country: "US" })
-            expect(result.current.isAddressAutocompleteEnabled).toBe(false)
+            expect(result.current.enabled).toBe(false)
           })
         })
 
         describe("selected country is not US", () => {
           it("returns false", () => {
             const { result } = setupHook({ country: "AF" })
-            expect(result.current.isAddressAutocompleteEnabled).toBe(false)
+            expect(result.current.enabled).toBe(false)
           })
         })
       })
@@ -389,14 +389,14 @@ describe("useAddressAutocomplete", () => {
         describe("selected country is US", () => {
           it("returns false", () => {
             const { result } = setupHook({ country: "US" })
-            expect(result.current.isAddressAutocompleteEnabled).toBe(false)
+            expect(result.current.enabled).toBe(false)
           })
         })
 
         describe("selected country is not US", () => {
           it("returns false", () => {
             const { result } = setupHook({ country: "AF" })
-            expect(result.current.isAddressAutocompleteEnabled).toBe(false)
+            expect(result.current.enabled).toBe(false)
           })
         })
       })

--- a/src/Components/Address/useAddressAutocomplete.ts
+++ b/src/Components/Address/useAddressAutocomplete.ts
@@ -2,7 +2,7 @@ import { AutocompleteInputOptionType } from "@artsy/palette"
 import { Address } from "Components/Address/AddressForm"
 import { useFeatureFlag } from "System/useFeatureFlag"
 import { getENV } from "Utils/getENV"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useMemo, useState } from "react"
 import { throttle } from "lodash"
 
 const THROTTLE_DELAY = 500
@@ -23,13 +23,17 @@ export interface AddressAutocompleteSuggestion
   entries: number
 }
 
+interface ServiceAvailability {
+  loaded: boolean
+  enabled?: boolean
+}
+
 export const useAddressAutocomplete = (
   address: Partial<Address> & { country: Address["country"] }
-): {
+): ServiceAvailability & {
   autocompleteOptions: AddressAutocompleteSuggestion[]
   suggestions: ProviderSuggestion[]
   fetchForAutocomplete: (args: { search: string; selected?: string }) => void
-  isAddressAutocompleteEnabled: boolean
   fetchSecondarySuggestions: (
     search: string,
     option: AddressAutocompleteSuggestion
@@ -42,10 +46,24 @@ export const useAddressAutocomplete = (
   const { key: apiKey } = getENV("SMARTY_EMBEDDED_KEY_JSON") || { key: "" }
 
   const isUSAddress = address.country === "US"
-  const isAPIKeyPresent = !!apiKey
   const isFeatureFlagEnabled = !!useFeatureFlag("address_autocomplete_us")
-  const isAddressAutocompleteEnabled =
-    isAPIKeyPresent && isFeatureFlagEnabled && isUSAddress
+
+  const [serviceAvailability, setServiceAvailability] = useState<
+    ServiceAvailability
+  >({
+    loaded: false,
+  })
+
+  const { enabled: isAddressAutocompleteEnabled } = serviceAvailability
+
+  useEffect(() => {
+    const isAPIKeyPresent = !!apiKey
+    const enabled = isAPIKeyPresent && isFeatureFlagEnabled && isUSAddress
+    setServiceAvailability({
+      loaded: true,
+      enabled,
+    })
+  }, [apiKey, isFeatureFlagEnabled, isUSAddress])
 
   // reset suggestions if the country changes
   useEffect(() => {
@@ -54,37 +72,35 @@ export const useAddressAutocomplete = (
     }
   }, [isUSAddress, result.length])
 
-  const fetchSuggestions = useCallback(
-    async ({ search, selected }: { search: string; selected?: string }) => {
-      const params = {
-        key: apiKey,
-        search: search,
+  const fetchSuggestions = useMemo(() => {
+    const throttledFetch = throttle(
+      async ({ search, selected }: { search: string; selected?: string }) => {
+        const params = {
+          key: apiKey,
+          search: search,
+        }
+
+        if (selected) {
+          params["selected"] = selected
+        }
+
+        if (!apiKey) return null
+        let url =
+          "https://us-autocomplete-pro.api.smarty.com/lookup?" +
+          new URLSearchParams(params).toString()
+
+        const response = await fetch(url)
+        const json = await response.json()
+        return json
+      },
+      THROTTLE_DELAY,
+      {
+        leading: true,
+        trailing: true,
       }
-
-      if (selected) {
-        params["selected"] = selected
-      }
-
-      if (!apiKey) return null
-      let url =
-        "https://us-autocomplete-pro.api.smarty.com/lookup?" +
-        new URLSearchParams(params).toString()
-
-      const response = await fetch(url)
-      const json = await response.json()
-      return json
-    },
-    [apiKey]
-  )
-
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  const throttledFetchSuggestions = useCallback(
-    throttle(fetchSuggestions, THROTTLE_DELAY, {
-      leading: true,
-      trailing: true,
-    }),
-    []
-  )
+    )
+    return throttledFetch
+  }, [apiKey])
 
   const fetchForAutocomplete = useCallback(
     // these are the parameters to the Smarty API call
@@ -97,14 +113,14 @@ export const useAddressAutocomplete = (
       }
 
       try {
-        const response = await throttledFetchSuggestions({ search, selected })
+        const response = await fetchSuggestions({ search, selected })
 
         setResult(response.suggestions)
       } catch (e) {
         console.error(e)
       }
     },
-    [throttledFetchSuggestions, isAddressAutocompleteEnabled]
+    [fetchSuggestions, isAddressAutocompleteEnabled]
   )
 
   const fetchSecondarySuggestions = useCallback(
@@ -152,7 +168,7 @@ export const useAddressAutocomplete = (
     autocompleteOptions,
     suggestions: result,
     fetchForAutocomplete,
-    isAddressAutocompleteEnabled,
     fetchSecondarySuggestions,
+    ...serviceAvailability,
   }
 }

--- a/src/Components/__tests__/Utils/addressForm.ts
+++ b/src/Components/__tests__/Utils/addressForm.ts
@@ -1,7 +1,7 @@
 import { Address } from "Components/Address/AddressForm"
 import { CountrySelect } from "Components/CountrySelect"
 import { Input } from "@artsy/palette"
-import { screen } from "@testing-library/react"
+import { screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 
 export const validAddress: Address = {
@@ -42,9 +42,13 @@ export const fillCountrySelect = (component, value) => {
   input.props().onSelect(value)
 }
 
-export const fillAddressForm = (address: Address) => {
+export const fillAddressForm = async (address: Address) => {
+  await waitFor(() => {
+    const line1Input = screen.getByPlaceholderText("Street address")
+    expect(line1Input).toBeEnabled()
+  })
   const name = screen.getByPlaceholderText("Full name")
-  const country = screen.getByRole("combobox")
+  const country = screen.getByTestId("AddressForm_country")
   const addressLine1 = screen.getByPlaceholderText("Street address")
   const addressLine2 = screen.getByPlaceholderText("Apt, floor, suite, etc.")
   const city = screen.getByPlaceholderText("City")


### PR DESCRIPTION
The type of this PR is: fix

This PR resolves [EMI-1457] by adding a brief loading state to the autocomplete input. While loading (and server-side) the address form renders the input, but disabled, then swaps it out if autocomplete is not available. This has the effect of making the 🔎  disappear, a small papercut and possible followup in palette.


[EMI-1457]: https://artsyproduct.atlassian.net/browse/EMI-1457?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ