### PR TITLE
feat: implements a transitioning panel

### DIFF
--- a/src/Components/TransitionPanel.tsx
+++ b/src/Components/TransitionPanel.tsx
@@ -1,0 +1,111 @@
+import { Box } from "@artsy/palette"
+import {
+  Children,
+  FC,
+  createContext,
+  isValidElement,
+  useContext,
+  useRef,
+  useState,
+} from "react"
+
+const TransitionPanelContext = createContext<{
+  active: number
+  navigateTo: (index: number) => void
+}>({
+  active: 0,
+  navigateTo: () => {},
+})
+
+interface TransitionPanelProviderProps {
+  children: JSX.Element[]
+}
+
+export const TransitionPanelProvider: FC<TransitionPanelProviderProps> = ({
+  children,
+}) => {
+  const screens = Children.toArray(children).filter(isValidElement)
+
+  const [active, setActive] = useState(0)
+  const [prevActive, setPrevActive] = useState(0)
+
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const railRef = useRef<HTMLDivElement | null>(null)
+  const activeRef = useRef<HTMLDivElement | null>(null)
+  const prevRef = useRef<HTMLDivElement | null>(null)
+
+  const [mode, setMode] = useState<"Idle" | "Transitioning">("Idle")
+
+  const navigateTo = (index: number) => {
+    if (index < 0 || index >= screens.length) {
+      throw new Error(`Invalid index: ${index}`)
+    }
+
+    setMode("Transitioning")
+    setActive(index)
+
+    requestAnimationFrame(async () => {
+      const prevWidth = prevRef.current?.offsetWidth ?? 0
+      const nextWidth = activeRef.current?.offsetWidth ?? 0
+
+      containerRef.current?.style.setProperty("width", `${nextWidth}px`)
+
+      const transforms =
+        index < prevActive
+          ? [
+              { transform: `translateX(-${nextWidth}px)` },
+              { transform: "translateX(0)" },
+            ]
+          : [
+              { transform: "translateX(0)" },
+              { transform: `translateX(-${prevWidth}px)` },
+            ]
+
+      const animation = railRef.current?.animate(transforms, {
+        duration: 400,
+        easing: "ease",
+      })
+
+      await animation?.finished
+
+      setMode("Idle")
+      setPrevActive(index)
+    })
+  }
+
+  return (
+    <TransitionPanelContext.Provider value={{ navigateTo, active }}>
+      <Box ref={containerRef as any} overflow="auto">
+        <Box ref={railRef as any} style={{ whiteSpace: "nowrap" }}>
+          {mode === "Transitioning" && (
+            <>
+              {active < prevActive && (
+                <Box ref={activeRef as any} display="inline-flex">
+                  {screens[active]}
+                </Box>
+              )}
+
+              <Box ref={prevRef as any} display="inline-flex">
+                {screens[prevActive]}
+              </Box>
+
+              {active > prevActive && (
+                <Box ref={activeRef as any} display="inline-flex">
+                  {screens[active]}
+                </Box>
+              )}
+            </>
+          )}
+
+          {mode === "Idle" && (
+            <Box display="inline-flex">{screens[active]}</Box>
+          )}
+        </Box>
+      </Box>
+    </TransitionPanelContext.Provider>
+  )
+}
+
+export const useTransitionPanel = () => {
+  return useContext(TransitionPanelContext)
+}

--- a/src/Components/__stories__/TransitionPanel.story.tsx
+++ b/src/Components/__stories__/TransitionPanel.story.tsx
@@ -1,0 +1,128 @@
+import { Text, Box, Button, ModalDialog, Stack } from "@artsy/palette"
+import {
+  TransitionPanelProvider,
+  useTransitionPanel,
+} from "Components/TransitionPanel"
+
+export default {
+  title: "Components/TransitionPanel",
+}
+
+export const Default = () => {
+  return (
+    <ModalDialog onClose={() => {}} dialogProps={{ width: "fit-content" }}>
+      <TransitionPanelProvider>
+        <PanelOne />
+        <PanelTwo />
+        <PanelThree />
+      </TransitionPanelProvider>
+    </ModalDialog>
+  )
+}
+
+const PanelOne = () => {
+  const { navigateTo } = useTransitionPanel()
+
+  return (
+    <Box
+      border="1px dotted"
+      borderColor="black60"
+      p={1}
+      width={300}
+      height={200}
+    >
+      <Stack gap={1}>
+        <Text variant="lg">First panel</Text>
+
+        <Stack gap={0.5} flexDirection="row">
+          <Button
+            variant="secondaryBlack"
+            size="small"
+            onClick={() => navigateTo(1)}
+          >
+            Go to 2
+          </Button>
+
+          <Button
+            variant="secondaryBlack"
+            size="small"
+            onClick={() => navigateTo(2)}
+          >
+            Go to 3
+          </Button>
+        </Stack>
+      </Stack>
+    </Box>
+  )
+}
+
+const PanelTwo = () => {
+  const { navigateTo } = useTransitionPanel()
+
+  return (
+    <Box
+      border="1px dotted"
+      borderColor="black60"
+      p={1}
+      width={400}
+      height={300}
+    >
+      <Stack gap={1}>
+        <Text variant="lg">Second panel</Text>
+
+        <Stack gap={0.5} flexDirection="row">
+          <Button
+            variant="secondaryBlack"
+            size="small"
+            onClick={() => navigateTo(0)}
+          >
+            Go to 1
+          </Button>
+
+          <Button
+            variant="secondaryBlack"
+            size="small"
+            onClick={() => navigateTo(2)}
+          >
+            Go to 3
+          </Button>
+        </Stack>
+      </Stack>
+    </Box>
+  )
+}
+
+const PanelThree = () => {
+  const { navigateTo } = useTransitionPanel()
+  return (
+    <Box
+      border="1px dotted"
+      borderColor="black60"
+      p={1}
+      width={500}
+      height={400}
+    >
+      <Stack gap={1}>
+        <Text variant="lg">Third panel</Text>
+
+        <Stack gap={0.5} flexDirection="row">
+          <Button
+            variant="secondaryBlack"
+            size="small"
+            onClick={() => navigateTo(0)}
+          >
+            Go to 1
+          </Button>
+
+          <Button
+            variant="secondaryBlack"
+            size="small"
+            onClick={() => navigateTo(1)}
+          >
+            Go to 2
+          </Button>
+        </Stack>
+      </Stack>
+    </Box>
+  )
+}


### PR DESCRIPTION
https://github.com/artsy/force/assets/112297/394dba7d-0514-4d95-835b-7e5b570ff303

The transition animation isn't the hard part here, rather it's maintaining a natural 'order' to the panels. If you're navigating to a new panel from the home, it should be oriented on the right, if you're navigating back then it should be oriented on the left. I support N panels here in the event we need more and they will appear on the left or right depending on their ordering within the provider. You also need to be able to trigger navigation from inside panels so that's where the context provider comes in.

We don't animate changes in modal size. Theoretically we could but this adds a lot more complexity. We may not be adjusting size at all, it turns out. I suspect this will appear a lot less strange when it contains real content.
