### PR TITLE
fix: update more filters button color

### DIFF
--- a/src/Components/Alert/Components/Form/SuggestedFilters.tsx
+++ b/src/Components/Alert/Components/Form/SuggestedFilters.tsx
@@ -102,7 +102,7 @@ export const SuggestedFilters: React.FC<SuggestedFiltersProps> = ({
 
         <Clickable onClick={transitionToFiltersAndTrack} mt={1}>
           <Flex justifyContent={"space-between"} alignItems={"center"}>
-            <Text variant="xs" color="black60" mr={0.5}>
+            <Text variant="xs" color="black100" mr={0.5}>
               More Filters
             </Text>
             <ChevronRightIcon height={14} width={14} />


### PR DESCRIPTION
The type of this PR is: **fix**

This PR solves [this request](https://www.notion.so/artsy/More-Filters-CTA-should-be-black-34bf69c3d3f04bde897d03eae5860d68?pvs=4) from design
 

### Description

Update more filters button color

