### PR TITLE
feat(EMI-1464): fill/clear all inputs when selecting new address

### DIFF
--- a/src/Components/Address/__tests__/useAddressAutocomplete.jest.ts
+++ b/src/Components/Address/__tests__/useAddressAutocomplete.jest.ts
@@ -92,6 +92,7 @@ describe("useAddressAutocomplete", () => {
           "https://us-autocomplete-pro.api.smarty.com/lookup?key=smarty-api-key&search=401+Broadway"
         )
       })
+
       it("returns the first 5 results in the correct shape", async () => {
         const { result } = setupHook({ country: "US" })
 
@@ -150,6 +151,33 @@ describe("useAddressAutocomplete", () => {
 
         const formattedAddress = result.current.autocompleteOptions[0].text
         expect(formattedAddress).toBe("401 Broadway Fl 13, New York NY 10013")
+      })
+
+      it("sets line 2 to an empty string if the value is missing", async () => {
+        mockFetch.mockResolvedValue({
+          json: jest.fn().mockResolvedValue({
+            suggestions: [
+              {
+                city: "New York",
+                entries: 2,
+                state: "NY",
+                street_line: "402 Broadway",
+                zipcode: "10014",
+              },
+            ],
+          }),
+        })
+
+        const { result } = setupHook({ country: "US" })
+
+        act(() => {
+          result.current.fetchForAutocomplete({ search: "402 Broadway" })
+        })
+
+        await waitFor(() => result.current.autocompleteOptions.length > 0)
+
+        const option = result.current.autocompleteOptions[0]
+        expect(option.address.addressLine2).toEqual("")
       })
 
       it("returns the correct single-line text for an address with multiple entries", async () => {

--- a/src/Components/Address/useAddressAutocomplete.ts
+++ b/src/Components/Address/useAddressAutocomplete.ts
@@ -154,7 +154,7 @@ export const useAddressAutocomplete = (
         entries: suggestion.entries,
         address: {
           addressLine1: suggestion.street_line,
-          addressLine2: suggestion.secondary,
+          addressLine2: suggestion.secondary || "",
           city: suggestion.city,
           region: suggestion.state,
           postalCode: suggestion.zipcode,


### PR DESCRIPTION
The type of this PR is: **FEAT**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-1464]

### Description
![Sep-22-2023 11-26-44](https://github.com/artsy/force/assets/23108927/a39fd00e-b4c4-453e-b127-b0908983fb2e)


<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EMI-1405]: https://artsyproduct.atlassian.net/browse/EMI-1405?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[EMI-1464]: https://artsyproduct.atlassian.net/browse/EMI-1464?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ