### PR TITLE
feat(articles): adds news module to top of page

### DIFF
--- a/src/Apps/Articles/ArticlesApp.tsx
+++ b/src/Apps/Articles/ArticlesApp.tsx
@@ -1,12 +1,13 @@
 import { FC } from "react"
 import { Link } from "react-head"
-import { Spacer, Text } from "@artsy/palette"
+import { Column, GridColumns, Spacer, Text } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { MetaTags } from "Components/MetaTags"
 import { ArticlesIndexArticlesPaginationContainer } from "./Components/ArticlesIndexArticles"
 import { getENV } from "Utils/getENV"
 import { ArticlesApp_viewer$data } from "__generated__/ArticlesApp_viewer.graphql"
 import { useScrollToOpenEditorialAuthModal } from "Utils/Hooks/useScrollToOpenEditorialAuthModal"
+import { ArticlesIndexNewsFragmentContainer } from "Apps/Articles/Components/ArticlesIndexNews"
 
 interface ArticlesAppProps {
   viewer: ArticlesApp_viewer$data
@@ -32,7 +33,15 @@ const ArticlesApp: FC<ArticlesAppProps> = ({ viewer }) => {
 
       <Spacer y={[2, 4]} />
 
-      <Text variant="xl">Editorial</Text>
+      <GridColumns gridRowGap={4}>
+        <Column span={[12, 4, 6]}>
+          <Text variant="xl">Editorial</Text>
+        </Column>
+
+        <Column span={[12, 8, 6]}>
+          <ArticlesIndexNewsFragmentContainer viewer={viewer} />
+        </Column>
+      </GridColumns>
 
       <Spacer y={6} />
 
@@ -46,6 +55,7 @@ export const ArticlesAppFragmentContainer = createFragmentContainer(
   {
     viewer: graphql`
       fragment ArticlesApp_viewer on Viewer {
+        ...ArticlesIndexNews_viewer
         ...ArticlesIndexArticles_viewer
       }
     `,

--- a/src/Apps/Articles/Components/ArticlesIndexNews.tsx
+++ b/src/Apps/Articles/Components/ArticlesIndexNews.tsx
@@ -1,0 +1,70 @@
+import { FC } from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { ArticlesIndexNews_viewer$data } from "__generated__/ArticlesIndexNews_viewer.graphql"
+import { Flex, Stack, Text } from "@artsy/palette"
+import { RouterLink } from "System/Router/RouterLink"
+
+interface ArticlesIndexNewsProps {
+  viewer: ArticlesIndexNews_viewer$data
+}
+
+const ArticlesIndexNews: FC<ArticlesIndexNewsProps> = ({ viewer }) => {
+  const date = new Date().toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+  })
+
+  return (
+    <Stack gap={4} border="1px solid" borderColor="black30" p={2}>
+      <Flex alignItems="center" justifyContent="space-between">
+        <Text variant="lg-display">News</Text>
+
+        <Text variant="lg-display">{date}</Text>
+      </Flex>
+
+      <Stack gap={2}>
+        {viewer.articles.map((article, i) => {
+          return (
+            <RouterLink
+              key={article.internalID}
+              to={article.href}
+              textDecoration="none"
+              inline
+              borderBottom={
+                i === viewer.articles.length - 1 ? "none" : "1px solid"
+              }
+              borderColor="black10"
+              pb={2}
+            >
+              <Text variant="sm-display">{article.title}</Text>
+            </RouterLink>
+          )
+        })}
+
+        <RouterLink to="/news" inline>
+          <Text variant="sm-display">More in News</Text>
+        </RouterLink>
+      </Stack>
+    </Stack>
+  )
+}
+
+export const ArticlesIndexNewsFragmentContainer = createFragmentContainer(
+  ArticlesIndexNews,
+  {
+    viewer: graphql`
+      fragment ArticlesIndexNews_viewer on Viewer {
+        articles(
+          published: true
+          limit: 3
+          sort: PUBLISHED_AT_DESC
+          layout: NEWS
+        ) {
+          internalID
+          title
+          href
+        }
+      }
+    `,
+  }
+)

--- a/src/__generated__/ArticlesApp_viewer.graphql.ts
+++ b/src/__generated__/ArticlesApp_viewer.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<47a3c930d2ad4868596ce6b4e8a68f7e>>
+ * @generated SignedSource<<c7ff57b3d633acc2d9e3e3f84e414f29>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,7 +11,7 @@
 import { Fragment, ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type ArticlesApp_viewer$data = {
-  readonly " $fragmentSpreads": FragmentRefs<"ArticlesIndexArticles_viewer">;
+  readonly " $fragmentSpreads": FragmentRefs<"ArticlesIndexArticles_viewer" | "ArticlesIndexNews_viewer">;
   readonly " $fragmentType": "ArticlesApp_viewer";
 };
 export type ArticlesApp_viewer$key = {
@@ -28,6 +28,11 @@ const node: ReaderFragment = {
     {
       "args": null,
       "kind": "FragmentSpread",
+      "name": "ArticlesIndexNews_viewer"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
       "name": "ArticlesIndexArticles_viewer"
     }
   ],
@@ -35,6 +40,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "17f39e1201099c7627271106edd9a319";
+(node as any).hash = "e90c5b665eb010cc1ad4e60ecd4bac26";
 
 export default node;

--- a/src/__generated__/ArticlesIndexNews_viewer.graphql.ts
+++ b/src/__generated__/ArticlesIndexNews_viewer.graphql.ts
@@ -1,0 +1,92 @@
+/**
+ * @generated SignedSource<<53dfb74e3a727455adf7137cce92276e>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { Fragment, ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ArticlesIndexNews_viewer$data = {
+  readonly articles: ReadonlyArray<{
+    readonly href: string | null;
+    readonly internalID: string;
+    readonly title: string | null;
+  }>;
+  readonly " $fragmentType": "ArticlesIndexNews_viewer";
+};
+export type ArticlesIndexNews_viewer$key = {
+  readonly " $data"?: ArticlesIndexNews_viewer$data;
+  readonly " $fragmentSpreads": FragmentRefs<"ArticlesIndexNews_viewer">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ArticlesIndexNews_viewer",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "layout",
+          "value": "NEWS"
+        },
+        {
+          "kind": "Literal",
+          "name": "limit",
+          "value": 3
+        },
+        {
+          "kind": "Literal",
+          "name": "published",
+          "value": true
+        },
+        {
+          "kind": "Literal",
+          "name": "sort",
+          "value": "PUBLISHED_AT_DESC"
+        }
+      ],
+      "concreteType": "Article",
+      "kind": "LinkedField",
+      "name": "articles",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "internalID",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "title",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "href",
+          "storageKey": null
+        }
+      ],
+      "storageKey": "articles(layout:\"NEWS\",limit:3,published:true,sort:\"PUBLISHED_AT_DESC\")"
+    }
+  ],
+  "type": "Viewer",
+  "abstractKey": null
+};
+
+(node as any).hash = "822ba23e4531800309d371ebde7d0d21";
+
+export default node;

--- a/src/__generated__/articlesRoutes_ArticlesQuery.graphql.ts
+++ b/src/__generated__/articlesRoutes_ArticlesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2d18eddf4c0aa264db25d6ed5a7a4489>>
+ * @generated SignedSource<<afd20ca1a76a72129a669546957b3971>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -22,7 +22,33 @@ export type articlesRoutes_ArticlesQuery = {
 };
 
 const node: ConcreteRequest = (function(){
-var v0 = [
+var v0 = {
+  "kind": "Literal",
+  "name": "sort",
+  "value": "PUBLISHED_AT_DESC"
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = [
   {
     "kind": "Literal",
     "name": "featured",
@@ -33,11 +59,7 @@ var v0 = [
     "name": "first",
     "value": 15
   },
-  {
-    "kind": "Literal",
-    "name": "sort",
-    "value": "PUBLISHED_AT_DESC"
-  }
+  (v0/*: any*/)
 ];
 return {
   "fragment": {
@@ -82,7 +104,45 @@ return {
         "selections": [
           {
             "alias": null,
-            "args": (v0/*: any*/),
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "layout",
+                "value": "NEWS"
+              },
+              {
+                "kind": "Literal",
+                "name": "limit",
+                "value": 3
+              },
+              {
+                "kind": "Literal",
+                "name": "published",
+                "value": true
+              },
+              (v0/*: any*/)
+            ],
+            "concreteType": "Article",
+            "kind": "LinkedField",
+            "name": "articles",
+            "plural": true,
+            "selections": [
+              (v1/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "title",
+                "storageKey": null
+              },
+              (v2/*: any*/),
+              (v3/*: any*/)
+            ],
+            "storageKey": "articles(layout:\"NEWS\",limit:3,published:true,sort:\"PUBLISHED_AT_DESC\")"
+          },
+          {
+            "alias": null,
+            "args": (v4/*: any*/),
             "concreteType": "ArticleConnection",
             "kind": "LinkedField",
             "name": "articlesConnection",
@@ -104,20 +164,8 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "internalID",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "href",
-                        "storageKey": null
-                      },
+                      (v1/*: any*/),
+                      (v2/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -206,13 +254,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "id",
-                        "storageKey": null
-                      },
+                      (v3/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -263,7 +305,7 @@ return {
           },
           {
             "alias": null,
-            "args": (v0/*: any*/),
+            "args": (v4/*: any*/),
             "filters": [
               "sort",
               "featured"
@@ -279,12 +321,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "0e6fb91de9319b2fce3e77264bb5222f",
+    "cacheID": "9f6b88922cedacb6f93c9a47fe7989b5",
     "id": null,
     "metadata": {},
     "name": "articlesRoutes_ArticlesQuery",
     "operationKind": "query",
-    "text": "query articlesRoutes_ArticlesQuery {\n  viewer {\n    ...ArticlesApp_viewer\n  }\n}\n\nfragment ArticlesApp_viewer on Viewer {\n  ...ArticlesIndexArticles_viewer\n}\n\nfragment ArticlesIndexArticle_article on Article {\n  href\n  thumbnailTitle\n  byline\n  publishedAt(format: \"MMMM Do YYYY\")\n  thumbnailImage {\n    cropped(width: 910, height: 607) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ArticlesIndexArticles_viewer on Viewer {\n  articlesConnection(first: 15, sort: PUBLISHED_AT_DESC, featured: true) {\n    edges {\n      node {\n        internalID\n        ...ArticlesIndexArticle_article\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query articlesRoutes_ArticlesQuery {\n  viewer {\n    ...ArticlesApp_viewer\n  }\n}\n\nfragment ArticlesApp_viewer on Viewer {\n  ...ArticlesIndexNews_viewer\n  ...ArticlesIndexArticles_viewer\n}\n\nfragment ArticlesIndexArticle_article on Article {\n  href\n  thumbnailTitle\n  byline\n  publishedAt(format: \"MMMM Do YYYY\")\n  thumbnailImage {\n    cropped(width: 910, height: 607) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ArticlesIndexArticles_viewer on Viewer {\n  articlesConnection(first: 15, sort: PUBLISHED_AT_DESC, featured: true) {\n    edges {\n      node {\n        internalID\n        ...ArticlesIndexArticle_article\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment ArticlesIndexNews_viewer on Viewer {\n  articles(published: true, limit: 3, sort: PUBLISHED_AT_DESC, layout: NEWS) {\n    internalID\n    title\n    href\n    id\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Closes [DIA-136](https://artsyproduct.atlassian.net/browse/DIA-136)

News is back and this brings back the news module on the articles index page.

The layout here is the one that Ryan tweaked [in this thread.](https://artsy.slack.com/archives/C05EEBNEF71/p1695816773386229)

[DIA-136]: https://artsyproduct.atlassian.net/browse/DIA-136?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

-----

![](https://static.damonzucconi.com/_capture/iuK2amKvnFDmdegJa6ppo2RBVNuAchVYwJj0y9aDjLdfeOFEgqHO4UHwsEoMZgweN6eW0FrRmWH0K3c8TmJHufxWPh12bRyZ7Ldw.png)