### PR TITLE
fix(start): Add --kill-all to exit when something errors out

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -11,7 +11,7 @@ if [ "${NODE_ENV}" != "production" ]; then
   fi
   OPT+=(--preserve-symlinks)
 
-  yarn concurrently 'yarn relay --watch' 'node --max_old_space_size=3072 ./src/dev.js'
+  yarn concurrently --kill-others 'yarn relay --watch' 'node --max_old_space_size=3072 ./src/dev.js'
 else
   exec node "${OPT[@]}" --no-experimental-fetch ./server.dist.js
 fi


### PR DESCRIPTION
The type of this PR is: **fix**

### Description

This (attempts) to fix our pipeline to prevent relay errors from slipping in by checking for errors in commands and then exiting. If relay isn't working, we should immediately fail so that devs can fix their relay command. 

Not sure if this is the best fix, but lets give it a shot and see if it doesn't create more problems. 
