### PR TITLE
feat(alerts): small style updates to the new create alert modal

### DIFF
--- a/src/Components/Alert/Components/Modal.tsx
+++ b/src/Components/Alert/Components/Modal.tsx
@@ -4,7 +4,6 @@ import {
   splitBoxProps,
   useDidMount,
   Box,
-  DROP_SHADOW,
   ModalClose,
 } from "@artsy/palette"
 import React from "react"
@@ -32,32 +31,20 @@ export const Modal: React.FC<AlertModalProps> = ({
           : { backgroundColor: "transparent" }
       }
       dialogProps={{
-        width: ["100%", 900],
-        height: ["100%", "90%"],
-        maxHeight: [null, 800],
+        height: ["100%", "auto"],
+        width: ["100%", "auto"],
+        maxHeight: ["auto", "90%"],
+        minWidth: ["auto", 500],
       }}
       {...modalProps}
       title="Create Alert"
     >
       <Box
         width="100%"
+        height="100%"
         position="relative"
-        bg="white100"
         overflowY="auto"
-        style={{
-          WebkitOverflowScrolling: "touch",
-          boxShadow: DROP_SHADOW,
-          ...(isMounted
-            ? {
-                opacity: 1,
-                transform: "translateX(0)",
-                transition: "opacity 5000ms, transform 5500ms",
-              }
-            : {
-                opacity: 0,
-                transform: "translateX(-2000px)",
-              }),
-        }}
+        bg="white100"
         {...boxProps}
       >
         <ModalClose onClick={onClose} position="absolute" top={0} right={0} />

--- a/src/Components/Alert/Components/Steps/Details.tsx
+++ b/src/Components/Alert/Components/Steps/Details.tsx
@@ -46,11 +46,11 @@ export const Details: FC = () => {
 
         return (
           <Flex flexDirection="column" p={2}>
+            <Text variant="lg">Create Alert</Text>
+            <Spacer y={2} />
+            <AlertNameInput />
+            <Spacer y={4} />
             <Join separator={<Spacer y={4} />}>
-              <Text variant="lg">Create Alert</Text>
-
-              <AlertNameInput />
-
               <Box>
                 <Text variant="sm-display" mb={1}>
                   Filters
@@ -108,7 +108,7 @@ export const Details: FC = () => {
                 }}
                 width="100%"
               >
-                Save Alert
+                Create Alert
               </Button>
             </Join>
           </Flex>

--- a/src/Components/Alert/Components/Steps/Filters.tsx
+++ b/src/Components/Alert/Components/Steps/Filters.tsx
@@ -12,7 +12,7 @@ export const Filters: FC = () => {
   const { goToDetails } = useAlertContext()
 
   return (
-    <>
+    <Box minWidth={[null, 700]}>
       <Flex flexDirection="column" width="auto">
         <Clickable
           onClick={() => {
@@ -37,6 +37,6 @@ export const Filters: FC = () => {
           </Join>
         </Box>
       </Flex>
-    </>
+    </Box>
   )
 }


### PR DESCRIPTION
The type of this PR is: **Feat**

cc/ @dariakoko @tam-kis 

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

- Filters step expands in size a bit from Details
- Remove horizontal scrolling transition (felt a bit buggy on mWeb)
- Adjust padding between Details sections
- "Save alert" > "Create alert"

### Screen Recordings

https://github.com/artsy/force/assets/123595/d3ed0253-5c92-4f16-9c07-830c30d222ec





[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ