### PR TITLE
feat(dia-226): filter experiment set up

### DIFF
--- a/src/Apps/Fair/Routes/__tests__/FairArtworks.jest.tsx
+++ b/src/Apps/Fair/Routes/__tests__/FairArtworks.jest.tsx
@@ -18,6 +18,12 @@ jest.mock("Utils/Hooks/useMatchMedia", () => ({
   __internal__useMatchMedia: () => ({}),
 }))
 
+jest.mock("Components/ArtworkFilter/useRevisedArtworkFilters", () => ({
+  useRevisedArtworkFilters: () => ({
+    enabled: false,
+  }),
+}))
+
 describe("FairArtworks", () => {
   const trackEvent = jest.fn()
 

--- a/src/Components/ArtworkFilter/ArtworkFilterCreateAlert.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilterCreateAlert.tsx
@@ -8,14 +8,16 @@ import { useSavedSearchAlertContext } from "Components/SavedSearchAlert/SavedSea
 import { getSearchCriteriaFromFilters } from "Components/SavedSearchAlert/Utils/savedSearchCriteria"
 import { DEFAULT_METRIC } from "Utils/metrics"
 import { isEmpty } from "lodash"
-import { FC } from "react"
+import { FC, ReactNode } from "react"
 
 interface ArtworkFilterCreateAlertProps {
   renderButton: (props: { onClick: () => void }) => JSX.Element
+  children?: ReactNode
 }
 
 export const ArtworkFilterCreateAlert: FC<ArtworkFilterCreateAlertProps> = ({
   renderButton,
+  children,
 }) => {
   const { entity } = useSavedSearchAlertContext()
   const { aggregations } = useArtworkFilterContext()
@@ -28,42 +30,46 @@ export const ArtworkFilterCreateAlert: FC<ArtworkFilterCreateAlertProps> = ({
   const metric = filters?.metric ?? DEFAULT_METRIC
 
   return (
-    <SavedSearchCreateAlertButtonContainer
-      entity={entity}
-      criteria={criteria}
-      metric={metric}
-      aggregations={aggregations}
-      authDialogOptions={{
-        options: {
-          title: "Sign up to create your alert",
-          afterAuthAction: {
-            action: "createAlert",
-            kind: "artworks",
-            objectId: entity.owner.slug,
+    <>
+      <SavedSearchCreateAlertButtonContainer
+        entity={entity}
+        criteria={criteria}
+        metric={metric}
+        aggregations={aggregations}
+        authDialogOptions={{
+          options: {
+            title: "Sign up to create your alert",
+            afterAuthAction: {
+              action: "createAlert",
+              kind: "artworks",
+              objectId: entity.owner.slug,
+            },
           },
-        },
-        analytics: {
-          contextModule: ContextModule.artworkGrid,
-          intent: Intent.createAlert,
-        },
-      }}
-      renderButton={({ onClick }) => (
-        <ProgressiveOnboardingAlertCreate>
-          {({ onSkip: createSkip }) => (
-            <ProgressiveOnboardingAlertReady>
-              {({ onSkip: readySkip }) =>
-                renderButton({
-                  onClick: () => {
-                    createSkip()
-                    readySkip()
-                    onClick()
-                  },
-                })
-              }
-            </ProgressiveOnboardingAlertReady>
-          )}
-        </ProgressiveOnboardingAlertCreate>
-      )}
-    />
+          analytics: {
+            contextModule: ContextModule.artworkGrid,
+            intent: Intent.createAlert,
+          },
+        }}
+        renderButton={({ onClick }) => (
+          <ProgressiveOnboardingAlertCreate>
+            {({ onSkip: createSkip }) => (
+              <ProgressiveOnboardingAlertReady>
+                {({ onSkip: readySkip }) =>
+                  renderButton({
+                    onClick: () => {
+                      createSkip()
+                      readySkip()
+                      onClick()
+                    },
+                  })
+                }
+              </ProgressiveOnboardingAlertReady>
+            )}
+          </ProgressiveOnboardingAlertCreate>
+        )}
+      />
+
+      {children}
+    </>
   )
 }

--- a/src/Components/ArtworkFilter/index.tsx
+++ b/src/Components/ArtworkFilter/index.tsx
@@ -423,9 +423,9 @@ export const BaseArtworkFilter: React.FC<
                         </Button>
                       )
                     }}
-                  />
-
-                  <Box width="1px" bg="black30" />
+                  >
+                    <Box width="1px" bg="black30" />
+                  </ArtworkFilterCreateAlert>
 
                   <Pill Icon={FilterIcon} size="small" onClick={handleOpen}>
                     All filters

--- a/src/Components/ArtworkFilter/index.tsx
+++ b/src/Components/ArtworkFilter/index.tsx
@@ -28,7 +28,6 @@ import { ProgressiveOnboardingAlertSelectFilter } from "Components/ProgressiveOn
 import { ActiveFilterPills } from "Components/SavedSearchAlert/Components/ActiveFilterPills"
 import { Sticky } from "Components/Sticky"
 import { useAnalyticsContext } from "System/Analytics/AnalyticsContext"
-import { useFeatureFlag } from "System/useFeatureFlag"
 import { useSystemContext } from "System/useSystemContext"
 import { Jump } from "Utils/Hooks/useJump"
 import { usePrevious } from "Utils/Hooks/usePrevious"
@@ -53,6 +52,7 @@ import { getTotalSelectedFiltersCount } from "./Utils/getTotalSelectedFiltersCou
 import { ArtworkFilterActiveFilters } from "Components/ArtworkFilter/ArtworkFilterActiveFilters"
 import { ArtworkFilterSort } from "Components/ArtworkFilter/ArtworkFilterSort"
 import { ArtworkFiltersQuick } from "Components/ArtworkFilter/ArtworkFiltersQuick"
+import { useRevisedArtworkFilters } from "Components/ArtworkFilter/useRevisedArtworkFilters"
 
 interface ArtworkFilterProps extends SharedArtworkFilterContextProps, BoxProps {
   Filters?: JSX.Element
@@ -147,9 +147,7 @@ export const BaseArtworkFilter: React.FC<
   const total = viewer.filtered_artworks?.counts?.total ?? 0
   const totalCountLabel = getTotalCountLabel({ total, isAuctionArtwork })
 
-  const isRevisedArtworkFilters = useFeatureFlag(
-    "diamond_revised-artwork-filters"
-  )
+  const { enabled: isRevisedArtworkFiltersEnabled } = useRevisedArtworkFilters()
 
   /**
    * Check to see if the current filter is different from the previous filter
@@ -228,7 +226,7 @@ export const BaseArtworkFilter: React.FC<
 
       {/* Mobile Artwork Filter */}
       <Media at="xs">
-        {isRevisedArtworkFilters ? (
+        {isRevisedArtworkFiltersEnabled ? (
           // New mobile filters
           <>
             <Sticky>
@@ -400,7 +398,7 @@ export const BaseArtworkFilter: React.FC<
 
       {/* Desktop Artwork Filter */}
       <Media greaterThan="xs">
-        {isRevisedArtworkFilters ? (
+        {isRevisedArtworkFiltersEnabled ? (
           // New desktop filters
           <>
             <Flex alignItems="center" justifyContent="space-between" gap={2}>

--- a/src/Components/ArtworkFilter/useRevisedArtworkFilters.ts
+++ b/src/Components/ArtworkFilter/useRevisedArtworkFilters.ts
@@ -1,0 +1,27 @@
+import {
+  useFeatureVariant,
+  useTrackFeatureVariant,
+} from "System/useFeatureFlag"
+import { useEffect } from "react"
+
+const EXPERIMENT_NAME = "diamond_revised-artwork-filters"
+const EXPERIMENT_VARIANTS = { enabled: "experiment", disabled: "control" }
+
+export const useRevisedArtworkFilters = () => {
+  const variant = useFeatureVariant(EXPERIMENT_NAME)
+
+  const variantName = variant?.name || EXPERIMENT_VARIANTS.disabled
+
+  const { trackFeatureVariant } = useTrackFeatureVariant({
+    experimentName: EXPERIMENT_NAME,
+    variantName,
+  })
+
+  useEffect(trackFeatureVariant, [trackFeatureVariant])
+
+  return {
+    experimentName: EXPERIMENT_NAME,
+    variantName: variantName,
+    enabled: variantName === EXPERIMENT_VARIANTS.enabled,
+  }
+}

--- a/src/System/useFeatureFlag.tsx
+++ b/src/System/useFeatureFlag.tsx
@@ -83,6 +83,9 @@ export function useTrackFeatureVariant({
     // HACK: Temporary hack while we refactor useAnalyticsContext
     // to update upon page navigation.
     const path = router.match.location.pathname
+
+    if (!path) return
+
     const pageParts = path.split("/")
     const pageSlug = pageParts[2]
     const pageType = pathToOwnerType(path)


### PR DESCRIPTION
Closes [DIA-226](https://artsyproduct.atlassian.net/browse/DIA-226)

[Variants in Unleash](https://unleash.artsy.net/projects/default/features/diamond_revised-artwork-filters/variants) on this flag are set up as follows:

![](https://static.damonzucconi.com/_capture/YbOLGQRPWLa5dDIvqi86u11476rdJBuRyRG7Jq3Kmz3SkmJI0qmGC8f8HRAUrQdMLyzTtXDAMu5N5nMywTgdGT18idbUoaI0QJVi.png)

Production will just need to be enabled to begin running the rollout. How long are we keeping these at 50/50?

[DIA-226]: https://artsyproduct.atlassian.net/browse/DIA-226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ