### PR TITLE
tracks clicks to read more link

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAdditionalInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAdditionalInfo.tsx
@@ -145,6 +145,13 @@ export const ArtworkDetailsAdditionalInfo: React.FC<ArtworkDetailsAdditionalInfo
       ) : (
         conditionDescription && conditionDescription.details
       ),
+      onReadMoreClicked: () => {
+        trackEvent({
+          action_type: "Click",
+          context_module: "Condition",
+          subject: "Read more",
+        })
+      },
     },
 
     {
@@ -174,14 +181,18 @@ export const ArtworkDetailsAdditionalInfo: React.FC<ArtworkDetailsAdditionalInfo
   return (
     <StackableBorderBox flexDirection="column">
       <Join separator={<Spacer y={1} />}>
-        {displayItems.map(({ title, value }, index) => (
+        {displayItems.map(({ title, value, onReadMoreClicked }, index) => (
           <ArtworkDefinitionList key={title + index} term={title}>
             <HTML variant="xs" color="black60">
               {/* TODO: not sure why this check is here */}
               {React.isValidElement(value) ? (
                 value
               ) : (
-                <ReadMore maxChars={140} content={value as string} />
+                <ReadMore
+                  onReadMoreClicked={onReadMoreClicked}
+                  maxChars={140}
+                  content={value as string}
+                />
               )}
             </HTML>
           </ArtworkDefinitionList>

--- a/src/Apps/Artwork/Components/ArtworkDetails/__tests__/ArtworkDetailsAdditionalInfo.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/__tests__/ArtworkDetailsAdditionalInfo.jest.tsx
@@ -122,5 +122,26 @@ describe("ArtworkDetailsAdditionalInfo", () => {
 
       expect(trackEvent).toBeCalledTimes(1)
     })
+
+    it("tracks the click on Condition read more", () => {
+      renderWithRelay({
+        Artwork: () => ({
+          conditionDescription: {
+            details:
+              "Excellent condition. Unframed Additional condition and detail images are available upon request. Please reach out to specialist@artsymail.com for further details.",
+          },
+        }),
+      })
+
+      fireEvent.click(screen.getByText("Read more"))
+
+      expect(trackEvent).toHaveBeenCalledWith({
+        action_type: "Click",
+        context_module: "Condition",
+        subject: "Read more",
+      })
+
+      expect(trackEvent).toBeCalledTimes(1)
+    })
   })
 })


### PR DESCRIPTION
# [AMBER-227](https://artsyproduct.atlassian.net/browse/AMBER-227) Add tracking to "read more" links on Lot page

From Sam: “can you please add a tracking event to the "Read more" of the various sections on the lot page? It's a very helpful signal to be able to reach back out to the collectors for Matchmaking and these tracking events are currently missing from the page (see thread linked in [#data-team](https://artsy.slack.com/archives/C0KEQD4B0)).I'm hoping that it's a fairly easy change. Please confirm when you'll be able to slot that in.“

<img width="377" alt="Screenshot 2023-10-02 at 11 29 28 AM" src="https://github.com/artsy/force/assets/5643895/9034c762-e187-45b5-84da-c97138318a0f">

https://artsy.slack.com/archives/C05F8TNKGAV/p1695067295001329 

Original thread: https://artsy.slack.com/archives/C0KEQD4B0/p1695063167749489

[AMBER-227]: https://artsyproduct.atlassian.net/browse/AMBER-227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ