### PR TITLE
fix: offer input value

### DIFF
--- a/src/Apps/Order/Components/OfferInput.tsx
+++ b/src/Apps/Order/Components/OfferInput.tsx
@@ -21,7 +21,7 @@ export const OfferInput: FC<OfferInputProps> = ({
   value,
 }) => {
   const formatValueForDisplay = (val: number | undefined) => {
-    if (val !== undefined) {
+    if (val !== undefined && val > 0) {
       return val.toLocaleString()
     }
     return ""

--- a/src/Apps/Order/Routes/Offer/index.tsx
+++ b/src/Apps/Order/Routes/Offer/index.tsx
@@ -245,6 +245,7 @@ export const OfferRoute: FC<OfferRouteProps> = ({
                   showError={formIsDirty && offerValue <= 0}
                   onChange={offerValue => setOfferValue(offerValue)}
                   onFocus={onOfferInputFocus}
+                  value={offerValue}
                 />
               </Flex>
               {priceNote}

--- a/src/Apps/Order/Routes/Respond/index.tsx
+++ b/src/Apps/Order/Routes/Respond/index.tsx
@@ -258,6 +258,7 @@ export const RespondRoute: FC<RespondProps> = ({
                   showError={isFormDirty && offerValue <= 0}
                   onChange={setOfferValue}
                   onFocus={onOfferInputFocus}
+                  value={offerValue}
                 />
                 {!order.isInquiryOrder && (
                   <>


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Solves https://artsy.slack.com/archives/C03GX7A4KV0/p1697034020143039
Since we're using the value of the OfferInput to properly format and display, we need to make sure that is being passed on by the parent component. This worked for the normal offer flow but it wasn't being set on the rest use cases for that component.

https://github.com/artsy/force/assets/7518671/d4a4b465-4eca-4696-ab94-50dba6c2462c


