### PR TITLE
fix: Show artist gallery reps even without insights DIA-173

### DIFF
--- a/src/Apps/Artist/Components/ArtistHeader/ArtistHeader2.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/ArtistHeader2.tsx
@@ -54,10 +54,12 @@ const ArtistHeader: React.FC<ArtistHeaderProps> = ({ artist }) => {
 
   const image = artist.coverArtwork?.image
   const hasImage = isValidImage(image)
-  const hasInsights = artist.insights.length > 0
   const hasBio = artist.biographyBlurb?.text
-  const hasSomething = hasImage || hasInsights || hasBio
   const hasVerifiedRepresentatives = artist?.verifiedRepresentatives?.length > 0
+  const hasInsights = artist.insights.length > 0
+  const hasRightDetails = hasVerifiedRepresentatives || hasInsights
+
+  const hasSomething = hasImage || hasBio || hasRightDetails
 
   if (mode === "Collapsed") {
     return (
@@ -120,7 +122,7 @@ const ArtistHeader: React.FC<ArtistHeaderProps> = ({ artist }) => {
               )}
 
               <Column
-                span={hasInsights ? 5 : 8}
+                span={hasRightDetails ? 5 : 8}
                 display="flex"
                 flexDirection="column"
                 gap={2}
@@ -197,7 +199,7 @@ const ArtistHeader: React.FC<ArtistHeaderProps> = ({ artist }) => {
                 </Text>
               </Column>
 
-              {artist.insights.length > 0 && (
+              {hasRightDetails && (
                 <Column span={4} {...(!hasImage && { start: 9 })}>
                   {hasVerifiedRepresentatives && (
                     <>


### PR DESCRIPTION
This PR updates the cocktail of booleans that we use to show and hide things in the new ArtistHeader component. I added a new boolean that indicates whether we have a third column - could be because we have gallery reps or could be because we have insights or both!

Then I just updated a few call sites to use that instead. I checked with a couple artists to verify that rendering works as expected:

<details><summary>screenshots</summary>
<img width="1312" alt="Screenshot 2023-09-22 at 10 59 42 AM" src="https://github.com/artsy/force/assets/79799/46316a01-bbc5-4f6e-a1ee-c713214da957">
<img width="1312" alt="Screenshot 2023-09-22 at 10 59 45 AM" src="https://github.com/artsy/force/assets/79799/83b7b023-499f-45bf-a261-a738bd721489">

</details> 

https://artsyproduct.atlassian.net/browse/DIA-173

/cc @artsy/diamond-devs