### PR TITLE
fix: get timezone from Luxon when Intl timezone is undefined [wip]

### DIFF
--- a/src/Components/CookieConsentManager/useConsentRequired.ts
+++ b/src/Components/CookieConsentManager/useConsentRequired.ts
@@ -4,6 +4,7 @@ import {
   DEFAULT_OPT_OUT_PREFERENCES,
 } from "Components/CookieConsentManager/categories"
 import { useDidMount } from "Utils/Hooks/useDidMount"
+import { getTimeZone } from "Utils/getTimeZone"
 import qs from "qs"
 
 /**
@@ -32,7 +33,7 @@ export const useConsentRequired = (): {
     ignoreQueryPrefix: true,
   })
 
-  const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone
+  const timezone = getTimeZone()
 
   const isEU =
     timezone.startsWith("Europe") ||

--- a/src/System/Relay/createRelaySSREnvironment.ts
+++ b/src/System/Relay/createRelaySSREnvironment.ts
@@ -1,9 +1,10 @@
+import { getENV } from "Utils/getENV"
+import { getTimeZone } from "Utils/getTimeZone"
+import createLogger from "Utils/logger"
 import "isomorphic-fetch"
-import "regenerator-runtime/runtime"
 import { isEmpty } from "lodash"
 import RelayClientSSR from "react-relay-network-modern-ssr/lib/client"
 import RelayServerSSR from "react-relay-network-modern-ssr/lib/server"
-import { Environment, INetwork, RecordSource, Store } from "relay-runtime"
 import {
   RelayNetworkLayer,
   batchMiddleware,
@@ -11,13 +12,13 @@ import {
   loggerMiddleware,
   urlMiddleware,
 } from "react-relay-network-modern/node8"
+import "regenerator-runtime/runtime"
+import { Environment, INetwork, RecordSource, Store } from "relay-runtime"
 import { cacheMiddleware } from "./middleware/cache/cacheMiddleware"
 import { metaphysicsErrorHandlerMiddleware } from "./middleware/metaphysicsErrorHandlerMiddleware"
 import { metaphysicsExtensionsLoggerMiddleware } from "./middleware/metaphysicsExtensionsLoggerMiddleware"
 import { principalFieldErrorHandlerMiddleware } from "./middleware/principalFieldErrorHandlerMiddleware"
 import { searchBarImmediateResolveMiddleware } from "./middleware/searchBarImmediateResolveMiddleware"
-import createLogger from "Utils/logger"
-import { getENV } from "Utils/getENV"
 
 const logger = createLogger("System/Relay/createRelaySSREnvironment")
 
@@ -82,7 +83,7 @@ export function createRelaySSREnvironment(config: Config = {}) {
 
   let timeZone
   try {
-    timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone
+    timeZone = getTimeZone()
     headers["X-TIMEZONE"] = timeZone
   } catch (error) {
     logger.warn("Browser does not support i18n API, not setting TZ header.")

--- a/src/Utils/getTimeZone.jest.ts
+++ b/src/Utils/getTimeZone.jest.ts
@@ -1,0 +1,49 @@
+import { getTimeZone } from "Utils/getTimeZone"
+import { DateTime } from "luxon"
+
+describe("getTimeZone", () => {
+  describe("When Intl is available", () => {
+    beforeAll(() => {
+      const originalDateResolvedOptions = new Intl.DateTimeFormat().resolvedOptions()
+      jest
+        .spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions")
+        .mockReturnValue({
+          ...originalDateResolvedOptions,
+          timeZone: "America/New_York",
+        })
+    })
+    afterAll(() => {
+      jest.restoreAllMocks()
+    })
+
+    it("should return Intl timezone when it's available", () => {
+      expect(getTimeZone()).toEqual("America/New_York")
+    })
+  })
+
+  describe("When Intl is not available", () => {
+    beforeAll(() => {
+      const originalDateResolvedOptions = new Intl.DateTimeFormat().resolvedOptions()
+      jest
+        .spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions")
+        .mockReturnValue({
+          ...originalDateResolvedOptions,
+          // timeZone is undefined in the latest chrome updates
+          // see https://support.google.com/chrome/thread/231926653/timezone-return-undefined?hl=en
+          timeZone: undefined as any,
+        })
+
+      const fakeLocal = DateTime.local(1982, 5, 25, {
+        zone: "Asia/Seoul",
+      })
+
+      DateTime.local = jest.fn(() => fakeLocal)
+    })
+    afterAll(() => {
+      jest.restoreAllMocks()
+    })
+    it("should return Luxon timezon", () => {
+      expect(getTimeZone()).toEqual("Asia/Seoul")
+    })
+  })
+})

--- a/src/Utils/getTimeZone.ts
+++ b/src/Utils/getTimeZone.ts
@@ -1,0 +1,8 @@
+import { DateTime } from "luxon"
+
+export const getTimeZone = () => {
+  return (
+    Intl.DateTimeFormat().resolvedOptions().timeZone ||
+    DateTime.local().zoneName
+  )
+}


### PR DESCRIPTION
The type of this PR is: **fix**

This PR comes as an attempt to solve an issue where multiple users in Seoul where not able to access `artsy.net` due to `Timezone` being returned as `undefined`. 



<!-- Implementation description -->
