### PR TITLE
feat(EMI-1425): Add `addressVerificationModal` to address verification modal

### DIFF
--- a/src/Apps/Order/Components/AddressVerificationFlow.tsx
+++ b/src/Apps/Order/Components/AddressVerificationFlow.tsx
@@ -225,6 +225,7 @@ const AddressVerificationFlow: React.FC<AddressVerificationFlowProps> = ({
       onClose={() => {
         handleCloseModal({ label: null, subject: modalTitle! })
       }}
+      data-test="addressVerificationModal"
     >
       {verificationPath === VerificationPath.SUGGESTIONS ? (
         <>

--- a/src/Apps/Order/Components/AddressVerificationFlow.tsx
+++ b/src/Apps/Order/Components/AddressVerificationFlow.tsx
@@ -225,7 +225,7 @@ const AddressVerificationFlow: React.FC<AddressVerificationFlowProps> = ({
       onClose={() => {
         handleCloseModal({ label: null, subject: modalTitle! })
       }}
-      data-test="addressVerificationModal"
+      data-testid="addressVerificationModal"
     >
       {verificationPath === VerificationPath.SUGGESTIONS ? (
         <>


### PR DESCRIPTION
The type of this PR is: **Test**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-1425]

### Description
This PR adds `addressVerificationModal` as data-test to address verification modal so it can be picked up by Integrity

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EMI-1425]: https://artsyproduct.atlassian.net/browse/EMI-1425?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ