### PR TITLE
feat(EMI-1593): update saves tooltip content for PartnerOffer

### DIFF
--- a/src/Components/ProgressiveOnboarding/ProgressiveOnboardingSaveArtwork.tsx
+++ b/src/Components/ProgressiveOnboarding/ProgressiveOnboardingSaveArtwork.tsx
@@ -11,6 +11,7 @@ import {
   withProgressiveOnboardingCounts,
   WithProgressiveOnboardingCountsProps,
 } from "Components/ProgressiveOnboarding/withProgressiveOnboardingCounts"
+import { useFeatureFlag } from "System/useFeatureFlag"
 
 interface ProgressiveOnboardingSaveArtworkProps
   extends WithProgressiveOnboardingCountsProps {}
@@ -20,6 +21,9 @@ export const __ProgressiveOnboardingSaveArtwork__: FC<ProgressiveOnboardingSaveA
   children,
 }) => {
   const { dismiss, isDismissed } = useProgressiveOnboarding()
+  const isPartnerOfferEnabled = useFeatureFlag(
+    "emerald_partner-offers-from-saves"
+  )
 
   const isDisplayble =
     !isDismissed(PROGRESSIVE_ONBOARDING_SAVE_ARTWORK).status &&
@@ -62,7 +66,15 @@ export const __ProgressiveOnboardingSaveArtwork__: FC<ProgressiveOnboardingSaveA
         <Text variant="xs">
           <strong>Like what you see?</strong>
           <br />
-          Hit the heart to save an artwork.
+          {isPartnerOfferEnabled ? (
+            <>
+              Tap the heart to save an artwork
+              <br />
+              and signal your interest to galleries.
+            </>
+          ) : (
+            <>Hit the heart to save an artwork.</>
+          )}
         </Text>
       }
     >


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-1593]

> [!Note]
> This change is behind the feature flag `emerald_partner-offers-from-saves`

### Description

This PR updates the content of the Progressive Onboarding tooltip content for the Partner Offer

### Screenshots

| Before | After |
|---|---|
| ![image](https://github.com/artsy/force/assets/20655703/3d7a7942-94ff-4cfd-996d-f32a6f859ef6) | ![image](https://github.com/artsy/force/assets/20655703/be5d2746-5429-4328-bdee-1770529c52b3) |

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EMI-1593]: https://artsyproduct.atlassian.net/browse/EMI-1593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ