### PR TITLE
chore(DIA-204): Display save tooltip regardless of logged in status

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkActions.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkActions.jest.tsx
@@ -21,7 +21,9 @@ jest.mock("System/SystemContext", () => ({
 }))
 
 jest.mock("System/Analytics/AnalyticsContext", () => ({
-  AnalyticsContext: { Provider: ({ children }) => children },
+  useAnalyticsContext: jest.fn(() => ({
+    contextPageOwnerId: "contextPageOwnerID",
+  })),
   track: jest.fn().mockReturnValue(jest.fn),
   useTracking: jest.fn().mockReturnValue({ trackEvent: jest.fn() }),
 }))

--- a/src/Components/ProgressiveOnboarding/ProgressiveOnboardingSaveArtwork.tsx
+++ b/src/Components/ProgressiveOnboarding/ProgressiveOnboardingSaveArtwork.tsx
@@ -11,7 +11,6 @@ import {
   withProgressiveOnboardingCounts,
   WithProgressiveOnboardingCountsProps,
 } from "Components/ProgressiveOnboarding/withProgressiveOnboardingCounts"
-import { useSystemContext } from "System/SystemContext"
 
 interface ProgressiveOnboardingSaveArtworkProps
   extends WithProgressiveOnboardingCountsProps {}
@@ -20,12 +19,9 @@ export const __ProgressiveOnboardingSaveArtwork__: FC<ProgressiveOnboardingSaveA
   counts,
   children,
 }) => {
-  const { isLoggedIn } = useSystemContext()
-
   const { dismiss, isDismissed } = useProgressiveOnboarding()
 
   const isDisplayble =
-    isLoggedIn &&
     !isDismissed(PROGRESSIVE_ONBOARDING_SAVE_ARTWORK).status &&
     counts.isReady &&
     counts.savedArtworks === 0

--- a/src/Components/ProgressiveOnboarding/__tests__/ProgressiveOnboardingSaves.jest.tsx
+++ b/src/Components/ProgressiveOnboarding/__tests__/ProgressiveOnboardingSaves.jest.tsx
@@ -12,10 +12,6 @@ import { ProgressiveOnboardingSaveHighlight } from "Components/ProgressiveOnboar
 import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
 import { FC, useEffect } from "react"
 
-jest.mock("System/useSystemContext", () => ({
-  useSystemContext: jest.fn().mockReturnValue({ isLoggedIn: true }),
-}))
-
 jest.mock(
   "Components/ProgressiveOnboarding/ProgressiveOnboardingHighlight",
   () => ({


### PR DESCRIPTION
The type of this PR is: Chore

This PR solves [DIA-204]

### Description

Removed the logged-in user conditional for the "Save" artwork tooltip, so now it's also visible for logged-out users.

<img width="1009" alt="Screenshot 2023-11-02 at 14 16 32" src="https://github.com/artsy/force/assets/7117670/87189eb6-7131-4cd4-8b75-411bcbdf2c17">


[DIA-204]: https://artsyproduct.atlassian.net/browse/DIA-204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ