### PR TITLE
feat: remove sections for churned profiles

### DIFF
--- a/src/Apps/Partner/Routes/Overview/index.tsx
+++ b/src/Apps/Partner/Routes/Overview/index.tsx
@@ -7,7 +7,6 @@ import { AboutPartnerFragmentContainer } from "Apps/Partner/Components/Overview/
 import { SubscriberBannerFragmentContainer } from "Apps/Partner/Components/Overview/SubscriberBanner"
 import { ArtworksRailRenderer } from "Apps/Partner/Components/Overview/ArtworksRail"
 import { ShowBannersRailRenderer } from "Apps/Partner/Components/Overview/ShowBannersRail/ShowBannersRail"
-import { NearbyGalleriesRailRenderer } from "Apps/Partner/Components/Overview/NearbyGalleriesRail"
 
 interface OverviewProps {
   partner: Overview_partner$data
@@ -20,10 +19,7 @@ const Overview: React.FC<OverviewProps> = ({ partner }) => {
     displayFullPartnerPage,
     profileBannerDisplay,
     displayArtistsSection,
-    locationsConnection,
   } = partner
-
-  const location = locationsConnection?.edges![0]?.node
 
   return displayFullPartnerPage ? (
     <>
@@ -48,21 +44,6 @@ const Overview: React.FC<OverviewProps> = ({ partner }) => {
       {partnerType !== "Brand" && (
         <SubscriberBannerFragmentContainer partner={partner} />
       )}
-
-      <AboutPartnerFragmentContainer partner={partner} />
-
-      <ShowsRailFragmentContainer mt={4} mb={[4, 12]} partner={partner} />
-
-      {displayArtistsSection && (
-        <ArtistsRailFragmentContainer mt={4} mb={[4, 12]} partner={partner} />
-      )}
-
-      {location && location.coordinates && (
-        <NearbyGalleriesRailRenderer
-          mt={[4, 6]}
-          near={`${location.coordinates.lat},${location.coordinates.lng}`}
-        />
-      )}
     </>
   )
 }
@@ -80,16 +61,6 @@ export const OverviewFragmentContainer = createFragmentContainer(Overview, {
       ...ArtistsRail_partner
       ...SubscriberBanner_partner
       ...ArticlesRail_partner
-      locationsConnection(first: 1) {
-        edges {
-          node {
-            coordinates {
-              lat
-              lng
-            }
-          }
-        }
-      }
     }
   `,
 })

--- a/src/__generated__/Overview_partner.graphql.ts
+++ b/src/__generated__/Overview_partner.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0ab92a3a839efd9268221b96e97cc79c>>
+ * @generated SignedSource<<e57d7572c01fa7f29aebfc5861dcf00d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,16 +13,6 @@ import { FragmentRefs } from "relay-runtime";
 export type Overview_partner$data = {
   readonly displayArtistsSection: boolean | null | undefined;
   readonly displayFullPartnerPage: boolean | null | undefined;
-  readonly locationsConnection: {
-    readonly edges: ReadonlyArray<{
-      readonly node: {
-        readonly coordinates: {
-          readonly lat: number | null | undefined;
-          readonly lng: number | null | undefined;
-        } | null | undefined;
-      } | null | undefined;
-    } | null | undefined> | null | undefined;
-  } | null | undefined;
   readonly partnerType: string | null | undefined;
   readonly profileBannerDisplay: string | null | undefined;
   readonly slug: string;
@@ -99,76 +89,12 @@ const node: ReaderFragment = {
       "args": null,
       "kind": "FragmentSpread",
       "name": "ArticlesRail_partner"
-    },
-    {
-      "alias": null,
-      "args": [
-        {
-          "kind": "Literal",
-          "name": "first",
-          "value": 1
-        }
-      ],
-      "concreteType": "LocationConnection",
-      "kind": "LinkedField",
-      "name": "locationsConnection",
-      "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": "LocationEdge",
-          "kind": "LinkedField",
-          "name": "edges",
-          "plural": true,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "concreteType": "Location",
-              "kind": "LinkedField",
-              "name": "node",
-              "plural": false,
-              "selections": [
-                {
-                  "alias": null,
-                  "args": null,
-                  "concreteType": "LatLng",
-                  "kind": "LinkedField",
-                  "name": "coordinates",
-                  "plural": false,
-                  "selections": [
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "lat",
-                      "storageKey": null
-                    },
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "lng",
-                      "storageKey": null
-                    }
-                  ],
-                  "storageKey": null
-                }
-              ],
-              "storageKey": null
-            }
-          ],
-          "storageKey": null
-        }
-      ],
-      "storageKey": "locationsConnection(first:1)"
     }
   ],
   "type": "Partner",
   "abstractKey": null
 };
 
-(node as any).hash = "863392a7d608cb535b05e18ed354289b";
+(node as any).hash = "d0a31ff389e9ae2c848d12fa894112f9";
 
 export default node;

--- a/src/__generated__/partnerRoutes_OverviewQuery.graphql.ts
+++ b/src/__generated__/partnerRoutes_OverviewQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9e705a2f866a771d46b212673799a9c1>>
+ * @generated SignedSource<<444e7460074ed42ec080e26ff3f4f4db>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -561,71 +561,6 @@ return {
             ],
             "storageKey": "articlesConnection(first:8)"
           },
-          {
-            "alias": null,
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "first",
-                "value": 1
-              }
-            ],
-            "concreteType": "LocationConnection",
-            "kind": "LinkedField",
-            "name": "locationsConnection",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "LocationEdge",
-                "kind": "LinkedField",
-                "name": "edges",
-                "plural": true,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Location",
-                    "kind": "LinkedField",
-                    "name": "node",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "LatLng",
-                        "kind": "LinkedField",
-                        "name": "coordinates",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "lat",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "lng",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v3/*: any*/)
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              }
-            ],
-            "storageKey": "locationsConnection(first:1)"
-          },
           (v3/*: any*/)
         ],
         "storageKey": null
@@ -633,12 +568,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "55eefefc42cf3f6b7de011a5143f290e",
+    "cacheID": "048a093aef7ce3070f7f2cb12ec06c34",
     "id": null,
     "metadata": {},
     "name": "partnerRoutes_OverviewQuery",
     "operationKind": "query",
-    "text": "query partnerRoutes_OverviewQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    ...Overview_partner\n    id\n  }\n}\n\nfragment AboutPartner_partner on Partner {\n  profile {\n    fullBio\n    bio\n    id\n  }\n  website\n  vatNumber\n  displayFullPartnerPage\n  slug\n  internalID\n}\n\nfragment ArticlesRail_partner on Partner {\n  slug\n  articlesConnection(first: 8) {\n    totalCount\n    edges {\n      node {\n        internalID\n        ...CellArticle_article\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistsRail_partner on Partner {\n  slug\n  profileArtistsLayout\n  displayFullPartnerPage\n  artistsWithPublishedArtworks: artistsConnection(hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  representedArtistsWithoutPublishedArtworks: artistsConnection(representedBy: true, hasPublishedArtworks: false, displayOnPartnerProfile: true) {\n    totalCount\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment CellShow_show on Show {\n  internalID\n  slug\n  name\n  href\n  startAt\n  endAt\n  isFairBooth\n  exhibitionPeriod\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  coverImage {\n    cropped(width: 445, height: 334, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment Overview_partner on Partner {\n  slug\n  partnerType\n  displayFullPartnerPage\n  profileBannerDisplay\n  displayArtistsSection\n  ...AboutPartner_partner\n  ...ShowsRail_partner\n  ...ArtistsRail_partner\n  ...SubscriberBanner_partner\n  ...ArticlesRail_partner\n  locationsConnection(first: 1) {\n    edges {\n      node {\n        coordinates {\n          lat\n          lng\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ShowsRail_partner on Partner {\n  slug\n  displayFullPartnerPage\n  showsConnection(status: ALL, first: 20, isDisplayable: true) {\n    totalCount\n    edges {\n      node {\n        ...CellShow_show\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment SubscriberBanner_partner on Partner {\n  hasFairPartnership\n  name\n}\n"
+    "text": "query partnerRoutes_OverviewQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    ...Overview_partner\n    id\n  }\n}\n\nfragment AboutPartner_partner on Partner {\n  profile {\n    fullBio\n    bio\n    id\n  }\n  website\n  vatNumber\n  displayFullPartnerPage\n  slug\n  internalID\n}\n\nfragment ArticlesRail_partner on Partner {\n  slug\n  articlesConnection(first: 8) {\n    totalCount\n    edges {\n      node {\n        internalID\n        ...CellArticle_article\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistsRail_partner on Partner {\n  slug\n  profileArtistsLayout\n  displayFullPartnerPage\n  artistsWithPublishedArtworks: artistsConnection(hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  representedArtistsWithoutPublishedArtworks: artistsConnection(representedBy: true, hasPublishedArtworks: false, displayOnPartnerProfile: true) {\n    totalCount\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment CellShow_show on Show {\n  internalID\n  slug\n  name\n  href\n  startAt\n  endAt\n  isFairBooth\n  exhibitionPeriod\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  coverImage {\n    cropped(width: 445, height: 334, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment Overview_partner on Partner {\n  slug\n  partnerType\n  displayFullPartnerPage\n  profileBannerDisplay\n  displayArtistsSection\n  ...AboutPartner_partner\n  ...ShowsRail_partner\n  ...ArtistsRail_partner\n  ...SubscriberBanner_partner\n  ...ArticlesRail_partner\n}\n\nfragment ShowsRail_partner on Partner {\n  slug\n  displayFullPartnerPage\n  showsConnection(status: ALL, first: 20, isDisplayable: true) {\n    totalCount\n    edges {\n      node {\n        ...CellShow_show\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment SubscriberBanner_partner on Partner {\n  hasFairPartnership\n  name\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [DIA-346]

### Description
It removes the sections for the churned profiles.

Before:
<img width="1728" alt="Screenshot 2023-12-07 at 11 55 11" src="https://github.com/artsy/force/assets/1176374/f90812ee-1732-4b96-8571-9a1a37075d52">

After:
<img width="1728" alt="Screenshot 2023-12-07 at 11 55 22" src="https://github.com/artsy/force/assets/1176374/97c8b616-7ac9-4f78-801d-14162dba8019">


<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DIA-346]: https://artsyproduct.atlassian.net/browse/DIA-346?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ