### PR TITLE
fix(article): uses channel name; falls back to byline

### DIFF
--- a/src/Apps/Article/Components/ArticleChannelRelatedArticles.tsx
+++ b/src/Apps/Article/Components/ArticleChannelRelatedArticles.tsx
@@ -21,7 +21,7 @@ const ArticleChannelRelatedArticles: FC<ArticleChannelRelatedArticlesProps> = ({
   return (
     <>
       <Text variant="lg-display" mb={4}>
-        More From {article.byline}
+        More From {article.channel?.name || article.byline}
       </Text>
 
       <Shelf alignItems="flex-start">
@@ -44,6 +44,9 @@ export const ArticleChannelRelatedArticlesFragmentContainer = createFragmentCont
     article: graphql`
       fragment ArticleChannelRelatedArticles_article on Article {
         byline
+        channel {
+          name
+        }
         channelArticles {
           internalID
           ...CellArticle_article

--- a/src/__generated__/ArticleChannelRelatedArticlesQuery.graphql.ts
+++ b/src/__generated__/ArticleChannelRelatedArticlesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d0291634c6ad02ea91bf973c04fcfbfc>>
+ * @generated SignedSource<<03391386a306c8dd376f3d5c250aba26>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -94,6 +94,25 @@ return {
         "plural": false,
         "selections": [
           (v2/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Channel",
+            "kind": "LinkedField",
+            "name": "channel",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              },
+              (v3/*: any*/)
+            ],
+            "storageKey": null
+          },
           {
             "alias": null,
             "args": null,
@@ -223,12 +242,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a7fef10af472812fe2d9b5dc94de6a91",
+    "cacheID": "e33a2d7a28c5b621dadb13059f984dc1",
     "id": null,
     "metadata": {},
     "name": "ArticleChannelRelatedArticlesQuery",
     "operationKind": "query",
-    "text": "query ArticleChannelRelatedArticlesQuery(\n  $id: String!\n) {\n  article(id: $id) {\n    ...ArticleChannelRelatedArticles_article\n    id\n  }\n}\n\nfragment ArticleChannelRelatedArticles_article on Article {\n  byline\n  channelArticles {\n    internalID\n    ...CellArticle_article\n    id\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n"
+    "text": "query ArticleChannelRelatedArticlesQuery(\n  $id: String!\n) {\n  article(id: $id) {\n    ...ArticleChannelRelatedArticles_article\n    id\n  }\n}\n\nfragment ArticleChannelRelatedArticles_article on Article {\n  byline\n  channel {\n    name\n    id\n  }\n  channelArticles {\n    internalID\n    ...CellArticle_article\n    id\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArticleChannelRelatedArticles_article.graphql.ts
+++ b/src/__generated__/ArticleChannelRelatedArticles_article.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a3351354fcff18d12b672f65eddcad53>>
+ * @generated SignedSource<<56a9f56dfc6cc5f4a8e94caa20fc1434>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,9 @@ import { Fragment, ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type ArticleChannelRelatedArticles_article$data = {
   readonly byline: string | null;
+  readonly channel: {
+    readonly name: string;
+  } | null;
   readonly channelArticles: ReadonlyArray<{
     readonly internalID: string;
     readonly " $fragmentSpreads": FragmentRefs<"CellArticle_article">;
@@ -34,6 +37,24 @@ const node: ReaderFragment = {
       "args": null,
       "kind": "ScalarField",
       "name": "byline",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Channel",
+      "kind": "LinkedField",
+      "name": "channel",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        }
+      ],
       "storageKey": null
     },
     {
@@ -64,6 +85,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "f14731273fb9b7023f44396acf49ba8f";
+(node as any).hash = "b8121df23a966cee47209d2ddd3c20a3";
 
 export default node;


### PR DESCRIPTION
Closes [DIA-294](https://artsyproduct.atlassian.net/browse/DIA-294)

This component displays articles from the same 'channel.' It's less confusing to use the channel name here over the article byeline.

[DIA-294]: https://artsyproduct.atlassian.net/browse/DIA-294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ