### PR TITLE
chore(webpack): Remove fork-ts-checker webpack plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -301,7 +301,6 @@
     "eslint-plugin-styled-components-a11y": "0.0.16",
     "eslint-plugin-testing-library": "^4.6.0",
     "fork-ts-checker-notifier-webpack-plugin": "4.0.0",
-    "fork-ts-checker-webpack-plugin": "6.2.10",
     "graphql-tag": "2.10.3",
     "graphql-tools": "4.0.3",
     "html-webpack-plugin": "5.3.1",

--- a/webpack/envs/clientDevelopmentConfig.js
+++ b/webpack/envs/clientDevelopmentConfig.js
@@ -7,7 +7,6 @@ import ReactRefreshWebpackPlugin from "@pmmmwh/react-refresh-webpack-plugin"
 import SimpleProgressWebpackPlugin from "simple-progress-webpack-plugin"
 import TimeFixPlugin from "time-fix-plugin"
 import { WebpackManifestPlugin } from "webpack-manifest-plugin"
-import ForkTsCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin"
 import path from "path"
 import webpack from "webpack"
 import { basePath, webpackEnv } from "../webpackEnv"
@@ -71,15 +70,6 @@ export const clientDevelopmentConfig = () => {
       ...sharedPlugins(),
       new webpack.HotModuleReplacementPlugin(),
       new CaseSensitivePathsPlugin(),
-      new ForkTsCheckerWebpackPlugin({
-        typescript: {
-          diagnosticOptions: {
-            semantic: true,
-            syntactic: true,
-          },
-        },
-        formatter: { type: "codeframe", options: { highlightCode: true } },
-      }),
       new LoadablePlugin({
         filename: "loadable-stats.json",
         path: path.resolve(basePath, "public", "assets"),

--- a/yarn.lock
+++ b/yarn.lock
@@ -11448,25 +11448,6 @@ fork-ts-checker-notifier-webpack-plugin@4.0.0:
   dependencies:
     node-notifier "^6.0.0"
 
-fork-ts-checker-webpack-plugin@6.2.10:
-  version "6.2.10"
-  resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.2.10.tgz#800ab1fa523c76011a3413bc4e7815e45b63e826"
-  integrity sha512-HveFCHWSH2WlYU1tU3PkrupvW8lNFMTfH3Jk0TfC2mtktE9ibHGcifhCsCFvj+kqlDfNIlwmNLiNqR9jnSA7OQ==
-  dependencies:
-    "@babel/code-frame" "^7.8.3"
-    "@types/json-schema" "^7.0.5"
-    chalk "^4.1.0"
-    chokidar "^3.4.2"
-    cosmiconfig "^6.0.0"
-    deepmerge "^4.2.2"
-    fs-extra "^9.0.0"
-    glob "^7.1.6"
-    memfs "^3.1.2"
-    minimatch "^3.0.4"
-    schema-utils "2.7.0"
-    semver "^7.3.2"
-    tapable "^1.0.0"
-
 fork-ts-checker-webpack-plugin@^4.1.6:
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-4.1.6.tgz#5055c703febcf37fa06405d400c122b905167fc5"


### PR DESCRIPTION
The type of this PR is: **Chore**

### Description

This removes the type-checker from our webpack pipeline. We check in a few different ways and this one is particularly noisy. 
