### PR TITLE
fix(filter): includes selected prop

### DIFF
--- a/src/Components/SavedSearchAlert/Components/SavedSearchAlertPills.tsx
+++ b/src/Components/SavedSearchAlert/Components/SavedSearchAlertPills.tsx
@@ -24,7 +24,12 @@ export const SavedSearchAlertPills: React.FC<SavedSearchAlertPillsProps> = props
         }
 
         return (
-          <Pill key={key} variant="filter" onClick={() => onDeletePress(item)}>
+          <Pill
+            key={key}
+            variant="filter"
+            selected
+            onClick={() => onDeletePress(item)}
+          >
             {item.displayValue}
           </Pill>
         )


### PR DESCRIPTION
A simple thing but: making some updates to the `Pill` components for consistency. `selected` isn't a distinct state but can stack with the other states. In the case of the `filter` variant; the idle state and selected state are the same. Idle should lack the `x` icon and it will be removed. This is the one case in which it's needed.