### PR TITLE
fix(follow): switches to visibility hidden instead of opacity for safari

### DIFF
--- a/src/Components/FollowButton/Button.tsx
+++ b/src/Components/FollowButton/Button.tsx
@@ -51,8 +51,7 @@ export const FollowButton: ForwardRefExoticComponent<
         <Box position="relative">
           <Box
             as="span"
-            opacity={0}
-            style={{ pointerEvents: "none" }}
+            style={{ pointerEvents: "none", visibility: "hidden" }}
             aria-hidden="true"
           >
             {children ? children("Following") : "Following"}


### PR DESCRIPTION
Re: [Slack thread](https://artsy.slack.com/archives/C03N12SR0RK/p1697636572915309)

Not entirely sure why `opacity: 0` wouldn't work with complex children, but `visibility: hidden` is probably better anyway.