### PR TITLE
fix: Alert filter modal overflow background

### DIFF
--- a/src/Components/Alert/Components/Modal.tsx
+++ b/src/Components/Alert/Components/Modal.tsx
@@ -42,6 +42,7 @@ export const Modal: React.FC<AlertModalProps> = ({
         width="100%"
         height="100%"
         position="relative"
+        overflowY="auto"
         bg="white100"
         {...boxProps}
       >


### PR DESCRIPTION
[ONYX-533](https://artsyproduct.atlassian.net/browse/ONYX-533)

## Description

This PR fixes Alert filter modal overflow background which is broken since [this](https://github.com/artsy/force/pull/13156/files#diff-e2d6453b65cffc01bdde27c288e20b8bfaa3dc5395e48579c9520c066f1eef04L46) change ([PR](https://github.com/artsy/force/pull/13156)).






| Before | After |
| --- | --- |
| <img width="396" alt="Screenshot 2023-11-20 at 15 25 15" src="https://github.com/artsy/force/assets/4691889/4b07f8fe-e85f-43f8-96d7-9dc52f6a37d6">| <img width="389" alt="Screenshot 2023-11-20 at 15 25 43" src="https://github.com/artsy/force/assets/4691889/556fab6d-2783-4472-b2cf-9f44876f7d05">|

[ONYX-533]: https://artsyproduct.atlassian.net/browse/ONYX-533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ