### PR TITLE
fix: long-running tests causing flaky CI failures

### DIFF
--- a/src/Apps/Order/Routes/Shipping2/AddressModal2.jest.tsx
+++ b/src/Apps/Order/Routes/Shipping2/AddressModal2.jest.tsx
@@ -8,13 +8,18 @@ import { validAddress } from "Components/__tests__/Utils/addressForm2"
 import { useSystemContext } from "System/useSystemContext"
 import { SavedAddressType } from "Apps/Order/Routes/Shipping2/Utils/shippingUtils"
 import { createMockEnvironment } from "relay-test-utils"
-import { waitFor } from "@testing-library/react"
 import { useComputeShippingContext } from "Apps/Order/Routes/Shipping2/Hooks/useShippingContext"
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
 import { graphql } from "react-relay"
 import { AddressModal2TestQuery } from "__generated__/AddressModal2TestQuery.graphql"
 import { ShippingContext } from "Apps/Order/Routes/Shipping2/Utils/ShippingContext"
 import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
+
+/*
+Some tests queue up promises that bleed into subsequent tests
+on the first flushPromiseQueue call.
+*/
+jest.setTimeout(10000)
 
 jest.unmock("react-relay")
 jest.mock("System/useSystemContext")
@@ -67,11 +72,20 @@ const { getWrapper: _getWrapper } = setupTestWrapper<AddressModal2TestQuery>({
   `,
 })
 
+let globalWrapper: ReturnType<typeof _getWrapper>["wrapper"]
 const getWrapper = ({
   mockResolvers = {},
   componentProps = testAddressModalProps,
   relayEnvironment = mockRelayEnv,
-} = {}) => _getWrapper(mockResolvers, componentProps, relayEnvironment)
+} = {}) => {
+  const result = _getWrapper(mockResolvers, componentProps, relayEnvironment)
+  globalWrapper = result.wrapper
+  return result
+}
+
+afterEach(() => {
+  globalWrapper?.unmount()
+})
 
 describe("AddressModal", () => {
   beforeEach(() => {
@@ -162,19 +176,20 @@ describe("AddressModal", () => {
 
   it("when the dialog is confirmed, the delete action happens", async () => {
     const { mockResolveLastOperation, wrapper } = getWrapper()
+
     const deleteButton = wrapper.find("Clickable[data-test='deleteButton']")
     deleteButton.simulate("click")
     const dialog = wrapper.find("ModalDialog[data-test='deleteAddressDialog']")
     const dialogDelete = dialog.find("Button").at(1)
     dialogDelete.simulate("click")
 
-    const { operationName, operationVariables } = await waitFor(() =>
-      mockResolveLastOperation({})
-    )
+    const {
+      operationName,
+      operationVariables,
+    } = await mockResolveLastOperation({})
 
-    await flushPromiseQueue()
-    await wrapper.update()
     expect(operationName).toBe("useDeleteSavedAddressMutation")
+
     expect(operationVariables).toEqual({
       input: { userAddressID: "internal-id" },
     })
@@ -189,18 +204,19 @@ describe("AddressModal", () => {
       const formik = wrapper.find("Formik").first()
       formik.props().onSubmit!(validAddress as any)
 
-      const { operationName, operationVariables } = await waitFor(() =>
-        mockResolveLastOperation({
-          UpdateUserAddressPayload: () => ({
-            userAddressOrErrors: {
-              __typename: "UserAddress",
-              ...savedAddress,
-              isDefault: true,
-            },
-          }),
-        })
-      )
-
+      await flushPromiseQueue()
+      const {
+        operationName,
+        operationVariables,
+      } = await mockResolveLastOperation({
+        UpdateUserAddressPayload: () => ({
+          userAddressOrErrors: {
+            __typename: "UserAddress",
+            ...savedAddress,
+            isDefault: true,
+          },
+        }),
+      })
       expect(operationName).toBe("useUpdateSavedAddressMutation")
       expect(operationVariables).toMatchObject({
         input: {
@@ -218,57 +234,48 @@ describe("AddressModal", () => {
         },
       })
 
-      await waitFor(() => {
-        expect(wrapper.find(AddressModal).props().onSuccess).toHaveBeenCalled()
-        expect(wrapper.find(AddressModal).props().closeModal).toHaveBeenCalled()
-      })
+      await flushPromiseQueue()
+      const addressModal = wrapper.find(AddressModal)
+      const { onSuccess, closeModal } = addressModal.props()
+      expect(onSuccess).toHaveBeenCalled()
+      expect(closeModal).toHaveBeenCalled()
     })
 
-    it("shows generic error when mutation fails", async () => {
-      const { wrapper, mockRejectLastOperation } = getWrapper()
-
-      const formik = wrapper.find("Formik").first()
-
-      formik.props().onSubmit!(validAddress as any)
-
-      await waitFor(() => {
-        mockRejectLastOperation(new TypeError("Network request failed"))
-      })
-
-      await waitFor(async () => {
-        await wrapper.update()
-        expect(wrapper.find(errorBoxQuery).text()).toContain(
-          GENERIC_FAIL_MESSAGE
-        )
-      })
-    })
     it("shows generic error when mutation returns error", async () => {
       const { mockResolveLastOperation, wrapper } = getWrapper()
 
       const formik = wrapper.find("Formik").first()
       formik.props().onSubmit!(validAddress as any)
 
-      await waitFor(() =>
-        mockResolveLastOperation({
-          UpdateUserAddressPayload: () => ({
-            userAddressOrErrors: {
-              __typename: "Errors",
-              errors: [
-                {
-                  code: "100",
-                  message: "Invalid address",
-                },
-              ],
-            },
-          }),
-        })
-      )
-      await waitFor(async () => {
-        await wrapper.update()
-        expect(wrapper.find(errorBoxQuery).text()).toContain(
-          GENERIC_FAIL_MESSAGE
-        )
+      await flushPromiseQueue()
+      mockResolveLastOperation({
+        UpdateUserAddressPayload: () => ({
+          userAddressOrErrors: {
+            __typename: "Errors",
+            errors: [
+              {
+                code: "100",
+                message: "Invalid address",
+              },
+            ],
+          },
+        }),
       })
+      await flushPromiseQueue()
+      await wrapper.update()
+      expect(wrapper.find(errorBoxQuery).text()).toContain(GENERIC_FAIL_MESSAGE)
+    })
+
+    it("shows generic error when mutation fails", async () => {
+      const { wrapper, mockRejectLastOperation } = getWrapper()
+
+      const formik = wrapper.find("Formik").first()
+      formik.props().onSubmit!(validAddress as any)
+      await flushPromiseQueue()
+      mockRejectLastOperation(new TypeError("Network request failed"))
+      await flushPromiseQueue()
+      await wrapper.update()
+      expect(wrapper.find(errorBoxQuery).text()).toContain(GENERIC_FAIL_MESSAGE)
     })
 
     it("sets formik error when address mutation returns phone validation error", async () => {
@@ -283,28 +290,27 @@ describe("AddressModal", () => {
         setSubmitting: jest.fn(),
       })
 
-      await waitFor(() =>
-        mockResolveLastOperation({
-          UpdateUserAddressPayload: () => ({
-            userAddressOrErrors: {
-              __typename: "Errors",
-              errors: [
-                {
-                  code: "invalid_phone_number",
-                  message: "Validation failed: Phone not a valid phone number",
-                  path: "phoneNumber",
-                },
-              ],
-            },
-          }),
-        })
-      )
-      await waitFor(() => {
-        expect(setFieldError).toHaveBeenCalledWith(
-          "phoneNumber",
-          "Please enter a valid phone number"
-        )
+      await flushPromiseQueue()
+      mockResolveLastOperation({
+        UpdateUserAddressPayload: () => ({
+          userAddressOrErrors: {
+            __typename: "Errors",
+            errors: [
+              {
+                code: "invalid_phone_number",
+                message: "Validation failed: Phone not a valid phone number",
+                path: "phoneNumber",
+              },
+            ],
+          },
+        }),
       })
+
+      await flushPromiseQueue()
+      expect(setFieldError).toHaveBeenCalledWith(
+        "phoneNumber",
+        "Please enter a valid phone number"
+      )
     })
   })
 })


### PR DESCRIPTION
#minor
This PR should fix some recent flakiness in CI due to long-running test failures. Investigation  🔒[here](https://artsy.slack.com/archives/CP9P4KR35/p1701184330992859). In short, tests seem to get backed up on their first `await` after a previous test, which may have queued up some promises that weren't resolved before the test passed and exited. Unmounting the enzyme wrapper after each test helps somewhat. I also increased the timeout on tests for this file.
- remove waitFor; use flushPromiseQueue (I had tried `waitFor()` as an experiment to make our tests more semantic and less reliant on knowing the internals of the component they are testing, but I don't think it is good to mix with enzyme tests)
- unmount wrapper after each test (~40% reduction in total time)
- increase jest timeout for file (just to be safe)
