### PR TITLE
feat: numeric input mode for auth code

### DIFF
--- a/src/Components/AuthDialog/Views/AuthDialogLogin.tsx
+++ b/src/Components/AuthDialog/Views/AuthDialogLogin.tsx
@@ -154,6 +154,7 @@ export const AuthDialogLogin: FC = () => {
                   name="authenticationCode"
                   title="Authentication Code"
                   placeholder="Enter an authentication code"
+                  inputMode={"numeric"}
                   onChange={handleChange}
                   onBlur={handleBlur}
                   autoFocus

--- a/src/Components/Inquiry/Views/InquiryLogin.tsx
+++ b/src/Components/Inquiry/Views/InquiryLogin.tsx
@@ -181,6 +181,7 @@ export const InquiryLogin: React.FC = () => {
             name="authenticationCode"
             title="Authentication Code"
             placeholder="Enter an authentication code"
+            inputMode={"numeric"}
             onChange={handleInputChange("authenticationCode")}
             required
             autoFocus


### PR DESCRIPTION
The type of this PR is: **Feat**

### Description

While working on #13011 I noticed we could use the numeric input mode for the auth code, to make the authentication flow easier on mobile web by triggering the numeric keyboard on that input
