### PR TITLE
fix(sticky): supports proper stacking and release

### DIFF
--- a/src/Components/Sticky/Sticky.tsx
+++ b/src/Components/Sticky/Sticky.tsx
@@ -28,12 +28,20 @@ import { useSticky } from "./StickyProvider"
  */
 export const Sticky: React.FC<
   Pick<ReactStickyProps, "bottomBoundary"> & {
+    id?: string
     // TODO: Remove this prop!
     withoutHeaderOffset?: boolean
     children: ReactNode | (({ stuck }: { stuck: boolean }) => ReactNode)
   }
-> = ({ children, bottomBoundary, withoutHeaderOffset }) => {
-  const { offsetTop, registerSticky, deregisterSticky } = useSticky()
+> = ({ children, bottomBoundary, withoutHeaderOffset, id }) => {
+  const {
+    offsetTop,
+    registerSticky,
+    deregisterSticky,
+    updateSticky,
+  } = useSticky({
+    id,
+  })
 
   const { desktop, mobile } = useNavBarHeight()
 
@@ -47,7 +55,6 @@ export const Sticky: React.FC<
 
   useEffect(() => {
     registerSticky(containerRef.current?.clientHeight)
-
     return deregisterSticky
   }, [registerSticky, deregisterSticky])
 
@@ -57,14 +64,21 @@ export const Sticky: React.FC<
       bottomBoundary={bottomBoundary}
       onStateChange={state => {
         switch (state.status) {
-          case ReactSticky.STATUS_FIXED:
+          case ReactSticky.STATUS_FIXED: {
             setStuck(true)
+            updateSticky({ status: "FIXED" })
             break
-          case ReactSticky.STATUS_ORIGINAL:
-          case ReactSticky.STATUS_RELEASED:
+          }
+          case ReactSticky.STATUS_ORIGINAL: {
             setStuck(false)
-            deregisterSticky()
+            updateSticky({ status: "ORIGINAL" })
             break
+          }
+          case ReactSticky.STATUS_RELEASED: {
+            setStuck(false)
+            updateSticky({ status: "RELEASED" })
+            break
+          }
         }
       }}
       innerZ={1}

--- a/src/Components/Sticky/__tests__/StickyProvider.jest.tsx
+++ b/src/Components/Sticky/__tests__/StickyProvider.jest.tsx
@@ -1,11 +1,14 @@
-import { getOffsetTopForSticky } from "../StickyProvider"
+import {
+  getOffsetTopForSticky,
+  TSticky,
+} from "Components/Sticky/StickyProvider"
 
-const EXAMPLE_STICKIES = [
-  { id: "example1", height: 80 },
-  { id: "example2", height: 200 },
-  { id: "example3", height: 15 },
-  { id: "example4", height: 333 },
-  { id: "example5", height: 66 },
+const EXAMPLE_STICKIES: TSticky[] = [
+  { id: "example1", height: 80, status: "ORIGINAL" },
+  { id: "example2", height: 200, status: "ORIGINAL" },
+  { id: "example3", height: 15, status: "ORIGINAL" },
+  { id: "example4", height: 333, status: "ORIGINAL" },
+  { id: "example5", height: 66, status: "ORIGINAL" },
 ]
 
 describe("getOffsetTopForSticky", () => {


### PR DESCRIPTION
Some work towards supporting sticky horizontal filters.

This took a moment to wrap my head around — we always want to register all Stickies on initialization, but we need to filter out any that may be "released" due to intercepting a bottom boundary, when getting the top offset.

I'm unable to merge sticky wrapped around the filters though because the drawer isn't actually implemented in a modal fashion (with portal).