### PR TITLE
test: set a longer timeout for shipping tests tentatively

### DIFF
--- a/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -41,6 +41,10 @@ import * as updateUserAddress from "Apps/Order/Mutations/UpdateUserAddress"
 import { within } from "@testing-library/dom"
 import { createMockEnvironment, MockPayloadGenerator } from "relay-test-utils"
 
+// TODO: Optimize test performance and remove long timeout setting
+// Set longer timeout for each test _only_ for this file.
+// https://jestjs.io/docs/jest-object#jestsettimeouttimeout
+jest.setTimeout(10000)
 jest.unmock("react-relay")
 jest.mock("react-tracking")
 jest.mock("Utils/Hooks/useMatchMedia", () => ({


### PR DESCRIPTION
The type of this PR is: **Test**

### Description

Reported on [Slack](https://artsy.slack.com/archives/C2TQ4PT8R/p1695298550790839), shipping tests sometimes time out on CI (> 5 seconds). [Previous attempt](https://github.com/artsy/force/pull/12867/commits/a5782ec99010954c22cfc6d2b5abeff0632e601e) to improve the performance is not sufficient.

To unblock the `main` branch/deployment, this tentatively increases the timeout _only_ for that particular file while I look into more performance improvements.
