### PR TITLE
chore(alerts): remove passing of authDialogOptions options to useAlert

### DIFF
--- a/src/Apps/Artist/Routes/WorksForSale/Components/ArtistWorksForSaleEmpty.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/ArtistWorksForSaleEmpty.tsx
@@ -26,20 +26,6 @@ const ArtistWorksForSaleEmpty: FC<ArtistWorksForSaleEmptyProps> = ({
   const { filters } = useArtworkFilterContext()
 
   const { alertComponent, showAlert } = useAlert({
-    authDialogOptions: {
-      options: {
-        title: "Sign up to create your alert",
-        afterAuthAction: {
-          action: "createAlert",
-          kind: "artist",
-          objectId: artist.internalID,
-        },
-      },
-      analytics: {
-        contextModule: ContextModule.artworkGrid,
-        intent: Intent.createAlert,
-      },
-    },
     initialCriteria: filters,
   })
   const newAlertModalEnabled = useFeatureFlag("onyx_artwork_alert_modal_v2")

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCreateAlert.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCreateAlert.tsx
@@ -78,20 +78,6 @@ const ArtworkSidebarCreateAlert: React.FC<ArtworkSidebarCreateAlertProps> = ({
 
   const newAlertModalEnabled = useFeatureFlag("onyx_artwork_alert_modal_v2")
   const { alertComponent, showAlert } = useAlert({
-    authDialogOptions: {
-      options: {
-        title: "Sign up to create your alert",
-        afterAuthAction: {
-          action: "createAlert",
-          kind: "artworks",
-          objectId: artwork.internalID,
-        },
-      },
-      analytics: {
-        contextModule: ContextModule.artworkSidebar,
-        intent: Intent.createAlert,
-      },
-    },
     initialCriteria: criteria,
   })
 

--- a/src/Components/Alert/Hooks/useAlert.tsx
+++ b/src/Components/Alert/Hooks/useAlert.tsx
@@ -7,14 +7,13 @@ import { Steps } from "Components/Alert/Components/Steps"
 import { useAuthDialog } from "Components/AuthDialog"
 import { useAuthIntent } from "Utils/Hooks/useAuthIntent"
 import { useSystemContext } from "System/SystemContext"
-import { ShowAuthDialogOptions } from "Components/AuthDialog/AuthDialogContext"
+import { AuthContextModule, ContextModule, Intent } from "@artsy/cohesion"
 
 interface UseAlert {
-  authDialogOptions?: Omit<ShowAuthDialogOptions, "mode">
   initialCriteria?: SearchCriteriaAttributes
 }
 
-export const useAlert = ({ authDialogOptions, initialCriteria }: UseAlert) => {
+export const useAlert = ({ initialCriteria }: UseAlert) => {
   const { showAuthDialog } = useAuthDialog()
   const { isLoggedIn } = useSystemContext()
 
@@ -32,8 +31,23 @@ export const useAlert = ({ authDialogOptions, initialCriteria }: UseAlert) => {
   const [isVisible, setIsVisible] = useState(false)
 
   const showDialog = () => {
-    if (!isLoggedIn && authDialogOptions) {
-      showAuthDialog({ mode: "SignUp", ...authDialogOptions })
+    if (!isLoggedIn) {
+      showAuthDialog({
+        mode: "SignUp",
+        options: {
+          title: "Sign up to create your alert",
+          afterAuthAction: {
+            action: Intent.createAlert,
+          },
+        },
+        analytics: {
+          intent: Intent.createAlert,
+          // TODO: Add `createAlert` ContextModule value to `AuthContextModule`
+          // list in @artsy/cohesion
+          contextModule: ContextModule.createAlert as AuthContextModule,
+        },
+      })
+
       return
     }
 

--- a/src/Components/ArtworkFilter/ArtworkFilterCreateAlert.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilterCreateAlert.tsx
@@ -36,20 +36,6 @@ export const ArtworkFilterCreateAlert: FC<ArtworkFilterCreateAlertProps> = ({
   }
 
   const { alertComponent, showAlert } = useAlert({
-    authDialogOptions: {
-      options: {
-        title: "Sign up to create your alert",
-        afterAuthAction: {
-          action: "createAlert",
-          kind: "artworks",
-          objectId: entity.owner.slug,
-        },
-      },
-      analytics: {
-        contextModule: ContextModule.artworkGrid,
-        intent: Intent.createAlert,
-      },
-    },
     initialCriteria: {
       ...rawFilters,
       ...initialCriteria,

--- a/src/Utils/Hooks/useAuthIntent/index.tsx
+++ b/src/Utils/Hooks/useAuthIntent/index.tsx
@@ -16,6 +16,7 @@ export const AFTER_AUTH_ACTION_KEY = "afterSignUpAction"
 
 export type AfterAuthAction =
   | { action: "associateSubmission"; kind: "submission"; objectId: string }
+  | { action: "createAlert" }
   | { action: "createAlert"; kind: "artist"; objectId: string }
   | { action: "createAlert"; kind: "artworks"; objectId: string }
   | { action: "follow"; kind: "artist"; objectId: string }


### PR DESCRIPTION
Note: this an PR against another feature branch (https://github.com/artsy/force/pull/13129), not main.

The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

Try to handle as much as we can within the hook itself, without relying on passed arguments.

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ