### PR TITLE
feat: add condition to artwork meta tags

### DIFF
--- a/src/Apps/Artwork/Components/Seo/SeoDataForArtwork.tsx
+++ b/src/Apps/Artwork/Components/Seo/SeoDataForArtwork.tsx
@@ -6,7 +6,6 @@ import { CreativeWork } from "Components/Seo/CreativeWork"
 import { Product } from "Components/Seo/Product"
 import { createFragmentContainer, graphql } from "react-relay"
 import { getENV } from "Utils/getENV"
-
 import { get } from "Utils/get"
 
 const APP_URL = getENV("APP_URL")

--- a/src/Apps/Artwork/Components/Seo/SeoDataForArtwork.tsx
+++ b/src/Apps/Artwork/Components/Seo/SeoDataForArtwork.tsx
@@ -5,10 +5,11 @@ import { SeoDataForArtwork_artwork$data } from "__generated__/SeoDataForArtwork_
 import { CreativeWork } from "Components/Seo/CreativeWork"
 import { Product } from "Components/Seo/Product"
 import { createFragmentContainer, graphql } from "react-relay"
-import { data as sd } from "sharify"
+import { getENV } from "Utils/getENV"
+
 import { get } from "Utils/get"
 
-const { APP_URL } = sd
+const APP_URL = getENV("APP_URL")
 
 interface SeoDataForArtworkProps {
   artwork: SeoDataForArtwork_artwork$data
@@ -40,6 +41,7 @@ export const SeoDataForArtwork: React.FC<SeoDataForArtworkProps> = ({
       "@type": "Person",
       name: artistsName,
     },
+    condition: "used",
   }
 
   // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION

--- a/src/Apps/Artwork/Components/Seo/__tests__/SeoDataForArtwork.jest.tsx
+++ b/src/Apps/Artwork/Components/Seo/__tests__/SeoDataForArtwork.jest.tsx
@@ -69,6 +69,7 @@ describe("SeoDataForArtwork", () => {
           "@type": "Person",
           name: "Artist McArtist",
         },
+        condition: "used",
         description: "artwork description",
         image: "artwork-image",
         name: "artwork title",
@@ -94,6 +95,7 @@ describe("SeoDataForArtwork", () => {
       const data = wrapper.find(Product).first().props().data
       expect(data).toEqual({
         brand: { "@type": "Person", name: "Artist McArtist" },
+        condition: "used",
         category: "Design/Decorative Art",
         description: "artwork description",
         image: "artwork-image",


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [DIA-183]

### Description

It adds the `condition` field to the artwork meta tags

Discussion [here](https://artsy.slack.com/archives/C05EEBNEF71/p1695807929724789).

![Screenshot 2023-09-29 at 11 16 00](https://github.com/artsy/force/assets/1176374/694e3bb5-3b6b-464e-9154-6e7e7275060a)


<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DIA-183]: https://artsyproduct.atlassian.net/browse/DIA-183?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ