### PR TITLE
feat: add artist series horizontal filter

### DIFF
--- a/src/Components/ArtworkFilter/ArtworkFiltersQuick.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFiltersQuick.tsx
@@ -3,6 +3,7 @@ import { ATTRIBUTION_CLASS_OPTIONS } from "Components/ArtworkFilter/ArtworkFilte
 import { MEDIUM_OPTIONS } from "Components/ArtworkFilter/ArtworkFilters/MediumFilter"
 import { FilterQuick } from "Components/ArtworkFilter/ArtworkFiltersQuick/FilterQuick"
 import { PriceRangeFilterQuick } from "Components/ArtworkFilter/ArtworkFiltersQuick/PriceRangeFilterQuick"
+import { ArtistSeriesFilterQuick } from "Components/ArtworkFilter/ArtworkFiltersQuick/ArtistSeriesFilterQuick"
 import { FC } from "react"
 
 // NOTE: Keep in sync with components below
@@ -34,6 +35,8 @@ export const ArtworkFiltersQuick: FC<ArtworkFiltersQuickProps> = props => {
       />
 
       <PriceRangeFilterQuick {...props} />
+
+      <ArtistSeriesFilterQuick {...props} />
     </>
   )
 }

--- a/src/Components/ArtworkFilter/ArtworkFiltersQuick/ArtistSeriesFilterQuick.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFiltersQuick/ArtistSeriesFilterQuick.tsx
@@ -1,0 +1,31 @@
+import { FC } from "react"
+import { useArtworkFilterContext } from "Components/ArtworkFilter/ArtworkFilterContext"
+import { DropdownProps } from "@artsy/palette"
+import { FilterQuick } from "Components/ArtworkFilter/ArtworkFiltersQuick/FilterQuick"
+import { useFeatureFlag } from "System/useFeatureFlag"
+
+export interface ArtistSeriesFilterQuickProps
+  extends Omit<DropdownProps, "dropdown" | "children"> {}
+
+export const ArtistSeriesFilterQuick: FC<ArtistSeriesFilterQuickProps> = props => {
+  const isArtistSeriesFilterEnabled = useFeatureFlag(
+    "onyx_enable-artist-series-filter"
+  )
+
+  const { aggregations } = useArtworkFilterContext()
+  const aggregation = aggregations?.find(agg => agg.slice === "ARTIST_SERIES")
+  const artistSeries = aggregation?.counts || []
+  const isDisplayable = isArtistSeriesFilterEnabled && artistSeries.length > 0
+
+  if (!isDisplayable) return null
+
+  return (
+    <FilterQuick
+      label="Artist Series"
+      name="artistSeriesIDs"
+      slice="ARTIST_SERIES"
+      options={[]}
+      {...props}
+    />
+  )
+}

--- a/src/Components/ArtworkFilter/ArtworkFiltersQuick/__tests__/ArtistSeriesFilterQuick.jest.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFiltersQuick/__tests__/ArtistSeriesFilterQuick.jest.tsx
@@ -1,0 +1,68 @@
+import { screen } from "@testing-library/react"
+import { createArtworkFilterTestRenderer } from "Components/ArtworkFilter/ArtworkFilters/__tests__/Utils"
+import { ArtworkFilterContextProps } from "Components/ArtworkFilter/ArtworkFilterContext"
+import { ArtistSeriesFilterQuick } from "Components/ArtworkFilter/ArtworkFiltersQuick/ArtistSeriesFilterQuick"
+import { useFeatureFlag } from "System/useFeatureFlag"
+
+jest.mock("System/useFeatureFlag", () => ({
+  useFeatureFlag: jest.fn(() => true),
+}))
+
+const artworkFilterContext: Partial<ArtworkFilterContextProps> = {
+  aggregations: [
+    {
+      slice: "ARTIST_SERIES",
+      counts: [
+        { name: "Companions", value: "kaws-companions", count: 42 },
+        { name: "Toys", value: "kaws-toys", count: 420 },
+      ],
+    },
+  ],
+}
+
+let render: ReturnType<typeof createArtworkFilterTestRenderer>
+
+describe(ArtistSeriesFilterQuick, () => {
+  beforeEach(() => {
+    render = createArtworkFilterTestRenderer(artworkFilterContext)
+  })
+
+  describe("when onyx_enable-artist-series-filter flag is enabled", () => {
+    beforeEach(() => {
+      ;(useFeatureFlag as jest.Mock).mockImplementation(() => true)
+    })
+
+    describe("when artist series aggregations are present", () => {
+      it("renders the artist series quick filter", () => {
+        render(<ArtistSeriesFilterQuick />)
+        expect(screen.getByText("Artist Series")).toBeInTheDocument()
+      })
+    })
+
+    describe("when artist series aggregations are absent", () => {
+      it("does not render the artist series quick filter", () => {
+        render = createArtworkFilterTestRenderer({
+          aggregations: [
+            {
+              slice: "ARTIST_SERIES",
+              counts: [],
+            },
+          ],
+        })
+        render(<ArtistSeriesFilterQuick />)
+        expect(screen.queryByText("Artist Series")).not.toBeInTheDocument()
+      })
+    })
+  })
+
+  describe("when onyx_enable-artist-series-filter flag is disabled", () => {
+    beforeEach(() => {
+      ;(useFeatureFlag as jest.Mock).mockImplementation(() => false)
+    })
+
+    it("does not render the artist series quick filter", () => {
+      render(<ArtistSeriesFilterQuick />)
+      expect(screen.queryByText("Artist Series")).not.toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [ONYX-567]

### Description

Per discussion with @jpoczik — this adds the new Artist Series filter as one of the preferred quick filters in the sticky horizontal filters section above artwork grids.

https://github.com/artsy/force/assets/140521/c6558c2a-939a-467c-841c-7fe095e40b87

This new filter will appear if and only if:

- The feature flag is enabled
- Artist Series aggregations are present (which will only be true on artist pages currently)


### When feature flag is enabled

|Artist series are present|Artist series are absent|Non-artist page|
|---|---|---|
|![presen](https://github.com/artsy/force/assets/140521/f28163a7-b970-466d-ba69-cccce45abce7)|![absen](https://github.com/artsy/force/assets/140521/597fcdc4-0b54-43dd-a46b-20c7f283a259)|![nonen](https://github.com/artsy/force/assets/140521/edbffac7-8dc1-49d5-921c-612f996ff22d)|

### When feature flag is disabled

|Artist series are present|Artist series are absent|Non-artist page|
|---|---|---|
|![presdis](https://github.com/artsy/force/assets/140521/575b2ac0-e5f7-4d3c-bd45-16472557f7c1)|![absdis](https://github.com/artsy/force/assets/140521/37090d5e-845c-403d-b9e9-e4a4d044ab99)|![nondis](https://github.com/artsy/force/assets/140521/be649ef3-2b54-4a20-996b-09dce0b165f5)|

[ONYX-567]: https://artsyproduct.atlassian.net/browse/ONYX-567?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ