### PR TITLE
fix(dia-333): prevent insertion of arbitrary error messages

### DIFF
--- a/src/Apps/Authentication/Components/AuthenticationInlineDialog.tsx
+++ b/src/Apps/Authentication/Components/AuthenticationInlineDialog.tsx
@@ -20,17 +20,25 @@ const AuthenticationInlineDialogContents: FC = () => {
     match: { location },
   } = useRouter()
 
-  // Errors might come back from 3rd party authentication
-  // as a string in an `error` query param, so display them if present.
+  // Errors might come back from 3rd party authentication so display them if present.
   useEffect(() => {
-    if (!location.query.error) return
+    if (!location.query.error_code) return
 
-    sendToast({
-      message: location.query.error,
-      variant: "error",
-      ttl: Infinity,
-    })
-  }, [location.query.error, sendToast])
+    const message = (
+      ERROR_CODES[location.query.error_code] || ERROR_CODES.UNKNOWN
+    ).replace(/{provider}/g, PROVIDERS[location.query.provider] || "—")
+
+    if (location.query.error) {
+      console.error(location.query.error)
+    }
+
+    sendToast({ message, variant: "error", ttl: Infinity })
+  }, [
+    location.query.error,
+    location.query.error_code,
+    location.query.provider,
+    sendToast,
+  ])
 
   return (
     <>
@@ -82,4 +90,18 @@ export const AuthenticationInlineDialog: FC<AuthenticationInlineDialogProps> = (
       <AuthenticationInlineDialogContents />
     </AuthenticationInlineDialogProvider>
   )
+}
+
+const ERROR_CODES = {
+  ALREADY_EXISTS: `A user with this email address already exists. Log in to Artsy via email and password and link {provider} in your settings instead.`,
+  PREVIOUSLY_LINKED_SETTINGS: `{provider} account previously linked to Artsy. Log in to your Artsy account via email and password and link {provider} in your settings instead.`,
+  PREVIOUSLY_LINKED: `{provider} account previously linked to Artsy.`,
+  IP_BLOCKED: "Your IP address was blocked by {provider}.",
+  UNKNOWN: "An unknown error occurred. Please try again.",
+}
+
+const PROVIDERS = {
+  facebook: "Facebook",
+  google: "Google",
+  apple: "Apple",
 }

--- a/src/Server/passport/lib/app/lifecycle.ts
+++ b/src/Server/passport/lib/app/lifecycle.ts
@@ -151,50 +151,47 @@ module.exports.afterSocialAuth = (provider: Provider) =>
     const linkingAccount = req.user != null
 
     passport.authenticate(provider)(req, res, function (err: any) {
-      let msg: string
       if (
-        err &&
-        err.response &&
-        err.response.body &&
-        err.response.body.error === "User Already Exists"
+        err?.response?.body?.error === "User Already Exists" &&
+        req.socialProfileEmail
       ) {
-        if (req.socialProfileEmail) {
-          msg =
-            `A user with the email address ${req.socialProfileEmail} already ` +
-            "exists. Log in to Artsy via email and password and link " +
-            `${providerName} in your settings instead.`
-        } else {
-          msg =
-            `${providerName} account previously linked to Artsy. ` +
-            "Log in to your Artsy account via email and password and link " +
-            `${providerName} in your settings instead.`
-        }
+        const msg =
+          `A user with the email address ${req.socialProfileEmail} already ` +
+          "exists. Log in to Artsy via email and password and link " +
+          `${providerName} in your settings instead.`
         return res.redirect(opts.loginPagePath + "?error=" + msg)
-      } else if (
-        err &&
-        err.response &&
-        err.response.body &&
-        err.response.body.error === "Another Account Already Linked"
-      ) {
-        msg = `${providerName} account previously linked to Artsy.`
+      }
+
+      if (err?.response?.body?.error === "User Already Exists") {
+        const msg =
+          `${providerName} account previously linked to Artsy. ` +
+          "Log in to your Artsy account via email and password and link " +
+          `${providerName} in your settings instead.`
+        return res.redirect(opts.loginPagePath + "?error=" + msg)
+      }
+
+      if (err?.response?.body?.error === "Another Account Already Linked") {
+        const msg = `${providerName} account previously linked to Artsy.`
         return res.redirect(`${opts.settingsPagePath}?error=${msg}`)
-      } else if (
-        err &&
-        err.message &&
-        err.message.match("Unauthorized source IP address")
-      ) {
-        msg = `Your IP address was blocked by ${providerName}.`
+      }
+
+      if (err?.message?.match("Unauthorized source IP address")) {
+        const msg = `Your IP address was blocked by ${providerName}.`
         return res.redirect(opts.loginPagePath + "?error=" + msg)
-      } else if (err != null) {
-        msg =
+      }
+
+      if (err !== null) {
+        const msg =
           err.message ||
           (typeof err.toString === "function" ? err.toString() : undefined)
         return res.redirect(opts.loginPagePath + "?error=" + msg)
-      } else if (linkingAccount) {
-        return res.redirect(opts.settingsPagePath)
-      } else {
-        return next()
       }
+
+      if (linkingAccount) {
+        return res.redirect(opts.settingsPagePath)
+      }
+
+      return next()
     })
   }
 

--- a/src/Server/passport/lib/app/lifecycle.ts
+++ b/src/Server/passport/lib/app/lifecycle.ts
@@ -145,6 +145,7 @@ module.exports.afterSocialAuth = (provider: Provider) =>
     if (req.query.denied) {
       return next(new Error(`${provider} denied`))
     }
+
     // Determine if we're linking the account and handle any Gravity errors
     // that we can do a better job explaining and redirecting for.
     const providerName = capitalize(provider)
@@ -155,36 +156,30 @@ module.exports.afterSocialAuth = (provider: Provider) =>
         err?.response?.body?.error === "User Already Exists" &&
         req.socialProfileEmail
       ) {
-        const msg =
-          `A user with the email address ${req.socialProfileEmail} already ` +
-          "exists. Log in to Artsy via email and password and link " +
-          `${providerName} in your settings instead.`
-        return res.redirect(opts.loginPagePath + "?error=" + msg)
+        const message = `A user with the email address ${req.socialProfileEmail} already exists. Log in to Artsy via email and password and link ${providerName} in your settings instead.`
+        return res.redirect(`${opts.loginPagePath}?error=${message}`)
       }
 
       if (err?.response?.body?.error === "User Already Exists") {
-        const msg =
-          `${providerName} account previously linked to Artsy. ` +
-          "Log in to your Artsy account via email and password and link " +
-          `${providerName} in your settings instead.`
-        return res.redirect(opts.loginPagePath + "?error=" + msg)
+        const message = `${providerName} account previously linked to Artsy. Log in to your Artsy account via email and password and link ${providerName} in your settings instead.`
+        return res.redirect(`${opts.loginPagePath}?error=${message}`)
       }
 
       if (err?.response?.body?.error === "Another Account Already Linked") {
-        const msg = `${providerName} account previously linked to Artsy.`
-        return res.redirect(`${opts.settingsPagePath}?error=${msg}`)
+        const message = `${providerName} account previously linked to Artsy.`
+        return res.redirect(`${opts.settingsPagePath}?error=${message}`)
       }
 
       if (err?.message?.match("Unauthorized source IP address")) {
-        const msg = `Your IP address was blocked by ${providerName}.`
-        return res.redirect(opts.loginPagePath + "?error=" + msg)
+        const message = `Your IP address was blocked by ${providerName}.`
+        return res.redirect(`${opts.loginPagePath}?error=${message}`)
       }
 
       if (err !== null) {
-        const msg =
+        const message =
           err.message ||
           (typeof err.toString === "function" ? err.toString() : undefined)
-        return res.redirect(opts.loginPagePath + "?error=" + msg)
+        return res.redirect(`${opts.loginPagePath}?error=${message}`)
       }
 
       if (linkingAccount) {

--- a/src/Server/passport/test/app/lifecycle.jest.js
+++ b/src/Server/passport/test/app/lifecycle.jest.js
@@ -168,7 +168,7 @@ describe("lifecycle", function () {
       )
       lifecycle.afterSocialAuth("facebook")(req, res, next)
       expect(res.redirect.args[0][0]).toEqual(
-        "/login?error=Your IP address was blocked by Facebook."
+        "/login?error_code=IP_BLOCKED&provider=facebook"
       )
     })
 
@@ -178,7 +178,7 @@ describe("lifecycle", function () {
       )
       lifecycle.afterSocialAuth("facebook")(req, res, next)
       expect(res.redirect.args[0][0]).toEqual(
-        "/login?error=Facebook authorization failed"
+        "/login?error_code=UNKNOWN&error=Facebook authorization failed"
       )
     })
   })


### PR DESCRIPTION
Closes [DIA-333](https://artsyproduct.atlassian.net/browse/DIA-333)

Cleaned up https://github.com/artsy/force/pull/13236 and removed the email insertion. Using Sharify here was actually a problem and this winds up being simpler.

---------

We were just rendering error toasts with the error message returned from the server. This is potentially a problem because you could send a login link with a custom (potentially malicious) error message. The utility of this would be limited though since you couldn't inject any code or links but 🤷 .

This switches to using error codes.

[DIA-333]: https://artsyproduct.atlassian.net/browse/DIA-333?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ