### PR TITLE
feat(eslint): Enable no-non-null-assertion rule

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -90,7 +90,7 @@ module.exports = {
     "react/no-unescaped-entities": 0,
     "@typescript-eslint/no-empty-function": 0,
     "@typescript-eslint/no-empty-interface": 0,
-    "@typescript-eslint/no-non-null-assertion": 0,
+    "@typescript-eslint/no-non-null-assertion": "error",
     "no-restricted-imports": [
       "error",
       {


### PR DESCRIPTION
The type of this PR is: **Feat**

### Description

Thank you @gkartalis for the suggestion to add this to our `estlint` 🙏 Looking at our eslint file, found that it was disabled, probably due to some migration at some point. Turned it back on!

<img width="756" alt="Screenshot 2023-10-30 at 10 00 05 AM" src="https://github.com/artsy/force/assets/236943/dbac78ca-cb6c-47ba-967d-8e69fe4d914c">

