### PR TITLE
Revert "fix(system): Dont clear relay cache after mutations -> speed up logged in experience"

### DIFF
--- a/src/Apps/Auction/auctionRoutes.tsx
+++ b/src/Apps/Auction/auctionRoutes.tsx
@@ -71,9 +71,6 @@ export const auctionRoutes: AppRouteConfig[] = [
         }
       }
     `,
-    cacheConfig: {
-      force: true,
-    },
     prepareVariables: (params, props) => {
       const auctionFilterDefaults = {
         sort: "sale_position",
@@ -117,9 +114,6 @@ export const auctionRoutes: AppRouteConfig[] = [
             }
           }
         `,
-        cacheConfig: {
-          force: true,
-        },
       },
       {
         path: "confirm-registration",
@@ -135,9 +129,6 @@ export const auctionRoutes: AppRouteConfig[] = [
             }
           }
         `,
-        cacheConfig: {
-          force: true,
-        },
       },
       {
         path: "bid/:artworkSlug?",
@@ -171,9 +162,6 @@ export const auctionRoutes: AppRouteConfig[] = [
             slug,
             artworkSlug,
           }
-        },
-        cacheConfig: {
-          force: true,
         },
       },
     ],

--- a/src/Apps/Settings/settingsRoutes.tsx
+++ b/src/Apps/Settings/settingsRoutes.tsx
@@ -128,9 +128,6 @@ export const settingsRoutes: AppRouteConfig[] = [
         }
       }
     `,
-    cacheConfig: {
-      force: true,
-    },
     children: [
       {
         path: "auctions",
@@ -146,9 +143,6 @@ export const settingsRoutes: AppRouteConfig[] = [
             }
           }
         `,
-        cacheConfig: {
-          force: true,
-        },
       },
       {
         path: "edit-profile",
@@ -164,9 +158,6 @@ export const settingsRoutes: AppRouteConfig[] = [
             }
           }
         `,
-        cacheConfig: {
-          force: true,
-        },
       },
       {
         path: "payments",
@@ -182,9 +173,6 @@ export const settingsRoutes: AppRouteConfig[] = [
             }
           }
         `,
-        cacheConfig: {
-          force: true,
-        },
       },
       {
         path: "purchases",
@@ -200,9 +188,6 @@ export const settingsRoutes: AppRouteConfig[] = [
             }
           }
         `,
-        cacheConfig: {
-          force: true,
-        },
       },
       {
         path: "saves",
@@ -224,9 +209,6 @@ export const settingsRoutes: AppRouteConfig[] = [
             }
           }
         `,
-        cacheConfig: {
-          force: true,
-        },
       },
       {
         path: "/alerts",
@@ -242,9 +224,6 @@ export const settingsRoutes: AppRouteConfig[] = [
             }
           }
         `,
-        cacheConfig: {
-          force: true,
-        },
       },
       {
         path: "edit-settings",
@@ -260,9 +239,6 @@ export const settingsRoutes: AppRouteConfig[] = [
             }
           }
         `,
-        cacheConfig: {
-          force: true,
-        },
       },
       {
         path: "delete",
@@ -278,9 +254,6 @@ export const settingsRoutes: AppRouteConfig[] = [
             }
           }
         `,
-        cacheConfig: {
-          force: true,
-        },
       },
       {
         path: "shipping",
@@ -296,9 +269,6 @@ export const settingsRoutes: AppRouteConfig[] = [
             }
           }
         `,
-        cacheConfig: {
-          force: true,
-        },
       },
     ],
   },

--- a/src/Components/FollowButton/FollowArtistButton.tsx
+++ b/src/Components/FollowButton/FollowArtistButton.tsx
@@ -251,7 +251,6 @@ export const FollowArtistButtonQueryRenderer: React.FC<FollowArtistButtonQueryRe
       `}
       placeholder={<FollowButton {...rest} />}
       variables={{ id }}
-      cacheConfig={{ force: true }}
       render={({ error, props }) => {
         if (error || !props?.artist) {
           return <FollowButton {...rest} />

--- a/src/Components/FollowButton/FollowGeneButton.tsx
+++ b/src/Components/FollowButton/FollowGeneButton.tsx
@@ -150,7 +150,6 @@ export const FollowGeneButtonQueryRenderer: React.FC<FollowGeneButtonQueryRender
       `}
       placeholder={<FollowButton {...rest} />}
       variables={{ id }}
-      cacheConfig={{ force: true }}
       render={({ error, props }) => {
         if (error || !props?.gene) {
           return <FollowButton {...rest} />

--- a/src/Components/FollowButton/FollowProfileButton.tsx
+++ b/src/Components/FollowButton/FollowProfileButton.tsx
@@ -152,7 +152,6 @@ export const FollowProfileButtonQueryRenderer: React.FC<FollowProfileButtonQuery
       `}
       placeholder={<FollowButton {...rest} />}
       variables={{ id }}
-      cacheConfig={{ force: true }}
       render={({ error, props }) => {
         if (error || !props?.profile) {
           return <FollowButton {...rest} />

--- a/src/System/Relay/createRelaySSREnvironment.ts
+++ b/src/System/Relay/createRelaySSREnvironment.ts
@@ -108,7 +108,7 @@ export function createRelaySSREnvironment(config: Config = {}) {
     cacheMiddleware({
       size: Number(getENV("NETWORK_CACHE_SIZE")) ?? 2000, // max 2000 requests
       ttl: Number(getENV("NETWORK_CACHE_TTL")) ?? 3600000, // 1 hour
-      clearOnMutation: false,
+      clearOnMutation: true,
       disableServerSideCache: !!user, // disable server-side cache if logged in
       onInit: queryResponseCache => {
         if (!isServer) {


### PR DESCRIPTION
Reverts artsy/force#13211

Noticed an issue where `cacheConfig: { force: true }` no longer seems to work when attached to individual routes (eg, after visiting an artwork page it remains cached, when it should never cache, due to force: true being present on the route). Might be something with a recent relay upgrade? But in any case, we need a way to force certain routes to always be fresh, and short of that we'll have to shortcircuit it as we have been (unknowingly). 