### PR TITLE
fix(progressive-onboarding): removes lazyload to prevent layout shift

### DIFF
--- a/src/Components/ProgressiveOnboarding/withProgressiveOnboardingCounts.tsx
+++ b/src/Components/ProgressiveOnboarding/withProgressiveOnboardingCounts.tsx
@@ -35,7 +35,6 @@ export const withProgressiveOnboardingCounts = <
 
     return (
       <SystemQueryRenderer<withProgressiveOnboardingCountsQuery>
-        lazyLoad
         placeholder={
           <Component
             {...props}


### PR DESCRIPTION
Closes [DIA-234](https://artsyproduct.atlassian.net/browse/DIA-234)

See: https://github.com/artsy/force/blob/cda34a6da2f0e37a190a86be1cc679dfdfb1b55f/src/System/Relay/SystemQueryRenderer.tsx#L77-L78

The query for counts for progressive onboarding is a HOC, which makes this kind of annoying. However, all of these components are above the fold already anyway making `lazyLoad` pointless. So I'm simply removing it, which then fixes the layout shift problem.


[DIA-234]: https://artsyproduct.atlassian.net/browse/DIA-234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ