### PR TITLE
fix(pricerange): respond to external value changes; adds debounced callback

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/PriceRangeFilter.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/PriceRangeFilter.tsx
@@ -4,16 +4,13 @@ import {
   CustomRange,
   DEFAULT_PRICE_RANGE,
 } from "Components/PriceRange/constants"
-import { FC, useMemo } from "react"
+import { FC } from "react"
 import {
   useAuctionResultsFilterContext,
   useCurrentlySelectedFiltersForAuctionResults,
 } from "Apps/Artist/Routes/AuctionResults/AuctionResultsFilterContext"
-import { debounce } from "lodash"
 import { aggregationsToHistogram } from "Components/ArtworkFilter/ArtworkFilters/PriceRangeFilter"
 import { Aggregations } from "Components/ArtworkFilter/ArtworkFilterContext"
-
-const DEBOUNCE_DELAY = 300
 
 export const PriceRangeFilter: FC = () => {
   const { setFilter, aggregations } = useAuctionResultsFilterContext()
@@ -24,13 +21,8 @@ export const PriceRangeFilter: FC = () => {
   } = useCurrentlySelectedFiltersForAuctionResults()
   const bars = aggregationsToHistogram(aggregations as Aggregations)
 
-  const setFilterDobounced = useMemo(
-    () => setFilter && debounce(setFilter, DEBOUNCE_DELAY),
-    [setFilter]
-  )
-
   const handlePriceRangeUpdate = (updatedRange: CustomRange) => {
-    setFilterDobounced?.("priceRange", updatedRange.join("-"))
+    setFilter?.("priceRange", updatedRange.join("-"))
   }
 
   return (
@@ -39,7 +31,7 @@ export const PriceRangeFilter: FC = () => {
       <PriceRange
         bars={bars}
         priceRange={priceRange || DEFAULT_PRICE_RANGE}
-        onPriceRangeUpdate={handlePriceRangeUpdate}
+        onDebouncedUpdate={handlePriceRangeUpdate}
       />
       <Spacer y={2} />
       <Checkbox

--- a/src/Components/Alert/Components/Form/PriceRange.tsx
+++ b/src/Components/Alert/Components/Form/PriceRange.tsx
@@ -1,6 +1,5 @@
 import { Expandable, Spacer } from "@artsy/palette"
 import { FC } from "react"
-
 import { useAlertContext } from "Components/Alert/Hooks/useAlertContext"
 import { PriceRange } from "Components/PriceRange/PriceRange"
 import {
@@ -34,7 +33,7 @@ export const PriceRangeFilter: FC<PricaRangeFilterProps> = ({
 
       <PriceRange
         priceRange={state.criteria.priceRange ?? DEFAULT_PRICE_RANGE}
-        onPriceRangeUpdate={handlePriceRangeUpdate}
+        onUpdate={handlePriceRangeUpdate}
       />
     </Expandable>
   )

--- a/src/Components/ArtworkFilter/ArtworkFiltersQuick/PriceRangeFilterQuick.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFiltersQuick/PriceRangeFilterQuick.tsx
@@ -41,7 +41,7 @@ export const PriceRangeFilterQuick: FC<PriceRangeFilterQuickProps> = props => {
             <PriceRange
               priceRange={range.join("-")}
               bars={histogram}
-              onPriceRangeUpdate={onPriceRangeUpdate}
+              onDebouncedUpdate={onPriceRangeUpdate}
             />
           </FilterQuickDropdownPanel>
         )

--- a/src/Components/SavedSearchAlert/Components/PriceRangeFilter.tsx
+++ b/src/Components/SavedSearchAlert/Components/PriceRangeFilter.tsx
@@ -32,7 +32,7 @@ export const PriceRangeFilter: FC<PricaRangeFilterProps> = ({
 
       <PriceRange
         priceRange={criteria.priceRange ?? DEFAULT_PRICE_RANGE}
-        onPriceRangeUpdate={handlePriceRangeUpdate}
+        onUpdate={handlePriceRangeUpdate}
       />
     </Expandable>
   )


### PR DESCRIPTION
Closes [DIA-309](https://artsyproduct.atlassian.net/browse/DIA-309)

The problem we were seeing was that, if you updated the price range within the quick filter dropdown, then opened up the all filters drawer, that price range filter wasn't in sync with the state.

This is because the price range component keeps local state and only sets it based on initial props, not responding to any props updates. We can't make it a controlled component because the artwork filter context is naive, firing off API requests on every change, the slider dragging is chatty, and I have no desire to touch the filter code.

So, this PR:
* Adds an `onDebouncedUpdate` internally to the slider so that we can just use it since that's generally what you want with this type of input
* Responds to external updates to the value that's passed in to update its local state
* Updates all call sites and removes extraneous debouncing.

[DIA-309]: https://artsyproduct.atlassian.net/browse/DIA-309?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ