### PR TITLE
chore: Update list of featured categories DIA-188

### DIFF
--- a/src/Apps/Collect/collectRoutes.tsx
+++ b/src/Apps/Collect/collectRoutes.tsx
@@ -149,11 +149,11 @@ function getArtworkFilterQuery() {
       marketingCollections(
         slugs: [
           "contemporary"
-          "post-war"
-          "impressionist-and-modern"
-          "pre-20th-century"
-          "photography"
+          "painting"
           "street-art"
+          "photography"
+          "emerging-art"
+          "20th-century-art"
         ]
       ) {
         ...Collect_marketingCollections


### PR DESCRIPTION
This PR updates the list of featured categories on the /collect page. It does NOT fix the order of them - that is a change I will make in Gravity. Looks like this:

![Screenshot 2023-10-24 at 1 02 59 PM](https://github.com/artsy/force/assets/79799/4213e08b-96e2-4c6c-8615-2973b573ebab)

Note that some of those thumbnails are empty just because staging data doesn't match production.

https://artsyproduct.atlassian.net/browse/DIA-188

/cc @artsy/diamond-devs