### PR TITLE
fix(ONYX-591): update copy for criteria pills in edit alert form

### DIFF
--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/NewSavedSearchAlertEditForm.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/NewSavedSearchAlertEditForm.tsx
@@ -144,7 +144,7 @@ const NewSavedSearchAlertEditForm: React.FC<NewSavedSearchAlertEditFormProps> = 
           <Box>
             <Join separator={<Spacer y={[4, 6]} />}>
               <Box>
-                <Text variant="xs">Filters</Text>
+                <Text variant="sm-display">We'll send you alerts for</Text>
                 <Spacer y={2} />
                 <Flex flexWrap="wrap" gap={1}>
                   <CriteriaPills />


### PR DESCRIPTION
The type of this PR is: Fix

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [ONYX-591](https://artsyproduct.atlassian.net/browse/ONYX-591)

### Description

Update copy for criteria pills title in the edit alert form

<img width="794" alt="Screenshot 2023-12-11 at 17 33 27" src="https://github.com/artsy/force/assets/17580625/584c4b93-2fe0-42f1-a25c-b98f9f6a9e14">




[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-591]: https://artsyproduct.atlassian.net/browse/ONYX-591?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ