### PR TITLE
feat(DIA-216,DIA-223): Re-structure existing layout; adds clear all button

### DIFF
--- a/src/Components/ArtworkFilter/ArtworkFilterActiveFilters.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilterActiveFilters.tsx
@@ -1,0 +1,31 @@
+import { FC } from "react"
+import { useActiveFilterPills } from "Components/SavedSearchAlert/useActiveFilterPills"
+import { Flex, Pill } from "@artsy/palette"
+
+export interface ArtworkFilterActiveFiltersProps {}
+
+export const ArtworkFilterActiveFilters: FC<ArtworkFilterActiveFiltersProps> = () => {
+  const { pills, removePill } = useActiveFilterPills()
+
+  if (pills.length === 0) {
+    return null
+  }
+
+  return (
+    <Flex flexWrap="wrap" data-testid="artworkGridFilterPills" gap={1}>
+      {pills.map(pill => {
+        const key = [pill.field, pill.value].join(":")
+        return (
+          <Pill
+            key={key}
+            variant="gray"
+            selected
+            onClick={() => removePill(pill)}
+          >
+            {pill.displayValue}
+          </Pill>
+        )
+      })}
+    </Flex>
+  )
+}

--- a/src/Components/ArtworkFilter/ArtworkFilterActiveFilters.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilterActiveFilters.tsx
@@ -1,11 +1,14 @@
 import { FC } from "react"
 import { useActiveFilterPills } from "Components/SavedSearchAlert/useActiveFilterPills"
-import { Flex, Pill } from "@artsy/palette"
+import { Button, Flex, Pill } from "@artsy/palette"
+import { useArtworkFilterContext } from "Components/ArtworkFilter/ArtworkFilterContext"
 
 export interface ArtworkFilterActiveFiltersProps {}
 
 export const ArtworkFilterActiveFilters: FC<ArtworkFilterActiveFiltersProps> = () => {
   const { pills, removePill } = useActiveFilterPills()
+
+  const { resetFilters } = useArtworkFilterContext()
 
   if (pills.length === 0) {
     return null
@@ -26,6 +29,10 @@ export const ArtworkFilterActiveFilters: FC<ArtworkFilterActiveFiltersProps> = (
           </Pill>
         )
       })}
+
+      <Button variant="tertiary" size="small" onClick={resetFilters}>
+        Clear all
+      </Button>
     </Flex>
   )
 }

--- a/src/Components/ArtworkFilter/index.tsx
+++ b/src/Components/ArtworkFilter/index.tsx
@@ -15,6 +15,7 @@ import {
   Flex,
   FullBleed,
   GridColumns,
+  Pill,
   Spacer,
   Text,
 } from "@artsy/palette"
@@ -399,20 +400,16 @@ export const BaseArtworkFilter: React.FC<
           // New desktop filters
           <>
             <Flex alignItems="center" justifyContent="space-between" gap={2}>
-              <Flex alignItems="center" gap={2}>
-                <Text variant="sm-display" fontWeight="bold" flexShrink={0}>
-                  {totalCountLabel}
-                </Text>
-
-                <ActiveFilterPills />
-              </Flex>
-
-              <Flex alignItems="center" gap={0.5} flexShrink={0}>
+              <Flex gap={1}>
                 <ArtworkFilterCreateAlert
                   renderButton={props => {
                     return (
                       <Button
-                        variant="tertiary"
+                        variant={
+                          appliedFiltersTotalCount > 0
+                            ? "primaryBlack"
+                            : "secondaryBlack"
+                        }
                         size="small"
                         Icon={BellStrokeIcon}
                         {...props}
@@ -423,15 +420,14 @@ export const BaseArtworkFilter: React.FC<
                   }}
                 />
 
-                <Button
-                  variant="tertiary"
-                  Icon={FilterIcon}
-                  size="small"
-                  onClick={handleOpen}
-                >
-                  Sort and Filter
-                </Button>
+                <Box width="1px" bg="black30" />
 
+                <Pill Icon={FilterIcon} size="small" onClick={handleOpen}>
+                  All filters
+                </Pill>
+              </Flex>
+
+              <Flex alignItems="center" gap={0.5} flexShrink={0}>
                 <ArtworkFilterDrawer open={isOpen} onClose={handleClose}>
                   <ArtworkSortFilter2 />
 
@@ -448,6 +444,16 @@ export const BaseArtworkFilter: React.FC<
                 </ArtworkFilterDrawer>
               </Flex>
             </Flex>
+
+            <Spacer y={2} />
+
+            <ActiveFilterPills />
+
+            <Spacer y={4} />
+
+            <Text variant="xs" flexShrink={0}>
+              {totalCountLabel}:
+            </Text>
 
             <Spacer y={2} />
 

--- a/src/Components/ArtworkFilter/index.tsx
+++ b/src/Components/ArtworkFilter/index.tsx
@@ -49,6 +49,7 @@ import { ArtworkSortFilter } from "./ArtworkFilters/ArtworkSortFilter"
 import { ArtworkQueryFilter } from "./ArtworkQueryFilter"
 import { allowedFilters } from "./Utils/allowedFilters"
 import { getTotalSelectedFiltersCount } from "./Utils/getTotalSelectedFiltersCount"
+import { ArtworkFilterActiveFilters } from "Components/ArtworkFilter/ArtworkFilterActiveFilters"
 
 interface ArtworkFilterProps extends SharedArtworkFilterContextProps, BoxProps {
   Filters?: JSX.Element
@@ -447,7 +448,7 @@ export const BaseArtworkFilter: React.FC<
 
             <Spacer y={2} />
 
-            <ActiveFilterPills />
+            <ArtworkFilterActiveFilters />
 
             <Spacer y={4} />
 


### PR DESCRIPTION
Re: [DIA-216](https://artsyproduct.atlassian.net/browse/DIA-216)
Closes: [DIA-223](https://artsyproduct.atlassian.net/browse/DIA-223)

This PR restructures our existing layout to match the new mock ups; then adds the new `Clear all` button.

https://github.com/artsy/force/assets/112297/8b256a23-72db-4ea3-a7c5-07876aaf6787



[DIA-216]: https://artsyproduct.atlassian.net/browse/DIA-216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DIA-223]: https://artsyproduct.atlassian.net/browse/DIA-223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ