### PR TITLE
fix(convos): ensure messages account for linebreaks

### DIFF
--- a/src/Apps/Conversations/components/Message/ConversationMessageBubble.tsx
+++ b/src/Apps/Conversations/components/Message/ConversationMessageBubble.tsx
@@ -47,7 +47,7 @@ export const ConversationMessageBubble: FC<ConversationMessageBubbleProps> = ({
     isValidElement(children) && children?.type === ConversationMessageImage
 
   return (
-    <Flex width={["80%", "68%"]} alignSelf={bubbleDirection}>
+    <Flex maxWidth="85%" alignSelf={bubbleDirection}>
       {/* Avatar section */}
       {!simplified && !fromViewer && (
         <Flex


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

This fixes the issue where email client inserted line-breaks are rendering badly in CMS due to HTML formatting. By extending the width out a bit, we can mask things. 

This also makes it so that the message bubble size adapts to the overall width of the message, vs always being a fixed width. 

Before:

![Screenshot 2023-12-04 at 8 40 20 PM](https://github.com/artsy/force/assets/236943/517e3db7-200b-4afc-a59a-7ca9b5ffee25)

After: 

![Screenshot 2023-12-04 at 8 42 09 PM](https://github.com/artsy/force/assets/236943/f2ca29c3-827b-49e2-aa3f-97fdcf6085c2)



