### PR TITLE
fix(EMI-1475): bank debit form error messaging

### DIFF
--- a/src/Components/BankDebitForm/BankDebitProvider.tsx
+++ b/src/Components/BankDebitForm/BankDebitProvider.tsx
@@ -143,16 +143,20 @@ export const BankDebitProvider: FC<Props> = ({ order, onError }) => {
         camelCase(selectedPaymentMethod)
       )}`}
     >
-      <LoadingArea isLoading={isStripePaymentElementLoading}>
-        {isStripePaymentElementLoading && <Box height={300}></Box>}
+      <LoadingArea
+        isLoading={isStripePaymentElementLoading && !bankDebitSetupError}
+      >
+        {isStripePaymentElementLoading && !bankDebitSetupError && (
+          <Box height={300}></Box>
+        )}
         <Spacer y={2} />
         {stripeClient && (
           <Elements options={options} stripe={stripePromise}>
             <BankDebitForm order={order} onError={onError} />
           </Elements>
         )}
-        {bankDebitSetupError && <BankSetupErrorMessage />}
       </LoadingArea>
+      {bankDebitSetupError && <BankSetupErrorMessage />}
     </div>
   )
 }


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-1475]

@artsy/emerald-devs 

### Description
In the case where there is a bank setup error and the payment element is still loading, don't show the loading spinner. 

<img width="1300" alt="Screenshot 2023-09-27 at 2 08 53 PM" src="https://github.com/artsy/force/assets/50849237/a4de9a8e-ab40-44a3-bb09-7f28c210adc2">



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EMI-1475]: https://artsyproduct.atlassian.net/browse/EMI-1475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ