### PR TITLE
feat: allow conditional editing of alert artist criteria

### DIFF
--- a/src/Components/Alert/Components/CriteriaPills.tsx
+++ b/src/Components/Alert/Components/CriteriaPills.tsx
@@ -30,7 +30,11 @@ export const CriteriaPills: FC<CriteriaPillsProps> = ({ editable = true }) => {
 
         const key = `filter-label-${label?.field}-${label?.value}`
 
-        if (!editable || label?.field === "artistIDs") {
+        if (
+          !editable ||
+          (label?.field === "artistIDs" &&
+            state.criteria.artistIDs?.length === 1)
+        ) {
           return (
             <Pill key={key} variant="filter" disabled>
               {label?.displayValue}

--- a/src/Components/Alert/Components/CriteriaPills.tsx
+++ b/src/Components/Alert/Components/CriteriaPills.tsx
@@ -30,11 +30,10 @@ export const CriteriaPills: FC<CriteriaPillsProps> = ({ editable = true }) => {
 
         const key = `filter-label-${label?.field}-${label?.value}`
 
-        if (
-          !editable ||
-          (label?.field === "artistIDs" &&
-            state.criteria.artistIDs?.length === 1)
-        ) {
+        const isLastArtistCriteria =
+          label?.field === "artistIDs" && state.criteria.artistIDs?.length === 1
+
+        if (!editable || isLastArtistCriteria) {
           return (
             <Pill key={key} variant="filter" disabled>
               {label?.displayValue}


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [ONYX-561](https://artsyproduct.atlassian.net/browse/ONYX-561)

### Description

Allow conditional editing of alert artist criteria when an alert is associated with more than one artist.

### Screen Recording


https://github.com/artsy/force/assets/123595/6bced048-9c9a-4f54-b4a5-2df68f730222




[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-561]: https://artsyproduct.atlassian.net/browse/ONYX-561?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ