### PR TITLE
feat: remove required asterisk from account settings phone input

### DIFF
--- a/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsInformation.tsx
+++ b/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsInformation.tsx
@@ -169,7 +169,6 @@ export const SettingsEditSettingsInformation: React.FC<SettingsEditSettingsInfor
                     setFieldValue("phoneNumberCountryCode", value)
                   },
                 }}
-                required
                 error={
                   (touched.phoneNumberCountryCode &&
                     errors.phoneNumberCountryCode) ||


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

Small follow-up to #12933 

We don't require a phone number when a user updates their account information so we shouldn't use this required indicator. Mistakenly added in [force#12933][].

[force#12933]: https://github.com/artsy/force/pull/12933

### Screenshots


| Before | After |
|--------|--------|
| <img width="978" alt="Screenshot 2023-09-26 at 17 33 13" src="https://github.com/artsy/force/assets/123595/dc02b95a-8a8f-4d5e-80b3-35c63d1a5bb7"> | <img width="965" alt="Screenshot 2023-09-26 at 17 34 22" src="https://github.com/artsy/force/assets/123595/868b2dad-b05b-43bb-b90e-c5addc070002"> |







[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ