### PR TITLE
feat(EMI-1512): add order tracking helper for new shipping route

### DIFF
--- a/src/Apps/Order/Routes/Shipping2/FulfillmentDetails.tsx
+++ b/src/Apps/Order/Routes/Shipping2/FulfillmentDetails.tsx
@@ -463,6 +463,7 @@ const FulfillmentDetailsFormLayout = (props: LayoutProps) => {
               onSelect={a => {
                 handleSelectSavedAddress(a)
               }}
+              orderID={props.order.internalID}
             />
           </Collapse>
           {/* NEW ADDRESS */}

--- a/src/Apps/Order/Routes/Shipping2/FulfillmentDetails.tsx
+++ b/src/Apps/Order/Routes/Shipping2/FulfillmentDetails.tsx
@@ -45,6 +45,7 @@ import {
   ShippingAddressFormValues,
 } from "Apps/Order/Routes/Shipping2/shippingUtils"
 import { RouterLink } from "System/Router/RouterLink"
+import { useOrderTracking } from "Apps/Order/Utils/useOrderTracking"
 
 export const ADDRESS_VALIDATION_SHAPE = {
   addressLine1: Yup.string().required("Street address is required"),
@@ -309,6 +310,8 @@ const FulfillmentDetailsFormLayout = (props: LayoutProps) => {
     isValid,
   } = formikContext
 
+  const { clickedFulfillmentType } = useOrderTracking()
+
   // Pass some key formik bits up to the shipping route
   useEffect(() => {
     if (active) {
@@ -419,15 +422,16 @@ const FulfillmentDetailsFormLayout = (props: LayoutProps) => {
             data-testid="shipping-options"
             onSelect={value => {
               setFieldValue("fulfillmentType", value)
+              clickedFulfillmentType(value as FulfillmentType)
             }}
             defaultValue={values.fulfillmentType}
           >
             <Text variant="lg-display" mb="1">
               Delivery method
             </Text>
-            <BorderedRadio value="SHIP" label="Shipping" />
+            <BorderedRadio value={FulfillmentType.SHIP} label="Shipping" />
             <BorderedRadio
-              value="PICKUP"
+              value={FulfillmentType.PICKUP}
               label="Arrange for pickup (free)"
               data-testid="pickupOption"
             >
@@ -463,7 +467,6 @@ const FulfillmentDetailsFormLayout = (props: LayoutProps) => {
               onSelect={a => {
                 handleSelectSavedAddress(a)
               }}
-              orderID={props.order.internalID}
             />
           </Collapse>
           {/* NEW ADDRESS */}

--- a/src/Apps/Order/Routes/Shipping2/FulfillmentDetails.tsx
+++ b/src/Apps/Order/Routes/Shipping2/FulfillmentDetails.tsx
@@ -310,7 +310,7 @@ const FulfillmentDetailsFormLayout = (props: LayoutProps) => {
     isValid,
   } = formikContext
 
-  const { clickedFulfillmentType } = useOrderTracking()
+  const orderTracking = useOrderTracking()
 
   // Pass some key formik bits up to the shipping route
   useEffect(() => {
@@ -422,7 +422,7 @@ const FulfillmentDetailsFormLayout = (props: LayoutProps) => {
             data-testid="shipping-options"
             onSelect={value => {
               setFieldValue("fulfillmentType", value)
-              clickedFulfillmentType(value as FulfillmentType)
+              orderTracking.clickedFulfillmentType(value as FulfillmentType)
             }}
             defaultValue={values.fulfillmentType}
           >

--- a/src/Apps/Order/Routes/Shipping2/SavedAddresses2.jest.tsx
+++ b/src/Apps/Order/Routes/Shipping2/SavedAddresses2.jest.tsx
@@ -6,6 +6,7 @@ import { RootTestPage } from "DevTools/RootTestPage"
 import { userAddressMutation } from "Apps/__tests__/Fixtures/Order/MutationResults"
 import { SavedAddressItem } from "Apps/Order/Routes/Shipping2/SavedAddressItem2"
 import { useTracking } from "react-tracking"
+import { AnalyticsCombinedContextProvider } from "System/Analytics/AnalyticsContext"
 
 jest.unmock("react-relay")
 jest.mock("react-tracking")
@@ -43,7 +44,13 @@ describe("Saved Addresses", () => {
   })
 
   const { getWrapper } = setupTestWrapper({
-    Component: (props: any) => <SavedAddressesFragmentContainer {...props} />,
+    Component: (props: any) => {
+      return (
+        <AnalyticsCombinedContextProvider contextPageOwnerId="example-order-id">
+          <SavedAddressesFragmentContainer {...props} />
+        </AnalyticsCombinedContextProvider>
+      )
+    },
     query: graphql`
       query SavedAddresses2Mutation_Test_Query @relay_test_operation {
         me {
@@ -133,16 +140,12 @@ describe("Saved Addresses", () => {
         await wrapper.update()
         wrapper.find("[data-test='shippingButton']").first().simulate("click")
 
-        expect(trackEvent).toHaveBeenCalled()
-        expect(trackEvent.mock.calls[0]).toMatchInlineSnapshot(`
-          [
-            {
-              "action": "clickedAddNewShippingAddress",
-              "context_module": "ordersShipping",
-              "context_page_owner_type": "orders-shipping",
-            },
-          ]
-        `)
+        expect(trackEvent).toHaveBeenCalledWith({
+          action: "clickedAddNewShippingAddress",
+          context_module: "ordersShipping",
+          context_page_owner_id: "example-order-id",
+          context_page_owner_type: "orders-shipping",
+        })
       })
     })
 

--- a/src/Apps/Order/Routes/Shipping2/SavedAddresses2.tsx
+++ b/src/Apps/Order/Routes/Shipping2/SavedAddresses2.tsx
@@ -42,7 +42,7 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
   )
   const shippingContext = useShippingContext()
 
-  const { onSelect, me, relay, orderID } = props
+  const { onSelect, me, relay } = props
 
   const addressList = compact<SavedAddressType>(
     extractNodes(me?.addressConnection) ?? []
@@ -65,7 +65,7 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
   const {
     clickedShippingAddress,
     clickedAddNewShippingAddress,
-  } = useOrderTracking(orderID)
+  } = useOrderTracking()
 
   React.useEffect(() => {
     if (!selectedAddressPresent) {

--- a/src/Apps/Order/Routes/Shipping2/SavedAddresses2.tsx
+++ b/src/Apps/Order/Routes/Shipping2/SavedAddresses2.tsx
@@ -32,7 +32,6 @@ export interface SavedAddressesProps {
   me: SavedAddresses2_me$data
   active: boolean
   onSelect: (address: ShippingAddressFormValues) => void
-  orderID: string
 }
 
 const SavedAddresses: React.FC<SavedAddressesProps> = props => {

--- a/src/Apps/Order/Routes/Shipping2/SavedAddresses2.tsx
+++ b/src/Apps/Order/Routes/Shipping2/SavedAddresses2.tsx
@@ -61,10 +61,7 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
     selectedAddressID && getAddressByID(addressList, selectedAddressID)
   const selectedAddressPresent = !!selectedAddress
 
-  const {
-    clickedShippingAddress,
-    clickedAddNewShippingAddress,
-  } = useOrderTracking()
+  const orderTracking = useOrderTracking()
 
   React.useEffect(() => {
     if (!selectedAddressPresent) {
@@ -90,13 +87,13 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
       if (!selectedAddress) {
         console.warn("Address not found: ", id)
       }
-      clickedShippingAddress()
+      orderTracking.clickedShippingAddress()
       // Set values on the fulfillment form context.
       // Can these values be invalid? If so, maybe we could pop a form up for
       // them to fix it. Seems unlikely.
       onSelect(addressWithFallbackValues(selectedAddress))
     },
-    [addressList, clickedShippingAddress, onSelect]
+    [addressList, onSelect, orderTracking]
   )
 
   const refetchAddresses = () => {
@@ -166,7 +163,7 @@ const SavedAddresses: React.FC<SavedAddressesProps> = props => {
           tabIndex={props.active ? 0 : -1}
           data-test="shippingButton"
           onClick={() => {
-            clickedAddNewShippingAddress()
+            orderTracking.clickedAddNewShippingAddress()
             setActiveModal({ type: AddressModalActionType.CREATE_USER_ADDRESS })
           }}
         >

--- a/src/Apps/Order/Routes/Shipping2/index.tsx
+++ b/src/Apps/Order/Routes/Shipping2/index.tsx
@@ -124,7 +124,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
     string | undefined
   >(initialValues.shippingQuotes.selectedShippingQuoteId)
 
-  const { clickedSelectShippingOption, errorMessageViewed } = useOrderTracking()
+  const orderTracking = useOrderTracking()
 
   const handleSubmitError = useCallback(
     (error: { code: string; data: string | null }) => {
@@ -135,7 +135,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
         error.code === "missing_country" ||
         error.code === "missing_postal_code"
       ) {
-        errorMessageViewed({
+        orderTracking.errorMessageViewed({
           error_code: error.code,
           title: "Missing information",
           message: "Please complete all required fields.",
@@ -151,7 +151,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
         error.code === "unsupported_shipping_location" &&
         parsedData.failure_code === "domestic_shipping_only"
       ) {
-        errorMessageViewed({
+        orderTracking.errorMessageViewed({
           error_code: error.code,
           title: "Can't ship to that address",
           message: "This work can only be shipped domestically.",
@@ -167,7 +167,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
           ErrorDialogs.DestinationCouldNotBeGeocoded
         )
 
-        errorMessageViewed({
+        orderTracking.errorMessageViewed({
           error_code: error.code,
           title: title,
           message: message,
@@ -179,7 +179,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
           message: formattedMessage,
         })
       } else if (isArtsyShipping && selectedShippingQuoteId) {
-        errorMessageViewed({
+        orderTracking.errorMessageViewed({
           error_code: null,
           title: "An error occurred",
           message:
@@ -191,7 +191,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
           message: <ArtaErrorDialogMessage />,
         })
       } else {
-        errorMessageViewed({
+        orderTracking.errorMessageViewed({
           error_code: error.code,
           title: "An error occurred",
           message:
@@ -202,7 +202,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
         props.dialog.showErrorDialog()
       }
     },
-    [errorMessageViewed, isArtsyShipping, props.dialog, selectedShippingQuoteId]
+    [isArtsyShipping, orderTracking, props.dialog, selectedShippingQuoteId]
   )
 
   const createUserAddressMutation = useCallback(
@@ -290,7 +290,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
       } catch (error) {
         logger.error(error)
 
-        errorMessageViewed({
+        orderTracking.errorMessageViewed({
           error_code: null,
           title: "An error occurred",
           message:
@@ -308,7 +308,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
       requiresArtsyShippingTo,
       handleSubmitError,
       createUserAddressMutation,
-      errorMessageViewed,
+      orderTracking,
     ]
   )
 
@@ -335,7 +335,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
       } catch (error) {
         logger.error(error)
 
-        errorMessageViewed({
+        orderTracking.errorMessageViewed({
           error_code: null,
           title: "An error occurred",
           message:
@@ -349,11 +349,11 @@ export const ShippingRoute: FC<ShippingProps> = props => {
       }
     }
   }, [
-    advanceToPayment,
-    handleSubmitError,
     props,
     selectedShippingQuoteId,
-    errorMessageViewed,
+    advanceToPayment,
+    handleSubmitError,
+    orderTracking,
   ])
 
   // TODO: Pass this into the fulfillment details form (according to current structure)
@@ -367,7 +367,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
   // }
 
   const handleShippingQuoteSelected = (newShippingQuoteId: string) => {
-    clickedSelectShippingOption(newShippingQuoteId)
+    orderTracking.clickedSelectShippingOption(newShippingQuoteId)
 
     setSelectedShippingQuoteId(newShippingQuoteId)
   }

--- a/src/Apps/Order/Routes/Shipping2/index.tsx
+++ b/src/Apps/Order/Routes/Shipping2/index.tsx
@@ -124,28 +124,7 @@ export const ShippingRoute: FC<ShippingProps> = props => {
     string | undefined
   >(initialValues.shippingQuotes.selectedShippingQuoteId)
 
-  const { clickedSelectShippingOption, errorMessageViewed } = useOrderTracking(
-    order.internalID
-  )
-
-  // const selectShipping = async (editedAddress?: MutationAddressResponse) => {
-  // ...
-
-  //   TODO: Tracking
-  //     trackEvent({
-  //       action: ActionType.errorMessageViewed,
-  //       context_owner_type: OwnerType.ordersShipping,
-  //       context_owner_id: props.order.internalID,
-  //       title: "An error occurred",
-  //       message:
-  //         "Something went wrong. Please try again or contact orders@artsy.net.",
-  //       error_code: null,
-  //       flow: "user selects a shipping option",
-  //     })
-
-  //     props.dialog.showErrorDialog()
-  //   }
-  // }
+  const { clickedSelectShippingOption, errorMessageViewed } = useOrderTracking()
 
   const handleSubmitError = useCallback(
     (error: { code: string; data: string | null }) => {
@@ -156,12 +135,12 @@ export const ShippingRoute: FC<ShippingProps> = props => {
         error.code === "missing_country" ||
         error.code === "missing_postal_code"
       ) {
-        errorMessageViewed(
-          error.code,
-          "Missing information",
-          "Please complete all required fields.",
-          "user submits a shipping option"
-        )
+        errorMessageViewed({
+          error_code: error.code,
+          title: "Missing information",
+          message: "Please complete all required fields.",
+          flow: "user submits a shipping option",
+        })
 
         props.dialog.showErrorDialog({
           title: "Invalid address",
@@ -172,12 +151,12 @@ export const ShippingRoute: FC<ShippingProps> = props => {
         error.code === "unsupported_shipping_location" &&
         parsedData.failure_code === "domestic_shipping_only"
       ) {
-        errorMessageViewed(
-          error.code,
-          "Can't ship to that address",
-          "This work can only be shipped domestically.",
-          "user submits a shipping option"
-        )
+        errorMessageViewed({
+          error_code: error.code,
+          title: "Can't ship to that address",
+          message: "This work can only be shipped domestically.",
+          flow: "user submits a shipping option",
+        })
 
         props.dialog.showErrorDialog({
           title: "Can't ship to that address",
@@ -188,35 +167,37 @@ export const ShippingRoute: FC<ShippingProps> = props => {
           ErrorDialogs.DestinationCouldNotBeGeocoded
         )
 
-        errorMessageViewed(
-          error.code,
-          title,
-          message,
-          "user submits a shipping option"
-        )
+        errorMessageViewed({
+          error_code: error.code,
+          title: title,
+          message: message,
+          flow: "user submits a shipping option",
+        })
 
         props.dialog.showErrorDialog({
           title,
           message: formattedMessage,
         })
       } else if (isArtsyShipping && selectedShippingQuoteId) {
-        errorMessageViewed(
-          null,
-          "An error occurred",
-          "There was a problem getting shipping quotes. Please contact orders@artsy.net.",
-          "user submits a shipping option"
-        )
+        errorMessageViewed({
+          error_code: null,
+          title: "An error occurred",
+          message:
+            "There was a problem getting shipping quotes. Please contact orders@artsy.net.",
+          flow: "user submits a shipping option",
+        })
 
         props.dialog.showErrorDialog({
           message: <ArtaErrorDialogMessage />,
         })
       } else {
-        errorMessageViewed(
-          error.code,
-          "An error occurred",
-          "Something went wrong. Please try again or contact orders@artsy.net.",
-          "user submits a shipping option"
-        )
+        errorMessageViewed({
+          error_code: error.code,
+          title: "An error occurred",
+          message:
+            "Something went wrong. Please try again or contact orders@artsy.net.",
+          flow: "user submits a shipping option",
+        })
 
         props.dialog.showErrorDialog()
       }
@@ -309,12 +290,13 @@ export const ShippingRoute: FC<ShippingProps> = props => {
       } catch (error) {
         logger.error(error)
 
-        errorMessageViewed(
-          null,
-          "An error occurred",
-          "Something went wrong. Please try again or contact orders@artsy.net.",
-          "user selects a shipping option"
-        )
+        errorMessageViewed({
+          error_code: null,
+          title: "An error occurred",
+          message:
+            "Something went wrong. Please try again or contact orders@artsy.net.",
+          flow: "user selects a shipping option",
+        })
 
         props.dialog.showErrorDialog()
       }
@@ -353,12 +335,13 @@ export const ShippingRoute: FC<ShippingProps> = props => {
       } catch (error) {
         logger.error(error)
 
-        errorMessageViewed(
-          null,
-          "An error occurred",
-          "There was a problem getting shipping quotes. Please contact orders@artsy.net.",
-          "user sets a shipping quote"
-        )
+        errorMessageViewed({
+          error_code: null,
+          title: "An error occurred",
+          message:
+            "There was a problem getting shipping quotes. Please contact orders@artsy.net.",
+          flow: "user sets a shipping quote",
+        })
 
         props.dialog.showErrorDialog({
           message: <ArtaErrorDialogMessage />,
@@ -380,25 +363,6 @@ export const ShippingRoute: FC<ShippingProps> = props => {
   //   // consider this a user-verified address (perform verification only once).
   //   if (addressVerifiedBy) {
   //     setAddressVerifiedBy(AddressVerifiedBy.USER)
-  //   }
-  // }
-
-  // const onSelectShippingOption = (
-  //   newShippingOption: CommerceOrderFulfillmentTypeEnum
-  // ) => {
-  //   TODO: (Erik): Tracking
-  //   trackEvent({
-  //     action_type: DeprecatedSchema.ActionType.Click,
-  //     subject:
-  //       newShippingOption === "SHIP"
-  //         ? DeprecatedSchema.Subject.BNMOProvideShipping
-  //         : DeprecatedSchema.Subject.BNMOArrangePickup,
-  //     flow: "buy now",
-  //     type: "button",
-  //   })
-
-  //   if (shippingOption !== newShippingOption) {
-  //     setShippingOption(newShippingOption)
   //   }
   // }
 

--- a/src/Apps/Order/Routes/Shipping2/index.tsx
+++ b/src/Apps/Order/Routes/Shipping2/index.tsx
@@ -137,8 +137,9 @@ export const ShippingRoute: FC<ShippingProps> = props => {
       ) {
         orderTracking.errorMessageViewed({
           error_code: error.code,
-          title: "Missing information",
-          message: "Please complete all required fields.",
+          title: "Invalid address",
+          message:
+            "There was an error processing your address. Please review and try again.",
           flow: "user submits a shipping option",
         })
 

--- a/src/Apps/Order/Utils/useOrderTracking.tsx
+++ b/src/Apps/Order/Utils/useOrderTracking.tsx
@@ -1,0 +1,76 @@
+import {
+  ActionType,
+  ClickedAddNewShippingAddress,
+  ClickedSelectShippingOption,
+  ClickedShippingAddress,
+  ContextModule,
+  ErrorMessageViewed,
+  OwnerType,
+} from "@artsy/cohesion"
+import { useMemo } from "react"
+
+import { useTracking } from "react-tracking"
+
+export const useOrderTracking = (orderID: string) => {
+  const { trackEvent } = useTracking()
+
+  const trackingCalls = useMemo(() => {
+    return {
+      clickedShippingAddress: () => {
+        const payload: ClickedShippingAddress = {
+          action: ActionType.clickedShippingAddress,
+          context_module: ContextModule.ordersShipping,
+          context_page_owner_type: "orders-shipping",
+          context_page_owner_id: orderID,
+        }
+
+        trackEvent(payload)
+      },
+
+      clickedSelectShippingOption: (newShippingQuoteId: string) => {
+        const payload: ClickedSelectShippingOption = {
+          action: ActionType.clickedSelectShippingOption,
+          context_module: ContextModule.ordersShipping,
+          context_page_owner_type: "orders-shipping",
+          subject: newShippingQuoteId,
+          context_page_owner_id: orderID,
+        }
+
+        trackEvent(payload)
+      },
+
+      errorMessageViewed: (
+        error_code: string | null,
+
+        title: string,
+        message: string,
+        flow: string
+      ) => {
+        const payload: ErrorMessageViewed = {
+          action: ActionType.errorMessageViewed,
+          context_owner_type: OwnerType.ordersShipping,
+          context_owner_id: orderID,
+          title,
+          message,
+          error_code: error_code || undefined,
+          flow,
+        }
+
+        trackEvent(payload)
+      },
+
+      clickedAddNewShippingAddress: () => {
+        const payload: ClickedAddNewShippingAddress = {
+          action: ActionType.clickedAddNewShippingAddress,
+          context_page_owner_type: OwnerType.ordersShipping,
+          context_page_owner_id: orderID,
+          context_module: ContextModule.ordersShipping,
+        }
+
+        trackEvent(payload)
+      },
+    }
+  }, [trackEvent, orderID])
+
+  return trackingCalls
+}

--- a/src/Apps/Order/Utils/useOrderTracking.tsx
+++ b/src/Apps/Order/Utils/useOrderTracking.tsx
@@ -7,12 +7,16 @@ import {
   ErrorMessageViewed,
   OwnerType,
 } from "@artsy/cohesion"
+import { useAnalyticsContext } from "System/Analytics/AnalyticsContext"
 import { useMemo } from "react"
-
+import * as DeprecatedSchema from "@artsy/cohesion/dist/DeprecatedSchema"
 import { useTracking } from "react-tracking"
+import { FulfillmentType } from "Apps/Order/Routes/Shipping2/shippingUtils"
 
-export const useOrderTracking = (orderID: string) => {
+export const useOrderTracking = () => {
   const { trackEvent } = useTracking()
+  const analytics = useAnalyticsContext()
+  const contextPageOwnerId = analytics.contextPageOwnerId!
 
   const trackingCalls = useMemo(() => {
     return {
@@ -21,7 +25,7 @@ export const useOrderTracking = (orderID: string) => {
           action: ActionType.clickedShippingAddress,
           context_module: ContextModule.ordersShipping,
           context_page_owner_type: "orders-shipping",
-          context_page_owner_id: orderID,
+          context_page_owner_id: contextPageOwnerId,
         }
 
         trackEvent(payload)
@@ -33,23 +37,27 @@ export const useOrderTracking = (orderID: string) => {
           context_module: ContextModule.ordersShipping,
           context_page_owner_type: "orders-shipping",
           subject: newShippingQuoteId,
-          context_page_owner_id: orderID,
+          context_page_owner_id: contextPageOwnerId,
         }
 
         trackEvent(payload)
       },
 
-      errorMessageViewed: (
-        error_code: string | null,
-
-        title: string,
-        message: string,
+      errorMessageViewed: ({
+        error_code,
+        title,
+        message,
+        flow,
+      }: {
+        error_code: string | null
+        title: string
+        message: string
         flow: string
-      ) => {
+      }) => {
         const payload: ErrorMessageViewed = {
           action: ActionType.errorMessageViewed,
           context_owner_type: OwnerType.ordersShipping,
-          context_owner_id: orderID,
+          context_owner_id: contextPageOwnerId,
           title,
           message,
           error_code: error_code || undefined,
@@ -63,14 +71,28 @@ export const useOrderTracking = (orderID: string) => {
         const payload: ClickedAddNewShippingAddress = {
           action: ActionType.clickedAddNewShippingAddress,
           context_page_owner_type: OwnerType.ordersShipping,
-          context_page_owner_id: orderID,
+          context_page_owner_id: contextPageOwnerId,
           context_module: ContextModule.ordersShipping,
         }
 
         trackEvent(payload)
       },
+
+      clickedFulfillmentType: (fulfillmentType: FulfillmentType) => {
+        const payload = {
+          action: DeprecatedSchema.ActionType.Click,
+          subject:
+            fulfillmentType === "SHIP"
+              ? DeprecatedSchema.Subject.BNMOProvideShipping
+              : DeprecatedSchema.Subject.BNMOArrangePickup,
+          flow: "buy now",
+          type: "button",
+        }
+
+        trackEvent(payload)
+      },
     }
-  }, [trackEvent, orderID])
+  }, [trackEvent, contextPageOwnerId])
 
   return trackingCalls
 }


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-1512]

@artsy/emerald-devs 

### Description

@erikdstock assigning you as I will be out on Monday. 

This adds a tracking helper for the checkout flow, starting with the new shipping route. We will be adding order tracking calls for all other routes to the helper in follow-up tickets. 

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EMI-1512]: https://artsyproduct.atlassian.net/browse/EMI-1512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ