### PR TITLE
fix(onyx-359): Rename the 'Sale' pill to 'Auction'

### DIFF
--- a/src/Components/Search/NewSearch/constants.ts
+++ b/src/Components/Search/NewSearch/constants.ts
@@ -35,7 +35,7 @@ export const ARTICLE_PILL: PillType = {
 }
 
 export const SALE_PILL: PillType = {
-  displayName: "Sale",
+  displayName: "Auction",
   key: "sale",
   searchEntityName: "SALE",
   analyticsContextModule: ContextModule.auctionTab,


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [ONYX-359]

### Description

The ‘Sale' pill is called ‘Auction’ in the app. In this PR we align the naming between the app and web.

![Screenshot 2023-09-22 at 11 17 28](https://github.com/artsy/force/assets/3934579/8fd08f2a-d613-4ef1-8c81-288a538c3ef9)


[ONYX-359]: https://artsyproduct.atlassian.net/browse/ONYX-359?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ