### PR TITLE
feat(EMI-1335): add error msg for credit_card_deactivated

### DIFF
--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -416,6 +416,19 @@ export const ReviewRoute: FC<ReviewProps> = props => {
         })
         break
       }
+      case "credit_card_deactivated": {
+        const title = "Unable to process card"
+        const message =
+          "This card is inactive or no longer available. Please confirm with your card issuer if this card is active, try another payment method, or contact orders@artsy.net."
+
+        trackErrorMessageEvent(title, message, error.code)
+
+        await props.dialog.showErrorDialog({
+          title: title,
+          message: message,
+        })
+        break
+      }
       default: {
         const { title, message } = getErrorDialogCopy()
         let errorCode = error.code || ""

--- a/src/Apps/Order/Routes/__tests__/Review.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Review.jest.tsx
@@ -337,6 +337,31 @@ describe("Review", () => {
       })
     })
 
+    it("shows a modal when the buyer's credit card is deactivated", async () => {
+      mockCommitMutation.mockResolvedValue({
+        commerceSubmitOrder: {
+          orderOrError: {
+            error: {
+              code: "credit_card_deactivated",
+            },
+          },
+        },
+      })
+
+      const wrapper = getWrapper({
+        CommerceOrder: () => testOrder,
+      })
+
+      const page = new ReviewTestPage(wrapper)
+      await page.clickSubmit()
+
+      expect(mockShowErrorDialog).toHaveBeenCalledWith({
+        title: "Unable to process card",
+        message:
+          "This card is inactive or no longer available. Please confirm with your card issuer if this card is active, try another payment method, or contact orders@artsy.net.",
+      })
+    })
+
     it("shows SCA modal when required", async () => {
       mockCommitMutation.mockResolvedValue(submitOrderWithActionRequired)
       const wrapper = getWrapper({


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-1335]

### Description

Add a more meaningful error message when buyers are trying to submit an order with a deactivated credit card.

Before
![SCR-20231005-oin](https://github.com/artsy/force/assets/554507/7e775b4f-47c3-4af0-9f24-748683ab1394)


After
![SCR-20231005-oi8](https://github.com/artsy/force/assets/554507/694bb21a-d5ab-49bc-adb6-537ee70633c8)


<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EMI-1335]: https://artsyproduct.atlassian.net/browse/EMI-1335?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ