### PR TITLE
fix(my-collection): Remove non-null assertion crasher

### DIFF
--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/MyCollectionArtworkSidebarTitleInfo.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSidebar/MyCollectionArtworkSidebarTitleInfo.tsx
@@ -18,9 +18,13 @@ const MyCollectionArtworkSidebarTitleInfo: React.FC<MyCollectionArtworkSidebarTi
         {artwork?.artist?.isPersonalArtist ? (
           artistNames
         ) : (
-          <RouterLink textDecoration="none" to={artist!.href}>
-            {artistNames}
-          </RouterLink>
+          <>
+            {artist?.href && (
+              <RouterLink textDecoration="none" to={artist.href}>
+                {artistNames}
+              </RouterLink>
+            )}
+          </>
         )}
       </Text>
       <Text as="h1" variant="lg-display" color="black60" mb={[0.5, 0]}>


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Fixes a bug that was [noted in the bugs and feedback channel](https://artsy.slack.com/archives/C03N12SR0RK/p1698683435339269). 

The issue arose because we were using `!`, which assumes that the code there is always safe. We should never use `!` (we can use `?` instead); but even so, best to guard and exit early.  As a general rule, UI not appearing is (data is null) is better than a crash. 
