### PR TITLE
fix(ONYX-598): fix resizing of the edit alert form and filters

### DIFF
--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/NewSavedSearchAlertEditForm.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/NewSavedSearchAlertEditForm.tsx
@@ -69,7 +69,7 @@ const NewSavedSearchAlertEditSteps: React.FC<NewSavedSearchAlertEditStepsProps> 
     <>
       <Media greaterThanOrEqual="md">
         {current === "ALERT_DETAILS" && (
-          <Box flex={1} p={4}>
+          <Box p={4} minWidth={[null, null]}>
             <Flex justifyContent="space-between">
               <ModalHeader />
               <Clickable onClick={onCloseClick}>
@@ -141,7 +141,7 @@ const NewSavedSearchAlertEditForm: React.FC<NewSavedSearchAlertEditFormProps> = 
         }
 
         return (
-          <Box>
+          <Box flex={1}>
             <Join separator={<Spacer y={[4, 6]} />}>
               <Box>
                 <Text variant="sm-display">We'll send you alerts for</Text>
@@ -221,6 +221,7 @@ const NewSavedSearchAlertEditForm: React.FC<NewSavedSearchAlertEditFormProps> = 
                 <Spacer y={1} />
 
                 <Button
+                  mb={2}
                   variant="secondaryBlack"
                   width="100%"
                   onClick={onDeleteClick}

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/NewSavedSearchAlertEditForm.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/NewSavedSearchAlertEditForm.tsx
@@ -69,7 +69,7 @@ const NewSavedSearchAlertEditSteps: React.FC<NewSavedSearchAlertEditStepsProps> 
     <>
       <Media greaterThanOrEqual="md">
         {current === "ALERT_DETAILS" && (
-          <Box p={4} minWidth={[null, null]}>
+          <Box p={4}>
             <Flex justifyContent="space-between">
               <ModalHeader />
               <Clickable onClick={onCloseClick}>

--- a/src/Components/Alert/Components/Steps/Filters.tsx
+++ b/src/Components/Alert/Components/Steps/Filters.tsx
@@ -6,39 +6,39 @@ import { PriceQueryRenderer } from "Components/Alert/Components/Filters/Price"
 import { WaysToBuy } from "Components/Alert/Components/Filters/WaysToBuy"
 import { Color } from "Components/Alert/Components/Filters/Color"
 import { useDidMount } from "Utils/Hooks/useDidMount"
+import { useAlertContext } from "Components/Alert/Hooks/useAlertContext"
 
 export const Filters: FC = () => {
   const isMounted = useDidMount()
+  const { state } = useAlertContext()
 
   return (
-    <>
-      <Box
-        minWidth={[null, 700]}
-        p={2}
-        style={{
-          ...(isMounted
-            ? {
-                opacity: 1,
-                transition: "opacity 250ms",
-              }
-            : {
-                opacity: 0,
-              }),
-        }}
-      >
-        <Flex flexDirection="column" width="auto">
-          <Text variant="lg">Filters</Text>
-          <Separator my={2} />
-          <Join separator={<Separator my={2} />}>
-            <Medium />
-            <Rarity />
-            <PriceQueryRenderer />
-            <WaysToBuy />
-            <Color />
-          </Join>
-          <Spacer y={[4, 6]} />
-        </Flex>
-      </Box>
-    </>
+    <Box
+      minWidth={[null, state.isEditMode ? null : 700]}
+      p={2}
+      style={{
+        ...(isMounted
+          ? {
+              opacity: 1,
+              transition: "opacity 250ms",
+            }
+          : {
+              opacity: 0,
+            }),
+      }}
+    >
+      <Flex flexDirection="column" width="auto">
+        <Text variant="lg">Filters</Text>
+        <Separator my={2} />
+        <Join separator={<Separator my={2} />}>
+          <Medium />
+          <Rarity />
+          <PriceQueryRenderer />
+          <WaysToBuy />
+          <Color />
+        </Join>
+        <Spacer y={[4, 6]} />
+      </Flex>
+    </Box>
   )
 }


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [ONYX-598]

### Description

<!-- Implementation description -->
[Notion ticket](https://www.notion.so/artsy/The-filters-do-not-resize-well-on-medium-size-screens-e-g-ipad-bb5d3dd0b328487eb50826d9bf97a240?pvs=4)
The size of the details and filters form did not change when resizing the screen. This PR fixes it

**Before**
https://www.notion.so/artsy/New-Edit-Alert-Form-web-QA-Session-ce3682253e194683b9417437560a0647?p=bb5d3dd0b328487eb50826d9bf97a240&pm=s 

**After**

https://github.com/artsy/force/assets/36167539/a06549a7-1906-4eb3-810f-e5917e6f7fb5




[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-598]: https://artsyproduct.atlassian.net/browse/ONYX-598?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ