### PR TITLE
feat: allow routing to edit panel of alerts app

### DIFF
--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditFormDesktop.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditFormDesktop.tsx
@@ -15,7 +15,7 @@ export const SavedSearchAlertEditFormDesktop: React.FC<EditAlertFormBase> = ({
         <Text variant={["md", "lg"]} flex={1} mr={1}>
           Edit Alert
         </Text>
-        <Clickable onClick={onCloseClick}>
+        <Clickable data-testid="closeButton" onClick={onCloseClick}>
           <CloseIcon display="flex" />
         </Clickable>
       </Flex>

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/__tests__/SavedSearchAlertsApp.jest.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/__tests__/SavedSearchAlertsApp.jest.tsx
@@ -116,10 +116,15 @@ describe("SavedSearchAlertsApp", () => {
         savedSearchesConnection: mockedSavedSearchesConnection,
       }),
     })
-
     fireEvent.click(screen.getAllByText("Edit")[0])
 
-    expect(screen.getAllByText("Edit Alert")[0]).toBeInTheDocument()
+    expect(window.location.pathname).toEqual(
+      `/settings/alerts/example-id-1/edit`
+    )
+
+    screen.getByTestId("closeButton").click()
+
+    expect(window.location.pathname).toEqual(`/settings/alerts`)
   })
 })
 
@@ -127,6 +132,7 @@ const mockedSavedSearchesConnection = {
   edges: [
     {
       node: {
+        internalID: "example-id-1",
         labels: [
           { displayValue: "Limited Edition" },
           { displayValue: "Andy Warhol" },
@@ -136,6 +142,7 @@ const mockedSavedSearchesConnection = {
     },
     {
       node: {
+        internalID: "example-id-2",
         displayName: "Alert Name 2",
       },
     },

--- a/src/Apps/Settings/settingsRoutes.tsx
+++ b/src/Apps/Settings/settingsRoutes.tsx
@@ -10,6 +10,17 @@ const SettingsApp = loadable(
   }
 )
 
+const AlertsRoute = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "settingsBundle" */ "./Routes/SavedSearchAlerts/SavedSearchAlertsApp"
+    ),
+  {
+    resolveComponent: component =>
+      component.SavedSearchAlertsAppPaginationContainer,
+  }
+)
+
 const AuctionsRoute = loadable(
   () =>
     import(
@@ -102,17 +113,6 @@ const handleServerSideRender = ({ req, res }) => {
     res.redirect("/")
   }
 }
-
-const SavedSearchAlertsApp = loadable(
-  () =>
-    import(
-      /* webpackChunkName: "settingsBundle" */ "./Routes/SavedSearchAlerts/SavedSearchAlertsApp"
-    ),
-  {
-    resolveComponent: component =>
-      component.SavedSearchAlertsAppPaginationContainer,
-  }
-)
 
 export const settingsRoutes: AppRouteConfig[] = [
   {
@@ -211,14 +211,29 @@ export const settingsRoutes: AppRouteConfig[] = [
         `,
       },
       {
-        path: "/alerts",
-        getComponent: () => SavedSearchAlertsApp,
+        path: "alerts",
+        getComponent: () => AlertsRoute,
         onClientSideRender: () => {
-          SavedSearchAlertsApp.preload()
+          AlertsRoute.preload()
         },
         onServerSideRender: handleServerSideRender,
         query: graphql`
           query settingsRoutes_SavedSearchAlertsAppQuery {
+            me {
+              ...SavedSearchAlertsApp_me
+            }
+          }
+        `,
+      },
+      {
+        path: "alerts/:searchCriteriaID/edit",
+        getComponent: () => AlertsRoute,
+        onClientSideRender: () => {
+          AlertsRoute.preload()
+        },
+        onServerSideRender: handleServerSideRender,
+        query: graphql`
+          query settingsRoutes_SavedSearchAlertsAppEditQuery {
             me {
               ...SavedSearchAlertsApp_me
             }
@@ -271,20 +286,5 @@ export const settingsRoutes: AppRouteConfig[] = [
         `,
       },
     ],
-  },
-
-  {
-    path: "/settings/alerts",
-    getComponent: () => SavedSearchAlertsApp,
-    onClientSideRender: () => {
-      SavedSearchAlertsApp.preload()
-    },
-    query: graphql`
-      query settingsRoutes_SavedSearchAlertsQuery {
-        me {
-          ...SavedSearchAlertsApp_me
-        }
-      }
-    `,
   },
 ]

--- a/src/__generated__/SavedSearchAlertsApp_Alert_Query.graphql.ts
+++ b/src/__generated__/SavedSearchAlertsApp_Alert_Query.graphql.ts
@@ -1,0 +1,151 @@
+/**
+ * @generated SignedSource<<a18716ffe9a1de2936016639bbd19841>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+export type SavedSearchAlertsApp_Alert_Query$variables = {
+  searchCriteriaID: string;
+};
+export type SavedSearchAlertsApp_Alert_Query$data = {
+  readonly me: {
+    readonly savedSearch: {
+      readonly artistIDs: ReadonlyArray<string> | null | undefined;
+      readonly internalID: string;
+      readonly userAlertSettings: {
+        readonly name: string | null | undefined;
+      };
+    } | null | undefined;
+  } | null | undefined;
+};
+export type SavedSearchAlertsApp_Alert_Query = {
+  response: SavedSearchAlertsApp_Alert_Query$data;
+  variables: SavedSearchAlertsApp_Alert_Query$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "searchCriteriaID"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Variable",
+      "name": "id",
+      "variableName": "searchCriteriaID"
+    }
+  ],
+  "concreteType": "SearchCriteria",
+  "kind": "LinkedField",
+  "name": "savedSearch",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "internalID",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "artistIDs",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "SavedSearchUserAlertSettings",
+      "kind": "LinkedField",
+      "name": "userAlertSettings",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "SavedSearchAlertsApp_Alert_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "SavedSearchAlertsApp_Alert_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "48fca4eb1e2e09efa701f574fe7619cc",
+    "id": null,
+    "metadata": {},
+    "name": "SavedSearchAlertsApp_Alert_Query",
+    "operationKind": "query",
+    "text": "query SavedSearchAlertsApp_Alert_Query(\n  $searchCriteriaID: ID!\n) {\n  me {\n    savedSearch(id: $searchCriteriaID) {\n      internalID\n      artistIDs\n      userAlertSettings {\n        name\n      }\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "3152f9c9bcc26ce920b71cd52732a3d4";
+
+export default node;

--- a/src/__generated__/settingsRoutes_SavedSearchAlertsAppEditQuery.graphql.ts
+++ b/src/__generated__/settingsRoutes_SavedSearchAlertsAppEditQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<91162d495be0770f31ee16d2163c506c>>
+ * @generated SignedSource<<89cd8e78e61c1e06e263081a37217a47>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,15 +10,15 @@
 
 import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type settingsRoutes_SavedSearchAlertsQuery$variables = Record<PropertyKey, never>;
-export type settingsRoutes_SavedSearchAlertsQuery$data = {
+export type settingsRoutes_SavedSearchAlertsAppEditQuery$variables = Record<PropertyKey, never>;
+export type settingsRoutes_SavedSearchAlertsAppEditQuery$data = {
   readonly me: {
     readonly " $fragmentSpreads": FragmentRefs<"SavedSearchAlertsApp_me">;
   } | null | undefined;
 };
-export type settingsRoutes_SavedSearchAlertsQuery = {
-  response: settingsRoutes_SavedSearchAlertsQuery$data;
-  variables: settingsRoutes_SavedSearchAlertsQuery$variables;
+export type settingsRoutes_SavedSearchAlertsAppEditQuery = {
+  response: settingsRoutes_SavedSearchAlertsAppEditQuery$data;
+  variables: settingsRoutes_SavedSearchAlertsAppEditQuery$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -39,7 +39,7 @@ return {
     "argumentDefinitions": [],
     "kind": "Fragment",
     "metadata": null,
-    "name": "settingsRoutes_SavedSearchAlertsQuery",
+    "name": "settingsRoutes_SavedSearchAlertsAppEditQuery",
     "selections": [
       {
         "alias": null,
@@ -65,7 +65,7 @@ return {
   "operation": {
     "argumentDefinitions": [],
     "kind": "Operation",
-    "name": "settingsRoutes_SavedSearchAlertsQuery",
+    "name": "settingsRoutes_SavedSearchAlertsAppEditQuery",
     "selections": [
       {
         "alias": null,
@@ -242,16 +242,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e947d48684cdf32f1d95f6ef26592269",
+    "cacheID": "c8b5db0ed191a7d37ee26c2b37da44f3",
     "id": null,
     "metadata": {},
-    "name": "settingsRoutes_SavedSearchAlertsQuery",
+    "name": "settingsRoutes_SavedSearchAlertsAppEditQuery",
     "operationKind": "query",
-    "text": "query settingsRoutes_SavedSearchAlertsQuery {\n  me {\n    ...SavedSearchAlertsApp_me\n    id\n  }\n}\n\nfragment SavedSearchAlertListItem_item on SearchCriteria {\n  internalID\n  displayName\n  artistIDs\n  artistSeriesIDs\n  href\n  labels {\n    displayValue\n  }\n  userAlertSettings {\n    name\n  }\n}\n\nfragment SavedSearchAlertsApp_me on Me {\n  savedSearchesConnection(first: 10, sort: CREATED_AT_DESC) {\n    edges {\n      node {\n        internalID\n        ...SavedSearchAlertListItem_item\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query settingsRoutes_SavedSearchAlertsAppEditQuery {\n  me {\n    ...SavedSearchAlertsApp_me\n    id\n  }\n}\n\nfragment SavedSearchAlertListItem_item on SearchCriteria {\n  internalID\n  displayName\n  artistIDs\n  artistSeriesIDs\n  href\n  labels {\n    displayValue\n  }\n  userAlertSettings {\n    name\n  }\n}\n\nfragment SavedSearchAlertsApp_me on Me {\n  savedSearchesConnection(first: 10, sort: CREATED_AT_DESC) {\n    edges {\n      node {\n        internalID\n        ...SavedSearchAlertListItem_item\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "1a1527fe89bb166c9f3f58b8618f9220";
+(node as any).hash = "8df33aeecf080d4a56a31f7b7411b096";
 
 export default node;


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [ONYX-548](https://artsyproduct.atlassian.net/browse/ONYX-548)

### Description

Allow explicit routing to `/settings/alerts/:id/edit`.

Supports routing to alerts not fetched within the list panel by fetching the alert data separately in a useEffect hook.

### Screen Recording



https://github.com/artsy/force/assets/123595/7c3f6b59-123d-4c59-a405-b27eb5b353e2





[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-548]: https://artsyproduct.atlassian.net/browse/ONYX-548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ