### PR TITLE
fix(artist): corrects empty condition; guards on extraneous fetches of subcomponents

### DIFF
--- a/src/Apps/Artist/Routes/Overview/__tests__/ArtistOverviewRoute.jest.tsx
+++ b/src/Apps/Artist/Routes/Overview/__tests__/ArtistOverviewRoute.jest.tsx
@@ -96,8 +96,9 @@ describe("ArtistOverviewRoute", () => {
         filterArtworksConnection: { edges: [] },
         insights: [],
         artistSeriesConnection: { totalCount: 0 },
-        articlesConnection: { totalCount: 0 },
         showsConnection: { totalCount: 0 },
+        counts: { articles: 0, relatedArtists: 0 },
+        related: { genes: { edges: [] } },
       }),
     })
 

--- a/src/__generated__/ArtistOverviewRoute_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistOverviewRoute_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7ba8c0f5a09a07739cbb9f3361cf736f>>
+ * @generated SignedSource<<aa96dd5782a0b49c208d96c712d254b5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -33,25 +33,15 @@ v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "internalID",
+  "name": "__typename",
   "storageKey": null
 },
 v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v3 = {
   "kind": "Literal",
   "name": "first",
   "value": 0
 },
-v4 = [
-  (v3/*: any*/)
-],
-v5 = [
+v3 = [
   {
     "alias": null,
     "args": null,
@@ -59,7 +49,14 @@ v5 = [
     "name": "totalCount",
     "storageKey": null
   }
-];
+],
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": [],
@@ -101,110 +98,19 @@ return {
         "name": "artist",
         "plural": false,
         "selections": [
-          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "internalID",
+            "storageKey": null
+          },
           {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
             "name": "name",
             "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "first",
-                "value": 1
-              }
-            ],
-            "concreteType": "FilterArtworksConnection",
-            "kind": "LinkedField",
-            "name": "filterArtworksConnection",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "FilterArtworksEdge",
-                "kind": "LinkedField",
-                "name": "edges",
-                "plural": true,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Artwork",
-                    "kind": "LinkedField",
-                    "name": "node",
-                    "plural": false,
-                    "selections": [
-                      (v1/*: any*/),
-                      (v2/*: any*/)
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
-              (v2/*: any*/)
-            ],
-            "storageKey": "filterArtworksConnection(first:1)"
-          },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "ArtistInsight",
-            "kind": "LinkedField",
-            "name": "insights",
-            "plural": true,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "__typename",
-                "storageKey": null
-              }
-            ],
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": (v4/*: any*/),
-            "concreteType": "ArtistSeriesConnection",
-            "kind": "LinkedField",
-            "name": "artistSeriesConnection",
-            "plural": false,
-            "selections": (v5/*: any*/),
-            "storageKey": "artistSeriesConnection(first:0)"
-          },
-          {
-            "alias": null,
-            "args": (v4/*: any*/),
-            "concreteType": "ArticleConnection",
-            "kind": "LinkedField",
-            "name": "articlesConnection",
-            "plural": false,
-            "selections": (v5/*: any*/),
-            "storageKey": "articlesConnection(first:0)"
-          },
-          {
-            "alias": null,
-            "args": [
-              (v3/*: any*/),
-              {
-                "kind": "Literal",
-                "name": "status",
-                "value": "running"
-              }
-            ],
-            "concreteType": "ShowConnection",
-            "kind": "LinkedField",
-            "name": "showsConnection",
-            "plural": false,
-            "selections": (v5/*: any*/),
-            "storageKey": "showsConnection(first:0,status:\"running\")"
           },
           {
             "alias": null,
@@ -240,6 +146,47 @@ return {
           {
             "alias": null,
             "args": null,
+            "concreteType": "ArtistInsight",
+            "kind": "LinkedField",
+            "name": "insights",
+            "plural": true,
+            "selections": [
+              (v1/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": [
+              (v2/*: any*/)
+            ],
+            "concreteType": "ArtistSeriesConnection",
+            "kind": "LinkedField",
+            "name": "artistSeriesConnection",
+            "plural": false,
+            "selections": (v3/*: any*/),
+            "storageKey": "artistSeriesConnection(first:0)"
+          },
+          {
+            "alias": null,
+            "args": [
+              (v2/*: any*/),
+              {
+                "kind": "Literal",
+                "name": "status",
+                "value": "running"
+              }
+            ],
+            "concreteType": "ShowConnection",
+            "kind": "LinkedField",
+            "name": "showsConnection",
+            "plural": false,
+            "selections": (v3/*: any*/),
+            "storageKey": "showsConnection(first:0,status:\"running\")"
+          },
+          {
+            "alias": null,
+            "args": null,
             "concreteType": "ArtistCounts",
             "kind": "LinkedField",
             "name": "counts",
@@ -251,23 +198,89 @@ return {
                 "kind": "ScalarField",
                 "name": "artworks",
                 "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "relatedArtists",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "articles",
+                "storageKey": null
               }
             ],
             "storageKey": null
           },
-          (v2/*: any*/)
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtistRelatedData",
+            "kind": "LinkedField",
+            "name": "related",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 1
+                  }
+                ],
+                "concreteType": "GeneConnection",
+                "kind": "LinkedField",
+                "name": "genes",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "GeneEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Gene",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v1/*: any*/),
+                          (v4/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "genes(first:1)"
+              }
+            ],
+            "storageKey": null
+          },
+          (v4/*: any*/)
         ],
         "storageKey": "artist(id:\"test\")"
       }
     ]
   },
   "params": {
-    "cacheID": "b5342b00acde15eab2f39cc0a266a882",
+    "cacheID": "3f45a29daa79c5a58f06602bd5b18113",
     "id": null,
     "metadata": {},
     "name": "ArtistOverviewRoute_Test_Query",
     "operationKind": "query",
-    "text": "query ArtistOverviewRoute_Test_Query {\n  artist(id: \"test\") {\n    ...ArtistOverviewRoute_artist\n    id\n  }\n}\n\nfragment ArtistOverviewRoute_artist on Artist {\n  internalID\n  name\n  filterArtworksConnection(first: 1) {\n    edges {\n      node {\n        internalID\n        id\n      }\n    }\n    id\n  }\n  insights {\n    __typename\n  }\n  artistSeriesConnection(first: 0) {\n    totalCount\n  }\n  articlesConnection(first: 0) {\n    totalCount\n  }\n  showsConnection(first: 0, status: \"running\") {\n    totalCount\n  }\n  meta(page: ABOUT) {\n    description\n    title\n  }\n  counts {\n    artworks\n  }\n}\n"
+    "text": "query ArtistOverviewRoute_Test_Query {\n  artist(id: \"test\") {\n    ...ArtistOverviewRoute_artist\n    id\n  }\n}\n\nfragment ArtistOverviewRoute_artist on Artist {\n  internalID\n  name\n  meta(page: ABOUT) {\n    description\n    title\n  }\n  insights {\n    __typename\n  }\n  artistSeriesConnection(first: 0) {\n    totalCount\n  }\n  showsConnection(first: 0, status: \"running\") {\n    totalCount\n  }\n  counts {\n    artworks\n    relatedArtists\n    articles\n  }\n  related {\n    genes(first: 1) {\n      edges {\n        node {\n          __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistOverviewRoute_artist.graphql.ts
+++ b/src/__generated__/ArtistOverviewRoute_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<11654270f93764311595c9e3a5519f41>>
+ * @generated SignedSource<<a2b74f5581c53cf7542c53249d830ef2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,21 +11,13 @@
 import { Fragment, ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type ArtistOverviewRoute_artist$data = {
-  readonly articlesConnection: {
-    readonly totalCount: number | null;
-  } | null;
   readonly artistSeriesConnection: {
     readonly totalCount: number;
   } | null;
   readonly counts: {
+    readonly articles: number | null;
     readonly artworks: any | null;
-  } | null;
-  readonly filterArtworksConnection: {
-    readonly edges: ReadonlyArray<{
-      readonly node: {
-        readonly internalID: string;
-      } | null;
-    } | null> | null;
+    readonly relatedArtists: number | null;
   } | null;
   readonly insights: ReadonlyArray<{
     readonly __typename: "ArtistInsight";
@@ -36,6 +28,15 @@ export type ArtistOverviewRoute_artist$data = {
     readonly title: string;
   };
   readonly name: string | null;
+  readonly related: {
+    readonly genes: {
+      readonly edges: ReadonlyArray<{
+        readonly node: {
+          readonly __typename: "Gene";
+        } | null;
+      } | null> | null;
+    } | null;
+  } | null;
   readonly showsConnection: {
     readonly totalCount: number | null;
   } | null;
@@ -47,22 +48,21 @@ export type ArtistOverviewRoute_artist$key = {
 };
 
 const node: ReaderFragment = (function(){
-var v0 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "__typename",
+    "storageKey": null
+  }
+],
 v1 = {
   "kind": "Literal",
   "name": "first",
   "value": 0
 },
 v2 = [
-  (v1/*: any*/)
-],
-v3 = [
   {
     "alias": null,
     "args": null,
@@ -77,108 +77,19 @@ return {
   "metadata": null,
   "name": "ArtistOverviewRoute_artist",
   "selections": [
-    (v0/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "internalID",
+      "storageKey": null
+    },
     {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
       "name": "name",
       "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": [
-        {
-          "kind": "Literal",
-          "name": "first",
-          "value": 1
-        }
-      ],
-      "concreteType": "FilterArtworksConnection",
-      "kind": "LinkedField",
-      "name": "filterArtworksConnection",
-      "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": "FilterArtworksEdge",
-          "kind": "LinkedField",
-          "name": "edges",
-          "plural": true,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "concreteType": "Artwork",
-              "kind": "LinkedField",
-              "name": "node",
-              "plural": false,
-              "selections": [
-                (v0/*: any*/)
-              ],
-              "storageKey": null
-            }
-          ],
-          "storageKey": null
-        }
-      ],
-      "storageKey": "filterArtworksConnection(first:1)"
-    },
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "ArtistInsight",
-      "kind": "LinkedField",
-      "name": "insights",
-      "plural": true,
-      "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "__typename",
-          "storageKey": null
-        }
-      ],
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": (v2/*: any*/),
-      "concreteType": "ArtistSeriesConnection",
-      "kind": "LinkedField",
-      "name": "artistSeriesConnection",
-      "plural": false,
-      "selections": (v3/*: any*/),
-      "storageKey": "artistSeriesConnection(first:0)"
-    },
-    {
-      "alias": null,
-      "args": (v2/*: any*/),
-      "concreteType": "ArticleConnection",
-      "kind": "LinkedField",
-      "name": "articlesConnection",
-      "plural": false,
-      "selections": (v3/*: any*/),
-      "storageKey": "articlesConnection(first:0)"
-    },
-    {
-      "alias": null,
-      "args": [
-        (v1/*: any*/),
-        {
-          "kind": "Literal",
-          "name": "status",
-          "value": "running"
-        }
-      ],
-      "concreteType": "ShowConnection",
-      "kind": "LinkedField",
-      "name": "showsConnection",
-      "plural": false,
-      "selections": (v3/*: any*/),
-      "storageKey": "showsConnection(first:0,status:\"running\")"
     },
     {
       "alias": null,
@@ -214,6 +125,45 @@ return {
     {
       "alias": null,
       "args": null,
+      "concreteType": "ArtistInsight",
+      "kind": "LinkedField",
+      "name": "insights",
+      "plural": true,
+      "selections": (v0/*: any*/),
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": [
+        (v1/*: any*/)
+      ],
+      "concreteType": "ArtistSeriesConnection",
+      "kind": "LinkedField",
+      "name": "artistSeriesConnection",
+      "plural": false,
+      "selections": (v2/*: any*/),
+      "storageKey": "artistSeriesConnection(first:0)"
+    },
+    {
+      "alias": null,
+      "args": [
+        (v1/*: any*/),
+        {
+          "kind": "Literal",
+          "name": "status",
+          "value": "running"
+        }
+      ],
+      "concreteType": "ShowConnection",
+      "kind": "LinkedField",
+      "name": "showsConnection",
+      "plural": false,
+      "selections": (v2/*: any*/),
+      "storageKey": "showsConnection(first:0,status:\"running\")"
+    },
+    {
+      "alias": null,
+      "args": null,
       "concreteType": "ArtistCounts",
       "kind": "LinkedField",
       "name": "counts",
@@ -225,6 +175,69 @@ return {
           "kind": "ScalarField",
           "name": "artworks",
           "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "relatedArtists",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "articles",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "ArtistRelatedData",
+      "kind": "LinkedField",
+      "name": "related",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "first",
+              "value": 1
+            }
+          ],
+          "concreteType": "GeneConnection",
+          "kind": "LinkedField",
+          "name": "genes",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "GeneEdge",
+              "kind": "LinkedField",
+              "name": "edges",
+              "plural": true,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "Gene",
+                  "kind": "LinkedField",
+                  "name": "node",
+                  "plural": false,
+                  "selections": (v0/*: any*/),
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": "genes(first:1)"
         }
       ],
       "storageKey": null
@@ -235,6 +248,6 @@ return {
 };
 })();
 
-(node as any).hash = "ccb37a4453e34d899487a888b2fcf573";
+(node as any).hash = "d98b6054e2b4bd57cfac9cd348ad9da1";
 
 export default node;

--- a/src/__generated__/artistRoutes_OverviewQuery.graphql.ts
+++ b/src/__generated__/artistRoutes_OverviewQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<08a638136fefb230079b8b7f70713370>>
+ * @generated SignedSource<<3c7fbfbdc5ae2050a9a275588f06e546>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -42,25 +42,15 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "internalID",
+  "name": "__typename",
   "storageKey": null
 },
 v3 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v4 = {
   "kind": "Literal",
   "name": "first",
   "value": 0
 },
-v5 = [
-  (v4/*: any*/)
-],
-v6 = [
+v4 = [
   {
     "alias": null,
     "args": null,
@@ -68,7 +58,14 @@ v6 = [
     "name": "totalCount",
     "storageKey": null
   }
-];
+],
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -110,110 +107,19 @@ return {
         "name": "artist",
         "plural": false,
         "selections": [
-          (v2/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "internalID",
+            "storageKey": null
+          },
           {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
             "name": "name",
             "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "first",
-                "value": 1
-              }
-            ],
-            "concreteType": "FilterArtworksConnection",
-            "kind": "LinkedField",
-            "name": "filterArtworksConnection",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "FilterArtworksEdge",
-                "kind": "LinkedField",
-                "name": "edges",
-                "plural": true,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Artwork",
-                    "kind": "LinkedField",
-                    "name": "node",
-                    "plural": false,
-                    "selections": [
-                      (v2/*: any*/),
-                      (v3/*: any*/)
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
-              (v3/*: any*/)
-            ],
-            "storageKey": "filterArtworksConnection(first:1)"
-          },
-          {
-            "alias": null,
-            "args": null,
-            "concreteType": "ArtistInsight",
-            "kind": "LinkedField",
-            "name": "insights",
-            "plural": true,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "__typename",
-                "storageKey": null
-              }
-            ],
-            "storageKey": null
-          },
-          {
-            "alias": null,
-            "args": (v5/*: any*/),
-            "concreteType": "ArtistSeriesConnection",
-            "kind": "LinkedField",
-            "name": "artistSeriesConnection",
-            "plural": false,
-            "selections": (v6/*: any*/),
-            "storageKey": "artistSeriesConnection(first:0)"
-          },
-          {
-            "alias": null,
-            "args": (v5/*: any*/),
-            "concreteType": "ArticleConnection",
-            "kind": "LinkedField",
-            "name": "articlesConnection",
-            "plural": false,
-            "selections": (v6/*: any*/),
-            "storageKey": "articlesConnection(first:0)"
-          },
-          {
-            "alias": null,
-            "args": [
-              (v4/*: any*/),
-              {
-                "kind": "Literal",
-                "name": "status",
-                "value": "running"
-              }
-            ],
-            "concreteType": "ShowConnection",
-            "kind": "LinkedField",
-            "name": "showsConnection",
-            "plural": false,
-            "selections": (v6/*: any*/),
-            "storageKey": "showsConnection(first:0,status:\"running\")"
           },
           {
             "alias": null,
@@ -249,6 +155,47 @@ return {
           {
             "alias": null,
             "args": null,
+            "concreteType": "ArtistInsight",
+            "kind": "LinkedField",
+            "name": "insights",
+            "plural": true,
+            "selections": [
+              (v2/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": [
+              (v3/*: any*/)
+            ],
+            "concreteType": "ArtistSeriesConnection",
+            "kind": "LinkedField",
+            "name": "artistSeriesConnection",
+            "plural": false,
+            "selections": (v4/*: any*/),
+            "storageKey": "artistSeriesConnection(first:0)"
+          },
+          {
+            "alias": null,
+            "args": [
+              (v3/*: any*/),
+              {
+                "kind": "Literal",
+                "name": "status",
+                "value": "running"
+              }
+            ],
+            "concreteType": "ShowConnection",
+            "kind": "LinkedField",
+            "name": "showsConnection",
+            "plural": false,
+            "selections": (v4/*: any*/),
+            "storageKey": "showsConnection(first:0,status:\"running\")"
+          },
+          {
+            "alias": null,
+            "args": null,
             "concreteType": "ArtistCounts",
             "kind": "LinkedField",
             "name": "counts",
@@ -260,23 +207,89 @@ return {
                 "kind": "ScalarField",
                 "name": "artworks",
                 "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "relatedArtists",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "articles",
+                "storageKey": null
               }
             ],
             "storageKey": null
           },
-          (v3/*: any*/)
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtistRelatedData",
+            "kind": "LinkedField",
+            "name": "related",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 1
+                  }
+                ],
+                "concreteType": "GeneConnection",
+                "kind": "LinkedField",
+                "name": "genes",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "GeneEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Gene",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          (v5/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "genes(first:1)"
+              }
+            ],
+            "storageKey": null
+          },
+          (v5/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "66149160b21665150658df55225f1103",
+    "cacheID": "2bd34abc90970abe0d5af720753c1651",
     "id": null,
     "metadata": {},
     "name": "artistRoutes_OverviewQuery",
     "operationKind": "query",
-    "text": "query artistRoutes_OverviewQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistOverviewRoute_artist\n    id\n  }\n}\n\nfragment ArtistOverviewRoute_artist on Artist {\n  internalID\n  name\n  filterArtworksConnection(first: 1) {\n    edges {\n      node {\n        internalID\n        id\n      }\n    }\n    id\n  }\n  insights {\n    __typename\n  }\n  artistSeriesConnection(first: 0) {\n    totalCount\n  }\n  articlesConnection(first: 0) {\n    totalCount\n  }\n  showsConnection(first: 0, status: \"running\") {\n    totalCount\n  }\n  meta(page: ABOUT) {\n    description\n    title\n  }\n  counts {\n    artworks\n  }\n}\n"
+    "text": "query artistRoutes_OverviewQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) {\n    ...ArtistOverviewRoute_artist\n    id\n  }\n}\n\nfragment ArtistOverviewRoute_artist on Artist {\n  internalID\n  name\n  meta(page: ABOUT) {\n    description\n    title\n  }\n  insights {\n    __typename\n  }\n  artistSeriesConnection(first: 0) {\n    totalCount\n  }\n  showsConnection(first: 0, status: \"running\") {\n    totalCount\n  }\n  counts {\n    artworks\n    relatedArtists\n    articles\n  }\n  related {\n    genes(first: 1) {\n      edges {\n        node {\n          __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Closes [DIA-311](https://artsyproduct.atlassian.net/browse/DIA-311)

Few issues uncovered here:
* One of the conditions for rendering the empty state was checking for featured artworks, which was removed, so if an artist had any artworks but nothing else, the page would appear empty
* We did not ever wrap any of these sub-components in the empty check which is two problems: unsure what to remove if the sub-components change and we were fetching for _all_ of those sub-components, even when we knew they weren't there. That lead to an inaccurate skeleton state for the page and extraneous requests to Metaphysics.
* The last two components on the page didn't have conditions factored into the empty state, so on artists where we might have related artists + related categories, we wouldn't display anything.

[DIA-311]: https://artsyproduct.atlassian.net/browse/DIA-311?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ