### PR TITLE
Add address verification tests

### DIFF
--- a/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -186,18 +186,14 @@ describe("Shipping", () => {
 
   beforeEach(() => {
     isCommittingMutation = false
-  })
-
-  afterEach(() => {
-    jest.clearAllMocks()
-    mockCommitMutation.mockReset()
-  })
-
-  beforeAll(() => {
     ;(useTracking as jest.Mock).mockImplementation(() => ({
       trackEvent: jest.fn(),
     }))
     ;(useFeatureFlag as jest.Mock).mockImplementation(() => false)
+  })
+
+  afterEach(() => {
+    jest.restoreAllMocks()
   })
 
   const { renderWithRelay } = setupTestWrapperTL({
@@ -659,7 +655,6 @@ describe("Shipping", () => {
           })
 
           afterEach(() => {
-            ;(useFeatureFlag as jest.Mock).mockReset()
             relayEnv = undefined
           })
 
@@ -781,7 +776,6 @@ describe("Shipping", () => {
           })
 
           afterEach(() => {
-            ;(useFeatureFlag as jest.Mock).mockReset()
             relayEnv = undefined
           })
 
@@ -944,7 +938,6 @@ describe("Shipping", () => {
           })
 
           afterEach(() => {
-            ;(useFeatureFlag as jest.Mock).mockReset()
             relayEnv = undefined
           })
 


### PR DESCRIPTION
The type of this PR is: **Test**

This PR solves [EMI-1413](https://artsyproduct.atlassian.net/browse/EMI-1413)

### Description

This adds tests to the shipping step for address verification flow. They might feel more like integration tests but given the number of regressions we saw in developing address verification, we think it's still important to cover the major flows.

The expanded test cases are:
```
Shipping
  with partner shipping
    with no saved address
      address verification
        with US enabled and international disabled
          ✓ uses recommended address
          ✓ goes back and edits address after verification
  with Artsy shipping
    with no saved address
      address verification
        with US enabled and international disabled
          ✓ uses recommended address
          ✓ goes back and edits address after verification
```

cc @artsy/emerald-devs 

[EMI-1413]: https://artsyproduct.atlassian.net/browse/EMI-1413?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ