### PR TITLE
feat: Dry run of testing horizontal filters

### DIFF
--- a/src/Apps/Artist/Routes/WorksForSale/ArtistWorksForSaleRoute.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/ArtistWorksForSaleRoute.tsx
@@ -7,6 +7,10 @@ import { Title, Meta } from "react-head"
 import { useRouter } from "System/Router/useRouter"
 import { useJump } from "Utils/Hooks/useJump"
 import { ArtistWorksForSaleEmptyFragmentContainer } from "Apps/Artist/Routes/WorksForSale/Components/ArtistWorksForSaleEmpty"
+import {
+  useFeatureVariant,
+  useTrackFeatureVariant,
+} from "System/useFeatureFlag"
 
 interface ArtistWorksForSaleRouteProps {
   artist: ArtistWorksForSaleRoute_artist$data
@@ -34,11 +38,24 @@ const ArtistWorksForSaleRoute: React.FC<ArtistWorksForSaleRouteProps> = ({
 
   const total = artist.sidebarAggregations?.counts?.total ?? 0
 
+  const experimentName = "diamond_dry_run_for_horizontal_filters"
+  const variant = useFeatureVariant(experimentName)
+  const variantName = variant?.name || "unknown"
+
+  const { trackFeatureVariant } = useTrackFeatureVariant({
+    experimentName,
+    variantName,
+  })
+
+  useEffect(trackFeatureVariant, [trackFeatureVariant])
+
   return (
     <>
       <Title>{title}</Title>
       <Meta name="title" content={title} />
       <Meta name="description" content={description} />
+      <Meta name="experimentName" content={experimentName} />
+      <Meta name="variantName" content={variantName} />
 
       {total === 0 ? (
         <ArtistWorksForSaleEmptyFragmentContainer artist={artist} />


### PR DESCRIPTION
This PR adds an invisible change to the artist page by adding a couple meta tags. It uses a feature I setup in Unleash so that we could do a dry run of testing for the horizontal filters. The idea is to let this sit on production for a bit and then we can verify that the data we want to analyze is flowing through the data pipeline as expected.

/cc @artsy/diamond-devs @leodmz 