### PR TITLE
feat: Reload artist page correctly when navigating from same artist page

### DIFF
--- a/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
@@ -67,6 +67,8 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
       ]}
       ZeroState={ZeroState}
       userPreferredMetric={userPreferences?.metric}
+      // Setting the key here to enforce a remount of the component when changing pages or query parameter filters within the query.
+      key={match.location.pathname + match.location.search}
     >
       <ArtworkFilterAlertContextProvider
         initialCriteria={{ artistIDs: [artist.internalID] }}

--- a/src/Components/Alert/Components/Steps/Confirmation.tsx
+++ b/src/Components/Alert/Components/Steps/Confirmation.tsx
@@ -6,7 +6,7 @@ import { ConfirmationArtworksGridQueryRenderer } from "Components/SavedSearchAle
 import { CriteriaPills } from "Components/Alert/Components/CriteriaPills"
 
 export const Confirmation: FC = () => {
-  const { state } = useAlertContext()
+  const { dispatch, state } = useAlertContext()
 
   return (
     <Flex flexDirection="column" p={2}>
@@ -25,7 +25,9 @@ export const Confirmation: FC = () => {
           </Join>
         </Flex>
         <ConfirmationArtworksGridQueryRenderer
-          onClose={() => false}
+          onClose={() => {
+            dispatch({ type: "RESET" })
+          }}
           searchCriteriaId={state.searchCriteriaID as string}
           excludeArtworkIDs={
             state.currentArtworkID ? [state.currentArtworkID] : undefined


### PR DESCRIPTION
Addresses [ONYX-551]

## Description

Reload artist page correctly when navigating from same artist page.

From the Alert modal confirmation footer we are linking to the same artist page but with different filters (passed as query params in the URL) [here](https://github.com/artsy/force/blob/9f1078cdfebf737af3a0d2b173cd77ccf43f890b/src/Components/SavedSearchAlert/Components/ConfirmationStepFooter.tsx#L34).

The issue at the moment is that the filter context doesn't get remounted and therefore doesn't get updated (because the internal filter state doesn't get reinitialized) when navigating to the same artist page. By adding a key to the filter context component, we ensure that the component remounts whenever the URL changes. This way, the filters are set correctly on the page.

The artwork grid already gets updated correctly because of Relay 🙌 




[ONYX-551]: https://artsyproduct.atlassian.net/browse/ONYX-551?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ