### PR TITLE
chore: Port mutation helpers to enzyme setupTestWrapper, return destructured wrapper

### DIFF
--- a/src/Apps/Artist/Components/__tests__/ArtistBackLink.jest.tsx
+++ b/src/Apps/Artist/Components/__tests__/ArtistBackLink.jest.tsx
@@ -34,7 +34,7 @@ describe("ArtistBackLink", () => {
   })
 
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Artist: () => ({ name: "Example Artist" }),
     })
 
@@ -42,7 +42,7 @@ describe("ArtistBackLink", () => {
   })
 
   it("tracks correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Artist: () => ({ href: "/artist/example-artist" }),
     })
 

--- a/src/Apps/Artist/Routes/Articles/__tests__/ArtistArticlesRoute.jest.tsx
+++ b/src/Apps/Artist/Routes/Articles/__tests__/ArtistArticlesRoute.jest.tsx
@@ -24,7 +24,7 @@ describe("ArtistArticlesRoute", () => {
   })
 
   it("render a zero state if no articles", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Artist: () => ({
         articlesConnection: { edges: null },
       }),
@@ -33,7 +33,7 @@ describe("ArtistArticlesRoute", () => {
   })
 
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Artist: () => ({
         name: "Example Artist",
       }),

--- a/src/Apps/Artist/Routes/AuctionResults/__tests__/MarketStats.jest.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/__tests__/MarketStats.jest.tsx
@@ -36,7 +36,7 @@ describe("MarketStats", () => {
   })
 
   it("does not render if no price insights", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       PriceInsightConnection: () => ({
         edges: null,
       }),
@@ -45,7 +45,7 @@ describe("MarketStats", () => {
   })
 
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       PriceInsightConnection: () => priceInsightsConnectionFixture,
     })
     expect(wrapper.text()).toContain("Market Signals")
@@ -56,7 +56,7 @@ describe("MarketStats", () => {
   })
 
   it("tracks correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       PriceInsightConnection: () => priceInsightsConnectionFixture,
     })
 

--- a/src/Apps/Artist/Routes/CV/__tests__/ArtistCVRoute.jest.tsx
+++ b/src/Apps/Artist/Routes/CV/__tests__/ArtistCVRoute.jest.tsx
@@ -24,7 +24,7 @@ describe("ArtistCVRoute", () => {
   })
 
   it("renders a message with no show info", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Artist: () => ({
         showsConnection: { edges: null },
       }),
@@ -33,7 +33,7 @@ describe("ArtistCVRoute", () => {
   })
 
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Artist: () => ({
         name: "artistName",
       }),

--- a/src/Apps/Artist/Routes/Overview/Components/__tests__/ArtistCurrentShowsRail.jest.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/__tests__/ArtistCurrentShowsRail.jest.tsx
@@ -29,7 +29,7 @@ describe("ArtistCurrentShowsRail", () => {
   })
 
   it("does not render rail if no shows", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Artist: () => ({
         showsConnection: { edges: null },
       }),
@@ -38,7 +38,7 @@ describe("ArtistCurrentShowsRail", () => {
   })
 
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Artist: () => ({
         name: "artistName",
         slug: "artistSlug",
@@ -59,7 +59,7 @@ describe("ArtistCurrentShowsRail", () => {
   })
 
   it("tracks to shows route", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     wrapper.find("RouterLink").first().simulate("click")
     expect(trackingSpy).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -72,7 +72,7 @@ describe("ArtistCurrentShowsRail", () => {
   })
 
   it("tracks show click", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Artist: () => ({
         internalId: "artistID",
         slug: "artistSlug",

--- a/src/Apps/Artist/Routes/Overview/Components/__tests__/ArtistEditorialNewsGrid.jest.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/__tests__/ArtistEditorialNewsGrid.jest.tsx
@@ -30,7 +30,7 @@ afterEach(() => {
 
 describe("ArtistEditorialNewsGrid", () => {
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Artist: () => ({
         name: "Test Artist",
         articlesConnection: {
@@ -54,7 +54,7 @@ describe("ArtistEditorialNewsGrid", () => {
 
   describe("tracking", () => {
     it("tracks item clicks", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Artist: () => ({
           internalID: "example-artist-id",
           slug: "example-artist-slug",
@@ -75,7 +75,7 @@ describe("ArtistEditorialNewsGrid", () => {
     })
 
     it("tracks view all", () => {
-      const wrapper = getWrapper()
+      const { wrapper } = getWrapper()
 
       wrapper.find("RouterLink").first().simulate("click")
 

--- a/src/Apps/Artist/Routes/Overview/Components/__tests__/ArtistWorksForSaleRail.jest.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/__tests__/ArtistWorksForSaleRail.jest.tsx
@@ -32,7 +32,7 @@ describe("ArtistWorksForSaleRail", () => {
   })
 
   it("does not render rail if no works", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Artist: () => ({
         artworksConnection: { edges: null },
       }),
@@ -41,7 +41,7 @@ describe("ArtistWorksForSaleRail", () => {
   })
 
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Artist: () => ({
         name: "artistName",
         slug: "artistSlug",
@@ -60,7 +60,7 @@ describe("ArtistWorksForSaleRail", () => {
   })
 
   it("tracks to works route", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     wrapper.find("RouterLink").first().simulate("click")
     expect(trackingSpy).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -73,7 +73,7 @@ describe("ArtistWorksForSaleRail", () => {
   })
 
   it("tracks work click", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     wrapper.find("RouterLink").at(2).simulate("click")
     expect(trackingSpy).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/Apps/Artist/__tests__/ArtistApp.jest.tsx
+++ b/src/Apps/Artist/__tests__/ArtistApp.jest.tsx
@@ -35,7 +35,7 @@ describe("ArtistApp", () => {
     it("renders correct components", () => {
       mockfindCurrentRoute.mockImplementation(() => ({}))
 
-      const wrapper = getWrapper(
+      const { wrapper } = getWrapper(
         {
           Artist: () => ({
             statuses: {
@@ -57,7 +57,7 @@ describe("ArtistApp", () => {
 
     it("tabs navigate to the correct urls", () => {
       mockfindCurrentRoute.mockImplementation(() => ({}))
-      const wrapper = getWrapper(
+      const { wrapper } = getWrapper(
         {
           Artist: () => ({
             slug: "artist-slug",

--- a/src/Apps/ArtistSeries/__tests__/ArtistSeriesArtworksFilter.jest.tsx
+++ b/src/Apps/ArtistSeries/__tests__/ArtistSeriesArtworksFilter.jest.tsx
@@ -60,13 +60,13 @@ describe("ArtistSeriesArtworksFilter", () => {
   })
 
   it("renders correctly", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     expect(wrapper.find("ArtworkFilterArtworkGrid").length).toBe(1)
     expect(wrapper.find("ArtworkGridItem").length).toBe(1)
   })
 
   it("renders filters in correct order", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       FilterArtworksConnection: () => ({
         counts: {
           followedArtists: 10,

--- a/src/Apps/Artists/__tests__/ArtistsByLetter.jest.tsx
+++ b/src/Apps/Artists/__tests__/ArtistsByLetter.jest.tsx
@@ -31,7 +31,7 @@ const { getWrapper } = setupTestWrapper<ArtistsByLetterQuery>({
 
 describe("ArtistsByLetter", () => {
   it("renders the page", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
 
     expect(wrapper.find("h1")).toHaveLength(1)
     expect(wrapper.find("h1").text()).toEqual("Artists - A")

--- a/src/Apps/Artists/__tests__/ArtistsIndex.jest.tsx
+++ b/src/Apps/Artists/__tests__/ArtistsIndex.jest.tsx
@@ -29,7 +29,7 @@ const { getWrapper } = setupTestWrapper<
 
 describe("ArtistsIndex", () => {
   it("renders the page", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       OrderedSet: () => ({ name: "Featured Artists" }),
     })
 

--- a/src/Apps/Artwork/Components/ArtworkDetails/__tests__/ArtworkDetails.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/__tests__/ArtworkDetails.jest.tsx
@@ -36,7 +36,7 @@ const { getWrapper } = setupTestWrapper<ArtworkDetails_Test_Query>({
 describe("ArtworkDetails", () => {
   describe("ArtworkDetailsAdditionalInfo for a live sale artwork", () => {
     it("displays a request lot condition report button when canRequestLotConditionsReport is true", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Artwork: () => ({
           canRequestLotConditionsReport: true,
           conditionDescription: {
@@ -53,7 +53,7 @@ describe("ArtworkDetails", () => {
     })
 
     it("display condition description when canRequestLotConditionsReport is false but has condition description", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Artwork: () => ({
           canRequestLotConditionsReport: false,
           conditionDescription: {
@@ -68,7 +68,7 @@ describe("ArtworkDetails", () => {
     })
 
     it("does not display the condition section at all when canRequestLotConditionsReport is false and condition Description is missing", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Artwork: () => ({
           canRequestLotConditionsReport: false,
           conditionDescription: null,
@@ -81,7 +81,7 @@ describe("ArtworkDetails", () => {
 
   describe("ArtworkDetails for a gallery artwork that is missing some fields", () => {
     it("renders additional info with just what is present", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Artwork: () => ({
           series: null,
           publisher: null,
@@ -123,7 +123,7 @@ describe("ArtworkDetails", () => {
       }),
     }
 
-    const wrapper = getWrapper(emptyData)
+    const { wrapper } = getWrapper(emptyData)
 
     expect(wrapper.find("ArtworkDetailsAdditionalInfo").find("dl").length).toBe(
       0
@@ -132,7 +132,7 @@ describe("ArtworkDetails", () => {
 
   describe("ArtworkDetails for gallery artwork with complete details", () => {
     it("renders a correct component tree", () => {
-      const wrapper = getWrapper()
+      const { wrapper } = getWrapper()
       const html = wrapper.html()
 
       expect(html).toContain("About the work")
@@ -145,7 +145,7 @@ describe("ArtworkDetails", () => {
 
   describe("ArtworkDetailsAboutTheWorkFromPartner", () => {
     it("displays partner additionalInformation for artwork", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Artwork: () => ({
           additionalInformation: "Here is some additional info for this work",
         }),
@@ -157,7 +157,7 @@ describe("ArtworkDetails", () => {
     })
 
     it("does not display avatar when profile is not available and no initials for partner", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Partner: () => ({ profile: null, initials: null }),
       })
 
@@ -167,7 +167,7 @@ describe("ArtworkDetails", () => {
     })
 
     it("does not render partner follow button if artwork is from an auction partner", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Partner: () => ({
           type: "Auction House",
         }),
@@ -177,7 +177,7 @@ describe("ArtworkDetails", () => {
     })
 
     it("works without a partner", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Artwork: () => ({
           partner: null,
         }),

--- a/src/Apps/Artwork/Components/ArtworkDetails/__tests__/RequestConditionReport.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/__tests__/RequestConditionReport.jest.tsx
@@ -88,7 +88,7 @@ describe("RequestConditionReport", () => {
   })
 
   it("requests a condition report and tracks click event", async () => {
-    const wrapper = getWrapper(
+    const { wrapper } = getWrapper(
       {
         Artwork: () => artwork,
       },
@@ -114,7 +114,7 @@ describe("RequestConditionReport", () => {
   })
 
   it("shows a toast if the mutation fails", async () => {
-    const wrapper = getWrapper(
+    const { wrapper } = getWrapper(
       {
         Artwork: () => artwork,
       },
@@ -144,7 +144,7 @@ describe("RequestConditionReport", () => {
       })
 
       me = null
-      const wrapper = getWrapper(
+      const { wrapper } = getWrapper(
         {
           Artwork: () => artwork,
         },

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkActions.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkActions.jest.tsx
@@ -72,7 +72,7 @@ describe("ArtworkActions", () => {
     it("renders proper components for a team user", () => {
       mockUserIsAdmin = true
       mockUserIsTeam = true
-      const wrapper = getWrapper()
+      const { wrapper } = getWrapper()
 
       expect(wrapper.find(EditIcon).length).toBe(1)
       expect(wrapper.find(GenomeIcon).length).toBe(1)
@@ -82,7 +82,7 @@ describe("ArtworkActions", () => {
     it("renders proper components for a non-team user", () => {
       mockUserIsAdmin = false
       mockUserIsTeam = false
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Artwork: () => ({ isHangable: true, isDownloadable: true }),
       })
 
@@ -97,21 +97,21 @@ describe("ArtworkActions", () => {
 
     describe("concerning SaveButton states icon states", () => {
       it("renders heart icon when not sale", () => {
-        const wrapper = getWrapper({ Artwork: () => ({ sale: null }) })
+        const { wrapper } = getWrapper({ Artwork: () => ({ sale: null }) })
 
         expect(wrapper.find(HeartStrokeIcon).length).toBe(1)
         expect(wrapper.find(BellStrokeIcon).length).toBe(0)
       })
 
       it("renders heart icon when sale is closed", () => {
-        const wrapper = getWrapper({ Sale: () => ({ isClosed: true }) })
+        const { wrapper } = getWrapper({ Sale: () => ({ isClosed: true }) })
 
         expect(wrapper.find(HeartStrokeIcon).length).toBe(1)
         expect(wrapper.find(BellStrokeIcon).length).toBe(0)
       })
 
       it("renders bell icon when sale is open", () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           Sale: () => ({
             isAuction: true,
             isClosed: false,
@@ -125,13 +125,17 @@ describe("ArtworkActions", () => {
 
     describe("view in a room", () => {
       it("available for artworks that are hangable", () => {
-        const wrapper = getWrapper({ Artwork: () => ({ isHangable: true }) })
+        const { wrapper } = getWrapper({
+          Artwork: () => ({ isHangable: true }),
+        })
 
         expect(wrapper.find(ShowIcon).length).toBe(1)
       })
 
       it("is not available for non hangable artworks", () => {
-        const wrapper = getWrapper({ Artwork: () => ({ isHangable: false }) })
+        const { wrapper } = getWrapper({
+          Artwork: () => ({ isHangable: false }),
+        })
 
         expect(wrapper.find(ShowIcon).length).toBe(0)
       })
@@ -142,7 +146,7 @@ describe("ArtworkActions", () => {
         it("renders link if isDownloadable", () => {
           mockUserIsAdmin = false
           mockUserIsTeam = false
-          const wrapper = getWrapper({
+          const { wrapper } = getWrapper({
             Artwork: () => ({ isDownloadable: true }),
           })
 
@@ -152,7 +156,7 @@ describe("ArtworkActions", () => {
         it("renders link if admin", () => {
           mockUserIsAdmin = true
           mockUserIsTeam = true
-          const wrapper = getWrapper({
+          const { wrapper } = getWrapper({
             Artwork: () => ({ isDownloadable: false }),
           })
 
@@ -162,7 +166,7 @@ describe("ArtworkActions", () => {
         it("hides link if isDownloadable=false and the user is not an admin", () => {
           mockUserIsAdmin = false
           mockUserIsTeam = false
-          const wrapper = getWrapper({
+          const { wrapper } = getWrapper({
             Artwork: () => ({ isDownloadable: false }),
           })
 
@@ -176,7 +180,7 @@ describe("ArtworkActions", () => {
     const getWrapper = getWrapperWithBreakpoint("xs")
 
     it("shows the More icon", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Artwork: () => ({ isHangable: true, isDownloadable: true }),
       })
 
@@ -192,7 +196,7 @@ describe("ArtworkActions", () => {
     it("shows no More icon if there are <= 3 actions", () => {
       mockUserIsAdmin = false
       mockUserIsTeam = false
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Artwork: () => ({ isDownloadable: false, isHangable: true }),
       })
 

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkImageBrowserLarge.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkImageBrowserLarge.jest.tsx
@@ -37,7 +37,7 @@ const { getWrapper } = setupTestWrapper<ArtworkImageBrowserLarge_Test_Query>({
 
 describe("ArtworkImageBrowserLarge", () => {
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Artwork: () => ({
         figures: [{ __typename: "Image" }],
       }),

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkImageBrowserSmall.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkImageBrowserSmall.jest.tsx
@@ -35,7 +35,7 @@ const { getWrapper } = setupTestWrapper<ArtworkImageBrowserSmall_Test_Query>({
 
 describe("ArtworkImageBrowserSmall", () => {
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Artwork: () => ({
         figures: [{ __typename: "Image" }],
       }),

--- a/src/Apps/Artwork/Components/ArtworkTopContextBar/__tests__/ArtworkTopContextBar.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkTopContextBar/__tests__/ArtworkTopContextBar.jest.tsx
@@ -19,7 +19,7 @@ describe("ArtworkTopContextBar", () => {
   })
 
   it("if no in show or auction or fair, render nothing", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Artwork: () => ({
         context: null,
       }),
@@ -30,7 +30,7 @@ describe("ArtworkTopContextBar", () => {
 
   describe("sale", () => {
     it("does not render if sale is invalid", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Artwork: () => ({
           sale: null,
         }),
@@ -39,7 +39,7 @@ describe("ArtworkTopContextBar", () => {
     })
 
     it("renders a sale banner", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Artwork: () => ({
           context: {
             __typename: "Sale",
@@ -66,7 +66,7 @@ describe("ArtworkTopContextBar", () => {
     })
 
     it("does not render partnerName if benefit or gallery auction", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Artwork: () => ({
           context: {
             __typename: "Sale",
@@ -87,7 +87,7 @@ describe("ArtworkTopContextBar", () => {
 
     describe("the auction registration countdown", () => {
       it("does not render by default", () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           Artwork: () => ({
             context: {
               __typename: "Sale",
@@ -114,7 +114,7 @@ describe("ArtworkTopContextBar", () => {
         const registrationEndsAt = DateTime.local()
           .plus({ hours: 1 })
           .toString()
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           Artwork: () => ({
             context: {
               __typename: "Sale",
@@ -141,7 +141,7 @@ describe("ArtworkTopContextBar", () => {
         const registrationEndsAt = DateTime.local()
           .plus({ hours: 1 })
           .toString()
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           Artwork: () => ({
             context: {
               __typename: "Sale",
@@ -168,7 +168,7 @@ describe("ArtworkTopContextBar", () => {
 
   describe("fair", () => {
     it("renders a fair banner", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Artwork: () => ({
           context: {
             __typename: "Fair",
@@ -192,7 +192,7 @@ describe("ArtworkTopContextBar", () => {
 
   describe("show", () => {
     it("renders a show banner with default status", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Artwork: () => ({
           context: {
             __typename: "Show",
@@ -215,7 +215,7 @@ describe("ArtworkTopContextBar", () => {
     })
 
     it("renders upcoming status", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Artwork: () => ({
           context: {
             __typename: "Show",
@@ -228,7 +228,7 @@ describe("ArtworkTopContextBar", () => {
     })
 
     it("renders closed status", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Artwork: () => ({
           context: {
             __typename: "Show",

--- a/src/Apps/Artwork/Components/TrustSignals/__tests__/AuthenticityCertificate.jest.tsx
+++ b/src/Apps/Artwork/Components/TrustSignals/__tests__/AuthenticityCertificate.jest.tsx
@@ -17,7 +17,7 @@ const { getWrapper } = setupTestWrapper({
 
 describe("AuthenticityCertificate", () => {
   it("Doesn't render when there's no certificate of authenticity", async () => {
-    const component = getWrapper({
+    const { wrapper } = getWrapper({
       Artwork: () => {
         return {
           hasCertificateOfAuthenticity: false,
@@ -26,13 +26,13 @@ describe("AuthenticityCertificate", () => {
         }
       },
     })
-    expect(component.text()).not.toContain(
+    expect(wrapper.text()).not.toContain(
       "Includes a Certificate of Authenticity."
     )
   })
 
   it("Doesn't render when the artwork is biddable", async () => {
-    const component = getWrapper({
+    const { wrapper } = getWrapper({
       Artwork: () => {
         return {
           hasCertificateOfAuthenticity: true,
@@ -41,13 +41,13 @@ describe("AuthenticityCertificate", () => {
         }
       },
     })
-    expect(component.text()).not.toContain(
+    expect(wrapper.text()).not.toContain(
       "Includes a Certificate of Authenticity."
     )
   })
 
   it("Renders when there's a certificate of authenticity, but the work is not biddable", async () => {
-    const component = getWrapper({
+    const { wrapper } = getWrapper({
       Artwork: () => {
         return {
           hasCertificateOfAuthenticity: true,
@@ -56,9 +56,7 @@ describe("AuthenticityCertificate", () => {
         }
       },
     })
-    expect(component.text()).toContain(
-      "Includes a Certificate of Authenticity."
-    )
+    expect(wrapper.text()).toContain("Includes a Certificate of Authenticity.")
   })
 
   it.todo("Click on certificate of authenticity link opens modal")

--- a/src/Apps/Artwork/Components/TrustSignals/__tests__/BuyerGuarantee.jest.tsx
+++ b/src/Apps/Artwork/Components/TrustSignals/__tests__/BuyerGuarantee.jest.tsx
@@ -1,5 +1,5 @@
 import { graphql } from "react-relay"
-import { BuyerGuaranteeFragmentContainer } from "../BuyerGuarantee"
+import { BuyerGuaranteeFragmentContainer } from "Apps/Artwork/Components/TrustSignals/BuyerGuarantee"
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
 
 jest.unmock("react-relay")
@@ -17,7 +17,7 @@ const { getWrapper } = setupTestWrapper({
 
 describe("BuyerGuarantee", () => {
   it("Doesn't render when work is neither acquireable nor offerable", async () => {
-    const component = getWrapper({
+    const { wrapper } = getWrapper({
       Artwork: () => {
         return {
           is_acquireable: false,
@@ -25,11 +25,11 @@ describe("BuyerGuarantee", () => {
         }
       },
     })
-    expect(component.find("TrustSignal").length).toBe(0)
+    expect(wrapper.find("TrustSignal").length).toBe(0)
   })
 
   it("Renders when the artwork is acquireable", async () => {
-    const component = getWrapper({
+    const { wrapper } = getWrapper({
       Artwork: () => {
         return {
           is_acquireable: true,
@@ -37,11 +37,11 @@ describe("BuyerGuarantee", () => {
         }
       },
     })
-    expect(component.find("TrustSignal").length).toBe(1)
+    expect(wrapper.find("TrustSignal").length).toBe(1)
   })
 
   it("Renders when the artwork is offerable", async () => {
-    const component = getWrapper({
+    const { wrapper } = getWrapper({
       Artwork: () => {
         return {
           is_acquireable: false,
@@ -49,6 +49,6 @@ describe("BuyerGuarantee", () => {
         }
       },
     })
-    expect(component.find("TrustSignal").length).toBe(1)
+    expect(wrapper.find("TrustSignal").length).toBe(1)
   })
 })

--- a/src/Apps/Artwork/Components/TrustSignals/__tests__/SecurePayment.jest.tsx
+++ b/src/Apps/Artwork/Components/TrustSignals/__tests__/SecurePayment.jest.tsx
@@ -1,5 +1,5 @@
 import { graphql } from "react-relay"
-import { SecurePaymentFragmentContainer } from "../SecurePayment"
+import { SecurePaymentFragmentContainer } from "Apps/Artwork/Components/TrustSignals/SecurePayment"
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
 
 jest.unmock("react-relay")
@@ -17,7 +17,7 @@ const { getWrapper } = setupTestWrapper({
 
 describe("SecurePayment", () => {
   it("Doesn't render when work is neither acquireable nor offerable", async () => {
-    const component = getWrapper({
+    const { wrapper } = getWrapper({
       Artwork: () => {
         return {
           is_acquireable: false,
@@ -25,11 +25,11 @@ describe("SecurePayment", () => {
         }
       },
     })
-    expect(component.find("TrustSignal").length).toBe(0)
+    expect(wrapper.find("TrustSignal").length).toBe(0)
   })
 
   it("Renders when the artwork is acquireable", async () => {
-    const component = getWrapper({
+    const { wrapper } = getWrapper({
       Artwork: () => {
         return {
           is_acquireable: true,
@@ -37,11 +37,11 @@ describe("SecurePayment", () => {
         }
       },
     })
-    expect(component.find("TrustSignal").length).toBe(1)
+    expect(wrapper.find("TrustSignal").length).toBe(1)
   })
 
   it("Renders when the artwork is offerable", async () => {
-    const component = getWrapper({
+    const { wrapper } = getWrapper({
       Artwork: () => {
         return {
           is_acquireable: false,
@@ -49,6 +49,6 @@ describe("SecurePayment", () => {
         }
       },
     })
-    expect(component.find("TrustSignal").length).toBe(1)
+    expect(wrapper.find("TrustSignal").length).toBe(1)
   })
 })

--- a/src/Apps/Artwork/Components/TrustSignals/__tests__/VerifiedSeller.jest.tsx
+++ b/src/Apps/Artwork/Components/TrustSignals/__tests__/VerifiedSeller.jest.tsx
@@ -1,5 +1,5 @@
 import { graphql } from "react-relay"
-import { VerifiedSellerFragmentContainer } from "../VerifiedSeller"
+import { VerifiedSellerFragmentContainer } from "Apps/Artwork/Components/TrustSignals/VerifiedSeller"
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
 
 jest.unmock("react-relay")
@@ -19,7 +19,7 @@ const partnerName = "partner-name"
 
 describe("VerifiedSeller", () => {
   it("Doesn't render when the partner is a verified seller", async () => {
-    const component = getWrapper({
+    const { wrapper } = getWrapper({
       Artwork: () => {
         return {
           id: "opaque-seller-id",
@@ -32,11 +32,11 @@ describe("VerifiedSeller", () => {
         }
       },
     })
-    expect(component.find("TrustSignal").length).toBe(0)
+    expect(wrapper.find("TrustSignal").length).toBe(0)
   })
 
   it("Doesn't render when the artwork is biddable", async () => {
-    const component = getWrapper({
+    const { wrapper } = getWrapper({
       Artwork: () => {
         return {
           id: "opaque-seller-id",
@@ -49,11 +49,11 @@ describe("VerifiedSeller", () => {
         }
       },
     })
-    expect(component.find("TrustSignal").length).toBe(0)
+    expect(wrapper.find("TrustSignal").length).toBe(0)
   })
 
   it("Renders when the partner is a verified seller, but the work is not biddable", async () => {
-    const component = getWrapper({
+    const { wrapper } = getWrapper({
       Artwork: () => {
         return {
           id: "opaque-seller-id",
@@ -66,7 +66,7 @@ describe("VerifiedSeller", () => {
         }
       },
     })
-    expect(component.find("TrustSignal").length).toBe(1)
-    expect(component.text()).toContain(partnerName)
+    expect(wrapper.find("TrustSignal").length).toBe(1)
+    expect(wrapper.text()).toContain(partnerName)
   })
 })

--- a/src/Apps/Artwork/Components/__tests__/ArtworkDetailsMediumModal.jest.tsx
+++ b/src/Apps/Artwork/Components/__tests__/ArtworkDetailsMediumModal.jest.tsx
@@ -35,7 +35,7 @@ const { getWrapper } = setupTestWrapper<ArtworkDetailsMediumModal_Test_Query>({
 
 describe("ArtworkDetailsMediumModal", () => {
   it("renders the mediumType", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Artwork: () => ({
         mediumType: {
           longDescription:

--- a/src/Apps/Artwork/Components/__tests__/ArtworkLightbox.jest.tsx
+++ b/src/Apps/Artwork/Components/__tests__/ArtworkLightbox.jest.tsx
@@ -1,6 +1,6 @@
 import { graphql } from "react-relay"
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
-import { ArtworkLightboxFragmentContainer } from "../ArtworkLightbox"
+import { ArtworkLightboxFragmentContainer } from "Apps/Artwork/Components/ArtworkLightbox"
 
 jest.unmock("react-relay")
 jest.mock("react-head", () => ({
@@ -27,12 +27,12 @@ describe("ArtworkLightbox", () => {
   }
 
   it("does not error out if activeIndex is undefined", () => {
-    const wrapper = setup({ activeIndex: null }).getWrapper()
+    const { wrapper } = setup({ activeIndex: null }).getWrapper()
     expect(wrapper.html()).toBeFalsy()
   })
 
   it("renders correctly", () => {
-    const wrapper = setup().getWrapper()
+    const { wrapper } = setup().getWrapper()
     expect(wrapper.find("Image").length).toBeTruthy()
   })
 })

--- a/src/Apps/Artwork/Components/__tests__/ArtworkSidebarClassificationsModal.jest.tsx
+++ b/src/Apps/Artwork/Components/__tests__/ArtworkSidebarClassificationsModal.jest.tsx
@@ -1,4 +1,4 @@
-import { ArtworkSidebarClassificationsModalFragmentContainer } from "../ArtworkSidebarClassificationsModal"
+import { ArtworkSidebarClassificationsModalFragmentContainer } from "Apps/Artwork/Components/ArtworkSidebarClassificationsModal"
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
 import { graphql } from "react-relay"
 
@@ -35,7 +35,7 @@ const getWrapperWithResponsibilityMessage = (showDisclaimer?: boolean) =>
 describe("ArtworkSidebarClassificationsModal", () => {
   it("renders the classifications with disclaimer", () => {
     const { getWrapper } = getWrapperWithResponsibilityMessage(true)
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       AttributionClass: () => ({
         name: "Unique",
         longDescription: "One of a kind piece, created by the artist.",
@@ -53,7 +53,7 @@ describe("ArtworkSidebarClassificationsModal", () => {
 
   it("renders the classifications without disclaimer", () => {
     const { getWrapper } = getWrapperWithResponsibilityMessage(false)
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       AttributionClass: () => ({
         name: "Unique",
         longDescription: "One of a kind piece, created by the artist.",

--- a/src/Apps/Auction/Components/AuctionDetails/__tests__/AuctionDetails.jest.tsx
+++ b/src/Apps/Auction/Components/AuctionDetails/__tests__/AuctionDetails.jest.tsx
@@ -1,5 +1,5 @@
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
-import { AuctionDetailsFragmentContainer } from "../AuctionDetails"
+import { AuctionDetailsFragmentContainer } from "Apps/Auction/Components/AuctionDetails/AuctionDetails"
 import { AuctionDetailsTestQuery } from "__generated__/AuctionDetailsTestQuery.graphql"
 import { graphql } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -36,7 +36,7 @@ describe("AuctionDetails", () => {
   })
 
   it("shows correct title", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Sale: () => ({
         name: "Auction Name",
       }),
@@ -45,7 +45,7 @@ describe("AuctionDetails", () => {
   })
 
   it("shows register button", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Sale: () => ({
         name: "Auction Name",
         isRegistrationClosed: false,
@@ -55,7 +55,7 @@ describe("AuctionDetails", () => {
   })
 
   it.skip("shows formatted start time", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Sale: () => ({
         auctionsDetailFormattedStartDateTime: "Mar 22, 2022 • 9:22pm GMT",
       }),
@@ -64,7 +64,7 @@ describe("AuctionDetails", () => {
   })
 
   it("shows add to calendar button", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Sale: () => ({
         isClosed: false,
       }),
@@ -73,7 +73,7 @@ describe("AuctionDetails", () => {
   })
 
   it("shows sale description", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Sale: () => ({
         description: "Auction description",
       }),
@@ -82,7 +82,7 @@ describe("AuctionDetails", () => {
   })
 
   it("shows the sidebar info", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     expect(wrapper.find("AuctionInfoSidebarFragmentContainer").length).toBe(1)
   })
 })

--- a/src/Apps/Auction/Components/AuctionDetails/__tests__/AuctionInfoSidebar.jest.tsx
+++ b/src/Apps/Auction/Components/AuctionDetails/__tests__/AuctionInfoSidebar.jest.tsx
@@ -1,6 +1,6 @@
 import { graphql } from "react-relay"
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
-import { AuctionInfoSidebarFragmentContainer } from "../AuctionInfoSidebar"
+import { AuctionInfoSidebarFragmentContainer } from "Apps/Auction/Components/AuctionDetails/AuctionInfoSidebar"
 import { AuctionInfoSidebarTestQuery } from "__generated__/AuctionInfoSidebarTestQuery.graphql"
 
 jest.unmock("react-relay")
@@ -20,7 +20,7 @@ describe("AuctionInfoSidebar", () => {
   })
 
   it("renders correct components", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     expect(wrapper.find("LiveAuctionToolTip")).toHaveLength(1)
     expect(wrapper.text()).toContain("How to bid on Artsy?")
     expect(wrapper.html()).toContain("/how-auctions-work")

--- a/src/Apps/Auction/Components/__tests__/AuctionActiveBids.jest.tsx
+++ b/src/Apps/Auction/Components/__tests__/AuctionActiveBids.jest.tsx
@@ -40,7 +40,7 @@ describe("AuctionActiveBids", () => {
         slug: "auction-slug",
       },
     })
-    return getWrapper
+    return { getWrapper }
   }
 
   beforeAll(() => {
@@ -63,10 +63,10 @@ describe("AuctionActiveBids", () => {
   })
 
   describe("mobile", () => {
-    const getWrapper = setup("sm")
+    const { getWrapper } = setup("sm")
 
     it("renders correct components", () => {
-      const wrapper = getWrapper()
+      const { wrapper } = getWrapper()
       expect(wrapper.text()).toContain("Your Active Bids")
       expect(
         wrapper.find("AuctionLotInfoFragmentContainer").exists()
@@ -77,10 +77,10 @@ describe("AuctionActiveBids", () => {
   })
 
   describe("desktop", () => {
-    const getWrapper = setup("lg")
+    const { getWrapper } = setup("lg")
 
     it("renders correct components", () => {
-      const wrapper = getWrapper()
+      const { wrapper } = getWrapper()
       expect(wrapper.text()).toContain("Your Active Bids")
       expect(
         wrapper.find("AuctionLotInfoFragmentContainer").exists()
@@ -88,7 +88,7 @@ describe("AuctionActiveBids", () => {
     })
 
     it("shows current bid", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Me: () => ({
           lotStandings: [
             {
@@ -107,7 +107,7 @@ describe("AuctionActiveBids", () => {
 
     describe("auction with cascading lots, some closed", () => {
       it("displays bidding closed for a lot that has closed", () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           Me: () => ({
             lotStandings: [
               {
@@ -137,7 +137,7 @@ describe("AuctionActiveBids", () => {
 
     describe("current bid", () => {
       it("shows current bid count", () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           Me: () => ({
             lotStandings: [
               {
@@ -155,7 +155,7 @@ describe("AuctionActiveBids", () => {
       })
 
       it("handles pluralization", () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           Me: () => ({
             lotStandings: [
               {
@@ -188,7 +188,7 @@ describe("AuctionActiveBids", () => {
       },
     }))
 
-    const wrapper = setup("sm")({
+    const { wrapper } = setup("sm").getWrapper({
       Me: () => ({
         internalID: "me-id",
       }),
@@ -218,7 +218,7 @@ describe("AuctionActiveBids", () => {
       },
     }))
 
-    const wrapper = setup("sm")({
+    const { wrapper } = setup("sm").getWrapper({
       Me: () => ({
         internalID: "me-id",
       }),

--- a/src/Apps/Auction/Components/__tests__/AuctionArtworkFilter.jest.tsx
+++ b/src/Apps/Auction/Components/__tests__/AuctionArtworkFilter.jest.tsx
@@ -47,7 +47,7 @@ describe("AuctionArtworkFilter", () => {
   })
 
   it("renders correct components", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     expect(wrapper.find("ArtworkGridContextProvider")).toHaveLength(1)
     expect(
       (wrapper.find("ArtworkGridContextProvider").props() as any)
@@ -57,7 +57,7 @@ describe("AuctionArtworkFilter", () => {
   })
 
   it("displays correct default sort", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     expect(
       (wrapper.find("ArtworkFilter").props() as any).sortOptions[0]
     ).toEqual({
@@ -67,7 +67,7 @@ describe("AuctionArtworkFilter", () => {
   })
 
   it("passes in correct slug from router into relayRefetchInputVariables", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     expect(
       (wrapper.find("ArtworkFilter").props() as any).relayRefetchInputVariables
     ).toEqual(

--- a/src/Apps/Auction/Components/__tests__/AuctionAssociatedSale.jest.tsx
+++ b/src/Apps/Auction/Components/__tests__/AuctionAssociatedSale.jest.tsx
@@ -20,7 +20,7 @@ describe("AuctionAssociatedSale", () => {
   })
 
   it("renders correct components", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Sale: () => ({
         name: "Sale Name",
         displayTimelyAt: "Starts tomorrow",

--- a/src/Apps/Auction/Components/__tests__/AuctionBuyNowRail.jest.tsx
+++ b/src/Apps/Auction/Components/__tests__/AuctionBuyNowRail.jest.tsx
@@ -1,6 +1,6 @@
 import { graphql } from "react-relay"
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
-import { AuctionBuyNowRailFragmentContainer } from "../AuctionBuyNowRail"
+import { AuctionBuyNowRailFragmentContainer } from "Apps/Auction/Components/AuctionBuyNowRail"
 import { AuctionBuyNowRailTestQuery } from "__generated__/AuctionBuyNowRailTestQuery.graphql"
 
 jest.unmock("react-relay")
@@ -20,12 +20,12 @@ describe("AuctionBuyNowRail", () => {
   })
 
   it("renders correct components", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     expect(wrapper.find("Rail")).toHaveLength(1)
   })
 
   it("renders correct title", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     expect(wrapper.text()).toContain("Buy Now")
   })
 })

--- a/src/Apps/Auction/Components/__tests__/AuctionWorksByFollowedArtistsRail.jest.tsx
+++ b/src/Apps/Auction/Components/__tests__/AuctionWorksByFollowedArtistsRail.jest.tsx
@@ -1,7 +1,7 @@
 import { graphql } from "react-relay"
 import { DateTime } from "luxon"
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
-import { AuctionWorksByFollowedArtistsRailFragmentContainer } from "../AuctionWorksByFollowedArtistsRail"
+import { AuctionWorksByFollowedArtistsRailFragmentContainer } from "Apps/Auction/Components/AuctionWorksByFollowedArtistsRail"
 import { AuctionWorksByFollowedArtistsRailTestQuery } from "__generated__/AuctionWorksByFollowedArtistsRailTestQuery.graphql"
 
 jest.unmock("react-relay")
@@ -23,12 +23,12 @@ describe("AuctionWorksByFollowedArtistsRail", () => {
   })
 
   it("renders correct components", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     expect(wrapper.find("Rail")).toHaveLength(1)
   })
 
   it("renders correct title", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     expect(wrapper.text()).toContain("Works By Artists You Follow")
   })
 
@@ -37,7 +37,7 @@ describe("AuctionWorksByFollowedArtistsRail", () => {
     const startDate = baseDate.minus({ hours: 1 })
     const endDate = baseDate.plus({ hours: 1 })
 
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Viewer: () => ({
         saleArtworksConnection: {
           edges: [

--- a/src/Apps/Auction/Components/__tests__/RegisterButton.jest.tsx
+++ b/src/Apps/Auction/Components/__tests__/RegisterButton.jest.tsx
@@ -56,7 +56,7 @@ describe("RegisterButton", () => {
   })
 
   it("returns null if ecommerce sale", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Sale: () => ({
         isAuction: false,
       }),
@@ -66,7 +66,7 @@ describe("RegisterButton", () => {
   })
 
   it("returns null if sale is closed", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Sale: () => ({
         isClosed: true,
       }),
@@ -77,7 +77,7 @@ describe("RegisterButton", () => {
 
   describe("live open", () => {
     it("renders correctly", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Sale: () => ({
           isLiveOpen: true,
         }),
@@ -89,7 +89,7 @@ describe("RegisterButton", () => {
 
   describe("qualified for bidding", () => {
     it("renders correctly", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Sale: () => ({
           isPreview: false,
           bidder: {
@@ -107,7 +107,7 @@ describe("RegisterButton", () => {
 
   describe("should prompt ID verification", () => {
     it("renders correctly", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Sale: () => ({
           requireIdentityVerification: true,
           bidder: {
@@ -130,7 +130,7 @@ describe("RegisterButton", () => {
 
   describe("registration pending", () => {
     it("renders correctly without identity verification", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Sale: () => ({
           requireIdentityVerification: true,
           bidder: {
@@ -150,7 +150,7 @@ describe("RegisterButton", () => {
     })
 
     it("renders correctly with identity verification", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Sale: () => ({
           requireIdentityVerification: false,
           bidder: {
@@ -166,7 +166,7 @@ describe("RegisterButton", () => {
 
   describe("registration closed", () => {
     it("renders correctly", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Sale: () => ({
           isRegistrationClosed: true,
         }),
@@ -178,7 +178,7 @@ describe("RegisterButton", () => {
 
   describe("registration open", () => {
     it("renders correctly with identity verification", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Sale: () => ({
           isClosed: false,
           isLiveOpen: false,
@@ -195,7 +195,7 @@ describe("RegisterButton", () => {
     })
 
     it("renders correctly without identity verification", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Sale: () => ({
           isClosed: false,
           isLiveOpen: false,
@@ -215,7 +215,7 @@ describe("RegisterButton", () => {
         return { showAuthDialog }
       })
 
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Me: () => ({
           internalID: null,
         }),
@@ -252,7 +252,7 @@ describe("RegisterButton", () => {
         },
       }))
 
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Me: () => ({
           hasCreditCards: false,
         }),
@@ -278,7 +278,7 @@ describe("RegisterButton", () => {
         },
       }))
 
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Me: () => ({
           hasCreditCards: true,
         }),
@@ -310,7 +310,7 @@ describe("RegisterButton", () => {
         },
       }))
 
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Sale: () => ({
           isLiveOpen: true,
           liveURLIfOpen: "live-url",
@@ -331,7 +331,7 @@ describe("RegisterButton", () => {
         },
       }))
 
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Me: () => ({
           internalID: "me-id",
           isIdentityVerified: false,
@@ -368,7 +368,7 @@ describe("RegisterButton", () => {
         },
       }))
 
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Me: () => ({
           hasCreditCards: true,
         }),

--- a/src/Apps/Auction/Routes/Bid/__tests__/AuctionBidRoute.jest.tsx
+++ b/src/Apps/Auction/Routes/Bid/__tests__/AuctionBidRoute.jest.tsx
@@ -129,7 +129,7 @@ describe("AuctionBidRoute", () => {
   })
 
   it("has the correct ModalDialog title", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Sale: () => ({
         name: "Sale Name",
       }),
@@ -157,7 +157,7 @@ describe("AuctionBidRoute", () => {
       },
     }))
 
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Sale: () => ({
         slug: "sale-slug",
       }),
@@ -171,7 +171,7 @@ describe("AuctionBidRoute", () => {
   })
 
   it("renders correct components", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Sale: () => ({
         bidder: null,
       }),
@@ -189,7 +189,7 @@ describe("AuctionBidRoute", () => {
   })
 
   it("doesn't ask for credit card info if user has one on file", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Sale: () => ({
         bidder: null,
       }),
@@ -209,7 +209,7 @@ describe("AuctionBidRoute", () => {
       submitBid: spy,
     }))
 
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     ;(wrapper.find("Formik").props() as any).onSubmit(values, helpers)
 
     expect(spy).toHaveBeenCalledWith(values, helpers)
@@ -238,7 +238,7 @@ describe("AuctionBidRoute", () => {
       },
     }))
 
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     ;(wrapper.find("Select").props() as any).onSelect("1000")
 
     expect(spy).toHaveBeenCalledWith({

--- a/src/Apps/Auction/Routes/__tests__/AuctionConfirmRegistrationRoute.jest.tsx
+++ b/src/Apps/Auction/Routes/__tests__/AuctionConfirmRegistrationRoute.jest.tsx
@@ -97,7 +97,7 @@ describe("AuctionConfirmRegistrationRoute", () => {
   })
 
   it("has the correct ModalDialog title", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Sale: () => ({
         name: "Sale Name",
       }),
@@ -120,7 +120,7 @@ describe("AuctionConfirmRegistrationRoute", () => {
       },
     }))
 
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Sale: () => ({
         slug: "sale-slug",
       }),
@@ -134,7 +134,7 @@ describe("AuctionConfirmRegistrationRoute", () => {
   })
 
   it("shows identity verification notification", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Sale: () => ({
         requireIdentityVerification: true,
         bidder: {
@@ -151,7 +151,7 @@ describe("AuctionConfirmRegistrationRoute", () => {
   })
 
   it("hides identity verification notification", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Sale: () => ({
         requireIdentityVerification: false,
       }),
@@ -166,7 +166,7 @@ describe("AuctionConfirmRegistrationRoute", () => {
   it.each([[true], [false]])(
     "hides phone number input if phoneNumber is present and requireIdentityVerification is %s",
     requireIdentityVerification => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Sale: () => ({
           requireIdentityVerification,
         }),
@@ -188,7 +188,7 @@ describe("AuctionConfirmRegistrationRoute", () => {
   it.each([[true], [false]])(
     "shows phone number input if phoneNumber is not present and requireIdentityVerification is %s",
     requireIdentityVerification => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Sale: () => ({
           requireIdentityVerification,
         }),
@@ -208,7 +208,7 @@ describe("AuctionConfirmRegistrationRoute", () => {
   )
 
   it("renders correct components", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Me: () => ({
         hasQualifiedCreditCards: true,
       }),
@@ -288,7 +288,7 @@ describe("AuctionConfirmRegistrationRoute", () => {
   })
 
   it("returns null if no qualified credit card", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Me: () => ({
         hasQualifiedCreditCards: false,
       }),
@@ -327,7 +327,7 @@ describe("AuctionConfirmRegistrationRoute", () => {
         },
       }))
 
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Sale: () => ({
           slug: "sale-slug",
           internalID: "saleInternalID",

--- a/src/Apps/Auction/Routes/__tests__/AuctionRegistrationRoute.jest.tsx
+++ b/src/Apps/Auction/Routes/__tests__/AuctionRegistrationRoute.jest.tsx
@@ -171,7 +171,7 @@ describe("AuctionRegistrationRoute", () => {
   })
 
   it("has the correct ModalDialog title", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     expect((wrapper.find("ModalDialog").props() as any).title).toEqual(
       "Register to Bid on Artsy"
     )
@@ -186,7 +186,7 @@ describe("AuctionRegistrationRoute", () => {
       },
     }))
 
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Sale: () => ({
         slug: "sale-slug",
       }),
@@ -197,7 +197,7 @@ describe("AuctionRegistrationRoute", () => {
   })
 
   it("shows identity verification notification", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Sale: () => ({
         requireIdentityVerification: true,
         bidder: {
@@ -214,7 +214,7 @@ describe("AuctionRegistrationRoute", () => {
   })
 
   it("hides identity verification notification", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Sale: () => ({
         requireIdentityVerification: false,
       }),
@@ -227,7 +227,7 @@ describe("AuctionRegistrationRoute", () => {
   })
 
   it("renders correct components", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Sale: () => ({
         requireIdentityVerification: true,
       }),
@@ -253,7 +253,7 @@ describe("AuctionRegistrationRoute", () => {
         },
       }))
 
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Sale: () => ({
           slug: "sale-slug",
           internalID: "saleInternalID",

--- a/src/Apps/Auction/__tests__/AuctionApp.jest.tsx
+++ b/src/Apps/Auction/__tests__/AuctionApp.jest.tsx
@@ -106,24 +106,24 @@ describe("AuctionApp", () => {
 
   it("embeds Salesforce widget", () => {
     mockGetENV.mockImplementation(() => ({ SALESFORCE_CHAT_ENABLED: true }))
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     expect(wrapper.find("SalesforceWrapper").exists()).toBeFalsy()
   })
 
   it("does not embed Salesforce widget on mobile", () => {
     breakpoint = "xs"
     mockGetENV.mockImplementation(() => ({ SALESFORCE_CHAT_ENABLED: true }))
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     expect(wrapper.find("SalesforceWrapper").exists()).toBeFalsy()
   })
 
   it("shows header if coverImage", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     expect(wrapper.find("FullBleedHeader").exists()).toBeTruthy()
   })
 
   it("hides header if no cover image", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Sale: () => ({
         coverImage: null,
       }),
@@ -132,7 +132,7 @@ describe("AuctionApp", () => {
   })
 
   it("renders auction details", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     expect(
       wrapper.find("AuctionDetailsFragmentContainer").exists()
     ).toBeTruthy()
@@ -140,7 +140,7 @@ describe("AuctionApp", () => {
 
   describe("explanatory banner for cascading", () => {
     it("includes banner when cascading is enabled", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Sale: () => ({
           cascadingEndTimeIntervalMinutes: 1,
         }),
@@ -152,7 +152,7 @@ describe("AuctionApp", () => {
     })
 
     it("hides banner when cascading is disabled", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Sale: () => ({
           cascadingEndTimeIntervalMinutes: null,
         }),
@@ -166,7 +166,7 @@ describe("AuctionApp", () => {
 
   describe("Tabs", () => {
     it("hides tab bar if conditions not met", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Me: () => ({
           showActiveBids: null,
         }),
@@ -184,7 +184,7 @@ describe("AuctionApp", () => {
 
     describe("Associated Sale", () => {
       it("shows tab", () => {
-        const wrapper = getWrapper()
+        const { wrapper } = getWrapper()
         wrapper.find("Tabs Clickable").at(0).simulate("click")
         wrapper.update()
         expect(
@@ -193,7 +193,7 @@ describe("AuctionApp", () => {
       })
 
       it("hides tab", () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           Sale: () => ({
             showAssociatedSale: null,
           }),
@@ -206,7 +206,7 @@ describe("AuctionApp", () => {
 
     describe("ActiveBids", () => {
       it("shows tab", () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           Me: () => ({
             showActiveBids: [1],
           }),
@@ -223,7 +223,7 @@ describe("AuctionApp", () => {
       })
 
       it("hides tab", () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           Me: () => ({
             showActiveBids: null,
           }),
@@ -237,7 +237,7 @@ describe("AuctionApp", () => {
 
     describe("Works by artists you follow", () => {
       it("shows tab", () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           Me: () => ({
             showActiveBids: [1],
           }),
@@ -262,7 +262,7 @@ describe("AuctionApp", () => {
       })
 
       it("hides tab", () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           Viewer: () => ({
             showFollowedArtistsTab: null,
           }),
@@ -278,7 +278,7 @@ describe("AuctionApp", () => {
 
     describe("Buy now tab", () => {
       it("shows tab", () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           Sale: () => ({
             showBuyNowTab: true,
             isClosed: false,
@@ -296,7 +296,7 @@ describe("AuctionApp", () => {
       })
 
       it("hides tab", () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           Sale: () => ({
             showBuyNowTab: null,
           }),
@@ -311,7 +311,7 @@ describe("AuctionApp", () => {
 
   describe("preview sales", () => {
     it("does not show message if there are eligible sale artworks", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Sale: () => ({
           status: "preview",
           eligibleSaleArtworksCount: 1,
@@ -326,7 +326,7 @@ describe("AuctionApp", () => {
     })
 
     it("shows message", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Sale: () => ({
           status: "preview",
           eligibleSaleArtworksCount: 0,
@@ -342,7 +342,7 @@ describe("AuctionApp", () => {
     })
 
     it("renders the auction rail", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Sale: () => ({
           status: "preview",
           eligibleSaleArtworksCount: 0,
@@ -352,7 +352,7 @@ describe("AuctionApp", () => {
     })
 
     it("does not render the auction rail", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Sale: () => ({}),
       })
       expect(wrapper.find("AuctionCurrentAuctionsRail").length).toBe(0)

--- a/src/Apps/Auctions/Components/MyBids/__tests__/MyBids.jest.tsx
+++ b/src/Apps/Auctions/Components/MyBids/__tests__/MyBids.jest.tsx
@@ -32,7 +32,7 @@ describe("MyBids", () => {
   })
 
   it("renders the correct components", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     expect(wrapper.find("CarouselRail")).toBeDefined()
     expect(wrapper.find("SaleContainer")).toBeDefined()
     expect(wrapper.find("MyBidsBidHeaderFragmentContainer")).toBeDefined()
@@ -40,7 +40,7 @@ describe("MyBids", () => {
   })
 
   it("renders the Bid Now button if only user interaction is registration and button links out to sale", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Me: () => ({
         myBids: {
           active: [
@@ -60,7 +60,7 @@ describe("MyBids", () => {
   })
 
   it("tracks clicks on the only registered button", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Me: () => ({
         myBids: {
           active: [

--- a/src/Apps/Auctions/Components/MyBids/__tests__/MyBidsBidHeader.jest.tsx
+++ b/src/Apps/Auctions/Components/MyBids/__tests__/MyBidsBidHeader.jest.tsx
@@ -32,7 +32,7 @@ describe("MyBidsBidHeaderFragmentContainer", () => {
   })
 
   it("renders correct components and data", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Sale: () => ({
         coverImage: {
           cropped: {
@@ -65,7 +65,7 @@ describe("MyBidsBidHeaderFragmentContainer", () => {
   })
 
   it("tracks clicks", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     wrapper.find("RouterLink").first().simulate("click")
     expect(trackEvent).toHaveBeenCalledWith({
       action: "clickedAuctionGroup",

--- a/src/Apps/Auctions/Components/MyBids/__tests__/MyBidsBidItem.jest.tsx
+++ b/src/Apps/Auctions/Components/MyBids/__tests__/MyBidsBidItem.jest.tsx
@@ -37,7 +37,7 @@ describe("MyBidsBidItem", () => {
   })
 
   it("renders correct components and data", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       SaleArtwork: () => ({
         slug: "saleArtworkSlug",
         name: "saleArtworkName",
@@ -77,7 +77,7 @@ describe("MyBidsBidItem", () => {
   describe("component behavior", () => {
     describe("when watching", () => {
       it("shows highest bid amount", () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           SaleArtwork: () => ({
             isWatching: true,
             currentBid: {
@@ -91,7 +91,7 @@ describe("MyBidsBidItem", () => {
       })
 
       it("shows estimate if no highest bid", () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           SaleArtwork: () => ({
             isWatching: true,
             estimate: "estimate",
@@ -108,7 +108,7 @@ describe("MyBidsBidItem", () => {
 
     describe("when not watching", () => {
       it("shows the current bid", () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           SaleArtwork: () => ({
             isWatching: false,
             currentBid: {
@@ -122,7 +122,7 @@ describe("MyBidsBidItem", () => {
       })
 
       it("shows proper bid label when only one bid", () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           SaleArtwork: () => ({
             isWatching: false,
             lotState: {
@@ -136,7 +136,7 @@ describe("MyBidsBidItem", () => {
       })
 
       it("shows proper bid label when multiple bids", () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           SaleArtwork: () => ({
             isWatching: false,
             lotState: {
@@ -152,7 +152,7 @@ describe("MyBidsBidItem", () => {
   })
 
   it("tracks clicks", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     wrapper.find("RouterLink").first().simulate("click")
     expect(trackEvent.mock.calls[0]).toMatchInlineSnapshot(`
       [

--- a/src/Apps/Auctions/Routes/__tests__/CurrentAuctions.jest.tsx
+++ b/src/Apps/Auctions/Routes/__tests__/CurrentAuctions.jest.tsx
@@ -47,7 +47,7 @@ describe("CurrentAuctions", () => {
   })
 
   it("renders zerostate if no auctions", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       SaleConnection: () => ({
         edges: [],
       }),
@@ -57,7 +57,7 @@ describe("CurrentAuctions", () => {
   })
 
   it("renders current auctions and correct components", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       SaleConnection: () => ({
         totalCount: 5,
         pageInfo: {

--- a/src/Apps/Auctions/Routes/__tests__/PastAuctions.jest.tsx
+++ b/src/Apps/Auctions/Routes/__tests__/PastAuctions.jest.tsx
@@ -47,7 +47,7 @@ describe("PastAuctions", () => {
   })
 
   it("renders zerostate if no auctions", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       SaleConnection: () => ({
         edges: [],
       }),
@@ -57,7 +57,7 @@ describe("PastAuctions", () => {
   })
 
   it("renders past auctions and correct components", async () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       SaleConnection: () => ({
         totalCount: 5,
         pageInfo: {

--- a/src/Apps/Auctions/Routes/__tests__/UpcomingAuctions.jest.tsx
+++ b/src/Apps/Auctions/Routes/__tests__/UpcomingAuctions.jest.tsx
@@ -47,7 +47,7 @@ describe("UpcomingAuctions", () => {
   })
 
   it("renders zerostate if no auctions", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       SaleConnection: () => ({
         edges: [],
       }),
@@ -57,7 +57,7 @@ describe("UpcomingAuctions", () => {
   })
 
   it("renders upcoming auctions and correct components", async () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       SaleConnection: () => ({
         totalCount: 5,
         pageInfo: {

--- a/src/Apps/Auctions/__tests__/AuctionsApp.jest.tsx
+++ b/src/Apps/Auctions/__tests__/AuctionsApp.jest.tsx
@@ -48,33 +48,33 @@ describe("AuctionsApp", () => {
   })
 
   it("displays the auctions landing page", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     expect(wrapper.find("AuctionsMeta").length).toBe(1)
   })
 
   it("renders the Current Auctions tab by default", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     const html = wrapper.html()
 
     expect(html).toContain("Current Auctions")
   })
 
   it("renders the Upcoming tab by default", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     const html = wrapper.html()
 
     expect(html).toContain("Upcoming")
   })
 
   it("renders the Past tab by default", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     const html = wrapper.html()
 
     expect(html).toContain("Past")
   })
 
   it("redirects to the Bid At Auction page", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     expect(wrapper.find("RouterLink")).toBeDefined()
     expect(wrapper.find("RouterLink").first().props().to).toBe(
       "https://support.artsy.net/s/article/How-do-I-place-a-bid-in-an-auction"
@@ -86,7 +86,7 @@ describe("AuctionsApp", () => {
       user: null,
     }))
 
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     const html = wrapper.html()
     expect(html).toContain("Trending Lots")
   })
@@ -96,13 +96,13 @@ describe("AuctionsApp", () => {
       user: null,
     }))
 
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     const html = wrapper.html()
     expect(html).toContain("Current Highlights")
   })
 
   it("does not render auctions if they are not present", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       salesConnection: () => ({ edges: [] }),
     })
 
@@ -119,7 +119,7 @@ describe("AuctionsApp", () => {
       user: null,
     }))
 
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
 
     expect(wrapper.find("MyBidsFragmentContainer").length).toBe(0)
     expect(

--- a/src/Apps/Categories/Components/__tests__/GeneFamilies.jest.tsx
+++ b/src/Apps/Categories/Components/__tests__/GeneFamilies.jest.tsx
@@ -28,7 +28,7 @@ const { getWrapper } = setupTestWrapper<GeneFamilies_Test_Query>({
 
 describe("GeneFamilies", () => {
   it("renders gene families", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       GeneFamilyConnection: () => ({
         edges: [
           {

--- a/src/Apps/Collect/Routes/Collection/Components/__tests__/CollectionArtworksFilter.jest.tsx
+++ b/src/Apps/Collect/Routes/Collection/Components/__tests__/CollectionArtworksFilter.jest.tsx
@@ -70,13 +70,13 @@ describe("CollectionArtworksFilter", () => {
   })
 
   it("renders correctly", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     expect(wrapper.find("ArtworkFilterArtworkGrid").length).toBe(1)
     expect(wrapper.find("ArtworkGridItem").length).toBe(1)
   })
 
   it("renders filters in correct order for just collection", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       MarketingCollectionQuery: () => ({
         artistIDs: [],
       }),
@@ -142,7 +142,7 @@ describe("CollectionArtworksFilter", () => {
   })
 
   it("renders filters in correct order for artist's collection", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       MarketingCollectionQuery: () => ({
         artistIDs: ["some-unique-artist-id"],
       }),

--- a/src/Apps/Fair/Components/FairEditorial/__tests__/FairEditorialRailArticles.jest.tsx
+++ b/src/Apps/Fair/Components/FairEditorial/__tests__/FairEditorialRailArticles.jest.tsx
@@ -19,7 +19,7 @@ describe("FairEditorialRailArticles", () => {
   })
 
   it("renders shelf containing 4 editorial items", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Fair: () => ({
         articlesConnection: {
           edges: [

--- a/src/Apps/Fair/Components/__tests__/ExhibitorsLetterNav.jest.tsx
+++ b/src/Apps/Fair/Components/__tests__/ExhibitorsLetterNav.jest.tsx
@@ -30,14 +30,14 @@ const { getWrapper } = setupTestWrapper<ExhibitorsLetterNav_Test_Query>({
 
 describe("ExhibitorsLetterNav", () => {
   it("displays 27 elements", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Fair: () => ({ exhibitorsGroupedByName }),
     })
     expect(wrapper.find("Letter").length).toBe(27)
   })
 
   it("displays letters either enabled or disabled", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Fair: () => ({ exhibitorsGroupedByName }),
     })
 
@@ -59,7 +59,7 @@ describe("ExhibitorsLetterNav", () => {
   })
 
   it("displays letters with proper on-hover title", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Fair: () => ({ exhibitorsGroupedByName }),
     })
 

--- a/src/Apps/Fair/Components/__tests__/FairBooths.jest.tsx
+++ b/src/Apps/Fair/Components/__tests__/FairBooths.jest.tsx
@@ -49,7 +49,7 @@ describe("FairBooths", () => {
   })
 
   it("renders the rails from exhibitors that have artworks", async () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Fair: () => ({
         edges: [
           {
@@ -64,7 +64,7 @@ describe("FairBooths", () => {
   })
 
   it("skips over any partners with no artworks", async () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Fair: () => ({
         edges: [
           {
@@ -83,13 +83,13 @@ describe("FairBooths", () => {
   })
 
   it("renders pagination", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     expect(wrapper.find(Pagination)).toHaveLength(1)
   })
 
   describe("sort", () => {
     it("renders correctly", () => {
-      const wrapper = getWrapper()
+      const { wrapper } = getWrapper()
       const text = wrapper.find(FairBoothSortFilter).text()
       expect(wrapper.find(FairBoothSortFilter).length).toBe(1)
       expect(text).toContain("Sort:")
@@ -98,7 +98,7 @@ describe("FairBooths", () => {
     })
 
     it("changes selected value on click", () => {
-      const wrapper = getWrapper()
+      const { wrapper } = getWrapper()
       const sort = wrapper.find(SortFilter)
       expect(sort.find("option")).toHaveLength(2)
       expect(sort.prop("selected")).toEqual("FEATURED_DESC")
@@ -107,7 +107,7 @@ describe("FairBooths", () => {
     })
 
     it("calls refetch with proper params", () => {
-      const wrapper = getWrapper()
+      const { wrapper } = getWrapper()
       const refetchSpy = jest.spyOn(
         (wrapper.find("FairBooths").props() as any).relay,
         "refetch"

--- a/src/Apps/Fair/Components/__tests__/FairHeader.jest.tsx
+++ b/src/Apps/Fair/Components/__tests__/FairHeader.jest.tsx
@@ -21,7 +21,7 @@ const { getWrapper } = setupTestWrapper({
 
 describe("FairHeader", () => {
   it("displays fair name", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Fair: () => ({
         name: "Miart 2020",
         slug: "miart-2020",

--- a/src/Apps/Fair/Components/__tests__/FairTimer.jest.tsx
+++ b/src/Apps/Fair/Components/__tests__/FairTimer.jest.tsx
@@ -19,7 +19,7 @@ describe("FairTimer", () => {
   })
 
   it("should return closed if the fair has passed", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Fair: () => ({
         startAt: "2020-08-19T08:00:00+00:00",
         endAt: "2020-09-19T08:00:00+00:00",
@@ -33,7 +33,7 @@ describe("FairTimer", () => {
     const startAt = DateTime.local().plus({ days: 1 }).toString()
     const endAt = DateTime.local().plus({ days: 2 }).toString()
 
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Fair: () => ({
         startAt,
         endAt,

--- a/src/Apps/Fair/Routes/__tests__/FairArticles.jest.tsx
+++ b/src/Apps/Fair/Routes/__tests__/FairArticles.jest.tsx
@@ -18,7 +18,7 @@ const { getWrapper } = setupTestWrapper({
 
 describe("FairArticles", () => {
   it("renders the articles", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Article: () => ({
         thumbnailTitle: "Example Article",
         byline: "Example Author",
@@ -32,7 +32,7 @@ describe("FairArticles", () => {
   })
 
   it("renders an empty state when there are no articles", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Fair: () => ({
         articlesConnection: {
           totalCount: 0,

--- a/src/Apps/Fair/Routes/__tests__/FairArtworks.jest.tsx
+++ b/src/Apps/Fair/Routes/__tests__/FairArtworks.jest.tsx
@@ -56,7 +56,7 @@ describe("FairArtworks", () => {
   })
 
   it("renders correctly", async () => {
-    const wrapper = await getWrapper({
+    const { wrapper } = await getWrapper({
       Fair: () => FAIR_ARTWORKS_FIXTURE.fair,
     })
 
@@ -65,7 +65,7 @@ describe("FairArtworks", () => {
   })
 
   it("includes the artist filter", async () => {
-    const wrapper = await getWrapper({
+    const { wrapper } = await getWrapper({
       Fair: () => FAIR_ARTWORKS_FIXTURE.fair,
     })
 

--- a/src/Apps/Fair/Routes/__tests__/FairOverview.jest.tsx
+++ b/src/Apps/Fair/Routes/__tests__/FairOverview.jest.tsx
@@ -41,7 +41,7 @@ describe("FairOverview", () => {
   })
 
   it("displays the about information", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Fair: () => ({
         about: "This is the about.",
       }),
@@ -51,7 +51,7 @@ describe("FairOverview", () => {
   })
 
   it("displays Read more if about section contains more than 480 symbols", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Fair: () => ({
         about:
           "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum bibendum nulla sit amet erat vehicula, ut scelerisque purus interdum. Quisque vel pretium arcu. Phasellus nunc tellus, laoreet eget cursus a, vehicula sit amet erat. Integer porttitor mollis tellus, ultrices euismod dolor aliquet et. Integer placerat turpis vitae ligula dignissim commodo. Vivamus id sapien eros. Vestibulum consequat, lacus eu facilisis auctor, dui odio dignissim arcu, nec tincidunt erat eros sed libero.",
@@ -62,7 +62,7 @@ describe("FairOverview", () => {
   })
 
   it("renders articles if they are present", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Fair: () => ({
         href: "/fair/example",
       }),
@@ -75,7 +75,7 @@ describe("FairOverview", () => {
   })
 
   it("does not render the collection when it is missing", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Fair: () => ({ marketingCollections: [] }),
     })
 
@@ -84,7 +84,7 @@ describe("FairOverview", () => {
   })
 
   it("does not render articles when they are missing", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Fair: () => ({
         href: "/fair/example",
         articlesConnection: {
@@ -97,7 +97,7 @@ describe("FairOverview", () => {
   })
 
   it("renders the collection when it is present", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       MarketingCollection: () => ({
         title: "Big Artists, Small Sculptures",
       }),
@@ -115,7 +115,7 @@ describe("FairOverview", () => {
     const openTime = new Date()
     openTime.setDate(openTime.getDate() + 1)
 
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Fair: () => ({
         endAt: openTime.toISOString(),
       }),
@@ -128,7 +128,7 @@ describe("FairOverview", () => {
     const closeTime = new Date()
     closeTime.setDate(closeTime.getDate() - 1)
 
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Fair: () => ({
         endAt: closeTime.toISOString(),
       }),

--- a/src/Apps/FairOrginizer/Components/FairOrganizerHeader/__tests__/FairOrganizerHeader.jest.tsx
+++ b/src/Apps/FairOrginizer/Components/FairOrganizerHeader/__tests__/FairOrganizerHeader.jest.tsx
@@ -22,7 +22,7 @@ const { getWrapper } = setupTestWrapper({
 
 describe("FairOrganizerHeader", () => {
   it("displays link to the fair page", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Fair: () => ({
         href: "fair/art-paris-2020",
       }),
@@ -33,7 +33,7 @@ describe("FairOrganizerHeader", () => {
   })
 
   it("displays title with organizer name", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       FairOrganizer: () => ({
         name: "Art Paris",
       }),
@@ -42,14 +42,14 @@ describe("FairOrganizerHeader", () => {
   })
 
   it("displays icon, follow button, and info", () => {
-    const wrapper = getWrapper({})
+    const { wrapper } = getWrapper({})
     expect(wrapper.html()).toContain("HeaderIcon")
     expect(wrapper.find("FairOrganizerFollowButton").length).toBe(1)
     expect(wrapper.find("FairOrganizerInfo").length).toBe(1)
   })
 
   it("displays period", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Fair: () => ({
         exhibitionPeriod: "Sep 10 - 19",
       }),
@@ -59,13 +59,13 @@ describe("FairOrganizerHeader", () => {
 
   it("doesn't display timer if event is passed", () => {
     const startAt = DateTime.local().minus({ days: 1 }).toString()
-    const wrapper = getWrapper({ Fair: () => ({ startAt }) })
+    const { wrapper } = getWrapper({ Fair: () => ({ startAt }) })
     expect(wrapper.find("Timer").length).toBe(0)
   })
 
   it("displays timer if event starts in future", () => {
     const startAt = DateTime.local().plus({ days: 1 }).toString()
-    const wrapper = getWrapper({ Fair: () => ({ startAt }) })
+    const { wrapper } = getWrapper({ Fair: () => ({ startAt }) })
     expect(wrapper.find("Timer").length).toBe(1)
     expect(wrapper.text()).toContain("Opens in:")
   })

--- a/src/Apps/FairOrginizer/Components/__tests__/DedicatedArticlesBreadcrumbs.jest.tsx
+++ b/src/Apps/FairOrginizer/Components/__tests__/DedicatedArticlesBreadcrumbs.jest.tsx
@@ -22,7 +22,9 @@ const { getWrapper } = setupTestWrapper<
 
 describe("DedicatedArticlesBreadcrumbs", () => {
   it("renders proper router link", () => {
-    const wrapper = getWrapper({ FairOrganizer: () => ({ slug: "organizer" }) })
+    const { wrapper } = getWrapper({
+      FairOrganizer: () => ({ slug: "organizer" }),
+    })
 
     expect(wrapper.find("RouterLink").length).toBe(1)
     expect(wrapper.find("RouterLink").prop("to")).toEqual(
@@ -31,7 +33,7 @@ describe("DedicatedArticlesBreadcrumbs", () => {
   })
 
   it("displays breadcrumbs item containing fair organizer name", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       FairOrganizer: () => ({ name: "Organizer" }),
     })
 
@@ -39,13 +41,13 @@ describe("DedicatedArticlesBreadcrumbs", () => {
   })
 
   it("displays arrow left icon", () => {
-    const wrapper = getWrapper({})
+    const { wrapper } = getWrapper({})
 
     expect(wrapper.find("ChevronLeftIcon").length).toBe(1)
   })
 
   it("displays image", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       FairOrganizer: () => ({
         profile: {
           image: { url: "some-src" },
@@ -58,7 +60,7 @@ describe("DedicatedArticlesBreadcrumbs", () => {
   })
 
   it("displays title containing fair organizer name", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       FairOrganizer: () => ({ name: "Organizer" }),
     })
 

--- a/src/Apps/FairOrginizer/Components/__tests__/FairOrganizerFollowButton.jest.tsx
+++ b/src/Apps/FairOrginizer/Components/__tests__/FairOrganizerFollowButton.jest.tsx
@@ -42,7 +42,7 @@ describe("FairOrganizerFollowButton", () => {
   })
 
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Profile: () => ({
         isFollowed: false,
       }),
@@ -52,7 +52,7 @@ describe("FairOrganizerFollowButton", () => {
   })
 
   it("toggles following label", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Profile: () => ({
         isFollowed: true,
       }),
@@ -68,7 +68,7 @@ describe("FairOrganizerFollowButton", () => {
 
     mockUseAuthDialog.mockImplementation(() => ({ showAuthDialog }))
 
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       FairOrganizer: () => ({
         internalID: "fairOrganizerInternalID",
         name: "fairOrganizerName",
@@ -100,7 +100,7 @@ describe("FairOrganizerFollowButton", () => {
       user: "user",
     }))
 
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Profile: () => ({
         id: "profileId",
         internalID: "profileInternalID",

--- a/src/Apps/FairOrginizer/Components/__tests__/FairOrganizerLatestArticles.jest.tsx
+++ b/src/Apps/FairOrginizer/Components/__tests__/FairOrganizerLatestArticles.jest.tsx
@@ -1,7 +1,7 @@
 import { graphql } from "react-relay"
 import { FairOrganizerLatestArticles_Test_Query } from "__generated__/FairOrganizerLatestArticles_Test_Query.graphql"
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
-import { FairOrganizerLatestArticlesFragmentContainer } from "../FairOrganizerLatestArticles"
+import { FairOrganizerLatestArticlesFragmentContainer } from "Apps/FairOrginizer/Components/FairOrganizerLatestArticles"
 
 jest.unmock("react-relay")
 
@@ -24,35 +24,35 @@ const { getWrapper } = setupTestWrapper<FairOrganizerLatestArticles_Test_Query>(
 
 describe("FairOrganizerLatestArticles", () => {
   it("does not render if no articles are present", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       FairOrganizer: () => ({ articlesConnection: { edges: [] } }),
     })
     expect(wrapper.html()).toBe("")
   })
 
   it("renders a section title with the fair name", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       FairOrganizer: () => ({ name: "Art Paris" }),
     })
     expect(wrapper.text()).toContain("Latest from Art Paris")
   })
 
   it("renders 7 article links", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       FairOrganizer: () => ({ articlesConnection: articlesFixture }),
     })
     expect(wrapper.find("a").length).toBe(7)
   })
 
   it("doesn't render read all button if articles count is not greater than 7", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       FairOrganizer: () => ({ articlesConnection: articlesFixture }),
     })
     expect(wrapper.find("Button").length).toBe(0)
   })
 
   it("renders read all button if articles count is greater than 7", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       FairOrganizer: () => ({
         articlesConnection: { totalCount: 10 },
       }),

--- a/src/Apps/FairOrginizer/Components/__tests__/FairOrganizerPastEventsRail.jest.tsx
+++ b/src/Apps/FairOrginizer/Components/__tests__/FairOrganizerPastEventsRail.jest.tsx
@@ -21,7 +21,7 @@ describe("FairOrganizerPastEventsRail", () => {
   })
 
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       CroppedImageUrl: () => ({
         width: 325,
         height: 140,
@@ -53,7 +53,7 @@ describe("FairOrganizerPastEventsRail", () => {
   })
 
   it("does not render rail if no collections", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       FairConnection: () => ({
         edges: null,
       }),

--- a/src/Apps/FairOrginizer/Routes/__tests__/FairOrganizerDedicatedArticles.jest.tsx
+++ b/src/Apps/FairOrginizer/Routes/__tests__/FairOrganizerDedicatedArticles.jest.tsx
@@ -43,7 +43,7 @@ const { getWrapper } = setupTestWrapper<
 
 describe("FairOrganizerDedicatedArticles", () => {
   it("renders a section title with the fair organizer name", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       FairOrganizer: () => ({ name: "The Armory Show" }),
     })
 
@@ -53,14 +53,14 @@ describe("FairOrganizerDedicatedArticles", () => {
   })
 
   it("renders 10 article links", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       FairOrganizer: () => ({ articlesConnection: articlesFixture }),
     })
     expect(wrapper.find("a").length).toBe(11)
   })
 
   it("renders pagination", () => {
-    const wrapper = getWrapper({})
+    const { wrapper } = getWrapper({})
     expect(wrapper.find("Pagination").length).toBe(1)
   })
 })

--- a/src/Apps/FairOrginizer/__tests__/FairOrganizerApp.jest.tsx
+++ b/src/Apps/FairOrginizer/__tests__/FairOrganizerApp.jest.tsx
@@ -25,14 +25,14 @@ const { getWrapper } = setupTestWrapper<FairOrganizerApp_Test_Query>({
 
 describe("FairOrganizerApp", () => {
   it("sets a title tag", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       FairOrganizer: () => ({ name: "Art Paris", slug: "art-paris" }),
     })
     expect(wrapper.find("Title").first().text()).toEqual("Art Paris | Artsy")
   })
 
   it("renders correctly", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     expect(wrapper.find("MetaTags").length).toBe(1)
     expect(wrapper.find("FairOrganizerHeaderImage").length).toBe(1)
     expect(wrapper.find("FairOrganizerHeader").length).toBe(1)

--- a/src/Apps/Fairs/Components/__tests__/FairsFairRow.jest.tsx
+++ b/src/Apps/Fairs/Components/__tests__/FairsFairRow.jest.tsx
@@ -1,4 +1,4 @@
-import { FairsFairRowFragmentContainer } from "../FairsFairRow"
+import { FairsFairRowFragmentContainer } from "Apps/Fairs/Components/FairsFairRow"
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
 import { graphql } from "react-relay"
 import { DateTime } from "luxon"
@@ -18,7 +18,7 @@ const { getWrapper } = setupTestWrapper({
 
 describe("FairsFairRow", () => {
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Fair: () => ({
         name: "Example Fair",
         isoStartAt: DateTime.local().minus({ day: 7 }).toISODate(),
@@ -32,7 +32,7 @@ describe("FairsFairRow", () => {
 
   describe("upcoming fair", () => {
     it("renders correctly", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Fair: () => ({
           name: "Example Fair",
           isoStartAt: DateTime.local().plus({ day: 7 }).toISODate(),

--- a/src/Apps/Fairs/Routes/__tests__/FairsIndex.jest.tsx
+++ b/src/Apps/Fairs/Routes/__tests__/FairsIndex.jest.tsx
@@ -29,7 +29,7 @@ const { getWrapper } = setupTestWrapper<FairsIndex_Test_Query>({
 
 describe("FairsIndex", () => {
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Viewer: () => ({
         runningFairs: [
           {

--- a/src/Apps/Feature/__tests__/FeatureApp.jest.tsx
+++ b/src/Apps/Feature/__tests__/FeatureApp.jest.tsx
@@ -26,7 +26,7 @@ const { getWrapper } = setupTestWrapper<FeatureApp_Test_Query>({
 
 describe("FeatureApp", () => {
   it("renders the correct components", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       OrderedSet: () => ({ itemType: "Artwork" }),
     })
 

--- a/src/Apps/Gene/Components/__tests__/GeneArtworkFilter.jest.tsx
+++ b/src/Apps/Gene/Components/__tests__/GeneArtworkFilter.jest.tsx
@@ -54,13 +54,13 @@ describe("GeneArtworkFilter", () => {
   })
 
   it("renders correctly", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     expect(wrapper.find("ArtworkFilterArtworkGrid").length).toBe(1)
     expect(wrapper.find("ArtworkGridItem").length).toBe(1)
   })
 
   it("renders filters in correct order", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       FilterArtworksConnection: () => ({
         counts: {
           followedArtists: 10,

--- a/src/Apps/Gene/Routes/__tests__/GeneShow.jest.tsx
+++ b/src/Apps/Gene/Routes/__tests__/GeneShow.jest.tsx
@@ -29,7 +29,7 @@ const { getWrapper } = setupTestWrapper<GeneShow_Test_Query>({
 
 describe("GeneShow", () => {
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Gene: () => ({
         name: "Example Gene",
         displayName: "Display Name",
@@ -41,7 +41,7 @@ describe("GeneShow", () => {
   })
 
   it("renders fallback title correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Gene: () => ({
         name: "Example Gene",
         displayName: "",
@@ -53,7 +53,7 @@ describe("GeneShow", () => {
   })
 
   it("renders meta description and title from query", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Gene: () => ({
         meta: { description: "Gene Meta Description" },
         displayName: "Display Name",
@@ -71,7 +71,7 @@ describe("GeneShow", () => {
   })
 
   it("renders fallback meta description and fallback title", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Gene: () => ({
         name: "Design",
         meta: { description: null },

--- a/src/Apps/Home/__tests__/HomeApp.jest.tsx
+++ b/src/Apps/Home/__tests__/HomeApp.jest.tsx
@@ -50,7 +50,7 @@ describe("HomeApp", () => {
     })
 
     it("renders the info blurb", () => {
-      const wrapper = getWrapper()
+      const { wrapper } = getWrapper()
 
       expect(wrapper.text()).toContain(
         "Collect art from leading galleries, fairs, and auctions"
@@ -62,7 +62,7 @@ describe("HomeApp", () => {
     })
 
     it("renders the events", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         FeaturedLink: () => ({
           title: "Exclusively on Artsy",
           subtitle: "Example Event",
@@ -82,7 +82,7 @@ describe("HomeApp", () => {
     })
 
     it("does not render the info blurb", () => {
-      const wrapper = getWrapper()
+      const { wrapper } = getWrapper()
 
       expect(wrapper.text()).not.toContain(
         "Collect art from leading galleries, fairs, and auctions"

--- a/src/Apps/Home/__tests__/HomeAuctionLotsRail.jest.tsx
+++ b/src/Apps/Home/__tests__/HomeAuctionLotsRail.jest.tsx
@@ -32,7 +32,7 @@ afterEach(() => {
 
 describe("HomeAuctionLotsRail", () => {
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Viewer: () => ({
         artworksConnection: {
           edges: [
@@ -55,7 +55,7 @@ describe("HomeAuctionLotsRail", () => {
 
   describe("tracking", () => {
     it("tracks artwork click", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Viewer: () => ({
           artworksConnection: {
             edges: [
@@ -86,7 +86,7 @@ describe("HomeAuctionLotsRail", () => {
     })
 
     it("tracks view all", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Viewer: () => ({
           artworksConnection: {
             edges: [

--- a/src/Apps/Home/__tests__/HomeCurrentFairs.jest.tsx
+++ b/src/Apps/Home/__tests__/HomeCurrentFairs.jest.tsx
@@ -32,7 +32,7 @@ afterEach(() => {
 
 describe("HomeCurrentFairs", () => {
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Viewer: () => ({
         fairs: [
           {
@@ -50,7 +50,7 @@ describe("HomeCurrentFairs", () => {
   })
 
   it("returns null when no data is received", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Viewer: () => ({
         fairs: null,
       }),
@@ -61,7 +61,7 @@ describe("HomeCurrentFairs", () => {
 
   describe("tracking", () => {
     it("tracks item clicks", () => {
-      const wrapper = getWrapper()
+      const { wrapper } = getWrapper()
       wrapper.find("RouterLink").last().simulate("click")
       expect(trackEvent).toBeCalledWith({
         action: "clickedFairGroup",
@@ -75,7 +75,7 @@ describe("HomeCurrentFairs", () => {
     })
 
     it("tracks view all", () => {
-      const wrapper = getWrapper()
+      const { wrapper } = getWrapper()
       wrapper.find("RouterLink").first().simulate("click")
       expect(trackEvent).toBeCalledWith({
         action: "clickedFairGroup",

--- a/src/Apps/Home/__tests__/HomeEmergingPicksArtworksRail.jest.tsx
+++ b/src/Apps/Home/__tests__/HomeEmergingPicksArtworksRail.jest.tsx
@@ -28,7 +28,7 @@ describe("HomeEmergingPicksArtworksRail", () => {
   })
 
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Viewer: () => artworksConnection,
     })
 
@@ -37,7 +37,7 @@ describe("HomeEmergingPicksArtworksRail", () => {
   })
 
   it("tracks artwork click", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Viewer: () => artworksConnection,
     })
 
@@ -54,7 +54,7 @@ describe("HomeEmergingPicksArtworksRail", () => {
   })
 
   it("tracks view all", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Viewer: () => artworksConnection,
     })
 

--- a/src/Apps/Home/__tests__/HomeFeaturedGalleriesRail.jest.tsx
+++ b/src/Apps/Home/__tests__/HomeFeaturedGalleriesRail.jest.tsx
@@ -36,7 +36,7 @@ afterEach(() => {
 
 describe("HomeFeaturedGalleriesRail", () => {
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         name: "Test Gallery",
         href: "/test-href",
@@ -50,7 +50,7 @@ describe("HomeFeaturedGalleriesRail", () => {
   })
 
   it("shows initials if no images", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Profile: () => ({
         owner: {
           initials: "initials",
@@ -68,7 +68,7 @@ describe("HomeFeaturedGalleriesRail", () => {
 
   describe("tracking", () => {
     it("tracks item clicks", () => {
-      const wrapper = getWrapper()
+      const { wrapper } = getWrapper()
       wrapper.find("RouterLink").last().simulate("click")
       expect(trackEvent).toBeCalledWith({
         action: "clickedGalleryGroup",
@@ -82,7 +82,7 @@ describe("HomeFeaturedGalleriesRail", () => {
     })
 
     it("tracks view all", () => {
-      const wrapper = getWrapper()
+      const { wrapper } = getWrapper()
       wrapper.find("RouterLink").first().simulate("click")
       expect(trackEvent).toBeCalledWith({
         action: "clickedGalleryGroup",

--- a/src/Apps/Home/__tests__/HomeFeaturedMarketNews.jest.tsx
+++ b/src/Apps/Home/__tests__/HomeFeaturedMarketNews.jest.tsx
@@ -30,7 +30,7 @@ afterEach(() => {
 
 describe("HomeFeaturedMarketNews", () => {
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Article: () => ({
         href: "/article/example-article",
         title: "Example Article",
@@ -45,7 +45,7 @@ describe("HomeFeaturedMarketNews", () => {
 
   describe("tracking", () => {
     it("tracks item clicks", () => {
-      const wrapper = getWrapper()
+      const { wrapper } = getWrapper()
       wrapper.find("RouterLink").last().simulate("click")
       expect(trackEvent).toBeCalledWith({
         action: "clickedArticleGroup",
@@ -59,7 +59,7 @@ describe("HomeFeaturedMarketNews", () => {
     })
 
     it("tracks view all", () => {
-      const wrapper = getWrapper()
+      const { wrapper } = getWrapper()
       wrapper.find("RouterLink").first().simulate("click")
       expect(trackEvent).toBeCalledWith({
         action: "clickedArticleGroup",

--- a/src/Apps/Home/__tests__/HomeFeaturedShowsRail.jest.tsx
+++ b/src/Apps/Home/__tests__/HomeFeaturedShowsRail.jest.tsx
@@ -30,7 +30,7 @@ afterEach(() => {
 
 describe("HomeFeaturedShowsRail", () => {
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Show: () => ({
         name: "Example Show",
         exhibitionPeriod: "June 9 – 25",
@@ -51,7 +51,7 @@ describe("HomeFeaturedShowsRail", () => {
 
   describe("tracking", () => {
     it("tracks item clicks", () => {
-      const wrapper = getWrapper()
+      const { wrapper } = getWrapper()
       wrapper.find("RouterLink").last().simulate("click")
       expect(trackEvent).toBeCalledWith({
         action: "clickedShowGroup",
@@ -65,7 +65,7 @@ describe("HomeFeaturedShowsRail", () => {
     })
 
     it("tracks view all", () => {
-      const wrapper = getWrapper()
+      const { wrapper } = getWrapper()
       wrapper.find("RouterLink").first().simulate("click")
       expect(trackEvent).toBeCalledWith({
         action: "clickedShowGroup",

--- a/src/Apps/Home/__tests__/HomeNewWorksForYouRail.jest.tsx
+++ b/src/Apps/Home/__tests__/HomeNewWorksForYouRail.jest.tsx
@@ -36,7 +36,7 @@ afterEach(() => {
 
 describe("HomeNewWorksForYouRail", () => {
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       ArtworkConnection: () => ({
         edges: [
           {
@@ -55,7 +55,7 @@ describe("HomeNewWorksForYouRail", () => {
 
   describe("tracking", () => {
     it("tracks item clicks", () => {
-      const wrapper = getWrapper()
+      const { wrapper } = getWrapper()
       wrapper.find("RouterLink").first().simulate("click")
       expect(trackEvent).toBeCalledWith({
         action: "clickedArtworkGroup",

--- a/src/Apps/Home/__tests__/HomeNewWorksFromGalleriesYouFollowRail.jest.tsx
+++ b/src/Apps/Home/__tests__/HomeNewWorksFromGalleriesYouFollowRail.jest.tsx
@@ -43,7 +43,7 @@ afterEach(() => {
 
 describe("HomeNewWorksFromGalleriesYouFollowRail", () => {
   it("renders correctly", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
 
     expect(wrapper.html()).toContain("/new-works-from-galleries-you-follow")
 
@@ -52,7 +52,7 @@ describe("HomeNewWorksFromGalleriesYouFollowRail", () => {
 
   describe("tracking", () => {
     it("tracks view all clicks", () => {
-      const wrapper = getWrapper()
+      const { wrapper } = getWrapper()
       wrapper.find("RouterLink").at(1).simulate("click")
 
       expect(trackEvent).toBeCalledWith({
@@ -64,7 +64,7 @@ describe("HomeNewWorksFromGalleriesYouFollowRail", () => {
     })
 
     it("tracks item clicks", () => {
-      const wrapper = getWrapper()
+      const { wrapper } = getWrapper()
       wrapper.find("RouterLink").at(2).simulate("click")
 
       expect(trackEvent).toBeCalledWith({

--- a/src/Apps/Home/__tests__/HomeRecentlyViewedRail.jest.tsx
+++ b/src/Apps/Home/__tests__/HomeRecentlyViewedRail.jest.tsx
@@ -34,7 +34,7 @@ afterEach(() => {
 
 describe("HomeRecentlyViewedRail", () => {
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       HomePage: () => ({
         artworkModule: {
           results: [
@@ -53,7 +53,7 @@ describe("HomeRecentlyViewedRail", () => {
 
   describe("tracking", () => {
     it("tracks item clicks", () => {
-      const wrapper = getWrapper()
+      const { wrapper } = getWrapper()
       wrapper.find("RouterLink").first().simulate("click")
       expect(trackEvent).toBeCalledWith({
         action: "clickedArtworkGroup",

--- a/src/Apps/Home/__tests__/HomeTrendingArtistsRail.jest.tsx
+++ b/src/Apps/Home/__tests__/HomeTrendingArtistsRail.jest.tsx
@@ -35,7 +35,7 @@ afterEach(() => {
 
 describe("HomeTrendingArtistsRail", () => {
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Artist: () => ({
         name: "Test Artist",
         href: "test-href",
@@ -51,7 +51,7 @@ describe("HomeTrendingArtistsRail", () => {
 
   describe("tracking", () => {
     it("tracks item clicks", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Artist: () => ({
           internalID: "test-artist-id",
           slug: "test-artist-slug",
@@ -72,7 +72,7 @@ describe("HomeTrendingArtistsRail", () => {
     })
 
     it("tracks view all", () => {
-      const wrapper = getWrapper()
+      const { wrapper } = getWrapper()
 
       wrapper.find("RouterLink").first().simulate("click")
 

--- a/src/Apps/Home/__tests__/HomeWorksByArtistsYouFollowRail.jest.tsx
+++ b/src/Apps/Home/__tests__/HomeWorksByArtistsYouFollowRail.jest.tsx
@@ -38,7 +38,7 @@ afterEach(() => {
 
 describe("HomeWorksByArtistsYouFollowRail", () => {
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       HomePage: () => ({
         artworkModule: {
           results: [
@@ -57,7 +57,7 @@ describe("HomeWorksByArtistsYouFollowRail", () => {
 
   describe("tracking", () => {
     it("tracks item clicks", () => {
-      const wrapper = getWrapper()
+      const { wrapper } = getWrapper()
       wrapper.find("RouterLink").first().simulate("click")
       expect(trackEvent).toBeCalledWith({
         action: "clickedArtworkGroup",

--- a/src/Apps/IdentityVerification/__tests__/IdentityVerificationApp.jest.tsx
+++ b/src/Apps/IdentityVerification/__tests__/IdentityVerificationApp.jest.tsx
@@ -60,7 +60,7 @@ describe("IdentityVerification route", () => {
       })
 
       it("renders a message about an identity verification that is `passed`", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           IdentityVerification: () => ({
             state: "passed",
           }),
@@ -73,7 +73,7 @@ describe("IdentityVerification route", () => {
       })
 
       it("renders a message about an identity verification that is `failed`", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           IdentityVerification: () => ({
             state: "failed",
           }),
@@ -86,7 +86,7 @@ describe("IdentityVerification route", () => {
       })
 
       it("renders a message about an identity verification that is `watchlist_hit`", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           IdentityVerification: () => ({
             state: "watchlist_hit",
           }),
@@ -102,7 +102,7 @@ describe("IdentityVerification route", () => {
     })
 
     it("allows an identity verification instance's owner to view the landing page", async () => {
-      const wrapper = getWrapper()
+      const { wrapper } = getWrapper()
       const page = new IdentityVerificationAppTestPage(wrapper)
 
       expect(page.text()).toContain("Artsy Identity Verification")
@@ -114,7 +114,7 @@ describe("IdentityVerification route", () => {
       })
 
       it("user click on 'continue to verification' button is tracked", async () => {
-        const wrapper = getWrapper()
+        const { wrapper } = getWrapper()
         const page = new IdentityVerificationAppTestPage(wrapper)
 
         await page.clickStartVerification()
@@ -129,7 +129,7 @@ describe("IdentityVerification route", () => {
 
       it("user is redirected to the verification flow on a successful mutation", async () => {
         const env = createMockEnvironment()
-        const wrapper = getWrapper({}, {}, env)
+        const { wrapper } = getWrapper({}, {}, env)
         const page = new IdentityVerificationAppTestPage(wrapper)
 
         await page.clickStartVerification()
@@ -152,7 +152,7 @@ describe("IdentityVerification route", () => {
 
       it("user sees an error toast if the mutation fails", async () => {
         const env = createMockEnvironment()
-        const wrapper = getWrapper({}, {}, env)
+        const { wrapper } = getWrapper({}, {}, env)
         const page = new IdentityVerificationAppTestPage(wrapper)
 
         await page.clickStartVerification()
@@ -180,7 +180,7 @@ describe("IdentityVerification route", () => {
 
       it("shows an error message on network failiure", async () => {
         const env = createMockEnvironment()
-        const wrapper = getWrapper({}, {}, env)
+        const { wrapper } = getWrapper({}, {}, env)
         const page = new IdentityVerificationAppTestPage(wrapper)
 
         await page.clickStartVerification()

--- a/src/Apps/Order/Components/__tests__/BankAccountPicker.jest.tsx
+++ b/src/Apps/Order/Components/__tests__/BankAccountPicker.jest.tsx
@@ -125,7 +125,7 @@ describe("BankAccountFragmentContainer", () => {
     })
 
     it("does not render bank account selection", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => defaultData.order,
         Me: () => defaultData.me,
       })
@@ -135,7 +135,7 @@ describe("BankAccountFragmentContainer", () => {
     })
 
     it("renders bank element form", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => defaultData.order,
         Me: () => defaultData.me,
       })
@@ -175,7 +175,7 @@ describe("BankAccountFragmentContainer", () => {
     ]
 
     it("renders a list of the users saved bank accounts", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => BuyOrderPickup,
         Me: () => ({
           bankAccounts: {
@@ -197,7 +197,7 @@ describe("BankAccountFragmentContainer", () => {
     })
 
     it("shows the bank element when user selects 'add another bank account'", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => BuyOrderPickup,
         Me: () => ({
           bankAccounts: {
@@ -216,7 +216,7 @@ describe("BankAccountFragmentContainer", () => {
         type: "existing",
       }
 
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => BuyOrderPickup,
         Me: () => ({
           bankAccounts: {
@@ -236,7 +236,7 @@ describe("BankAccountFragmentContainer", () => {
         type: "existing",
       }
 
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => BuyOrderPickup,
         Me: () => ({
           bankAccounts: {
@@ -260,7 +260,7 @@ describe("BankAccountFragmentContainer", () => {
         }
       })
 
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => orderWithBankAccount,
         Me: () => ({
           bankAccounts: {
@@ -298,7 +298,7 @@ describe("BankAccountFragmentContainer", () => {
         submitMutation: submitMutationMock,
       }))
 
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => BuyOrderPickup,
         Me: () => ({
           bankAccounts: {
@@ -346,7 +346,7 @@ describe("BankAccountFragmentContainer", () => {
         submitMutation: submitMutationMock,
       }))
 
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => BuyOrderPickup,
         Me: () => ({
           bankAccounts: {

--- a/src/Apps/Order/Components/__tests__/CreditCardPicker.jest.tsx
+++ b/src/Apps/Order/Components/__tests__/CreditCardPicker.jest.tsx
@@ -190,7 +190,7 @@ describe("CreditCardPickerFragmentContainer", () => {
 
   describe("with no existing cards", () => {
     it("renders", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => defaultData.order,
         Me: () => defaultData.me,
       })
@@ -203,7 +203,7 @@ describe("CreditCardPickerFragmentContainer", () => {
 
     it("does not show the 'manage cards' link if eigen", () => {
       isEigen = true
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => defaultData.order,
         Me: () => defaultData.me,
       })
@@ -214,7 +214,7 @@ describe("CreditCardPickerFragmentContainer", () => {
   })
 
   it("always shows the billing address form without checkbox when the user selected 'pick' shipping option", async () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       CommerceOrder: () => BuyOrderPickup,
     })
     const page = new CreditCardPickerTestPage(wrapper)
@@ -227,7 +227,7 @@ describe("CreditCardPickerFragmentContainer", () => {
   })
 
   it("does not pre-populate with available details when returning to the payment route", async () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       CommerceOrder: () => ({
         ...BuyOrderPickup,
         id: "1234",
@@ -262,7 +262,7 @@ describe("CreditCardPickerFragmentContainer", () => {
   })
 
   it("always uses the billing address for stripe tokenization when the user selected 'pick' shipping option", async () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       CommerceOrder: () => ({
         ...BuyOrderPickup,
         id: "1234",
@@ -288,7 +288,7 @@ describe("CreditCardPickerFragmentContainer", () => {
   })
 
   it("tokenizes credit card information using shipping address as billing address", async () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       CommerceOrder: () => defaultData.order,
       Me: () => defaultData.me,
     })
@@ -308,7 +308,7 @@ describe("CreditCardPickerFragmentContainer", () => {
   })
 
   it("tokenizes credit card information with a different billing address", async () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       CommerceOrder: () => defaultData.order,
       Me: () => defaultData.me,
     })
@@ -336,7 +336,7 @@ describe("CreditCardPickerFragmentContainer", () => {
       },
     }
     _mockStripe().createToken.mockReturnValue(Promise.resolve(stripeToken))
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       CommerceOrder: () => defaultData.order,
       Me: () => defaultData.me,
     })
@@ -363,7 +363,7 @@ describe("CreditCardPickerFragmentContainer", () => {
       },
     }
     _mockStripe().createToken.mockReturnValue(Promise.resolve(stripeError))
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       CommerceOrder: () => defaultData.order,
       Me: () => defaultData.me,
     })
@@ -446,7 +446,7 @@ describe("CreditCardPickerFragmentContainer", () => {
 
     describe("with one card", () => {
       it("renders", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => orderWithoutCard,
           Me: () => ({
             creditCards: {
@@ -478,7 +478,7 @@ describe("CreditCardPickerFragmentContainer", () => {
 
       it("has no 'manage cards' link if eigen", () => {
         isEigen = true
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => orderWithoutCard,
           Me: () => ({
             creditCards: {
@@ -491,7 +491,7 @@ describe("CreditCardPickerFragmentContainer", () => {
       })
 
       it("shows the 'use new card' section when you select that option", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => orderWithoutCard,
           Me: () => ({
             creditCards: {
@@ -506,7 +506,7 @@ describe("CreditCardPickerFragmentContainer", () => {
       })
 
       it("hides the 'use new card' section if you select the card again", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => orderWithoutCard,
           Me: () => ({
             creditCards: {
@@ -523,7 +523,7 @@ describe("CreditCardPickerFragmentContainer", () => {
 
     describe("with two cards", () => {
       it("has three radio buttons", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => orderWithoutCard,
           Me: () => ({
             creditCards: {
@@ -559,7 +559,7 @@ describe("CreditCardPickerFragmentContainer", () => {
 
       it("shows the 'manage cards' link if eigen", () => {
         isEigen = true
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => orderWithoutCard,
           Me: () => ({
             creditCards: {
@@ -573,7 +573,7 @@ describe("CreditCardPickerFragmentContainer", () => {
       })
 
       it("returns the relevante credit card id if you select a different card", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => orderWithoutCard,
           Me: () => ({
             creditCards: {
@@ -591,7 +591,7 @@ describe("CreditCardPickerFragmentContainer", () => {
       })
 
       it("shows the 'use new card' section when you select that option", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => orderWithoutCard,
           Me: () => ({
             creditCards: {
@@ -609,7 +609,7 @@ describe("CreditCardPickerFragmentContainer", () => {
     describe("when returning to the payment page when the initial card is saved", () => {
       describe("with two cards", () => {
         it("the card associated with the order is selected", async () => {
-          const wrapper = getWrapper({
+          const { wrapper } = getWrapper({
             CommerceOrder: () => orderWithCard,
             Me: () => ({
               creditCards: {
@@ -629,7 +629,7 @@ describe("CreditCardPickerFragmentContainer", () => {
     describe("when returning to the payment page when the initial card is not saved", () => {
       describe("with two saved cards", () => {
         it("shows a radio button for the unsaved card with a selected radio", async () => {
-          const wrapper = getWrapper({
+          const { wrapper } = getWrapper({
             CommerceOrder: () => orderWithUnsavedCard,
             Me: () => ({
               creditCards: {
@@ -658,7 +658,7 @@ describe("CreditCardPickerFragmentContainer", () => {
       _mockStripe().createToken.mockReturnValue(
         Promise.resolve({ token: { id: "tokenId", postalCode: "1324" } })
       )
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => defaultData.order,
         Me: () => defaultData.me,
       })
@@ -682,7 +682,7 @@ describe("CreditCardPickerFragmentContainer", () => {
       _mockStripe().createToken.mockReturnValue(
         Promise.resolve({ token: { id: "tokenId" } })
       )
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => defaultData.order,
         Me: () => defaultData.me,
       })
@@ -710,7 +710,7 @@ describe("CreditCardPickerFragmentContainer", () => {
 
   describe("Analytics", () => {
     it("tracks click when use shipping address checkbox transitions from checked to unchecked but not from unchecked to checked", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => defaultData.order,
         Me: () => defaultData.me,
       })
@@ -735,7 +735,7 @@ describe("CreditCardPickerFragmentContainer", () => {
     })
 
     it("doesn't track clicks on the address checkbox when order status is not pending", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => ({
           ...OfferOrderWithShippingDetails,
           state: "SUBMITTED",
@@ -751,7 +751,7 @@ describe("CreditCardPickerFragmentContainer", () => {
 
   describe("Validations", () => {
     it("says a required field is required with billing address exposed", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => defaultData.order,
         Me: () => defaultData.me,
       })
@@ -766,7 +766,7 @@ describe("CreditCardPickerFragmentContainer", () => {
     })
 
     it("before submit, only shows a validation error on inputs that have been touched", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => defaultData.order,
         Me: () => defaultData.me,
       })
@@ -786,7 +786,7 @@ describe("CreditCardPickerFragmentContainer", () => {
     })
 
     it("after submit, shows all validation errors on inputs that have been touched", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => defaultData.order,
         Me: () => defaultData.me,
       })
@@ -806,7 +806,7 @@ describe("CreditCardPickerFragmentContainer", () => {
     })
 
     it("does not submit an empty form with billing address exposed", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => defaultData.order,
         Me: () => defaultData.me,
       })
@@ -819,7 +819,7 @@ describe("CreditCardPickerFragmentContainer", () => {
     })
 
     it("does not submit the mutation with an incomplete form with billing address exposed", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => defaultData.order,
         Me: () => defaultData.me,
       })
@@ -835,7 +835,7 @@ describe("CreditCardPickerFragmentContainer", () => {
       _mockStripe().createToken.mockReturnValue(
         Promise.resolve({ token: { id: "tokenId" } })
       )
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => defaultData.order,
         Me: () => defaultData.me,
       })
@@ -865,7 +865,7 @@ describe("CreditCardPickerFragmentContainer", () => {
       _mockStripe().createToken.mockReturnValue(
         Promise.resolve({ token: { id: "tokenId" } })
       )
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => defaultData.order,
         Me: () => defaultData.me,
       })
@@ -892,7 +892,7 @@ describe("CreditCardPickerFragmentContainer", () => {
     })
 
     it("overwrites null shipping address items with empty string when shipping address is selected for billing", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => ({
           ...BuyOrderWithShippingDetails,
           creditCard: null,

--- a/src/Apps/Order/Components/__tests__/OfferHistoryItem.jest.tsx
+++ b/src/Apps/Order/Components/__tests__/OfferHistoryItem.jest.tsx
@@ -30,7 +30,7 @@ const { getWrapper } = setupTestWrapper({
 
 describe("OfferHistoryItem", () => {
   it("shows the current offer", async () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       CommerceOrder: () => order,
     })
 
@@ -41,7 +41,7 @@ describe("OfferHistoryItem", () => {
   })
 
   it("doesn't show the 'show offer history' button if no other offers", async () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       CommerceOrder: () => order,
     })
 
@@ -49,7 +49,7 @@ describe("OfferHistoryItem", () => {
   })
 
   it("does show the 'show offer history' button if there are other offers", async () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       CommerceOrder: () => ({
         ...order,
         offers: { edges: Offers },
@@ -60,7 +60,7 @@ describe("OfferHistoryItem", () => {
   })
 
   it("shows the other offers if you click the button", async () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       CommerceOrder: () => ({
         ...order,
         offers: { edges: Offers },
@@ -85,7 +85,7 @@ describe("OfferHistoryItem", () => {
   })
 
   it("shows right copy if the last submitted offer was from the buyer", async () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       CommerceOrder: () => ({
         ...order,
         lastOffer: {

--- a/src/Apps/Order/Components/__tests__/SavedAddresses.jest.tsx
+++ b/src/Apps/Order/Components/__tests__/SavedAddresses.jest.tsx
@@ -44,7 +44,7 @@ describe("Saved Addresses", () => {
 
   describe("Saved Addresses mutations", () => {
     it("edits the saved addresses after calling edit address mutation", async () => {
-      const wrapper = getWrapper({ Me: () => userAddressMutation.me })
+      const { wrapper } = getWrapper({ Me: () => userAddressMutation.me })
       const page = new SavedAddressesTestPage(wrapper)
       page.selectEdit()
       const addresses = page.find(SavedAddressItem).first().text()
@@ -56,7 +56,7 @@ describe("Saved Addresses", () => {
 
   describe("Saved Addresses", () => {
     it("renders modal when button is clicked", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Me: () => ({
           addressConnection: mockAddressConnection,
         }),
@@ -70,7 +70,7 @@ describe("Saved Addresses", () => {
     })
 
     it("add address modal with expected props", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Me: () => ({
           addressConnection: mockAddressConnection,
         }),
@@ -88,7 +88,7 @@ describe("Saved Addresses", () => {
     })
 
     it("render an add address button", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Me: () => ({
           addressConnection: mockAddressConnection,
         }),
@@ -100,7 +100,7 @@ describe("Saved Addresses", () => {
 
     describe("when clicking on the add address button", () => {
       it("tracks an analytics event", () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           Me: () => ({
             addressConnection: mockAddressConnection,
           }),
@@ -122,7 +122,7 @@ describe("Saved Addresses", () => {
     })
 
     it("renders radio buttons with addresses", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Me: () => ({
           addressConnection: mockAddressConnection,
         }),

--- a/src/Apps/Order/Components/__tests__/TransactionDetailsSummary.jest.tsx
+++ b/src/Apps/Order/Components/__tests__/TransactionDetailsSummary.jest.tsx
@@ -103,7 +103,7 @@ describe("TransactionDetailsSummaryItem", () => {
   describe("Order breakdown messaging", () => {
     it("shows the shipping and tax price as 'Calculated in next steps' when null before shipping address was added", async () => {
       transactionStep = "shipping"
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => ({
           ...transactionSummaryBuyOrder,
           taxTotal: null,
@@ -120,7 +120,7 @@ describe("TransactionDetailsSummaryItem", () => {
     })
 
     it("shows the shipping and tax price as 'Waiting for final costs' when null after shipping address was added", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => ({
           ...transactionSummaryBuyOrder,
           taxTotal: null,
@@ -137,7 +137,7 @@ describe("TransactionDetailsSummaryItem", () => {
     })
 
     it("shows tax import reminder", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => transactionSummaryBuyOrder,
       })
 
@@ -148,7 +148,7 @@ describe("TransactionDetailsSummaryItem", () => {
     })
 
     it("shows shipping confirmation note when shipping cannot be calculated after shipping address was added", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => ({
           ...transactionSummaryBuyOrder,
           shippingTotal: null,
@@ -164,7 +164,7 @@ describe("TransactionDetailsSummaryItem", () => {
     })
 
     it("does not show list price in the transaction summary", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => transactionSummaryOfferOrder,
       })
 
@@ -174,7 +174,7 @@ describe("TransactionDetailsSummaryItem", () => {
     })
 
     it("shows 'Waiting for final costs' when buyer total has not been calucuated yet", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => ({
           ...transactionSummaryBuyOrder,
           buyerTotal: null,
@@ -189,7 +189,7 @@ describe("TransactionDetailsSummaryItem", () => {
 
   describe("CommerceBuyOrder", () => {
     it("shows a US prefix on the price when currency is USD", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => transactionSummaryBuyOrder,
       })
 
@@ -202,7 +202,7 @@ describe("TransactionDetailsSummaryItem", () => {
     })
 
     it("shows the shipping and tax price if it's greater than 0", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => transactionSummaryBuyOrder,
       })
 
@@ -216,7 +216,7 @@ describe("TransactionDetailsSummaryItem", () => {
 
     describe("artsy shipping specific", () => {
       it("shows the shipping quote name if shipping by Arta", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () =>
             transactionSummaryBuyOrderWithSelectedShippingQuote,
         })
@@ -227,7 +227,7 @@ describe("TransactionDetailsSummaryItem", () => {
       })
 
       it("shows the correct footnotes for offers when user has not made selection yet", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () =>
             UntouchedMakeOfferWithArtsyShippingDomesticFromUS,
         })
@@ -242,7 +242,7 @@ describe("TransactionDetailsSummaryItem", () => {
       })
 
       it("shows the correct footnotes for offers when user selects a shipping quote", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => ({
             ...transactionSummaryOfferOrder,
             requestedFulfillment: {
@@ -286,7 +286,7 @@ describe("TransactionDetailsSummaryItem", () => {
 
     it("shows the congratulations message when order gets submmited", async () => {
       showCongratulationMessage = true
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => transactionSummaryBuyOrder,
       })
 
@@ -303,7 +303,7 @@ describe("TransactionDetailsSummaryItem", () => {
 
   describe("CommerceOfferOrder", () => {
     it("shows the shipping and tax price if it's greater than 0", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => transactionSummaryOfferOrder,
       })
 
@@ -317,7 +317,7 @@ describe("TransactionDetailsSummaryItem", () => {
 
     it("shows the last submitted offer if requested", async () => {
       useLastSubmittedOffer = true
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => ({
           ...transactionSummaryOfferOrderPounds,
           __typename: "CommerceOfferOrder",
@@ -343,7 +343,7 @@ describe("TransactionDetailsSummaryItem", () => {
 
     it("says 'seller's offer' when the last submitted offer is from the seller", async () => {
       useLastSubmittedOffer = true
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => ({
           ...transactionSummaryOfferOrderPounds,
           lastOffer: {
@@ -363,7 +363,7 @@ describe("TransactionDetailsSummaryItem", () => {
     it("takes an offer override parameter", async () => {
       useLastSubmittedOffer = true
       offerOverride = "$1billion"
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => ({
           ...transactionSummaryOfferOrder,
           lastOffer: {
@@ -382,7 +382,7 @@ describe("TransactionDetailsSummaryItem", () => {
 
     it("lets you specify whether to use list price or last offer as context price", async () => {
       offerContextPrice = "LAST_OFFER"
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => ({
           ...transactionSummaryOfferOrderPounds,
           lastOffer: {

--- a/src/Apps/Order/Routes/Shipping2/SavedAddresses2.jest.tsx
+++ b/src/Apps/Order/Routes/Shipping2/SavedAddresses2.jest.tsx
@@ -62,7 +62,7 @@ describe("Saved Addresses", () => {
 
   describe("Saved Addresses mutations", () => {
     it("edits the saved addresses after calling edit address mutation", async () => {
-      const wrapper = getWrapper(
+      const { wrapper } = getWrapper(
         { Me: () => userAddressMutation.me },
         { active: true }
       )
@@ -77,7 +77,7 @@ describe("Saved Addresses", () => {
 
   describe("Saved Addresses", () => {
     it("add address modal with expected props", async () => {
-      const wrapper = getWrapper(
+      const { wrapper } = getWrapper(
         {
           Me: () => ({
             addressConnection: mockAddressConnection,
@@ -95,7 +95,7 @@ describe("Saved Addresses", () => {
       })
     })
     it("edit address modal with expected props", async () => {
-      const wrapper = getWrapper(
+      const { wrapper } = getWrapper(
         {
           Me: () => ({
             addressConnection: mockAddressConnection,
@@ -119,7 +119,7 @@ describe("Saved Addresses", () => {
     })
 
     it("render an add address button", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Me: () => ({
           addressConnection: mockAddressConnection,
         }),
@@ -131,7 +131,7 @@ describe("Saved Addresses", () => {
 
     describe("when clicking on the add address button", () => {
       it("tracks an analytics event", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           Me: () => ({
             addressConnection: mockAddressConnection,
           }),
@@ -150,7 +150,7 @@ describe("Saved Addresses", () => {
     })
 
     it("renders radio buttons with addresses", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Me: () => ({
           addressConnection: mockAddressConnection,
         }),

--- a/src/Apps/Order/Routes/__tests__/Accept.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Accept.jest.tsx
@@ -133,7 +133,7 @@ describe("Accept seller offer", () => {
     })
 
     it("renders", async () => {
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => ({
           ...testOrder,
           stateExpiresAt: DateTime.fromISO(NOW)
@@ -180,7 +180,7 @@ describe("Accept seller offer", () => {
 
     it("routes to status page after mutation completes", async () => {
       commitMutation.mockReturnValue(acceptOfferSuccess)
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       let page = new OrderAppTestPage(wrapper)
@@ -193,7 +193,7 @@ describe("Accept seller offer", () => {
 
     it("shows the button spinner while loading the mutation", () => {
       isCommittingMutation = true
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       let page = new OrderAppTestPage(wrapper)
@@ -203,7 +203,7 @@ describe("Accept seller offer", () => {
 
     it("shows an error modal when there is an error from the server", async () => {
       commitMutation.mockReturnValue(acceptOfferFailed)
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       let page = new OrderAppTestPage(wrapper)
@@ -214,7 +214,7 @@ describe("Accept seller offer", () => {
 
     it("shows SCA modal when required", async () => {
       commitMutation.mockReturnValue(acceptOfferWithActionRequired)
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       let page = new OrderAppTestPage(wrapper)
@@ -225,7 +225,7 @@ describe("Accept seller offer", () => {
 
     it("shows an error modal if there is a capture_failed error", async () => {
       commitMutation.mockReturnValue(acceptOfferPaymentFailed)
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       let page = new OrderAppTestPage(wrapper)
@@ -242,7 +242,7 @@ describe("Accept seller offer", () => {
 
     it("shows an error modal if there is a capture_failed error with insufficient_funds", async () => {
       commitMutation.mockReturnValue(acceptOfferPaymentFailedInsufficientFunds)
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       let page = new OrderAppTestPage(wrapper)
@@ -259,7 +259,7 @@ describe("Accept seller offer", () => {
 
     it("shows an error modal and routes the user to the artist page if there is insufficient inventory", async () => {
       commitMutation.mockReturnValue(acceptOfferInsufficientInventoryFailure)
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       let page = new OrderAppTestPage(wrapper)

--- a/src/Apps/Order/Routes/__tests__/Counter.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Counter.jest.tsx
@@ -117,7 +117,7 @@ describe("Submit Pending Counter Offer", () => {
     })
 
     it("renders", () => {
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => commerceOrder,
       })
       let page = new OrderAppTestPage(wrapper)
@@ -152,7 +152,7 @@ describe("Submit Pending Counter Offer", () => {
 
     it("loading given isCommitingMutation", async () => {
       isCommittingMutation = true
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       let page = new OrderAppTestPage(wrapper)
@@ -172,7 +172,7 @@ describe("Submit Pending Counter Offer", () => {
 
     it("routes to status page after mutation completes", async () => {
       mockCommitMutation.mockResolvedValue(submitPendingOfferSuccess)
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => commerceOrder,
       })
       let page = new OrderAppTestPage(wrapper)
@@ -185,7 +185,7 @@ describe("Submit Pending Counter Offer", () => {
 
     it("shows an error modal with proper error when there is insufficient inventory", async () => {
       mockCommitMutation.mockReturnValue(insufficientInventoryResponse)
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => commerceOrder,
       })
       let page = new OrderAppTestPage(wrapper)
@@ -199,7 +199,7 @@ describe("Submit Pending Counter Offer", () => {
 
     it("shows generic error modal when there is an error from the server", async () => {
       mockCommitMutation.mockReturnValue(submitPendingOfferFailed)
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => commerceOrder,
       })
       let page = new OrderAppTestPage(wrapper)
@@ -210,7 +210,7 @@ describe("Submit Pending Counter Offer", () => {
 
     it("shows an error modal when there is a network error", async () => {
       mockCommitMutation.mockRejectedValue({})
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => commerceOrder,
       })
       let page = new OrderAppTestPage(wrapper)

--- a/src/Apps/Order/Routes/__tests__/NewPayment.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/NewPayment.jest.tsx
@@ -133,7 +133,7 @@ describe("Payment", () => {
   })
 
   it("shows the countdown timer", async () => {
-    let wrapper = getWrapper({
+    let { wrapper } = getWrapper({
       CommerceOrder: () => ({
         ...testOrder,
         stateExpiresAt: DateTime.fromISO(NOW)
@@ -148,14 +148,14 @@ describe("Payment", () => {
 
   it("shows the button spinner while loading the mutation", async () => {
     isCommittingMutation = true
-    let wrapper = getWrapper()
+    let { wrapper } = getWrapper()
     let page = new OrderAppTestPage(wrapper)
 
     expect(page.isLoading()).toBeTruthy()
   })
 
   it("commits fixFailedPayment mutation with Gravity credit card id", async () => {
-    let wrapper = getWrapper({ CommerceOrder: () => testOrder })
+    let { wrapper } = getWrapper({ CommerceOrder: () => testOrder })
     let page = new OrderAppTestPage(wrapper)
     await page.clickSubmit()
 
@@ -174,7 +174,7 @@ describe("Payment", () => {
 
   it("takes the user to the status page", async () => {
     mockCommitMutation.mockResolvedValue(fixFailedPaymentSuccess)
-    let wrapper = getWrapper({ CommerceOrder: () => testOrder })
+    let { wrapper } = getWrapper({ CommerceOrder: () => testOrder })
     let page = new OrderAppTestPage(wrapper)
     await page.clickSubmit()
 
@@ -182,7 +182,7 @@ describe("Payment", () => {
   })
 
   it("does not do anything when there are form errors", async () => {
-    let wrapper = getWrapper({ CommerceOrder: () => testOrder })
+    let { wrapper } = getWrapper({ CommerceOrder: () => testOrder })
     let page = new OrderAppTestPage(wrapper)
     CreditCardPickerMock.useInvalidFormResult()
     await page.clickSubmit()
@@ -192,7 +192,7 @@ describe("Payment", () => {
 
   it("shows the default error modal when the payment picker throws an error", async () => {
     CreditCardPickerMock.useThrownError()
-    let wrapper = getWrapper({ CommerceOrder: () => testOrder })
+    let { wrapper } = getWrapper({ CommerceOrder: () => testOrder })
     let page = new OrderAppTestPage(wrapper)
 
     await page.clickSubmit()
@@ -203,7 +203,7 @@ describe("Payment", () => {
     mockCommitMutation.mockResolvedValueOnce(
       fixFailedPaymentInsufficientInventoryFailure
     )
-    let wrapper = getWrapper({ CommerceOrder: () => testOrder })
+    let { wrapper } = getWrapper({ CommerceOrder: () => testOrder })
     let page = new OrderAppTestPage(wrapper)
     await page.clickSubmit()
 
@@ -218,7 +218,7 @@ describe("Payment", () => {
 
   it("shows a custom error modal with when the payment picker returns a normal error", async () => {
     CreditCardPickerMock.useErrorResult()
-    let wrapper = getWrapper({ CommerceOrder: () => testOrder })
+    let { wrapper } = getWrapper({ CommerceOrder: () => testOrder })
     let page = new OrderAppTestPage(wrapper)
     await page.clickSubmit()
 
@@ -231,7 +231,7 @@ describe("Payment", () => {
 
   it("shows an error modal with the title 'An internal error occurred' and the default message when the payment picker returns an error with the type 'internal_error'", async () => {
     CreditCardPickerMock.useInternalErrorResult()
-    let wrapper = getWrapper({ CommerceOrder: () => testOrder })
+    let { wrapper } = getWrapper({ CommerceOrder: () => testOrder })
     let page = new OrderAppTestPage(wrapper)
     await page.clickSubmit()
 
@@ -242,7 +242,7 @@ describe("Payment", () => {
 
   it("shows an error modal when fixing the failed payment fails", async () => {
     mockCommitMutation.mockResolvedValueOnce(fixFailedPaymentFailure)
-    let wrapper = getWrapper({ CommerceOrder: () => testOrder })
+    let { wrapper } = getWrapper({ CommerceOrder: () => testOrder })
     let page = new OrderAppTestPage(wrapper)
     await page.clickSubmit()
 
@@ -255,7 +255,7 @@ describe("Payment", () => {
 
   it("shows an error modal when there is a network error", async () => {
     mockCommitMutation.mockRejectedValue({})
-    let wrapper = getWrapper({ CommerceOrder: () => testOrder })
+    let { wrapper } = getWrapper({ CommerceOrder: () => testOrder })
     let page = new OrderAppTestPage(wrapper)
     await page.clickSubmit()
 
@@ -264,7 +264,7 @@ describe("Payment", () => {
 
   it("shows SCA modal when required", async () => {
     mockCommitMutation.mockResolvedValue(fixFailedPaymentWithActionRequired)
-    let wrapper = getWrapper({ CommerceOrder: () => testOrder })
+    let { wrapper } = getWrapper({ CommerceOrder: () => testOrder })
     let page = new OrderAppTestPage(wrapper)
     await page.clickSubmit()
 

--- a/src/Apps/Order/Routes/__tests__/Offer.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Offer.jest.tsx
@@ -115,7 +115,7 @@ describe("Offer InitialMutation", () => {
 
   describe("the page layout", () => {
     it("has 4 price options - unique artwork", () => {
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => testOffer,
       })
       let page = new OrderAppTestPage(wrapper)
@@ -125,7 +125,7 @@ describe("Offer InitialMutation", () => {
       expect(page.text()).toContain("All offers are binding")
     })
     it("has price options - single edition with price", () => {
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => ({
           ...UntouchedOfferOrderSingleEditionSet,
           internalID: "1234",
@@ -137,7 +137,7 @@ describe("Offer InitialMutation", () => {
       expect(page.priceOptions.find("BorderedRadio")).toHaveLength(4)
     })
     it("doesn't have price options - single edition without price", () => {
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => ({
           ...UntouchedOfferOrderSingleEditionSetNoPrice,
           internalID: "1234",
@@ -147,7 +147,7 @@ describe("Offer InitialMutation", () => {
       expect(page.find("PriceOptions").exists()).toBeFalsy()
     })
     it("doesn't have price options - multiple editions", () => {
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => ({
           ...UntouchedOfferOrderMultipleEditionSets,
           internalID: "1234",
@@ -158,7 +158,7 @@ describe("Offer InitialMutation", () => {
     })
 
     it("can receive input, which updates the transaction summary", async () => {
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => testOffer,
       })
       let page = new OrderAppTestPage(wrapper)
@@ -172,7 +172,7 @@ describe("Offer InitialMutation", () => {
     })
 
     it("can select a price option which updates the transaction summary", async () => {
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => testOffer,
       })
       let page = new OrderAppTestPage(wrapper)
@@ -194,7 +194,7 @@ describe("Offer InitialMutation", () => {
     const offer = { ...testOffer, ...UntouchedOfferOrderInPounds }
 
     it("can receive input, which updates the transaction summary", async () => {
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => offer,
       })
       let page = new OrderAppTestPage(wrapper)
@@ -212,7 +212,7 @@ describe("Offer InitialMutation", () => {
     const offer = { ...testOffer, ...UntouchedOfferOrderWithRange }
 
     it("shows the list price as a range", () => {
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => offer,
       })
       let page = new OrderAppTestPage(wrapper)
@@ -222,7 +222,7 @@ describe("Offer InitialMutation", () => {
     })
 
     it("does not show the offer is too small warning", async () => {
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => offer,
       })
       let page = new OrderAppTestPage(wrapper)
@@ -233,7 +233,7 @@ describe("Offer InitialMutation", () => {
     })
 
     it("does not show the offer amount is too high warning", async () => {
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => offer,
       })
       let page = new OrderAppTestPage(wrapper)
@@ -247,7 +247,7 @@ describe("Offer InitialMutation", () => {
   describe("a offer note", () => {
     describe("non inquiry order offer", () => {
       it("displays OfferNote button", () => {
-        let wrapper = getWrapper({
+        let { wrapper } = getWrapper({
           CommerceOrder: () => testOffer,
         })
         let page = new OrderAppTestPage(wrapper)
@@ -259,7 +259,7 @@ describe("Offer InitialMutation", () => {
 
     describe("inquiry order offer", () => {
       it("hides the OfferNote button for an inquiry order", () => {
-        let wrapper = getWrapper({
+        let { wrapper } = getWrapper({
           CommerceOrder: () => ({ ...testOffer, isInquiryOrder: true }),
         })
         let page = new OrderAppTestPage(wrapper)
@@ -272,7 +272,7 @@ describe("Offer InitialMutation", () => {
 
   describe("mutation", () => {
     it("doesn't let the user continue if custom amount is invalid", async () => {
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => testOffer,
       })
       let page = new OrderAppTestPage(wrapper)
@@ -289,7 +289,7 @@ describe("Offer InitialMutation", () => {
     })
 
     it("lets the user continue with list price as offer if they haven't clicked any option", async () => {
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => testOffer,
       })
       let page = new OrderAppTestPage(wrapper)
@@ -301,7 +301,7 @@ describe("Offer InitialMutation", () => {
 
     it("routes to shipping screen after mutation completes - option", async () => {
       mockCommitMutation.mockResolvedValue(initialOfferSuccess)
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => testOffer,
       })
       let page = new OrderAppTestPage(wrapper)
@@ -317,7 +317,7 @@ describe("Offer InitialMutation", () => {
 
     it("routes to shipping screen after mutation completes - custom amount", async () => {
       mockCommitMutation.mockResolvedValue(initialOfferSuccess)
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => testOffer,
       })
       let page = new OrderAppTestPage(wrapper)
@@ -330,7 +330,7 @@ describe("Offer InitialMutation", () => {
 
     it("shows the button spinner while committing the mutation", async () => {
       isCommittingMutation = true
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => testOffer,
       })
       let page = new OrderAppTestPage(wrapper)
@@ -340,7 +340,7 @@ describe("Offer InitialMutation", () => {
 
     it("shows an error modal when there is an error from the server", async () => {
       mockCommitMutation.mockResolvedValue(initialOfferFailedCannotOffer)
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => testOffer,
       })
       let page = new OrderAppTestPage(wrapper)
@@ -353,7 +353,7 @@ describe("Offer InitialMutation", () => {
 
     it("shows a helpful error message in a modal when there is an error from the server because the amount is invalid", async () => {
       mockCommitMutation.mockResolvedValue(initialOfferFailedAmountIsInvalid)
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => testOffer,
       })
       let page = new OrderAppTestPage(wrapper)
@@ -369,7 +369,7 @@ describe("Offer InitialMutation", () => {
 
     it("shows no modal warning when an offer made on work with hidden price", async () => {
       mockCommitMutation.mockResolvedValue(initialOfferSuccess)
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => ({
           ...UntouchedOfferOrderPriceHidden,
           internalID: "1234",
@@ -386,7 +386,7 @@ describe("Offer InitialMutation", () => {
     })
 
     it("jumps to the custom amount input if custom amount is invalid", async () => {
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => testOffer,
       })
       let page = new OrderAppTestPage(wrapper)
@@ -401,7 +401,7 @@ describe("Offer InitialMutation", () => {
 
     describe("The 'amount too small' speed bump", () => {
       it("shows if the offer amount is too small", async () => {
-        let wrapper = getWrapper({
+        let { wrapper } = getWrapper({
           CommerceOrder: () => ({
             ...UntouchedOfferOrderMultipleEditionSets,
             internalID: "1234",
@@ -428,7 +428,7 @@ describe("Offer InitialMutation", () => {
 
   describe("Analytics", () => {
     it("tracks the offer input focus", () => {
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => testOffer,
       })
       let page = new OrderAppTestPage(wrapper)
@@ -450,7 +450,7 @@ describe("Offer InitialMutation", () => {
         flow: "Make offer",
         order_id: "1234",
       }
-      let wrapper = getWrapper({
+      let { wrapper } = getWrapper({
         CommerceOrder: () => testOffer,
       })
       let page = new OrderAppTestPage(wrapper)

--- a/src/Apps/Order/Routes/__tests__/Payment.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Payment.jest.tsx
@@ -190,7 +190,7 @@ describe("Payment", () => {
         }
       })
       isCommittingMutation = false
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       page = new PaymentTestPage(wrapper)
@@ -303,7 +303,7 @@ describe("Payment", () => {
     let page: PaymentTestPage
 
     beforeEach(() => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => OfferOrderWithShippingDetails,
       })
       page = new PaymentTestPage(wrapper)
@@ -341,7 +341,7 @@ describe("Payment", () => {
       })
       isCommittingMutation = false
 
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => achOrder,
       })
       page = new PaymentTestPage(wrapper)
@@ -423,7 +423,7 @@ describe("Payment", () => {
     }
 
     beforeEach(() => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => bankOrder,
       })
       page = new PaymentTestPage(wrapper)
@@ -458,7 +458,7 @@ describe("Payment", () => {
       })
       isCommittingMutation = false
 
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => sepaOrder,
       })
       page = new PaymentTestPage(wrapper)
@@ -519,7 +519,7 @@ describe("Payment", () => {
     }
 
     beforeEach(() => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => sepaOrder,
       })
       page = new PaymentTestPage(wrapper)
@@ -563,7 +563,7 @@ describe("Payment", () => {
         submitMutation: submitMutationMock,
       }))
 
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => wireOrder,
       })
       page = new PaymentTestPage(wrapper)
@@ -630,7 +630,7 @@ describe("Payment", () => {
     }
 
     beforeEach(() => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => wireOrder,
       })
       page = new PaymentTestPage(wrapper)
@@ -701,7 +701,7 @@ describe("Payment", () => {
     beforeEach(() => {
       jest.clearAllMocks()
 
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => privateSaleOrderWithWire,
       })
       page = new PaymentTestPage(wrapper)
@@ -759,7 +759,7 @@ describe("Payment", () => {
           }
         })
 
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => order,
         })
         page = new PaymentTestPage(wrapper)

--- a/src/Apps/Order/Routes/__tests__/Reject.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Reject.jest.tsx
@@ -96,7 +96,7 @@ describe("Buyer rejects seller offer", () => {
     })
 
     it("renders", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => ({
           ...testOrder,
           stateExpiresAt: DateTime.fromISO(NOW)
@@ -115,7 +115,7 @@ describe("Buyer rejects seller offer", () => {
     })
 
     it("Shows a change link that takes the user back to the respond page", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new OrderAppTestPage(wrapper)
@@ -138,7 +138,7 @@ describe("Buyer rejects seller offer", () => {
 
     it("routes to status page after mutation completes", async () => {
       mockCommitMutation.mockResolvedValue(rejectOfferSuccess)
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new OrderAppTestPage(wrapper)
@@ -151,7 +151,7 @@ describe("Buyer rejects seller offer", () => {
 
     it("shows the button spinner while loading the mutation", async () => {
       isCommittingMutation = true
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new OrderAppTestPage(wrapper)
@@ -161,7 +161,7 @@ describe("Buyer rejects seller offer", () => {
 
     it("shows an error modal when there is an error from the server", async () => {
       mockCommitMutation.mockResolvedValue(rejectOfferFailed)
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new OrderAppTestPage(wrapper)
@@ -172,7 +172,7 @@ describe("Buyer rejects seller offer", () => {
 
     it("shows an error modal when there is a network error", async () => {
       mockCommitMutation.mockRejectedValue({})
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new OrderAppTestPage(wrapper)

--- a/src/Apps/Order/Routes/__tests__/Respond.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Respond.jest.tsx
@@ -133,7 +133,7 @@ describe("The respond page", () => {
     })
 
     it("renders", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => ({
           ...testOrder,
 
@@ -174,7 +174,7 @@ describe("The respond page", () => {
     })
 
     it("shows a note if there is one", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => OfferOrderWithShippingDetailsAndNote,
       })
       const page = new RespondTestPage(wrapper)
@@ -183,7 +183,7 @@ describe("The respond page", () => {
     })
 
     it("shows the offer history item", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new RespondTestPage(wrapper)
@@ -198,7 +198,7 @@ describe("The respond page", () => {
     })
 
     it("hides offer note button for inquiry order", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => ({
           ...testOrder,
           isInquiryOrder: true,
@@ -224,7 +224,7 @@ describe("The respond page", () => {
 
     it("Accepting the seller's offer works", async () => {
       mockCommitMutation.mockResolvedValue(buyerCounterOfferSuccess)
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new RespondTestPage(wrapper)
@@ -238,7 +238,7 @@ describe("The respond page", () => {
 
     it("Declining the seller's offer works", async () => {
       mockCommitMutation.mockResolvedValue(buyerCounterOfferSuccess)
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new RespondTestPage(wrapper)
@@ -260,7 +260,7 @@ describe("The respond page", () => {
       })
 
       it("doesn't work if nothing was typed in", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => testOrder,
         })
         const page = new RespondTestPage(wrapper)
@@ -274,7 +274,7 @@ describe("The respond page", () => {
       })
 
       it("doesn't let the user continue if the offer value is not positive", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => testOrder,
         })
         const page = new RespondTestPage(wrapper)
@@ -289,7 +289,7 @@ describe("The respond page", () => {
 
       it("works when a valid number is inputted", async () => {
         mockCommitMutation.mockResolvedValue(buyerCounterOfferSuccess)
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => testOrder,
         })
         const page = new RespondTestPage(wrapper)
@@ -316,7 +316,7 @@ describe("The respond page", () => {
 
       it("works when a valid number is inputted for a non-usd currency", async () => {
         mockCommitMutation.mockResolvedValue(buyerCounterOfferSuccess)
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => ({ ...testOrder, currencyCode: "GBP" }),
         })
         const page = new RespondTestPage(wrapper)
@@ -344,7 +344,7 @@ describe("The respond page", () => {
 
     it("shows the error modal if submitting a counter offer fails at network level", async () => {
       mockCommitMutation.mockRejectedValue({})
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new RespondTestPage(wrapper)
@@ -362,7 +362,7 @@ describe("The respond page", () => {
 
     it("shows the error modal if submitting a counter offer fails for business reasons", async () => {
       mockCommitMutation.mockResolvedValue(buyerCounterOfferFailed)
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new RespondTestPage(wrapper)
@@ -388,7 +388,7 @@ describe("The respond page", () => {
 
       it("shows if the offer amount is too small", async () => {
         mockCommitMutation.mockResolvedValue(buyerCounterOfferSuccess)
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => testOrder,
         })
         const page = new RespondTestPage(wrapper)
@@ -426,7 +426,7 @@ describe("The respond page", () => {
 
       it("shows if the offer amount is too high", async () => {
         mockCommitMutation.mockResolvedValue(buyerCounterOfferSuccess)
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => testOrder,
         })
         const page = new RespondTestPage(wrapper)
@@ -463,7 +463,7 @@ describe("The respond page", () => {
     })
 
     it("tracks the offer input focus", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new RespondTestPage(wrapper)
@@ -482,7 +482,7 @@ describe("The respond page", () => {
     })
 
     it("tracks viwing the low offer speedbump", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new RespondTestPage(wrapper)
@@ -501,7 +501,7 @@ describe("The respond page", () => {
     })
 
     it("tracks viwing the high offer speedbump", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new RespondTestPage(wrapper)

--- a/src/Apps/Order/Routes/__tests__/Review.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Review.jest.tsx
@@ -137,7 +137,7 @@ describe("Review", () => {
   describe("buy-mode orders", () => {
     it("enables the button and routes to the payoff page", async () => {
       mockCommitMutation.mockResolvedValue(submitOrderSuccess)
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new ReviewTestPage(wrapper)
@@ -149,7 +149,7 @@ describe("Review", () => {
 
     it("disables the submit button when props.stripe is not present", () => {
       loadStripe.mockReturnValueOnce(null)
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new ReviewTestPage(wrapper)
@@ -157,7 +157,7 @@ describe("Review", () => {
     })
 
     it("takes the user back to the /shipping view", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new ReviewTestPage(wrapper)
@@ -169,7 +169,7 @@ describe("Review", () => {
     })
 
     it("takes the user back to the /payment view", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new ReviewTestPage(wrapper)
@@ -181,7 +181,7 @@ describe("Review", () => {
     })
 
     it("shows buyer guarentee", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new ReviewTestPage(wrapper)
@@ -191,7 +191,7 @@ describe("Review", () => {
 
     it("shows an error modal when there is an error in submitOrderPayload", async () => {
       mockCommitMutation.mockResolvedValue(submitOrderWithFailure)
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new ReviewTestPage(wrapper)
@@ -202,7 +202,7 @@ describe("Review", () => {
 
     it("shows an error modal when there is a network error", async () => {
       mockCommitMutation.mockRejectedValue({})
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new ReviewTestPage(wrapper)
@@ -215,7 +215,7 @@ describe("Review", () => {
       mockCommitMutation.mockResolvedValue(
         submitOrderWithVersionMismatchFailure
       )
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new ReviewTestPage(wrapper)
@@ -231,7 +231,7 @@ describe("Review", () => {
 
     it("shows a modal with a helpful error message if a user has not entered shipping and payment information", async () => {
       mockCommitMutation.mockResolvedValue(submitOrderWithMissingInfo)
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new ReviewTestPage(wrapper)
@@ -246,7 +246,7 @@ describe("Review", () => {
 
     it("shows a modal with a helpful error message if the user's card is declined", async () => {
       mockCommitMutation.mockResolvedValue(submitOrderWithFailureCardDeclined)
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new ReviewTestPage(wrapper)
@@ -263,7 +263,7 @@ describe("Review", () => {
       mockCommitMutation.mockResolvedValue(
         submitOrderWithFailureInsufficientFunds
       )
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new ReviewTestPage(wrapper)
@@ -280,7 +280,7 @@ describe("Review", () => {
       mockCommitMutation.mockResolvedValue(
         submitOrderWithFailureCurrencyNotSupported
       )
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new ReviewTestPage(wrapper)
@@ -299,7 +299,7 @@ describe("Review", () => {
 
     it("shows a modal that redirects to the artist page if there is an insufficient inventory", async () => {
       mockCommitMutation.mockResolvedValue(submitOrderWithNoInventoryFailure)
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new ReviewTestPage(wrapper)
@@ -323,7 +323,7 @@ describe("Review", () => {
         },
       })
 
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
 
@@ -348,7 +348,7 @@ describe("Review", () => {
         },
       })
 
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
 
@@ -364,7 +364,7 @@ describe("Review", () => {
 
     it("shows SCA modal when required", async () => {
       mockCommitMutation.mockResolvedValue(submitOrderWithActionRequired)
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new ReviewTestPage(wrapper)
@@ -382,7 +382,7 @@ describe("Review", () => {
     }
 
     it("shows an active offer stepper if the order is an Offer Order", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOffer,
       })
       const page = new ReviewTestPage(wrapper)
@@ -395,7 +395,7 @@ describe("Review", () => {
     })
 
     it("shows an offer section in the shipping and payment review", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOffer,
       })
       const page = new ReviewTestPage(wrapper)
@@ -408,7 +408,7 @@ describe("Review", () => {
     })
 
     it("shows an offer note if one exists", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => ({
           ...OfferOrderWithShippingDetailsAndNote,
           impulseConversationId: null,
@@ -421,7 +421,7 @@ describe("Review", () => {
 
     it("enables the button and routes to the artwork page", async () => {
       mockCommitMutation.mockResolvedValue(submitOfferOrderSuccess)
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOffer,
       })
       const page = new ReviewTestPage(wrapper)
@@ -435,7 +435,7 @@ describe("Review", () => {
 
     it("shows an error modal when there is an error in submitOrderPayload", async () => {
       mockCommitMutation.mockResolvedValue(submitOfferOrderWithFailure)
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOffer,
       })
       const page = new ReviewTestPage(wrapper)
@@ -446,7 +446,7 @@ describe("Review", () => {
 
     it("shows an error modal when there is a network error", async () => {
       mockCommitMutation.mockRejectedValue({})
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOffer,
       })
       const page = new ReviewTestPage(wrapper)
@@ -459,7 +459,7 @@ describe("Review", () => {
       mockCommitMutation.mockResolvedValue(
         submitOfferOrderWithVersionMismatchFailure
       )
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOffer,
       })
       const page = new ReviewTestPage(wrapper)
@@ -475,7 +475,7 @@ describe("Review", () => {
 
     it("shows a modal if there is a payment_method_confirmation_failed", async () => {
       mockCommitMutation.mockResolvedValue(submitOfferOrderFailedConfirmation)
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOffer,
       })
       const page = new ReviewTestPage(wrapper)
@@ -492,7 +492,7 @@ describe("Review", () => {
       mockCommitMutation.mockResolvedValue(
         submitOfferOrderWithNoInventoryFailure
       )
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOffer,
       })
       const page = new ReviewTestPage(wrapper)
@@ -506,7 +506,7 @@ describe("Review", () => {
 
     it("shows SCA modal when required", async () => {
       mockCommitMutation.mockResolvedValue(submitOfferOrderWithActionRequired)
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOffer,
       })
       const page = new ReviewTestPage(wrapper)
@@ -528,7 +528,7 @@ describe("Review", () => {
 
       it("dispatches message given Eigen when the offer is submitted", async () => {
         mockCommitMutation.mockResolvedValue(submitOfferOrderSuccess)
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => testOffer,
         })
         const page = new ReviewTestPage(wrapper)
@@ -563,7 +563,7 @@ describe("Review", () => {
     }
 
     it("takes the user back to the /shipping view", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new ReviewTestPage(wrapper)
@@ -575,7 +575,7 @@ describe("Review", () => {
     })
 
     it("renders shipping information", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new ReviewTestPage(wrapper)
@@ -599,7 +599,7 @@ describe("Review", () => {
 
   describe("Inquiry offer orders", () => {
     it("renders with inquiry extra information", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => ({
           ...OfferOrderWithMissingMetadata,
           impulseConversationId: "5665",
@@ -616,7 +616,7 @@ describe("Review", () => {
     })
 
     it("does not show message about shipping and tax confirmation for buy now orders", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => ({
           ...BuyOrderWithShippingDetails,
           impulseConversationId: null,
@@ -631,7 +631,7 @@ describe("Review", () => {
 
     it("enables the button and routes to the conversation", async () => {
       mockCommitMutation.mockResolvedValue(submitOfferOrderSuccess)
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => ({
           ...OfferOrderWithMissingMetadata,
           impulseConversationId: "5665",
@@ -648,7 +648,7 @@ describe("Review", () => {
   describe("Inquiry buy-mode orders", () => {
     it("enables the button and routes to the conversation", async () => {
       mockCommitMutation.mockResolvedValue(submitOfferOrderSuccess)
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => ({
           ...BuyOrderWithShippingDetails,
           source: "inquiry",
@@ -665,7 +665,7 @@ describe("Review", () => {
 
   describe("Bank debit orders", () => {
     it("shows bank transfer as payment method", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => ({
           ...BuyOrderWithBankDebitDetails,
           impulseConversationId: null,
@@ -681,7 +681,7 @@ describe("Review", () => {
 
   describe("Wire transfer orders", () => {
     it("shows bank transfer as payment method", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => ({
           ...BuyOrderWithWireTransferDetails,
           impulseConversationId: null,
@@ -704,7 +704,7 @@ describe("Review", () => {
     }
 
     beforeEach(() => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => privateSaleOrderWithWire,
       })
       page = new ReviewTestPage(wrapper)
@@ -769,7 +769,7 @@ describe("Review", () => {
 
       it("routes to the status page", async () => {
         mockCommitMutation.mockResolvedValue(submitOfferOrderSuccessInReview)
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => OfferOrderInReviewFromArtworkPage,
         })
         const page = new ReviewTestPage(wrapper)
@@ -789,7 +789,7 @@ describe("Review", () => {
 
       it("routes to the conversation", async () => {
         mockCommitMutation.mockResolvedValue(submitOfferOrderSuccessInReview)
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => OfferOrderInReviewFromInquiry,
         })
         const page = new ReviewTestPage(wrapper)
@@ -815,7 +815,7 @@ describe("Review", () => {
 
         it("dispatches message and routes to status page", async () => {
           mockCommitMutation.mockResolvedValue(submitOfferOrderSuccessInReview)
-          const wrapper = getWrapper({
+          const { wrapper } = getWrapper({
             CommerceOrder: () => OfferOrderInReviewFromArtworkPage,
           })
           const page = new ReviewTestPage(wrapper)
@@ -844,7 +844,7 @@ describe("Review", () => {
 
         it("doesn't dispatch a message and routes to status page", async () => {
           mockCommitMutation.mockResolvedValue(submitOfferOrderSuccessInReview)
-          const wrapper = getWrapper({
+          const { wrapper } = getWrapper({
             CommerceOrder: () => OfferOrderInReviewFromInquiry,
           })
           const page = new ReviewTestPage(wrapper)

--- a/src/Apps/Order/Routes/__tests__/Status.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Status.jest.tsx
@@ -66,7 +66,7 @@ describe("Status", () => {
 
   describe("offers", () => {
     it("should should have a title containing status", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
 
@@ -75,7 +75,7 @@ describe("Status", () => {
 
     describe("submitted", () => {
       it("should say order submitted and have message box", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => testOrder,
         })
         const page = new StatusTestPage(wrapper)
@@ -98,7 +98,7 @@ describe("Status", () => {
 
       it("should say order submitted and have message to continue to inbox on Eigen", async () => {
         isEigen = true
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => testOrder,
         })
         const page = new StatusTestPage(wrapper)
@@ -118,7 +118,7 @@ describe("Status", () => {
       })
 
       it("should not show a note section if none exists", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () =>
             produce(testOrder, order => {
               // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
@@ -133,7 +133,7 @@ describe("Status", () => {
 
     describe("in review", () => {
       it("should say order submitted and have message box", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => ({
             ...testOrder,
             state: "IN_REVIEW",
@@ -160,7 +160,7 @@ describe("Status", () => {
 
       it("should say order submitted and have message to continue to inbox on Eigen", async () => {
         isEigen = true
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => ({
             ...testOrder,
             state: "IN_REVIEW",
@@ -186,7 +186,7 @@ describe("Status", () => {
 
     describe("approved", () => {
       it("should say confirmed and have message box", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => ({
             ...OfferOrderWithShippingDetails,
             displayState: "APPROVED",
@@ -201,7 +201,7 @@ describe("Status", () => {
 
     describe("processing", () => {
       it("should say confirmed and have message box", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => ({
             ...OfferOrderWithShippingDetails,
             displayState: "PROCESSING",
@@ -217,7 +217,7 @@ describe("Status", () => {
     describe("processing approval", () => {
       describe("with wire payment method", () => {
         it("should say 'Thank you, your offer has been accepted' and have message box", async () => {
-          const wrapper = getWrapper({
+          const { wrapper } = getWrapper({
             CommerceOrder: () => ({
               ...OfferOrderWithShippingDetails,
               displayState: "PROCESSING_APPROVAL",
@@ -233,7 +233,7 @@ describe("Status", () => {
         })
 
         it("renders Message with alert variant and 'please proceed' message", async () => {
-          const wrapper = getWrapper({
+          const { wrapper } = getWrapper({
             CommerceOrder: () => ({
               ...OfferOrderWithShippingDetails,
               displayState: "PROCESSING_APPROVAL",
@@ -251,7 +251,7 @@ describe("Status", () => {
         })
 
         it("renders the alert Message with correct messages", async () => {
-          const wrapper = getWrapper({
+          const { wrapper } = getWrapper({
             CommerceOrder: () => ({
               ...OfferOrderWithShippingDetails,
               displayState: "PROCESSING_APPROVAL",
@@ -272,7 +272,7 @@ describe("Status", () => {
         })
 
         it("renders content for Artsy's bank details", async () => {
-          const wrapper = getWrapper({
+          const { wrapper } = getWrapper({
             CommerceOrder: () => ({
               ...OfferOrderWithShippingDetails,
               displayState: "PROCESSING_APPROVAL",
@@ -295,7 +295,7 @@ describe("Status", () => {
 
       describe("with non-wire payment methods", () => {
         it("should say 'Offer accepted. Payment processing.' and have message box", async () => {
-          const wrapper = getWrapper({
+          const { wrapper } = getWrapper({
             CommerceOrder: () => ({
               ...OfferOrderWithShippingDetails,
               displayState: "PROCESSING_APPROVAL",
@@ -309,7 +309,7 @@ describe("Status", () => {
         })
 
         it("renders description", async () => {
-          const wrapper = getWrapper({
+          const { wrapper } = getWrapper({
             CommerceOrder: () => ({
               ...OfferOrderWithShippingDetails,
               displayState: "PROCESSING_APPROVAL",
@@ -324,7 +324,7 @@ describe("Status", () => {
         })
 
         it("does not render an alert message", async () => {
-          const wrapper = getWrapper({
+          const { wrapper } = getWrapper({
             CommerceOrder: () => ({
               ...OfferOrderWithShippingDetails,
               displayState: "PROCESSING_APPROVAL",
@@ -341,7 +341,7 @@ describe("Status", () => {
 
     describe("in transit", () => {
       it("should say confirmed, have message box and the tracking URL", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => ({
             ...OfferOrderWithShippingDetails,
             displayState: "IN_TRANSIT",
@@ -358,7 +358,7 @@ describe("Status", () => {
       })
 
       it("should display non linked tracking number if no Url", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => ({
             ...ArtaShippedWithTrackingIdNoTrackingUrl,
             displayState: "IN_TRANSIT",
@@ -373,7 +373,7 @@ describe("Status", () => {
       })
 
       it("should display note about shipping when tracking is not available", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => ({
             ...ArtaShippedWithNoTrackingIdNoTrackingUrl,
             ...CreditCardPaymentDetails,
@@ -390,7 +390,7 @@ describe("Status", () => {
 
     describe("fulfilled (ship)", () => {
       it("should say order has shipped and have message box", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => ({
             ...OfferOrderWithShippingDetails,
             displayState: "FULFILLED",
@@ -406,7 +406,7 @@ describe("Status", () => {
 
     describe("fulfilled (pickup)", () => {
       it("should say order has been picked up and NOT have message box", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => ({
             ...OfferOrderPickup,
             ...CreditCardPaymentDetails,
@@ -422,7 +422,7 @@ describe("Status", () => {
 
     describe("buyer rejected", () => {
       it("should say that offer was declined", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => ({
             ...OfferOrderPickup,
             ...CreditCardPaymentDetails,
@@ -439,7 +439,7 @@ describe("Status", () => {
 
     describe("seller rejected", () => {
       it("should say that offer was declined", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => ({
             ...OfferOrderPickup,
             ...CreditCardPaymentDetails,
@@ -456,7 +456,7 @@ describe("Status", () => {
 
     describe("seller lapsed", () => {
       it("should say that offer expired", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => ({
             ...OfferOrderPickup,
             ...CreditCardPaymentDetails,
@@ -473,7 +473,7 @@ describe("Status", () => {
 
     describe("buyer lapsed", () => {
       it("should say that offer expired", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => ({
             ...OfferOrderPickup,
             ...CreditCardPaymentDetails,
@@ -490,7 +490,7 @@ describe("Status", () => {
 
     describe("refunded", () => {
       it("should say that order was canceled", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => ({
             ...OfferOrderPickup,
             ...CreditCardPaymentDetails,
@@ -506,7 +506,7 @@ describe("Status", () => {
 
     describe("canceled after accept", () => {
       it("should say that order was canceled", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => ({
             ...OfferOrderPickup,
             ...CreditCardPaymentDetails,
@@ -525,7 +525,7 @@ describe("Status", () => {
 
   describe("orders", () => {
     it("should should have a title containing status", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         CommerceOrder: () => BuyOrderWithShippingDetails,
       })
 
@@ -534,7 +534,7 @@ describe("Status", () => {
 
     describe("submitted", () => {
       it("should say order submitted and have message box", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => ({
             ...BuyOrderWithShippingDetails,
             ...CreditCardPaymentDetails,
@@ -555,7 +555,7 @@ describe("Status", () => {
 
     describe("approved", () => {
       it("should say confirmed", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => ({
             ...BuyOrderWithShippingDetails,
             ...CreditCardPaymentDetails,
@@ -568,7 +568,7 @@ describe("Status", () => {
       })
 
       it("should render correct title for Private Sale orders", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => ({
             ...BuyOrderWithShippingDetails,
             ...CreditCardPaymentDetails,
@@ -584,7 +584,7 @@ describe("Status", () => {
       })
 
       it("should render correct description for Private Sale orders", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => ({
             ...BuyOrderWithShippingDetails,
             ...CreditCardPaymentDetails,
@@ -600,7 +600,7 @@ describe("Status", () => {
       })
 
       it("should render help email in description for Private Sale orders", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => ({
             ...BuyOrderWithShippingDetails,
             ...CreditCardPaymentDetails,
@@ -617,7 +617,7 @@ describe("Status", () => {
     describe("processing approval", () => {
       describe("with wire payment method", () => {
         it("should render correct title and have message box", async () => {
-          const wrapper = getWrapper({
+          const { wrapper } = getWrapper({
             CommerceOrder: () => ({
               ...BuyOrderWithShippingDetails,
               displayState: "PROCESSING_APPROVAL",
@@ -633,7 +633,7 @@ describe("Status", () => {
         })
 
         it("should render correct title for wire private sale orders", async () => {
-          const wrapper = getWrapper({
+          const { wrapper } = getWrapper({
             CommerceOrder: () => ({
               ...BuyOrderWithShippingDetails,
               displayState: "PROCESSING_APPROVAL",
@@ -649,7 +649,7 @@ describe("Status", () => {
         })
 
         it("renders Message with alert variant and 'please proceed' message", async () => {
-          const wrapper = getWrapper({
+          const { wrapper } = getWrapper({
             CommerceOrder: () => ({
               ...BuyOrderWithShippingDetails,
               displayState: "PROCESSING_APPROVAL",
@@ -667,7 +667,7 @@ describe("Status", () => {
         })
 
         it("should render correct instruction for wire private sale orders", async () => {
-          const wrapper = getWrapper({
+          const { wrapper } = getWrapper({
             CommerceOrder: () => ({
               ...BuyOrderWithShippingDetails,
               displayState: "PROCESSING_APPROVAL",
@@ -681,7 +681,7 @@ describe("Status", () => {
         })
 
         it("should not render any description for wire private sale orders", async () => {
-          const wrapper = getWrapper({
+          const { wrapper } = getWrapper({
             CommerceOrder: () => ({
               ...BuyOrderWithShippingDetails,
               displayState: "PROCESSING_APPROVAL",
@@ -695,7 +695,7 @@ describe("Status", () => {
         })
 
         it("renders the alert Message with correct messages", async () => {
-          const wrapper = getWrapper({
+          const { wrapper } = getWrapper({
             CommerceOrder: () => ({
               ...BuyOrderWithShippingDetails,
               displayState: "PROCESSING_APPROVAL",
@@ -716,7 +716,7 @@ describe("Status", () => {
         })
 
         it("renders correct Artsy bank details for orders in USD", async () => {
-          const wrapper = getWrapper({
+          const { wrapper } = getWrapper({
             CommerceOrder: () => ({
               ...BuyOrderWithShippingDetails,
               displayState: "PROCESSING_APPROVAL",
@@ -738,7 +738,7 @@ describe("Status", () => {
         })
 
         it("renders correct Artsy bank details for orders in GBP", async () => {
-          const wrapper = getWrapper({
+          const { wrapper } = getWrapper({
             CommerceOrder: () => ({
               ...BuyOrderWithShippingDetails,
               displayState: "PROCESSING_APPROVAL",
@@ -762,7 +762,7 @@ describe("Status", () => {
         })
 
         it("renders correct Artsy bank details for orders in EUR", async () => {
-          const wrapper = getWrapper({
+          const { wrapper } = getWrapper({
             CommerceOrder: () => ({
               ...BuyOrderWithShippingDetails,
               displayState: "PROCESSING_APPROVAL",
@@ -787,7 +787,7 @@ describe("Status", () => {
 
       describe("with non-wire payment methods", () => {
         it("should say 'Your order is confirmed. Payment processing.' and have message box", async () => {
-          const wrapper = getWrapper({
+          const { wrapper } = getWrapper({
             CommerceOrder: () => ({
               ...BuyOrderWithShippingDetails,
               displayState: "PROCESSING_APPROVAL",
@@ -803,7 +803,7 @@ describe("Status", () => {
         })
 
         it("should render correct title for private sale orders", async () => {
-          const wrapper = getWrapper({
+          const { wrapper } = getWrapper({
             CommerceOrder: () => ({
               ...BuyOrderWithShippingDetails,
               displayState: "PROCESSING_APPROVAL",
@@ -819,7 +819,7 @@ describe("Status", () => {
         })
 
         it("renders description", async () => {
-          const wrapper = getWrapper({
+          const { wrapper } = getWrapper({
             CommerceOrder: () => ({
               ...BuyOrderWithShippingDetails,
               displayState: "PROCESSING_APPROVAL",
@@ -834,7 +834,7 @@ describe("Status", () => {
         })
 
         it("should render correct description for private sale orders", async () => {
-          const wrapper = getWrapper({
+          const { wrapper } = getWrapper({
             CommerceOrder: () => ({
               ...BuyOrderWithShippingDetails,
               displayState: "PROCESSING_APPROVAL",
@@ -851,7 +851,7 @@ describe("Status", () => {
         })
 
         it("does not render an alert message", async () => {
-          const wrapper = getWrapper({
+          const { wrapper } = getWrapper({
             CommerceOrder: () => ({
               ...BuyOrderWithShippingDetails,
               displayState: "PROCESSING_APPROVAL",
@@ -868,7 +868,7 @@ describe("Status", () => {
 
     describe("fulfilled (ship)", () => {
       it("should say order has shipped and have message box", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => ({
             ...BuyOrderWithShippingDetails,
             ...CreditCardPaymentDetails,
@@ -884,7 +884,7 @@ describe("Status", () => {
 
     describe("fulfilled (pickup)", () => {
       it("should say order has been picked up and NOT have message box", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => ({
             ...BuyOrderPickup,
             ...CreditCardPaymentDetails,
@@ -900,7 +900,7 @@ describe("Status", () => {
 
     describe("canceled (ship)", () => {
       it("should say that order was canceled", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => ({
             ...BuyOrderWithShippingDetails,
             ...CreditCardPaymentDetails,
@@ -916,7 +916,7 @@ describe("Status", () => {
 
     describe("canceled (pickup)", () => {
       it("should say that order was canceled", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => ({
             ...BuyOrderPickup,
             ...CreditCardPaymentDetails,
@@ -932,7 +932,7 @@ describe("Status", () => {
 
     describe("refunded", () => {
       it("should say that order was canceled", async () => {
-        const wrapper = getWrapper({
+        const { wrapper } = getWrapper({
           CommerceOrder: () => ({
             ...BuyOrderPickup,
             ...CreditCardPaymentDetails,

--- a/src/Apps/Partner/Components/__tests__/NavigationTabs.jest.tsx
+++ b/src/Apps/Partner/Components/__tests__/NavigationTabs.jest.tsx
@@ -26,7 +26,7 @@ const { getWrapper } = setupTestWrapper<NavigationTabs_Test_PartnerQuery>({
 
 describe("PartnerNavigationTabs", () => {
   it("renders all tabs by default", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         id: "white-cube",
         slug: "white-cube",
@@ -48,7 +48,7 @@ describe("PartnerNavigationTabs", () => {
   })
 
   it("display Shop instead of Works for Brand partner", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         id: "white-cube",
         partnerType: "Brand",
@@ -61,7 +61,7 @@ describe("PartnerNavigationTabs", () => {
   })
 
   it("doesn't display contact tab if no locations", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({ locations: { totalCount: null } }),
     })
     const html = wrapper.html()
@@ -70,7 +70,7 @@ describe("PartnerNavigationTabs", () => {
   })
 
   it("doesn't display articles tab if no locations", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({ articles: { totalCount: null } }),
     })
     const html = wrapper.html()
@@ -79,7 +79,7 @@ describe("PartnerNavigationTabs", () => {
   })
 
   it("doesn't display artists tab if no artists", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         displayArtistsSection: true,
         representedArtists: { totalCount: 0 },
@@ -92,7 +92,7 @@ describe("PartnerNavigationTabs", () => {
   })
 
   it("doesn't display artists tab if displayArtistsSection is false", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         displayArtistsSection: false,
         representedArtists: { totalCount: 10 },
@@ -105,7 +105,7 @@ describe("PartnerNavigationTabs", () => {
   })
 
   it("doesn't display viewing rooms tab if no vieving rooms", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         viewingRooms: { totalCount: 0 },
       }),

--- a/src/Apps/Partner/Components/__tests__/Overview/AboutPartner.jest.tsx
+++ b/src/Apps/Partner/Components/__tests__/Overview/AboutPartner.jest.tsx
@@ -1,4 +1,4 @@
-import { AboutPartnerFragmentContainer } from "../../Overview/AboutPartner"
+import { AboutPartnerFragmentContainer } from "Apps/Partner/Components/Overview/AboutPartner"
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
 import { graphql } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -40,7 +40,7 @@ describe("AboutPartner", () => {
     limitedBio = limitedBio ? limitedBio : fullBio
     fullBio = fullBio ? fullBio : limitedBio
 
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         website,
         vatNumber,
@@ -64,7 +64,7 @@ describe("AboutPartner", () => {
     const slug = "the-unit-ldn"
     const internalID = "1234asdf"
 
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         website,
         slug,
@@ -83,7 +83,7 @@ describe("AboutPartner", () => {
   })
 
   it("doesn't render the text if data is empty", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         website: null,
         vatNumber: null,
@@ -97,7 +97,7 @@ describe("AboutPartner", () => {
   })
 
   it("doesn't render the component if all data is empty", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         website: null,
         vatNumber: null,

--- a/src/Apps/Partner/Components/__tests__/Overview/ArtistsRail.jest.tsx
+++ b/src/Apps/Partner/Components/__tests__/Overview/ArtistsRail.jest.tsx
@@ -28,7 +28,7 @@ const { getWrapper } = setupTestWrapper({
 
 describe("ArtistsRail", () => {
   it("renders artist list if partner not eligible for full profile", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         slug: "unit-london",
         profileArtistsLayout: "Grid",
@@ -48,7 +48,7 @@ describe("ArtistsRail", () => {
 
   describe("renders carousel", () => {
     it("renders container correctly", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Partner: () => ({
           slug: "unit-london",
           profileArtistsLayout: "Grid",
@@ -66,7 +66,7 @@ describe("ArtistsRail", () => {
     })
 
     it("doesn't render if no artists with published artworks", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Partner: () => ({
           slug: "unit-london",
           profileArtistsLayout: "Grid",
@@ -86,7 +86,7 @@ describe("ArtistsRail", () => {
 
   describe("renders list", () => {
     it("renders container correctly", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Partner: () => ({
           slug: "unit-london",
           profileArtistsLayout: "List",
@@ -104,7 +104,7 @@ describe("ArtistsRail", () => {
     })
 
     it("doesn't render if no artists", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Partner: () => ({
           slug: "unit-london",
           profileArtistsLayout: "List",

--- a/src/Apps/Partner/Components/__tests__/PartnerContacts/PartnerContacts.jest.tsx
+++ b/src/Apps/Partner/Components/__tests__/PartnerContacts/PartnerContacts.jest.tsx
@@ -25,7 +25,7 @@ const { getWrapper } = setupTestWrapper<PartnerContacts_Test_Query>({
 
 describe("PartnerContacts", () => {
   it("displays partner contact cards", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         locations: {
           totalCount: 2,
@@ -53,7 +53,7 @@ describe("PartnerContacts", () => {
   })
 
   it("doesn't display contact card if there is no info", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         locations: {
           edges: null,

--- a/src/Apps/Partner/Components/__tests__/PartnerHeader.jest.tsx
+++ b/src/Apps/Partner/Components/__tests__/PartnerHeader.jest.tsx
@@ -27,7 +27,7 @@ const { getWrapper } = setupTestWrapper<PartnerHeader_Test_Query>({
 
 describe("PartnerHeader", () => {
   it("displays basic information about partner profile", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         name: "White cube",
         profile: {
@@ -60,7 +60,7 @@ describe("PartnerHeader", () => {
   })
 
   it("displays unique address value", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         locations: {
           totalCount: 4,
@@ -97,7 +97,7 @@ describe("PartnerHeader", () => {
   })
 
   it("displays few addresses", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         locations: {
           totalCount: 4,
@@ -136,7 +136,7 @@ describe("PartnerHeader", () => {
   })
 
   it("does not display address", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         name: "White cube",
         locations: {
@@ -156,7 +156,7 @@ describe("PartnerHeader", () => {
   })
 
   it("displays links to partner profile page", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         name: "White cube",
         slug: "white-cube",
@@ -189,7 +189,7 @@ describe("PartnerHeader", () => {
   })
 
   it("doesn't display profile address if there is no info", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         locations: {
           totalCount: 0,
@@ -201,7 +201,7 @@ describe("PartnerHeader", () => {
   })
 
   it("doesn't display profile icon if there is no info", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         profile: null,
       }),
@@ -211,7 +211,7 @@ describe("PartnerHeader", () => {
   })
 
   it("doesn't display follow button if there is no info", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         profile: null,
       }),
@@ -221,7 +221,7 @@ describe("PartnerHeader", () => {
   })
 
   it("doesn't display follow button if partner type is equal to Auction House", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         type: "Auction House",
       }),
@@ -231,7 +231,7 @@ describe("PartnerHeader", () => {
   })
 
   it("doesn't display the follow count", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         name: "White cube",
         profile: {
@@ -246,7 +246,7 @@ describe("PartnerHeader", () => {
   })
 
   it("displays the follow count", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         name: "White cube",
         profile: {

--- a/src/Apps/Partner/Components/__tests__/PartnerShows/ShowBanner.jest.tsx
+++ b/src/Apps/Partner/Components/__tests__/PartnerShows/ShowBanner.jest.tsx
@@ -1,6 +1,6 @@
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
 import { graphql } from "react-relay"
-import { ShowBannerFragmentContainer } from "../../PartnerShows"
+import { ShowBannerFragmentContainer } from "Apps/Partner/Components/PartnerShows"
 
 jest.unmock("react-relay")
 
@@ -29,7 +29,7 @@ const { getWrapper } = setupTestWrapper({
 
 describe("ShowBanner", () => {
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Show: () => ({
         name: "Ellen Altfest | Nature",
         href: "/show/white-cube-ellen-altfest-nature",
@@ -79,7 +79,7 @@ describe("ShowBanner", () => {
   ])(
     "renders correct type label(isFairBooth: %s, status: %s)",
     (isFairBooth, status, result) => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Show: () => ({
           isFairBooth,
           status,

--- a/src/Apps/Partner/Components/__tests__/PartnerViewingRooms/ViewingRoomCard.jest.tsx
+++ b/src/Apps/Partner/Components/__tests__/PartnerViewingRooms/ViewingRoomCard.jest.tsx
@@ -34,7 +34,7 @@ const { getWrapper } = setupTestWrapper({
 
 describe("ViewingRoomCard", () => {
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       ViewingRoom: () => ({
         title: "Ceramic Girl(s)",
         href: "/viewing-room/antonio-colombo-ceramic-girl-s",
@@ -66,7 +66,7 @@ describe("ViewingRoomCard", () => {
   })
 
   it("not renders the text if no data is null/undefined", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       ViewingRoom: () => ({
         title: null,
         href: null,

--- a/src/Apps/Partner/Routes/__tests__/Works.jest.tsx
+++ b/src/Apps/Partner/Routes/__tests__/Works.jest.tsx
@@ -79,13 +79,13 @@ describe("PartnerArtworks", () => {
   })
 
   it("renders correctly", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     expect(wrapper.find("ArtworkFilterArtworkGrid").length).toBe(1)
     expect(wrapper.find("ArtworkGridItem").length).toBe(1)
   })
 
   it("renders filters in correct order", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       FilterArtworksConnection: () => ({
         counts: {
           followedArtists: 10,

--- a/src/Apps/Partner/__tests__/PartnerApp.jest.tsx
+++ b/src/Apps/Partner/__tests__/PartnerApp.jest.tsx
@@ -47,7 +47,7 @@ const { getWrapper } = setupTestWrapper<PartnerApp_Test_Query>({
 
 describe("PartnerApp", () => {
   it("displays navigation tabs for the partner page", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         displayFullPartnerPage: true,
         isDefaultProfilePublic: true,
@@ -58,7 +58,7 @@ describe("PartnerApp", () => {
   })
 
   it("does not display nav tabs for limited profile", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         displayFullPartnerPage: false,
         isDefaultProfilePublic: true,
@@ -69,7 +69,7 @@ describe("PartnerApp", () => {
   })
 
   it("displays navigation tabs for brand partner", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         displayFullPartnerPage: false,
         partnerType: "Brand",
@@ -81,7 +81,7 @@ describe("PartnerApp", () => {
   })
 
   it("displays header image for the partner page", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         profile: {
           image: {
@@ -101,7 +101,7 @@ describe("PartnerApp", () => {
   })
 
   it("doesn't display profile image if there is no info", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         profile: {
           image: null,
@@ -112,7 +112,7 @@ describe("PartnerApp", () => {
   })
 
   it("doesn't display profile image if the partner isn't eligible for a full profile", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         displayFullPartnerPage: false,
       }),

--- a/src/Apps/Search/__tests__/SearchApp.jest.tsx
+++ b/src/Apps/Search/__tests__/SearchApp.jest.tsx
@@ -42,7 +42,7 @@ const { getWrapper } = setupTestWrapper<SearchApp_Test_Query>({
 
 describe("SearchApp", () => {
   it("includes the total count", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Viewer: () => VIEWER_FIXTURE,
     })
     const html = wrapper.find("TotalResults").text()
@@ -50,7 +50,7 @@ describe("SearchApp", () => {
   })
 
   it("includes tabs w/ counts", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Viewer: () => VIEWER_FIXTURE,
     })
     const html = wrapper.find("NavigationTabs").text()

--- a/src/Apps/Settings/Routes/Auctions/Components/__tests__/UserRegistrationAuctions.jest.tsx
+++ b/src/Apps/Settings/Routes/Auctions/Components/__tests__/UserRegistrationAuctions.jest.tsx
@@ -18,7 +18,7 @@ describe("UserRegistrationAuctions", () => {
   })
 
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Me: () => ({
         saleRegistrationsConnection: {
           edges: [
@@ -38,7 +38,7 @@ describe("UserRegistrationAuctions", () => {
   })
 
   it("renders -Nothing to Show- message when no available sale found", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Me: () => ({
         saleRegistrationsConnection: {
           edges: [],
@@ -50,7 +50,7 @@ describe("UserRegistrationAuctions", () => {
   })
 
   it("renders -Registration for Upcoming Auctions- title even if data is not there", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Me: () => ({
         saleRegistrationsConnection: {
           edges: [],
@@ -62,7 +62,7 @@ describe("UserRegistrationAuctions", () => {
   })
 
   it("renders button with correct href of sale", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Me: () => ({
         saleRegistrationsConnection: {
           edges: [

--- a/src/Apps/Settings/Routes/Auctions/__tests__/SettingsAuctionsRoute.jest.tsx
+++ b/src/Apps/Settings/Routes/Auctions/__tests__/SettingsAuctionsRoute.jest.tsx
@@ -20,7 +20,7 @@ describe("SettingsAuctionsRoute", () => {
   })
 
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Me: () => {},
     })
 
@@ -28,7 +28,7 @@ describe("SettingsAuctionsRoute", () => {
   })
 
   it("renders 3 correct children", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Me: () => {},
     })
 

--- a/src/Apps/Show/__tests__/ShowApp.jest.tsx
+++ b/src/Apps/Show/__tests__/ShowApp.jest.tsx
@@ -41,7 +41,7 @@ const { getWrapper } = setupTestWrapper<ShowApp_Test_Query>({
 
 describe("ShowApp", () => {
   it("renders the title", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Show: () => ({ name: "Example Show" }),
     })
     expect(wrapper.find("h1")).toHaveLength(1)
@@ -49,7 +49,7 @@ describe("ShowApp", () => {
   })
 
   it("renders the appropriate info", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({
         name: "Example Partner",
       }),
@@ -72,7 +72,7 @@ describe("ShowApp", () => {
   })
 
   it("renders a viewing room if there are any", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Show: () => ({
         viewingRoomsConnection: {
           edges: [
@@ -88,7 +88,7 @@ describe("ShowApp", () => {
   })
 
   it("does not render `Back to Fair` banner by default", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Show: () => ({
         isFairBooth: false,
         name: "Example Show",
@@ -100,7 +100,7 @@ describe("ShowApp", () => {
   })
 
   it("does not render `Back to Fair` banner without full featured fair", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Show: () => ({
         isFairBooth: true,
         name: "Example Show",
@@ -112,7 +112,7 @@ describe("ShowApp", () => {
   })
 
   it("render `Back to Fair` banner on fair booth pages", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Show: () => ({
         isFairBooth: true,
         name: "Example Show",

--- a/src/Apps/Show/__tests__/ShowArtworks.jest.tsx
+++ b/src/Apps/Show/__tests__/ShowArtworks.jest.tsx
@@ -60,14 +60,14 @@ describe("ShowArtworks", () => {
   })
 
   it("renders correctly", () => {
-    const wrapper = getWrapper({ Show: () => ({ __typename: "Show" }) })
+    const { wrapper } = getWrapper({ Show: () => ({ __typename: "Show" }) })
 
     expect(wrapper.find("ArtworkFilterArtworkGrid").length).toBe(1)
     expect(wrapper.find("ArtworkGridItem").length).toBe(1)
   })
 
   it("renders filters in correct order", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       FilterArtworksConnection: () => ({
         counts: {
           followedArtists: 10,

--- a/src/Apps/Show/__tests__/ShowArtworksEmptyState.jest.tsx
+++ b/src/Apps/Show/__tests__/ShowArtworksEmptyState.jest.tsx
@@ -19,7 +19,7 @@ const { getWrapper } = setupTestWrapper<ShowArtworksEmptyState_Test_Query>({
 describe("ShowArtworksEmptyState", () => {
   describe("fair booth", () => {
     it("renders the correct message for non-closed fair booths", () => {
-      const wrapper = getWrapper({ Show: () => ({ isFairBooth: true }) })
+      const { wrapper } = getWrapper({ Show: () => ({ isFairBooth: true }) })
       const html = wrapper.html()
 
       expect(html).toContain(
@@ -28,7 +28,7 @@ describe("ShowArtworksEmptyState", () => {
     })
 
     it("renders the correct message for closed fair booths", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Show: () => ({ isFairBooth: true, status: "closed" }),
       })
       const html = wrapper.html()
@@ -42,7 +42,7 @@ describe("ShowArtworksEmptyState", () => {
 
   describe("show", () => {
     it("renders the correct message for non-closed shows", () => {
-      const wrapper = getWrapper({ Show: () => ({ isFairBooth: false }) })
+      const { wrapper } = getWrapper({ Show: () => ({ isFairBooth: false }) })
       const html = wrapper.html()
 
       expect(html).toContain(
@@ -51,7 +51,7 @@ describe("ShowArtworksEmptyState", () => {
     })
 
     it("renders the correct message for closed shows", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Show: () => ({ isFairBooth: false, status: "closed" }),
       })
       const html = wrapper.html()

--- a/src/Apps/Show/__tests__/ShowContextCard.jest.tsx
+++ b/src/Apps/Show/__tests__/ShowContextCard.jest.tsx
@@ -39,7 +39,7 @@ describe("ShowContextCard", () => {
   })
 
   it("renders correctly for a fair", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Fair: () => {
         return {
           name: "Catty Art Fair",
@@ -52,7 +52,7 @@ describe("ShowContextCard", () => {
   })
 
   it("renders correctly for a partner", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Show: () => {
         return {
           isFairBooth: false,
@@ -70,7 +70,7 @@ describe("ShowContextCard", () => {
   })
 
   it("tracks clicks for partner cards", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Show: () => ({ isFairBooth: false }),
       Partner: () => ({
         internalID: "catty-gallery-id",
@@ -96,7 +96,7 @@ describe("ShowContextCard", () => {
   })
 
   it("tracks clicks for fair cards", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Show: () => ({ isFairBooth: true }),
       Fair: () => ({
         internalID: "catty-fair-id",

--- a/src/Apps/Show/__tests__/ShowContextualLink.jest.tsx
+++ b/src/Apps/Show/__tests__/ShowContextualLink.jest.tsx
@@ -25,7 +25,7 @@ const { getWrapper } = setupTestWrapper<ShowContextualLink_Test_Query>({
 describe("ShowContextualLink", () => {
   describe("is a fair booth", () => {
     it("renders the fair link", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Show: () => ({ isFairBooth: true }),
         Fair: () => ({ name: "Catty Fair", isActive: true }),
       })
@@ -34,7 +34,7 @@ describe("ShowContextualLink", () => {
     })
 
     it("hides link if show.isActive = false", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Show: () => ({ isFairBooth: true }),
         Fair: () => ({ name: "Catty Fair", isActive: false }),
       })
@@ -45,7 +45,7 @@ describe("ShowContextualLink", () => {
 
   describe("when not a fair booth", () => {
     it("renders the partner link when the partner is linkable", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Show: () => ({ isFairBooth: false }),
         Partner: () => ({
           name: "Catty Partner",
@@ -62,7 +62,7 @@ describe("ShowContextualLink", () => {
     })
 
     it("does not render the partner link when the partner is not linkable", () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Show: () => ({ isFairBooth: false }),
         Partner: () => ({
           name: "Catty Partner",

--- a/src/Apps/Show/__tests__/ShowHours.jest.tsx
+++ b/src/Apps/Show/__tests__/ShowHours.jest.tsx
@@ -1,5 +1,5 @@
 import { graphql } from "react-relay"
-import { ShowHoursFragmentContainer } from "../Components/ShowHours"
+import { ShowHoursFragmentContainer } from "Apps/Show/Components/ShowHours"
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
 
 jest.unmock("react-relay")
@@ -17,7 +17,7 @@ const { getWrapper } = setupTestWrapper({
 
 describe("ShowHours", () => {
   it("renders the schedules if they exist", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Location: () => ({ openingHours: { __typename: "OpeningHoursArray" } }),
       OpeningHoursArray: () => ({
         schedules: [
@@ -40,7 +40,7 @@ describe("ShowHours", () => {
   })
 
   it("renders the text if it exists", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Location: () => ({ openingHours: { __typename: "OpeningHoursText" } }),
       OpeningHoursText: () => ({ text: "Open 24-7" }),
     })
@@ -51,7 +51,7 @@ describe("ShowHours", () => {
   })
 
   it("renders nothing if the opening hours are text but the text is null", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Location: () => ({ openingHours: { __typename: "OpeningHoursText" } }),
       OpeningHoursText: () => ({ text: null }),
     })
@@ -62,7 +62,7 @@ describe("ShowHours", () => {
   })
 
   it("renders nothing if the opening hours are an array but null", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Location: () => ({ openingHours: { __typename: "OpeningHoursArray" } }),
       OpeningHoursArray: () => ({ schedules: null }),
     })

--- a/src/Apps/Show/__tests__/ShowInfo.jest.tsx
+++ b/src/Apps/Show/__tests__/ShowInfo.jest.tsx
@@ -1,5 +1,5 @@
 import { graphql } from "react-relay"
-import { ShowInfoFragmentContainer } from "../Routes/ShowInfo"
+import { ShowInfoFragmentContainer } from "Apps/Show/Routes/ShowInfo"
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
 
 jest.unmock("react-relay")
@@ -20,7 +20,7 @@ describe("ShowInfo", () => {
     it("renders the basic page", () => {
       const events = []
 
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Show: () => ({ events }),
         Partner: () => ({ type: "Gallery" }),
       })
@@ -42,7 +42,7 @@ describe("ShowInfo", () => {
 
       const events = [event]
 
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Show: () => ({ events }),
         Partner: () => ({ type: "Gallery" }),
       })
@@ -67,7 +67,7 @@ describe("ShowInfo", () => {
 
       const events = [event]
 
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Show: () => ({ events }),
         Partner: () => ({ type: "Gallery" }),
       })
@@ -82,7 +82,7 @@ describe("ShowInfo", () => {
 
       const events = [event]
 
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         Show: () => ({ events }),
         Partner: () => ({ type: "Gallery" }),
       })

--- a/src/Apps/Show/__tests__/ShowInstallShots.jest.tsx
+++ b/src/Apps/Show/__tests__/ShowInstallShots.jest.tsx
@@ -25,13 +25,13 @@ const { getWrapper } = setupTestWrapper({
 
 describe("ShowInstallShots", () => {
   it("renders empty string if there are no images", () => {
-    const wrapper = getWrapper({ Show: () => ({ images: [] }) })
+    const { wrapper } = getWrapper({ Show: () => ({ images: [] }) })
 
     expect(wrapper.html()).toBe("")
   })
 
   it("renders the images", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Show: (_, generateID) => ({
         images: [{ internalID: generateID() }, { internalID: generateID() }],
       }),
@@ -42,7 +42,7 @@ describe("ShowInstallShots", () => {
   })
 
   it("zooms the second image when it is clicked", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Show: (_, generateID) => ({
         images: [
           { internalID: generateID() },

--- a/src/Apps/Show/__tests__/ShowViewingRoom.jest.tsx
+++ b/src/Apps/Show/__tests__/ShowViewingRoom.jest.tsx
@@ -41,7 +41,7 @@ describe("ShowViewingRoom", () => {
   })
 
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       ViewingRoom: () => ({
         title: "Example Viewing Room",
         status: "closed",
@@ -59,7 +59,7 @@ describe("ShowViewingRoom", () => {
   })
 
   it("tracks clicks", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       ViewingRoom: () => ({
         internalID: "example-viewing-room-id",
         slug: "example-viewing-room-slug",

--- a/src/Apps/Shows/Routes/__tests__/ShowsCity.jest.tsx
+++ b/src/Apps/Shows/Routes/__tests__/ShowsCity.jest.tsx
@@ -41,7 +41,7 @@ const { getWrapper } = setupTestWrapper<ShowsCity_Test_Query>({
 
 describe("ShowsCity", () => {
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       City: () => ({ name: "Sunnydale" }),
       Show: () => ({ name: "Example Show", startAt: new Date().toISOString() }),
       ShowConnection: () => ({ totalCount: 44 }),

--- a/src/Apps/Shows/Routes/__tests__/ShowsIndex.jest.tsx
+++ b/src/Apps/Shows/Routes/__tests__/ShowsIndex.jest.tsx
@@ -35,7 +35,7 @@ const { getWrapper } = setupTestWrapper<ShowsIndex_Test_Query>({
 
 describe("ShowsIndex", () => {
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       OrderedSet: () => ({ name: "Featured Shows" }),
       Show: () => ({ name: "Example Show" }),
     })

--- a/src/Apps/Tag/Components/__tests__/TagArtworkFilter.jest.tsx
+++ b/src/Apps/Tag/Components/__tests__/TagArtworkFilter.jest.tsx
@@ -54,13 +54,13 @@ describe("TagArtworkFilter", () => {
   })
 
   it("renders correctly", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
     expect(wrapper.find("ArtworkFilterArtworkGrid").length).toBe(1)
     expect(wrapper.find("ArtworkGridItem").length).toBe(1)
   })
 
   it("renders filters in correct order", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       FilterArtworksConnection: () => ({
         counts: {
           followedArtists: 10,

--- a/src/Components/Artwork/SaveButton/__tests__/DeprecatedSaveButton.jest.tsx
+++ b/src/Components/Artwork/SaveButton/__tests__/DeprecatedSaveButton.jest.tsx
@@ -82,7 +82,7 @@ describe("Deprecated Save artwork", () => {
   })
 
   it("can save an artwork", async () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Artwork: () => artwork,
     })
     const page = new DeprecatedSaveButtonTestPage(wrapper)
@@ -98,7 +98,7 @@ describe("Deprecated Save artwork", () => {
 
   it("can remove a saved artwork", async () => {
     defaultMutationResults.saveArtwork.artwork.isSaved = false
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Artwork: () => ({ ...artwork, isSaved: true }),
     })
     const page = new DeprecatedSaveButtonTestPage(wrapper)
@@ -123,7 +123,7 @@ describe("Deprecated Save artwork", () => {
       return { showAuthDialog }
     })
 
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Artwork: () => artwork,
     })
     const page = new DeprecatedSaveButtonTestPage(wrapper)

--- a/src/Components/ArtworkGrid/__tests__/ArtworkGrid.jest.tsx
+++ b/src/Components/ArtworkGrid/__tests__/ArtworkGrid.jest.tsx
@@ -123,7 +123,7 @@ describe("ArtworkGrid", () => {
     })
 
     it("Renders artworks if present", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         FilterArtworksConnection: () => ArtworkGridFixture,
       })
 
@@ -132,7 +132,7 @@ describe("ArtworkGrid", () => {
     })
 
     it("Renders empty message if no artworks", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         FilterArtworksConnection: () => ({ edges: [] }),
       })
 
@@ -140,7 +140,7 @@ describe("ArtworkGrid", () => {
     })
 
     it("Can call onClearFilters from empty message", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         FilterArtworksConnection: () => ({ edges: [] }),
       })
       wrapper.find(ResetFilterLink).simulate("click")
@@ -149,7 +149,7 @@ describe("ArtworkGrid", () => {
     })
 
     it("#componentDidMount sets state.interval if props.onLoadMore", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         FilterArtworksConnection: () => ArtworkGridFixture,
       })
       const artworkGridContainer = await wrapper.find(ArtworkGridContainer)
@@ -161,7 +161,7 @@ describe("ArtworkGrid", () => {
     })
 
     it("#componentWillUnmount calls #clearInterval if state.interval exists", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         FilterArtworksConnection: () => ArtworkGridFixture,
       })
       const artworkGridContainer = await wrapper.find(ArtworkGridContainer)
@@ -182,7 +182,7 @@ describe("ArtworkGrid", () => {
     })
 
     it("#sectionedArtworks divides artworks into columns", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         FilterArtworksConnection: () => ArtworkGridFixture,
       })
       const artworkGridContainer = (await wrapper
@@ -196,7 +196,7 @@ describe("ArtworkGrid", () => {
     })
 
     it("Renders artworks if present (2)", async () => {
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         FilterArtworksConnection: () => ArtworkGridFixture,
       })
       const artworkGridContainer = await wrapper.find(ArtworkGridContainer)
@@ -210,7 +210,7 @@ describe("ArtworkGrid", () => {
     it("Should preload same number of images as specified in preloadImageCount", async () => {
       columnCount = 2
       preloadImageCount = 2
-      const wrapper = getWrapper({
+      const { wrapper } = getWrapper({
         FilterArtworksConnection: () => ArtworkGridFixture,
       })
 

--- a/src/Components/DeepZoom/__tests__/DeepZoom.jest.tsx
+++ b/src/Components/DeepZoom/__tests__/DeepZoom.jest.tsx
@@ -30,7 +30,7 @@ describe("DeepZoom", () => {
   })
 
   it("renders correctly", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
 
     expect(wrapper.html()).toContain(
       'input min="0" max="1" step="0.001" type="range"'
@@ -38,7 +38,7 @@ describe("DeepZoom", () => {
   })
 
   it("calls onClose when the close button is clicked", () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
 
     expect(handleClose).not.toBeCalled()
 

--- a/src/Components/Inquiry/__tests__/Views/InquiryBasicInfo.jest.tsx
+++ b/src/Components/Inquiry/__tests__/Views/InquiryBasicInfo.jest.tsx
@@ -51,7 +51,7 @@ describe("InquiryBasicInfo", () => {
   })
 
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Partner: () => ({ name: "Example Partner" }),
     })
 
@@ -64,7 +64,7 @@ describe("InquiryBasicInfo", () => {
   })
 
   it("updates the collector profile when the form is submitted", async () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
 
     expect(mockSubmitUpdateMyUserProfile).not.toBeCalled()
     expect(mockNext).not.toBeCalled()
@@ -84,7 +84,7 @@ describe("InquiryBasicInfo", () => {
   })
 
   it("updates the collector profile when the form is submitted with more information", async () => {
-    const wrapper = getWrapper()
+    const { wrapper } = getWrapper()
 
     expect(mockSubmitUpdateMyUserProfile).not.toBeCalled()
     expect(mockNext).not.toBeCalled()

--- a/src/Components/ViewInRoom/__tests__/ViewInRoom.jest.tsx
+++ b/src/Components/ViewInRoom/__tests__/ViewInRoom.jest.tsx
@@ -24,7 +24,7 @@ const { getWrapper } = setupTestWrapper({
 
 describe("ViewInRoom", () => {
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Artwork: () => ({ widthCm: 33, heightCm: 66 }),
       ResizedImageUrl: () => ({
         src: "example.jpg",

--- a/src/Components/ViewInRoom/__tests__/ViewInRoomArtwork.jest.tsx
+++ b/src/Components/ViewInRoom/__tests__/ViewInRoomArtwork.jest.tsx
@@ -17,7 +17,7 @@ const { getWrapper } = setupTestWrapper({
 
 describe("ViewInRoomArtwork", () => {
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Artwork: () => ({
         widthCm: 40,
         heightCm: 30,

--- a/src/Components/__tests__/ArtistCurrentArticlesRail.jest.tsx
+++ b/src/Components/__tests__/ArtistCurrentArticlesRail.jest.tsx
@@ -31,7 +31,7 @@ describe("ArtistCurrentArticlesRail", () => {
   })
 
   it("does not render rail if no articles", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Artist: () => ({
         articlesConnection: { edges: null },
       }),
@@ -41,7 +41,7 @@ describe("ArtistCurrentArticlesRail", () => {
   })
 
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Artist: () => ({
         name: "artistName",
         slug: "artistSlug",
@@ -60,7 +60,7 @@ describe("ArtistCurrentArticlesRail", () => {
   })
 
   it("tracks to articles route", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Artist: () => ({
         internalID: "test-artist-id",
         slug: "test-artist-slug",
@@ -82,7 +82,7 @@ describe("ArtistCurrentArticlesRail", () => {
   })
 
   it("tracks article click", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Article: () => ({
         internalID: "test-article-id",
         slug: "test-article-slug",

--- a/src/Components/__tests__/AuctionFAQsDialog.jest.tsx
+++ b/src/Components/__tests__/AuctionFAQsDialog.jest.tsx
@@ -1,6 +1,6 @@
 import { graphql } from "react-relay"
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
-import { AuctionFAQsDialogFragmentContainer } from "../AuctionFAQsDialog"
+import { AuctionFAQsDialogFragmentContainer } from "Components/AuctionFAQsDialog"
 
 jest.unmock("react-relay")
 
@@ -17,7 +17,7 @@ const { getWrapper } = setupTestWrapper({
 
 describe("AuctionFAQsDialog", () => {
   it("renders correctly", () => {
-    const wrapper = getWrapper({
+    const { wrapper } = getWrapper({
       Page: () => ({
         name: "How Auctions Work: Example",
         content: "<p>Hello world</p>",


### PR DESCRIPTION
The type of this PR is: **Chore**
This PR follows #13111 to add our mutation helper support to tests using the legacy enzyme `setupTestWrapper`. In order to do this I changed that file's `return wrapper` to a destructurable `return { wrapper, ...otherStuff }`, matching the return interface of our current preferred `setupTestWrapperTL`.