### PR TITLE
feat: Add Medium Alert Filter

### DIFF
--- a/src/Components/Alert/Components/Filters/BaseAlertFilter.tsx
+++ b/src/Components/Alert/Components/Filters/BaseAlertFilter.tsx
@@ -1,0 +1,73 @@
+import { Checkbox, Column, GridColumns, Spacer, Text } from "@artsy/palette"
+import { FC } from "react"
+import { useAlertContext } from "Components/Alert/Hooks/useAlertContext"
+import { ShowMore } from "Components/Alert/Components/Filters/ShowMore"
+import { SearchCriteriaAttributeKeys } from "Components/SavedSearchAlert/types"
+
+interface BaseAlertFilterProps {
+  criteriaKey: SearchCriteriaAttributeKeys
+  description?: string
+  expanded?: boolean
+  label: string
+  options: { value: string; name: string }[]
+}
+
+export const BaseAlertFilter: FC<BaseAlertFilterProps> = ({
+  criteriaKey,
+  description,
+  expanded = false,
+  label,
+  options,
+}) => {
+  const { state, dispatch } = useAlertContext()
+
+  const toggleSelection = (selected, name) => {
+    let updatedValues = (state.criteria[criteriaKey] || []) as string[]
+
+    if (selected) {
+      updatedValues = [...updatedValues, name]
+    } else {
+      updatedValues = updatedValues.filter(item => item !== name)
+    }
+
+    dispatch({
+      type: "SET_CRITERIA_ATTRIBUTE",
+      payload: { key: criteriaKey, value: updatedValues },
+    })
+  }
+
+  return (
+    <>
+      <Text variant="sm-display" pb={1}>
+        {label}
+      </Text>
+
+      {!!description && (
+        <Text variant="xs" pb={1} mt={2}>
+          {description}
+        </Text>
+      )}
+
+      <Spacer y={2} />
+
+      <GridColumns>
+        <ShowMore expanded={expanded}>
+          {options.map(({ name, value }, index) => {
+            return (
+              <Column span={6} key={index}>
+                <Checkbox
+                  onSelect={selected => toggleSelection(selected, value)}
+                  selected={(state.criteria[criteriaKey] as
+                    | string[]
+                    | null)?.includes(value)}
+                >
+                  {name}
+                </Checkbox>
+              </Column>
+            )
+          })}
+        </ShowMore>
+      </GridColumns>
+    </>
+  )
+}

--- a/src/Components/Alert/Components/Filters/Medium.tsx
+++ b/src/Components/Alert/Components/Filters/Medium.tsx
@@ -1,51 +1,14 @@
-import { Checkbox, Column, GridColumns, Spacer, Text } from "@artsy/palette"
 import { FC } from "react"
-import { useAlertContext } from "Components/Alert/Hooks/useAlertContext"
 import { MEDIUM_OPTIONS } from "Components/ArtworkFilter/ArtworkFilters/MediumFilter"
-import { ShowMore } from "Components/Alert/Components/Filters/ShowMore"
+import { BaseAlertFilter } from "Components/Alert/Components/Filters/BaseAlertFilter"
 
 export const Medium: FC = () => {
-  const { state, dispatch } = useAlertContext()
-
-  const toggleSelection = (selected, name) => {
-    let updatedValues = state.criteria.additionalGeneIDs || []
-
-    if (selected) {
-      updatedValues = [...updatedValues, name]
-    } else {
-      updatedValues = updatedValues.filter(item => item !== name)
-    }
-
-    dispatch({
-      type: "SET_CRITERIA_ATTRIBUTE",
-      payload: { key: "additionalGeneIDs", value: updatedValues },
-    })
-  }
-
   return (
-    <>
-      <Text variant="sm-display" pb={1}>
-        Medium
-      </Text>
-
-      <Spacer y={2} />
-
-      <GridColumns>
-        <ShowMore expanded={false}>
-          {MEDIUM_OPTIONS.map(({ name, value }, index) => {
-            return (
-              <Column span={6} key={index}>
-                <Checkbox
-                  onSelect={selected => toggleSelection(selected, value)}
-                  selected={state.criteria.additionalGeneIDs?.includes(value)}
-                >
-                  {name}
-                </Checkbox>
-              </Column>
-            )
-          })}
-        </ShowMore>
-      </GridColumns>
-    </>
+    <BaseAlertFilter
+      expanded
+      label="Medium"
+      criteriaKey="additionalGeneIDs"
+      options={MEDIUM_OPTIONS}
+    />
   )
 }

--- a/src/Components/Alert/Components/Filters/Medium.tsx
+++ b/src/Components/Alert/Components/Filters/Medium.tsx
@@ -1,0 +1,74 @@
+import { Checkbox, Column, GridColumns, Text } from "@artsy/palette"
+import { FC } from "react"
+import { useAlertContext } from "Components/Alert/Hooks/useAlertContext"
+import { MEDIUM_OPTIONS } from "Components/ArtworkFilter/ArtworkFilters/MediumFilter"
+import { useArtworkFilterContext } from "Components/ArtworkFilter/ArtworkFilterContext"
+import { sortResults } from "Components/ArtworkFilter/ArtworkFilters/Utils/sortResults"
+import { intersection } from "lodash"
+import {
+  INITIAL_ITEMS_TO_SHOW,
+  ShowMore,
+} from "Components/Alert/Components/Filters/ShowMore"
+
+export const Medium: FC = () => {
+  const { state, dispatch } = useAlertContext()
+  const filters = useArtworkFilterContext()
+
+  const additionalGeneIDs = state.criteria.additionalGeneIDs || []
+
+  const toggleSelection = (selected, name) => {
+    let updatedValues = state.criteria.additionalGeneIDs || []
+
+    if (selected) {
+      updatedValues = [...updatedValues, name]
+    } else {
+      updatedValues = updatedValues.filter(item => item !== name)
+    }
+
+    dispatch({
+      type: "SET_CRITERIA_ATTRIBUTE",
+      payload: { key: "additionalGeneIDs", value: updatedValues },
+    })
+  }
+
+  const mediums = filters.aggregations?.find(agg => agg.slice === "MEDIUM") || {
+    slice: "",
+    counts: [],
+  }
+
+  const allowedMediums = mediums?.counts?.length
+    ? mediums.counts
+    : MEDIUM_OPTIONS
+
+  const intersected = intersection(
+    additionalGeneIDs,
+    allowedMediums.slice(INITIAL_ITEMS_TO_SHOW).map(({ value }) => value)
+  )
+  const hasBelowTheFoldMediumFilter = intersected.length > 0
+  const resultsSorted = sortResults(additionalGeneIDs, allowedMediums)
+
+  return (
+    <>
+      <Text variant="sm-display" mb={3}>
+        Medium
+      </Text>
+
+      <GridColumns>
+        <ShowMore expanded={hasBelowTheFoldMediumFilter}>
+          {resultsSorted.map(({ name, value }, index) => {
+            return (
+              <Column span={6} key={index}>
+                <Checkbox
+                  onSelect={selected => toggleSelection(selected, value)}
+                  selected={state.criteria.additionalGeneIDs?.includes(value)}
+                >
+                  {name}
+                </Checkbox>
+              </Column>
+            )
+          })}
+        </ShowMore>
+      </GridColumns>
+    </>
+  )
+}

--- a/src/Components/Alert/Components/Filters/Medium.tsx
+++ b/src/Components/Alert/Components/Filters/Medium.tsx
@@ -1,10 +1,10 @@
 import { FC } from "react"
 import { MEDIUM_OPTIONS } from "Components/ArtworkFilter/ArtworkFilters/MediumFilter"
-import { BaseAlertFilter } from "Components/Alert/Components/Filters/BaseAlertFilter"
+import { QuickMultipleSelectAlertFilter } from "Components/Alert/Components/Filters/QuickMultipleSelectAlertFilter"
 
 export const Medium: FC = () => {
   return (
-    <BaseAlertFilter
+    <QuickMultipleSelectAlertFilter
       expanded
       label="Medium"
       criteriaKey="additionalGeneIDs"

--- a/src/Components/Alert/Components/Filters/Medium.tsx
+++ b/src/Components/Alert/Components/Filters/Medium.tsx
@@ -2,19 +2,10 @@ import { Checkbox, Column, GridColumns, Spacer, Text } from "@artsy/palette"
 import { FC } from "react"
 import { useAlertContext } from "Components/Alert/Hooks/useAlertContext"
 import { MEDIUM_OPTIONS } from "Components/ArtworkFilter/ArtworkFilters/MediumFilter"
-import { useArtworkFilterContext } from "Components/ArtworkFilter/ArtworkFilterContext"
-import { sortResults } from "Components/ArtworkFilter/ArtworkFilters/Utils/sortResults"
-import { intersection } from "lodash"
-import {
-  INITIAL_ITEMS_TO_SHOW,
-  ShowMore,
-} from "Components/Alert/Components/Filters/ShowMore"
+import { ShowMore } from "Components/Alert/Components/Filters/ShowMore"
 
 export const Medium: FC = () => {
   const { state, dispatch } = useAlertContext()
-  const filters = useArtworkFilterContext()
-
-  const additionalGeneIDs = state.criteria.additionalGeneIDs || []
 
   const toggleSelection = (selected, name) => {
     let updatedValues = state.criteria.additionalGeneIDs || []
@@ -31,22 +22,6 @@ export const Medium: FC = () => {
     })
   }
 
-  const mediums = filters.aggregations?.find(agg => agg.slice === "MEDIUM") || {
-    slice: "",
-    counts: [],
-  }
-
-  const allowedMediums = mediums?.counts?.length
-    ? mediums.counts
-    : MEDIUM_OPTIONS
-
-  const intersected = intersection(
-    additionalGeneIDs,
-    allowedMediums.slice(INITIAL_ITEMS_TO_SHOW).map(({ value }) => value)
-  )
-  const hasBelowTheFoldMediumFilter = intersected.length > 0
-  const resultsSorted = sortResults(additionalGeneIDs, allowedMediums)
-
   return (
     <>
       <Text variant="sm-display" pb={1}>
@@ -56,8 +31,8 @@ export const Medium: FC = () => {
       <Spacer y={2} />
 
       <GridColumns>
-        <ShowMore expanded={hasBelowTheFoldMediumFilter}>
-          {resultsSorted.map(({ name, value }, index) => {
+        <ShowMore expanded={false}>
+          {MEDIUM_OPTIONS.map(({ name, value }, index) => {
             return (
               <Column span={6} key={index}>
                 <Checkbox

--- a/src/Components/Alert/Components/Filters/Medium.tsx
+++ b/src/Components/Alert/Components/Filters/Medium.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Column, GridColumns, Text } from "@artsy/palette"
+import { Checkbox, Column, GridColumns, Spacer, Text } from "@artsy/palette"
 import { FC } from "react"
 import { useAlertContext } from "Components/Alert/Hooks/useAlertContext"
 import { MEDIUM_OPTIONS } from "Components/ArtworkFilter/ArtworkFilters/MediumFilter"
@@ -49,9 +49,11 @@ export const Medium: FC = () => {
 
   return (
     <>
-      <Text variant="sm-display" mb={3}>
+      <Text variant="sm-display" pb={1}>
         Medium
       </Text>
+
+      <Spacer y={2} />
 
       <GridColumns>
         <ShowMore expanded={hasBelowTheFoldMediumFilter}>

--- a/src/Components/Alert/Components/Filters/QuickMultipleSelectAlertFilter.tsx
+++ b/src/Components/Alert/Components/Filters/QuickMultipleSelectAlertFilter.tsx
@@ -4,7 +4,7 @@ import { useAlertContext } from "Components/Alert/Hooks/useAlertContext"
 import { ShowMore } from "Components/Alert/Components/Filters/ShowMore"
 import { SearchCriteriaAttributeKeys } from "Components/SavedSearchAlert/types"
 
-interface BaseAlertFilterProps {
+interface QuickMultipleSelectAlertFilterProps {
   criteriaKey: SearchCriteriaAttributeKeys
   description?: string
   expanded?: boolean
@@ -12,7 +12,7 @@ interface BaseAlertFilterProps {
   options: { value: string; name: string }[]
 }
 
-export const BaseAlertFilter: FC<BaseAlertFilterProps> = ({
+export const QuickMultipleSelectAlertFilter: FC<QuickMultipleSelectAlertFilterProps> = ({
   criteriaKey,
   description,
   expanded = false,

--- a/src/Components/Alert/Components/Filters/Rarity.tsx
+++ b/src/Components/Alert/Components/Filters/Rarity.tsx
@@ -1,62 +1,13 @@
-import { Box, Checkbox, Flex, Spacer, Text } from "@artsy/palette"
+import { BaseAlertFilter } from "Components/Alert/Components/Filters/BaseAlertFilter"
+import { ATTRIBUTION_CLASS_OPTIONS } from "Components/ArtworkFilter/ArtworkFilters/AttributionClassFilter"
 import { FC } from "react"
 
-import { useAlertContext } from "Components/Alert/Hooks/useAlertContext"
-
-export const RARITY_OPTIONS = [
-  {
-    name: "Unique",
-    value: "unique",
-  },
-  {
-    name: "Limited Edition",
-    value: "limited edition",
-  },
-  {
-    name: "Open Edition",
-    value: "open edition",
-  },
-  {
-    name: "Unknown Edition",
-    value: "unknown edition",
-  },
-]
-
 export const Rarity: FC = () => {
-  const { state, dispatch } = useAlertContext()
-  const toggleSelection = (selected, name) => {
-    let updatedValues = state.criteria.attributionClass || []
-
-    if (selected) {
-      updatedValues = [...updatedValues, name]
-    } else {
-      updatedValues = updatedValues.filter(item => item !== name)
-    }
-    dispatch({
-      type: "SET_CRITERIA_ATTRIBUTE",
-      payload: { key: "attributionClass", value: updatedValues },
-    })
-  }
   return (
-    <>
-      <Text variant="sm-display">Rarity</Text>
-      <Spacer y={2} />
-      <Box style={{ columns: "2" }}>
-        <Flex flexDirection="column">
-          {RARITY_OPTIONS.map(({ name, value }, index) => {
-            return (
-              <Checkbox
-                key={index}
-                my={1}
-                onSelect={selected => toggleSelection(selected, value)}
-                selected={state.criteria.attributionClass?.includes(value)}
-              >
-                {name}
-              </Checkbox>
-            )
-          })}
-        </Flex>
-      </Box>
-    </>
+    <BaseAlertFilter
+      label="Rarity"
+      criteriaKey="attributionClass"
+      options={ATTRIBUTION_CLASS_OPTIONS}
+    />
   )
 }

--- a/src/Components/Alert/Components/Filters/Rarity.tsx
+++ b/src/Components/Alert/Components/Filters/Rarity.tsx
@@ -1,10 +1,10 @@
-import { BaseAlertFilter } from "Components/Alert/Components/Filters/BaseAlertFilter"
+import { QuickMultipleSelectAlertFilter } from "Components/Alert/Components/Filters/QuickMultipleSelectAlertFilter"
 import { ATTRIBUTION_CLASS_OPTIONS } from "Components/ArtworkFilter/ArtworkFilters/AttributionClassFilter"
 import { FC } from "react"
 
 export const Rarity: FC = () => {
   return (
-    <BaseAlertFilter
+    <QuickMultipleSelectAlertFilter
       label="Rarity"
       criteriaKey="attributionClass"
       options={ATTRIBUTION_CLASS_OPTIONS}

--- a/src/Components/Alert/Components/Filters/ShowMore.tsx
+++ b/src/Components/Alert/Components/Filters/ShowMore.tsx
@@ -30,7 +30,7 @@ export const ShowMore: React.FC<ShowMoreProps> = ({
             textAlign="left"
             onClick={() => setExpanded(visibility => !visibility)}
           >
-            <Text>{isExpanded ? "Hide" : "Show more"}</Text>
+            {!expanded && <Text>{isExpanded ? "Hide" : "Show more"}</Text>}
           </Clickable>
         </Column>
       )}

--- a/src/Components/Alert/Components/Filters/ShowMore.tsx
+++ b/src/Components/Alert/Components/Filters/ShowMore.tsx
@@ -1,0 +1,39 @@
+import { Clickable, Column, Text } from "@artsy/palette"
+import { Children, isValidElement, useState } from "react"
+import * as React from "react"
+
+interface ShowMoreProps {
+  initial?: number
+  expanded?: boolean
+}
+
+export const INITIAL_ITEMS_TO_SHOW = 6
+
+export const ShowMore: React.FC<ShowMoreProps> = ({
+  initial = INITIAL_ITEMS_TO_SHOW,
+  children,
+  expanded = false,
+}) => {
+  const nodes = Children.toArray(children).filter(isValidElement)
+  const hasMore = nodes.length > initial
+
+  const [isExpanded, setExpanded] = useState(expanded)
+
+  return (
+    <>
+      {isExpanded ? nodes : nodes.slice(0, initial)}
+
+      {hasMore && (
+        <Column span={12}>
+          <Clickable
+            textDecoration="underline"
+            textAlign="left"
+            onClick={() => setExpanded(visibility => !visibility)}
+          >
+            <Text>{isExpanded ? "Hide" : "Show more"}</Text>
+          </Clickable>
+        </Column>
+      )}
+    </>
+  )
+}

--- a/src/Components/Alert/Components/Filters/__tests__/Medium.jest.tsx
+++ b/src/Components/Alert/Components/Filters/__tests__/Medium.jest.tsx
@@ -4,37 +4,50 @@ import {
   useAlertContext,
 } from "Components/Alert/Hooks/useAlertContext"
 import { Medium } from "Components/Alert/Components/Filters/Medium"
+import {
+  ArtworkFilterContextProvider,
+  useArtworkFilterContext,
+} from "Components/ArtworkFilter/ArtworkFilterContext"
 
 jest.mock("Utils/Hooks/useMatchMedia", () => ({
   __internal__useMatchMedia: () => ({}),
 }))
 
 describe("MediumFilter", () => {
+  let filterContext
   let alertContext
 
   const MediumFilterTestComponent = () => {
+    filterContext = useArtworkFilterContext()
     alertContext = useAlertContext()
 
     return <Medium />
   }
 
-  const getWrapper = (initialCriteria = {}) => {
+  const getWrapper = (contextProps = {}, initialCriteria = {}) => {
     return mount(
-      <AlertProvider initialCriteria={initialCriteria}>
-        <MediumFilterTestComponent />
-      </AlertProvider>
+      <ArtworkFilterContextProvider {...contextProps}>
+        <AlertProvider initialCriteria={initialCriteria}>
+          <MediumFilterTestComponent />
+        </AlertProvider>
+      </ArtworkFilterContextProvider>
     )
   }
 
-  it("only shows custom mediums if aggregations passed to context", () => {
+  it("displays all mediums", () => {
     const wrapper = getWrapper()
+
+    expect(wrapper.find("Checkbox").length).toBe(14)
 
     expect(wrapper.html()).toContain("Painting")
   })
 
-  it("shows a maximum of six mediums when not expanded.", () => {
+  it("selects mediums and only updates alert context", () => {
     const wrapper = getWrapper()
 
-    expect(wrapper.find("Checkbox").length).toBe(6)
+    wrapper.find("Checkbox").first().simulate("click")
+
+    expect(alertContext.state.criteria.additionalGeneIDs).toEqual(["painting"])
+    expect(filterContext.filters.additionalGeneIDs).toEqual([])
   })
 })

--- a/src/Components/Alert/Components/Filters/__tests__/Medium.jest.tsx
+++ b/src/Components/Alert/Components/Filters/__tests__/Medium.jest.tsx
@@ -1,0 +1,83 @@
+import { mount } from "enzyme"
+import {
+  AlertProvider,
+  useAlertContext,
+} from "Components/Alert/Hooks/useAlertContext"
+import { Medium } from "Components/Alert/Components/Filters/Medium"
+import {
+  ArtworkFilterContextProvider,
+  useArtworkFilterContext,
+} from "Components/ArtworkFilter/ArtworkFilterContext"
+import { range } from "lodash"
+
+jest.mock("Utils/Hooks/useMatchMedia", () => ({
+  __internal__useMatchMedia: () => ({}),
+}))
+
+describe("MediumFilter", () => {
+  let filterContext
+  let alertContext
+
+  const MediumFilterTestComponent = () => {
+    filterContext = useArtworkFilterContext()
+    alertContext = useAlertContext()
+
+    return <Medium />
+  }
+
+  const getWrapper = (contextProps = {}, initialCriteria = {}) => {
+    return mount(
+      <ArtworkFilterContextProvider {...contextProps}>
+        <AlertProvider initialCriteria={initialCriteria}>
+          <MediumFilterTestComponent />
+        </AlertProvider>
+      </ArtworkFilterContextProvider>
+    )
+  }
+
+  it("only shows custom mediums if aggregations passed to context", () => {
+    const wrapper = getWrapper({
+      aggregations: [
+        {
+          slice: "MEDIUM",
+          counts: [
+            {
+              name: "Foo Medium",
+              value: "foo-medium",
+            },
+          ],
+        },
+      ],
+    })
+
+    expect(wrapper.html()).toContain("Foo Medium")
+    expect(wrapper.html()).not.toContain("Painting")
+  })
+
+  it("selects mediums and only updates alert context", () => {
+    const wrapper = getWrapper()
+
+    wrapper.find("Checkbox").first().simulate("click")
+
+    expect(alertContext.state.criteria.additionalGeneIDs).toEqual(["painting"])
+    expect(filterContext.filters.additionalGeneIDs).toEqual([])
+  })
+
+  it("shows a maximum of six mediums when not expanded.", () => {
+    const wrapper = getWrapper({
+      aggregations: [
+        {
+          slice: "MEDIUM",
+          counts: range(7).map(i => [
+            {
+              name: `Foo Medium ${i}`,
+              value: `foo-medium-${i}`,
+            },
+          ]),
+        },
+      ],
+    })
+
+    expect(wrapper.find("Checkbox").length).toBe(6)
+  })
+})

--- a/src/Components/Alert/Components/Filters/__tests__/Medium.jest.tsx
+++ b/src/Components/Alert/Components/Filters/__tests__/Medium.jest.tsx
@@ -4,79 +4,36 @@ import {
   useAlertContext,
 } from "Components/Alert/Hooks/useAlertContext"
 import { Medium } from "Components/Alert/Components/Filters/Medium"
-import {
-  ArtworkFilterContextProvider,
-  useArtworkFilterContext,
-} from "Components/ArtworkFilter/ArtworkFilterContext"
-import { range } from "lodash"
 
 jest.mock("Utils/Hooks/useMatchMedia", () => ({
   __internal__useMatchMedia: () => ({}),
 }))
 
 describe("MediumFilter", () => {
-  let filterContext
   let alertContext
 
   const MediumFilterTestComponent = () => {
-    filterContext = useArtworkFilterContext()
     alertContext = useAlertContext()
 
     return <Medium />
   }
 
-  const getWrapper = (contextProps = {}, initialCriteria = {}) => {
+  const getWrapper = (initialCriteria = {}) => {
     return mount(
-      <ArtworkFilterContextProvider {...contextProps}>
-        <AlertProvider initialCriteria={initialCriteria}>
-          <MediumFilterTestComponent />
-        </AlertProvider>
-      </ArtworkFilterContextProvider>
+      <AlertProvider initialCriteria={initialCriteria}>
+        <MediumFilterTestComponent />
+      </AlertProvider>
     )
   }
 
   it("only shows custom mediums if aggregations passed to context", () => {
-    const wrapper = getWrapper({
-      aggregations: [
-        {
-          slice: "MEDIUM",
-          counts: [
-            {
-              name: "Foo Medium",
-              value: "foo-medium",
-            },
-          ],
-        },
-      ],
-    })
-
-    expect(wrapper.html()).toContain("Foo Medium")
-    expect(wrapper.html()).not.toContain("Painting")
-  })
-
-  it("selects mediums and only updates alert context", () => {
     const wrapper = getWrapper()
 
-    wrapper.find("Checkbox").first().simulate("click")
-
-    expect(alertContext.state.criteria.additionalGeneIDs).toEqual(["painting"])
-    expect(filterContext.filters.additionalGeneIDs).toEqual([])
+    expect(wrapper.html()).toContain("Painting")
   })
 
   it("shows a maximum of six mediums when not expanded.", () => {
-    const wrapper = getWrapper({
-      aggregations: [
-        {
-          slice: "MEDIUM",
-          counts: range(7).map(i => [
-            {
-              name: `Foo Medium ${i}`,
-              value: `foo-medium-${i}`,
-            },
-          ]),
-        },
-      ],
-    })
+    const wrapper = getWrapper()
 
     expect(wrapper.find("Checkbox").length).toBe(6)
   })

--- a/src/Components/Alert/Components/Steps/Filters.tsx
+++ b/src/Components/Alert/Components/Steps/Filters.tsx
@@ -4,6 +4,7 @@ import { FC } from "react"
 
 import { Rarity } from "Components/Alert/Components/Filters/Rarity"
 import { useAlertContext } from "Components/Alert/Hooks/useAlertContext"
+import { Medium } from "Components/Alert/Components/Filters/Medium"
 
 export const Filters: FC = () => {
   const { goToDetails } = useAlertContext()
@@ -27,6 +28,7 @@ export const Filters: FC = () => {
           <Separator my={2} />
           <Join separator={<Separator my={2} />}>
             <Rarity />
+            <Medium />
           </Join>
         </Box>
       </Flex>


### PR DESCRIPTION
Addresses [ONYX-480]

## Description

This PR adds the Medium filter to the new Alert Filter modal.

It also moves the filter logic, which we would probably need to duplicate between the different filters, into a base filter component.

![Screenshot 2023-11-07 at 13 17 13](https://github.com/artsy/force/assets/4691889/cad0e48a-2837-4c35-af5b-e3dae1e94ecc)




[ONYX-480]: https://artsyproduct.atlassian.net/browse/ONYX-480?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ