### PR TITLE
fix(filters): fixes issue with range + labeled input interaction

### DIFF
--- a/src/Components/NumericInput.tsx
+++ b/src/Components/NumericInput.tsx
@@ -2,7 +2,13 @@ import { LabeledInput } from "@artsy/palette"
 import styled from "styled-components"
 
 // Disables arrows in numeric inputs
-export const NumericInput = styled(LabeledInput).attrs({ type: "number" })`
+export const NumericInput = styled(LabeledInput).attrs({
+  type: "number",
+  // HACK: Work around sizing issue in Drawer component by removing padding
+  // to accommodate labels. Extremely unlikely to cause an issue in practice
+  // because you'd have to insert prices into the quadrillions to encounter overlap.
+  style: {},
+})`
   /* Chrome, Safari, Edge, Opera */
   input::-webkit-outer-spin-button,
   input::-webkit-inner-spin-button {


### PR DESCRIPTION
Closes [DIA-217](https://artsyproduct.atlassian.net/browse/DIA-217)

The bug is that when the price range filter was placed in a `Drawer` component, the `Range` handles would be off/visually missing. I determined that this would only happen when the two `LabeledInput` components were also present. What appears to be happening is that it's something to do with [how we apply padding to prevent overlapping with the label](https://github.com/artsy/palette/blob/382d9289ed1c1ce63f9b535f76673bb38ecf90c5/packages/palette/src/elements/LabeledInput/LabeledInput.tsx#L32), when present within the `Drawer`. Best I can tell it's just an _extremely_ obscure browser rendering bug — but it's not entirely clear to me exactly what's happening.

We can simply fix the issue by just disabling the padding on those inputs, which would only be an "issue" if someone input numbers well into the quadrillions.

There really should be some max handling on these inputs but that is a separate issue.

[DIA-217]: https://artsyproduct.atlassian.net/browse/DIA-217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ