### PR TITLE
chore(tests): Hide RTL html output on failed tests by default

### DIFF
--- a/src/tests.ts
+++ b/src/tests.ts
@@ -4,6 +4,20 @@ import Adapter from "@wojtekmaj/enzyme-adapter-react-17"
 import "regenerator-runtime/runtime"
 import { format } from "util"
 import "@testing-library/jest-dom"
+import { configure } from "@testing-library/react"
+
+configure({
+  // Fixes issue where testing-library react await would time out on CI
+  asyncUtilTimeout: 10000,
+  // Don't spit out html output on failed tests by default. If needing to see
+  // html, use screen.debug(undefined, Infinity)
+  getElementError: (message: string) => {
+    const error = new Error(message)
+    error.name = "TestingLibraryElementError"
+    error.stack = null as any
+    return error
+  },
+})
 
 jest.mock("react-tracking")
 import _track, { useTracking as _useTracking } from "react-tracking"


### PR DESCRIPTION
The type of this PR is: **Chore**

### Description

This updates our RTL testing lib to hide HTML test output on failed tests by default. Reasoning: 
- HTML output is almost always truncated except for in the shortest of components. This makes things not too helpful
- It makes tracking down tests in large files difficult, because the terminal is getting spammed with unhelpful output
- It severely hampers CI output for failed tests. Not only is the CI window frequently truncated entirely (due to output being exceeded), but again, it makes figuring out which tests are failing ever more difficult 

With this disabled, we still get nice RTL hints for failures which _are_ useful. We also get proper stack traces. AND we get our quick-look overviews back, which were hidden due to all of the RTL output. 

If we want to inspect the dom in failed tests, we can use `screen.debug(undefined, Infinity)` which will spit out a full html node list, not truncated. 

**Screenshots of the new behavior:**

<img width="743" alt="Screenshot 2023-10-04 at 9 59 12 AM" src="https://github.com/artsy/force/assets/236943/bf6ba6e3-ac84-472c-96ae-c9e14f899da8">

<img width="1510" alt="Screenshot 2023-10-04 at 10 16 30 AM" src="https://github.com/artsy/force/assets/236943/d3422c83-3dea-469e-82da-e1f0cba28ba4">
