### PR TITLE
chore: cleanup unused default alert placeholder value

### DIFF
--- a/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
@@ -34,7 +34,6 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
   }
 
   const savedSearchEntity: SavedSearchEntity = {
-    placeholder: artist.name!,
     owner: {
       type: OwnerType.artist,
       id: artist.internalID,

--- a/src/Apps/Artist/Routes/WorksForSale/Components/ArtistWorksForSaleEmpty.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/ArtistWorksForSaleEmpty.tsx
@@ -37,7 +37,6 @@ const ArtistWorksForSaleEmpty: FC<ArtistWorksForSaleEmptyProps> = ({
 
           <SavedSearchCreateAlertButtonContainer
             entity={{
-              placeholder: artist.name!,
               owner: {
                 id: contextPageOwnerId!,
                 name: artist.name!,

--- a/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/ArtworkAuctionCreateAlertHeader.tsx
+++ b/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/ArtworkAuctionCreateAlertHeader.tsx
@@ -47,7 +47,6 @@ const ArtworkAuctionCreateAlertHeader: FC<ArtworkAuctionCreateAlertHeaderProps> 
   const artists = compact(artwork.artists)
   const attributionClass = compact([artwork.attributionClass?.internalID])
   const artistIDs = artists.map(artist => artist.internalID)
-  const placeholder = `Artworks like: ${artwork.title!}`
   const defaultArtistsCriteria: SavedSearchEntityCriteria[] = artists.map(
     artist => ({
       value: artist.internalID,
@@ -55,7 +54,6 @@ const ArtworkAuctionCreateAlertHeader: FC<ArtworkAuctionCreateAlertHeaderProps> 
     })
   )
   const entity: SavedSearchEntity = {
-    placeholder,
     defaultCriteria: {
       artistIDs: defaultArtistsCriteria,
     },

--- a/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/__tests__/ArtworkAuctionCreateAlertTooltip.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/__tests__/ArtworkAuctionCreateAlertTooltip.jest.tsx
@@ -6,7 +6,6 @@ import { SavedSearchEntity } from "Components/SavedSearchAlert/types"
 
 describe("ArtworkAuctionCreateAlertTooltip", () => {
   const savedSearchEntity: SavedSearchEntity = {
-    placeholder: "Works by Andy Warhol",
     defaultCriteria: {
       artistIDs: [
         {

--- a/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/__tests__/SuggestedArtworksModal.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/__tests__/SuggestedArtworksModal.jest.tsx
@@ -6,7 +6,6 @@ import { SavedSearchEntity } from "Components/SavedSearchAlert/types"
 
 describe("SuggestedArtworksModal", () => {
   const savedSearchEntity: SavedSearchEntity = {
-    placeholder: "Test Artist",
     defaultCriteria: {
       artistIDs: [
         {

--- a/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/__tests__/SuggestedArtworksModalGrid.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/__tests__/SuggestedArtworksModalGrid.jest.tsx
@@ -11,7 +11,6 @@ jest.unmock("react-relay")
 
 describe("SuggestedArtworksModalGrid", () => {
   const savedSearchEntity: SavedSearchEntity = {
-    placeholder: "Test Artist",
     defaultCriteria: {
       artistIDs: [
         {

--- a/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/__tests__/SuggestedArtworksShelf.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/__tests__/SuggestedArtworksShelf.jest.tsx
@@ -11,7 +11,6 @@ jest.unmock("react-relay")
 
 describe("SuggestedArtworksShelf", () => {
   const savedSearchEntity: SavedSearchEntity = {
-    placeholder: "Test Artist",
     defaultCriteria: {
       artistIDs: [
         {

--- a/src/Apps/Artwork/Components/ArtworkCreateAlertButton.tsx
+++ b/src/Apps/Artwork/Components/ArtworkCreateAlertButton.tsx
@@ -28,7 +28,6 @@ const ArtworkCreateAlertButton: FC<ArtworkCreateAlertButtonProps> = ({
   const artists = compact(artwork.artists)
   const attributionClass = compact([artwork.attributionClass?.internalID])
   const artistIDs = artists.map(artist => artist.internalID)
-  const placeholder = `Artworks like: ${artwork.title!}`
   const defaultArtistsCriteria: SavedSearchEntityCriteria[] = artists.map(
     artist => ({
       value: artist.internalID,
@@ -36,7 +35,6 @@ const ArtworkCreateAlertButton: FC<ArtworkCreateAlertButtonProps> = ({
     })
   )
   const entity: SavedSearchEntity = {
-    placeholder,
     defaultCriteria: {
       artistIDs: defaultArtistsCriteria,
     },

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCreateArtworkAlert.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCreateArtworkAlert.tsx
@@ -27,7 +27,6 @@ const ArtworkSidebarCreateArtworkAlert: React.FC<ArtworkSidebarCreateArtworkAler
   const artists = compact(artwork.artists)
   const attributionClass = compact([artwork.attributionClass?.internalID])
   const artistIDs = artists.map(artist => artist.internalID)
-  const placeholder = `Artworks like: ${artwork.title!}`
 
   const defaultArtistsCriteria: SavedSearchEntityCriteria[] = artists.map(
     artist => ({
@@ -37,7 +36,6 @@ const ArtworkSidebarCreateArtworkAlert: React.FC<ArtworkSidebarCreateArtworkAler
   )
 
   const entity: SavedSearchEntity = {
-    placeholder,
     defaultCriteria: {
       artistIDs: defaultArtistsCriteria,
     },

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditForm.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditForm.tsx
@@ -298,7 +298,6 @@ const SavedSearchAlertEditFormContainer: React.FC<SavedSearchAlertEditFormProps>
   )
 
   const entity: SavedSearchEntity = {
-    placeholder: defaultArtistsCriteria[0].displayValue,
     defaultCriteria: {
       artistIDs: defaultArtistsCriteria,
     },

--- a/src/Components/SavedSearchAlert/Components/__tests__/ConfirmationModalHeader.jest.tsx
+++ b/src/Components/SavedSearchAlert/Components/__tests__/ConfirmationModalHeader.jest.tsx
@@ -7,7 +7,6 @@ import { SavedSearchEntity } from "Components/SavedSearchAlert/types"
 describe("ConfirmationModalHeader", () => {
   it("renders title and pills", () => {
     const savedSearchEntity: SavedSearchEntity = {
-      placeholder: "Test Artist",
       defaultCriteria: {
         artistIDs: [
           {

--- a/src/Components/SavedSearchAlert/Components/__tests__/SavedSearchCreateAlertButtonContainer.jest.tsx
+++ b/src/Components/SavedSearchAlert/Components/__tests__/SavedSearchCreateAlertButtonContainer.jest.tsx
@@ -12,7 +12,6 @@ jest.mock("react-tracking")
 jest.mock("Components/AuthDialog/useAuthDialog")
 
 const savedSearchEntity: SavedSearchEntity = {
-  placeholder: "placeholder-label",
   defaultCriteria: {
     artistIDs: [
       {

--- a/src/Components/SavedSearchAlert/Utils/__tests__/savedSearchCriteria.jest.ts
+++ b/src/Components/SavedSearchAlert/Utils/__tests__/savedSearchCriteria.jest.ts
@@ -1,14 +1,13 @@
 import { OwnerType } from "@artsy/cohesion"
 import { ArtworkFilters } from "Components/ArtworkFilter/ArtworkFilterContext"
-import { SavedSearchEntity } from "../../types"
+import { SavedSearchEntity } from "Components/SavedSearchAlert/types"
 import {
   parseDefaultCriteria,
   getSearchCriteriaFromFilters,
   isDefaultValue,
-} from "../savedSearchCriteria"
+} from "Components/SavedSearchAlert/Utils/savedSearchCriteria"
 
 const mockedSavedSearchEntity: SavedSearchEntity = {
-  placeholder: "alertName",
   defaultCriteria: {
     artistIDs: [
       {
@@ -63,7 +62,6 @@ describe("getSearchCriteriaFromFilters", () => {
 
   it("returns correct criteria when a single artist is passed to defaultCriteria", () => {
     const entity: SavedSearchEntity = {
-      placeholder: "",
       defaultCriteria: {
         artistIDs: [
           {

--- a/src/Components/SavedSearchAlert/__tests__/SavedSearchAlertModal.jest.tsx
+++ b/src/Components/SavedSearchAlert/__tests__/SavedSearchAlertModal.jest.tsx
@@ -22,7 +22,6 @@ const formInitialValues: SavedSearchAlertFormValues = {
 }
 
 const savedSearchEntity: SavedSearchEntity = {
-  placeholder: "Test Artist",
   defaultCriteria: {
     artistIDs: [
       {

--- a/src/Components/SavedSearchAlert/types.ts
+++ b/src/Components/SavedSearchAlert/types.ts
@@ -42,7 +42,6 @@ export type SavedSearchDefaultCriteria = {
 }
 
 export interface SavedSearchEntity {
-  placeholder: string
   owner: SavedSearchEntityOwner
   defaultCriteria: SavedSearchDefaultCriteria
 }


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR related to [ONYX-271].

### Description

Follow-up to [#13059][].

As of [#12751][], we no longer rely on an explicitly passed value for an alert's default name, also rendered as a placeholder on the text input. Instead, we query Metaphysics for a default/generated name based on the working alert criteria, which we also show in the input placeholder but no longer persist with the alert. This default/generated name is also used after the alert has been created and stays in sync with any changes to the criteria.

The previous cleanup PR ([#13059][]) removed the feature flag branching logic and this PR follow-ups and removes the `placeholder` attribute from the `SavedSearchEntity` type and any instances of a placeholder passed in elsewhere.

[#13059]: https://github.com/artsy/force/pull/13059
[#12751]: https://github.com/artsy/force/pull/12751


<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-271]: https://artsyproduct.atlassian.net/browse/ONYX-271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ