### PR TITLE
fix(onyx-396): fixes search pagination issue when previous search results appear

### DIFF
--- a/src/Apps/Search/Routes/SearchResultsArtworks.tsx
+++ b/src/Apps/Search/Routes/SearchResultsArtworks.tsx
@@ -11,6 +11,7 @@ import {
 } from "Components/ArtworkFilter/ArtworkFilterContext"
 import { useSystemContext } from "System/useSystemContext"
 import { SearchResultsArtworksFilters } from "Apps/Search/Components/SearchResultsArtworksFilters"
+import { useEffect, useState } from "react"
 
 interface SearchResultsRouteProps {
   viewer: SearchResultsArtworks_viewer$data
@@ -19,11 +20,20 @@ interface SearchResultsRouteProps {
 export const SearchResultsArtworksRoute: React.FC<SearchResultsRouteProps> = props => {
   const { match } = useRouter()
   const { userPreferences } = useSystemContext()
+  const [searchFitlerKey, setSearchFilterKey] = useState(
+    match.location.query.term
+  )
   const { viewer } = props
   const { sidebar } = viewer
 
+  useEffect(() => {
+    // refresh artwork filter on query change
+    setSearchFilterKey(match.location.query.term)
+  }, [match.location.query.term])
+
   return (
     <ArtworkFilter
+      key={searchFitlerKey}
       mt={4}
       viewer={viewer}
       filters={match.location.query}


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [ONYX-396]

### Description

Steps to reproduce:

- Type "kaws" in search input, press enter
- Type "warhol" in search input, press enter
- Under artworks grid, click on the "next" link

Outcome before this fix:

- Kaws's artworks are displayed in the grid

Expected outcome:

- Warhol's artworks should be displayed

[ONYX-396]: https://artsyproduct.atlassian.net/browse/ONYX-396?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ