### PR TITLE
fix: feedback mutation

### DIFF
--- a/src/Apps/Search/Components/SendFeedback.tsx
+++ b/src/Apps/Search/Components/SendFeedback.tsx
@@ -31,6 +31,17 @@ export const SendFeedback: FC = () => {
         sendFeedback(input: $input) {
           feedbackOrError {
             __typename
+            ... on SendFeedbackMutationSuccess {
+              feedback {
+                internalID
+              }
+            }
+            ... on SendFeedbackMutationFailure {
+              mutationError {
+                message
+                detail
+              }
+            }
           }
         }
       }
@@ -61,10 +72,11 @@ export const SendFeedback: FC = () => {
               },
             },
             rejectIf: res => {
-              return (
-                res.sendFeedback?.feedbackOrError?.__typename ===
-                "SendFeedbackMutationFailure"
-              )
+              const result = res.sendFeedback?.feedbackOrError
+
+              return result?.__typename === "SendFeedbackMutationFailure"
+                ? result.mutationError
+                : false
             },
           })
 

--- a/src/__generated__/SendFeedbackSearchResultsMutation.graphql.ts
+++ b/src/__generated__/SendFeedbackSearchResultsMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4cba76942be80e1e74983334e3d3f9b7>>
+ * @generated SignedSource<<b48d34eb0318683e16dbff3c84f455df>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -22,7 +22,20 @@ export type SendFeedbackSearchResultsMutation$variables = {
 export type SendFeedbackSearchResultsMutation$data = {
   readonly sendFeedback: {
     readonly feedbackOrError: {
-      readonly __typename: string;
+      readonly __typename: "SendFeedbackMutationFailure";
+      readonly mutationError: {
+        readonly detail: string | null;
+        readonly message: string;
+      } | null;
+    } | {
+      readonly __typename: "SendFeedbackMutationSuccess";
+      readonly feedback: {
+        readonly internalID: string;
+      } | null;
+    } | {
+      // This will never be '%other', but we need some
+      // value in case none of the concrete values match.
+      readonly __typename: "%other";
     } | null;
   } | null;
 };
@@ -41,48 +54,108 @@ var v0 = [
 ],
 v1 = [
   {
-    "alias": null,
-    "args": [
-      {
-        "kind": "Variable",
-        "name": "input",
-        "variableName": "input"
-      }
-    ],
-    "concreteType": "SendFeedbackMutationPayload",
-    "kind": "LinkedField",
-    "name": "sendFeedback",
-    "plural": false,
-    "selections": [
-      {
-        "alias": null,
-        "args": null,
-        "concreteType": null,
-        "kind": "LinkedField",
-        "name": "feedbackOrError",
-        "plural": false,
-        "selections": [
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "__typename",
-            "storageKey": null
-          }
-        ],
-        "storageKey": null
-      }
-    ],
-    "storageKey": null
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
   }
-];
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v4 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "GravityMutationError",
+      "kind": "LinkedField",
+      "name": "mutationError",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "message",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "detail",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "SendFeedbackMutationFailure",
+  "abstractKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "SendFeedbackSearchResultsMutation",
-    "selections": (v1/*: any*/),
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "SendFeedbackMutationPayload",
+        "kind": "LinkedField",
+        "name": "sendFeedback",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "feedbackOrError",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Feedback",
+                    "kind": "LinkedField",
+                    "name": "feedback",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "SendFeedbackMutationSuccess",
+                "abstractKey": null
+              },
+              (v4/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
     "type": "Mutation",
     "abstractKey": null
   },
@@ -91,19 +164,70 @@ return {
     "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "SendFeedbackSearchResultsMutation",
-    "selections": (v1/*: any*/)
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "SendFeedbackMutationPayload",
+        "kind": "LinkedField",
+        "name": "sendFeedback",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "feedbackOrError",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Feedback",
+                    "kind": "LinkedField",
+                    "name": "feedback",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "id",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "SendFeedbackMutationSuccess",
+                "abstractKey": null
+              },
+              (v4/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
   },
   "params": {
-    "cacheID": "aed2b499b05332303b5518aa063466b1",
+    "cacheID": "0495699a58ae9c1bfae5fe0f293230c1",
     "id": null,
     "metadata": {},
     "name": "SendFeedbackSearchResultsMutation",
     "operationKind": "mutation",
-    "text": "mutation SendFeedbackSearchResultsMutation(\n  $input: SendFeedbackMutationInput!\n) {\n  sendFeedback(input: $input) {\n    feedbackOrError {\n      __typename\n    }\n  }\n}\n"
+    "text": "mutation SendFeedbackSearchResultsMutation(\n  $input: SendFeedbackMutationInput!\n) {\n  sendFeedback(input: $input) {\n    feedbackOrError {\n      __typename\n      ... on SendFeedbackMutationSuccess {\n        feedback {\n          internalID\n          id\n        }\n      }\n      ... on SendFeedbackMutationFailure {\n        mutationError {\n          message\n          detail\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "155a7a2823962b6d892c21c2e6ac2e05";
+(node as any).hash = "682ec1c907a87967fae7fcf1ed68eb7a";
 
 export default node;


### PR DESCRIPTION
The type of this PR is: **Fix**

[FF]

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves https://artsyproduct.atlassian.net/browse/PHIRE-212

### Description

We recently added [throttling to the feedback endpoint](https://github.com/artsy/gravity/pull/16958) in order to [resolve a security submission](https://artsyproduct.atlassian.net/browse/PHIRE-212). While testing end to end I noticed that the client was returning a generic message however the server was returning a more descriptive message. This fixes the mutation to extract the returned fields and display the appropriate message.

Before

<img width="651" alt="Screenshot 2023-10-19 at 2 15 16 PM" src="https://github.com/artsy/force/assets/29984068/e7ade49d-5c64-4eb2-9edb-036406407f01">


After

![Screenshot 2023-10-20 at 11 37 32 AM](https://github.com/artsy/force/assets/29984068/0e8dd3fe-38c0-4cc5-853e-cf329675cf1b)

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ