### PR TITLE
fix(sell): fix hard jump between sell and sell/submission, and fix broken back button to /contact-info

### DIFF
--- a/src/Apps/Consign/Routes/SubmissionFlow/Utils/redirects.ts
+++ b/src/Apps/Consign/Routes/SubmissionFlow/Utils/redirects.ts
@@ -5,8 +5,8 @@ import { redirects_submission$data } from "__generated__/redirects_submission.gr
 import {
   getArtworkDetailsFormInitialValues,
   SubmissionType,
-} from "../ArtworkDetails/Components/ArtworkDetailsForm"
-import { getUploadPhotosFormInitialValues } from "../UploadPhotos/UploadPhotos"
+} from "Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtworkDetailsForm"
+import { getUploadPhotosFormInitialValues } from "Apps/Consign/Routes/SubmissionFlow/UploadPhotos/UploadPhotos"
 import {
   artworkDetailsValidationSchema,
   uploadPhotosValidationSchema,
@@ -37,7 +37,8 @@ const checkArtworkDetailsFormValid = redirectToIf(
     )
 )
 
-const checkUploadPhotosFormValid = redirectToIf(
+// TODO: Is this needed as a rule to go back to edit contact info?
+export const checkUploadPhotosFormValid = redirectToIf(
   id => `/sell/submission/${id}/upload-photos`,
   submission =>
     !uploadPhotosValidationSchema.isValidSync(
@@ -65,8 +66,12 @@ export const redirects = {
       path: "/:id/contact-information",
       rules: [
         checkSubmissionExist,
-        checkArtworkDetailsFormValid,
-        checkUploadPhotosFormValid,
+        // TODO: Is this needed? A user should be able to edit their contact
+        // info independent of all else. With these rules enabled, the back
+        // button is broken.
+
+        // checkArtworkDetailsFormValid,
+        // checkUploadPhotosFormValid,
       ],
     },
   ],

--- a/src/Apps/Consign/consignRoutes.tsx
+++ b/src/Apps/Consign/consignRoutes.tsx
@@ -283,10 +283,19 @@ export const consignRoutes: AppRouteConfig[] = [
   {
     path: "/sell/submission",
     getComponent: () => SubmissionLayout,
-    onServerSideRender: ({ res }) => {
-      res.redirect("/sell/submission/contact-information")
-    },
     children: [
+      {
+        // Default landing is the same as /contact-information
+        path: "",
+        layout: "ContainerOnly",
+        getComponent: () => ContactInformation,
+        onClientSideRender: () => {
+          ContactInformation.preload()
+        },
+        query: contactInformationQuery,
+        render: renderSubmissionFlowStep,
+        prepareVariables: prepareSubmissionFlowStepVariables,
+      },
       {
         path: "artwork-details",
         layout: "ContainerOnly",


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Noticed that the Sell button on /sell page was doing hard jumps between pages, circumventing our SPA router and impacting performance. This was due to the button pointing to a URL which on the server then performs a server-side redirect. Instead, just add a proper route that matches `/sell/submission`. This is to preserve the SEO of having a canonical `sell/submission` link, vs updating the button to point directly at `sell/submission/contact-info`. 

Additionally, this fixes the back button that goes back to contact info, as it currently force redirects you to artwork details, which is confusing. I'm not sure entirely of the history behind this code, but a back button shouldn't ever be subject to redirect rules that prevent one from going back! 


