### PR TITLE
feat(ONYX-479): add color and ways to buy filters

### DIFF
--- a/src/Components/Alert/Components/Filters/Color.tsx
+++ b/src/Components/Alert/Components/Filters/Color.tsx
@@ -43,7 +43,6 @@ const ColorFilterOption: React.FC<{ colorOption: ColorOption }> = ({
         key={name}
         onSelect={selected => toggleColor(selected, value)}
         selected={state.criteria.colors?.includes(value)}
-        my={1}
       >
         <Box
           display="flex"

--- a/src/Components/Alert/Components/Filters/Color.tsx
+++ b/src/Components/Alert/Components/Filters/Color.tsx
@@ -1,0 +1,106 @@
+import { Checkbox, Box, Text, Flex, Spacer } from "@artsy/palette"
+import * as React from "react"
+import styled from "styled-components"
+import { themeGet } from "@styled-system/theme-get"
+import { COLOR_OPTIONS } from "Components/ArtworkFilter/ArtworkFilters/ColorFilter"
+import { useAlertContext } from "Components/Alert/Hooks/useAlertContext"
+
+type ColorOption = typeof COLOR_OPTIONS[number]
+
+const ColorSwatch = styled.div`
+  width: ${themeGet("space.2")};
+  height: ${themeGet("space.2")};
+  border-radius: ${themeGet("space.2")};
+  flex-shrink: 0;
+`
+
+const BlackAndWhiteSwatch = styled(ColorSwatch)`
+  position: relative;
+  overflow: hidden;
+  border: 1px solid ${themeGet("colors.black10")};
+  transform: rotate(-135deg);
+
+  &::after {
+    content: "";
+    display: block;
+    width: 100%;
+    height: 50%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    background-color: ${themeGet("colors.black100")};
+  }
+`
+
+const ColorFilterOption: React.FC<{ colorOption: ColorOption }> = ({
+  colorOption,
+}) => {
+  const { state, dispatch } = useAlertContext()
+  const { name, value, hex } = colorOption
+
+  const toggleColor = (selected: boolean, color: string) => {
+    let updatedValues = (state.criteria.colors || []) as string[]
+
+    if (selected) {
+      updatedValues = [...updatedValues, color]
+    } else {
+      updatedValues = updatedValues.filter(
+        selectedColor => color !== selectedColor
+      )
+    }
+
+    dispatch({
+      type: "SET_CRITERIA_ATTRIBUTE",
+      payload: { key: "colors", value: updatedValues },
+    })
+  }
+
+  return (
+    <>
+      <Checkbox
+        key={name}
+        onSelect={selected => toggleColor(selected, value)}
+        selected={state.criteria.colors?.includes(value)}
+        my={1}
+      >
+        <Box
+          display="flex"
+          width="65%"
+          justifyContent="space-between"
+          alignItems="center"
+        >
+          <Text textAlign="left" variant="sm" lineHeight={1}>
+            {name}
+          </Text>
+
+          {value === "black-and-white" ? (
+            <BlackAndWhiteSwatch />
+          ) : (
+            <ColorSwatch style={{ backgroundColor: hex }} />
+          )}
+        </Box>
+      </Checkbox>
+    </>
+  )
+}
+
+export const Color: React.FC = () => {
+  return (
+    <>
+      <Text variant="sm-display">Colors</Text>
+      <Spacer y={2} />
+      <Box style={{ columns: "2" }}>
+        <Flex flexDirection="column">
+          {COLOR_OPTIONS.map(colorOption => {
+            return (
+              <ColorFilterOption
+                key={colorOption.value}
+                colorOption={colorOption as any}
+              />
+            )
+          })}
+        </Flex>
+      </Box>
+    </>
+  )
+}

--- a/src/Components/Alert/Components/Filters/Color.tsx
+++ b/src/Components/Alert/Components/Filters/Color.tsx
@@ -1,4 +1,11 @@
-import { Checkbox, Box, Text, Flex, Spacer } from "@artsy/palette"
+import {
+  Checkbox,
+  Box,
+  Text,
+  Spacer,
+  GridColumns,
+  Column,
+} from "@artsy/palette"
 import * as React from "react"
 import styled from "styled-components"
 import { themeGet } from "@styled-system/theme-get"
@@ -6,31 +13,6 @@ import { COLOR_OPTIONS } from "Components/ArtworkFilter/ArtworkFilters/ColorFilt
 import { useAlertContext } from "Components/Alert/Hooks/useAlertContext"
 
 type ColorOption = typeof COLOR_OPTIONS[number]
-
-const ColorSwatch = styled.div`
-  width: ${themeGet("space.2")};
-  height: ${themeGet("space.2")};
-  border-radius: ${themeGet("space.2")};
-  flex-shrink: 0;
-`
-
-const BlackAndWhiteSwatch = styled(ColorSwatch)`
-  position: relative;
-  overflow: hidden;
-  border: 1px solid ${themeGet("colors.black10")};
-  transform: rotate(-135deg);
-
-  &::after {
-    content: "";
-    display: block;
-    width: 100%;
-    height: 50%;
-    position: absolute;
-    top: 0;
-    left: 0;
-    background-color: ${themeGet("colors.black100")};
-  }
-`
 
 const ColorFilterOption: React.FC<{ colorOption: ColorOption }> = ({
   colorOption,
@@ -89,18 +71,43 @@ export const Color: React.FC = () => {
     <>
       <Text variant="sm-display">Colors</Text>
       <Spacer y={2} />
-      <Box style={{ columns: "2" }}>
-        <Flex flexDirection="column">
-          {COLOR_OPTIONS.map(colorOption => {
-            return (
+      <GridColumns>
+        {COLOR_OPTIONS.map(colorOption => {
+          return (
+            <Column span={6} key={colorOption.value}>
               <ColorFilterOption
                 key={colorOption.value}
                 colorOption={colorOption as any}
               />
-            )
-          })}
-        </Flex>
-      </Box>
+            </Column>
+          )
+        })}
+      </GridColumns>
     </>
   )
 }
+
+const ColorSwatch = styled.div`
+  width: ${themeGet("space.2")};
+  height: ${themeGet("space.2")};
+  border-radius: ${themeGet("space.2")};
+  flex-shrink: 0;
+`
+
+const BlackAndWhiteSwatch = styled(ColorSwatch)`
+  position: relative;
+  overflow: hidden;
+  border: 1px solid ${themeGet("colors.black10")};
+  transform: rotate(-135deg);
+
+  &::after {
+    content: "";
+    display: block;
+    width: 100%;
+    height: 50%;
+    position: absolute;
+    top: 0;
+    left: 0;
+    background-color: ${themeGet("colors.black100")};
+  }
+`

--- a/src/Components/Alert/Components/Filters/WaysToBuy.tsx
+++ b/src/Components/Alert/Components/Filters/WaysToBuy.tsx
@@ -1,0 +1,56 @@
+import { Box, Checkbox, Flex, Join, Spacer, Text } from "@artsy/palette"
+import { entries } from "lodash"
+import { FC } from "react"
+import { WAYS_TO_BUY_OPTIONS } from "Components/ArtworkFilter/ArtworkFilters/WaysToBuyFilter"
+import { useAlertContext } from "Components/Alert/Hooks/useAlertContext"
+import { SearchCriteriaAttributeKeys } from "Components/SavedSearchAlert/types"
+
+interface WayToBuy {
+  selected: boolean
+  name: string
+  key: SearchCriteriaAttributeKeys
+}
+
+export const WaysToBuy: FC = () => {
+  const { state, dispatch } = useAlertContext()
+
+  const checkboxes: WayToBuy[] = entries(WAYS_TO_BUY_OPTIONS).map(
+    ([key, value]) => ({
+      key: key as SearchCriteriaAttributeKeys,
+      name: value.name,
+      selected: state.criteria[key],
+    })
+  )
+
+  return (
+    <>
+      <Text variant="sm-display">Ways to buy</Text>
+      <Spacer y={2} />
+      <Box style={{ columns: "2" }}>
+        <Flex flexDirection="column">
+          {checkboxes.map((checkbox, index) => {
+            return (
+              <>
+                <Join separator={<Spacer y={1} />}>
+                  <Checkbox
+                    key={index}
+                    onSelect={value => {
+                      dispatch({
+                        type: "SET_CRITERIA_ATTRIBUTE",
+                        payload: { key: checkbox.key, value },
+                      })
+                    }}
+                    selected={checkbox.selected}
+                    my={1}
+                  >
+                    {checkbox.name}
+                  </Checkbox>
+                </Join>
+              </>
+            )
+          })}
+        </Flex>
+      </Box>
+    </>
+  )
+}

--- a/src/Components/Alert/Components/Filters/WaysToBuy.tsx
+++ b/src/Components/Alert/Components/Filters/WaysToBuy.tsx
@@ -1,4 +1,4 @@
-import { Box, Checkbox, Flex, Join, Spacer, Text } from "@artsy/palette"
+import { Checkbox, Column, GridColumns, Spacer, Text } from "@artsy/palette"
 import { entries } from "lodash"
 import { FC } from "react"
 import { WAYS_TO_BUY_OPTIONS } from "Components/ArtworkFilter/ArtworkFilters/WaysToBuyFilter"
@@ -26,31 +26,26 @@ export const WaysToBuy: FC = () => {
     <>
       <Text variant="sm-display">Ways to buy</Text>
       <Spacer y={2} />
-      <Box style={{ columns: "2" }}>
-        <Flex flexDirection="column">
-          {checkboxes.map((checkbox, index) => {
-            return (
-              <>
-                <Join separator={<Spacer y={1} />}>
-                  <Checkbox
-                    key={index}
-                    onSelect={value => {
-                      dispatch({
-                        type: "SET_CRITERIA_ATTRIBUTE",
-                        payload: { key: checkbox.key, value },
-                      })
-                    }}
-                    selected={checkbox.selected}
-                    my={1}
-                  >
-                    {checkbox.name}
-                  </Checkbox>
-                </Join>
-              </>
-            )
-          })}
-        </Flex>
-      </Box>
+      <GridColumns>
+        {checkboxes.map((checkbox, index) => {
+          return (
+            <Column span={6} key={index}>
+              <Checkbox
+                key={index}
+                onSelect={value => {
+                  dispatch({
+                    type: "SET_CRITERIA_ATTRIBUTE",
+                    payload: { key: checkbox.key, value },
+                  })
+                }}
+                selected={checkbox.selected}
+              >
+                {checkbox.name}
+              </Checkbox>
+            </Column>
+          )
+        })}
+      </GridColumns>
     </>
   )
 }

--- a/src/Components/Alert/Components/Filters/__tests__/Color.jest.tsx
+++ b/src/Components/Alert/Components/Filters/__tests__/Color.jest.tsx
@@ -1,0 +1,44 @@
+import { mount } from "enzyme"
+import {
+  AlertProvider,
+  useAlertContext,
+} from "Components/Alert/Hooks/useAlertContext"
+import { Color } from "Components/Alert/Components/Filters/Color"
+
+jest.mock("Utils/Hooks/useMatchMedia", () => ({
+  __internal__useMatchMedia: () => ({}),
+}))
+
+describe("ColorFilter", () => {
+  let alertContext
+
+  const ColorFilterTestComponent = () => {
+    alertContext = useAlertContext()
+
+    return <Color />
+  }
+
+  const getWrapper = (contextProps = {}, initialCriteria = {}) => {
+    return mount(
+      <AlertProvider initialCriteria={initialCriteria}>
+        <ColorFilterTestComponent />
+      </AlertProvider>
+    )
+  }
+
+  it("displays all Colors", () => {
+    const wrapper = getWrapper()
+
+    expect(wrapper.find("Checkbox").length).toBe(10)
+
+    expect(wrapper.html()).toContain("Red")
+  })
+
+  it("selects colors and only updates alert context", () => {
+    const wrapper = getWrapper()
+
+    wrapper.find("Checkbox").first().simulate("click")
+
+    expect(alertContext.state.criteria.colors).toEqual(["red"])
+  })
+})

--- a/src/Components/Alert/Components/Filters/__tests__/WaysToBuy.jest.tsx
+++ b/src/Components/Alert/Components/Filters/__tests__/WaysToBuy.jest.tsx
@@ -1,0 +1,44 @@
+import { mount } from "enzyme"
+import {
+  AlertProvider,
+  useAlertContext,
+} from "Components/Alert/Hooks/useAlertContext"
+import { WaysToBuy } from "Components/Alert/Components/Filters/WaysToBuy"
+
+jest.mock("Utils/Hooks/useMatchMedia", () => ({
+  __internal__useMatchMedia: () => ({}),
+}))
+
+describe("WaysToBuyFilter", () => {
+  let alertContext
+
+  const WaysToBuyFilterTestComponent = () => {
+    alertContext = useAlertContext()
+
+    return <WaysToBuy />
+  }
+
+  const getWrapper = (contextProps = {}, initialCriteria = {}) => {
+    return mount(
+      <AlertProvider initialCriteria={initialCriteria}>
+        <WaysToBuyFilterTestComponent />
+      </AlertProvider>
+    )
+  }
+
+  it("displays all Ways To Buy", () => {
+    const wrapper = getWrapper()
+
+    expect(wrapper.find("Checkbox").length).toBe(4)
+
+    expect(wrapper.html()).toContain("Purchase")
+  })
+
+  it("selects ways to buy and only updates alert context", () => {
+    const wrapper = getWrapper()
+
+    wrapper.find("Checkbox").first().simulate("click")
+
+    expect(alertContext.state.criteria.acquireable).toEqual(true)
+  })
+})

--- a/src/Components/Alert/Components/Steps/Filters.tsx
+++ b/src/Components/Alert/Components/Steps/Filters.tsx
@@ -1,10 +1,12 @@
 import ChevronLeftIcon from "@artsy/icons/ChevronLeftIcon"
 import { Box, Clickable, Flex, Join, Separator, Text } from "@artsy/palette"
 import { FC } from "react"
-import { Rarity } from "Components/Alert/Components/Filters/Rarity"
 import { useAlertContext } from "Components/Alert/Hooks/useAlertContext"
+import { Rarity } from "Components/Alert/Components/Filters/Rarity"
 import { Medium } from "Components/Alert/Components/Filters/Medium"
 import { Price } from "Components/Alert/Components/Filters/Price"
+import { WaysToBuy } from "Components/Alert/Components/Filters/WaysToBuy"
+import { Color } from "Components/Alert/Components/Filters/Color"
 
 export const Filters: FC = () => {
   const { goToDetails } = useAlertContext()
@@ -30,6 +32,8 @@ export const Filters: FC = () => {
             <Price />
             <Rarity />
             <Medium />
+            <WaysToBuy />
+            <Color />
           </Join>
         </Box>
       </Flex>


### PR DESCRIPTION
The type of this PR is: Feat

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [ONYX-479](https://artsyproduct.atlassian.net/browse/ONYX-479)

### Description

Adds Colors and Ways To Buy filters.

https://github.com/artsy/force/assets/17580625/8cd6b0b7-7103-482e-8aeb-d22d1768fbd9



<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-479]: https://artsyproduct.atlassian.net/browse/ONYX-479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ