### PR TITLE
fix(EMI-1377): default to address form jump

### DIFF
--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -274,16 +274,16 @@ export const ShippingRoute: FC<ShippingProps> = props => {
       hasError: invalidPhoneNumber,
     } = validatePhoneNumber(phoneNumber)
 
+    if (invalidPhoneNumber) {
+      setPhoneNumberError(phoneNumberError!)
+      setPhoneNumberTouched(true)
+      !invalidAddress && jumpTo("phoneNumberTop", { behavior: "smooth" })
+    }
+
     if (invalidAddress) {
       setAddressErrors(addressErrors!)
       setAddressTouched(touchedAddress)
       jumpTo("deliveryAddressTop", { behavior: "smooth" })
-    }
-
-    if (invalidPhoneNumber) {
-      setPhoneNumberError(phoneNumberError!)
-      setPhoneNumberTouched(true)
-      jumpTo("phoneNumberTop", { behavior: "smooth" })
     }
 
     return !invalidAddress && !invalidPhoneNumber

--- a/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -949,9 +949,59 @@ describe("Shipping", () => {
           Me: () => meWithoutAddress,
         })
 
+        await fillAddressForm({
+          name: "Erik David",
+          addressLine1: "401 Broadway",
+          addressLine2: "",
+          city: "",
+          region: "",
+          postalCode: "",
+          phoneNumber: "8888888888",
+          country: "",
+        })
+
         await saveAndContinue()
 
-        expect(mockJumpTo).toBeCalled()
+        expect(mockJumpTo).toBeCalledWith("deliveryAddressTop", {
+          behavior: "smooth",
+        })
+      })
+
+      it("scrolls to top of phone number form when there are phone number errors", async () => {
+        renderWithRelay({
+          CommerceOrder: () => UntouchedOfferOrder,
+          Me: () => meWithoutAddress,
+        })
+
+        await fillAddressForm({
+          name: "Erik David",
+          addressLine1: "401 Broadway",
+          addressLine2: "",
+          city: "New York",
+          region: "NY",
+          postalCode: "10013",
+          phoneNumber: "",
+          country: "US",
+        })
+
+        await saveAndContinue()
+
+        expect(mockJumpTo).toBeCalledWith("phoneNumberTop", {
+          behavior: "smooth",
+        })
+      })
+
+      it("scrolls to top of address form when there are both address and phone number errors", async () => {
+        renderWithRelay({
+          CommerceOrder: () => UntouchedOfferOrder,
+          Me: () => meWithoutAddress,
+        })
+
+        await saveAndContinue()
+
+        expect(mockJumpTo).toBeCalledWith("deliveryAddressTop", {
+          behavior: "smooth",
+        })
       })
     })
 


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-1377]

### Description

Follow up to https://github.com/artsy/force/pull/13021

@iskounen Pointed out that we want to default to scroll to the address form instead of the phone number input in the case where both of these are invalid. 

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EMI-1377]: https://artsyproduct.atlassian.net/browse/EMI-1377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ