### PR TITLE
chore: AMBER-361 - remove draft visibility level

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -20882,7 +20882,6 @@ input ViewingRoomSubsectionInput {
 }
 
 enum Visibility {
-  DRAFT
   LISTED
   UNLISTED
 }

--- a/src/__generated__/ArtworkApp_artwork.graphql.ts
+++ b/src/__generated__/ArtworkApp_artwork.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b94c48db6e3483f259ef586265793a58>>
+ * @generated SignedSource<<31331498e0e33e31dce953a06795bac9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,7 +9,7 @@
 // @ts-nocheck
 
 import { Fragment, ReaderFragment } from 'relay-runtime';
-export type Visibility = "DRAFT" | "LISTED" | "UNLISTED" | "%future added value";
+export type Visibility = "LISTED" | "UNLISTED" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type ArtworkApp_artwork$data = {
   readonly artist: {

--- a/src/__generated__/ArtworkMeta_artwork.graphql.ts
+++ b/src/__generated__/ArtworkMeta_artwork.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4f57916ebd96e684530391d1abac06d2>>
+ * @generated SignedSource<<cbdf9fba2a51d91b25dceec68fe1bbba>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,7 +9,7 @@
 // @ts-nocheck
 
 import { Fragment, ReaderFragment } from 'relay-runtime';
-export type Visibility = "DRAFT" | "LISTED" | "UNLISTED" | "%future added value";
+export type Visibility = "LISTED" | "UNLISTED" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type ArtworkMeta_artwork$data = {
   readonly href: string | null | undefined;


### PR DESCRIPTION
The type of this PR is: **CHORE**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR partially solves [AMBER-361]

### Description

<!-- Implementation description -->
This PR unblocks the Metaphysics PR: https://github.com/artsy/metaphysics/pull/5467. As part of some ongoing Gravity changes, we are removing support for the `draft` `visibility_level`. The `published` attribute is the decider of whether an artwork is a draft (aka unpublished) or not.

cc: @artsy/amber-devs 