### PR TITLE
feat: add structured phone input to User > Account Settings

### DIFF
--- a/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsInformation.tsx
+++ b/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsInformation.tsx
@@ -16,6 +16,10 @@ import { createFragmentContainer, graphql } from "react-relay"
 import * as Yup from "yup"
 import { SettingsEditSettingsInformation_me$data } from "__generated__/SettingsEditSettingsInformation_me.graphql"
 import { useUpdateSettingsInformation } from "./useUpdateSettingsInformation"
+import {
+  PhoneNumberInput,
+  validatePhoneNumber,
+} from "Components/PhoneNumberInput"
 
 interface SettingsEditSettingsInformationProps {
   me: SettingsEditSettingsInformation_me$data
@@ -36,6 +40,7 @@ export const SettingsEditSettingsInformation: React.FC<SettingsEditSettingsInfor
         initialValues={{
           email: me.email ?? "",
           phone: me.phone ?? "",
+          phoneNumberCountryCode: me.phoneNumber?.regionCode ?? "us",
           priceRange: me.priceRange ?? "",
           priceRangeMax: me.priceRangeMax,
           priceRangeMin: me.priceRangeMin,
@@ -50,17 +55,23 @@ export const SettingsEditSettingsInformation: React.FC<SettingsEditSettingsInfor
             is: email => email !== me.email,
             otherwise: field => field.notRequired(),
           }),
-          phone: Yup.string().test(
-            "Phone must be valid",
-            "Phone number must be valid",
-            value => {
-              // https://github.com/artsy/gravity/blob/a8227694da735dc03c8ba50928325d84e4b2846b/app/models/util/phone_validation.rb#L2
-              if (!value) return true
-              const digits = (value.match(/\d/g) ?? []).length
-              const validChars = /^[+\/\-()\.\s0-9A-Za-z]+$/g.test(value)
-              return digits >= 3 && validChars
-            }
-          ),
+          phone: Yup.string()
+            .test({
+              name: "phone-number-is-valid",
+              message: "Please enter a valid phone number",
+              test: (national, context) => {
+                if (!national || !national.length) {
+                  return true
+                }
+
+                return validatePhoneNumber({
+                  national: `${national}`,
+                  regionCode: `${context.parent.phoneNumberCountryCode}`,
+                })
+              },
+            })
+            .notRequired(),
+          phoneNumberCountryCode: Yup.string().notRequired(),
         })}
         onSubmit={async (
           { email, password, phone, priceRangeMin, priceRangeMax },
@@ -117,6 +128,7 @@ export const SettingsEditSettingsInformation: React.FC<SettingsEditSettingsInfor
       >
         {({
           errors,
+          touched,
           handleBlur,
           handleChange,
           setFieldValue,
@@ -139,16 +151,30 @@ export const SettingsEditSettingsInformation: React.FC<SettingsEditSettingsInfor
                 autoComplete="email"
               />
 
-              <Input
+              <PhoneNumberInput
                 title="Mobile Number"
-                name="phone"
-                placeholder="Enter your mobile phone number"
-                value={values.phone}
-                onChange={handleChange}
-                onBlur={handleBlur}
-                type="tel"
-                autoComplete="tel"
-                error={errors.phone}
+                mt={4}
+                inputProps={{
+                  name: "phone",
+                  onBlur: handleBlur,
+                  onChange: handleChange,
+                  placeholder: "Enter your mobile phone number",
+                  value: values.phone,
+                }}
+                selectProps={{
+                  name: "phoneNumberCountryCode",
+                  onBlur: handleBlur,
+                  selected: values.phoneNumberCountryCode,
+                  onSelect: value => {
+                    setFieldValue("phoneNumberCountryCode", value)
+                  },
+                }}
+                required
+                error={
+                  (touched.phoneNumberCountryCode &&
+                    errors.phoneNumberCountryCode) ||
+                  (touched.phone && errors.phone)
+                }
               />
 
               <Select
@@ -219,6 +245,9 @@ export const SettingsEditSettingsInformationFragmentContainer = createFragmentCo
         name
         paddleNumber
         phone
+        phoneNumber {
+          regionCode
+        }
         priceRange
         priceRangeMin
         priceRangeMax

--- a/src/__generated__/SettingsEditSettingsInformation_Test_Query.graphql.ts
+++ b/src/__generated__/SettingsEditSettingsInformation_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b2166c781268c501e1a8dcfc198f4c67>>
+ * @generated SignedSource<<9120194e62b6f997f9cc69f86f7a270c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -106,6 +106,24 @@ return {
           {
             "alias": null,
             "args": null,
+            "concreteType": "PhoneNumberType",
+            "kind": "LinkedField",
+            "name": "phoneNumber",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "regionCode",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "kind": "ScalarField",
             "name": "priceRange",
             "storageKey": null
@@ -137,7 +155,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "3f491ef23d59c097bac59b4018329499",
+    "cacheID": "d718012167c209a686eae933b844f6c7",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -157,6 +175,13 @@ return {
         "me.name": (v0/*: any*/),
         "me.paddleNumber": (v0/*: any*/),
         "me.phone": (v0/*: any*/),
+        "me.phoneNumber": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "PhoneNumberType"
+        },
+        "me.phoneNumber.regionCode": (v0/*: any*/),
         "me.priceRange": (v0/*: any*/),
         "me.priceRangeMax": (v1/*: any*/),
         "me.priceRangeMin": (v1/*: any*/)
@@ -164,7 +189,7 @@ return {
     },
     "name": "SettingsEditSettingsInformation_Test_Query",
     "operationKind": "query",
-    "text": "query SettingsEditSettingsInformation_Test_Query {\n  me {\n    ...SettingsEditSettingsInformation_me\n    id\n  }\n}\n\nfragment SettingsEditSettingsInformation_me on Me {\n  email\n  name\n  paddleNumber\n  phone\n  priceRange\n  priceRangeMin\n  priceRangeMax\n}\n"
+    "text": "query SettingsEditSettingsInformation_Test_Query {\n  me {\n    ...SettingsEditSettingsInformation_me\n    id\n  }\n}\n\nfragment SettingsEditSettingsInformation_me on Me {\n  email\n  name\n  paddleNumber\n  phone\n  phoneNumber {\n    regionCode\n  }\n  priceRange\n  priceRangeMin\n  priceRangeMax\n}\n"
   }
 };
 })();

--- a/src/__generated__/SettingsEditSettingsInformation_me.graphql.ts
+++ b/src/__generated__/SettingsEditSettingsInformation_me.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<89af01036aa0d6337cab0148a4d9f65e>>
+ * @generated SignedSource<<c187c938c6eb8987979db3e146a4ceeb>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,6 +15,9 @@ export type SettingsEditSettingsInformation_me$data = {
   readonly name: string | null;
   readonly paddleNumber: string | null;
   readonly phone: string | null;
+  readonly phoneNumber: {
+    readonly regionCode: string | null;
+  } | null;
   readonly priceRange: string | null;
   readonly priceRangeMax: number | null;
   readonly priceRangeMin: number | null;
@@ -62,6 +65,24 @@ const node: ReaderFragment = {
     {
       "alias": null,
       "args": null,
+      "concreteType": "PhoneNumberType",
+      "kind": "LinkedField",
+      "name": "phoneNumber",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "regionCode",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
       "kind": "ScalarField",
       "name": "priceRange",
       "storageKey": null
@@ -85,6 +106,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "472799a84214c4526123d3aa93cd73ad";
+(node as any).hash = "dd431d2be14132d3807372cffd2d676f";
 
 export default node;

--- a/src/__generated__/settingsRoutes_SettingsEditSettingsRouteQuery.graphql.ts
+++ b/src/__generated__/settingsRoutes_SettingsEditSettingsRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fed133f440b89018dd9885654a8e087f>>
+ * @generated SignedSource<<e17b71f2b247907c661ac312216919c0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -111,6 +111,24 @@ return {
             "args": null,
             "kind": "ScalarField",
             "name": "phone",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "PhoneNumberType",
+            "kind": "LinkedField",
+            "name": "phoneNumber",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "regionCode",
+                "storageKey": null
+              }
+            ],
             "storageKey": null
           },
           {
@@ -258,12 +276,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "dae5408d31d9afd2798b8fae7ce0b526",
+    "cacheID": "75062f3173be9c0b26ee583a777d3b24",
     "id": null,
     "metadata": {},
     "name": "settingsRoutes_SettingsEditSettingsRouteQuery",
     "operationKind": "query",
-    "text": "query settingsRoutes_SettingsEditSettingsRouteQuery {\n  me {\n    ...SettingsEditSettingsRoute_me\n    id\n  }\n}\n\nfragment AppSecondFactor_me on Me {\n  hasSecondFactorEnabled\n  appSecondFactors: secondFactors(kinds: [app]) {\n    __typename\n    ... on AppSecondFactor {\n      __typename\n      internalID\n      name\n    }\n  }\n}\n\nfragment SettingsEditSettingsInformation_me on Me {\n  email\n  name\n  paddleNumber\n  phone\n  priceRange\n  priceRangeMin\n  priceRangeMax\n}\n\nfragment SettingsEditSettingsLinkedAccounts_me on Me {\n  authentications {\n    provider\n    id\n  }\n}\n\nfragment SettingsEditSettingsPassword_me on Me {\n  hasPassword\n}\n\nfragment SettingsEditSettingsRoute_me on Me {\n  ...SettingsEditSettingsInformation_me\n  ...SettingsEditSettingsPassword_me\n  ...SettingsEditSettingsTwoFactor_me\n  ...SettingsEditSettingsLinkedAccounts_me\n}\n\nfragment SettingsEditSettingsTwoFactorBackupCodes_me on Me {\n  backupSecondFactors: secondFactors(kinds: [backup]) {\n    __typename\n    ... on BackupSecondFactor {\n      __typename\n    }\n  }\n}\n\nfragment SettingsEditSettingsTwoFactor_me on Me {\n  hasSecondFactorEnabled\n  ...AppSecondFactor_me\n  ...SmsSecondFactor_me\n  ...SettingsEditSettingsTwoFactorBackupCodes_me\n}\n\nfragment SmsSecondFactor_me on Me {\n  email\n  hasSecondFactorEnabled\n  smsSecondFactors: secondFactors(kinds: [sms]) {\n    __typename\n    ... on SmsSecondFactor {\n      __typename\n      internalID\n      formattedPhoneNumber\n    }\n  }\n}\n"
+    "text": "query settingsRoutes_SettingsEditSettingsRouteQuery {\n  me {\n    ...SettingsEditSettingsRoute_me\n    id\n  }\n}\n\nfragment AppSecondFactor_me on Me {\n  hasSecondFactorEnabled\n  appSecondFactors: secondFactors(kinds: [app]) {\n    __typename\n    ... on AppSecondFactor {\n      __typename\n      internalID\n      name\n    }\n  }\n}\n\nfragment SettingsEditSettingsInformation_me on Me {\n  email\n  name\n  paddleNumber\n  phone\n  phoneNumber {\n    regionCode\n  }\n  priceRange\n  priceRangeMin\n  priceRangeMax\n}\n\nfragment SettingsEditSettingsLinkedAccounts_me on Me {\n  authentications {\n    provider\n    id\n  }\n}\n\nfragment SettingsEditSettingsPassword_me on Me {\n  hasPassword\n}\n\nfragment SettingsEditSettingsRoute_me on Me {\n  ...SettingsEditSettingsInformation_me\n  ...SettingsEditSettingsPassword_me\n  ...SettingsEditSettingsTwoFactor_me\n  ...SettingsEditSettingsLinkedAccounts_me\n}\n\nfragment SettingsEditSettingsTwoFactorBackupCodes_me on Me {\n  backupSecondFactors: secondFactors(kinds: [backup]) {\n    __typename\n    ... on BackupSecondFactor {\n      __typename\n    }\n  }\n}\n\nfragment SettingsEditSettingsTwoFactor_me on Me {\n  hasSecondFactorEnabled\n  ...AppSecondFactor_me\n  ...SmsSecondFactor_me\n  ...SettingsEditSettingsTwoFactorBackupCodes_me\n}\n\nfragment SmsSecondFactor_me on Me {\n  email\n  hasSecondFactorEnabled\n  smsSecondFactors: secondFactors(kinds: [sms]) {\n    __typename\n    ... on SmsSecondFactor {\n      __typename\n      internalID\n      formattedPhoneNumber\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/useUpdateSettingsInformationMutation.graphql.ts
+++ b/src/__generated__/useUpdateSettingsInformationMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4c44d97626ab9ecbbfc10b385c3e6571>>
+ * @generated SignedSource<<cee6d8592dad113c4a215c072e75fa04>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -328,6 +328,24 @@ return {
               {
                 "alias": null,
                 "args": null,
+                "concreteType": "PhoneNumberType",
+                "kind": "LinkedField",
+                "name": "phoneNumber",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "regionCode",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
                 "kind": "ScalarField",
                 "name": "priceRange",
                 "storageKey": null
@@ -383,12 +401,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "fbad94103a650700d2a8a721d7efcb76",
+    "cacheID": "d515c974e2bc0de9afca94c5f633fb94",
     "id": null,
     "metadata": {},
     "name": "useUpdateSettingsInformationMutation",
     "operationKind": "mutation",
-    "text": "mutation useUpdateSettingsInformationMutation(\n  $input: UpdateMyProfileInput!\n) {\n  updateMyUserProfile(input: $input) {\n    me {\n      ...SettingsEditSettingsInformation_me\n      email\n      name\n      phone\n      priceRangeMin\n      priceRangeMax\n      id\n    }\n    userOrError {\n      __typename\n      ... on UpdateMyProfileMutationSuccess {\n        user {\n          internalID\n          id\n        }\n      }\n      ... on UpdateMyProfileMutationFailure {\n        mutationError {\n          type\n          message\n          detail\n          error\n          fieldErrors {\n            name\n            message\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment SettingsEditSettingsInformation_me on Me {\n  email\n  name\n  paddleNumber\n  phone\n  priceRange\n  priceRangeMin\n  priceRangeMax\n}\n"
+    "text": "mutation useUpdateSettingsInformationMutation(\n  $input: UpdateMyProfileInput!\n) {\n  updateMyUserProfile(input: $input) {\n    me {\n      ...SettingsEditSettingsInformation_me\n      email\n      name\n      phone\n      priceRangeMin\n      priceRangeMax\n      id\n    }\n    userOrError {\n      __typename\n      ... on UpdateMyProfileMutationSuccess {\n        user {\n          internalID\n          id\n        }\n      }\n      ... on UpdateMyProfileMutationFailure {\n        mutationError {\n          type\n          message\n          detail\n          error\n          fieldErrors {\n            name\n            message\n          }\n        }\n      }\n    }\n  }\n}\n\nfragment SettingsEditSettingsInformation_me on Me {\n  email\n  name\n  paddleNumber\n  phone\n  phoneNumber {\n    regionCode\n  }\n  priceRange\n  priceRangeMin\n  priceRangeMax\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

### Description

<!-- Implementation description -->

Doesn't yet persist the country code selected but it does use it for async client-side validation.

Note that I'm planning a follow-up iteration of this which would also pass a `phoneNumberCountryCode` value to the backend for more robust validation ([Gravity PR](https://github.com/artsy/gravity/pull/16875) / 🔒 )

### Screen Recording


https://github.com/artsy/force/assets/123595/4619d656-e270-457b-ab94-e7a029df0dda



### Screenshots

**No number persisted yet, form is still valid**

<img width="1059" alt="Screenshot 2023-09-25 at 14 36 33" src="https://github.com/artsy/force/assets/123595/bf8a6be6-9ff7-45e2-a6f4-8aab9326c2b3">

---

**Form becomes invalid if invalid number is entered or user tries to submit a form with an invalid number previously persisted**

<img width="1028" alt="Screenshot 2023-09-25 at 14 38 45" src="https://github.com/artsy/force/assets/123595/5effc7b1-34f8-40a6-b1e9-89a0dc29eaca">

---

**Client-side validation detects country code / regional number mismatches**

<img width="1019" alt="Screenshot 2023-09-25 at 14 38 54" src="https://github.com/artsy/force/assets/123595/5bbca4e7-f224-4a8e-9600-2f56bd40bb82">

