### PR TITLE
fix(ONYX-386): remove new artwork alert modal from auctions header

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/ArtworkAuctionCreateAlertHeader.tsx
+++ b/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/ArtworkAuctionCreateAlertHeader.tsx
@@ -22,9 +22,6 @@ import { SuggestedArtworksShelfQueryRenderer } from "Apps/Artwork/Components/Art
 import { Media } from "Utils/Responsive"
 import { RouterLink } from "System/Router/RouterLink"
 import BellStrokeIcon from "@artsy/icons/BellStrokeIcon"
-import { useFeatureFlag } from "System/useFeatureFlag"
-import { useAlert } from "Components/Alert"
-import { ProgressiveOnboardingAlertCreateSimple } from "Components/ProgressiveOnboarding/ProgressiveOnboardingAlertCreateSimple"
 
 interface ArtworkAuctionCreateAlertHeaderProps {
   artwork: ArtworkAuctionCreateAlertHeader_artwork$data
@@ -103,46 +100,7 @@ const ArtworkAuctionCreateAlertHeader: FC<ArtworkAuctionCreateAlertHeaderProps> 
   const isHighest = artwork.myLotStandingManageAlerts?.[0]?.isHighestBidder
   const hasLostBid = isBidder && !isHighest
 
-  const newAlertModalEnabled = useFeatureFlag("onyx_artwork_alert_modal_v2")
-
-  const { alertComponent, showAlert } = useAlert({
-    initialCriteria: {
-      attributionClass: compact([artwork.attributionClass?.internalID]),
-      artistIDs: compact(artwork.artists).map(artist => artist.internalID),
-      additionalGeneIDs: [artwork.mediumType?.filterGene?.slug as string],
-    },
-  })
-
   if (!displayAuctionCreateAlertHeader) return null
-
-  const AlertSwitch: FC = () => {
-    if (newAlertModalEnabled) {
-      return (
-        <>
-          <ProgressiveOnboardingAlertCreateSimple>
-            <Button
-              width="100%"
-              size="large"
-              onClick={showAlert}
-              Icon={BellStrokeIcon}
-            >
-              Create Alert
-            </Button>
-          </ProgressiveOnboardingAlertCreateSimple>
-          {alertComponent}
-        </>
-      )
-    } else {
-      return (
-        <>
-          <ArtworkCreateAlertButtonFragmentContainer
-            artwork={artwork}
-            analyticsContextModule={ContextModule.artworkSidebar}
-          />
-        </>
-      )
-    }
-  }
 
   return (
     <SavedSearchAlertContextProvider
@@ -190,7 +148,10 @@ const ArtworkAuctionCreateAlertHeader: FC<ArtworkAuctionCreateAlertHeaderProps> 
                 Manage your alerts
               </Button>
             ) : (
-              <AlertSwitch />
+              <ArtworkCreateAlertButtonFragmentContainer
+                artwork={artwork}
+                analyticsContextModule={ContextModule.artworkSidebar}
+              />
             )}
           </Box>
         </Column>


### PR DESCRIPTION
The type of this PR is: Fix

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PROJECT-XX]
Relates to this PR: https://github.com/artsy/force/pull/13092

### Description

Removes the [new Alert modal](src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/ArtworkAuctionCreateAlertHeader.tsx) from the Auctions closed lot header due to an issue with rendering the modal. This issue will be addressed separately to unblock the current deploy block on Force.

<!-- Implementation description -->

After removing the new alert modal, in this PR:


https://github.com/artsy/force/assets/17580625/f9a59cdf-f4ac-4c25-8448-2d3d24c5998f


With the new alert modal, with modal rendering bug:


https://github.com/artsy/force/assets/17580625/490534b5-0f19-4049-a8b2-9668c1f75d61



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ