### PR TITLE
feat(progressive-onboarding): sync saving artwork logged out

### DIFF
--- a/src/Components/ProgressiveOnboarding/ProgressiveOnboardingFollowArtist.tsx
+++ b/src/Components/ProgressiveOnboarding/ProgressiveOnboardingFollowArtist.tsx
@@ -33,7 +33,7 @@ export const __ProgressiveOnboardingFollowArtist__: FC<ProgressiveOnboardingFoll
     // Hasn't followed an artist yet.
     counts.isReady &&
     counts.followedArtists === 0 &&
-    // If you've already dismissed the alerts onboarding OR you're not on the artist page.
+    // If you've already dismissed the alerts onboarding OR you're logged out OR you're not on the artist page.
     (!isLoggedIn ||
       PROGRESSIVE_ONBOARDING_ALERT_CHAIN.every(
         key => isDismissed(key).status

--- a/src/Components/ProgressiveOnboarding/ProgressiveOnboardingFollowArtist.tsx
+++ b/src/Components/ProgressiveOnboarding/ProgressiveOnboardingFollowArtist.tsx
@@ -13,6 +13,7 @@ import {
 } from "Components/ProgressiveOnboarding/withProgressiveOnboardingCounts"
 import { useRouter } from "System/Router/useRouter"
 import { pathToRegexp } from "path-to-regexp"
+import { useSystemContext } from "System/SystemContext"
 
 interface ProgressiveOnboardingFollowArtistProps
   extends WithProgressiveOnboardingCountsProps {}
@@ -22,6 +23,7 @@ export const __ProgressiveOnboardingFollowArtist__: FC<ProgressiveOnboardingFoll
   children,
 }) => {
   const router = useRouter()
+  const { isLoggedIn } = useSystemContext()
 
   const { dismiss, isDismissed } = useProgressiveOnboarding()
 
@@ -32,7 +34,10 @@ export const __ProgressiveOnboardingFollowArtist__: FC<ProgressiveOnboardingFoll
     counts.isReady &&
     counts.followedArtists === 0 &&
     // If you've already dismissed the alerts onboarding OR you're not on the artist page.
-    (PROGRESSIVE_ONBOARDING_ALERT_CHAIN.every(key => isDismissed(key).status) ||
+    (!isLoggedIn ||
+      PROGRESSIVE_ONBOARDING_ALERT_CHAIN.every(
+        key => isDismissed(key).status
+      ) ||
       !pathToRegexp("/artist/:artistID").test(router.match.location.pathname))
 
   const handleClose = useCallback(() => {

--- a/src/Utils/Hooks/useAuthIntent/index.tsx
+++ b/src/Utils/Hooks/useAuthIntent/index.tsx
@@ -140,6 +140,12 @@ export const useRunAuthIntent = () => {
               case "artist":
                 syncFromLoggedOutUser()
             }
+            break
+          case "saveArtworkToLists":
+            switch (value.kind) {
+              case "artworks":
+                syncFromLoggedOutUser()
+            }
         }
       },
     })


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [DIA-327]

### Description

This PR syncs the action of saving an Artwork to the progressive onboarding and contains a small fix to show the Follow Artist popover when logged out correctly.




[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DIA-327]: https://artsyproduct.atlassian.net/browse/DIA-327?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ