### PR TITLE
test: extract shared RTL patterns for artwork filter specs

### DIFF
--- a/src/Components/ArtworkFilter/ArtworkFilters/__tests__/KeywordFilter.jest.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/__tests__/KeywordFilter.jest.tsx
@@ -1,69 +1,18 @@
-import React, { ReactElement } from "react"
-import {
-  render as originalRender,
-  RenderOptions,
-  screen,
-  fireEvent,
-} from "@testing-library/react"
+import React from "react"
+import { screen, fireEvent } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
-
 import {
-  ArtworkFilterContextProps,
-  ArtworkFilterContextProvider,
-  useArtworkFilterContext,
-} from "Components/ArtworkFilter/ArtworkFilterContext"
+  createArtworkFilterTestRenderer,
+  currentArtworkFilterContext,
+} from "Components/ArtworkFilter/ArtworkFilters/__tests__/Utils"
 
-import { KeywordFilter } from "../KeywordFilter"
+import { KeywordFilter } from "Components/ArtworkFilter/ArtworkFilters/KeywordFilter"
 
 jest.mock("Utils/Hooks/useMatchMedia", () => ({
   __internal__useMatchMedia: () => ({}),
 }))
 
-const render = (ui: ReactElement, options: RenderOptions = {}) =>
-  originalRender(ui, { wrapper: Wrapper, ...options })
-
-const Wrapper: React.FC = ({ children }) => {
-  return (
-    <ArtworkFilterContextProvider>
-      <ClearAllButton />
-      {children}
-      <ArtworkFilterContextInspector />
-    </ArtworkFilterContextProvider>
-  )
-}
-
-const ClearAllButton: React.FC = () => {
-  const artworkFilterContext = useArtworkFilterContext()
-
-  return (
-    <button onClick={() => artworkFilterContext.resetFilters()}>
-      Clear all
-    </button>
-  )
-}
-
-const ArtworkFilterContextInspector: React.FC = () => {
-  const artworkFilterContext = useArtworkFilterContext()
-
-  return (
-    <aside data-testid="artwork-filter-context-inspector">
-      {JSON.stringify(artworkFilterContext, null, 2)}
-    </aside>
-  )
-}
-
-const currentContext = (): ArtworkFilterContextProps => {
-  let contextInspector: HTMLElement
-  try {
-    contextInspector = screen.getByTestId("artwork-filter-context-inspector")
-  } catch (error) {
-    if (error.name === "TestingLibraryElementError")
-      throw new Error(
-        `The currentContext() helper function requires an <ArtworkFilterContextInspector /> to be mounted in the current DOM.`
-      )
-  }
-  return JSON.parse(contextInspector!.textContent!)
-}
+const render = createArtworkFilterTestRenderer()
 
 describe("KeywordFilter", () => {
   // FIXME: SWC_COMPILER_MIGRATION
@@ -72,12 +21,12 @@ describe("KeywordFilter", () => {
     expect(screen.getByText("Keyword Search")).toBeInTheDocument()
 
     userEvent.type(screen.getByTestId("keywordSearchInput"), "Chopper")
-    expect(currentContext().filters?.keyword).toEqual("Chopper")
+    expect(currentArtworkFilterContext().filters?.keyword).toEqual("Chopper")
 
     fireEvent.change(screen.getByTestId("keywordSearchInput"), {
       target: { value: "" },
     })
-    expect(currentContext().filters?.keyword).toEqual(undefined)
+    expect(currentArtworkFilterContext().filters?.keyword).toEqual(undefined)
   })
 
   // FIXME: SWC_COMPILER_MIGRATION
@@ -85,14 +34,14 @@ describe("KeywordFilter", () => {
     render(<KeywordFilter />)
 
     userEvent.type(screen.getByTestId("keywordSearchInput"), "Chopper")
-    expect(currentContext().filters?.keyword).toEqual("Chopper")
+    expect(currentArtworkFilterContext().filters?.keyword).toEqual("Chopper")
     expect(
       (screen.getByTestId("keywordSearchInput") as HTMLInputElement).value
     ).toEqual("Chopper")
 
     userEvent.click(screen.getByText("Clear all"))
 
-    expect(currentContext().filters?.keyword).toEqual(undefined)
+    expect(currentArtworkFilterContext().filters?.keyword).toEqual(undefined)
     expect(
       (screen.getByTestId("keywordSearchInput") as HTMLInputElement).value
     ).toEqual("")

--- a/src/Components/ArtworkFilter/ArtworkFilters/__tests__/KeywordFilter.jest.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/__tests__/KeywordFilter.jest.tsx
@@ -15,8 +15,7 @@ jest.mock("Utils/Hooks/useMatchMedia", () => ({
 const render = createArtworkFilterTestRenderer()
 
 describe("KeywordFilter", () => {
-  // FIXME: SWC_COMPILER_MIGRATION
-  it.skip("updates context on filter change", () => {
+  it("updates context on filter change", () => {
     render(<KeywordFilter />)
     expect(screen.getByText("Keyword Search")).toBeInTheDocument()
 
@@ -29,8 +28,7 @@ describe("KeywordFilter", () => {
     expect(currentArtworkFilterContext().filters?.keyword).toEqual(undefined)
   })
 
-  // FIXME: SWC_COMPILER_MIGRATION
-  it.skip("clears local input state after Clear All", () => {
+  it("clears local input state after Clear All", () => {
     render(<KeywordFilter />)
 
     userEvent.type(screen.getByTestId("keywordSearchInput"), "Chopper")

--- a/src/Components/ArtworkFilter/ArtworkFilters/__tests__/SizeFilter.jest.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/__tests__/SizeFilter.jest.tsx
@@ -1,16 +1,11 @@
-import React, { ReactElement } from "react"
-import {
-  render as originalRender,
-  RenderOptions,
-  screen,
-} from "@testing-library/react"
+import React from "react"
+import { screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
-
 import {
-  ArtworkFilterContextProps,
-  ArtworkFilterContextProvider,
-  useArtworkFilterContext,
-} from "Components/ArtworkFilter/ArtworkFilterContext"
+  createArtworkFilterTestRenderer,
+  currentArtworkFilterContext,
+} from "Components/ArtworkFilter/ArtworkFilters/__tests__/Utils"
+
 import {
   getPredefinedSizesByMetric,
   parseRange,
@@ -19,57 +14,13 @@ import {
   SIZES_IN_INCHES,
   getCustomSizeRangeInInches,
   CustomSize,
-} from "../SizeFilter"
+} from "Components/ArtworkFilter/ArtworkFilters/SizeFilter"
 
 jest.mock("Utils/Hooks/useMatchMedia", () => ({
   __internal__useMatchMedia: () => ({}),
 }))
 
-const render = (ui: ReactElement, options: RenderOptions = {}) =>
-  originalRender(ui, { wrapper: Wrapper, ...options })
-
-const Wrapper: React.FC = ({ children }) => {
-  return (
-    <ArtworkFilterContextProvider>
-      <ClearAllButton />
-      {children}
-      <ArtworkFilterContextInspector />
-    </ArtworkFilterContextProvider>
-  )
-}
-
-const ClearAllButton: React.FC = () => {
-  const artworkFilterContext = useArtworkFilterContext()
-
-  return (
-    <button onClick={() => artworkFilterContext.resetFilters()}>
-      Clear all
-    </button>
-  )
-}
-
-const ArtworkFilterContextInspector: React.FC = () => {
-  const artworkFilterContext = useArtworkFilterContext()
-
-  return (
-    <aside data-testid="artwork-filter-context-inspector">
-      {JSON.stringify(artworkFilterContext, null, 2)}
-    </aside>
-  )
-}
-
-const currentContext = (): ArtworkFilterContextProps => {
-  let contextInspector: HTMLElement
-  try {
-    contextInspector = screen.getByTestId("artwork-filter-context-inspector")
-  } catch (error) {
-    if (error.name === "TestingLibraryElementError")
-      throw new Error(
-        `The currentContext() helper function requires an <ArtworkFilterContextInspector /> to be mounted in the current DOM.`
-      )
-  }
-  return JSON.parse(contextInspector!.textContent!)
-}
+const render = createArtworkFilterTestRenderer()
 
 describe("SizeFilter", () => {
   it("toggles custom input render", () => {
@@ -88,13 +39,16 @@ describe("SizeFilter", () => {
 
   it("updates context on filter change", () => {
     render(<SizeFilter expanded />)
-    expect(currentContext().filters?.sizes).toEqual([])
+    expect(currentArtworkFilterContext().filters?.sizes).toEqual([])
 
     userEvent.click(screen.getAllByRole("checkbox")[0])
-    expect(currentContext().filters?.sizes).toEqual(["SMALL"])
+    expect(currentArtworkFilterContext().filters?.sizes).toEqual(["SMALL"])
 
     userEvent.click(screen.getAllByRole("checkbox")[2])
-    expect(currentContext().filters?.sizes).toEqual(["SMALL", "LARGE"])
+    expect(currentArtworkFilterContext().filters?.sizes).toEqual([
+      "SMALL",
+      "LARGE",
+    ])
   })
 
   it("updates the filter values", async () => {
@@ -107,11 +61,11 @@ describe("SizeFilter", () => {
     userEvent.type(screen.getAllByRole("spinbutton")[3], "16")
     userEvent.click(screen.getByText("Set size"))
 
-    expect(currentContext().filters?.sizes).toEqual([])
-    expect(currentContext().filters?.height).toEqual(
+    expect(currentArtworkFilterContext().filters?.sizes).toEqual([])
+    expect(currentArtworkFilterContext().filters?.height).toEqual(
       "4.724409448818897-6.299212598425196"
     )
-    expect(currentContext().filters?.width).toEqual(
+    expect(currentArtworkFilterContext().filters?.width).toEqual(
       "4.724409448818897-6.299212598425196"
     )
   })
@@ -124,19 +78,19 @@ describe("SizeFilter", () => {
     userEvent.type(screen.getAllByRole("spinbutton")[3], "24")
     userEvent.click(screen.getByText("Set size"))
 
-    expect(currentContext().filters?.sizes).toEqual([])
-    expect(currentContext().filters?.height).toEqual(
+    expect(currentArtworkFilterContext().filters?.sizes).toEqual([])
+    expect(currentArtworkFilterContext().filters?.height).toEqual(
       "4.724409448818897-9.448818897637794"
     )
-    expect(currentContext().filters?.width).toEqual("*-*")
+    expect(currentArtworkFilterContext().filters?.width).toEqual("*-*")
   })
 
   it("clears local input state after Clear All", () => {
     render(<SizeFilter expanded />)
 
     // before: filter state and input state are empty
-    expect(currentContext().filters?.height).toEqual("*-*")
-    expect(currentContext().filters?.width).toEqual("*-*")
+    expect(currentArtworkFilterContext().filters?.height).toEqual("*-*")
+    expect(currentArtworkFilterContext().filters?.width).toEqual("*-*")
     expect(screen.queryByDisplayValue("1")).not.toBeInTheDocument()
     expect(screen.queryByDisplayValue("2")).not.toBeInTheDocument()
     expect(screen.queryByDisplayValue("3")).not.toBeInTheDocument()
@@ -152,11 +106,11 @@ describe("SizeFilter", () => {
     userEvent.click(screen.getByText("Set size"))
 
     // assert: state and ui are updated
-    expect(currentContext().filters?.sizes).toEqual([])
-    expect(currentContext().filters?.width).toEqual(
+    expect(currentArtworkFilterContext().filters?.sizes).toEqual([])
+    expect(currentArtworkFilterContext().filters?.width).toEqual(
       "0.39370078740157477-0.7874015748031495"
     )
-    expect(currentContext().filters?.height).toEqual(
+    expect(currentArtworkFilterContext().filters?.height).toEqual(
       "1.1811023622047243-1.574803149606299"
     )
     expect(screen.queryByDisplayValue("1")).toBeInTheDocument()
@@ -168,8 +122,8 @@ describe("SizeFilter", () => {
     userEvent.click(screen.getByText("Clear all"))
 
     // assert: state and ui are cleared
-    expect(currentContext().filters?.height).toEqual("*-*")
-    expect(currentContext().filters?.width).toEqual("*-*")
+    expect(currentArtworkFilterContext().filters?.height).toEqual("*-*")
+    expect(currentArtworkFilterContext().filters?.width).toEqual("*-*")
     expect(screen.queryByDisplayValue("1")).not.toBeInTheDocument()
     expect(screen.queryByDisplayValue("2")).not.toBeInTheDocument()
     expect(screen.queryByDisplayValue("3")).not.toBeInTheDocument()

--- a/src/Components/ArtworkFilter/ArtworkFilters/__tests__/Utils.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/__tests__/Utils.tsx
@@ -1,0 +1,149 @@
+import {
+  RenderOptions,
+  render as originalRender,
+  screen,
+} from "@testing-library/react"
+import {
+  ArtworkFilterContextProps,
+  ArtworkFilterContextProvider,
+  useArtworkFilterContext,
+} from "Components/ArtworkFilter/ArtworkFilterContext"
+import { ReactElement } from "react"
+
+/**
+ * A test helper that can be used to render components that depend
+ * on an enclosing `ArtworkFilterContext`.
+ *
+ * This returns a render function can wrap some provided UI in a
+ * properly initialized `ArtworkFilterContextProvider`.
+ *
+ * Example:
+ *
+ * ```tsx
+ * const myContext: Partial<ArtworkFilterContextProps> = {
+ *   aggregations: [
+ *     {
+ *       slice: "ARTIST",
+ *       counts: [
+ *         { name: "Artist A", value: "artist-a", count: 42 },
+ *         { name: "Artist B", value: "artist-b", count: 420 },
+ *       ],
+ *     },
+ *   ],
+ * }
+ *
+ * const render = createArtworkFilterTestRenderer(myContext)
+ *
+ * it("renders a list of options based on current aggregation", () => {
+ *   render(<ArtistsFilter expanded />)
+ *   expect(screen.getByText("Artist A")).toBeInTheDocument()
+ *   expect(screen.getByText("Artist B")).toBeInTheDocument()
+ * })
+ * ```
+ *
+ * Use it with `currentArtworkFilterContext` if you want inspect
+ * the current state of the context after some user interaction.
+ *
+ * @param {ArtworkFilterContextProps} artworkFilterContext - context props to initialize the `ArtworkFilterContextProvider`
+ * @returns a render function that wraps its provided UI in an initialized `ArtworkFilterContextProvider`
+ *
+ * @see currentArtworkFilterContext
+ */
+export const createArtworkFilterTestRenderer = (
+  artworkFilterContext: Partial<ArtworkFilterContextProps> = {}
+) => {
+  return (ui: ReactElement, options: RenderOptions = {}) =>
+    originalRender(ui, {
+      wrapper: ({ children }) => {
+        return (
+          <ArtworkFilterContextProvider {...artworkFilterContext}>
+            <ClearAllButton />
+            {children}
+            <ArtworkFilterContextInspector />
+          </ArtworkFilterContextProvider>
+        )
+      },
+      ...options,
+    })
+}
+
+/**
+ * A test helper that can be used in conjunction with `createArtworkFilterTestRenderer`
+ * in order to inspect the current state of the ArtworkFilterContext.
+ *
+ * Example:
+ *
+ * ```tsx
+ * const myContext: Partial<ArtworkFilterContextProps> = {
+ *   aggregations: [
+ *     {
+ *       slice: "ARTIST",
+ *       counts: [
+ *         { name: "Artist A", value: "artist-a", count: 42 },
+ *         { name: "Artist B", value: "artist-b", count: 420 },
+ *       ],
+ *     },
+ *   ],
+ * }
+ *
+ * const render = createArtworkFilterTestRenderer(myContext)
+ *
+ * it("updates context on filter change", () => {
+ *   render(<ArtistsFilter expanded />)
+ *   expect(currentArtworkFilterContext().filters?.artistIDs).toEqual([])
+ *
+ *   userEvent.click(screen.getAllByRole("checkbox")[0])
+ *   expect(currentArtworkFilterContext().filters?.artistIDs).toEqual(["artist-a"])
+ * ```
+ *
+ * @returns An object representing the current state of the `ArtworkFilterContext`
+ *
+ * @see createArtworkFilterTestRenderer
+ */
+export const currentArtworkFilterContext = (): ArtworkFilterContextProps => {
+  let contextInspector: HTMLElement
+  try {
+    contextInspector = screen.getByTestId("artwork-filter-context-inspector")
+  } catch (error) {
+    if (error.name === "TestingLibraryElementError")
+      throw new Error(
+        `The currentContext() helper function requires an <ArtworkFilterContextInspector /> to be mounted in the current DOM.`
+      )
+  }
+  return JSON.parse(contextInspector!.textContent!)
+}
+
+/**
+ * A component whose only job is to call `resetFilters` on the
+ * `ArtworkFilterContext` when clicked.
+ */
+
+const ClearAllButton: React.FC = () => {
+  const artworkFilterContext = useArtworkFilterContext()
+
+  return (
+    <button onClick={() => artworkFilterContext.resetFilters()}>
+      Clear all
+    </button>
+  )
+}
+
+/**
+ * A component that renders a pretty-printed version of the current state
+ * of the `ArtworkFilterContext` into the DOM.
+ *
+ * (This allows us to use currentArtworkFilterContext() to inspect the
+ * internal state of the ArtworkFilterContext, while still adhering to
+ * Testing Library's philosophy of interacting only with
+ * components that are visible to the user.)
+ */
+
+const ArtworkFilterContextInspector: React.FC = () => {
+  const artworkFilterContext = useArtworkFilterContext()
+
+  return (
+    <aside data-testid="artwork-filter-context-inspector">
+      {JSON.stringify(artworkFilterContext, null, 2)}
+    </aside>
+  )
+}


### PR DESCRIPTION
The type of this PR is: **Test**

Decided to split this from https://github.com/artsy/force/pull/13041#discussion_r1366195014 so that I can get this on `main` and then include it in that PR.

### Description

This takes some patterns for working with artwork filters in a react-testing-library friendly way and extracts them into shared helpers.

This was [introduced](https://github.com/artsy/force/pull/7629#discussion_r639742956) in the original RTL spike for the `SizeFilter` spec, [copied over](https://github.com/artsy/force/pull/10379) to the `KeywordFilter` spec and now will be [used](https://github.com/artsy/force/pull/13041/commits/686e2e5ed163b117f6ab35f015c250e604d50f3b) for the `ArtistSeriesFilter` spec as well.

Seems like a good time to extract and document this shareable code.

