### PR TITLE
fix(EMI-1336): don't show cookie banner for Eigen

### DIFF
--- a/src/Components/CookieConsentManager/CookieConsentManager.tsx
+++ b/src/Components/CookieConsentManager/CookieConsentManager.tsx
@@ -17,6 +17,7 @@ import { CookieConsentManagerProvider } from "Components/CookieConsentManager/Co
 import { CookieConsentManagerSetter } from "Components/CookieConsentManager/CookieConsentManagerSetter"
 import { SavedCookieConsentPreferences } from "@artsy/cohesion/dist/Schema/Events/CookieConsent"
 import { ActionType } from "@artsy/cohesion"
+import { useSystemContext } from "System/useSystemContext"
 
 export const COOKIE_CONSENT_MANAGER_COOKIE_NAME = "tracking-preferences"
 
@@ -28,6 +29,8 @@ export const CookieConsentManager: FC<CookieConsentManagerProps> = ({
   children,
 }) => {
   const isMounted = useDidMount()
+
+  const { isEigen } = useSystemContext()
 
   const { trackEvent } = useTracking()
 
@@ -72,7 +75,7 @@ export const CookieConsentManager: FC<CookieConsentManagerProps> = ({
 
             // If there are no new destinations, we don't need to show the banner
             const isBannerDisplayable =
-              isDisplayable && newDestinations.length > 0
+              !isEigen && isDisplayable && newDestinations.length > 0
 
             const handleAccept = () => {
               saveConsent(ALLOW_ALL_PREFERENCES)


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [EMI-1336]

### Description

Cookie consent banner shows up when opening the checkout flow in the app. Introducing a `isEigen` check to avoid showing it in those scenarios.
Note: I found an Eigen check [in the past implementation](https://github.com/artsy/force/pull/12280/files#diff-62f5fc92583c63dc0ef6698014cb81e6d7db0a22c0bf70bd599482fd876785deL7)

[EMI-1336]: https://artsyproduct.atlassian.net/browse/EMI-1336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ