### PR TITLE
fix(router): Ensure page transitions execute only when page is fully done loading 

### DIFF
--- a/src/Apps/Components/Layouts/index.tsx
+++ b/src/Apps/Components/Layouts/index.tsx
@@ -1,8 +1,10 @@
+import { usePrevious } from "@artsy/palette"
 import { LayoutBlank } from "Apps/Components/Layouts/LayoutBlank"
 import { LayoutContainerOnly } from "Apps/Components/Layouts/LayoutContainerOnly"
 import { LayoutDefault } from "Apps/Components/Layouts/LayoutDefault"
 import { LayoutLogoOnly } from "Apps/Components/Layouts/LayoutLogoOnly"
 import { LayoutNavOnly } from "Apps/Components/Layouts/LayoutNavOnly"
+import { useSystemContext } from "System/SystemContext"
 import { FC, ReactNode } from "react"
 
 export interface BaseLayoutProps {
@@ -24,6 +26,17 @@ export const LAYOUTS = {
 export type LayoutVariant = keyof typeof LAYOUTS
 
 export const Layout: FC<LayoutProps> = ({ variant = "Default", children }) => {
+  const { isFetching } = useSystemContext()
+
+  // If we're fetching, we want to render the previous layout and not execute
+  // the new one right away.
+  const previousVariant = usePrevious(variant)
+  const Previous = LAYOUTS[previousVariant]
+
+  if (isFetching) {
+    return <Previous>{children}</Previous>
+  }
+
   const Component = LAYOUTS[variant]
 
   return <Component>{children}</Component>

--- a/src/System/Router/RenderStatus.tsx
+++ b/src/System/Router/RenderStatus.tsx
@@ -10,28 +10,15 @@ import { PageLoader } from "./PageLoader"
 import { AppShell } from "Apps/Components/AppShell"
 import { getENV } from "Utils/getENV"
 import { HttpError } from "found"
-import { FC, useRef } from "react"
 
 const logger = createLogger("Artsy/Router/Utils/RenderStatus")
 
 export const RenderPending = () => {
-  const { isFetching, setFetching } = useSystemContext()
-
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-
-  /**
-   * First, set fetching to ensure that components that are listening for this
-   * value have a chance to respond to the fetching state. This is necessary
-   * because the `<Renderer>` component below will freeze all updates for the
-   * duration of the fetch.
-   */
+  const { isFetching } = useSystemContext()
 
   if (!isFetching) {
-    timeoutRef.current = setTimeout(() => setFetching?.(true), 0)
     return undefined
   }
-
-  if (timeoutRef.current) clearTimeout(timeoutRef.current)
 
   return (
     <>
@@ -56,16 +43,11 @@ export const RenderPending = () => {
 }
 
 export const RenderReady = ({ elements }: { elements: React.ReactNode }) => {
-  const { isFetching, setFetching } = useSystemContext()
-
-  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const { isFetching } = useSystemContext()
 
   if (isFetching) {
-    timeoutRef.current = setTimeout(() => setFetching?.(false), 0)
     return undefined
   }
-
-  if (timeoutRef.current) clearTimeout(timeoutRef.current)
 
   return (
     <Renderer shouldUpdate>
@@ -74,7 +56,7 @@ export const RenderReady = ({ elements }: { elements: React.ReactNode }) => {
   )
 }
 
-export const RenderError: FC<{
+export const RenderError: React.FC<{
   error: { status?: number; data?: any }
 }> = ({ error }) => {
   logger.error(error.data)

--- a/src/System/Router/buildClientApp.tsx
+++ b/src/System/Router/buildClientApp.tsx
@@ -28,6 +28,7 @@ import { trackingMiddleware } from "System/Analytics/trackingMiddleware"
 import { RenderError, RenderPending, RenderReady } from "./RenderStatus"
 import { shouldUpdateScroll } from "./Utils/shouldUpdateScroll"
 import { buildClientAppContext } from "System/Router/buildClientAppContext"
+import { loadingIndicatorMiddleware } from "System/Router/loadingIndicatorMiddleware"
 
 interface Resolve {
   ClientApp: ComponentType<any>
@@ -67,6 +68,7 @@ export function buildClientApp(config: RouterConfig): Promise<Resolve> {
         }
 
         const historyMiddlewares = [
+          loadingIndicatorMiddleware(),
           createQueryMiddleware({
             parse: queryStringParsing,
             stringify: qs.stringify,

--- a/src/System/Router/loadingIndicatorMiddleware.ts
+++ b/src/System/Router/loadingIndicatorMiddleware.ts
@@ -1,0 +1,29 @@
+import { setRouteFetching } from "System/SystemContext"
+import { ActionTypes as FarceActionTypes } from "farce"
+import { ActionTypes as FoundActionTypes } from "found"
+
+export function loadingIndicatorMiddleware() {
+  return _store => next => action => {
+    const { type } = action
+
+    switch (type) {
+      case FarceActionTypes.NAVIGATE: {
+        setRouteFetching?.(true)
+        next(action)
+        break
+      }
+      case FarceActionTypes.UPDATE_LOCATION: {
+        setRouteFetching?.(true)
+        next(action)
+        break
+      }
+      case FoundActionTypes.RESOLVE_MATCH: {
+        setRouteFetching?.(false)
+        next(action)
+        break
+      }
+      default:
+        return next(action)
+    }
+  }
+}

--- a/src/System/SystemContext.tsx
+++ b/src/System/SystemContext.tsx
@@ -1,5 +1,5 @@
 import { Router } from "found"
-import { createContext, FC, useState } from "react"
+import { createContext, FC, useMemo, useState } from "react"
 // eslint-disable-next-line no-restricted-imports
 import { data as sd } from "sharify"
 import { Environment } from "relay-runtime"
@@ -79,6 +79,8 @@ export interface SystemContextProps extends SystemContextState {
 
 export const SystemContext = createContext<SystemContextProps>({})
 
+export let setRouteFetching
+
 /**
  * Creates a new Context.Provider with a user and Relay environment, or defaults
  * if not passed in as props.
@@ -92,6 +94,10 @@ export const SystemContextProvider: FC<SystemContextProps> = ({
   const [user, setUser] = useState<SystemContextProps["user"]>(
     getUser(props.user!)
   )
+
+  // Globally export the fetch toggle so that we can access it from the router's
+  // loadingIndicatorMiddleware actions
+  setRouteFetching = useMemo(() => setFetching, [setFetching])
 
   const relayEnvironment =
     props.relayEnvironment || createRelaySSREnvironment({ user })


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

This addresses a long-standing and difficult to fix issue involving very unacceptable UX layout jank when transitioning between routes that have different route layouts. 

**The problem:**
- User navigates to an artwork page, with a default layout
- User clicks "Make Offer", which transitions to the Order app, with a `LogoOnly` layout
- Immediately upon click, the page layout changes and the logo-only appears, but the main content stays because the page is still fetching the query
- When fetch is done, main content updates to the latest

I've attempted to fix this about 20 times! But ran into it yet again today while working on migrating convos work from V2 over to force and thought I'd give it another shot. 

**The solution**
- Globally export the `isFetching` setState hook so that it can be used from outside a react component 
- Add a new `loadingIndicatorMiddleware` to our router
- Tap into the lower-most router lifecycle actions to trigger loading and not loading states
  -  `NAVIGATE` and `UPDATE_LOCATION` should always set fetching to true
  - `RESOLVE_MATCH` should set loading to false 
- When these actions match, update the state
- Cached pages resolve so quickly as to never show loader

Obviously, this fix isn't entirely ideal and open to other approaches, but at least it does afford us the ability to clean up all of the extreme weirdness that was present in `RenderStatus`. And tapping into the root router lifecycle events _does_ feel more correct. However, there's some hidden complexity added here. 

**Before:**


https://github.com/artsy/force/assets/236943/f90f573c-d484-4876-aaed-cbea0d55f817


**After:**

https://github.com/artsy/force/assets/236943/db37ecf1-9d88-4510-b702-3437ba81667c


