### PR TITLE
fix(search): uses cover artworks for avatar images on artists

### DIFF
--- a/src/Components/Search/Mobile/SearchResultsList.tsx
+++ b/src/Components/Search/Mobile/SearchResultsList.tsx
@@ -58,7 +58,12 @@ const SearchResultsList: FC<SearchResultsListProps> = ({
   }, [viewer.searchConnection])
 
   const formattedOptions: SuggestionItemOptionProps[] = formatOptions(
-    options as SearchNodeOption[]
+    options.map(option => {
+      return {
+        ...option,
+        imageUrl: option.coverArtwork?.image?.src || option.imageUrl,
+      }
+    }) as SearchNodeOption[]
   )
 
   if (!viewer.searchConnection) {
@@ -155,6 +160,11 @@ export const SearchResultsListPaginationContainer = createPaginationContainer(
                 statuses {
                   artworks
                   auctionLots
+                }
+                coverArtwork {
+                  image {
+                    src: url(version: ["small"])
+                  }
                 }
               }
             }

--- a/src/Components/Search/SearchBarInput.tsx
+++ b/src/Components/Search/SearchBarInput.tsx
@@ -66,16 +66,16 @@ const SearchBarInput: FC<SearchBarInputProps> = ({
   const formattedOptions: SuggestionItemOptionProps[] = [
     ...options.map(option => {
       return {
-        text: option.displayLabel!,
-        value: option.displayLabel!,
+        text: option.displayLabel ?? "Unknown",
+        value: option.displayLabel ?? "unknown",
         subtitle:
           getLabel({
             displayType: option.displayType ?? "",
             typename: option.__typename,
           }) ?? "",
-        imageUrl: option.imageUrl!,
+        imageUrl: option.coverArtwork?.image?.src || option.imageUrl || "",
         showAuctionResultsButton: !!option.statuses?.auctionLots,
-        href: option.href!,
+        href: option.href ?? "/",
         typename: option.__typename,
       }
     }),
@@ -283,6 +283,11 @@ export const SearchBarInputRefetchContainer = createRefetchContainer(
                 statuses {
                   artworks
                   auctionLots
+                }
+                coverArtwork {
+                  image {
+                    src: url(version: ["square"])
+                  }
                 }
               }
             }

--- a/src/__generated__/MobileSearchBarSuggestQuery.graphql.ts
+++ b/src/__generated__/MobileSearchBarSuggestQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<77ba21e0d3014be8abf5b7828f753ecc>>
+ * @generated SignedSource<<b98ca340c47b37152fb26842027b8fee>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -66,7 +66,14 @@ v6 = [
   },
   (v4/*: any*/),
   (v5/*: any*/)
-];
+],
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": [
@@ -295,6 +302,44 @@ return {
                                   }
                                 ],
                                 "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Artwork",
+                                "kind": "LinkedField",
+                                "name": "coverArtwork",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": "src",
+                                        "args": [
+                                          {
+                                            "kind": "Literal",
+                                            "name": "version",
+                                            "value": [
+                                              "small"
+                                            ]
+                                          }
+                                        ],
+                                        "kind": "ScalarField",
+                                        "name": "url",
+                                        "storageKey": "url(version:[\"small\"])"
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  (v7/*: any*/)
+                                ],
+                                "storageKey": null
                               }
                             ],
                             "type": "Artist",
@@ -303,13 +348,7 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "id",
-                                "storageKey": null
-                              }
+                              (v7/*: any*/)
                             ],
                             "type": "Node",
                             "abstractKey": "__isNode"
@@ -376,12 +415,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a8ecd532bce9234175e39e17e3a1de5f",
+    "cacheID": "79b72f43c6d0d4fc4ac4ab91b7f29430",
     "id": null,
     "metadata": {},
     "name": "MobileSearchBarSuggestQuery",
     "operationKind": "query",
-    "text": "query MobileSearchBarSuggestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n  $entities: [SearchEntity]\n) {\n  viewer {\n    ...Overlay_viewer_1B9obU\n  }\n}\n\nfragment Overlay_viewer_1B9obU on Viewer {\n  ...SearchInputPills_viewer_4hh6ED\n  ...SearchResultsList_viewer_plJt2 @include(if: $hasTerm)\n}\n\nfragment SearchInputPills_viewer_4hh6ED on Viewer {\n  searchConnectionAggregation: searchConnection(first: 0, mode: AUTOSUGGEST, query: $term, aggregations: [TYPE]) {\n    aggregations {\n      counts {\n        count\n        name\n      }\n    }\n  }\n}\n\nfragment SearchResultsList_viewer_plJt2 on Viewer {\n  searchConnection(query: $term, entities: $entities, mode: AUTOSUGGEST, first: 10) {\n    edges {\n      node {\n        displayLabel\n        href\n        imageUrl\n        __typename\n        ... on SearchableItem {\n          displayType\n          slug\n        }\n        ... on Artist {\n          statuses {\n            artworks\n            auctionLots\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query MobileSearchBarSuggestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n  $entities: [SearchEntity]\n) {\n  viewer {\n    ...Overlay_viewer_1B9obU\n  }\n}\n\nfragment Overlay_viewer_1B9obU on Viewer {\n  ...SearchInputPills_viewer_4hh6ED\n  ...SearchResultsList_viewer_plJt2 @include(if: $hasTerm)\n}\n\nfragment SearchInputPills_viewer_4hh6ED on Viewer {\n  searchConnectionAggregation: searchConnection(first: 0, mode: AUTOSUGGEST, query: $term, aggregations: [TYPE]) {\n    aggregations {\n      counts {\n        count\n        name\n      }\n    }\n  }\n}\n\nfragment SearchResultsList_viewer_plJt2 on Viewer {\n  searchConnection(query: $term, entities: $entities, mode: AUTOSUGGEST, first: 10) {\n    edges {\n      node {\n        displayLabel\n        href\n        imageUrl\n        __typename\n        ... on SearchableItem {\n          displayType\n          slug\n        }\n        ... on Artist {\n          statuses {\n            artworks\n            auctionLots\n          }\n          coverArtwork {\n            image {\n              src: url(version: [\"small\"])\n            }\n            id\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/OverlayRefetchQuery.graphql.ts
+++ b/src/__generated__/OverlayRefetchQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5450b674fe3c3cbcd48f1a22218d4d4f>>
+ * @generated SignedSource<<79b0378b7dc21b7c1c45841fbc309d77>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -66,7 +66,14 @@ v6 = [
   },
   (v4/*: any*/),
   (v5/*: any*/)
-];
+],
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": [
@@ -295,6 +302,44 @@ return {
                                   }
                                 ],
                                 "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Artwork",
+                                "kind": "LinkedField",
+                                "name": "coverArtwork",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": "src",
+                                        "args": [
+                                          {
+                                            "kind": "Literal",
+                                            "name": "version",
+                                            "value": [
+                                              "small"
+                                            ]
+                                          }
+                                        ],
+                                        "kind": "ScalarField",
+                                        "name": "url",
+                                        "storageKey": "url(version:[\"small\"])"
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  (v7/*: any*/)
+                                ],
+                                "storageKey": null
                               }
                             ],
                             "type": "Artist",
@@ -303,13 +348,7 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "id",
-                                "storageKey": null
-                              }
+                              (v7/*: any*/)
                             ],
                             "type": "Node",
                             "abstractKey": "__isNode"
@@ -376,12 +415,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "95962632acfb59f97ffbe37c2f4b1ffd",
+    "cacheID": "7971c608ca2fb0a4b1c23c1c1bc90101",
     "id": null,
     "metadata": {},
     "name": "OverlayRefetchQuery",
     "operationKind": "query",
-    "text": "query OverlayRefetchQuery(\n  $term: String!\n  $hasTerm: Boolean!\n  $entities: [SearchEntity]\n) {\n  viewer {\n    ...Overlay_viewer_1B9obU\n  }\n}\n\nfragment Overlay_viewer_1B9obU on Viewer {\n  ...SearchInputPills_viewer_4hh6ED\n  ...SearchResultsList_viewer_plJt2 @include(if: $hasTerm)\n}\n\nfragment SearchInputPills_viewer_4hh6ED on Viewer {\n  searchConnectionAggregation: searchConnection(first: 0, mode: AUTOSUGGEST, query: $term, aggregations: [TYPE]) {\n    aggregations {\n      counts {\n        count\n        name\n      }\n    }\n  }\n}\n\nfragment SearchResultsList_viewer_plJt2 on Viewer {\n  searchConnection(query: $term, entities: $entities, mode: AUTOSUGGEST, first: 10) {\n    edges {\n      node {\n        displayLabel\n        href\n        imageUrl\n        __typename\n        ... on SearchableItem {\n          displayType\n          slug\n        }\n        ... on Artist {\n          statuses {\n            artworks\n            auctionLots\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query OverlayRefetchQuery(\n  $term: String!\n  $hasTerm: Boolean!\n  $entities: [SearchEntity]\n) {\n  viewer {\n    ...Overlay_viewer_1B9obU\n  }\n}\n\nfragment Overlay_viewer_1B9obU on Viewer {\n  ...SearchInputPills_viewer_4hh6ED\n  ...SearchResultsList_viewer_plJt2 @include(if: $hasTerm)\n}\n\nfragment SearchInputPills_viewer_4hh6ED on Viewer {\n  searchConnectionAggregation: searchConnection(first: 0, mode: AUTOSUGGEST, query: $term, aggregations: [TYPE]) {\n    aggregations {\n      counts {\n        count\n        name\n      }\n    }\n  }\n}\n\nfragment SearchResultsList_viewer_plJt2 on Viewer {\n  searchConnection(query: $term, entities: $entities, mode: AUTOSUGGEST, first: 10) {\n    edges {\n      node {\n        displayLabel\n        href\n        imageUrl\n        __typename\n        ... on SearchableItem {\n          displayType\n          slug\n        }\n        ... on Artist {\n          statuses {\n            artworks\n            auctionLots\n          }\n          coverArtwork {\n            image {\n              src: url(version: [\"small\"])\n            }\n            id\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SearchBarInputRefetchQuery.graphql.ts
+++ b/src/__generated__/SearchBarInputRefetchQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<22e3e8dc60108193e44bfb07a0ecd3da>>
+ * @generated SignedSource<<43619b35b8c43d25692afa599846687b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -56,6 +56,13 @@ v5 = {
   "kind": "Variable",
   "name": "query",
   "variableName": "term"
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -232,6 +239,44 @@ return {
                                   }
                                 ],
                                 "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Artwork",
+                                "kind": "LinkedField",
+                                "name": "coverArtwork",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": "src",
+                                        "args": [
+                                          {
+                                            "kind": "Literal",
+                                            "name": "version",
+                                            "value": [
+                                              "square"
+                                            ]
+                                          }
+                                        ],
+                                        "kind": "ScalarField",
+                                        "name": "url",
+                                        "storageKey": "url(version:[\"square\"])"
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  (v6/*: any*/)
+                                ],
+                                "storageKey": null
                               }
                             ],
                             "type": "Artist",
@@ -240,13 +285,7 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "id",
-                                "storageKey": null
-                              }
+                              (v6/*: any*/)
                             ],
                             "type": "Node",
                             "abstractKey": "__isNode"
@@ -330,12 +369,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "855144d4a4af8828e5f8e2f5b19ee01f",
+    "cacheID": "ad2d6366eda13892968061868dc1636d",
     "id": null,
     "metadata": {},
     "name": "SearchBarInputRefetchQuery",
     "operationKind": "query",
-    "text": "query SearchBarInputRefetchQuery(\n  $term: String!\n  $hasTerm: Boolean!\n  $entities: [SearchEntity]\n) {\n  viewer {\n    ...SearchBarInput_viewer_1B9obU\n  }\n}\n\nfragment SearchBarInput_viewer_1B9obU on Viewer {\n  searchConnection(query: $term, entities: $entities, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {\n    edges {\n      node {\n        displayLabel\n        href\n        imageUrl\n        __typename\n        ... on SearchableItem {\n          displayType\n          slug\n        }\n        ... on Artist {\n          statuses {\n            artworks\n            auctionLots\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n  ...SearchInputPills_viewer_4hh6ED\n}\n\nfragment SearchInputPills_viewer_4hh6ED on Viewer {\n  searchConnectionAggregation: searchConnection(first: 0, mode: AUTOSUGGEST, query: $term, aggregations: [TYPE]) {\n    aggregations {\n      counts {\n        count\n        name\n      }\n    }\n  }\n}\n"
+    "text": "query SearchBarInputRefetchQuery(\n  $term: String!\n  $hasTerm: Boolean!\n  $entities: [SearchEntity]\n) {\n  viewer {\n    ...SearchBarInput_viewer_1B9obU\n  }\n}\n\nfragment SearchBarInput_viewer_1B9obU on Viewer {\n  searchConnection(query: $term, entities: $entities, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {\n    edges {\n      node {\n        displayLabel\n        href\n        imageUrl\n        __typename\n        ... on SearchableItem {\n          displayType\n          slug\n        }\n        ... on Artist {\n          statuses {\n            artworks\n            auctionLots\n          }\n          coverArtwork {\n            image {\n              src: url(version: [\"square\"])\n            }\n            id\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n  ...SearchInputPills_viewer_4hh6ED\n}\n\nfragment SearchInputPills_viewer_4hh6ED on Viewer {\n  searchConnectionAggregation: searchConnection(first: 0, mode: AUTOSUGGEST, query: $term, aggregations: [TYPE]) {\n    aggregations {\n      counts {\n        count\n        name\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SearchBarInputSuggestQuery.graphql.ts
+++ b/src/__generated__/SearchBarInputSuggestQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0a012d9fdb4915c7e2274bd8f01ae91d>>
+ * @generated SignedSource<<b802b9cf796d1481439de2258445fba6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -56,6 +56,13 @@ v5 = {
   "kind": "Variable",
   "name": "query",
   "variableName": "term"
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -232,6 +239,44 @@ return {
                                   }
                                 ],
                                 "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Artwork",
+                                "kind": "LinkedField",
+                                "name": "coverArtwork",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "image",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": "src",
+                                        "args": [
+                                          {
+                                            "kind": "Literal",
+                                            "name": "version",
+                                            "value": [
+                                              "square"
+                                            ]
+                                          }
+                                        ],
+                                        "kind": "ScalarField",
+                                        "name": "url",
+                                        "storageKey": "url(version:[\"square\"])"
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  (v6/*: any*/)
+                                ],
+                                "storageKey": null
                               }
                             ],
                             "type": "Artist",
@@ -240,13 +285,7 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "id",
-                                "storageKey": null
-                              }
+                              (v6/*: any*/)
                             ],
                             "type": "Node",
                             "abstractKey": "__isNode"
@@ -330,12 +369,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "244adb5043b2f3806342f9da61a8e76b",
+    "cacheID": "0a6af76749f51a04324c827fafb1378a",
     "id": null,
     "metadata": {},
     "name": "SearchBarInputSuggestQuery",
     "operationKind": "query",
-    "text": "query SearchBarInputSuggestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n  $entities: [SearchEntity]\n) {\n  viewer {\n    ...SearchBarInput_viewer_1B9obU\n  }\n}\n\nfragment SearchBarInput_viewer_1B9obU on Viewer {\n  searchConnection(query: $term, entities: $entities, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {\n    edges {\n      node {\n        displayLabel\n        href\n        imageUrl\n        __typename\n        ... on SearchableItem {\n          displayType\n          slug\n        }\n        ... on Artist {\n          statuses {\n            artworks\n            auctionLots\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n  ...SearchInputPills_viewer_4hh6ED\n}\n\nfragment SearchInputPills_viewer_4hh6ED on Viewer {\n  searchConnectionAggregation: searchConnection(first: 0, mode: AUTOSUGGEST, query: $term, aggregations: [TYPE]) {\n    aggregations {\n      counts {\n        count\n        name\n      }\n    }\n  }\n}\n"
+    "text": "query SearchBarInputSuggestQuery(\n  $term: String!\n  $hasTerm: Boolean!\n  $entities: [SearchEntity]\n) {\n  viewer {\n    ...SearchBarInput_viewer_1B9obU\n  }\n}\n\nfragment SearchBarInput_viewer_1B9obU on Viewer {\n  searchConnection(query: $term, entities: $entities, mode: AUTOSUGGEST, first: 7) @include(if: $hasTerm) {\n    edges {\n      node {\n        displayLabel\n        href\n        imageUrl\n        __typename\n        ... on SearchableItem {\n          displayType\n          slug\n        }\n        ... on Artist {\n          statuses {\n            artworks\n            auctionLots\n          }\n          coverArtwork {\n            image {\n              src: url(version: [\"square\"])\n            }\n            id\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n  ...SearchInputPills_viewer_4hh6ED\n}\n\nfragment SearchInputPills_viewer_4hh6ED on Viewer {\n  searchConnectionAggregation: searchConnection(first: 0, mode: AUTOSUGGEST, query: $term, aggregations: [TYPE]) {\n    aggregations {\n      counts {\n        count\n        name\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SearchBarInput_viewer.graphql.ts
+++ b/src/__generated__/SearchBarInput_viewer.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<953a6914a20668a8c9233b6d2ffb5817>>
+ * @generated SignedSource<<b45b7f174b5a108b5c2902bcc972eff2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,6 +15,11 @@ export type SearchBarInput_viewer$data = {
     readonly edges: ReadonlyArray<{
       readonly node: {
         readonly __typename: string;
+        readonly coverArtwork?: {
+          readonly image: {
+            readonly src: string | null;
+          } | null;
+        } | null;
         readonly displayLabel: string | null;
         readonly displayType?: string | null;
         readonly href: string | null;
@@ -183,6 +188,43 @@ const node: ReaderFragment = {
                             }
                           ],
                           "storageKey": null
+                        },
+                        {
+                          "alias": null,
+                          "args": null,
+                          "concreteType": "Artwork",
+                          "kind": "LinkedField",
+                          "name": "coverArtwork",
+                          "plural": false,
+                          "selections": [
+                            {
+                              "alias": null,
+                              "args": null,
+                              "concreteType": "Image",
+                              "kind": "LinkedField",
+                              "name": "image",
+                              "plural": false,
+                              "selections": [
+                                {
+                                  "alias": "src",
+                                  "args": [
+                                    {
+                                      "kind": "Literal",
+                                      "name": "version",
+                                      "value": [
+                                        "square"
+                                      ]
+                                    }
+                                  ],
+                                  "kind": "ScalarField",
+                                  "name": "url",
+                                  "storageKey": "url(version:[\"square\"])"
+                                }
+                              ],
+                              "storageKey": null
+                            }
+                          ],
+                          "storageKey": null
                         }
                       ],
                       "type": "Artist",
@@ -215,6 +257,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "92e9fc123f592d6f0778d455c3febb50";
+(node as any).hash = "806eab8056a659b4acab2a86966190c5";
 
 export default node;

--- a/src/__generated__/SearchResultsListPaginationQuery.graphql.ts
+++ b/src/__generated__/SearchResultsListPaginationQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<15d3732f9f54838b3df76963437cbd22>>
+ * @generated SignedSource<<c94ac78913c8f85216cb3936ab38b314>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -70,7 +70,14 @@ v5 = [
     "name": "query",
     "variableName": "term"
   }
-];
+],
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": [
@@ -228,6 +235,44 @@ return {
                               }
                             ],
                             "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Artwork",
+                            "kind": "LinkedField",
+                            "name": "coverArtwork",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Image",
+                                "kind": "LinkedField",
+                                "name": "image",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": "src",
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "version",
+                                        "value": [
+                                          "small"
+                                        ]
+                                      }
+                                    ],
+                                    "kind": "ScalarField",
+                                    "name": "url",
+                                    "storageKey": "url(version:[\"small\"])"
+                                  }
+                                ],
+                                "storageKey": null
+                              },
+                              (v6/*: any*/)
+                            ],
+                            "storageKey": null
                           }
                         ],
                         "type": "Artist",
@@ -236,13 +281,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "id",
-                            "storageKey": null
-                          }
+                          (v6/*: any*/)
                         ],
                         "type": "Node",
                         "abstractKey": "__isNode"
@@ -307,12 +346,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a67d4b061d5b5e4f5c305ea4afa5b2a7",
+    "cacheID": "5fccbc2e95a60c3c6c5c305bff951f35",
     "id": null,
     "metadata": {},
     "name": "SearchResultsListPaginationQuery",
     "operationKind": "query",
-    "text": "query SearchResultsListPaginationQuery(\n  $after: String\n  $term: String!\n  $entities: [SearchEntity]\n) {\n  viewer {\n    ...SearchResultsList_viewer_1PWAgx\n  }\n}\n\nfragment SearchResultsList_viewer_1PWAgx on Viewer {\n  searchConnection(query: $term, entities: $entities, mode: AUTOSUGGEST, first: 10, after: $after) {\n    edges {\n      node {\n        displayLabel\n        href\n        imageUrl\n        __typename\n        ... on SearchableItem {\n          displayType\n          slug\n        }\n        ... on Artist {\n          statuses {\n            artworks\n            auctionLots\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query SearchResultsListPaginationQuery(\n  $after: String\n  $term: String!\n  $entities: [SearchEntity]\n) {\n  viewer {\n    ...SearchResultsList_viewer_1PWAgx\n  }\n}\n\nfragment SearchResultsList_viewer_1PWAgx on Viewer {\n  searchConnection(query: $term, entities: $entities, mode: AUTOSUGGEST, first: 10, after: $after) {\n    edges {\n      node {\n        displayLabel\n        href\n        imageUrl\n        __typename\n        ... on SearchableItem {\n          displayType\n          slug\n        }\n        ... on Artist {\n          statuses {\n            artworks\n            auctionLots\n          }\n          coverArtwork {\n            image {\n              src: url(version: [\"small\"])\n            }\n            id\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SearchResultsList_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsList_viewer.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bbe1f8e3653baacfec535af3f5b34993>>
+ * @generated SignedSource<<ddd12f458f855cea1d0b853961035b00>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,6 +15,11 @@ export type SearchResultsList_viewer$data = {
     readonly edges: ReadonlyArray<{
       readonly node: {
         readonly __typename: string;
+        readonly coverArtwork?: {
+          readonly image: {
+            readonly src: string | null;
+          } | null;
+        } | null;
         readonly displayLabel: string | null;
         readonly displayType?: string | null;
         readonly href: string | null;
@@ -188,6 +193,43 @@ const node: ReaderFragment = {
                         }
                       ],
                       "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "Artwork",
+                      "kind": "LinkedField",
+                      "name": "coverArtwork",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "concreteType": "Image",
+                          "kind": "LinkedField",
+                          "name": "image",
+                          "plural": false,
+                          "selections": [
+                            {
+                              "alias": "src",
+                              "args": [
+                                {
+                                  "kind": "Literal",
+                                  "name": "version",
+                                  "value": [
+                                    "small"
+                                  ]
+                                }
+                              ],
+                              "kind": "ScalarField",
+                              "name": "url",
+                              "storageKey": "url(version:[\"small\"])"
+                            }
+                          ],
+                          "storageKey": null
+                        }
+                      ],
+                      "storageKey": null
                     }
                   ],
                   "type": "Artist",
@@ -239,6 +281,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "6d35cdcc07fad9feee082d440b665d7c";
+(node as any).hash = "8ebbcb51fdd52ce906eb31c9608d3d8a";
 
 export default node;


### PR DESCRIPTION
Closes [DIA-192](https://artsyproduct.atlassian.net/browse/DIA-192)

| Before | After |
| --- | --- |
| <img src="https://static.damonzucconi.com/_capture/VHFhOBEodNu5PjElvFf1cspAEwhpQsiVcwZfmZUWzb4zdcafZzS8QusOWtrPH7sXCPtfD0KIIUwTDOPjEzL37RTuaTGHfFAk0NZV.png"> | <img src="https://static.damonzucconi.com/_capture/Rnih1twd72eipTqx0OAKIjKd0SNinjz2IgICTgEizMRvYhJT4iQzSi45s5jKHPfMvN7crjOvmyqb2NaU4V8TOyHeQufiFg5GXlyL.png"> |

So this winds up being the minimal change we can make here. Swapping out the `imageUrl` field for just the artist type winds up being really painful in Metaphysics and of very limited utility. I'm just going to follow up with some deprecations and call this one. We will have to address Eigen separately.

The search could/should be simplified a lot by just switching to use fragment containers + matchConnection. I may also follow up with that.

[DIA-192]: https://artsyproduct.atlassian.net/browse/DIA-192?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ