### PR TITLE
chore(analytics): add analytics events to new create alert modal

### DIFF
--- a/src/Apps/Artist/Routes/WorksForSale/Components/ArtistWorksForSaleEmpty.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/ArtistWorksForSaleEmpty.tsx
@@ -9,6 +9,7 @@ import { useAnalyticsContext } from "System/Analytics/AnalyticsContext"
 import { useAlert } from "Components/Alert"
 import { useFeatureFlag } from "System/useFeatureFlag"
 import { useArtworkFilterContext } from "Components/ArtworkFilter/ArtworkFilterContext"
+import { CreateAlertButton } from "Components/Alert/Components/CreateAlertButton"
 
 interface ArtistWorksForSaleEmptyProps {
   artist: ArtistWorksForSaleEmpty_artist$data
@@ -47,13 +48,7 @@ const ArtistWorksForSaleEmpty: FC<ArtistWorksForSaleEmptyProps> = ({
 
           {newAlertModalEnabled ? (
             <>
-              <Button
-                onClick={showAlert}
-                Icon={BellStrokeIcon}
-                variant="secondaryBlack"
-              >
-                Create Alert
-              </Button>
+              <CreateAlertButton onClick={showAlert} />
               {alertComponent}
             </>
           ) : (

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarBiddingClosedMessage.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarBiddingClosedMessage.tsx
@@ -1,14 +1,14 @@
 import { createFragmentContainer, graphql } from "react-relay"
-import { Button, Spacer, Text } from "@artsy/palette"
+import { Spacer, Text } from "@artsy/palette"
 import { ArtworkCreateAlertButtonFragmentContainer } from "Apps/Artwork/Components/ArtworkCreateAlertButton"
 import { useTranslation } from "react-i18next"
 import { ArtworkSidebarBiddingClosedMessage_artwork$data } from "__generated__/ArtworkSidebarBiddingClosedMessage_artwork.graphql"
 import { ContextModule } from "@artsy/cohesion"
 import { useFeatureFlag } from "System/useFeatureFlag"
 import { ProgressiveOnboardingAlertCreateSimple } from "Components/ProgressiveOnboarding/ProgressiveOnboardingAlertCreateSimple"
-import BellStrokeIcon from "@artsy/icons/BellStrokeIcon"
 import { useAlert } from "Components/Alert"
 import { compact } from "lodash"
+import { CreateAlertButton } from "Components/Alert/Components/CreateAlertButton"
 
 interface BiddingClosedMessageProps {
   artwork: ArtworkSidebarBiddingClosedMessage_artwork$data
@@ -43,14 +43,11 @@ const BiddingClosedMessage: React.FC<BiddingClosedMessageProps> = ({
           {newAlertModalEnabled ? (
             <>
               <ProgressiveOnboardingAlertCreateSimple>
-                <Button
+                <CreateAlertButton
                   width="100%"
                   size="large"
                   onClick={showAlert}
-                  Icon={BellStrokeIcon}
-                >
-                  Create Alert
-                </Button>
+                />
               </ProgressiveOnboardingAlertCreateSimple>
               {alertComponent}
             </>

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
@@ -31,9 +31,9 @@ import { useRouter } from "System/Router/useRouter"
 import { useFeatureFlag } from "System/useFeatureFlag"
 import { ProgressiveOnboardingAlertCreateSimple } from "Components/ProgressiveOnboarding/ProgressiveOnboardingAlertCreateSimple"
 import { useAlert } from "Components/Alert"
-import BellStrokeIcon from "@artsy/icons/BellStrokeIcon"
 import RelayModernEnvironment from "relay-runtime/lib/store/RelayModernEnvironment"
 import { compact } from "lodash"
+import { CreateAlertButton } from "Components/Alert/Components/CreateAlertButton"
 
 interface SaleMessageProps {
   saleMessage: string | null
@@ -341,14 +341,7 @@ const ArtworkSidebarCommerialButtons: React.FC<ArtworkSidebarCommercialButtonsPr
       return (
         <>
           <ProgressiveOnboardingAlertCreateSimple>
-            <Button
-              width="100%"
-              size="large"
-              onClick={showAlert}
-              Icon={BellStrokeIcon}
-            >
-              Create Alert
-            </Button>
+            <CreateAlertButton width="100%" size="large" onClick={showAlert} />
           </ProgressiveOnboardingAlertCreateSimple>
           {alertComponent}
         </>

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCreateAlert.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCreateAlert.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, Separator, Text } from "@artsy/palette"
+import { Flex, Separator, Text } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ArtworkSidebarCreateAlert_artwork$data } from "__generated__/ArtworkSidebarCreateAlert_artwork.graphql"
 import {
@@ -15,7 +15,7 @@ import { Aggregations } from "Components/ArtworkFilter/ArtworkFilterContext"
 import { useTranslation } from "react-i18next"
 import { useAlert } from "Components/Alert"
 import { useFeatureFlag } from "System/useFeatureFlag"
-import BellStrokeIcon from "@artsy/icons/BellStrokeIcon"
+import { CreateAlertButton } from "Components/Alert/Components/CreateAlertButton"
 
 interface ArtworkSidebarCreateAlertProps {
   artwork: ArtworkSidebarCreateAlert_artwork$data
@@ -98,14 +98,7 @@ const ArtworkSidebarCreateAlert: React.FC<ArtworkSidebarCreateAlertProps> = ({
         </Text>
         {newAlertModalEnabled ? (
           <>
-            <Button
-              onClick={showAlert}
-              variant="secondaryBlack"
-              size="small"
-              Icon={BellStrokeIcon}
-            >
-              Create Alert
-            </Button>
+            <CreateAlertButton onClick={showAlert} />
             {alertComponent}
           </>
         ) : (

--- a/src/Components/Alert/Components/CreateAlertButton.tsx
+++ b/src/Components/Alert/Components/CreateAlertButton.tsx
@@ -1,0 +1,31 @@
+import { FC } from "react"
+import BellStrokeIcon from "@artsy/icons/BellStrokeIcon"
+import { Button, ButtonProps } from "@artsy/palette"
+
+import { useAlertTracking } from "Components/Alert/Hooks/useAlertTracking"
+
+export interface Props extends ButtonProps {
+  onClick: () => void
+}
+
+export const CreateAlertButton: FC<Props> = ({ onClick, ...buttonProps }) => {
+  const { clickedCreateAlert } = useAlertTracking()
+
+  const handleClick = () => {
+    clickedCreateAlert()
+
+    return onClick()
+  }
+
+  return (
+    <Button
+      onClick={handleClick}
+      variant="secondaryBlack"
+      size="small"
+      Icon={BellStrokeIcon}
+      {...buttonProps}
+    >
+      Create Alert
+    </Button>
+  )
+}

--- a/src/Components/Alert/Hooks/useAlertContext.tsx
+++ b/src/Components/Alert/Hooks/useAlertContext.tsx
@@ -22,6 +22,7 @@ import {
 import { Environment, fetchQuery, graphql } from "react-relay"
 import { useDebouncedValue } from "Utils/Hooks/useDebounce"
 import { CustomRange } from "Components/PriceRange/constants"
+import { useAlertTracking } from "Components/Alert/Hooks/useAlertTracking"
 
 type Settings = {
   details: string
@@ -178,6 +179,7 @@ export const AlertProvider: FC<AlertProviderProps> = ({
   >("ALERT_DETAILS")
 
   const { submitMutation } = useCreateAlert()
+  const { createdAlert } = useAlertTracking()
 
   const handleComplete = async () => {
     try {
@@ -189,11 +191,16 @@ export const AlertProvider: FC<AlertProviderProps> = ({
           },
         },
       })
-      if (reponse.createSavedSearch?.savedSearchOrErrors.internalID) {
+      const searchCriteriaID =
+        reponse.createSavedSearch?.savedSearchOrErrors.internalID
+
+      if (searchCriteriaID) {
         dispatch({
           type: "SET_SEARCH_CRITERIA_ID",
-          payload: reponse.createSavedSearch?.savedSearchOrErrors.internalID,
+          payload: searchCriteriaID,
         })
+
+        createdAlert(searchCriteriaID)
       }
       setCurrent("ALERT_CONFIRMATION")
     } catch (error) {

--- a/src/Components/Alert/Hooks/useAlertTracking.ts
+++ b/src/Components/Alert/Hooks/useAlertTracking.ts
@@ -1,0 +1,59 @@
+import {
+  ActionType,
+  ClickedCreateAlert,
+  DeletedSavedSearch,
+  ScreenOwnerType,
+  ToggledSavedSearch,
+} from "@artsy/cohesion"
+import { useTracking } from "react-tracking"
+
+import { useAnalyticsContext } from "System/Analytics/AnalyticsContext"
+
+export const useAlertTracking = () => {
+  const { trackEvent } = useTracking()
+
+  const {
+    contextPageOwnerId,
+    contextPageOwnerSlug,
+    contextPageOwnerType,
+  } = useAnalyticsContext()
+
+  if (!contextPageOwnerId || !contextPageOwnerSlug || !contextPageOwnerType) {
+    console.warn("Missing analytics context")
+  }
+
+  return {
+    createdAlert: (searchCriteriaID: string) => {
+      const payload: ToggledSavedSearch = {
+        action: ActionType.toggledSavedSearch,
+        search_criteria_id: searchCriteriaID,
+        context_screen_owner_id: contextPageOwnerId,
+        context_screen_owner_slug: contextPageOwnerSlug,
+        context_screen_owner_type: contextPageOwnerType as ScreenOwnerType,
+      }
+
+      trackEvent(payload)
+    },
+
+    deletedAlert: () => {
+      const payload: DeletedSavedSearch = {
+        action: ActionType.deletedSavedSearch,
+        context_screen_owner_id: contextPageOwnerId,
+        context_screen_owner_type: contextPageOwnerType as ScreenOwnerType,
+      }
+
+      trackEvent(payload)
+    },
+
+    clickedCreateAlert: () => {
+      const payload: ClickedCreateAlert = {
+        action: ActionType.clickedCreateAlert,
+        context_page_owner_id: contextPageOwnerId,
+        context_page_owner_slug: contextPageOwnerSlug,
+        context_page_owner_type: contextPageOwnerType,
+      }
+
+      trackEvent(payload)
+    },
+  }
+}

--- a/src/Components/ArtworkFilter/ArtworkFilterCreateAlert.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilterCreateAlert.tsx
@@ -12,6 +12,7 @@ import { useFeatureFlag } from "System/useFeatureFlag"
 import { usePrepareFiltersForPills } from "Components/ArtworkFilter/Utils/usePrepareFiltersForPills"
 import { useSavedSearchAlertContext } from "Components/SavedSearchAlert/SavedSearchAlertContext"
 import { SearchCriteriaAttributes } from "Components/SavedSearchAlert/types"
+import { useAlertTracking } from "Components/Alert/Hooks/useAlertTracking"
 
 interface ArtworkFilterCreateAlertProps {
   renderButton: (props: { onClick: () => void }) => JSX.Element
@@ -42,6 +43,8 @@ export const ArtworkFilterCreateAlert: FC<ArtworkFilterCreateAlertProps> = ({
     },
   })
 
+  const { clickedCreateAlert } = useAlertTracking()
+
   if (newAlertModalEnabled) {
     return (
       <>
@@ -54,6 +57,7 @@ export const ArtworkFilterCreateAlert: FC<ArtworkFilterCreateAlertProps> = ({
                     createSkip()
                     readySkip()
                     showAlert()
+                    clickedCreateAlert()
                   },
                 })
               }


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [ONYX-388](https://artsyproduct.atlassian.net/browse/ONYX-388)

### Description

- createdAlert: ToggledSavedSearch
- deletedAlert: DeletedSavedSearch
- clickedCreateAlert: ClickedCreateAlert

Note: this does not yet include analytics events for the new filters flow. That will be covered in a subsequent PR after attribute have been added to artsy/cohesion.

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-388]: https://artsyproduct.atlassian.net/browse/ONYX-388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ