### PR TITLE
fix(dia-333): prevent insertion of arbitrary error messages

### DIFF
--- a/src/Apps/Authentication/Components/AuthenticationInlineDialog.tsx
+++ b/src/Apps/Authentication/Components/AuthenticationInlineDialog.tsx
@@ -20,17 +20,23 @@ const AuthenticationInlineDialogContents: FC = () => {
     match: { location },
   } = useRouter()
 
-  // Errors might come back from 3rd party authentication
-  // as a string in an `error` query param, so display them if present.
+  // Errors might come back from 3rd party authentication so display them if present.
   useEffect(() => {
-    if (!location.query.error) return
+    if (!location.query.error_code) return
 
-    sendToast({
-      message: location.query.error,
-      variant: "error",
-      ttl: Infinity,
-    })
-  }, [location.query.error, sendToast])
+    const message = (
+      ERROR_CODES[location.query.error_code] || ERROR_CODES.UNKNOWN
+    )
+      // Resolve templates
+      .replace("{email}", location.query.email || "—")
+      .replace("{provider}", PROVIDERS[location.query.provider] || "—")
+
+    if (location.query.error) {
+      console.error(location.query.error)
+    }
+
+    sendToast({ message, variant: "error", ttl: Infinity })
+  }, [location.query, sendToast])
 
   return (
     <>
@@ -82,4 +88,18 @@ export const AuthenticationInlineDialog: FC<AuthenticationInlineDialogProps> = (
       <AuthenticationInlineDialogContents />
     </AuthenticationInlineDialogProvider>
   )
+}
+
+const ERROR_CODES = {
+  ALREADY_EXISTS: `A user with the email address {email} already exists. Log in to Artsy via email and password and link {provider} in your settings instead.`,
+  PREVIOUSLY_LINKED_SETTINGS: `{provider} account previously linked to Artsy. Log in to your Artsy account via email and password and link {provider} in your settings instead.`,
+  PREVIOUSLY_LINKED: `{provider} account previously linked to Artsy.`,
+  IP_BLOCKED: "Your IP address was blocked by {provider}.",
+  UNKNOWN: "An unknown error occurred. Please try again.",
+}
+
+const PROVIDERS = {
+  facebook: "Facebook",
+  google: "Google",
+  apple: "Apple",
 }

--- a/src/Server/passport/test/app/lifecycle.jest.js
+++ b/src/Server/passport/test/app/lifecycle.jest.js
@@ -168,7 +168,7 @@ describe("lifecycle", function () {
       )
       lifecycle.afterSocialAuth("facebook")(req, res, next)
       expect(res.redirect.args[0][0]).toEqual(
-        "/login?error=Your IP address was blocked by Facebook."
+        "/login?error_code=IP_BLOCKED&provider=facebook"
       )
     })
 
@@ -178,7 +178,7 @@ describe("lifecycle", function () {
       )
       lifecycle.afterSocialAuth("facebook")(req, res, next)
       expect(res.redirect.args[0][0]).toEqual(
-        "/login?error=Facebook authorization failed"
+        "/login?error_code=UNKNOWN&error=Facebook authorization failed"
       )
     })
   })


### PR DESCRIPTION
Closes [DIA-333](https://artsyproduct.atlassian.net/browse/DIA-333)

We were just rendering error toasts with the error message returned from the server. This is potentially a problem because you could send a login link with a custom (potentially malicious) error message. The utility of this would be limited though since you couldn't inject any code or links but 🤷 .

This switches to using error codes. We still have to use the query string to insert the email address but I don't see that as being a problem really?

Theoretically we could insert an error through Sharify but all this stuff being in JS makes small refactors annoying. But I can do that if we think this doesn't solve our problem.

[DIA-333]: https://artsyproduct.atlassian.net/browse/DIA-333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ