### PR TITLE
feat(artist series filter): add to artist page's artwork grid

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -114,6 +114,7 @@ module.exports = {
       "warn",
       { allowSameFolder: true, rootDir: "src" },
     ],
+    "jest/valid-title": ["error", { ignoreTypeOfDescribeName: true }],
   },
   overrides: [
     {

--- a/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters.tsx
@@ -25,14 +25,14 @@ interface ArtistArtworkFiltersProps {
 export const ArtistArtworkFilters: React.FC<ArtistArtworkFiltersProps> = props => {
   const { relayEnvironment } = props
   const { user } = useSystemContext()
-  const enableArtistSeriesFilter = useFeatureFlag(
+  const isArtistSeriesFilterEnabled = useFeatureFlag(
     "onyx_enable-artist-series-filter"
   )
 
   return (
     <Join separator={<Spacer y={4} />}>
       <KeywordFilter />
-      {enableArtistSeriesFilter && <ArtistSeriesFilter expanded />}
+      {isArtistSeriesFilterEnabled && <ArtistSeriesFilter expanded />}
       <ArtistsFilter relayEnvironment={relayEnvironment} user={user} expanded />
       <ProgressiveOnboardingAlertSelectFilter>
         <AttributionClassFilter expanded />

--- a/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters.tsx
@@ -16,6 +16,7 @@ import { useSystemContext } from "System/useSystemContext"
 import { Join, Spacer } from "@artsy/palette"
 import { ProgressiveOnboardingAlertSelectFilter } from "Components/ProgressiveOnboarding/ProgressiveOnboardingAlertSelectFilter"
 import { ArtistSeriesFilter } from "Components/ArtworkFilter/ArtworkFilters/ArtistSeriesFilter"
+import { useFeatureFlag } from "System/useFeatureFlag"
 
 interface ArtistArtworkFiltersProps {
   relayEnvironment?: RelayModernEnvironment
@@ -24,11 +25,14 @@ interface ArtistArtworkFiltersProps {
 export const ArtistArtworkFilters: React.FC<ArtistArtworkFiltersProps> = props => {
   const { relayEnvironment } = props
   const { user } = useSystemContext()
+  const enableArtistSeriesFilter = useFeatureFlag(
+    "onyx_enable-artist-series-filter"
+  )
 
   return (
     <Join separator={<Spacer y={4} />}>
       <KeywordFilter />
-      <ArtistSeriesFilter expanded />
+      {enableArtistSeriesFilter && <ArtistSeriesFilter expanded />}
       <ArtistsFilter relayEnvironment={relayEnvironment} user={user} expanded />
       <ProgressiveOnboardingAlertSelectFilter>
         <AttributionClassFilter expanded />

--- a/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters.tsx
@@ -15,6 +15,7 @@ import type RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvi
 import { useSystemContext } from "System/useSystemContext"
 import { Join, Spacer } from "@artsy/palette"
 import { ProgressiveOnboardingAlertSelectFilter } from "Components/ProgressiveOnboarding/ProgressiveOnboardingAlertSelectFilter"
+import { ArtistSeriesFilter } from "Components/ArtworkFilter/ArtworkFilters/ArtistSeriesFilter"
 
 interface ArtistArtworkFiltersProps {
   relayEnvironment?: RelayModernEnvironment
@@ -27,6 +28,7 @@ export const ArtistArtworkFilters: React.FC<ArtistArtworkFiltersProps> = props =
   return (
     <Join separator={<Spacer y={4} />}>
       <KeywordFilter />
+      <ArtistSeriesFilter expanded />
       <ArtistsFilter relayEnvironment={relayEnvironment} user={user} expanded />
       <ProgressiveOnboardingAlertSelectFilter>
         <AttributionClassFilter expanded />

--- a/src/Apps/Artist/Routes/WorksForSale/Components/__tests__/ArtistArtworkFilters.jest.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/__tests__/ArtistArtworkFilters.jest.tsx
@@ -1,0 +1,55 @@
+import {
+  RenderOptions,
+  render as originalRender,
+  screen,
+} from "@testing-library/react"
+import { ArtistArtworkFilters } from "Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters"
+import { ArtworkFilterContextProvider } from "Components/ArtworkFilter/ArtworkFilterContext"
+import { ReactElement } from "react"
+
+const render = (ui: ReactElement, options: RenderOptions = {}) =>
+  originalRender(ui, { wrapper: Wrapper, ...options })
+
+const Wrapper: React.FC = ({ children }) => {
+  return (
+    <ArtworkFilterContextProvider
+      aggregations={[
+        {
+          slice: "ARTIST_SERIES",
+          counts: [{ name: "Series Name", value: "series-value", count: 42 }],
+        },
+        {
+          slice: "MATERIALS_TERMS",
+          counts: [
+            { name: "Material Name", value: "material-value", count: 42 },
+          ],
+        },
+        {
+          slice: "LOCATION_CITY",
+          counts: [{ name: "City Name", value: "city-value", count: 42 }],
+        },
+        {
+          slice: "PARTNER",
+          counts: [{ name: "Partner Name", value: "partner-value", count: 42 }],
+        },
+      ]}
+    >
+      {children}
+    </ArtworkFilterContextProvider>
+  )
+}
+
+it("renders all expected filters", () => {
+  render(<ArtistArtworkFilters />)
+
+  expect(screen.getByText("Keyword Search")).toBeInTheDocument()
+  expect(screen.getByText("Rarity")).toBeInTheDocument()
+  expect(screen.getByText("Medium")).toBeInTheDocument()
+  expect(screen.getByText("Price")).toBeInTheDocument()
+  expect(screen.getByText("Ways to Buy")).toBeInTheDocument()
+  expect(screen.getByText("Material")).toBeInTheDocument()
+  expect(screen.getByText("Artwork Location")).toBeInTheDocument()
+  expect(screen.getByText("Time Period")).toBeInTheDocument()
+  expect(screen.getByText("Color")).toBeInTheDocument()
+  expect(screen.getByText("Galleries and Institutions")).toBeInTheDocument()
+})

--- a/src/Apps/Artist/Routes/WorksForSale/Components/__tests__/ArtistArtworkFilters.jest.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/__tests__/ArtistArtworkFilters.jest.tsx
@@ -6,6 +6,7 @@ import {
 import { ArtistArtworkFilters } from "Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters"
 import { ArtworkFilterContextProvider } from "Components/ArtworkFilter/ArtworkFilterContext"
 import { ReactElement } from "react"
+import { useFeatureFlag } from "System/useFeatureFlag"
 
 const render = (ui: ReactElement, options: RenderOptions = {}) =>
   originalRender(ui, { wrapper: Wrapper, ...options })
@@ -39,6 +40,10 @@ const Wrapper: React.FC = ({ children }) => {
   )
 }
 
+jest.mock("System/useFeatureFlag", () => ({
+  useFeatureFlag: jest.fn(() => true),
+}))
+
 it("renders all expected filters", () => {
   render(<ArtistArtworkFilters />)
 
@@ -52,4 +57,25 @@ it("renders all expected filters", () => {
   expect(screen.getByText("Time Period")).toBeInTheDocument()
   expect(screen.getByText("Color")).toBeInTheDocument()
   expect(screen.getByText("Galleries and Institutions")).toBeInTheDocument()
+})
+
+describe("feature flag: onyx_enable-artist-series-filter", () => {
+  describe("when the feature flag is enabled", () => {
+    beforeEach(() => {
+      ;(useFeatureFlag as jest.Mock).mockImplementation(() => true)
+    })
+    it("renders the Artist Series filter", () => {
+      render(<ArtistArtworkFilters />)
+      expect(screen.getByText("Artist Series")).toBeInTheDocument()
+    })
+  })
+  describe("when the feature flag is disabled", () => {
+    beforeEach(() => {
+      ;(useFeatureFlag as jest.Mock).mockImplementation(() => false)
+    })
+    it("does not render the Artist Series filter", () => {
+      render(<ArtistArtworkFilters />)
+      expect(screen.queryByText("Artist Series")).not.toBeInTheDocument()
+    })
+  })
 })

--- a/src/Apps/Artist/Routes/WorksForSale/Utils/getWorksForSaleRouteVariables.ts
+++ b/src/Apps/Artist/Routes/WorksForSale/Utils/getWorksForSaleRouteVariables.ts
@@ -1,4 +1,5 @@
 import { getInitialFilterState } from "Components/ArtworkFilter/Utils/getInitialFilterState"
+import { getENV } from "Utils/getENV"
 
 export function getWorksForSaleRouteVariables({ artistID }, { location }) {
   // FIXME: The initial render includes `location` in props, but subsequent
@@ -18,12 +19,21 @@ export function getWorksForSaleRouteVariables({ artistID }, { location }) {
     "LOCATION_CITY",
     "MATERIALS_TERMS",
     "SIMPLE_PRICE_HISTOGRAM",
-    "ARTIST_SERIES",
   ]
+
+  if (isArtistSeriesFilterEnabled()) {
+    aggregations.push("ARTIST_SERIES")
+  }
 
   return {
     input: filterParams,
     aggregations,
     artistID,
   }
+}
+
+function isArtistSeriesFilterEnabled() {
+  const featureFlags = getENV("FEATURE_FLAGS")
+  const artistSeriesFlag = featureFlags?.["onyx_enable-artist-series-filter"]
+  return !!artistSeriesFlag?.flagEnabled
 }

--- a/src/Apps/Artist/Routes/WorksForSale/Utils/getWorksForSaleRouteVariables.ts
+++ b/src/Apps/Artist/Routes/WorksForSale/Utils/getWorksForSaleRouteVariables.ts
@@ -18,6 +18,7 @@ export function getWorksForSaleRouteVariables({ artistID }, { location }) {
     "LOCATION_CITY",
     "MATERIALS_TERMS",
     "SIMPLE_PRICE_HISTOGRAM",
+    "ARTIST_SERIES",
   ]
 
   return {

--- a/src/Apps/Artist/artistRoutes.tsx
+++ b/src/Apps/Artist/artistRoutes.tsx
@@ -138,6 +138,7 @@ export const artistRoutes: AppRouteConfig[] = [
           query artistRoutes_WorksForSaleQuery(
             $artistID: String!
             $input: FilterArtworksInput
+            # TODO:(?) only request the artist series aggregation if user has the Unleash flag enabled?
             $aggregations: [ArtworkAggregation]
           ) {
             artist(id: $artistID) {

--- a/src/Components/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilterContext.tsx
@@ -19,6 +19,7 @@ export const initialArtworkFilterState: ArtworkFilters = {
   sizes: [],
   sort: "-decayed_merch",
   artistIDs: [],
+  artistSeriesIDs: [],
   attributionClass: [],
   keyword: undefined,
   partnerIDs: [],
@@ -39,6 +40,7 @@ export const initialArtworkFilterState: ArtworkFilters = {
 export enum FilterParamName {
   additionalGeneIDs = "additionalGeneIDs",
   artistIDs = "artistIDs",
+  artistSeriesIDs = "artistSeriesIDs",
   artistNationalities = "artistNationalities",
   artistsIFollow = "includeArtworksByFollowedArtists",
   attributionClass = "attributionClass",
@@ -78,6 +80,7 @@ export const customSizeFilterNames = [
 export interface MultiSelectArtworkFilters {
   attributionClass?: string[]
   artistIDs?: string[]
+  artistSeriesIDs?: string[]
   colors?: string[]
   additionalGeneIDs?: string[]
   majorPeriods?: string[]
@@ -169,6 +172,7 @@ export type SelectedFiltersCounts = {
 export enum SelectedFiltersCountsLabels {
   additionalGeneIDs = "additionalGeneIDs",
   artistIDs = "artistIDs",
+  artistSeriesIDs = "artistSeriesIDs",
   artistNationalities = "artistNationalities",
   attributionClass = "attributionClass",
   colors = "colors",
@@ -464,6 +468,7 @@ const artworkFilterReducer = (
   const arrayFilterTypes: Array<keyof ArtworkFilters> = [
     "sizes",
     "artistIDs",
+    "artistSeriesIDs",
     "attributionClass",
     "partnerIDs",
     "additionalGeneIDs",

--- a/src/Components/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilterContext.tsx
@@ -122,6 +122,7 @@ export interface ArtworkFiltersState extends ArtworkFilters {
 export type Slice =
   | "ARTIST_NATIONALITY"
   | "ARTIST"
+  | "ARTIST_SERIES"
   | "COLOR"
   | "DIMENSION_RANGE"
   | "GALLERY"

--- a/src/Components/ArtworkFilter/ArtworkFilters/ArtistSeriesFilter.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/ArtistSeriesFilter.tsx
@@ -1,0 +1,26 @@
+import * as React from "react"
+import { SelectedFiltersCountsLabels } from "Components/ArtworkFilter/ArtworkFilterContext"
+import { ResultsFilter } from "./ResultsFilter"
+
+export interface ArtistSeriesFilterProps {
+  expanded?: boolean
+  label?: string
+}
+
+export const ArtistSeriesFilter: React.FC<ArtistSeriesFilterProps> = ({
+  expanded,
+  label = "Artist Series",
+}) => {
+  return (
+    <>
+      <ResultsFilter
+        expanded={expanded}
+        facetName="artistSeriesIDs"
+        filtersCountKey={SelectedFiltersCountsLabels.artistSeriesIDs}
+        label={label}
+        placeholder="Enter an artist series"
+        slice="ARTIST_SERIES"
+      />
+    </>
+  )
+}

--- a/src/Components/ArtworkFilter/ArtworkFilters/__tests__/ArtistSeriesFilter.jest.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/__tests__/ArtistSeriesFilter.jest.tsx
@@ -1,0 +1,71 @@
+import { screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import {
+  createArtworkFilterTestRenderer,
+  currentArtworkFilterContext,
+} from "Components/ArtworkFilter/ArtworkFilters/__tests__/Utils"
+import { ArtworkFilterContextProps } from "Components/ArtworkFilter/ArtworkFilterContext"
+import { ArtistSeriesFilter } from "Components/ArtworkFilter/ArtworkFilters/ArtistSeriesFilter"
+
+const artworkFilterContext: Partial<ArtworkFilterContextProps> = {
+  aggregations: [
+    {
+      slice: "ARTIST_SERIES",
+      counts: [
+        { name: "Companions", value: "kaws-companions", count: 42 },
+        { name: "Toys", value: "kaws-toys", count: 420 },
+      ],
+    },
+  ],
+}
+
+const render = createArtworkFilterTestRenderer(artworkFilterContext)
+
+describe(ArtistSeriesFilter, () => {
+  it("renders a list of options based on current aggregation", () => {
+    render(<ArtistSeriesFilter expanded />)
+    expect(screen.getByText("Companions")).toBeInTheDocument()
+    expect(screen.getByText("Toys")).toBeInTheDocument()
+  })
+
+  it("updates context on filter change", () => {
+    render(<ArtistSeriesFilter expanded />)
+    expect(currentArtworkFilterContext().filters?.artistSeriesIDs).toEqual([])
+
+    userEvent.click(screen.getAllByRole("checkbox")[0])
+    expect(currentArtworkFilterContext().filters?.artistSeriesIDs).toEqual([
+      "kaws-companions",
+    ])
+
+    userEvent.click(screen.getAllByRole("checkbox")[1])
+    expect(currentArtworkFilterContext().filters?.artistSeriesIDs).toEqual([
+      "kaws-companions",
+      "kaws-toys",
+    ])
+  })
+
+  it("clears local input state after Clear All", () => {
+    render(<ArtistSeriesFilter expanded />)
+    userEvent.click(screen.getAllByRole("checkbox")[0])
+    userEvent.click(screen.getAllByRole("checkbox")[1])
+    expect(currentArtworkFilterContext().filters?.artistSeriesIDs).toEqual([
+      "kaws-companions",
+      "kaws-toys",
+    ])
+
+    userEvent.click(screen.getByText("Clear all"))
+
+    expect(currentArtworkFilterContext().filters?.artistSeriesIDs).toEqual([])
+  })
+
+  it("can render in expanded or collapsed state", () => {
+    render(<ArtistSeriesFilter />)
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument()
+
+    render(<ArtistSeriesFilter expanded={false} />)
+    expect(screen.queryByRole("checkbox")).not.toBeInTheDocument()
+
+    render(<ArtistSeriesFilter expanded={true} />)
+    expect(screen.getAllByRole("checkbox")).toHaveLength(2)
+  })
+})

--- a/src/Components/ArtworkFilter/Utils/__tests__/countChangedFilters.jest.ts
+++ b/src/Components/ArtworkFilter/Utils/__tests__/countChangedFilters.jest.ts
@@ -1,11 +1,13 @@
-import { countChangedFilters } from "../countChangedFilters"
+import { ArtworkFilters } from "Components/ArtworkFilter/ArtworkFilterContext"
+import { countChangedFilters } from "Components/ArtworkFilter/Utils/countChangedFilters"
 
-const EMPTY_FILTER = {
+const EMPTY_FILTER: ArtworkFilters = {
   majorPeriods: [],
   page: 1,
   sizes: [],
   sort: "-decayed_merch",
   artistIDs: [],
+  artistSeriesIDs: [],
   attributionClass: [],
   partnerIDs: [],
   additionalGeneIDs: [],

--- a/src/Components/ArtworkFilter/Utils/__tests__/getSelectedFiltersCounts.jest.ts
+++ b/src/Components/ArtworkFilter/Utils/__tests__/getSelectedFiltersCounts.jest.ts
@@ -1,19 +1,22 @@
 import {
   initialArtworkFilterState,
   getSelectedFiltersCounts,
-} from "../../ArtworkFilterContext"
+  MultiSelectArtworkFilters,
+} from "Components/ArtworkFilter/ArtworkFilterContext"
 
 describe("getSelectedFiltersCounts helper", () => {
-  const multiSelectFilters = {
+  const multiSelectFilters: MultiSelectArtworkFilters = {
     additionalGeneIDs: ["prints", "design", "installation", "drawing"],
     attributionClass: ["unique", "unknown-edition"],
     artistNationalities: ["british", "japanese"],
+    artistSeriesIDs: ["kaws-toys", "kaws-companions"],
   }
 
   const multiSelectFiltersExpectedResult = {
     attributionClass: 2,
     additionalGeneIDs: 4,
     artistNationalities: 2,
+    artistSeriesIDs: 2,
   }
 
   const singleOptionFilters = {

--- a/src/Components/ArtworkFilter/Utils/__tests__/urlBuilder.jest.tsx
+++ b/src/Components/ArtworkFilter/Utils/__tests__/urlBuilder.jest.tsx
@@ -1,4 +1,7 @@
-import { paramsToCamelCase, paramsToSnakeCase } from "../urlBuilder"
+import {
+  paramsToCamelCase,
+  paramsToSnakeCase,
+} from "Components/ArtworkFilter/Utils/urlBuilder"
 
 describe(paramsToSnakeCase, () => {
   it("converts camel cased filter arguments to snake case", () => {
@@ -8,6 +11,7 @@ describe(paramsToSnakeCase, () => {
       atAuction: true,
       inquireableOnly: false,
       artistIDs: ["catty-gallery", "doggy-gallery"],
+      artistSeriesIDs: ["kaws-toys", "kaws-companions"],
     }
     expect(paramsToSnakeCase(params)).toEqual({
       partner_id: "gagosian-gallery",
@@ -15,6 +19,7 @@ describe(paramsToSnakeCase, () => {
       at_auction: true,
       inquireable_only: false,
       artist_ids: ["catty-gallery", "doggy-gallery"],
+      artist_series_ids: ["kaws-toys", "kaws-companions"],
     })
   })
 })

--- a/src/Components/ArtworkFilter/Utils/allowedFilters.ts
+++ b/src/Components/ArtworkFilter/Utils/allowedFilters.ts
@@ -53,6 +53,7 @@ const SUPPORTED_INPUT_ARGS = [
   "artistIDs",
   "artistNationalities",
   "artistSeriesID",
+  "artistSeriesIDs",
   "atAuction",
   "attributionClass",
   "before",

--- a/src/Components/ArtworkFilter/Utils/isDefaultFilter.tsx
+++ b/src/Components/ArtworkFilter/Utils/isDefaultFilter.tsx
@@ -1,5 +1,5 @@
 import { DEFAULT_METRIC } from "Utils/metrics"
-import { ArtworkFilters } from "../ArtworkFilterContext"
+import { ArtworkFilters } from "Components/ArtworkFilter/ArtworkFilterContext"
 
 export const isDefaultFilter: (
   name: keyof ArtworkFilters,
@@ -19,6 +19,7 @@ export const isDefaultFilter: (
   switch (true) {
     case name === "sizes" ||
       name === "artistIDs" ||
+      name === "artistSeriesIDs" ||
       name === "attributionClass" ||
       name === "partnerIDs" ||
       name === "additionalGeneIDs" ||

--- a/src/Components/SavedSearchAlert/constants.ts
+++ b/src/Components/SavedSearchAlert/constants.ts
@@ -1,4 +1,4 @@
-import { Slice } from "../ArtworkFilter/ArtworkFilterContext"
+import { Slice } from "Components/ArtworkFilter/ArtworkFilterContext"
 import { SavedSearchFrequency } from "./types"
 
 export const shouldExtractValueNamesFromAggregation = [
@@ -7,6 +7,7 @@ export const shouldExtractValueNamesFromAggregation = [
   "additionalGeneIDs",
   "partnerIDs",
   "artistIDs",
+  "artistSeriesIDs",
   "artistNationalities",
 ]
 
@@ -16,12 +17,14 @@ export const aggregationNameFromFilter: Record<string, Slice> = {
   additionalGeneIDs: "MEDIUM",
   partnerIDs: "PARTNER",
   artistIDs: "ARTIST",
+  artistSeriesIDs: "ARTIST_SERIES",
   artistNationalities: "ARTIST_NATIONALITY",
 }
 
 export const allowedSearchCriteriaKeys = [
   "artistID",
   "artistIDs",
+  "artistSeriesIDs",
   "locationCities",
   "colors",
   "partnerIDs",


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [ONYX-442]

### Description

Implements a new Artist Series filter and places it behind an Unleash flag (`onyx_enable-artist-series-filter`)

There is also a review app, which does _not_ require anyone to have the flag enabled: https://artist-series-filter.artsy.net/

It's been a while since we added a new facet to the artwork grid. So I came to this like a 👶🏽 and was a little flummoxed by all the wiring that needed to happen. But it appears to work!

https://github.com/artsy/force/assets/140521/f6718503-0994-405b-b0fa-428e35ca2575




[ONYX-442]: https://artsyproduct.atlassian.net/browse/ONYX-442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ