### PR TITLE
chore [EMI-1447]: add a test for autocomplete functionality (wip: only works alone)

### DIFF
--- a/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -972,7 +972,7 @@ describe("Shipping", () => {
             // TODO: This test passes in isolation but fails when run with any test
             // before it enabled. It seems to be related to the presence of the _.throttle
             // in the hook - removing that makes the test pass with others.
-            it("fills in the address from an autocomplete option on a US address", async () => {
+            it.skip("fills in the address from an autocomplete option on a US address", async () => {
               mockFetch.mockResolvedValue({
                 json: jest.fn().mockResolvedValue({
                   suggestions: [

--- a/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -972,7 +972,7 @@ describe("Shipping", () => {
             // TODO: This test passes in isolation but fails when run with any test
             // before it enabled. It seems to be related to the presence of the _.throttle
             // in the hook - removing that makes the test pass with others.
-            it.skip("fills in the address from an autocomplete option on a US address", async () => {
+            it("fills in the address from an autocomplete option on a US address", async () => {
               mockFetch.mockResolvedValue({
                 json: jest.fn().mockResolvedValue({
                   suggestions: [

--- a/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -57,6 +57,14 @@ jest.mock("Utils/getENV", () => ({
   getENV: jest.fn(),
 }))
 
+// jest.mock("lodash", () => {
+//   const lodash = jest.requireActual("lodash")
+//   return {
+//     ...lodash,
+//     throttle: fn => fn,
+//   }
+// })
+
 jest.mock("@artsy/palette", () => {
   return {
     ...jest.requireActual("@artsy/palette"),
@@ -924,7 +932,7 @@ describe("Shipping", () => {
             expect(env.mock.getAllOperations()).toHaveLength(0)
           })
 
-          it("triggers the flow for international address after clicking continue", async () => {
+          it.only("triggers the flow for international address after clicking continue", async () => {
             const { env } = renderWithRelay(
               {
                 CommerceOrder: () => order,
@@ -972,7 +980,7 @@ describe("Shipping", () => {
             // TODO: This test passes in isolation but fails when run with any test
             // before it enabled. It seems to be related to the presence of the _.throttle
             // in the hook - removing that makes the test pass with others.
-            it.skip("fills in the address from an autocomplete option on a US address", async () => {
+            it.only("fills in the address from an autocomplete option on a US address", async () => {
               mockFetch.mockResolvedValue({
                 json: jest.fn().mockResolvedValue({
                   suggestions: [

--- a/src/Components/Address/AddressForm.tsx
+++ b/src/Components/Address/AddressForm.tsx
@@ -193,7 +193,7 @@ export const AddressForm: React.FC<AddressFormProps> = ({
   }
 
   return (
-    <GridColumns>
+    <GridColumns data-testid="AddressForm_inputs">
       <Column span={12}>
         <Input
           tabIndex={tabIndex}

--- a/src/Components/Address/useAddressAutocomplete.ts
+++ b/src/Components/Address/useAddressAutocomplete.ts
@@ -88,31 +88,33 @@ export const useAddressAutocomplete = (
   }, [isUSAddress, result.length])
 
   const fetchSuggestions = useMemo(() => {
-    return async ({
-      search,
-      selected,
-    }: {
-      search: string
-      selected?: string
-    }) => {
-      const params = {
-        key: apiKey,
-        search: search,
+    const throttledFetch = throttle(
+      async ({ search, selected }: { search: string; selected?: string }) => {
+        const params = {
+          key: apiKey,
+          search: search,
+        }
+
+        if (selected) {
+          params["selected"] = selected
+        }
+
+        if (!apiKey) return null
+        let url =
+          "https://us-autocomplete-pro.api.smarty.com/lookup?" +
+          new URLSearchParams(params).toString()
+
+        const response = await fetch(url)
+        const json = await response.json()
+        return json
+      },
+      THROTTLE_DELAY,
+      {
+        leading: true,
+        trailing: true,
       }
-
-      if (selected) {
-        params["selected"] = selected
-      }
-
-      if (!apiKey) return null
-      let url =
-        "https://us-autocomplete-pro.api.smarty.com/lookup?" +
-        new URLSearchParams(params).toString()
-
-      const response = await fetch(url)
-      const json = await response.json()
-      return json
-    }
+    )
+    return throttledFetch
   }, [apiKey])
 
   const buildAddressText = useCallback(

--- a/src/Components/Address/useAddressAutocomplete.ts
+++ b/src/Components/Address/useAddressAutocomplete.ts
@@ -73,6 +73,7 @@ export const useAddressAutocomplete = (
   useEffect(() => {
     const isAPIKeyPresent = !!apiKey
     const enabled = isAPIKeyPresent && isFeatureFlagEnabled && isUSAddress
+
     setServiceAvailability({
       loaded: true,
       enabled,

--- a/src/Components/Address/useAddressAutocomplete.ts
+++ b/src/Components/Address/useAddressAutocomplete.ts
@@ -88,33 +88,31 @@ export const useAddressAutocomplete = (
   }, [isUSAddress, result.length])
 
   const fetchSuggestions = useMemo(() => {
-    const throttledFetch = throttle(
-      async ({ search, selected }: { search: string; selected?: string }) => {
-        const params = {
-          key: apiKey,
-          search: search,
-        }
-
-        if (selected) {
-          params["selected"] = selected
-        }
-
-        if (!apiKey) return null
-        let url =
-          "https://us-autocomplete-pro.api.smarty.com/lookup?" +
-          new URLSearchParams(params).toString()
-
-        const response = await fetch(url)
-        const json = await response.json()
-        return json
-      },
-      THROTTLE_DELAY,
-      {
-        leading: true,
-        trailing: true,
+    return async ({
+      search,
+      selected,
+    }: {
+      search: string
+      selected?: string
+    }) => {
+      const params = {
+        key: apiKey,
+        search: search,
       }
-    )
-    return throttledFetch
+
+      if (selected) {
+        params["selected"] = selected
+      }
+
+      if (!apiKey) return null
+      let url =
+        "https://us-autocomplete-pro.api.smarty.com/lookup?" +
+        new URLSearchParams(params).toString()
+
+      const response = await fetch(url)
+      const json = await response.json()
+      return json
+    }
   }, [apiKey])
 
   const buildAddressText = useCallback(


### PR DESCRIPTION
The type of this PR is: **Chore** and it partially completes [EMI-1447]
TODOs
- [ ] Fix the issues documented below with these tests
- [ ] Add these new tests to shipping refactor (Shipping2) routes - pending ok if they can't be immediately enabled, but ticket it in checkout flow `epic/refactor-shipping` label.

This is a test for the basic address autocomplete functionality in the shipping route. It only works when you run it alone - any tests that appear above it will cause it to fail due to `mockFetch()` not being called. For that reason the test is currently skipped.

I paired with @starsirius and we were able to fix this issue by [removing the `_.throttle()` usage in the autocomplete hook](https://github.com/artsy/force/pull/12971#:~:text=_.throttle%20call-,296cd7e,-Revert%20%22poc%3A%20fix). Before that I was sure that I was mocking `fetch` wrong. It's not clear why this is happening, but if you log the private, memoized, throttled `fetchSuggestions` right before it is called, then run the spec with two tests that exercise autocomplete (eg, duplicate the existing spec, or use a tracking one when that gets implemented), you can see that `fetchSuggestions` is a function in the first spec and undefined in each subsequent spec.

<details><summary>example showing broken spec with missing memoized function - removing `_.throttle` call fixes this</summary>

![image](https://github.com/artsy/force/assets/9088720/55abc66e-85ce-45a5-839d-5087def37510)

</details> 


[EMI-1447]: https://artsyproduct.atlassian.net/browse/EMI-1447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ