### PR TITLE
chore: Suppress opening section for online show page DIA-98

### DIFF
--- a/src/Apps/Shows/Routes/ShowsCity.tsx
+++ b/src/Apps/Shows/Routes/ShowsCity.tsx
@@ -96,6 +96,7 @@ export const ShowsCity: React.FC<ShowsCityProps> = ({
     handleClick(endCursor, page)
   }
 
+  const isOnlinePage = city.slug === "online"
   const showOpeningThisWeek = openingThisWeek.length > 0
 
   return (
@@ -110,7 +111,7 @@ export const ShowsCity: React.FC<ShowsCityProps> = ({
         {showOpeningThisWeek && (
           <>
             <Text as="h2" variant="xl">
-              {city.slug === "online"
+              {isOnlinePage
                 ? "Opening This Week"
                 : `Opening This Week in ${city.name}`}
 
@@ -138,9 +139,7 @@ export const ShowsCity: React.FC<ShowsCityProps> = ({
         <Jump id={CURRENT_SHOWS_JUMP_ID} />
 
         <Text as="h2" variant="xl">
-          {city.slug === "online"
-            ? "Current Shows"
-            : `Current Shows in ${city.name}`}
+          {isOnlinePage ? "Current Shows" : `Current Shows in ${city.name}`}
 
           {(city.currentShows?.totalCount ?? 0) > 0 && (
             <>

--- a/src/Apps/Shows/Routes/ShowsCity.tsx
+++ b/src/Apps/Shows/Routes/ShowsCity.tsx
@@ -96,6 +96,8 @@ export const ShowsCity: React.FC<ShowsCityProps> = ({
     handleClick(endCursor, page)
   }
 
+  const showOpeningThisWeek = openingThisWeek.length > 0
+
   return (
     <>
       <ShowsMeta cityName={city.name} />
@@ -105,14 +107,14 @@ export const ShowsCity: React.FC<ShowsCityProps> = ({
       <Join separator={<Spacer y={6} />}>
         <ShowsHeaderFragmentContainer viewer={viewer} />
 
-        {openingThisWeek.length > 0 && (
+        {showOpeningThisWeek && (
           <>
             <Text as="h2" variant="xl">
               {city.slug === "online"
                 ? "Opening This Week"
                 : `Opening This Week in ${city.name}`}
 
-              {openingThisWeek.length > 0 && (
+              {showOpeningThisWeek && (
                 <>
                   &nbsp;
                   <Sup color="brand">{openingThisWeek.length}</Sup>

--- a/src/Apps/Shows/Routes/ShowsCity.tsx
+++ b/src/Apps/Shows/Routes/ShowsCity.tsx
@@ -97,7 +97,7 @@ export const ShowsCity: React.FC<ShowsCityProps> = ({
   }
 
   const isOnlinePage = city.slug === "online"
-  const showOpeningThisWeek = openingThisWeek.length > 0
+  const showOpeningThisWeek = openingThisWeek.length > 0 && !isOnlinePage
 
   return (
     <>
@@ -111,10 +111,7 @@ export const ShowsCity: React.FC<ShowsCityProps> = ({
         {showOpeningThisWeek && (
           <>
             <Text as="h2" variant="xl">
-              {isOnlinePage
-                ? "Opening This Week"
-                : `Opening This Week in ${city.name}`}
-
+              Opening This Week in {city.name}
               <>
                 &nbsp;
                 <Sup color="brand">{openingThisWeek.length}</Sup>

--- a/src/Apps/Shows/Routes/ShowsCity.tsx
+++ b/src/Apps/Shows/Routes/ShowsCity.tsx
@@ -114,12 +114,10 @@ export const ShowsCity: React.FC<ShowsCityProps> = ({
                 ? "Opening This Week"
                 : `Opening This Week in ${city.name}`}
 
-              {showOpeningThisWeek && (
-                <>
-                  &nbsp;
-                  <Sup color="brand">{openingThisWeek.length}</Sup>
-                </>
-              )}
+              <>
+                &nbsp;
+                <Sup color="brand">{openingThisWeek.length}</Sup>
+              </>
             </Text>
 
             <GridColumns gridRowGap={4}>


### PR DESCRIPTION
This PR extracts a couple locals to help us control when we show various elements of the city page for shows. The city slug does double-duty here and can be the string `online` - when this is the case we want to suppress the first part of the page.

<details><summary>screenshots</summary>
<img width="1219" alt="Screenshot 2023-09-26 at 3 42 53 PM" src="https://github.com/artsy/force/assets/79799/cc88ba2f-c8c9-4d9f-9842-fcdfef51efd9">
<img width="1219" alt="Screenshot 2023-09-26 at 3 42 55 PM" src="https://github.com/artsy/force/assets/79799/73f66c5d-ab3d-496d-9da0-54ac02607151">

</details> 

https://artsyproduct.atlassian.net/browse/DIA-98

/cc @artsy/diamond-devs