### PR TITLE
feat(EMI-1378): use thousand separator for offer input

### DIFF
--- a/src/Apps/Order/Components/OfferInput.tsx
+++ b/src/Apps/Order/Components/OfferInput.tsx
@@ -20,6 +20,13 @@ export const OfferInput: FC<OfferInputProps> = ({
   onChange,
   value,
 }) => {
+  const formatValueForDisplay = (val: number | undefined) => {
+    if (val !== undefined) {
+      return val.toLocaleString()
+    }
+    return ""
+  }
+
   return (
     <Input
       id={id}
@@ -27,21 +34,14 @@ export const OfferInput: FC<OfferInputProps> = ({
       type="text"
       pattern="[0-9]"
       error={showError ? "Offer amount missing or invalid." : false}
+      inputMode={"numeric"}
       onFocus={onFocus}
       onBlur={onBlur}
-      value={value}
+      value={formatValueForDisplay(value)}
       onChange={ev => {
         const currentValue = ev.currentTarget.value
-        const nonDigitMatch = currentValue.match(/\D/)
-
-        if (nonDigitMatch) {
-          const cursorOffset = currentValue.indexOf(nonDigitMatch[0])
-          const nextValue = currentValue.replace(/\D/g, "")
-          ev.currentTarget.value = nextValue
-          ev.currentTarget.setSelectionRange(cursorOffset, cursorOffset)
-        }
-
-        onChange(Number(ev.currentTarget.value || "0"))
+        const cleanedValue = currentValue.replace(/[^\d]/g, "") // Remove non-digits
+        onChange(Number(cleanedValue))
       }}
     />
   )

--- a/src/Apps/Order/Components/__tests__/OfferInput.jest.tsx
+++ b/src/Apps/Order/Components/__tests__/OfferInput.jest.tsx
@@ -1,5 +1,5 @@
 import { ReactWrapper, mount } from "enzyme"
-import { OfferInput, OfferInputProps } from "../OfferInput"
+import { OfferInput, OfferInputProps } from "Apps/Order/Components/OfferInput"
 
 // https://github.com/airbnb/enzyme/issues/218#issuecomment-388481390
 const setInputValue = (
@@ -37,6 +37,23 @@ describe("Offer input", () => {
     expect(onChange).toHaveBeenCalledWith(2389274922)
   })
 
+  it("displays the value with comma separators at the thousands", () => {
+    let input = render({ value: 12 })
+
+    let inputValue = input.find("input").prop("value")
+    expect(inputValue).toBe("12")
+
+    input = render({ value: 4200 })
+
+    inputValue = input.find("input").prop("value")
+    expect(inputValue).toBe("4,200")
+
+    input = render({ value: 2389274922 })
+
+    inputValue = input.find("input").prop("value")
+    expect(inputValue).toBe("2,389,274,922")
+  })
+
   it("shows no error message when showError is false", () => {
     const input = render({ showError: false })
 
@@ -61,19 +78,5 @@ describe("Offer input", () => {
 
     setInputValue(input.find("input"), "2139hello8729")
     expect(onChange).toHaveBeenCalledWith(21398729)
-  })
-
-  it("keeps the cursor in the right place if the input is given non-numeric input", () => {
-    const setSelectionRange = jest.fn()
-    const input = render({})
-
-    setInputValue(input.find("input"), "1d1", setSelectionRange)
-    expect(setSelectionRange).toHaveBeenCalledWith(1, 1)
-
-    setInputValue(input.find("input"), "d2", setSelectionRange)
-    expect(setSelectionRange).toHaveBeenCalledWith(0, 0)
-
-    setInputValue(input.find("input"), "2139hello8729", setSelectionRange)
-    expect(setSelectionRange).toHaveBeenCalledWith(4, 4)
   })
 })


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves https://artsyproduct.atlassian.net/browse/EMI-1378

### Description

- Use thousand separator for the offer input

Extra: Use numeric input mode to trigger number keyboard in mobile, instead of the full qwerty keyboard


https://github.com/artsy/force/assets/7518671/bb962fc2-f167-40bf-b194-8c22b9c9c5af


