### PR TITLE
refactor: use recommended instead of preferred for App Auth 2fa

### DIFF
--- a/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
+++ b/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/Components/AppSecondFactor/index.tsx
@@ -169,7 +169,7 @@ export const AppSecondFactor: React.FC<AppSecondFactorProps> = ({
       >
         <Box flexBasis="50%">
           <Text variant={["md", "lg"]}>
-            App Authenticator <Sup color="brand">Preferred</Sup>
+            App Authenticator <Sup color="brand">Recommended</Sup>
           </Text>
 
           {enabledSecondFactorLabel && (


### PR DESCRIPTION
The type of this PR is: refactor

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

<!-- Implementation description -->
This PR updates the wording used next to the App Authenticator 2fa options. It changes "Preferred" to "Recommended" as requested by design in this Slack 🔒 [thread](https://artsy.slack.com/archives/C02BGC5PW/p1699892493938409)

<img width="1190" alt="Screenshot 2023-11-15 at 8 10 31 AM" src="https://github.com/artsy/force/assets/38149304/6b768721-2879-4bbb-a8b3-6c2c1d49d9ba">


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ