### PR TITLE
fix(alerts): ensure artist series is editable in new form

### DIFF
--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/NewSavedSearchAlertEditForm.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/NewSavedSearchAlertEditForm.tsx
@@ -254,6 +254,7 @@ export const NewSavedSearchAlertEditFormFragmentContainer = createFragmentContai
         acquireable
         additionalGeneIDs
         artistIDs
+        artistSeriesIDs
         atAuction
         attributionClass
         colors

--- a/src/__generated__/NewSavedSearchAlertEditFormQuery.graphql.ts
+++ b/src/__generated__/NewSavedSearchAlertEditFormQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3f62589a13a74921b3248be238f8b525>>
+ * @generated SignedSource<<55c8d19b6d7dd2217f0314877cdbff02>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -19,6 +19,7 @@ export type NewSavedSearchAlertEditFormQuery$data = {
       readonly acquireable: boolean | null | undefined;
       readonly additionalGeneIDs: ReadonlyArray<string>;
       readonly artistIDs: ReadonlyArray<string> | null | undefined;
+      readonly artistSeriesIDs: ReadonlyArray<string>;
       readonly atAuction: boolean | null | undefined;
       readonly attributionClass: ReadonlyArray<string>;
       readonly colors: ReadonlyArray<string>;
@@ -106,6 +107,13 @@ v2 = {
       "args": null,
       "kind": "ScalarField",
       "name": "artistIDs",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "artistSeriesIDs",
       "storageKey": null
     },
     {
@@ -346,12 +354,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "2174b7718bb0957bce7a4d8758ae51b7",
+    "cacheID": "04bb3500b151eb23817586e4d5b38ba8",
     "id": null,
     "metadata": {},
     "name": "NewSavedSearchAlertEditFormQuery",
     "operationKind": "query",
-    "text": "query NewSavedSearchAlertEditFormQuery(\n  $id: ID!\n) {\n  viewer {\n    ...NewSavedSearchAlertEditForm_viewer\n  }\n  me {\n    savedSearch(id: $id) {\n      internalID\n      acquireable\n      additionalGeneIDs\n      artistIDs\n      atAuction\n      attributionClass\n      colors\n      dimensionRange\n      sizes\n      width\n      height\n      inquireableOnly\n      locationCities\n      majorPeriods\n      materialsTerms\n      offerable\n      partnerIDs\n      priceRange\n      userAlertSettings {\n        name\n        email\n        push\n        details\n      }\n    }\n    id\n  }\n}\n\nfragment NewSavedSearchAlertEditForm_viewer on Viewer {\n  notificationPreferences {\n    status\n    name\n    channel\n  }\n}\n"
+    "text": "query NewSavedSearchAlertEditFormQuery(\n  $id: ID!\n) {\n  viewer {\n    ...NewSavedSearchAlertEditForm_viewer\n  }\n  me {\n    savedSearch(id: $id) {\n      internalID\n      acquireable\n      additionalGeneIDs\n      artistIDs\n      artistSeriesIDs\n      atAuction\n      attributionClass\n      colors\n      dimensionRange\n      sizes\n      width\n      height\n      inquireableOnly\n      locationCities\n      majorPeriods\n      materialsTerms\n      offerable\n      partnerIDs\n      priceRange\n      userAlertSettings {\n        name\n        email\n        push\n        details\n      }\n    }\n    id\n  }\n}\n\nfragment NewSavedSearchAlertEditForm_viewer on Viewer {\n  notificationPreferences {\n    status\n    name\n    channel\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/NewSavedSearchAlertEditForm_searchCriteria.graphql.ts
+++ b/src/__generated__/NewSavedSearchAlertEditForm_searchCriteria.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7e9ed5578689a4fad30c1069b0ad763f>>
+ * @generated SignedSource<<15a6c639161ed96de104cc20bb36930e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -14,6 +14,7 @@ export type NewSavedSearchAlertEditForm_searchCriteria$data = {
   readonly acquireable: boolean | null | undefined;
   readonly additionalGeneIDs: ReadonlyArray<string>;
   readonly artistIDs: ReadonlyArray<string> | null | undefined;
+  readonly artistSeriesIDs: ReadonlyArray<string>;
   readonly atAuction: boolean | null | undefined;
   readonly attributionClass: ReadonlyArray<string>;
   readonly colors: ReadonlyArray<string>;
@@ -74,6 +75,13 @@ const node: ReaderFragment = {
       "args": null,
       "kind": "ScalarField",
       "name": "artistIDs",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "artistSeriesIDs",
       "storageKey": null
     },
     {
@@ -218,6 +226,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "e7f4e7a2d12753dfb192d9ac4a0b269d";
+(node as any).hash = "89ca30cf0aa095c54123abd353fbcb35";
 
 export default node;


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [ONYX-599]

### Description

From the QA session for the new edit form — quick easy fix to ensure that artist series criteria, when present, are displayed and actionable.


https://github.com/artsy/force/assets/140521/e4801e19-82cf-4707-9d9f-a25901d0a185



[ONYX-599]: https://artsyproduct.atlassian.net/browse/ONYX-599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ