### PR TITLE
fix(artist): corrects spacing in safari

### DIFF
--- a/src/Apps/Artist/Routes/Overview/ArtistOverviewRoute.tsx
+++ b/src/Apps/Artist/Routes/Overview/ArtistOverviewRoute.tsx
@@ -1,4 +1,4 @@
-import { Flex, Spacer } from "@artsy/palette"
+import { Join, Spacer } from "@artsy/palette"
 import * as React from "react"
 import { Title, Meta } from "react-head"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -57,7 +57,7 @@ const ArtistOverviewRoute: React.FC<ArtistOverviewRouteProps> = ({
 
       <Spacer y={[2, 0]} />
 
-      <Flex flexDirection="column" gap={6}>
+      <Join separator={<Spacer y={6} />}>
         <ArtistCareerHighlightsQueryRenderer id={artist.internalID} />
 
         <ArtistSeriesRailQueryRenderer
@@ -72,7 +72,7 @@ const ArtistOverviewRoute: React.FC<ArtistOverviewRouteProps> = ({
         <ArtistRelatedArtistsRailQueryRenderer slug={artist.internalID} />
 
         <ArtistRelatedGeneCategoriesQueryRenderer slug={artist.internalID} />
-      </Flex>
+      </Join>
     </>
   )
 }


### PR DESCRIPTION
Closes [DIA-306](https://artsyproduct.atlassian.net/browse/DIA-306)

Some really odd behavior in Safari with flex gaps. It winds up being much simpler to use a `Join` here because it requires less knowledge of the child components — If any of them return an empty div or parallel divs for instance, it won't matter since `Spacers` on the `y` axis are margins that collapse.

[DIA-306]: https://artsyproduct.atlassian.net/browse/DIA-306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ