### PR TITLE
chore: add silentPush and silentReplace to useRouter hook

### DIFF
--- a/src/Apps/Article/Components/ArticleVisibilityMetadata.tsx
+++ b/src/Apps/Article/Components/ArticleVisibilityMetadata.tsx
@@ -2,6 +2,7 @@ import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useIntersectionObserver } from "Utils/Hooks/useIntersectionObserver"
 import { ArticleVisibilityMetadata_article$data } from "__generated__/ArticleVisibilityMetadata_article.graphql"
+import { useRouter } from "System/Router/useRouter"
 
 interface ArticleVisibilityMetadataProps {
   article: ArticleVisibilityMetadata_article$data
@@ -14,6 +15,7 @@ const ArticleVisibilityMetadata: FC<ArticleVisibilityMetadataProps> = ({
   article,
   children,
 }) => {
+  const { silentReplace } = useRouter()
   const { ref } = useIntersectionObserver({
     once: false,
     onIntersection: () => {
@@ -21,7 +23,7 @@ const ArticleVisibilityMetadata: FC<ArticleVisibilityMetadataProps> = ({
 
       document.title = `${article.searchTitle || article.title} | Artsy`
 
-      window.history.replaceState({}, "", article.href)
+      silentReplace(article.href)
     },
   })
 

--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -85,7 +85,7 @@ const BelowTheFoldArtworkDetails: React.FC<BelowTheFoldArtworkDetailsProps> = ({
 
 export const ArtworkApp: React.FC<Props> = props => {
   const { artwork, me, referrer, tracking, shouldTrackPageView } = props
-  const { match } = useRouter()
+  const { match, silentPush } = useRouter()
 
   const showUnlistedArtworkBanner =
     artwork?.visibilityLevel == "UNLISTED" && artwork?.partner
@@ -170,7 +170,7 @@ export const ArtworkApp: React.FC<Props> = props => {
     if (!!submittedOrderId) {
       // TODO: Look into using router push
       // this.props.router.replace(this.props.match.location.pathname)
-      window.history.pushState({}, null, props.match.location.pathname)
+      silentPush(props.match.location.pathname)
     }
     track()
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/Apps/Collect/Routes/Collect/index.tsx
+++ b/src/Apps/Collect/Routes/Collect/index.tsx
@@ -19,6 +19,7 @@ import {
   SharedArtworkFilterContextProps,
 } from "Components/ArtworkFilter/ArtworkFilterContext"
 import { useSystemContext } from "System/useSystemContext"
+import { useRouter } from "System/Router/useRouter"
 
 export interface CollectAppProps {
   match: Match
@@ -34,6 +35,7 @@ export const CollectApp: React.FC<CollectAppProps> = ({
   match: { location, params },
   viewer,
 }) => {
+  const { silentReplace } = useRouter()
   const { userPreferences } = useSystemContext()
   const medium = params?.medium as Medium
   const color = params?.color as Color
@@ -119,26 +121,7 @@ export const CollectApp: React.FC<CollectAppProps> = ({
             onChange={filters => {
               const url = buildUrlForCollectApp(filters)
 
-              if (typeof window !== "undefined") {
-                window.history.replaceState({}, "", url)
-              }
-
-              /**
-             * FIXME: Ideally we route using our router, but are running into
-             * synchronization issues between router state and URL bar state.
-             *
-             * See below example as an illustration:
-             *
-              const newLocation = router.createLocation(url)
-
-              router.replace({
-                ...newLocation,
-                state: {
-                  scrollTo: "#JUMP--artworkFilter"
-                },
-              })
-            *
-            */
+              silentReplace(url)
             }}
             userPreferredMetric={userPreferences?.metric}
           />

--- a/src/Apps/Search/Routes/SearchResultsArtists.tsx
+++ b/src/Apps/Search/Routes/SearchResultsArtists.tsx
@@ -88,10 +88,9 @@ export class SearchResultsArtistsRoute extends React.Component<Props, State> {
           page,
           term,
         })
-        // TODO: Look into using router push w/ query params.
-        // this.props.router.replace(`/search/artists?${urlParams}`)
-        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-        window.history.pushState({}, null, `/search/artists?${urlParams}`)
+        // TODO: use silentPush from useRouter if this class component is
+        // converted to a function component
+        window.history.pushState({}, "", `/search/artists?${urlParams}`)
       }
     )
   }

--- a/src/Apps/Search/Routes/SearchResultsEntity.tsx
+++ b/src/Apps/Search/Routes/SearchResultsEntity.tsx
@@ -90,10 +90,9 @@ export class SearchResultsEntityRoute extends React.Component<Props, State> {
           page,
           term,
         })
-        // TODO: Look into using router push w/ query params.
-        // this.props.router.replace(`/search/${tab}?${urlParams}`)
-        // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-        window.history.pushState({}, null, `/search/${tab}?${urlParams}`)
+        // TODO: use silentPush from useRouter if this class component is
+        // converted to a function component
+        window.history.pushState({}, "", `/search/${tab}?${urlParams}`)
       }
     )
   }

--- a/src/Apps/Shows/Routes/ShowsCity.tsx
+++ b/src/Apps/Shows/Routes/ShowsCity.tsx
@@ -20,6 +20,7 @@ import { extractNodes } from "Utils/extractNodes"
 import { FragmentRefs } from "relay-runtime"
 import { PaginationFragmentContainer } from "Components/Pagination"
 import { Jump, useJump } from "Utils/Hooks/useJump"
+import { useRouter } from "System/Router/useRouter"
 
 interface ShowsCityProps {
   viewer: ShowsCity_viewer$data
@@ -63,6 +64,7 @@ export const ShowsCity: React.FC<ShowsCityProps> = ({
   const [loading, setLoading] = useState(false)
 
   const { jumpTo } = useJump({ offset: 20 })
+  const { silentReplace } = useRouter()
 
   const handleClick = (cursor: string, page: number) => {
     jumpTo(CURRENT_SHOWS_JUMP_ID)
@@ -79,7 +81,7 @@ export const ShowsCity: React.FC<ShowsCityProps> = ({
 
         setLoading(false)
 
-        window.history.replaceState({}, "", `?page=${page}`)
+        silentReplace(`?page=${page}`)
       }
     )
   }

--- a/src/System/Router/useRouter.tsx
+++ b/src/System/Router/useRouter.tsx
@@ -7,10 +7,21 @@ export function useRouter(): {
   match: Match
   router: Router
   route: AppRouteConfig
+  silentPush: (path: string) => void
+  silentReplace: (path: string) => void
 } {
   const { match, router } = useContext(RouterContext) ?? {}
   const route = findCurrentRoute(match)
-  return { match, router, route }
+
+  const silentPush = (path: string) => {
+    history.pushState({}, "", path)
+  }
+
+  const silentReplace = (path: string) => {
+    history.replaceState({}, "", path)
+  }
+
+  return { match, router, route, silentPush, silentReplace }
 }
 
 export function useIsRouteActive(


### PR DESCRIPTION
The type of this PR is: **Chore**

### Description

We've occasionally needed to perform a silent URL update instead of performing a full navigation event via our routing layer. This commit adds two new functions, `silentPush` and `silentReplace`, to consolidate our pattern for doing so in one place.

Follow-up on this [review comment](https://github.com/artsy/force/pull/13215#discussion_r1410897022).