### PR TITLE
feat(articles): adds h-tags and testid

### DIFF
--- a/src/Apps/Articles/ArticlesApp.tsx
+++ b/src/Apps/Articles/ArticlesApp.tsx
@@ -35,7 +35,9 @@ const ArticlesApp: FC<ArticlesAppProps> = ({ viewer }) => {
 
       <GridColumns gridRowGap={4}>
         <Column span={[12, 4, 6]}>
-          <Text variant="xl">Editorial</Text>
+          <Text as="h1" variant="xl">
+            Editorial
+          </Text>
         </Column>
 
         <Column span={[12, 8, 6]}>

--- a/src/Apps/Articles/Components/ArticlesIndexArticle.tsx
+++ b/src/Apps/Articles/Components/ArticlesIndexArticle.tsx
@@ -22,14 +22,21 @@ const ArticlesIndexArticle: FC<ArticlesIndexArticleProps> = ({ article }) => {
   return (
     <GridColumns gridRowGap={2}>
       <Column span={6}>
-        <RouterLink to={article.href} display="block" textDecoration="none">
+        <RouterLink
+          data-testid="ArticlesIndexArticle"
+          to={article.href}
+          display="block"
+          textDecoration="none"
+        >
           <Text variant="xs" mb={1}>
             {article.publishedAt}
           </Text>
 
-          <Text variant="xl">{article.thumbnailTitle}</Text>
+          <Text as="h2" variant="xl">
+            {article.thumbnailTitle}
+          </Text>
 
-          <Text variant="xl" color="black60">
+          <Text as="h3" variant="xl" color="black60">
             {article.byline}
           </Text>
         </RouterLink>


### PR DESCRIPTION
This adds some additional markup to differentiate links to main articles with links to news articles. There is an Integrity spec which tries to load an article with an ad on it. News doesn't contain ads so this is now failing since the first links are news articles.

Added h1, h2, h3 tags while I'm at it.