### PR TITLE
feat(dia-295): filter q/a

### DIFF
--- a/src/Components/ArtworkFilter/ArtworkFilterDrawer.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilterDrawer.tsx
@@ -14,7 +14,7 @@ export const ArtworkFilterDrawer: FC<ArtworkFilterDrawerProps> = ({
   onClose,
 }) => {
   return (
-    <Drawer zIndex={Z.dropdown} open={open} onClose={onClose}>
+    <Drawer zIndex={Z.dropdown} open={open} onClose={onClose} anchor="left">
       <Box p={2} minWidth={375} position="relative">
         <Flex alignItems="center">
           <Text variant="xs" flex={1}>

--- a/src/Components/ArtworkFilter/ArtworkFilterDrawer.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilterDrawer.tsx
@@ -18,7 +18,7 @@ export const ArtworkFilterDrawer: FC<ArtworkFilterDrawerProps> = ({
       <Box p={2} minWidth={375} position="relative">
         <Flex alignItems="center">
           <Text variant="xs" flex={1}>
-            Sort & Filter
+            Filters
           </Text>
 
           <ModalClose onClick={onClose} />

--- a/src/Components/ArtworkFilter/ArtworkFiltersQuick.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFiltersQuick.tsx
@@ -4,6 +4,13 @@ import { FilterQuick } from "Components/ArtworkFilter/ArtworkFiltersQuick/Filter
 import { PriceRangeFilterQuick } from "Components/ArtworkFilter/ArtworkFiltersQuick/PriceRangeFilterQuick"
 import { FC } from "react"
 
+// NOTE: Keep in sync with components below
+export const ARTWORK_FILTERS_QUICK_FIELDS = [
+  "attributionClass",
+  "additionalGeneIDs",
+  "priceRange",
+]
+
 export const ArtworkFiltersQuick: FC = () => {
   return (
     <>

--- a/src/Components/ArtworkFilter/ArtworkFiltersQuick/FilterQuick.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFiltersQuick/FilterQuick.tsx
@@ -151,6 +151,7 @@ export const FilterQuickDropdownPanel: FC<FilterQuickDropdownPanelProps> = ({
   onConfirm,
   children,
   count,
+  p = 1,
   ...rest
 }) => {
   return (
@@ -162,7 +163,7 @@ export const FilterQuickDropdownPanel: FC<FilterQuickDropdownPanelProps> = ({
       {...rest}
     >
       <Box
-        p={1}
+        p={p}
         flex={1}
         minHeight={0}
         style={{

--- a/src/Components/ArtworkFilter/ArtworkFiltersQuick/FilterQuick.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFiltersQuick/FilterQuick.tsx
@@ -157,7 +157,7 @@ export const FilterQuickDropdownPanel: FC<FilterQuickDropdownPanelProps> = ({
     <Box
       display="flex"
       flexDirection="column"
-      height={230}
+      maxHeight={230}
       width={300}
       {...rest}
     >

--- a/src/Components/ArtworkFilter/ArtworkFiltersQuick/FilterQuick.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFiltersQuick/FilterQuick.tsx
@@ -72,6 +72,7 @@ export const FilterQuick: FC<FilterQuickProps> = ({
       dropdown={({ onHide }) => {
         return (
           <FilterQuickDropdownPanel
+            count={count}
             onConfirm={onHide}
             onClear={() => {
               handleClear()
@@ -142,12 +143,14 @@ interface FilterQuickDropdownPanelProps extends BoxProps {
   onClear: () => void
   onConfirm: () => void
   children: React.ReactNode
+  count: number
 }
 
 export const FilterQuickDropdownPanel: FC<FilterQuickDropdownPanelProps> = ({
   onClear,
   onConfirm,
   children,
+  count,
   ...rest
 }) => {
   return (
@@ -178,11 +181,21 @@ export const FilterQuickDropdownPanel: FC<FilterQuickDropdownPanelProps> = ({
         p={1}
         zIndex={1}
       >
-        <Button size="small" variant="secondaryBlack" onClick={onClear}>
+        <Button
+          size="small"
+          variant="secondaryBlack"
+          onClick={onClear}
+          disabled={count === 0}
+        >
           Clear
         </Button>
 
-        <Button size="small" variant="primaryBlack" onClick={onConfirm}>
+        <Button
+          size="small"
+          variant="primaryBlack"
+          onClick={onConfirm}
+          disabled={count === 0}
+        >
           Confirm
         </Button>
       </Box>

--- a/src/Components/ArtworkFilter/ArtworkFiltersQuick/PriceRangeFilterQuick.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFiltersQuick/PriceRangeFilterQuick.tsx
@@ -29,6 +29,7 @@ export const PriceRangeFilterQuick: FC<PriceRangeFilterQuickProps> = props => {
       dropdown={({ onHide }) => {
         return (
           <FilterQuickDropdownPanel
+            count={count}
             onConfirm={onHide}
             onClear={() => {
               handleClear()

--- a/src/Components/ArtworkFilter/ArtworkFiltersQuick/PriceRangeFilterQuick.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFiltersQuick/PriceRangeFilterQuick.tsx
@@ -35,6 +35,8 @@ export const PriceRangeFilterQuick: FC<PriceRangeFilterQuickProps> = props => {
               handleClear()
               onHide()
             }}
+            maxHeight="auto"
+            p={2}
           >
             <PriceRange
               priceRange={range.join("-")}

--- a/src/Components/ArtworkFilter/ArtworkFiltersQuick/PriceRangeFilterQuick.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFiltersQuick/PriceRangeFilterQuick.tsx
@@ -50,7 +50,7 @@ export const PriceRangeFilterQuick: FC<PriceRangeFilterQuickProps> = props => {
       {props => {
         return (
           <FilterQuickDropdownAnchor
-            label="Price range"
+            label="Price Range"
             count={count}
             {...props}
           />

--- a/src/Components/ArtworkFilter/index.tsx
+++ b/src/Components/ArtworkFilter/index.tsx
@@ -426,7 +426,7 @@ export const BaseArtworkFilter: React.FC<
                   </ArtworkFilterCreateAlert>
 
                   <Pill Icon={FilterIcon} size="small" onClick={handleOpen}>
-                    All filters
+                    All Filters
                   </Pill>
 
                   <ArtworkFiltersQuick />

--- a/src/Components/ArtworkFilter/index.tsx
+++ b/src/Components/ArtworkFilter/index.tsx
@@ -166,7 +166,7 @@ export const BaseArtworkFilter: React.FC<
             const pageTrackingParams: ClickedChangePage = {
               action: ActionType.clickedChangePage,
               context_module: ContextModule.artworkGrid,
-              context_page_owner_type: contextPageOwnerType!,
+              context_page_owner_type: contextPageOwnerType,
               context_page_owner_id: contextPageOwnerId,
               context_page_owner_slug: contextPageOwnerSlug,
               page_current: previousFilter,
@@ -184,7 +184,7 @@ export const BaseArtworkFilter: React.FC<
                 }),
                 contextOwnerId: contextPageOwnerId,
                 contextOwnerSlug: contextPageOwnerSlug,
-                contextOwnerType: contextPageOwnerType!,
+                contextOwnerType: contextPageOwnerType,
                 current: JSON.stringify({
                   ...onlyAllowedFilters,
                   metric: filterContext?.filters?.metric,
@@ -205,7 +205,7 @@ export const BaseArtworkFilter: React.FC<
         first: 30,
         ...relayRefetchInputVariables,
         ...allowedFilters(filterContext.filters),
-        keyword: filterContext.filters!.term || filterContext.filters!.keyword,
+        keyword: filterContext.filters?.term || filterContext.filters?.keyword,
       },
       ...relayVariables,
     }
@@ -389,7 +389,7 @@ export const BaseArtworkFilter: React.FC<
         <Spacer y={2} />
 
         <ArtworkFilterArtworkGrid
-          filtered_artworks={viewer.filtered_artworks!}
+          filtered_artworks={viewer.filtered_artworks}
           isLoading={isLoading}
           offset={offset}
           columnCount={[2, 2, 2, 3]}
@@ -463,7 +463,7 @@ export const BaseArtworkFilter: React.FC<
 
             {children || (
               <ArtworkFilterArtworkGrid
-                filtered_artworks={viewer.filtered_artworks!}
+                filtered_artworks={viewer.filtered_artworks}
                 isLoading={isLoading}
                 offset={offset}
                 columnCount={[2, 3, 3, 4]}
@@ -527,7 +527,7 @@ export const BaseArtworkFilter: React.FC<
 
               {children || (
                 <ArtworkFilterArtworkGrid
-                  filtered_artworks={viewer.filtered_artworks!}
+                  filtered_artworks={viewer.filtered_artworks}
                   isLoading={isLoading}
                   offset={offset}
                   columnCount={[2, 2, 2, 3]}

--- a/src/Components/ArtworkFilter/index.tsx
+++ b/src/Components/ArtworkFilter/index.tsx
@@ -154,7 +154,7 @@ export const BaseArtworkFilter: React.FC<
 
   // Count of all filters, sans `sort`
   const revisedArtworkFiltersCount = useMemo(() => {
-    return Object.entries(filterContext.selectedFiltersCounts).reduce(
+    return Object.entries(filterContext.selectedFiltersCounts || {}).reduce(
       (acc, [field, count]) => {
         if (field === "sort") return acc
         return acc + count
@@ -165,7 +165,7 @@ export const BaseArtworkFilter: React.FC<
 
   // Count of only quick filters
   const quickArtworkFiltersCount = useMemo(() => {
-    return Object.entries(filterContext.selectedFiltersCounts).reduce(
+    return Object.entries(filterContext.selectedFiltersCounts || {}).reduce(
       (acc, [field, count]) => {
         if (!ARTWORK_FILTERS_QUICK_FIELDS.includes(field)) return acc
         return acc + count

--- a/src/Components/ArtworkFilter/index.tsx
+++ b/src/Components/ArtworkFilter/index.tsx
@@ -404,30 +404,32 @@ export const BaseArtworkFilter: React.FC<
             <Flex alignItems="center" justifyContent="space-between" gap={2}>
               <HorizontalOverflow minWidth={0}>
                 <Flex gap={1}>
-                  <ArtworkFilterCreateAlert
-                    renderButton={props => {
-                      return (
-                        <Button
-                          variant={
-                            appliedFiltersTotalCount > 0
-                              ? "primaryBlack"
-                              : "secondaryBlack"
-                          }
-                          size="small"
-                          Icon={BellStrokeIcon}
-                          {...props}
-                        >
-                          Create Alert
-                        </Button>
-                      )
-                    }}
-                  >
-                    <Box width="1px" bg="black30" />
-                  </ArtworkFilterCreateAlert>
+                  <Flex gap={2}>
+                    <ArtworkFilterCreateAlert
+                      renderButton={props => {
+                        return (
+                          <Button
+                            variant={
+                              appliedFiltersTotalCount > 0
+                                ? "primaryBlack"
+                                : "secondaryBlack"
+                            }
+                            size="small"
+                            Icon={BellStrokeIcon}
+                            {...props}
+                          >
+                            Create Alert
+                          </Button>
+                        )
+                      }}
+                    >
+                      <Box width="1px" bg="black30" />
+                    </ArtworkFilterCreateAlert>
 
-                  <Pill Icon={FilterIcon} size="small" onClick={handleOpen}>
-                    All Filters
-                  </Pill>
+                    <Pill Icon={FilterIcon} size="small" onClick={handleOpen}>
+                      All Filters
+                    </Pill>
+                  </Flex>
 
                   <ArtworkFiltersQuick />
                 </Flex>


### PR DESCRIPTION
Re: [DIA-295](https://artsyproduct.atlassian.net/browse/DIA-295)
[Q/A board](https://www.notion.so/artsy/14381bc3646e40a6a92ac9b1a0776960?v=6c29026ec39b41b6941567d3a688c589)

This tackles all the issues sans 2:
* When I check “artists you follow,” “Andy Warhol” appears as a filter pill
  * This has been in production since perhaps when this feature was introduced.
* Bug with the two instances of the price range filter keeping in sync
  * Going to PR that one separately because I do not understand why it's doing what it was doing in the first place.

[DIA-295]: https://artsyproduct.atlassian.net/browse/DIA-295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ