### PR TITLE
chore(eslint): relax non-null assertions in tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -131,5 +131,11 @@ module.exports = {
         "no-console": "off",
       },
     },
+    {
+      files: ["*.test.ts", "*.test.tsx", "*.jest.ts", "**/*.jest.tsx"],
+      rules: {
+        "@typescript-eslint/no-non-null-assertion": "off",
+      },
+    },
   ],
 }


### PR DESCRIPTION
The type of this PR is: **Chore**

### Description

This relaxes the rule in our tests, since its often helpful to assert in relay test setup (which will never be null). 
