### PR TITLE
docs: mark deprecated testing utilities and point to updated docs

### DIFF
--- a/src/DevTools/README.md
+++ b/src/DevTools/README.md
@@ -1,5 +1,12 @@
 # Guide to mocking relay data using `renderRelayTree`, `mockData`, and `mockMutationResults`
 
+> [!WARNING]
+> These docs refer to deprecated utility functions backed by enzyme. For all new
+> tests, use `@testing-library/react` and the `setupTestWrapperTL` helper. See
+> our [best practices][] doc for more guidelines.
+
+[best practices]: https://github.com/artsy/force/blob/main/docs/best_practices.md#testing
+
 ## The basics
 
 If your are testing a component that makes a query to metaphysics, you can use the `renderRelayTree` helper to mock out the data that would be returned by metaphysics. Previously this was done with the `mockResolvers` prop, but now we have an easier and less confusing way: `mockData` and `mockMutationResults`. The idea is that these properties should match the exact data shape that metaphysics would return.

--- a/src/DevTools/renderRelayTree.tsx
+++ b/src/DevTools/renderRelayTree.tsx
@@ -25,6 +25,9 @@ const RelayFinishedLoading: RenderUntilPredicate<any, any, any> = tree =>
  * function for your `QueryRenderer` where possible, as it will do this plumbing
  * by default.
  *
+ * @deprecated This method should _not_ be used for new tests. See
+ * `setupTestWrapperTL` which uses `@testing-library/react`.
+ * 
  * @note
  * Use this function in tests, but not storybooks. For storybooks you should
  * usually use {@link MockRelayRenderer}.

--- a/src/DevTools/setupTestWrapper.tsx
+++ b/src/DevTools/setupTestWrapper.tsx
@@ -162,7 +162,8 @@ export const setupTestWrapperTL = <T extends OperationType>({
 }
 
 /**
- * @note See `setupTestWrapperTL`, which uses `@testing-library/react`
+ * @deprecated This method should _not_ be used for new tests. See
+ * `setupTestWrapperTL` which uses `@testing-library/react`.
  */
 export const setupTestWrapper = <T extends OperationType>({
   Component,


### PR DESCRIPTION
The type of this PR is: **Docs**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

Mark deprecated testing utilities and point to updated docs.

The `@deprecated` comment adds some visual discouragement and a hover note in VSCode. The `[!WARNING]` tag adds a colored alert section in GitHub-flavored Markdown ([documented here](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts)).


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ