### PR TITLE
fix(system): Dont clear relay cache after mutations -> speed up logged in experience

### DIFF
--- a/src/Apps/Auction/auctionRoutes.tsx
+++ b/src/Apps/Auction/auctionRoutes.tsx
@@ -71,6 +71,9 @@ export const auctionRoutes: AppRouteConfig[] = [
         }
       }
     `,
+    cacheConfig: {
+      force: true,
+    },
     prepareVariables: (params, props) => {
       const auctionFilterDefaults = {
         sort: "sale_position",
@@ -114,6 +117,9 @@ export const auctionRoutes: AppRouteConfig[] = [
             }
           }
         `,
+        cacheConfig: {
+          force: true,
+        },
       },
       {
         path: "confirm-registration",
@@ -129,6 +135,9 @@ export const auctionRoutes: AppRouteConfig[] = [
             }
           }
         `,
+        cacheConfig: {
+          force: true,
+        },
       },
       {
         path: "bid/:artworkSlug?",
@@ -162,6 +171,9 @@ export const auctionRoutes: AppRouteConfig[] = [
             slug,
             artworkSlug,
           }
+        },
+        cacheConfig: {
+          force: true,
         },
       },
     ],

--- a/src/Apps/Settings/settingsRoutes.tsx
+++ b/src/Apps/Settings/settingsRoutes.tsx
@@ -128,6 +128,9 @@ export const settingsRoutes: AppRouteConfig[] = [
         }
       }
     `,
+    cacheConfig: {
+      force: true,
+    },
     children: [
       {
         path: "auctions",
@@ -143,6 +146,9 @@ export const settingsRoutes: AppRouteConfig[] = [
             }
           }
         `,
+        cacheConfig: {
+          force: true,
+        },
       },
       {
         path: "edit-profile",
@@ -158,6 +164,9 @@ export const settingsRoutes: AppRouteConfig[] = [
             }
           }
         `,
+        cacheConfig: {
+          force: true,
+        },
       },
       {
         path: "payments",
@@ -173,6 +182,9 @@ export const settingsRoutes: AppRouteConfig[] = [
             }
           }
         `,
+        cacheConfig: {
+          force: true,
+        },
       },
       {
         path: "purchases",
@@ -188,6 +200,9 @@ export const settingsRoutes: AppRouteConfig[] = [
             }
           }
         `,
+        cacheConfig: {
+          force: true,
+        },
       },
       {
         path: "saves",
@@ -209,6 +224,9 @@ export const settingsRoutes: AppRouteConfig[] = [
             }
           }
         `,
+        cacheConfig: {
+          force: true,
+        },
       },
       {
         path: "/alerts",
@@ -224,6 +242,9 @@ export const settingsRoutes: AppRouteConfig[] = [
             }
           }
         `,
+        cacheConfig: {
+          force: true,
+        },
       },
       {
         path: "edit-settings",
@@ -239,6 +260,9 @@ export const settingsRoutes: AppRouteConfig[] = [
             }
           }
         `,
+        cacheConfig: {
+          force: true,
+        },
       },
       {
         path: "delete",
@@ -254,6 +278,9 @@ export const settingsRoutes: AppRouteConfig[] = [
             }
           }
         `,
+        cacheConfig: {
+          force: true,
+        },
       },
       {
         path: "shipping",
@@ -269,6 +296,9 @@ export const settingsRoutes: AppRouteConfig[] = [
             }
           }
         `,
+        cacheConfig: {
+          force: true,
+        },
       },
     ],
   },

--- a/src/Components/FollowButton/FollowArtistButton.tsx
+++ b/src/Components/FollowButton/FollowArtistButton.tsx
@@ -251,6 +251,7 @@ export const FollowArtistButtonQueryRenderer: React.FC<FollowArtistButtonQueryRe
       `}
       placeholder={<FollowButton {...rest} />}
       variables={{ id }}
+      cacheConfig={{ force: true }}
       render={({ error, props }) => {
         if (error || !props?.artist) {
           return <FollowButton {...rest} />

--- a/src/Components/FollowButton/FollowGeneButton.tsx
+++ b/src/Components/FollowButton/FollowGeneButton.tsx
@@ -150,6 +150,7 @@ export const FollowGeneButtonQueryRenderer: React.FC<FollowGeneButtonQueryRender
       `}
       placeholder={<FollowButton {...rest} />}
       variables={{ id }}
+      cacheConfig={{ force: true }}
       render={({ error, props }) => {
         if (error || !props?.gene) {
           return <FollowButton {...rest} />

--- a/src/Components/FollowButton/FollowProfileButton.tsx
+++ b/src/Components/FollowButton/FollowProfileButton.tsx
@@ -152,6 +152,7 @@ export const FollowProfileButtonQueryRenderer: React.FC<FollowProfileButtonQuery
       `}
       placeholder={<FollowButton {...rest} />}
       variables={{ id }}
+      cacheConfig={{ force: true }}
       render={({ error, props }) => {
         if (error || !props?.profile) {
           return <FollowButton {...rest} />

--- a/src/System/Relay/createRelaySSREnvironment.ts
+++ b/src/System/Relay/createRelaySSREnvironment.ts
@@ -108,7 +108,7 @@ export function createRelaySSREnvironment(config: Config = {}) {
     cacheMiddleware({
       size: Number(getENV("NETWORK_CACHE_SIZE")) ?? 2000, // max 2000 requests
       ttl: Number(getENV("NETWORK_CACHE_TTL")) ?? 3600000, // 1 hour
-      clearOnMutation: true,
+      clearOnMutation: false,
       disableServerSideCache: !!user, // disable server-side cache if logged in
       onInit: queryResponseCache => {
         if (!isServer) {


### PR DESCRIPTION
The type of this PR is: **Feat**

### Description

Have been puzzling for a while why the logged out experience on Artsy.net is so much faster than the logged-in experience and finally figured out why: we were clearing the cache every time a mutation occurred, which was generally triggered by [viewing an artwork](https://github.com/artsy/force/blob/58f8a45ad69c3f69f59ca2291a3dc5f24218de1a/src/Apps/Artwork/useRecordArtworkView.ts#L36). If not logged in, we short circuit the mutation, and the cache remains. 

As [we typically attach `force: true`](https://github.com/artsy/force/blob/58f8a45ad69c3f69f59ca2291a3dc5f24218de1a/src/Apps/Artwork/artworkRoutes.tsx#L34-L36) to our relay queries for areas that _must_ remain fresh, and when we perform mutations for various sections of the UI we typically refresh the related Relay fragment [by spreading it into the response](https://github.com/artsy/force/blob/58f8a45ad69c3f69f59ca2291a3dc5f24218de1a/src/Apps/Conversations/mutations/useSendConversationMessage.ts#L11). 

So, with this change, we get a much snappier logged in experience for pages we have already visited (page loading is basically instant), and less load on MP and related services.
