### PR TITLE
fix(DIA-308): implements less confusing "artists you follow" filter behavior

### DIFF
--- a/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
@@ -37,13 +37,13 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
     owner: {
       type: OwnerType.artist,
       id: artist.internalID,
-      name: artist.name!,
+      name: artist.name ?? "Unknown",
       slug: artist.slug,
     },
     defaultCriteria: {
       artistIDs: [
         {
-          displayValue: artist.name!,
+          displayValue: artist.name ?? "Unknown",
           value: artist.internalID,
         },
       ],
@@ -71,9 +71,7 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
         <BaseArtworkFilter
           relay={relay}
           viewer={artist}
-          Filters={
-            <ArtistArtworkFilters relayEnvironment={relay.environment} />
-          }
+          Filters={<ArtistArtworkFilters />}
           relayVariables={{
             aggregations: ["TOTAL"],
           }}

--- a/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters.tsx
@@ -11,19 +11,15 @@ import { MaterialsFilter } from "Components/ArtworkFilter/ArtworkFilters/Materia
 import { PartnersFilter } from "Components/ArtworkFilter/ArtworkFilters/PartnersFilter"
 import { ArtistsFilter } from "Components/ArtworkFilter/ArtworkFilters/ArtistsFilter"
 import { KeywordFilter } from "Components/ArtworkFilter/ArtworkFilters/KeywordFilter"
-import type RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
 import { useSystemContext } from "System/useSystemContext"
 import { Join, Spacer } from "@artsy/palette"
 import { ProgressiveOnboardingAlertSelectFilter } from "Components/ProgressiveOnboarding/ProgressiveOnboardingAlertSelectFilter"
 import { ArtistSeriesFilter } from "Components/ArtworkFilter/ArtworkFilters/ArtistSeriesFilter"
 import { useFeatureFlag } from "System/useFeatureFlag"
 
-interface ArtistArtworkFiltersProps {
-  relayEnvironment?: RelayModernEnvironment
-}
+interface ArtistArtworkFiltersProps {}
 
 export const ArtistArtworkFilters: React.FC<ArtistArtworkFiltersProps> = props => {
-  const { relayEnvironment } = props
   const { user } = useSystemContext()
   const isArtistSeriesFilterEnabled = useFeatureFlag(
     "onyx_enable-artist-series-filter"
@@ -33,7 +29,7 @@ export const ArtistArtworkFilters: React.FC<ArtistArtworkFiltersProps> = props =
     <Join separator={<Spacer y={4} />}>
       <KeywordFilter />
       {isArtistSeriesFilterEnabled && <ArtistSeriesFilter expanded />}
-      <ArtistsFilter relayEnvironment={relayEnvironment} user={user} expanded />
+      <ArtistsFilter user={user} expanded />
       <ProgressiveOnboardingAlertSelectFilter>
         <AttributionClassFilter expanded />
       </ProgressiveOnboardingAlertSelectFilter>

--- a/src/Apps/Fair/Routes/__tests__/FairArtworks.jest.tsx
+++ b/src/Apps/Fair/Routes/__tests__/FairArtworks.jest.tsx
@@ -74,7 +74,7 @@ describe("FairArtworks", () => {
 
     artistFilter.find("button").simulate("click")
     expect(artistFilter.find("Checkbox").at(0).text()).toMatch(
-      "Artists You Follow (10)"
+      "Artists You Follow"
     )
   })
 })

--- a/src/Components/ArtworkFilter/ArtworkFilters/ShowMore.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/ShowMore.tsx
@@ -1,8 +1,8 @@
-import { Clickable, Text } from "@artsy/palette"
+import { BoxProps, Clickable, Text } from "@artsy/palette"
 import { Children, isValidElement, useState } from "react"
 import * as React from "react"
 
-interface ShowMoreProps {
+interface ShowMoreProps extends BoxProps {
   initial?: number
   expanded?: boolean
 }
@@ -13,6 +13,7 @@ export const ShowMore: React.FC<ShowMoreProps> = ({
   initial = INITIAL_ITEMS_TO_SHOW,
   children,
   expanded = false,
+  ...rest
 }) => {
   const nodes = Children.toArray(children).filter(isValidElement)
   const hasMore = nodes.length > initial
@@ -25,10 +26,12 @@ export const ShowMore: React.FC<ShowMoreProps> = ({
 
       {hasMore && (
         <Clickable
+          // FIXME: Remove external margin
           mt={1}
           textDecoration="underline"
           textAlign="left"
           onClick={() => setExpanded(visibility => !visibility)}
+          {...rest}
         >
           <Text variant="xs">{isExpanded ? "Hide" : "Show more"}</Text>
         </Clickable>

--- a/src/Components/ArtworkFilter/ArtworkFilters/index.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/index.tsx
@@ -11,23 +11,21 @@ import { ArtistNationalityFilter } from "./ArtistNationalityFilter"
 import { MaterialsFilter } from "./MaterialsFilter"
 import { PartnersFilter } from "./PartnersFilter"
 import { ArtistsFilter } from "./ArtistsFilter"
-import type RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
 import { Join, Spacer } from "@artsy/palette"
 import { KeywordFilter } from "Components/ArtworkFilter/ArtworkFilters/KeywordFilter"
 
 interface ArtworkFiltersProps {
   user?: User
-  relayEnvironment?: RelayModernEnvironment
 }
 
 // Some filters will be rendered only if there is the necessary data in aggregations (for example, ArtistsFilter)
 export const ArtworkFilters: React.FC<ArtworkFiltersProps> = props => {
-  const { user, relayEnvironment } = props
+  const { user } = props
 
   return (
     <Join separator={<Spacer y={4} />}>
       <KeywordFilter />
-      <ArtistsFilter relayEnvironment={relayEnvironment} user={user} expanded />
+      <ArtistsFilter user={user} expanded />
       <AttributionClassFilter expanded />
       <MediumFilter expanded />
       <PriceRangeFilter expanded />

--- a/src/Components/ArtworkFilter/index.tsx
+++ b/src/Components/ArtworkFilter/index.tsx
@@ -292,14 +292,7 @@ export const BaseArtworkFilter: React.FC<
 
                         <Spacer y={4} />
 
-                        {Filters ? (
-                          Filters
-                        ) : (
-                          <ArtworkFilters
-                            user={user}
-                            relayEnvironment={relay.environment}
-                          />
-                        )}
+                        {Filters ? Filters : <ArtworkFilters user={user} />}
                       </ArtworkFilterMobileOverlay>
                     )}
                   </ProgressiveOnboardingAlertSelectFilter>
@@ -368,10 +361,7 @@ export const BaseArtworkFilter: React.FC<
                               {Filters ? (
                                 Filters
                               ) : (
-                                <ArtworkFilters
-                                  relayEnvironment={relay.environment}
-                                  user={user}
-                                />
+                                <ArtworkFilters user={user} />
                               )}
                             </Box>
                           </ArtworkFilterMobileOverlay>
@@ -472,14 +462,7 @@ export const BaseArtworkFilter: React.FC<
               <ArtworkFilterSort />
 
               <ArtworkFilterDrawer open={isOpen} onClose={handleClose}>
-                {Filters ? (
-                  Filters
-                ) : (
-                  <ArtworkFilters
-                    user={user}
-                    relayEnvironment={relay.environment}
-                  />
-                )}
+                {Filters ? Filters : <ArtworkFilters user={user} />}
               </ArtworkFilterDrawer>
             </Flex>
 
@@ -522,14 +505,7 @@ export const BaseArtworkFilter: React.FC<
             </Column>
 
             <Column span={3}>
-              {Filters ? (
-                Filters
-              ) : (
-                <ArtworkFilters
-                  user={user}
-                  relayEnvironment={relay.environment}
-                />
-              )}
+              {Filters ? Filters : <ArtworkFilters user={user} />}
             </Column>
 
             <Column

--- a/src/Components/SavedSearchAlert/Utils/extractPills.ts
+++ b/src/Components/SavedSearchAlert/Utils/extractPills.ts
@@ -28,6 +28,7 @@ export const extractPillFromAggregation = (
   aggregations: Aggregations
 ) => {
   const { paramName, paramValue } = filter
+
   const aggregation = aggregationForFilter(paramName, aggregations)
   const aggregationByValue = keyBy(aggregation?.counts, "value")
   const pills = (paramValue as string[]).map(value => {
@@ -67,9 +68,10 @@ export const extractSizeLabel = ({
   value: string
   metric: Metric
 }) => {
-  const [min, max] = parseRange(value, metric)!
+  const [min, max] = parseRange(value, metric)
 
-  let label
+  let label: string
+
   if (max === "*") {
     label = `from ${min}`
   } else if (min === "*") {
@@ -86,7 +88,7 @@ const extractPriceLabel = (range: string) => {
     return value === "*" ? value : (+value).toLocaleString()
   })
 
-  let label
+  let label: string
 
   if (min === "*") {
     label = `$0-$${max}`
@@ -191,6 +193,14 @@ export const extractPillsFromCriteria = ({
             value: paramValue,
             displayValue: extractPriceLabel(paramValue),
           }
+        }
+        break
+      }
+      case "includeArtworksByFollowedArtists": {
+        result = {
+          field: paramName,
+          value: paramValue,
+          displayValue: "Artists You Follow",
         }
         break
       }

--- a/src/Components/SavedSearchAlert/constants.ts
+++ b/src/Components/SavedSearchAlert/constants.ts
@@ -2,13 +2,13 @@ import { Slice } from "Components/ArtworkFilter/ArtworkFilterContext"
 import { SavedSearchFrequency } from "./types"
 
 export const shouldExtractValueNamesFromAggregation = [
+  "additionalGeneIDs",
+  "artistIDs",
+  "artistNationalities",
+  "artistSeriesIDs",
   "locationCities",
   "materialsTerms",
-  "additionalGeneIDs",
   "partnerIDs",
-  "artistIDs",
-  "artistSeriesIDs",
-  "artistNationalities",
 ]
 
 export const aggregationNameFromFilter: Record<string, Slice> = {
@@ -22,25 +22,26 @@ export const aggregationNameFromFilter: Record<string, Slice> = {
 }
 
 export const allowedSearchCriteriaKeys = [
+  "acquireable",
+  "additionalGeneIDs",
   "artistID",
   "artistIDs",
+  "artistNationalities",
   "artistSeriesIDs",
-  "locationCities",
-  "colors",
-  "partnerIDs",
-  "additionalGeneIDs",
-  "attributionClass",
-  "majorPeriods",
-  "acquireable",
   "atAuction",
+  "attributionClass",
+  "colors",
+  "height",
+  "includeArtworksByFollowedArtists",
   "inquireableOnly",
-  "offerable",
+  "locationCities",
+  "majorPeriods",
   "materialsTerms",
+  "offerable",
+  "partnerIDs",
   "priceRange",
   "sizes",
-  "height",
   "width",
-  "artistNationalities",
 ]
 
 export const DEFAULT_FREQUENCY: SavedSearchFrequency = "daily"

--- a/src/Components/SavedSearchAlert/useActiveFilterPills.ts
+++ b/src/Components/SavedSearchAlert/useActiveFilterPills.ts
@@ -5,21 +5,23 @@ import {
   useArtworkFilterContext,
 } from "Components/ArtworkFilter/ArtworkFilterContext"
 import { DEFAULT_METRIC } from "Utils/metrics"
-import { usePrepareFiltersForPills } from "Components/ArtworkFilter/Utils/usePrepareFiltersForPills"
 import { FilterPill } from "./types"
 import { extractPillsFromCriteria } from "./Utils/extractPills"
 import { getAllowedSearchCriteria } from "./Utils/savedSearchCriteria"
 
 export const useActiveFilterPills = (defaultPills: FilterPill[] = []) => {
-  const { aggregations, setFilter } = useArtworkFilterContext()
-  const filters = usePrepareFiltersForPills()
+  const { aggregations, setFilter, filters } = useArtworkFilterContext()
+
   const criteria = getAllowedSearchCriteria(filters ?? {})
+
   const metric = filters?.metric ?? DEFAULT_METRIC
+
   const filterPills = extractPillsFromCriteria({
     criteria,
     aggregations,
     metric,
   })
+
   const pills = [...defaultPills, ...filterPills]
 
   const removePill = (pill: FilterPill) => {
@@ -27,7 +29,7 @@ export const useActiveFilterPills = (defaultPills: FilterPill[] = []) => {
       return
     }
 
-    let filterValue = filters![pill.field]
+    let filterValue = (filters || {})[pill.field]
 
     if (isArray(filterValue)) {
       filterValue = filterValue.filter(value => value !== pill.value)
@@ -36,10 +38,6 @@ export const useActiveFilterPills = (defaultPills: FilterPill[] = []) => {
     }
 
     setFilter(pill.field as keyof ArtworkFilters, filterValue)
-
-    if (pill.field === "artistIDs") {
-      setFilter("includeArtworksByFollowedArtists", false)
-    }
   }
 
   return { pills, removePill }


### PR DESCRIPTION
Closes [DIA-308](https://artsyproduct.atlassian.net/browse/DIA-308)

Q/A of the filters revealed a very confusing behavior: Checking the "Artists You Follow" checkbox would display one or two artist filter pills. Turns out this is because: we fetch [the first 99 artists you follow](https://github.com/artsy/force/blob/2cc6cd481f3e9838c1c953062facec815bd20b8c/src/Components/ArtworkFilter/Utils/fetchFollowedArtists.ts#L37) — if you follow more than that, sorry. We then just cross reference those with whatever happens to land in the artist aggregations. If you tried to edit this selection it would switch out of this mode, but the counts would be completely wrong because you'd still be sending artist IDs which were then un-toggleable. This is not a useful UX.

This PR changes that behavior to the following:
* When you check "Artists You Follow" we just disable any artist checkboxes that are in the aggregations (this does not solve the more than 99 follows problem).
* We display a single filter pill: "Artists You Follow"
* If you start checking more, we just uncheck the artists you follow checkbox and any of the artists that were previously incorporated.

https://github.com/artsy/force/assets/112297/f10eb5a1-3f9f-4e1f-a727-ef99f84cba00




[DIA-308]: https://artsyproduct.atlassian.net/browse/DIA-308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ