### PR TITLE
feat: Include news in artist overview tab DIA-291

### DIFF
--- a/src/Apps/Artist/Routes/Articles/ArtistArticlesRoute.tsx
+++ b/src/Apps/Artist/Routes/Articles/ArtistArticlesRoute.tsx
@@ -86,12 +86,7 @@ export const ArtistArticlesRouteFragmentContainer = createRefetchContainer(
         @argumentDefinitions(page: { type: "Int", defaultValue: 1 }) {
         name
         slug
-        articlesConnection(
-          page: $page
-          size: 12
-          sort: PUBLISHED_AT_DESC
-          inEditorialFeed: false
-        ) {
+        articlesConnection(page: $page, size: 12, sort: PUBLISHED_AT_DESC) {
           pageInfo {
             hasNextPage
           }

--- a/src/Apps/Artist/Routes/Overview/Components/ArtistEditorialNewsGrid.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtistEditorialNewsGrid.tsx
@@ -166,11 +166,7 @@ export const ArtistEditorialNewsGridFragmentContainer = createFragmentContainer(
         name
         slug
         href
-        articlesConnection(
-          first: 6
-          sort: PUBLISHED_AT_DESC
-          inEditorialFeed: true
-        ) {
+        articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {
           edges {
             node {
               ...CellArticle_article

--- a/src/Components/ArtistCurrentArticlesRail.tsx
+++ b/src/Components/ArtistCurrentArticlesRail.tsx
@@ -97,11 +97,7 @@ export const ArtistCurrentArticlesRailFragmentContainer = createFragmentContaine
         internalID
         name
         slug
-        articlesConnection(
-          first: 10
-          sort: PUBLISHED_AT_DESC
-          inEditorialFeed: true
-        ) {
+        articlesConnection(first: 10, sort: PUBLISHED_AT_DESC) {
           edges {
             node {
               ...CellArticle_article

--- a/src/__generated__/ArtistArticlesRouteQuery.graphql.ts
+++ b/src/__generated__/ArtistArticlesRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<816a7403390c35165dade6151a86d373>>
+ * @generated SignedSource<<4996a900f8600126ed94da749c9bb776>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -145,11 +145,6 @@ return {
           {
             "alias": null,
             "args": [
-              {
-                "kind": "Literal",
-                "name": "inEditorialFeed",
-                "value": false
-              },
               (v3/*: any*/),
               {
                 "kind": "Literal",
@@ -388,12 +383,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1b1275b2b9d9f556fd105e378812aece",
+    "cacheID": "29a72d083234277dd1b6f4ebdd77bcaa",
     "id": null,
     "metadata": {},
     "name": "ArtistArticlesRouteQuery",
     "operationKind": "query",
-    "text": "query ArtistArticlesRouteQuery(\n  $page: Int\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistArticlesRoute_artist_2Pg8Wv\n    id\n  }\n}\n\nfragment ArtistArticlesRoute_artist_2Pg8Wv on Artist {\n  name\n  slug\n  articlesConnection(page: $page, size: 12, sort: PUBLISHED_AT_DESC, inEditorialFeed: false) {\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        ...CellArticle_article\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
+    "text": "query ArtistArticlesRouteQuery(\n  $page: Int\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistArticlesRoute_artist_2Pg8Wv\n    id\n  }\n}\n\nfragment ArtistArticlesRoute_artist_2Pg8Wv on Artist {\n  name\n  slug\n  articlesConnection(page: $page, size: 12, sort: PUBLISHED_AT_DESC) {\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        ...CellArticle_article\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistArticlesRoute_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistArticlesRoute_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<69a2933eeb3fac662b3158f37556def1>>
+ * @generated SignedSource<<11a67df23de3a79829e9a687ec1cbb72>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -155,11 +155,6 @@ return {
           {
             "alias": null,
             "args": [
-              {
-                "kind": "Literal",
-                "name": "inEditorialFeed",
-                "value": false
-              },
               {
                 "kind": "Literal",
                 "name": "page",
@@ -393,7 +388,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "articlesConnection(inEditorialFeed:false,page:1,size:12,sort:\"PUBLISHED_AT_DESC\")"
+            "storageKey": "articlesConnection(page:1,size:12,sort:\"PUBLISHED_AT_DESC\")"
           },
           (v4/*: any*/)
         ],
@@ -402,7 +397,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "9c710f1452f3a1b3a4650bc27eb35e01",
+    "cacheID": "4e463f9239232fffe4e0e97d6fd49d0f",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -494,7 +489,7 @@ return {
     },
     "name": "ArtistArticlesRoute_Test_Query",
     "operationKind": "query",
-    "text": "query ArtistArticlesRoute_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistArticlesRoute_artist\n    id\n  }\n}\n\nfragment ArtistArticlesRoute_artist on Artist {\n  name\n  slug\n  articlesConnection(page: 1, size: 12, sort: PUBLISHED_AT_DESC, inEditorialFeed: false) {\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        ...CellArticle_article\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
+    "text": "query ArtistArticlesRoute_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistArticlesRoute_artist\n    id\n  }\n}\n\nfragment ArtistArticlesRoute_artist on Artist {\n  name\n  slug\n  articlesConnection(page: 1, size: 12, sort: PUBLISHED_AT_DESC) {\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        ...CellArticle_article\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistArticlesRoute_artist.graphql.ts
+++ b/src/__generated__/ArtistArticlesRoute_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ed7032bc6131cd65534a284bad0d48fe>>
+ * @generated SignedSource<<e64ed87c46377c942046620941499217>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -63,11 +63,6 @@ const node: ReaderFragment = {
     {
       "alias": null,
       "args": [
-        {
-          "kind": "Literal",
-          "name": "inEditorialFeed",
-          "value": false
-        },
         {
           "kind": "Variable",
           "name": "page",
@@ -165,6 +160,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "2fb7b28b26c703b2c69caaa3705c09a5";
+(node as any).hash = "6bf7647c939cc4f697409621eaa37a3b";
 
 export default node;

--- a/src/__generated__/ArtistCurrentArticlesRailQuery.graphql.ts
+++ b/src/__generated__/ArtistCurrentArticlesRailQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a753373a769f02f18354a4fe1f014c8a>>
+ * @generated SignedSource<<6982d1ed5808e509ebbb8f74522bd1dd>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -116,11 +116,6 @@ return {
                 "kind": "Literal",
                 "name": "first",
                 "value": 10
-              },
-              {
-                "kind": "Literal",
-                "name": "inEditorialFeed",
-                "value": true
               },
               {
                 "kind": "Literal",
@@ -268,7 +263,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "articlesConnection(first:10,inEditorialFeed:true,sort:\"PUBLISHED_AT_DESC\")"
+            "storageKey": "articlesConnection(first:10,sort:\"PUBLISHED_AT_DESC\")"
           },
           (v4/*: any*/)
         ],
@@ -277,12 +272,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "5946a149c3ab1c7f794a3364b4961509",
+    "cacheID": "d1907b685fa253ca6e99ec032d5982f1",
     "id": null,
     "metadata": {},
     "name": "ArtistCurrentArticlesRailQuery",
     "operationKind": "query",
-    "text": "query ArtistCurrentArticlesRailQuery(\n  $slug: String!\n) {\n  artist(id: $slug) {\n    ...ArtistCurrentArticlesRail_artist\n    id\n  }\n}\n\nfragment ArtistCurrentArticlesRail_artist on Artist {\n  internalID\n  name\n  slug\n  articlesConnection(first: 10, sort: PUBLISHED_AT_DESC, inEditorialFeed: true) {\n    edges {\n      node {\n        ...CellArticle_article\n        internalID\n        slug\n        href\n        id\n      }\n    }\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n"
+    "text": "query ArtistCurrentArticlesRailQuery(\n  $slug: String!\n) {\n  artist(id: $slug) {\n    ...ArtistCurrentArticlesRail_artist\n    id\n  }\n}\n\nfragment ArtistCurrentArticlesRail_artist on Artist {\n  internalID\n  name\n  slug\n  articlesConnection(first: 10, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        ...CellArticle_article\n        internalID\n        slug\n        href\n        id\n      }\n    }\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistCurrentArticlesRail_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistCurrentArticlesRail_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a34e2e9596265731adc5af991e58ff02>>
+ * @generated SignedSource<<2b3762e4858d42e6cffa77d80553718b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -131,11 +131,6 @@ return {
                 "kind": "Literal",
                 "name": "first",
                 "value": 10
-              },
-              {
-                "kind": "Literal",
-                "name": "inEditorialFeed",
-                "value": true
               },
               {
                 "kind": "Literal",
@@ -283,7 +278,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "articlesConnection(first:10,inEditorialFeed:true,sort:\"PUBLISHED_AT_DESC\")"
+            "storageKey": "articlesConnection(first:10,sort:\"PUBLISHED_AT_DESC\")"
           },
           (v3/*: any*/)
         ],
@@ -292,7 +287,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "5e6dc751569d4a76207d7063bfad2be7",
+    "cacheID": "331da03cb18e9b2cab06d62c7c331b47",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -353,7 +348,7 @@ return {
     },
     "name": "ArtistCurrentArticlesRail_Test_Query",
     "operationKind": "query",
-    "text": "query ArtistCurrentArticlesRail_Test_Query {\n  artist(id: \"test\") {\n    ...ArtistCurrentArticlesRail_artist\n    id\n  }\n}\n\nfragment ArtistCurrentArticlesRail_artist on Artist {\n  internalID\n  name\n  slug\n  articlesConnection(first: 10, sort: PUBLISHED_AT_DESC, inEditorialFeed: true) {\n    edges {\n      node {\n        ...CellArticle_article\n        internalID\n        slug\n        href\n        id\n      }\n    }\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n"
+    "text": "query ArtistCurrentArticlesRail_Test_Query {\n  artist(id: \"test\") {\n    ...ArtistCurrentArticlesRail_artist\n    id\n  }\n}\n\nfragment ArtistCurrentArticlesRail_artist on Artist {\n  internalID\n  name\n  slug\n  articlesConnection(first: 10, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        ...CellArticle_article\n        internalID\n        slug\n        href\n        id\n      }\n    }\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistCurrentArticlesRail_artist.graphql.ts
+++ b/src/__generated__/ArtistCurrentArticlesRail_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<147eaa4b1217963f730f121d9dca02ce>>
+ * @generated SignedSource<<a1076b855e7aa9cde1ea8e1d75dd73d3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -71,11 +71,6 @@ return {
         },
         {
           "kind": "Literal",
-          "name": "inEditorialFeed",
-          "value": true
-        },
-        {
-          "kind": "Literal",
           "name": "sort",
           "value": "PUBLISHED_AT_DESC"
         }
@@ -122,7 +117,7 @@ return {
           "storageKey": null
         }
       ],
-      "storageKey": "articlesConnection(first:10,inEditorialFeed:true,sort:\"PUBLISHED_AT_DESC\")"
+      "storageKey": "articlesConnection(first:10,sort:\"PUBLISHED_AT_DESC\")"
     }
   ],
   "type": "Artist",
@@ -130,6 +125,6 @@ return {
 };
 })();
 
-(node as any).hash = "c08088f56451680766023365484066e6";
+(node as any).hash = "170f5cd74be3e6b4b010e205644e1127";
 
 export default node;

--- a/src/__generated__/ArtistEditorialNewsGridQuery.graphql.ts
+++ b/src/__generated__/ArtistEditorialNewsGridQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7d7dde181cd132c19a3665499a54c3a3>>
+ * @generated SignedSource<<3918bfcb8bfd8b5beccaeb3ea3257f1d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -157,11 +157,6 @@ return {
               },
               {
                 "kind": "Literal",
-                "name": "inEditorialFeed",
-                "value": true
-              },
-              {
-                "kind": "Literal",
                 "name": "sort",
                 "value": "PUBLISHED_AT_DESC"
               }
@@ -292,7 +287,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "articlesConnection(first:6,inEditorialFeed:true,sort:\"PUBLISHED_AT_DESC\")"
+            "storageKey": "articlesConnection(first:6,sort:\"PUBLISHED_AT_DESC\")"
           },
           (v6/*: any*/)
         ],
@@ -301,12 +296,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "7e7186886f5c4abacb28b024ce2eb89a",
+    "cacheID": "fae04e66246a0bd8c84e7fa2c1c4146e",
     "id": null,
     "metadata": {},
     "name": "ArtistEditorialNewsGridQuery",
     "operationKind": "query",
-    "text": "query ArtistEditorialNewsGridQuery(\n  $id: String!\n) {\n  artist(id: $id) {\n    ...ArtistEditorialNewsGrid_artist\n    id\n  }\n}\n\nfragment ArtistEditorialNewsGrid_artist on Artist {\n  internalID\n  name\n  slug\n  href\n  articlesConnection(first: 6, sort: PUBLISHED_AT_DESC, inEditorialFeed: true) {\n    edges {\n      node {\n        ...CellArticle_article\n        internalID\n        href\n        byline\n        slug\n        title\n        publishedAt(format: \"MMM D, YYYY\")\n        vertical\n        thumbnailTitle\n        thumbnailImage {\n          large: cropped(width: 670, height: 720) {\n            width\n            height\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n"
+    "text": "query ArtistEditorialNewsGridQuery(\n  $id: String!\n) {\n  artist(id: $id) {\n    ...ArtistEditorialNewsGrid_artist\n    id\n  }\n}\n\nfragment ArtistEditorialNewsGrid_artist on Artist {\n  internalID\n  name\n  slug\n  href\n  articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        ...CellArticle_article\n        internalID\n        href\n        byline\n        slug\n        title\n        publishedAt(format: \"MMM D, YYYY\")\n        vertical\n        thumbnailTitle\n        thumbnailImage {\n          large: cropped(width: 670, height: 720) {\n            width\n            height\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistEditorialNewsGrid_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistEditorialNewsGrid_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4fd89e4449151ca6b83075fbd556cb02>>
+ * @generated SignedSource<<9c6fd4ee74bc15dc4a33616ef860ec9d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -178,11 +178,6 @@ return {
               },
               {
                 "kind": "Literal",
-                "name": "inEditorialFeed",
-                "value": true
-              },
-              {
-                "kind": "Literal",
                 "name": "sort",
                 "value": "PUBLISHED_AT_DESC"
               }
@@ -313,7 +308,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "articlesConnection(first:6,inEditorialFeed:true,sort:\"PUBLISHED_AT_DESC\")"
+            "storageKey": "articlesConnection(first:6,sort:\"PUBLISHED_AT_DESC\")"
           },
           (v5/*: any*/)
         ],
@@ -322,7 +317,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "91c114556b821d788c27a9ef57f83c3a",
+    "cacheID": "0a22e5c7ee4958827bb611a5dc7f663a",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -384,7 +379,7 @@ return {
     },
     "name": "ArtistEditorialNewsGrid_Test_Query",
     "operationKind": "query",
-    "text": "query ArtistEditorialNewsGrid_Test_Query {\n  artist(id: \"test-artist\") {\n    ...ArtistEditorialNewsGrid_artist\n    id\n  }\n}\n\nfragment ArtistEditorialNewsGrid_artist on Artist {\n  internalID\n  name\n  slug\n  href\n  articlesConnection(first: 6, sort: PUBLISHED_AT_DESC, inEditorialFeed: true) {\n    edges {\n      node {\n        ...CellArticle_article\n        internalID\n        href\n        byline\n        slug\n        title\n        publishedAt(format: \"MMM D, YYYY\")\n        vertical\n        thumbnailTitle\n        thumbnailImage {\n          large: cropped(width: 670, height: 720) {\n            width\n            height\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n"
+    "text": "query ArtistEditorialNewsGrid_Test_Query {\n  artist(id: \"test-artist\") {\n    ...ArtistEditorialNewsGrid_artist\n    id\n  }\n}\n\nfragment ArtistEditorialNewsGrid_artist on Artist {\n  internalID\n  name\n  slug\n  href\n  articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {\n    edges {\n      node {\n        ...CellArticle_article\n        internalID\n        href\n        byline\n        slug\n        title\n        publishedAt(format: \"MMM D, YYYY\")\n        vertical\n        thumbnailTitle\n        thumbnailImage {\n          large: cropped(width: 670, height: 720) {\n            width\n            height\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistEditorialNewsGrid_artist.graphql.ts
+++ b/src/__generated__/ArtistEditorialNewsGrid_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0607469d7af2be38213ef1d6b78fbdb6>>
+ * @generated SignedSource<<47d5812c270f15c6a7f084063efad368>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -90,11 +90,6 @@ return {
           "kind": "Literal",
           "name": "first",
           "value": 6
-        },
-        {
-          "kind": "Literal",
-          "name": "inEditorialFeed",
-          "value": true
         },
         {
           "kind": "Literal",
@@ -240,7 +235,7 @@ return {
           "storageKey": null
         }
       ],
-      "storageKey": "articlesConnection(first:6,inEditorialFeed:true,sort:\"PUBLISHED_AT_DESC\")"
+      "storageKey": "articlesConnection(first:6,sort:\"PUBLISHED_AT_DESC\")"
     }
   ],
   "type": "Artist",
@@ -248,6 +243,6 @@ return {
 };
 })();
 
-(node as any).hash = "d595312130a224034cb1731778946676";
+(node as any).hash = "2c4858bc3f6fd5463107859ea94c5f93";
 
 export default node;

--- a/src/__generated__/artistRoutes_ArticlesQuery.graphql.ts
+++ b/src/__generated__/artistRoutes_ArticlesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ef26931435b3d9cb4dc00540336abe63>>
+ * @generated SignedSource<<c9ece4681fc0850c6dd75026efecad85>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -128,11 +128,6 @@ return {
           {
             "alias": null,
             "args": [
-              {
-                "kind": "Literal",
-                "name": "inEditorialFeed",
-                "value": false
-              },
               {
                 "kind": "Literal",
                 "name": "page",
@@ -366,7 +361,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "articlesConnection(inEditorialFeed:false,page:1,size:12,sort:\"PUBLISHED_AT_DESC\")"
+            "storageKey": "articlesConnection(page:1,size:12,sort:\"PUBLISHED_AT_DESC\")"
           },
           (v5/*: any*/)
         ],
@@ -375,12 +370,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d83d347f8bb509de3250a86403b96847",
+    "cacheID": "0cd6777e78b4567d6e81c3416e5f240f",
     "id": null,
     "metadata": {},
     "name": "artistRoutes_ArticlesQuery",
     "operationKind": "query",
-    "text": "query artistRoutes_ArticlesQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistArticlesRoute_artist\n    id\n  }\n}\n\nfragment ArtistArticlesRoute_artist on Artist {\n  name\n  slug\n  articlesConnection(page: 1, size: 12, sort: PUBLISHED_AT_DESC, inEditorialFeed: false) {\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        ...CellArticle_article\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
+    "text": "query artistRoutes_ArticlesQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistArticlesRoute_artist\n    id\n  }\n}\n\nfragment ArtistArticlesRoute_artist on Artist {\n  name\n  slug\n  articlesConnection(page: 1, size: 12, sort: PUBLISHED_AT_DESC) {\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        ...CellArticle_article\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Over on https://github.com/artsy/force/pull/13091 I missed places where we were sending this flag and then @dzucconi had the idea that I should just reverse the default and remove this flag altogether.

https://artsyproduct.atlassian.net/browse/DIA-291

/cc @artsy/diamond-devs