### PR TITLE
fix(onyx-560): Searching for a number results in errors that break pagination

### DIFF
--- a/src/Apps/Search/Routes/SearchResultsEntity.tsx
+++ b/src/Apps/Search/Routes/SearchResultsEntity.tsx
@@ -71,7 +71,7 @@ export class SearchResultsEntityRoute extends React.Component<Props, State> {
         first: PAGE_SIZE,
         last: null,
         page: null,
-        term,
+        term: String(term),
       },
       null,
       error => {

--- a/src/Components/ArtworkFilter/index.tsx
+++ b/src/Components/ArtworkFilter/index.tsx
@@ -236,12 +236,15 @@ export const BaseArtworkFilter: React.FC<
       jumpTo("artworkFilter")
     }
 
+    const keyword =
+      filterContext.filters?.term || filterContext.filters?.keyword
+
     const refetchVariables = {
       input: {
         first: 30,
         ...relayRefetchInputVariables,
         ...allowedFilters(filterContext.filters),
-        keyword: filterContext.filters?.term || filterContext.filters?.keyword,
+        keyword: keyword ? String(keyword) : undefined,
       },
       ...relayVariables,
     }


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [ONYX-560]

### Description

When searching by a number (2019, for example) and then clicking on the "Next" link (or a number in pagination list), Force sends 2019 as a number, but Metaphysics expects a string. MP fails on such requests -> pagination doesn't work.

I'm opening a PR with a "naive" fix - explicitly convert keyword to a string, but I am wondering if we will forget to add such conversion somewhere and stumble upon the same issue.

| Before | After |
|---|---|
| <video src="https://github.com/artsy/force/assets/3934579/2611e50e-fa98-4e61-ac1a-ec6a094219de" /> | <video src="https://github.com/artsy/force/assets/3934579/b61f20c8-e220-48fd-8694-b4ab30823e46" /> |





[ONYX-560]: https://artsyproduct.atlassian.net/browse/ONYX-560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ