### PR TITLE
feat(devx): allow configurability of RTL output level

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,9 @@
 # -- Display analytics calls in browser console
 # SHOW_ANALYTICS_CALLS=true
 #
+# -- Hide detailed debugging output from react-testing-library
+# TERSE_RTL_OUTPUT=true
+#
 
 # ------------------------
 # Localhost Environment

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "docker:clean": "docker rmi force force:builder force:electron",
     "jest": "node_modules/.bin/jest --config jest.config.js",
     "jest:debug": "node --inspect node_modules/.bin/jest --runInBand",
+    "jest:terse": "TERSE_RTL_OUTPUT=true jest",
     "lint": "eslint --cache --cache-location '.cache/eslint/' --ext ts,tsx --ignore-pattern 'src/__generated__'",
     "local-palette-dev": "./scripts/yalc-link-local-palette",
     "local-palette-dev:stop": "./scripts/yalc-unlink-local-palette",

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -6,18 +6,23 @@ import { format } from "util"
 import "@testing-library/jest-dom"
 import { configure } from "@testing-library/react"
 
-configure({
-  // Fixes issue where testing-library react await would time out on CI
-  asyncUtilTimeout: 10000,
-  // Don't spit out html output on failed tests by default. If needing to see
-  // html, use screen.debug(undefined, Infinity)
-  getElementError: (message: string) => {
-    const error = new Error(message)
-    error.name = "TestingLibraryElementError"
-    error.stack = null as any
-    return error
-  },
-})
+if (
+  process.env.CIRCLECI === "true" ||
+  process.env.TERSE_RTL_OUTPUT === "true"
+) {
+  configure({
+    // Fixes issue where testing-library react await would time out on CI
+    asyncUtilTimeout: 10000,
+    // Don't spit out html output on failed tests by default. If needing to see
+    // html, use screen.debug(undefined, Infinity)
+    getElementError: (message: string) => {
+      const error = new Error(message)
+      error.name = "TestingLibraryElementError"
+      error.stack = null as any
+      return error
+    },
+  })
+}
 
 jest.mock("react-tracking")
 import _track, { useTracking as _useTracking } from "react-tracking"


### PR DESCRIPTION
Welcome to the bike shed  🚲 🏠  🎨🖌️  

Follow-up to https://github.com/artsy/force/pull/12984 which kicked off a discussion about the detailed output of React Testing Library.

This PR:

- retains the quieter output configured above^ when running in CI
- allows developers to opt-in to this behavior locally via env var, rather than making it the default
- adds `yarn jest:terse` so you don't have to remember the env var

See [this comment thread](https://github.com/artsy/force/pull/12984#discussion_r1346424738), and particularly the output [examples here](https://github.com/artsy/force/pull/12984#discussion_r1346458121) to see my reasoning for this change.