### PR TITLE
fix(onyx-559): search pills - fixes wrong pill state that makes counter superscript invisible

### DIFF
--- a/src/Apps/Search/Components/NavigationTabs.tsx
+++ b/src/Apps/Search/Components/NavigationTabs.tsx
@@ -1,9 +1,9 @@
 import * as React from "react"
-import { HorizontalOverflow, Pill } from "@artsy/palette"
+import { BoxProps, HorizontalOverflow, Pill } from "@artsy/palette"
 import { NavigationTabs_searchableConnection$data } from "__generated__/NavigationTabs_searchableConnection.graphql"
 import { useAnalyticsContext } from "System/Analytics/AnalyticsContext"
 import { createFragmentContainer, graphql } from "react-relay"
-import { RouterLink } from "System/Router/RouterLink"
+import { RouterLink, RouterLinkProps } from "System/Router/RouterLink"
 import { useIsRouteActive } from "System/Router/useRouter"
 import {
   ActionType,
@@ -37,23 +37,42 @@ const TAB_NAME_MAP = {
   gene: "Categories",
 }
 
-interface TabProps {
+interface RouteTabProps extends BoxProps, RouterLinkProps {
   text: string
-  to: string
-  exact?: boolean
   count?: number
 }
 
-const Tab: React.FC<TabProps> = ({ text, to, exact, count }) => {
-  const router = useRouter()
+const RoundedRouteTab: React.FC<RouteTabProps> = ({ text, count, ...rest }) => {
+  const isSelected = useIsRouteActive(rest.to, { exact: rest.exact ?? true })
+
+  return (
+    // @ts-ignore
+    <Pill
+      variant="search"
+      count={count}
+      as={RouterLink}
+      my={1}
+      mr={1}
+      selected={isSelected}
+      {...rest}
+    >
+      {text}
+    </Pill>
+  )
+}
+
+export const NavigationTabs: React.FC<NavigationTabsProps> = ({
+  term,
+  artworkCount,
+  searchableConnection,
+}) => {
   const tracking = useTracking()
+  const router = useRouter()
   const {
     contextPageOwnerId,
     contextPageOwnerSlug,
     contextPageOwnerType,
   } = useAnalyticsContext()
-  const tabName = text.replace(/[0-9]/g, "").trim()
-  const isSelected = useIsRouteActive(to, { exact: exact ?? true })
 
   const trackClick = (destinationPath: string, subject: string) => () => {
     const trackingData: ClickedNavigationTab = {
@@ -69,32 +88,6 @@ const Tab: React.FC<TabProps> = ({ text, to, exact, count }) => {
     tracking.trackEvent(trackingData)
   }
 
-  return (
-    // @ts-ignore
-    <Pill
-      variant="search"
-      count={count}
-      as={RouterLink}
-      my={1}
-      mr={1}
-      selected={isSelected}
-      key={tabName}
-      onClick={event => {
-        event.preventDefault()
-        router.router.push(to)
-        trackClick(tabName, to)
-      }}
-    >
-      {text}
-    </Pill>
-  )
-}
-
-export const NavigationTabs: React.FC<NavigationTabsProps> = ({
-  term,
-  artworkCount,
-  searchableConnection,
-}) => {
   const route = (tab: string) => {
     const encodedTerm = encodeURIComponent(term)
     const formattedTab = tab.replace(/\s/g, "_")
@@ -102,36 +95,72 @@ export const NavigationTabs: React.FC<NavigationTabsProps> = ({
     return `/search${formattedTab}?term=${encodedTerm}`
   }
 
+  // FIXME: Not rendering keys correctly.
+  // Move to it's own component & render normally.
+  // Avoid declaring "render functions" within other render bodies.
+  const renderTab = (
+    text: string,
+    to: string,
+    options: {
+      exact?: boolean
+      count?: number
+    } = {}
+  ) => {
+    const { exact, count } = options
+    const tabName = text.replace(/[0-9]/g, "").trim()
+
+    return (
+      <RoundedRouteTab
+        to={to}
+        text={tabName}
+        key={tabName}
+        exact={exact}
+        count={count}
+        onClick={event => {
+          event.preventDefault()
+          router.router.push(to)
+          trackClick(tabName, to)
+        }}
+      />
+    )
+  }
+
+  const tabs: JSX.Element[] = []
+
+  artworkCount > 0 &&
+    tabs.push(
+      renderTab("Artworks", route(""), {
+        count: artworkCount,
+        exact: true,
+      })
+    )
+
+  Object.entries(tabCountMap(searchableConnection)).map(
+    ([key, value]: [string, number]) => {
+      tabs.push(
+        renderTab(key, route(`/${key.toLowerCase()}`), {
+          count: value,
+        })
+      )
+    }
+  )
+
   const restAggregationCount = MORE_TABS.reduce((prev, key) => {
     const tabAggregation = aggregationFor(searchableConnection, key)?.count ?? 0
 
     return tabAggregation ? (prev += tabAggregation) : prev
   }, 0)
 
+  restAggregationCount > 0 &&
+    tabs.push(
+      renderTab("More", route("/more"), {
+        count: restAggregationCount,
+      })
+    )
+
   return (
     <AppContainer>
-      <HorizontalOverflow pl={[2, 4]}>
-        {artworkCount > 0 && (
-          <Tab text="Artworks" to={route("")} exact count={artworkCount} />
-        )}
-
-        {Object.entries(tabCountMap(searchableConnection)).map(
-          ([key, value]: [string, number]) => {
-            return (
-              <Tab
-                key={`pill-${key}`}
-                text={key}
-                to={route(`/${key.toLowerCase()}`)}
-                count={value}
-              />
-            )
-          }
-        )}
-
-        {restAggregationCount > 0 && (
-          <Tab text="More" to={route("/more")} count={restAggregationCount} />
-        )}
-      </HorizontalOverflow>
+      <HorizontalOverflow pl={[2, 4]}>{tabs}</HorizontalOverflow>
     </AppContainer>
   )
 }


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [ONYX-559]

### Description

Solves the issue when clicking on a pill makes a counter invisible:

| Before | After |
|---|---|
| <video src="https://github.com/artsy/force/assets/3934579/9e23dfbe-96ff-497c-8268-a863ee1cfd60" /> | <video src="https://github.com/artsy/force/assets/3934579/9cb5cf4e-c708-4ab1-bc6f-cb40bd62d29f" /> |

It seems like there is a "bug" in palette: when clicking on a pill that is an `active` state - such pill changes background to grey and text colour to blue (counter colour remains white though) . Maybe this shouldn't even be fixed, I think that `active` state shouldn't be used here at all. In my fix I've decided to use another state - `selected`, which doesn't have the counter bug.

I've also tried to address this [FIXME comment](https://github.com/artsy/force/blob/main/src/Apps/Search/Components/NavigationTabs.tsx#L98) made by @dzucconi.

[ONYX-559]: https://artsyproduct.atlassian.net/browse/ONYX-559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ