### PR TITLE
Feat: Address autocomplete input for new shipping route

### DIFF
--- a/src/Components/Address/AddressAutocompleteInput.tsx
+++ b/src/Components/Address/AddressAutocompleteInput.tsx
@@ -1,0 +1,361 @@
+import {
+  AutocompleteInput,
+  AutocompleteInputOptionType,
+  AutocompleteInputProps,
+  Input,
+  usePrevious,
+} from "@artsy/palette"
+import { Address } from "Components/Address/AddressForm"
+import { useFeatureFlag } from "System/useFeatureFlag"
+import { getENV } from "Utils/getENV"
+import { useCallback, useEffect, useMemo, useState } from "react"
+import { throttle, uniqBy } from "lodash"
+import { useTracking } from "react-tracking"
+import {
+  ActionType,
+  AddressAutoCompletionResult,
+  ContextModule,
+  EditedAutocompletedAddress,
+  PageOwnerType,
+  SelectedItemFromAddressAutoCompletion,
+} from "@artsy/cohesion"
+
+const THROTTLE_DELAY = 500
+
+export interface AddressAutocompleteInputProps
+  extends Partial<AutocompleteInputProps<AddressAutocompleteSuggestion>> {
+  /* The address [including at least a country] to use for autocomplete suggestions */
+  address: Partial<Address> & { country: Address["country"] }
+
+  disableAutocomplete?: boolean
+  onSelect: NonNullable<
+    AutocompleteInputProps<AddressAutocompleteSuggestion>["onSelect"]
+  >
+  onClear: NonNullable<
+    AutocompleteInputProps<AddressAutocompleteSuggestion>["onClear"]
+  >
+  onChange: NonNullable<
+    AutocompleteInputProps<AddressAutocompleteSuggestion>["onChange"]
+  >
+  onReceiveAutocompleteResult?: (input: string, resultCount: number) => void
+  "data-testid"?: string
+}
+
+type ProviderSuggestion = {
+  city: string
+  entries: number
+  secondary: string
+  state: string
+  street_line: string
+  zipcode: string
+  source?: "postal" | "other"
+}
+
+interface AddressAutocompleteSuggestion extends AutocompleteInputOptionType {
+  address: Omit<Address, "name">
+  // entries are null if secondary suggestions are not enabled
+  entries: number | null
+}
+
+interface ServiceAvailability {
+  loading: boolean
+  enabled?: boolean
+  fetching: boolean
+}
+
+/**
+ * A wrapper around the Palette AutocompleteInput that handles efficiently
+ * fetching address suggestions from an autocomplete provider. Use the
+ * `useAddressAutocompleteTracking` hook to get pre-loaded tracking helpers.
+ * See AddressAutocompleteInput.jest.tsx for implementation examples.
+ */
+export const AddressAutocompleteInput = ({
+  address,
+  onReceiveAutocompleteResult,
+  disableAutocomplete = false,
+  tabIndex,
+  value = "",
+  error,
+  id,
+  name,
+  placeholder,
+  title,
+  onChange,
+  onClear,
+  onSelect,
+  "data-testid": dataTestId,
+  ...autocompleteProps
+}: AddressAutocompleteInputProps) => {
+  const [providerSuggestions, setProviderSuggestions] = useState<
+    ProviderSuggestion[]
+  >([])
+  const [fetching, setFetching] = useState(false)
+
+  // NOTE: Due to the format of this key (a long string of numbers that cannot be parsed as json)
+  // This key must be set in the env as a json string like SMARTY_EMBEDDED_KEY_JSON={ "key": "xxxxxxxxxxxxxxxxxx" }
+  const { key: apiKey } = getENV("SMARTY_EMBEDDED_KEY_JSON") || { key: "" }
+
+  const isUSAddress = address.country === "US"
+  const isFeatureFlagEnabled = !!useFeatureFlag("address_autocomplete_us")
+
+  const [serviceAvailability, setServiceAvailability] = useState<
+    ServiceAvailability
+  >({
+    loading: true,
+    fetching: false,
+  })
+
+  useEffect(() => {
+    const isAPIKeyPresent = !!apiKey
+    const enabled = isAPIKeyPresent && isFeatureFlagEnabled && isUSAddress
+    if (enabled !== serviceAvailability.enabled) {
+      setServiceAvailability({
+        fetching,
+        loading: false,
+        enabled,
+      })
+    }
+  }, [
+    apiKey,
+    isFeatureFlagEnabled,
+    isUSAddress,
+    fetching,
+    serviceAvailability.enabled,
+  ])
+
+  // reset suggestions if the country changes
+  useEffect(() => {
+    if (providerSuggestions.length > 0 && !isUSAddress) {
+      setProviderSuggestions([])
+    }
+  }, [isUSAddress, providerSuggestions.length])
+
+  const fetchSuggestions = useMemo(() => {
+    const throttledFetch = throttle(
+      async ({ search, selected }: { search: string; selected?: string }) => {
+        const params = {
+          key: apiKey,
+          search: search,
+        }
+
+        if (selected) {
+          params["selected"] = selected
+        }
+
+        if (!apiKey) return null
+        let url =
+          "https://us-autocomplete-pro.api.smarty.com/lookup?" +
+          new URLSearchParams(params).toString()
+
+        setFetching(true)
+        const response = await fetch(url)
+        setFetching(false)
+        const json = await response.json()
+        return json
+      },
+      THROTTLE_DELAY,
+      {
+        leading: true,
+        trailing: true,
+      }
+    )
+    return throttledFetch
+  }, [apiKey])
+
+  const buildAddressText = useCallback(
+    (suggestion: ProviderSuggestion): string => {
+      let buildingAddress = suggestion.street_line
+      if (suggestion.secondary) buildingAddress += ` ${suggestion.secondary}`
+
+      return [
+        `${buildingAddress}, ${suggestion.city}`,
+        suggestion.state,
+        suggestion.zipcode,
+      ].join(" ")
+    },
+    []
+  )
+  const filterSecondarySuggestions = useCallback(
+    (suggestions: ProviderSuggestion[]) => {
+      const noSecondaryData = suggestions.map(
+        ({ secondary, ...suggestion }) => ({
+          ...suggestion,
+          secondary: "",
+        })
+      )
+      return uniqBy(noSecondaryData, (suggestion: ProviderSuggestion) =>
+        buildAddressText(suggestion)
+      )
+    },
+    [buildAddressText]
+  )
+
+  const fetchForAutocomplete = useCallback(
+    // these are the parameters to the Smarty API call
+    async ({ search, selected }: { search: string; selected?: string }) => {
+      if (!serviceAvailability.enabled) return
+
+      if (search.length < 3) {
+        setProviderSuggestions([])
+        return
+      }
+
+      try {
+        const response = await fetchSuggestions({ search, selected })
+        const finalSuggestions = filterSecondarySuggestions(
+          response.suggestions
+        )
+
+        setProviderSuggestions(finalSuggestions.slice(0, 5))
+      } catch (e) {
+        console.error(e)
+      }
+    },
+    [fetchSuggestions, filterSecondarySuggestions, serviceAvailability.enabled]
+  )
+
+  const autocompleteOptions = providerSuggestions.map(
+    (suggestion: ProviderSuggestion): AddressAutocompleteSuggestion => {
+      const text = buildAddressText(suggestion)
+
+      return {
+        text,
+        value: text,
+        entries: null,
+        address: {
+          addressLine1: suggestion.street_line,
+          addressLine2: suggestion.secondary || "",
+          city: suggestion.city,
+          region: suggestion.state,
+          postalCode: suggestion.zipcode,
+          country: "US",
+        },
+      }
+    }
+  )
+
+  const definitelyDisabled =
+    disableAutocomplete ||
+    (!serviceAvailability.loading && !serviceAvailability.enabled)
+
+  const previousOptions = usePrevious(autocompleteOptions)
+  const serializedOptions = JSON.stringify(autocompleteOptions)
+  const serializedPreviousOptions = JSON.stringify(previousOptions)
+
+  useEffect(() => {
+    if (
+      serviceAvailability.enabled &&
+      onReceiveAutocompleteResult &&
+      serializedOptions !== serializedPreviousOptions
+    ) {
+      onReceiveAutocompleteResult(value as string, providerSuggestions.length)
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    serviceAvailability.enabled,
+    serializedOptions,
+    serializedPreviousOptions,
+  ])
+
+  if (definitelyDisabled) {
+    return (
+      <Input
+        tabIndex={tabIndex}
+        id={id}
+        name={name}
+        placeholder={placeholder}
+        title={title}
+        value={value}
+        onChange={onChange}
+        error={error}
+        data-testid={dataTestId}
+      />
+    )
+  }
+
+  return (
+    <AutocompleteInput<AddressAutocompleteSuggestion>
+      data-testid={dataTestId}
+      tabIndex={tabIndex}
+      id={id}
+      name={name}
+      placeholder={placeholder}
+      loading={serviceAvailability.loading || serviceAvailability.fetching}
+      options={autocompleteOptions}
+      title="Address line 1"
+      value={value}
+      error={error}
+      onChange={event => {
+        onChange(event)
+        fetchForAutocomplete({ search: event.target.value })
+      }}
+      onClear={() => {
+        onClear()
+        fetchForAutocomplete({ search: "" })
+      }}
+      onSelect={(option, index) => {
+        onSelect(option, index)
+      }}
+      {...autocompleteProps}
+    />
+  )
+}
+
+interface TrackingValues {
+  contextPageOwnerId: string
+  contextOwnerType: PageOwnerType
+  contextModule: ContextModule
+}
+
+export const useAddressAutocompleteTracking = (
+  trackingValues: TrackingValues
+) => {
+  const { trackEvent } = useTracking()
+
+  const receivedAutocompleteResult = (input: string, resultCount: number) => {
+    const event: AddressAutoCompletionResult = {
+      action: ActionType.addressAutoCompletionResult,
+      context_module: trackingValues.contextModule,
+      context_owner_type: trackingValues.contextOwnerType,
+      context_owner_id: trackingValues.contextPageOwnerId,
+      input,
+      suggested_addresses_results: resultCount,
+    }
+
+    trackEvent(event)
+  }
+
+  const selectedAutocompletedAddress = (
+    option: AddressAutocompleteSuggestion,
+    input: string
+  ) => {
+    const event: SelectedItemFromAddressAutoCompletion = {
+      action: ActionType.selectedItemFromAddressAutoCompletion,
+      context_module: trackingValues.contextModule,
+      context_owner_type: trackingValues.contextOwnerType,
+      context_owner_id: trackingValues.contextPageOwnerId,
+      input: input,
+      item: option.value,
+    }
+
+    trackEvent(event)
+  }
+
+  const editedAutocompletedAddress = (field: string) => {
+    const event: EditedAutocompletedAddress = {
+      action: ActionType.editedAutocompletedAddress,
+      context_module: trackingValues.contextModule,
+      context_owner_type: trackingValues.contextOwnerType,
+      context_owner_id: trackingValues.contextPageOwnerId,
+      field: field,
+    }
+
+    trackEvent(event)
+  }
+
+  return {
+    receivedAutocompleteResult,
+    selectedAutocompletedAddress,
+    editedAutocompletedAddress,
+  }
+}

--- a/src/Components/Address/__tests__/AddressAutocompleteInput.jest.tsx
+++ b/src/Components/Address/__tests__/AddressAutocompleteInput.jest.tsx
@@ -1,0 +1,414 @@
+import { ContextModule, OwnerType } from "@artsy/cohesion"
+import { screen, render, within, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import {
+  AddressAutocompleteInput,
+  AddressAutocompleteInputProps,
+  useAddressAutocompleteTracking,
+} from "Components/Address/AddressAutocompleteInput"
+import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
+import compact from "lodash/compact"
+import { FC, useState } from "react"
+import { useTracking } from "react-tracking"
+import { useFeatureFlag } from "System/useFeatureFlag"
+
+jest.mock("System/useFeatureFlag", () => ({
+  useFeatureFlag: jest.fn(),
+}))
+
+jest.mock("Utils/getENV", () => ({
+  getENV: jest.fn().mockImplementation(() => {
+    return {
+      key: "smarty-api-key",
+    }
+  }),
+}))
+
+const mockTrackEvent = jest.fn()
+jest.mock("react-tracking")
+
+let mockFetch: jest.Mock
+beforeEach(() => {
+  ;(useTracking as jest.Mock).mockImplementation(() => ({
+    trackEvent: mockTrackEvent,
+  }))
+  mockFetch = jest.fn().mockResolvedValue({
+    json: jest.fn().mockResolvedValue({
+      suggestions: [
+        {
+          city: "New York",
+          entries: 2,
+          secondary: "Fl 25",
+          state: "NY",
+          street_line: "401 Broadway",
+          zipcode: "10013",
+        },
+      ],
+    }),
+  })
+
+  global.fetch = mockFetch
+})
+
+afterEach(() => {
+  jest.clearAllMocks()
+})
+
+interface ImplementationProps extends Partial<AddressAutocompleteInputProps> {
+  initialAddress?: {
+    line1?: string
+    line2?: string
+    city?: string
+    region?: string
+    postalCode?: string
+    country: string
+  }
+}
+
+const mockOnChange = jest.fn()
+const mockOnClear = jest.fn()
+const mockOnSelect = jest.fn()
+
+const TestImplementation: FC<ImplementationProps> = ({
+  initialAddress = { country: "US" },
+  ...rest
+}) => {
+  const [address, setAddress] = useState(initialAddress)
+
+  const formattedAddressLines = compact([
+    address.line1,
+    address.line2,
+    `${address.city}, ${address.region} ${address.postalCode}`,
+    address.country,
+  ])
+
+  const autocompleteTracking = useAddressAutocompleteTracking({
+    contextModule: ContextModule.ordersShipping,
+    contextOwnerType: OwnerType.ordersShipping,
+    contextPageOwnerId: "1234",
+  })
+
+  return (
+    <>
+      {
+        <AddressAutocompleteInput
+          data-testid="autocomplete-input"
+          placeholder="Autocomplete input"
+          address={address}
+          value={address.line1}
+          onChange={mockOnChange.mockImplementation(e => {
+            setAddress({ ...address, line1: e.target.value })
+          })}
+          onClear={mockOnClear.mockImplementation(() => {
+            setAddress({ ...address, line1: "" })
+          })}
+          onSelect={mockOnSelect.mockImplementation(suggestion => {
+            setAddress({
+              ...address,
+              line1: suggestion.address.addressLine1,
+              line2: suggestion.address.addressLine2,
+              city: suggestion.address.city,
+              region: suggestion.address.region,
+              postalCode: suggestion.address.postalCode,
+            })
+            autocompleteTracking.selectedAutocompletedAddress(
+              suggestion,
+              address.line1!
+            )
+          })}
+          onReceiveAutocompleteResult={(input, resultCount) =>
+            autocompleteTracking.receivedAutocompleteResult(input, resultCount)
+          }
+          {...rest}
+        />
+      }
+      <select
+        data-testid="AddressForm_country"
+        value={address.country}
+        onChange={e => {
+          setAddress({ ...address, country: e.target.value })
+        }}
+      >
+        <option value="US">United States</option>
+        <option value="CA">Canada</option>
+      </select>
+      <div>
+        {formattedAddressLines.map((line, index) => (
+          <p key={index}>{line}</p>
+        ))}
+      </div>
+      <button
+        onClick={() => {
+          setAddress({ ...address, line2: String(Date.now()) })
+          autocompleteTracking.editedAutocompletedAddress("line2")
+        }}
+      >
+        Edit Address
+      </button>
+    </>
+  )
+}
+
+describe("AddressAutocompleteInput", () => {
+  describe("address autocomplete is enabled for US only", () => {
+    beforeEach(() => {
+      ;(useFeatureFlag as jest.Mock).mockImplementation(
+        featureName => featureName === "address_autocomplete_us"
+      )
+    })
+
+    it("renders an autocomplete input for a US address", async () => {
+      render(<TestImplementation initialAddress={{ country: "US" }} />)
+
+      const line1Input = screen.getByPlaceholderText("Autocomplete input")
+      await userEvent.type(line1Input, "40")
+      expect(screen.getByLabelText("Clear input")).toBeInTheDocument()
+    })
+
+    it("renders a normal input for a non-US address", async () => {
+      render(<TestImplementation initialAddress={{ country: "CA" }} />)
+
+      const line1Input = screen.getByPlaceholderText("Autocomplete input")
+      await userEvent.type(line1Input, "40")
+      expect(screen.queryByLabelText("Clear input")).not.toBeInTheDocument()
+    })
+
+    it("shows suggestions for a US address", async () => {
+      render(<TestImplementation />)
+
+      const line1Input = screen.getByPlaceholderText("Autocomplete input")
+      await userEvent.type(line1Input, "401 Broadway")
+
+      const listbox = await screen.findByRole("listbox", { hidden: true })
+
+      expect(listbox).toHaveTextContent("401 Broadway, New York NY 10013")
+    })
+
+    it("does not fetch for a query of less than 3 characters", async () => {
+      render(<TestImplementation />)
+
+      const line1Input = screen.getByPlaceholderText("Autocomplete input")
+      await userEvent.type(line1Input, "40")
+
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
+    it("resets the suggestions when the user clears the input", async () => {
+      render(<TestImplementation />)
+
+      const line1Input = screen.getByPlaceholderText("Autocomplete input")
+      await userEvent.type(line1Input, "401 Broadway")
+
+      const listbox = await screen.findByRole("listbox", { hidden: true })
+
+      expect(listbox).toHaveTextContent("401 Broadway, New York NY 10013")
+
+      const clearButton = screen.getByLabelText("Clear input")
+      await userEvent.click(clearButton)
+
+      expect(listbox).not.toBeInTheDocument()
+    })
+
+    it("resets the suggestions when the country changes", async () => {
+      render(<TestImplementation />)
+
+      const line1Input = screen.getByPlaceholderText("Autocomplete input")
+      await userEvent.type(line1Input, "401 Broadway")
+
+      const listbox = await screen.findByRole("listbox", { hidden: true })
+
+      expect(listbox).toHaveTextContent("401 Broadway, New York NY 10013")
+
+      const countrySelect = screen.getByTestId("AddressForm_country")
+      await userEvent.selectOptions(countrySelect, ["Canada"])
+
+      expect(listbox).not.toBeInTheDocument()
+    })
+
+    it("resets suggestions when the search term is too short", async () => {
+      render(<TestImplementation />)
+
+      const line1Input = screen.getByPlaceholderText("Autocomplete input")
+      await userEvent.type(line1Input, "401")
+
+      const listbox = await screen.findByRole("listbox", { hidden: true })
+      expect(listbox).toBeInTheDocument()
+
+      await userEvent.type(line1Input, "{backspace}")
+
+      expect(listbox).not.toBeInTheDocument()
+    })
+
+    it("calls the onChange callback when the user types", async () => {
+      render(<TestImplementation />)
+
+      const line1Input = screen.getByPlaceholderText("Autocomplete input")
+      await userEvent.type(line1Input, "401 Broadway")
+
+      expect(mockOnChange).toHaveBeenCalledWith(
+        expect.objectContaining({
+          target: expect.objectContaining({ value: "401 Broadway" }),
+        })
+      )
+    })
+
+    it("calls the onClear callback when the user clears the input", async () => {
+      render(<TestImplementation />)
+
+      const line1Input = screen.getByPlaceholderText("Autocomplete input")
+      await userEvent.type(line1Input, "401 Broadway")
+
+      const clearButton = screen.getByLabelText("Clear input")
+      await userEvent.click(clearButton)
+
+      expect(mockOnClear).toHaveBeenCalledTimes(1)
+    })
+
+    it("calls the onSelect callback with the option and its index when the user selects a suggestion", async () => {
+      render(<TestImplementation />)
+
+      const line1Input = screen.getByPlaceholderText("Autocomplete input")
+      await userEvent.paste(line1Input, "401 Broadway")
+
+      const dropdown = await screen.findByRole("listbox", { hidden: true })
+      const option = within(dropdown).getByText(
+        "401 Broadway, New York NY 10013"
+      )
+
+      await userEvent.click(option)
+      await flushPromiseQueue()
+
+      expect(mockOnSelect).toHaveBeenCalledTimes(1)
+      expect(mockOnSelect).toHaveBeenCalledWith(
+        {
+          address: {
+            addressLine1: "401 Broadway",
+            addressLine2: "",
+            city: "New York",
+            country: "US",
+            postalCode: "10013",
+            region: "NY",
+          },
+          entries: null,
+          text: "401 Broadway, New York NY 10013",
+          value: "401 Broadway, New York NY 10013",
+        },
+        0
+      )
+    })
+
+    it("can use props.disableAutocomplete to force a normal input", async () => {
+      render(<TestImplementation disableAutocomplete />)
+
+      const line1Input = screen.getByPlaceholderText("Autocomplete input")
+
+      await userEvent.type(line1Input, "40")
+      expect(screen.queryByLabelText("Clear input")).not.toBeInTheDocument()
+    })
+
+    // See TestImplementation for implementation details
+    describe("tracking", () => {
+      it("developer can track when suggested addresses update with hook + `onReceiveAutocompleteResult` prop", async () => {
+        render(<TestImplementation />)
+
+        const line1Input = screen.getByPlaceholderText("Autocomplete input")
+        await userEvent.type(line1Input, "401 Broadway")
+
+        await screen.findByRole("listbox", { hidden: true })
+
+        expect(mockTrackEvent).toHaveBeenCalledWith({
+          action: "addressAutoCompletionResult",
+          context_module: "ordersShipping",
+          context_owner_id: "1234",
+          context_owner_type: "orders-shipping",
+          input: "401 Broadway",
+          suggested_addresses_results: 1,
+        })
+        mockFetch.mockResolvedValue({
+          json: jest.fn().mockResolvedValue({
+            suggestions: [
+              {
+                city: "New York",
+                entries: 2,
+                secondary: "Fl 25",
+                state: "NY",
+                street_line: "156 Quincy",
+                zipcode: "10013",
+              },
+              {
+                city: "Brooklyn",
+                entries: 2,
+                secondary: "Apt 1",
+                state: "NY",
+                street_line: "156 Quincy",
+                zipcode: "11216",
+              },
+            ],
+          }),
+        })
+        await userEvent.clear(line1Input)
+        await userEvent.type(line1Input, "156 Quincy")
+        await waitFor(() => {
+          expect(mockTrackEvent).toHaveBeenCalledWith({
+            action: "addressAutoCompletionResult",
+            context_module: "ordersShipping",
+            context_owner_id: "1234",
+            context_owner_type: "orders-shipping",
+            input: "156 Quincy",
+            suggested_addresses_results: 2,
+          })
+        })
+      })
+
+      it("developer can use tracking hook with `onSelect` prop to track when an address is selected", async () => {
+        render(<TestImplementation />)
+
+        const line1Input = screen.getByPlaceholderText("Autocomplete input")
+        await userEvent.paste(line1Input, "401 Broadway")
+
+        const dropdown = await screen.findByRole("listbox", { hidden: true })
+        const option = within(dropdown).getByText(
+          "401 Broadway, New York NY 10013"
+        )
+
+        await userEvent.click(option)
+        await flushPromiseQueue()
+
+        expect(mockTrackEvent).toHaveBeenCalledWith({
+          action: "selectedItemFromAddressAutoCompletion",
+          context_module: "ordersShipping",
+          context_owner_id: "1234",
+          context_owner_type: "orders-shipping",
+          input: "401 Broadway",
+          item: "401 Broadway, New York NY 10013",
+        })
+      })
+
+      it("developer can use hook to track when the user edits an autocompleted address", async () => {
+        render(<TestImplementation />)
+
+        const line1Input = screen.getByPlaceholderText("Autocomplete input")
+        await userEvent.paste(line1Input, "401 Broadway")
+
+        const dropdown = await screen.findByRole("listbox", { hidden: true })
+        const option = within(dropdown).getByText(
+          "401 Broadway, New York NY 10013"
+        )
+
+        await userEvent.click(option)
+        await flushPromiseQueue()
+
+        const editAddressButton = screen.getByText("Edit Address")
+        await userEvent.click(editAddressButton)
+
+        expect(mockTrackEvent).toHaveBeenCalledWith({
+          action: "editedAutocompletedAddress",
+          context_module: "ordersShipping",
+          context_owner_id: "1234",
+          context_owner_type: "orders-shipping",
+          field: "line2",
+        })
+      })
+    })
+  })
+})

--- a/src/Components/Address/useAddressAutocomplete.ts
+++ b/src/Components/Address/useAddressAutocomplete.ts
@@ -37,6 +37,9 @@ interface ServiceAvailability {
   enabled?: boolean
 }
 
+/**
+ * @deprecated - Use AddressAutocompleteInput instead
+ */
 export const useAddressAutocomplete = (
   address: Partial<Address> & { country: Address["country"] },
   {


### PR DESCRIPTION
The type of this PR is: **Chore**

Closes [EMI-1447]
Related to #12971 

### Description

This PR brings address autocomplete functionality to the new shipping route, refactoring the [existing autocomplete functionality](https://github.com/artsy/force/blob/337575304df1b338c1463795ac13041d563cc4e5/src/Components/Address/AddressForm.tsx#L238-L240) into a single component along the way.

TODOs:
- [x] Finish adding tests
- [x] Add to the new form

Since the autocomplete input and its fallback are straightforward but bulky, I decided to pull its functionality into a component that can render either an autocomplete or fallback input and handle most tracking. As a result, tracking helpers are exported form the component file, and the `useAddressAutocomplete()` hook has been deprecated (its logic now living in the hook. I have also removed the secondary address suggestion capability since it isn't used yet.

[EMI-1447]: https://artsyproduct.atlassian.net/browse/EMI-1447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ