### PR TITLE
chore(eslint): Add rule guarding against relay-runtime `graphql` import

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -109,6 +109,11 @@ module.exports = {
         name: "react-waypoint",
         message: "Please use `useIntersectionObserver`",
       },
+      {
+        name: "react-runtime",
+        importNames: ["graphql"],
+        message: "Please import `graphql` from `react-relay`.",
+      },
     ],
     "no-relative-import-paths/no-relative-import-paths": [
       "warn",


### PR DESCRIPTION
The type of this PR is: **Chore**

### Description

With latest relay, the graphql import needs to come from `react-relay`, not `relay-runtime` for typescript to be satisfied. This also applies to a few other things (like `commitMutation`, etc). However, using those things directly only apply to legacy patterns given our current set of tools, so should be fine. 
