### PR TITLE
fix: Do not reset email preferences after submitting

### DIFF
--- a/src/Apps/Preferences/PreferencesApp.tsx
+++ b/src/Apps/Preferences/PreferencesApp.tsx
@@ -75,7 +75,6 @@ export const PreferencesApp: FC<PreferencesAppProps> = ({ viewer }) => {
         Email Preference Center
       </Text>
       <Formik<FormValuesForNotificationPreferences>
-        // @ts-ignore
         initialValues={{ ...NOTIFICATION_FIELDS, ...initialValues }}
         onSubmit={async (values, actions) => {
           try {
@@ -94,9 +93,7 @@ export const PreferencesApp: FC<PreferencesAppProps> = ({ viewer }) => {
               variables: { input: { authenticationToken, subscriptionGroups } },
             })
 
-            actions.resetForm({
-              touched: {},
-            })
+            actions.setTouched({})
 
             sendToast({
               variant: "success",


### PR DESCRIPTION
## Description


We should not reset the email preferences after submitting because the update in Gravity [runs in a background job](https://github.com/artsy/gravity/blob/35fd62b809c3e40fb09c7a948fd56aa9b8022a43/app/api/v1/notification_preferences_endpoint.rb#L30), and the preferences won't be updated immediately.

Even reading the return data from the mutation will return the previously set preferences. It takes a few seconds until the backend returns the updated preferences.

This PR doesn't fix the underlying issue but at least it fixes the form by not resetting the value.



https://github.com/artsy/force/assets/4691889/ec2454d6-c4b3-445b-8f0e-657b0a5043dd



