### PR TITLE
feat: Include news in artist articles section DIA-291

### DIFF
--- a/src/Apps/Artist/Routes/Articles/ArtistArticlesRoute.tsx
+++ b/src/Apps/Artist/Routes/Articles/ArtistArticlesRoute.tsx
@@ -90,7 +90,7 @@ export const ArtistArticlesRouteFragmentContainer = createRefetchContainer(
           page: $page
           size: 12
           sort: PUBLISHED_AT_DESC
-          inEditorialFeed: true
+          inEditorialFeed: false
         ) {
           pageInfo {
             hasNextPage

--- a/src/__generated__/ArtistArticlesRouteQuery.graphql.ts
+++ b/src/__generated__/ArtistArticlesRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7996c8744bc480949eb4b1e4dc257bc6>>
+ * @generated SignedSource<<816a7403390c35165dade6151a86d373>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -148,7 +148,7 @@ return {
               {
                 "kind": "Literal",
                 "name": "inEditorialFeed",
-                "value": true
+                "value": false
               },
               (v3/*: any*/),
               {
@@ -388,12 +388,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "47f2c47ca664bc0f70473f83ef59df08",
+    "cacheID": "1b1275b2b9d9f556fd105e378812aece",
     "id": null,
     "metadata": {},
     "name": "ArtistArticlesRouteQuery",
     "operationKind": "query",
-    "text": "query ArtistArticlesRouteQuery(\n  $page: Int\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistArticlesRoute_artist_2Pg8Wv\n    id\n  }\n}\n\nfragment ArtistArticlesRoute_artist_2Pg8Wv on Artist {\n  name\n  slug\n  articlesConnection(page: $page, size: 12, sort: PUBLISHED_AT_DESC, inEditorialFeed: true) {\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        ...CellArticle_article\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
+    "text": "query ArtistArticlesRouteQuery(\n  $page: Int\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistArticlesRoute_artist_2Pg8Wv\n    id\n  }\n}\n\nfragment ArtistArticlesRoute_artist_2Pg8Wv on Artist {\n  name\n  slug\n  articlesConnection(page: $page, size: 12, sort: PUBLISHED_AT_DESC, inEditorialFeed: false) {\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        ...CellArticle_article\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistArticlesRoute_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistArticlesRoute_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<06a71a7a5c3ae4a70ed85b2777af1d48>>
+ * @generated SignedSource<<69a2933eeb3fac662b3158f37556def1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -158,7 +158,7 @@ return {
               {
                 "kind": "Literal",
                 "name": "inEditorialFeed",
-                "value": true
+                "value": false
               },
               {
                 "kind": "Literal",
@@ -393,7 +393,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "articlesConnection(inEditorialFeed:true,page:1,size:12,sort:\"PUBLISHED_AT_DESC\")"
+            "storageKey": "articlesConnection(inEditorialFeed:false,page:1,size:12,sort:\"PUBLISHED_AT_DESC\")"
           },
           (v4/*: any*/)
         ],
@@ -402,7 +402,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a4336c0399f460e96494caa9da0f7549",
+    "cacheID": "9c710f1452f3a1b3a4650bc27eb35e01",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -494,7 +494,7 @@ return {
     },
     "name": "ArtistArticlesRoute_Test_Query",
     "operationKind": "query",
-    "text": "query ArtistArticlesRoute_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistArticlesRoute_artist\n    id\n  }\n}\n\nfragment ArtistArticlesRoute_artist on Artist {\n  name\n  slug\n  articlesConnection(page: 1, size: 12, sort: PUBLISHED_AT_DESC, inEditorialFeed: true) {\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        ...CellArticle_article\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
+    "text": "query ArtistArticlesRoute_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistArticlesRoute_artist\n    id\n  }\n}\n\nfragment ArtistArticlesRoute_artist on Artist {\n  name\n  slug\n  articlesConnection(page: 1, size: 12, sort: PUBLISHED_AT_DESC, inEditorialFeed: false) {\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        ...CellArticle_article\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistArticlesRoute_artist.graphql.ts
+++ b/src/__generated__/ArtistArticlesRoute_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9f2c39944f7a7d571919f70272be5183>>
+ * @generated SignedSource<<ed7032bc6131cd65534a284bad0d48fe>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -66,7 +66,7 @@ const node: ReaderFragment = {
         {
           "kind": "Literal",
           "name": "inEditorialFeed",
-          "value": true
+          "value": false
         },
         {
           "kind": "Variable",
@@ -165,6 +165,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "30032b69fe2127dee1d1c91d9b310a4c";
+(node as any).hash = "2fb7b28b26c703b2c69caaa3705c09a5";
 
 export default node;

--- a/src/__generated__/artistRoutes_ArticlesQuery.graphql.ts
+++ b/src/__generated__/artistRoutes_ArticlesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<411190aaa27f2914ae079a64f3fb839c>>
+ * @generated SignedSource<<ef26931435b3d9cb4dc00540336abe63>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -131,7 +131,7 @@ return {
               {
                 "kind": "Literal",
                 "name": "inEditorialFeed",
-                "value": true
+                "value": false
               },
               {
                 "kind": "Literal",
@@ -366,7 +366,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "articlesConnection(inEditorialFeed:true,page:1,size:12,sort:\"PUBLISHED_AT_DESC\")"
+            "storageKey": "articlesConnection(inEditorialFeed:false,page:1,size:12,sort:\"PUBLISHED_AT_DESC\")"
           },
           (v5/*: any*/)
         ],
@@ -375,12 +375,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1c3c96ad3eb19684a6c2c8aac58ca1f0",
+    "cacheID": "d83d347f8bb509de3250a86403b96847",
     "id": null,
     "metadata": {},
     "name": "artistRoutes_ArticlesQuery",
     "operationKind": "query",
-    "text": "query artistRoutes_ArticlesQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistArticlesRoute_artist\n    id\n  }\n}\n\nfragment ArtistArticlesRoute_artist on Artist {\n  name\n  slug\n  articlesConnection(page: 1, size: 12, sort: PUBLISHED_AT_DESC, inEditorialFeed: true) {\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        ...CellArticle_article\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
+    "text": "query artistRoutes_ArticlesQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistArticlesRoute_artist\n    id\n  }\n}\n\nfragment ArtistArticlesRoute_artist on Artist {\n  name\n  slug\n  articlesConnection(page: 1, size: 12, sort: PUBLISHED_AT_DESC, inEditorialFeed: false) {\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        ...CellArticle_article\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Prior to his PR we excluded news from the articles being shown on the About tab for an Artist. This removes that exclusion with the intention of showing those news items.

There's more to it though - in addition to removing this filter we _also_ have some examples where we aren't connecting an article with artists. That's not a code question though that's more of an operational question and we'll pursue it with our editorial friends to see what's intentional and what's a mistake.

https://artsyproduct.atlassian.net/browse/DIA-291

/cc @artsy/diamond-devs