### PR TITLE
feat: Allow multiple artist IDs for Alert price histogram

### DIFF
--- a/src/Components/Alert/Components/Filters/Price.tsx
+++ b/src/Components/Alert/Components/Filters/Price.tsx
@@ -73,7 +73,7 @@ export const PriceQueryRenderer = () => {
       placeholder={<Price />}
       variables={{ artistIDs }}
       query={graphql`
-        query PriceAggregationsQuery($artistIDs: [String!]) {
+        query PriceAggregationsQuery($artistIDs: [String!]!) {
           artworksConnection(
             aggregations: [SIMPLE_PRICE_HISTOGRAM]
             artistIDs: $artistIDs

--- a/src/Components/Alert/Components/Filters/Price.tsx
+++ b/src/Components/Alert/Components/Filters/Price.tsx
@@ -63,22 +63,22 @@ export const PriceFragmentContainer = createFragmentContainer(Price, {
 export const PriceQueryRenderer = () => {
   const { state } = useAlertContext()
 
-  const artistID = state.criteria.artistIDs?.[0]
+  const artistIDs = state.criteria.artistIDs
 
-  if (!artistID) return <Price />
+  if (!artistIDs?.length) return <Price />
 
   return (
     <SystemQueryRenderer<PriceAggregationsQuery>
       lazyLoad
       placeholder={<Price />}
-      variables={{ artistID }}
+      variables={{ artistIDs }}
       // TODO: Pass in many artist IDs after fixing Gravity
       // https://github.com/artsy/force/pull/13158#discussion_r1399214348
       query={graphql`
-        query PriceAggregationsQuery($artistID: String!) {
+        query PriceAggregationsQuery($artistIDs: [String!]) {
           artworksConnection(
             aggregations: [SIMPLE_PRICE_HISTOGRAM]
-            artistID: $artistID
+            artistIDs: $artistIDs
             first: 0
           ) {
             ...Price_artworksConnection

--- a/src/Components/Alert/Components/Filters/Price.tsx
+++ b/src/Components/Alert/Components/Filters/Price.tsx
@@ -72,8 +72,6 @@ export const PriceQueryRenderer = () => {
       lazyLoad
       placeholder={<Price />}
       variables={{ artistIDs }}
-      // TODO: Pass in many artist IDs after fixing Gravity
-      // https://github.com/artsy/force/pull/13158#discussion_r1399214348
       query={graphql`
         query PriceAggregationsQuery($artistIDs: [String!]) {
           artworksConnection(

--- a/src/__generated__/PriceAggregationsQuery.graphql.ts
+++ b/src/__generated__/PriceAggregationsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<34736a1822221259a99df368fd5473c1>>
+ * @generated SignedSource<<132dcd7b300de07ed24e5ecc78ee79e9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,7 +11,7 @@
 import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type PriceAggregationsQuery$variables = {
-  artistIDs?: ReadonlyArray<string> | null | undefined;
+  artistIDs: ReadonlyArray<string>;
 };
 export type PriceAggregationsQuery$data = {
   readonly artworksConnection: {
@@ -154,16 +154,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a083c88f50af5933a00da6fb07fbcefd",
+    "cacheID": "c4eff41d88c01a162bcfb26bb4bd2214",
     "id": null,
     "metadata": {},
     "name": "PriceAggregationsQuery",
     "operationKind": "query",
-    "text": "query PriceAggregationsQuery(\n  $artistIDs: [String!]\n) {\n  artworksConnection(aggregations: [SIMPLE_PRICE_HISTOGRAM], artistIDs: $artistIDs, first: 0) {\n    ...Price_artworksConnection\n    id\n  }\n}\n\nfragment Price_artworksConnection on FilterArtworksConnection {\n  aggregations {\n    slice\n    counts {\n      name\n      value\n      count\n    }\n  }\n}\n"
+    "text": "query PriceAggregationsQuery(\n  $artistIDs: [String!]!\n) {\n  artworksConnection(aggregations: [SIMPLE_PRICE_HISTOGRAM], artistIDs: $artistIDs, first: 0) {\n    ...Price_artworksConnection\n    id\n  }\n}\n\nfragment Price_artworksConnection on FilterArtworksConnection {\n  aggregations {\n    slice\n    counts {\n      name\n      value\n      count\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "709bd463dcc68a76c56392c28fc8db6c";
+(node as any).hash = "396b6104acd1c8e196c00f8b0d7c2d0b";
 
 export default node;

--- a/src/__generated__/PriceAggregationsQuery.graphql.ts
+++ b/src/__generated__/PriceAggregationsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fbe06979f8c06153c1ab37e4793f1d21>>
+ * @generated SignedSource<<34736a1822221259a99df368fd5473c1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,7 +11,7 @@
 import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type PriceAggregationsQuery$variables = {
-  artistID: string;
+  artistIDs?: ReadonlyArray<string> | null | undefined;
 };
 export type PriceAggregationsQuery$data = {
   readonly artworksConnection: {
@@ -28,7 +28,7 @@ var v0 = [
   {
     "defaultValue": null,
     "kind": "LocalArgument",
-    "name": "artistID"
+    "name": "artistIDs"
   }
 ],
 v1 = [
@@ -41,8 +41,8 @@ v1 = [
   },
   {
     "kind": "Variable",
-    "name": "artistID",
-    "variableName": "artistID"
+    "name": "artistIDs",
+    "variableName": "artistIDs"
   },
   {
     "kind": "Literal",
@@ -154,16 +154,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "2145e19ab94ac1486d9e8c0c04170cc6",
+    "cacheID": "a083c88f50af5933a00da6fb07fbcefd",
     "id": null,
     "metadata": {},
     "name": "PriceAggregationsQuery",
     "operationKind": "query",
-    "text": "query PriceAggregationsQuery(\n  $artistID: String!\n) {\n  artworksConnection(aggregations: [SIMPLE_PRICE_HISTOGRAM], artistID: $artistID, first: 0) {\n    ...Price_artworksConnection\n    id\n  }\n}\n\nfragment Price_artworksConnection on FilterArtworksConnection {\n  aggregations {\n    slice\n    counts {\n      name\n      value\n      count\n    }\n  }\n}\n"
+    "text": "query PriceAggregationsQuery(\n  $artistIDs: [String!]\n) {\n  artworksConnection(aggregations: [SIMPLE_PRICE_HISTOGRAM], artistIDs: $artistIDs, first: 0) {\n    ...Price_artworksConnection\n    id\n  }\n}\n\nfragment Price_artworksConnection on FilterArtworksConnection {\n  aggregations {\n    slice\n    counts {\n      name\n      value\n      count\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "c2c782473ddf596ca7e52c75d4bdb55e";
+(node as any).hash = "709bd463dcc68a76c56392c28fc8db6c";
 
 export default node;


### PR DESCRIPTION
Addresses [ONYX-525]

- Resolves https://github.com/artsy/force/pull/13158#discussion_r1399214348

- 🔴  Blocked by https://github.com/artsy/gravity/pull/17110

## Description

With this change, we will be able to show the price histogram for all artists that the alert is created with.

[ONYX-525]: https://artsyproduct.atlassian.net/browse/ONYX-525?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ