### PR TITLE
fix(filters): scroll to top if in experiment branch

### DIFF
--- a/src/Components/ArtworkFilter/index.tsx
+++ b/src/Components/ArtworkFilter/index.tsx
@@ -29,7 +29,7 @@ import { ActiveFilterPills } from "Components/SavedSearchAlert/Components/Active
 import { Sticky } from "Components/Sticky"
 import { useAnalyticsContext } from "System/Analytics/AnalyticsContext"
 import { useSystemContext } from "System/useSystemContext"
-import { Jump } from "Utils/Hooks/useJump"
+import { Jump, useJump } from "Utils/Hooks/useJump"
 import { usePrevious } from "Utils/Hooks/usePrevious"
 import { Media } from "Utils/Responsive"
 import { isEqual } from "lodash"
@@ -227,8 +227,14 @@ export const BaseArtworkFilter: React.FC<
     )
   }, [filterContext.filters])
 
+  const { jumpTo } = useJump()
+
   const fetchResults = () => {
     setIsLoading(true)
+
+    if (isRevisedArtworkFiltersEnabled) {
+      jumpTo("artworkFilter")
+    }
 
     const refetchVariables = {
       input: {


### PR DESCRIPTION
One of the problems that surfaced with the old sidebar filters was that inputs might be multi-step — meaning the page would scroll after applying some state, and maybe you want to refine the state (price filter, for example). Because the sidebar isn't sticky, this would be disruptive. So we only scroll on the new filters.