### PR TITLE
feat(relay-test-utils): Add support for mutations

### DIFF
--- a/src/DevTools/setupTestWrapper.tsx
+++ b/src/DevTools/setupTestWrapper.tsx
@@ -128,20 +128,17 @@ export const setupTestWrapperTL = <T extends OperationType>({
     })
 
     const mockResolveLastOperation = (mockResolvers: MockResolvers) => {
-      let operation
+      const operation = env.mock.getMostRecentOperation()
 
       act(() => {
-        env.mock.resolveMostRecentOperation(relayOperation => {
-          operation = relayOperation
-          return MockPayloadGenerator.generate(operation, mockResolvers)
-        })
+        env.mock.resolve(
+          operation,
+          MockPayloadGenerator.generate(operation, mockResolvers)
+        )
       })
 
-      // Cast here to get around use-before-assign rule
-      const _operation = operation as OperationDescriptor
-
-      const operationName = _operation?.request.node.operation.name
-      const operationVariables = _operation?.request.variables
+      const operationName = operation?.request.node.operation.name
+      const operationVariables = operation?.request.variables
 
       return { operation, operationName, operationVariables }
     }


### PR DESCRIPTION
The type of this PR is: **Feat**

### Description

Following Eigen, this allows for better mutation testing support from directly within our common testing patterns. 

### Example

```tsx
it("follows the artist", () => {
  const { mockResolveLastOperation } = renderWithRelay({ Artist: () => artist })

  fireEvent.press(screen.getByText("Follow"))

  mockResolveLastOperation({
    Artist: () => ({
      isFollowed: true,
    }),
  })

  expect(screen.getByText("Following")).toBeOnTheScreen()
})

it("unfollows the artist", () => {
  const { mockResolveLastOperation } = renderWithRelay({
    Artist: () => ({
      isFollowed: true,
    }),
  })

  fireEvent.press(screen.getByText("Following"))

  const { operationName, operationVariables } = mockResolveLastOperation({ 
    Artist: () => ({ 
      isFollowed: false 
    }) 
  })

  expect(screen.getByText("Follow")).toBeOnTheScreen()
  expect(operationName).toBe("foo")
  expect(operationVariables).toBe("bar")
})
```