### PR TITLE
feat: Show email preference warning in create alert flow

### DIFF
--- a/src/Components/Alert/Components/Filters/EmailPreferenceWarningMessage.tsx
+++ b/src/Components/Alert/Components/Filters/EmailPreferenceWarningMessage.tsx
@@ -1,0 +1,90 @@
+import { Message } from "@artsy/palette"
+import { useAlertContext } from "Components/Alert/Hooks/useAlertContext"
+import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
+import { RouterLink } from "System/Router/RouterLink"
+import { FC } from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { EmailPreferenceWarningMessage_viewer$data } from "__generated__/EmailPreferenceWarningMessage_viewer.graphql"
+import { EmailPreferenceWarningMessageQuery } from "__generated__/EmailPreferenceWarningMessageQuery.graphql"
+
+interface EmailPreferenceWarningMessageProps {
+  viewer?: EmailPreferenceWarningMessage_viewer$data
+}
+
+export const EmailPreferenceWarningMessage: FC<EmailPreferenceWarningMessageProps> = ({
+  viewer,
+}) => {
+  const { state } = useAlertContext()
+
+  const areCustomAlertsEmailNotificationsEnabled = viewer?.notificationPreferences?.some(
+    preference => {
+      return (
+        preference.channel === "email" &&
+        preference.name === "custom_alerts" &&
+        preference.status === "SUBSCRIBED"
+      )
+    }
+  )
+
+  const showEmailPreferenceWarning =
+    state.settings.email && !areCustomAlertsEmailNotificationsEnabled
+
+  if (!showEmailPreferenceWarning) return null
+
+  return (
+    <Message variant="alert" title="Change your email preferences" mt={2}>
+      To receive Email Alerts, please update{" "}
+      <RouterLink inline to="/unsubscribe">
+        your email preferences
+      </RouterLink>
+      .
+    </Message>
+  )
+}
+
+export const EmailPreferenceWarningMessageFragmentContainer = createFragmentContainer(
+  EmailPreferenceWarningMessage,
+  {
+    viewer: graphql`
+      fragment EmailPreferenceWarningMessage_viewer on Viewer
+        @argumentDefinitions(authenticationToken: { type: "String" }) {
+        notificationPreferences(authenticationToken: $authenticationToken) {
+          channel
+          name
+          status
+        }
+      }
+    `,
+  }
+)
+
+export const EmailPreferenceWarningMessageQueryRenderer: React.FC = () => {
+  return (
+    <SystemQueryRenderer<EmailPreferenceWarningMessageQuery>
+      lazyLoad
+      query={graphql`
+        query EmailPreferenceWarningMessageQuery {
+          viewer {
+            ...EmailPreferenceWarningMessage_viewer
+          }
+        }
+      `}
+      render={({ props, error }) => {
+        if (error) {
+          console.error(error)
+          return null
+        }
+
+        if (!props?.viewer) {
+          return null
+        }
+
+        return (
+          <EmailPreferenceWarningMessageFragmentContainer
+            viewer={props.viewer}
+          />
+        )
+      }}
+    />
+  )
+}

--- a/src/Components/Alert/Components/Steps/Details.tsx
+++ b/src/Components/Alert/Components/Steps/Details.tsx
@@ -20,6 +20,7 @@ import { PriceRangeFilter } from "Components/Alert/Components/Form/PriceRange"
 import { useAlertContext } from "Components/Alert/Hooks/useAlertContext"
 import { useFeatureFlag } from "System/useFeatureFlag"
 import { useAlertTracking } from "Components/Alert/Hooks/useAlertTracking"
+import { EmailPreferenceWarningMessageQueryRenderer } from "Components/Alert/Components/Filters/EmailPreferenceWarningMessage"
 
 export interface AlertFormikValues {
   name: string
@@ -113,6 +114,8 @@ export const Details: FC = () => {
                       selected={values.email}
                     />
                   </Box>
+
+                  <EmailPreferenceWarningMessageQueryRenderer />
 
                   <Spacer y={2} />
 

--- a/src/__generated__/EmailPreferenceWarningMessageQuery.graphql.ts
+++ b/src/__generated__/EmailPreferenceWarningMessageQuery.graphql.ts
@@ -1,0 +1,114 @@
+/**
+ * @generated SignedSource<<d6422ec78efe6a9bd1f85959e6c2ff65>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type EmailPreferenceWarningMessageQuery$variables = Record<PropertyKey, never>;
+export type EmailPreferenceWarningMessageQuery$data = {
+  readonly viewer: {
+    readonly " $fragmentSpreads": FragmentRefs<"EmailPreferenceWarningMessage_viewer">;
+  } | null | undefined;
+};
+export type EmailPreferenceWarningMessageQuery = {
+  response: EmailPreferenceWarningMessageQuery$data;
+  variables: EmailPreferenceWarningMessageQuery$variables;
+};
+
+const node: ConcreteRequest = {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "EmailPreferenceWarningMessageQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "EmailPreferenceWarningMessage_viewer"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "EmailPreferenceWarningMessageQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Viewer",
+        "kind": "LinkedField",
+        "name": "viewer",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "NotificationPreference",
+            "kind": "LinkedField",
+            "name": "notificationPreferences",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "channel",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "status",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "2b118ed57279ed579c6c061f0d9781ca",
+    "id": null,
+    "metadata": {},
+    "name": "EmailPreferenceWarningMessageQuery",
+    "operationKind": "query",
+    "text": "query EmailPreferenceWarningMessageQuery {\n  viewer {\n    ...EmailPreferenceWarningMessage_viewer\n  }\n}\n\nfragment EmailPreferenceWarningMessage_viewer on Viewer {\n  notificationPreferences {\n    channel\n    name\n    status\n  }\n}\n"
+  }
+};
+
+(node as any).hash = "b70cc7290e95e848f43d8a7b17889665";
+
+export default node;

--- a/src/__generated__/EmailPreferenceWarningMessage_viewer.graphql.ts
+++ b/src/__generated__/EmailPreferenceWarningMessage_viewer.graphql.ts
@@ -1,0 +1,84 @@
+/**
+ * @generated SignedSource<<6ebea59df1e6794ab929625ca9cdefed>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { Fragment, ReaderFragment } from 'relay-runtime';
+export type SubGroupStatus = "SUBSCRIBED" | "UNSUBSCRIBED" | "%future added value";
+import { FragmentRefs } from "relay-runtime";
+export type EmailPreferenceWarningMessage_viewer$data = {
+  readonly notificationPreferences: ReadonlyArray<{
+    readonly channel: string;
+    readonly name: string;
+    readonly status: SubGroupStatus;
+  }>;
+  readonly " $fragmentType": "EmailPreferenceWarningMessage_viewer";
+};
+export type EmailPreferenceWarningMessage_viewer$key = {
+  readonly " $data"?: EmailPreferenceWarningMessage_viewer$data;
+  readonly " $fragmentSpreads": FragmentRefs<"EmailPreferenceWarningMessage_viewer">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [
+    {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "authenticationToken"
+    }
+  ],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "EmailPreferenceWarningMessage_viewer",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Variable",
+          "name": "authenticationToken",
+          "variableName": "authenticationToken"
+        }
+      ],
+      "concreteType": "NotificationPreference",
+      "kind": "LinkedField",
+      "name": "notificationPreferences",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "channel",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "status",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Viewer",
+  "abstractKey": null
+};
+
+(node as any).hash = "e76be824e2eadf69fd3e4d9a4ed1a9c8";
+
+export default node;


### PR DESCRIPTION


The type of this PR is: **Feature**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [ONYX-236]

### Description

Show email preference warning in create alert flow. The message is already implemented on the **Edit** Alert page and looks exactly the same.

<img width="522" alt="Screenshot 2023-11-27 at 14 02 29" src="https://github.com/artsy/force/assets/4691889/189c69d0-84ff-4aa1-8ac4-6130c494869b">


<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-236]: https://artsyproduct.atlassian.net/browse/ONYX-236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ