### PR TITLE
Feat(ONYX-512): add tracking for alerts filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "superagent": "3.8.3"
   },
   "dependencies": {
-    "@artsy/cohesion": "4.157.0",
+    "@artsy/cohesion": "4.158.0",
     "@artsy/commerce_helpers": "artsy/commerce_helpers",
     "@artsy/detect-responsive-traits": "^0.1.0",
     "@artsy/eigen-web-association": "^1.6.0",

--- a/src/Components/Alert/Components/Steps/Details.tsx
+++ b/src/Components/Alert/Components/Steps/Details.tsx
@@ -19,6 +19,7 @@ import { DetailsInput } from "Components/SavedSearchAlert/Components/DetailsInpu
 import { PriceRangeFilter } from "Components/Alert/Components/Form/PriceRange"
 import { useAlertContext } from "Components/Alert/Hooks/useAlertContext"
 import { useFeatureFlag } from "System/useFeatureFlag"
+import { useAlertTracking } from "Components/Alert/Hooks/useAlertTracking"
 
 export interface AlertFormikValues {
   name: string
@@ -28,6 +29,8 @@ export interface AlertFormikValues {
 }
 
 export const Details: FC = () => {
+  const { clickedAddFilters } = useAlertTracking()
+
   const { onComplete, dispatch, goToFilters, state } = useAlertContext()
 
   const newAlertModalFilteresEnabled = useFeatureFlag(
@@ -41,9 +44,10 @@ export const Details: FC = () => {
       onSubmit={onComplete}
     >
       {({ isSubmitting, values, setFieldValue, handleSubmit }) => {
-        const transitionToFilters = () => {
+        const transitionToFiltersAndTrack = () => {
           dispatch({ type: "SET_SETTINGS", payload: values })
           goToFilters()
+          clickedAddFilters()
         }
 
         return (
@@ -78,7 +82,7 @@ export const Details: FC = () => {
                 </Box>
 
                 {newAlertModalFilteresEnabled ? (
-                  <Clickable onClick={transitionToFilters} width="100%">
+                  <Clickable onClick={transitionToFiltersAndTrack} width="100%">
                     <Flex justifyContent="space-between" alignItems={"center"}>
                       <Box>
                         <Text variant="sm-display">Add Filters:</Text>

--- a/src/Components/Alert/Hooks/useAlertTracking.ts
+++ b/src/Components/Alert/Hooks/useAlertTracking.ts
@@ -73,7 +73,7 @@ export const useAlertTracking = () => {
       const payload: ClickedArtworkGroup = {
         action: ActionType.clickedArtworkGroup,
         context_module: ContextModule.alertConfirmation,
-        context_page_owner_type: OwnerType.alertConfirmation,
+        context_page_owner_type: contextPageOwnerType,
         destination_page_owner_id: internalId,
         destination_page_owner_slug: slug,
         destination_page_owner_type: OwnerType.artwork,

--- a/src/Components/Alert/Hooks/useAlertTracking.ts
+++ b/src/Components/Alert/Hooks/useAlertTracking.ts
@@ -1,7 +1,11 @@
 import {
   ActionType,
+  ClickedAddFilters,
+  ClickedArtworkGroup,
   ClickedCreateAlert,
+  ContextModule,
   DeletedSavedSearch,
+  OwnerType,
   ScreenOwnerType,
   ToggledSavedSearch,
 } from "@artsy/cohesion"
@@ -51,6 +55,29 @@ export const useAlertTracking = () => {
         context_page_owner_id: contextPageOwnerId,
         context_page_owner_slug: contextPageOwnerSlug,
         context_page_owner_type: contextPageOwnerType,
+      }
+
+      trackEvent(payload)
+    },
+
+    clickedAddFilters: () => {
+      const payload: ClickedAddFilters = {
+        action: ActionType.clickedAddFilters,
+        context_module: ContextModule.alertFilters,
+      }
+
+      trackEvent(payload)
+    },
+
+    clickedArtworkGroup: (internalId: string, slug: string) => {
+      const payload: ClickedArtworkGroup = {
+        action: ActionType.clickedArtworkGroup,
+        context_module: ContextModule.alertConfirmation,
+        context_page_owner_type: OwnerType.alertConfirmation,
+        destination_page_owner_id: internalId,
+        destination_page_owner_slug: slug,
+        destination_page_owner_type: OwnerType.artwork,
+        type: "thumbnail",
       }
 
       trackEvent(payload)

--- a/src/Components/SavedSearchAlert/ConfirmationArtworksGrid.tsx
+++ b/src/Components/SavedSearchAlert/ConfirmationArtworksGrid.tsx
@@ -23,6 +23,7 @@ import {
   ConfirmationStepFooterContentPlaceholder,
   ConfirmationStepFooterQueryRenderer,
 } from "Components/SavedSearchAlert/Components/ConfirmationStepFooter"
+import { useAlertTracking } from "Components/Alert/Hooks/useAlertTracking"
 
 export const NUMBER_OF_ARTWORKS_TO_SHOW = 10
 
@@ -38,6 +39,7 @@ export const ConfirmationArtworks: FC<ConfirmationArtworksProps> = ({
   onClose,
 }) => {
   const { t } = useTranslation()
+  const { clickedArtworkGroup } = useAlertTracking()
   const artworksCount = artworksConnection?.counts?.total ?? 0
 
   if (artworksCount === 0) {
@@ -84,7 +86,13 @@ export const ConfirmationArtworks: FC<ConfirmationArtworksProps> = ({
       <ArtworkGridContextProvider saveOnlyToDefaultList>
         <GridColumns>
           <Column span={12}>
-            <ArtworkGrid artworks={artworksConnection!} columnCount={2} />
+            <ArtworkGrid
+              artworks={artworksConnection!}
+              columnCount={2}
+              onBrickClick={artwork =>
+                clickedArtworkGroup(artwork.internalID, artwork.slug)
+              }
+            />
           </Column>
         </GridColumns>
       </ArtworkGridContextProvider>

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,10 +22,10 @@
   dependencies:
     tslib "~2.0.1"
 
-"@artsy/cohesion@4.157.0":
-  version "4.157.0"
-  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-4.157.0.tgz#2d08c1b3c1217b7269adfe1acfd22b3ec1534ae6"
-  integrity sha512-JlNbcVz1MeAN5b6aFWbc3ZZNBujNPFiZtRoyJrE5FZ/PW4BeE0dV2NrzaQf+9WaxzO28H82lb4ujS9YXXaTSDw==
+"@artsy/cohesion@4.158.0":
+  version "4.158.0"
+  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-4.158.0.tgz#351174a08d1be56355dc0bbf2c8d34703137bd53"
+  integrity sha512-77Dzs80DrQg1jEQsN+PvDT8OrFXtvPzsZtPLrf/smtN88N/hxFiLq5TW4eK82qLb2CGhFUUkBhJP84QGjEOFCw==
   dependencies:
     core-js "3"
 


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [ONYX-512]

### Description

<!-- Implementation description -->
Added tracking for alerts filters flow
- Add Filters button
- Click on the artwork on the confirmation screen

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-512]: https://artsyproduct.atlassian.net/browse/ONYX-512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ