### PR TITLE
feat(EMI-1597): artwork page partner offer messaging

### DIFF
--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -41,6 +41,7 @@ import { ArtworkDetailsPartnerInfoQueryRenderer } from "Apps/Artwork/Components/
 import { ArtworkAuctionCreateAlertHeaderFragmentContainer } from "Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/ArtworkAuctionCreateAlertHeader"
 import { compact } from "lodash"
 import { AlertProvider } from "Components/Alert/AlertProvider"
+import { FullBleedBanner } from "Components/FullBleedBanner"
 
 export interface Props {
   artwork: ArtworkApp_artwork$data
@@ -89,6 +90,9 @@ export const ArtworkApp: React.FC<Props> = props => {
 
   const showUnlistedArtworkBanner =
     artwork?.visibilityLevel == "UNLISTED" && artwork?.partner
+
+  const showExpiredOfferBanner = !!match?.location?.query?.expired_offer
+  const showUnavailableArtworkBanner = !!match?.location?.query?.unavailable
 
   const trackPageview = useCallback(() => {
     const { listPrice, availability, is_offerable, is_acquireable } = artwork
@@ -208,6 +212,24 @@ export const ArtworkApp: React.FC<Props> = props => {
       )}
       {showUnlistedArtworkBanner && (
         <UnlistedArtworkBannerFragmentContainer partner={artwork.partner} />
+      )}
+
+      {showExpiredOfferBanner && (
+        <FullBleedBanner variant="brand">
+          <Text>
+            This offer has expired. Please make a new offer or contact the
+            gallery.
+          </Text>
+        </FullBleedBanner>
+      )}
+
+      {showUnavailableArtworkBanner && (
+        <FullBleedBanner variant="brand">
+          <Text>
+            Sorry, this artwork is no longer available. Please create an alert
+            or contact orders@artsy.net to find similar artworks.
+          </Text>
+        </FullBleedBanner>
       )}
 
       <ArtworkMetaFragmentContainer artwork={artwork} />

--- a/src/Apps/PartnerOffer/Routes/PartnerOfferCheckout.tsx
+++ b/src/Apps/PartnerOffer/Routes/PartnerOfferCheckout.tsx
@@ -23,20 +23,21 @@ export const PartnerOfferCheckout: FC = () => {
         })
 
         let redirectUrl = "/"
-        let orderOrError = response.commerceCreatePartnerOfferOrder?.orderOrError
+        let orderOrError =
+          response.commerceCreatePartnerOfferOrder?.orderOrError
 
         if (orderOrError?.error) {
           const errorCode = orderOrError.error.code
-          const errorData = JSON.parse(orderOrError.error.data?.toString() ?? "")
+          const errorData = JSON.parse(
+            orderOrError.error.data?.toString() ?? ""
+          )
 
           switch (errorCode) {
             case "expired_partner_offer":
-              // TODO: Show error message in artwork page
-              redirectUrl = `/artwork/${errorData.artwork_id}`
+              redirectUrl = `/artwork/${errorData.artwork_id}?expired_offer=true`
               break
             case "not_acquireable":
-              // TODO: Show error message in artwork page
-              redirectUrl = `/artwork/${errorData.artwork_id}`
+              redirectUrl = `/artwork/${errorData.artwork_id}?unavailable=true`
               break
           }
         } else {

--- a/src/Apps/PartnerOffer/Routes/__tests__/PartnerOfferCheckout.jest.tsx
+++ b/src/Apps/PartnerOffer/Routes/__tests__/PartnerOfferCheckout.jest.tsx
@@ -53,7 +53,9 @@ describe("PartnerOfferCheckout", () => {
       })
     )
     await waitFor(() => {
-      expect(mockRouterPush).toHaveBeenCalledWith("/artwork/1234")
+      expect(mockRouterPush).toHaveBeenCalledWith(
+        "/artwork/1234?expired_offer=true"
+      )
     })
   })
 
@@ -82,7 +84,9 @@ describe("PartnerOfferCheckout", () => {
       })
     )
     await waitFor(() => {
-      expect(mockRouterPush).toHaveBeenCalledWith("/artwork/1235")
+      expect(mockRouterPush).toHaveBeenCalledWith(
+        "/artwork/1235?unavailable=true"
+      )
     })
   })
 


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [EMI-1597]

### Description

Whenever the user clicks on the email or push notification to proceed with the purchase of a Partner Offer artwork, they land in a Force page whose job is to create the order in Exchange, redirecting accordingly depending on the scenarios. If the artwork is not available or the offer expired, we show specific messaging in the artwork page.

<img width="1243" alt="Screenshot 2023-12-05 at 11 23 10" src="https://github.com/artsy/force/assets/7518671/3f374eb0-72dd-4617-b74f-0eda8f6b19c0">
<img width="1243" alt="Screenshot 2023-12-05 at 11 42 08" src="https://github.com/artsy/force/assets/7518671/9e5c971c-2175-416e-8231-23a8fc249942">



[EMI-1597]: https://artsyproduct.atlassian.net/browse/EMI-1597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ