### PR TITLE
feat(EMI-1592): show the list price for a partner offer

### DIFF
--- a/src/Apps/Order/Components/ArtworkSummaryItem.tsx
+++ b/src/Apps/Order/Components/ArtworkSummaryItem.tsx
@@ -82,12 +82,17 @@ const ArtworkSummaryItem: React.FC<ArtworkSummaryItemProps> = ({
             </Text>
           </>
         )}
-        {!isPrivateSale && artworkPrice && (
+        {!isPrivateSale && artworkPrice?.price && (
           <Text variant="sm">
             {`${priceLabel} ${appendCurrencySymbol(
               artworkPrice.price,
               currencyCode
             )}`}
+          </Text>
+        )}
+        {isPartnerOffer && !artworkPrice?.price && (
+          <Text variant="sm">
+            {`${priceLabel}`}: Not publicly listed
           </Text>
         )}
       </Flex>

--- a/src/Apps/Order/Components/ArtworkSummaryItem.tsx
+++ b/src/Apps/Order/Components/ArtworkSummaryItem.tsx
@@ -90,7 +90,7 @@ const ArtworkSummaryItem: React.FC<ArtworkSummaryItemProps> = ({
             )}`}
           </Text>
         )}
-        {isPartnerOffer && !artworkPrice?.price && (
+        {!artworkPrice?.price && (
           <Text variant="sm">
             {`${priceLabel}`}: Not publicly listed
           </Text>

--- a/src/Apps/Order/Components/ArtworkSummaryItem.tsx
+++ b/src/Apps/Order/Components/ArtworkSummaryItem.tsx
@@ -49,9 +49,10 @@ const ArtworkSummaryItem: React.FC<ArtworkSummaryItemProps> = ({
 
   const artworkPrice = getOfferItemFromOrder(lineItems)
 
-  const priceLabel = mode === "OFFER" ? "List price" : "Price"
-
   const isPrivateSale = source === "private_sale"
+  const isPartnerOffer = source === "partner_offer"
+
+  const priceLabel = ((mode === "OFFER") || isPartnerOffer) ? "List price" : "Price"
 
   return (
     <StackableBorderBox flexDirection="row" {...others}>


### PR DESCRIPTION
The type of this PR is: Feat

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves EMI-1592

### Description

When the order is a partner offer without a list price, the price label should be `List price` and the value for the price should be `Not publicly listed` now. 

#### ScreenShot

##### Price range

![Screenshot 2023-12-08 at 10 52 27](https://github.com/artsy/force/assets/827596/f5ea849b-5283-422d-8fc8-433c07c33201)

##### Price hidden


<img width="1735" alt="Screenshot 2023-12-08 at 15 24 44" src="https://github.com/artsy/force/assets/827596/3898cd69-8a07-4af7-a79b-b02b10249fc1">


<!-- Implementation description -->

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ