### PR TITLE
feat [EMI-1480]: disable autocomplete secondary suggestions by default

### DIFF
--- a/src/Components/Address/AddressForm.tsx
+++ b/src/Components/Address/AddressForm.tsx
@@ -15,6 +15,8 @@ import {
   useAddressAutocomplete,
 } from "Components/Address/useAddressAutocomplete"
 
+const ENABLE_SECONDARY_SUGGESTIONS = false
+
 export interface Address {
   name: string
   country: string
@@ -90,7 +92,9 @@ export const AddressForm: React.FC<AddressFormProps> = ({
     fetchForAutocomplete,
     fetchSecondarySuggestions,
     ...autocomplete
-  } = useAddressAutocomplete(address)
+  } = useAddressAutocomplete(address, {
+    enableSecondarySuggestions: ENABLE_SECONDARY_SUGGESTIONS,
+  })
 
   if (!isEqual(value, prevValue)) {
     setPrevValue(value)
@@ -210,25 +214,9 @@ export const AddressForm: React.FC<AddressFormProps> = ({
               fetchForAutocomplete({ search: "" })
             }}
             onSelect={option => {
-              const hasSecondarySuggestions = option.entries > 1
-              if (hasSecondarySuggestions) {
-                // Fill in the address form with the selection, but skip line 2
-                Object.entries(option.address).forEach(([key, value]) => {
-                  if (key === "addressLine2") return
-                  changeValueHandler(key as keyof Address)(value)
-                })
-                fetchSecondarySuggestions(value!.addressLine1!, option)
-
-                // TODO: make the secondary options appear
-                // console.log({ autocompleteRefCurrent: autocompleteRef.current })
-                setTimeout(() => {
-                  autocompleteRef.current?.focus()
-                }, 1000)
-              } else {
-                Object.entries(option.address).forEach(([key, value]) => {
-                  changeValueHandler(key as keyof Address)(value)
-                })
-              }
+              Object.entries(option.address).forEach(([key, value]) => {
+                changeValueHandler(key as keyof Address)(value)
+              })
             }}
             error={getError("addressLine1")}
             data-testid="AddressForm_addressLine1"

--- a/src/Components/Address/__tests__/AddressForm.jest.tsx
+++ b/src/Components/Address/__tests__/AddressForm.jest.tsx
@@ -71,7 +71,7 @@ describe("AddressForm", () => {
           suggestions: [
             {
               city: "New York",
-              entries: 0,
+              entries: 2,
               secondary: "Fl 25",
               state: "NY",
               street_line: "401 Broadway",
@@ -105,9 +105,7 @@ describe("AddressForm", () => {
 
         const listbox = await screen.findByRole("listbox", { hidden: true })
 
-        expect(listbox).toHaveTextContent(
-          "401 Broadway Fl 25, New York NY 10013"
-        )
+        expect(listbox).toHaveTextContent("401 Broadway, New York NY 10013")
       })
 
       // Skipped because it's not working even though I see it working in manual testing

--- a/src/Components/Address/useAddressAutocomplete.ts
+++ b/src/Components/Address/useAddressAutocomplete.ts
@@ -29,7 +29,10 @@ interface ServiceAvailability {
 }
 
 export const useAddressAutocomplete = (
-  address: Partial<Address> & { country: Address["country"] }
+  address: Partial<Address> & { country: Address["country"] },
+  {
+    enableSecondarySuggestions = false,
+  }: { enableSecondarySuggestions?: boolean } = {}
 ): ServiceAvailability & {
   autocompleteOptions: AddressAutocompleteSuggestion[]
   suggestions: ProviderSuggestion[]
@@ -125,16 +128,19 @@ export const useAddressAutocomplete = (
 
   const fetchSecondarySuggestions = useCallback(
     async (search: string, option: AddressAutocompleteSuggestion) => {
+      if (!enableSecondarySuggestions) {
+        return
+      }
       const selectedParam = `${option.address.addressLine1} ${option.address.addressLine2} (${option.entries}) ${option.address.city} ${option.address.region} ${option.address.postalCode}`
       fetchForAutocomplete({ search, selected: selectedParam })
     },
-    [fetchForAutocomplete]
+    [fetchForAutocomplete, enableSecondarySuggestions]
   )
 
   const buildAddressText = (suggestion: ProviderSuggestion): string => {
     let buildingAddress = suggestion.street_line
     if (suggestion.secondary) buildingAddress += ` ${suggestion.secondary}`
-    if (suggestion.entries > 1)
+    if (enableSecondarySuggestions && suggestion.entries > 1)
       buildingAddress += ` (${suggestion.entries} entries)`
 
     return [


### PR DESCRIPTION
This PR makes the secondary suggestion feature of our autocomplete hook disabled by default. The reasoning here is that we need a strategy for handling apartment/unit/suite information in a [more specific way than "address line 1/2"](https://www.smarty.com/articles/address-line-2-meaning), and until then this experience will give a bad UX when automatically filling suggestions.

Change
The change is to disable this functionality in the hook unless it receives a specific parameter. We can turn this back on and refine it later.

User facing changes unless the secondary suggestions are explicitly enabled:
- No more `(3 entries)` when an address has sub-entries.
- Secondary information that doesn't rest in a nested entries like above is stripped out. This way we won't autofill that input (they still will, but we aren't contributing to the negative experience).
- Addresses are deduplicated based on their text representation.


~~The change will _not_ prevent us from showing a user addresses with additional unit numbers, so we should check if that part is still a big enough pain point that we want to go for a deeper change in how we present suggestions~~ (eg we could remove secondary information from the suggestions and then filter for unique addresses) **(update: I had to do this).**

<details><summary>Before and after (plus the `(entries)` were removed):</summary>

Before (note in this screenshot the `(entries)` has already been removed): 
![image](https://github.com/artsy/force/assets/9088720/874d328b-d14a-431a-913a-afcd6cc9381e)
After:
![image](https://github.com/artsy/force/assets/9088720/819cd9cd-b588-48fc-8d52-520ba1339a89)


</details> 

<details><summary>Behavior documented in specs:</summary>
<pre>
 PASS  src/Components/Address/__tests__/useAddressAutocomplete.jest.ts
  useAddressAutocomplete
    when the US address autocomplete feature flag is enabled
      fetching for autocomplete suggestions
        ✓ does not fetch for a query of less than 3 characters (2 ms)
        ✓ fetches top-level suggestions from the API with correct parameters (2 ms)
        ✓ sets line 2 to an empty string if the value is missing (3 ms)
        ✓ resets the suggestions when the country changes (4 ms)
        ✓ resets the suggestions without fetching when the search term is too short (2 ms)
        ✓ throttles calls to the Smarty API (2 ms)
        fetching secondary suggestions enabled
          ✓ returns the first 5 results in the correct shape (61 ms)
        fetching secondary suggestions not enabled
          ✓ returns simplified, deduplicated results without considering secondary information (54 ms)
          ✓ returns the correct single-line text for an address with multiple entries (3 ms)
          ✓ returns the first 5 results in the correct shape (52 ms)
          ✓ returns the correct single-line text for an address without multiple entries (3 ms)
      fetching secondary suggestions not enabled
        ✓ fetchSecondaySuggestions() does nothing (1 ms)
      fetching secondary suggestions enabled
        ✓ fetches secondary suggestions from the API with correct parameters (52 ms)
        ✓ returns the correct single-line text for an address with multiple entries (2 ms)
    enabled
      feature flag is enabled
        API key is availaible
          selected country is US
            ✓ returns true (1 ms)
          selected country is not US
            ✓ returns false (1 ms)
        API key is missing
          selected country is US
            ✓ returns false
          selected country is not US
            ✓ returns false (1 ms)
      feature flag is disabled
        API key is availaible
          selected country is US
            ✓ returns false (1 ms)
          selected country is not US
            ✓ returns false
        API key is missing
          selected country is US
            ✓ returns false (1 ms)
          selected country is not US
            ✓ returns false (1 ms)
</pre>
</details> 
