### PR TITLE
chore: guard after auth behavior behind same feature flag

### DIFF
--- a/src/Components/Alert/AlertProvider.tsx
+++ b/src/Components/Alert/AlertProvider.tsx
@@ -23,6 +23,7 @@ import {
   PreviewSavedSearchAttributes,
   AlertProviderPreviewQuery,
 } from "__generated__/AlertProviderPreviewQuery.graphql"
+import { useFeatureFlag } from "System/useFeatureFlag"
 
 interface AlertProviderProps {
   initialCriteria?: SearchCriteriaAttributes
@@ -40,6 +41,7 @@ export const AlertProvider: FC<AlertProviderProps> = ({
   const { showAuthDialog } = useAuthDialog()
   const { value, clearValue } = useAuthIntent()
   const { submitMutation } = useCreateAlert()
+  const newAlertModalEnabled = useFeatureFlag("onyx_artwork_alert_modal_v2")
   const { isLoggedIn, relayEnvironment } = useSystemContext()
 
   const initialState = {
@@ -171,12 +173,13 @@ export const AlertProvider: FC<AlertProviderProps> = ({
   }, [state.visible, debouncedCriteria, relayEnvironment])
 
   useEffect(() => {
-    if (!value || value.action !== Intent.createAlert) return
+    if (!newAlertModalEnabled || !value || value.action !== Intent.createAlert)
+      return
 
     dispatch({ type: "SHOW" })
 
     clearValue()
-  }, [value, clearValue])
+  }, [newAlertModalEnabled, value, clearValue])
 
   return (
     <AlertContext.Provider


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

Guard the after auth intent handling behind the same feature flag so we don't accidentally dispatch both the old and new alert modals.

| Before (double dispatch) | After |
|--------|--------|
| <video src="https://github.com/artsy/force/assets/123595/939e4a75-a5f0-4df5-b7c5-4c37b0852693" /> | <video src="https://github.com/artsy/force/assets/123595/7bcf08ef-30d3-4ddd-bb42-4e82a51e1cd7" /> |










[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ