### PR TITLE
chore: simplify S3 path for shared configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "publish-assets": "node scripts/uploadToS3.js",
     "publish-assets:local": "yarn clean && yarn build:client:prod && yarn publish-assets",
     "relay": "relay-compiler",
-    "sync-env": "aws s3 cp s3://artsy-citadel/dev/.env.force .env.shared && echo 'ENV sync complete.'",
+    "sync-env": "aws s3 cp s3://artsy-citadel/force/.env.shared ./ && echo 'ENV sync complete.'",
     "start": "scripts/start.sh",
     "start:prod": "yarn build && SESSION_LOCAL_INSECURE=true NODE_ENV=production yarn start",
     "start:prod:debug": "SESSION_LOCAL_INSECURE=true NODE_ENV=production node --inspect --max_old_space_size=3072 ./server.dist.js",

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -24,7 +24,7 @@ yarn install || (npm install --global yarn@latest && yarn install)
 # For more info on shared configuration see:
 # https://github.com/artsy/force/blob/main/docs/env_configuration.md
 echo "Downloading .env.shared file..."
-if ! aws s3 cp s3://artsy-citadel/dev/.env.force .env.shared; then
+if ! aws s3 cp s3://artsy-citadel/force/.env.shared ./; then
   echo "Unable to download shared config from s3. Using .env.oss!"
   echo "This is expected for open source contributors."
   echo "If you work at Artsy, please check your s3 access."


### PR DESCRIPTION
As per https://github.com/artsy/README/pull/530, this updates setup to pull shared configuration from its new, simpler location.