### PR TITLE
fix: Fix for artist series pills not being displayed on the edit alerts page

### DIFF
--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditForm.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditForm.tsx
@@ -343,6 +343,7 @@ export const SavedSearchAlertEditFormFragmentContainer = createFragmentContainer
           artistIDs
           atAuction
           attributionClass
+          artistSeriesIDs
           colors
           dimensionRange
           sizes
@@ -408,7 +409,14 @@ const SAVED_SEARCH_ALERT_EDIT_FORM_QUERY = graphql`
     artworksConnection(
       first: 0
       artistIDs: $artistIds
-      aggregations: [LOCATION_CITY, MATERIALS_TERMS, MEDIUM, PARTNER, COLOR]
+      aggregations: [
+        ARTIST_SERIES
+        LOCATION_CITY
+        MATERIALS_TERMS
+        MEDIUM
+        PARTNER
+        COLOR
+      ]
     ) {
       ...SavedSearchAlertEditForm_artworksConnection
     }

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/__tests__/SavedSearchAlertEditForm.jest.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/__tests__/SavedSearchAlertEditForm.jest.tsx
@@ -85,7 +85,14 @@ describe("SavedSearchAlertEditForm", () => {
         artworksConnection(
           first: 0
           artistIDs: $artistIDs
-          aggregations: [LOCATION_CITY, MATERIALS_TERMS, MEDIUM, PARTNER, COLOR]
+          aggregations: [
+            ARTIST_SERIES
+            LOCATION_CITY
+            MATERIALS_TERMS
+            MEDIUM
+            PARTNER
+            COLOR
+          ]
         ) {
           ...SavedSearchAlertEditForm_artworksConnection
         }
@@ -415,6 +422,7 @@ const savedSearchAlertMocked = {
   artistIDs,
   atAuction: true,
   attributionClass: [],
+  artistSeriesIDs: [],
   colors: [],
   dimensionRange: null,
   displayName: "Alert #1",

--- a/src/Components/SavedSearchAlert/types.ts
+++ b/src/Components/SavedSearchAlert/types.ts
@@ -8,6 +8,7 @@ export interface SearchCriteriaAttributes {
   partnerIDs?: string[] | null
   additionalGeneIDs?: string[] | null
   attributionClass?: string[] | null
+  artistSeriesIDs?: string[] | null
   majorPeriods?: string[] | null
   acquireable?: boolean | null
   atAuction?: boolean | null

--- a/src/__generated__/SavedSearchAlertEditFormQuery.graphql.ts
+++ b/src/__generated__/SavedSearchAlertEditFormQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<99a2792f4efefaaabb1bc3437aca933d>>
+ * @generated SignedSource<<1a7f865996b43341f51e3752562de298>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -56,6 +56,7 @@ v3 = [
     "kind": "Literal",
     "name": "aggregations",
     "value": [
+      "ARTIST_SERIES",
       "LOCATION_CITY",
       "MATERIALS_TERMS",
       "MEDIUM",
@@ -281,6 +282,13 @@ return {
                 "args": null,
                 "kind": "ScalarField",
                 "name": "attributionClass",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "artistSeriesIDs",
                 "storageKey": null
               },
               {
@@ -516,16 +524,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "412a70c4c8265960843c68dfcd044b52",
+    "cacheID": "c6eb6b248cb9901451e6c4cc2762a9f6",
     "id": null,
     "metadata": {},
     "name": "SavedSearchAlertEditFormQuery",
     "operationKind": "query",
-    "text": "query SavedSearchAlertEditFormQuery(\n  $id: ID!\n  $artistIds: [String!]\n) {\n  viewer {\n    ...SavedSearchAlertEditForm_viewer\n  }\n  me {\n    ...SavedSearchAlertEditForm_me_3PSMXk\n    id\n  }\n  artistsConnection(slugs: $artistIds) {\n    ...SavedSearchAlertEditForm_artistsConnection\n  }\n  artworksConnection(first: 0, artistIDs: $artistIds, aggregations: [LOCATION_CITY, MATERIALS_TERMS, MEDIUM, PARTNER, COLOR]) {\n    ...SavedSearchAlertEditForm_artworksConnection\n    id\n  }\n}\n\nfragment SavedSearchAlertEditForm_artistsConnection on ArtistConnection {\n  edges {\n    node {\n      internalID\n      name\n      slug\n      id\n    }\n  }\n}\n\nfragment SavedSearchAlertEditForm_artworksConnection on FilterArtworksConnection {\n  aggregations {\n    slice\n    counts {\n      count\n      name\n      value\n    }\n  }\n}\n\nfragment SavedSearchAlertEditForm_me_3PSMXk on Me {\n  savedSearch(id: $id) {\n    internalID\n    acquireable\n    additionalGeneIDs\n    artistIDs\n    atAuction\n    attributionClass\n    colors\n    dimensionRange\n    sizes\n    width\n    height\n    inquireableOnly\n    locationCities\n    majorPeriods\n    materialsTerms\n    offerable\n    partnerIDs\n    priceRange\n    userAlertSettings {\n      name\n      email\n      push\n      frequency\n      details\n    }\n  }\n}\n\nfragment SavedSearchAlertEditForm_viewer on Viewer {\n  notificationPreferences {\n    status\n    name\n    channel\n  }\n}\n"
+    "text": "query SavedSearchAlertEditFormQuery(\n  $id: ID!\n  $artistIds: [String!]\n) {\n  viewer {\n    ...SavedSearchAlertEditForm_viewer\n  }\n  me {\n    ...SavedSearchAlertEditForm_me_3PSMXk\n    id\n  }\n  artistsConnection(slugs: $artistIds) {\n    ...SavedSearchAlertEditForm_artistsConnection\n  }\n  artworksConnection(first: 0, artistIDs: $artistIds, aggregations: [ARTIST_SERIES, LOCATION_CITY, MATERIALS_TERMS, MEDIUM, PARTNER, COLOR]) {\n    ...SavedSearchAlertEditForm_artworksConnection\n    id\n  }\n}\n\nfragment SavedSearchAlertEditForm_artistsConnection on ArtistConnection {\n  edges {\n    node {\n      internalID\n      name\n      slug\n      id\n    }\n  }\n}\n\nfragment SavedSearchAlertEditForm_artworksConnection on FilterArtworksConnection {\n  aggregations {\n    slice\n    counts {\n      count\n      name\n      value\n    }\n  }\n}\n\nfragment SavedSearchAlertEditForm_me_3PSMXk on Me {\n  savedSearch(id: $id) {\n    internalID\n    acquireable\n    additionalGeneIDs\n    artistIDs\n    atAuction\n    attributionClass\n    artistSeriesIDs\n    colors\n    dimensionRange\n    sizes\n    width\n    height\n    inquireableOnly\n    locationCities\n    majorPeriods\n    materialsTerms\n    offerable\n    partnerIDs\n    priceRange\n    userAlertSettings {\n      name\n      email\n      push\n      frequency\n      details\n    }\n  }\n}\n\nfragment SavedSearchAlertEditForm_viewer on Viewer {\n  notificationPreferences {\n    status\n    name\n    channel\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "6a2fcb73f75659fbfc752add92e3e408";
+(node as any).hash = "79f8ea4db2e57e1f06b299ceca7c791d";
 
 export default node;

--- a/src/__generated__/SavedSearchAlertEditForm_Test_Query.graphql.ts
+++ b/src/__generated__/SavedSearchAlertEditForm_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fb0bbdd4901147739e05acc3d2f8ef3e>>
+ * @generated SignedSource<<0546374b03f913e6f8ad95d220990532>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -117,6 +117,7 @@ v2 = [
     "kind": "Literal",
     "name": "aggregations",
     "value": [
+      "ARTIST_SERIES",
       "LOCATION_CITY",
       "MATERIALS_TERMS",
       "MEDIUM",
@@ -578,16 +579,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "8319324a5ff61ccef41c4022f25c5086",
+    "cacheID": "1bdfc1c7d5d4112fd1e25a43a4070def",
     "id": null,
     "metadata": {},
     "name": "SavedSearchAlertEditForm_Test_Query",
     "operationKind": "query",
-    "text": "query SavedSearchAlertEditForm_Test_Query(\n  $artistIDs: [String!]\n) {\n  viewer {\n    ...SavedSearchAlertEditForm_viewer\n  }\n  me {\n    ...SavedSearchAlertEditForm_me_1LtJCq\n    id\n  }\n  artistsConnection(slugs: $artistIDs) {\n    ...SavedSearchAlertEditForm_artistsConnection\n  }\n  artworksConnection(first: 0, artistIDs: $artistIDs, aggregations: [LOCATION_CITY, MATERIALS_TERMS, MEDIUM, PARTNER, COLOR]) {\n    ...SavedSearchAlertEditForm_artworksConnection\n    id\n  }\n}\n\nfragment SavedSearchAlertEditForm_artistsConnection on ArtistConnection {\n  edges {\n    node {\n      internalID\n      name\n      slug\n      id\n    }\n  }\n}\n\nfragment SavedSearchAlertEditForm_artworksConnection on FilterArtworksConnection {\n  aggregations {\n    slice\n    counts {\n      count\n      name\n      value\n    }\n  }\n}\n\nfragment SavedSearchAlertEditForm_me_1LtJCq on Me {\n  savedSearch(id: \"id\") {\n    internalID\n    acquireable\n    additionalGeneIDs\n    artistIDs\n    atAuction\n    attributionClass\n    artistSeriesIDs\n    colors\n    dimensionRange\n    sizes\n    width\n    height\n    inquireableOnly\n    locationCities\n    majorPeriods\n    materialsTerms\n    offerable\n    partnerIDs\n    priceRange\n    userAlertSettings {\n      name\n      email\n      push\n      frequency\n      details\n    }\n  }\n}\n\nfragment SavedSearchAlertEditForm_viewer on Viewer {\n  notificationPreferences {\n    status\n    name\n    channel\n  }\n}\n"
+    "text": "query SavedSearchAlertEditForm_Test_Query(\n  $artistIDs: [String!]\n) {\n  viewer {\n    ...SavedSearchAlertEditForm_viewer\n  }\n  me {\n    ...SavedSearchAlertEditForm_me_1LtJCq\n    id\n  }\n  artistsConnection(slugs: $artistIDs) {\n    ...SavedSearchAlertEditForm_artistsConnection\n  }\n  artworksConnection(first: 0, artistIDs: $artistIDs, aggregations: [ARTIST_SERIES, LOCATION_CITY, MATERIALS_TERMS, MEDIUM, PARTNER, COLOR]) {\n    ...SavedSearchAlertEditForm_artworksConnection\n    id\n  }\n}\n\nfragment SavedSearchAlertEditForm_artistsConnection on ArtistConnection {\n  edges {\n    node {\n      internalID\n      name\n      slug\n      id\n    }\n  }\n}\n\nfragment SavedSearchAlertEditForm_artworksConnection on FilterArtworksConnection {\n  aggregations {\n    slice\n    counts {\n      count\n      name\n      value\n    }\n  }\n}\n\nfragment SavedSearchAlertEditForm_me_1LtJCq on Me {\n  savedSearch(id: \"id\") {\n    internalID\n    acquireable\n    additionalGeneIDs\n    artistIDs\n    atAuction\n    attributionClass\n    artistSeriesIDs\n    colors\n    dimensionRange\n    sizes\n    width\n    height\n    inquireableOnly\n    locationCities\n    majorPeriods\n    materialsTerms\n    offerable\n    partnerIDs\n    priceRange\n    userAlertSettings {\n      name\n      email\n      push\n      frequency\n      details\n    }\n  }\n}\n\nfragment SavedSearchAlertEditForm_viewer on Viewer {\n  notificationPreferences {\n    status\n    name\n    channel\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "0fd6c343dbccdef68e5ff723d83fe274";
+(node as any).hash = "929f36360d72c82991ec0e9c83fcf455";
 
 export default node;

--- a/src/__generated__/SavedSearchAlertEditForm_Test_Query.graphql.ts
+++ b/src/__generated__/SavedSearchAlertEditForm_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a2f12eddfac56519ab5dea76c195ae66>>
+ * @generated SignedSource<<fb0bbdd4901147739e05acc3d2f8ef3e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -58,6 +58,7 @@ export type SavedSearchAlertEditForm_Test_Query$rawResponse = {
       readonly acquireable: boolean | null | undefined;
       readonly additionalGeneIDs: ReadonlyArray<string>;
       readonly artistIDs: ReadonlyArray<string> | null | undefined;
+      readonly artistSeriesIDs: ReadonlyArray<string>;
       readonly atAuction: boolean | null | undefined;
       readonly attributionClass: ReadonlyArray<string>;
       readonly colors: ReadonlyArray<string>;
@@ -341,6 +342,13 @@ return {
                 "alias": null,
                 "args": null,
                 "kind": "ScalarField",
+                "name": "artistSeriesIDs",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
                 "name": "colors",
                 "storageKey": null
               },
@@ -570,12 +578,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "544025fa6a5a2969e41393d9bc8dfbde",
+    "cacheID": "8319324a5ff61ccef41c4022f25c5086",
     "id": null,
     "metadata": {},
     "name": "SavedSearchAlertEditForm_Test_Query",
     "operationKind": "query",
-    "text": "query SavedSearchAlertEditForm_Test_Query(\n  $artistIDs: [String!]\n) {\n  viewer {\n    ...SavedSearchAlertEditForm_viewer\n  }\n  me {\n    ...SavedSearchAlertEditForm_me_1LtJCq\n    id\n  }\n  artistsConnection(slugs: $artistIDs) {\n    ...SavedSearchAlertEditForm_artistsConnection\n  }\n  artworksConnection(first: 0, artistIDs: $artistIDs, aggregations: [LOCATION_CITY, MATERIALS_TERMS, MEDIUM, PARTNER, COLOR]) {\n    ...SavedSearchAlertEditForm_artworksConnection\n    id\n  }\n}\n\nfragment SavedSearchAlertEditForm_artistsConnection on ArtistConnection {\n  edges {\n    node {\n      internalID\n      name\n      slug\n      id\n    }\n  }\n}\n\nfragment SavedSearchAlertEditForm_artworksConnection on FilterArtworksConnection {\n  aggregations {\n    slice\n    counts {\n      count\n      name\n      value\n    }\n  }\n}\n\nfragment SavedSearchAlertEditForm_me_1LtJCq on Me {\n  savedSearch(id: \"id\") {\n    internalID\n    acquireable\n    additionalGeneIDs\n    artistIDs\n    atAuction\n    attributionClass\n    colors\n    dimensionRange\n    sizes\n    width\n    height\n    inquireableOnly\n    locationCities\n    majorPeriods\n    materialsTerms\n    offerable\n    partnerIDs\n    priceRange\n    userAlertSettings {\n      name\n      email\n      push\n      frequency\n      details\n    }\n  }\n}\n\nfragment SavedSearchAlertEditForm_viewer on Viewer {\n  notificationPreferences {\n    status\n    name\n    channel\n  }\n}\n"
+    "text": "query SavedSearchAlertEditForm_Test_Query(\n  $artistIDs: [String!]\n) {\n  viewer {\n    ...SavedSearchAlertEditForm_viewer\n  }\n  me {\n    ...SavedSearchAlertEditForm_me_1LtJCq\n    id\n  }\n  artistsConnection(slugs: $artistIDs) {\n    ...SavedSearchAlertEditForm_artistsConnection\n  }\n  artworksConnection(first: 0, artistIDs: $artistIDs, aggregations: [LOCATION_CITY, MATERIALS_TERMS, MEDIUM, PARTNER, COLOR]) {\n    ...SavedSearchAlertEditForm_artworksConnection\n    id\n  }\n}\n\nfragment SavedSearchAlertEditForm_artistsConnection on ArtistConnection {\n  edges {\n    node {\n      internalID\n      name\n      slug\n      id\n    }\n  }\n}\n\nfragment SavedSearchAlertEditForm_artworksConnection on FilterArtworksConnection {\n  aggregations {\n    slice\n    counts {\n      count\n      name\n      value\n    }\n  }\n}\n\nfragment SavedSearchAlertEditForm_me_1LtJCq on Me {\n  savedSearch(id: \"id\") {\n    internalID\n    acquireable\n    additionalGeneIDs\n    artistIDs\n    atAuction\n    attributionClass\n    artistSeriesIDs\n    colors\n    dimensionRange\n    sizes\n    width\n    height\n    inquireableOnly\n    locationCities\n    majorPeriods\n    materialsTerms\n    offerable\n    partnerIDs\n    priceRange\n    userAlertSettings {\n      name\n      email\n      push\n      frequency\n      details\n    }\n  }\n}\n\nfragment SavedSearchAlertEditForm_viewer on Viewer {\n  notificationPreferences {\n    status\n    name\n    channel\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SavedSearchAlertEditForm_me.graphql.ts
+++ b/src/__generated__/SavedSearchAlertEditForm_me.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2994c0a0dc5165da8c2b754ea5784a9b>>
+ * @generated SignedSource<<5ec57b2ebf2f66b4e3b769a7be4f38ef>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,6 +16,7 @@ export type SavedSearchAlertEditForm_me$data = {
     readonly acquireable: boolean | null | undefined;
     readonly additionalGeneIDs: ReadonlyArray<string>;
     readonly artistIDs: ReadonlyArray<string> | null | undefined;
+    readonly artistSeriesIDs: ReadonlyArray<string>;
     readonly atAuction: boolean | null | undefined;
     readonly attributionClass: ReadonlyArray<string>;
     readonly colors: ReadonlyArray<string>;
@@ -112,6 +113,13 @@ const node: ReaderFragment = {
           "args": null,
           "kind": "ScalarField",
           "name": "attributionClass",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "artistSeriesIDs",
           "storageKey": null
         },
         {
@@ -252,6 +260,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "fcd6cc64d79a3e95184e59d7fe5ee730";
+(node as any).hash = "c02bdca221ec190d5391c18a7711a636";
 
 export default node;


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Pills were not displayed on edit alert pages before.

### Demo

Here is a video which demonstrated the whole user flow working:

https://github.com/artsy/force/assets/3934579/8c9a1956-104b-4091-9bce-5556b975de35

