### PR TITLE
feat(EMI-1594): Update Save Artwork toast

### DIFF
--- a/src/Components/Artwork/SaveButton/__tests__/SaveArtworkToListsButton.jest.tsx
+++ b/src/Components/Artwork/SaveButton/__tests__/SaveArtworkToListsButton.jest.tsx
@@ -8,9 +8,11 @@ import { MockBoot } from "DevTools/MockBoot"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { graphql } from "react-relay"
 import { SaveArtworkToListsButton_Test_Query } from "__generated__/SaveArtworkToListsButton_Test_Query.graphql"
+import { useFeatureFlag } from "System/useFeatureFlag"
 
 jest.unmock("react-relay")
 jest.mock("Components/Artwork/SaveButton/SaveArtworkMutation")
+jest.mock("System/useFeatureFlag", () => ({ useFeatureFlag: jest.fn() }))
 
 describe("SaveArtworkToListsButton", () => {
   const mockSaveArtwork = SaveArtwork as jest.Mock
@@ -71,15 +73,51 @@ describe("SaveArtworkToListsButton", () => {
       }))
     })
 
-    it("should display a toast message", async () => {
-      renderWithRelay({
-        Artwork: () => unsavedArtwork,
+    describe("when PartnerOffer feature flag is enabled", () => {
+      beforeAll(() => {
+        ;(useFeatureFlag as jest.Mock).mockImplementation(
+          featureName => featureName === "emerald_partner-offers-from-saves"
+        )
       })
 
-      fireEvent.click(screen.getByLabelText("Save"))
+      it("should display a toast message with the description", async () => {
+        renderWithRelay({
+          Artwork: () => unsavedArtwork,
+        })
 
-      expect(await screen.findByText("Artwork saved")).toBeInTheDocument()
-      expect(await screen.findByText("Add to a List")).toBeInTheDocument()
+        fireEvent.click(screen.getByLabelText("Save"))
+
+        expect(await screen.findByText("Artwork saved")).toBeInTheDocument()
+        expect(
+          await screen.findByText(
+            "Saving an artwork signals interest to galleries."
+          )
+        ).toBeInTheDocument()
+        expect(await screen.findByText("Add to a List")).toBeInTheDocument()
+      })
+    })
+
+    describe("when PartnerOffer feature flag is disabled", () => {
+      beforeAll(() => {
+        ;(useFeatureFlag as jest.Mock).mockImplementation(
+          featureName => featureName !== "emerald_partner-offers-from-saves"
+        )
+      })
+
+      it("should display a toast message with the description", async () => {
+        renderWithRelay({
+          Artwork: () => unsavedArtwork,
+        })
+
+        fireEvent.click(screen.getByLabelText("Save"))
+
+        expect(await screen.findByText("Artwork saved")).toBeInTheDocument()
+        expect(await screen.findByText("Add to a List")).toBeInTheDocument()
+
+        expect(
+          screen.queryByText("Saving an artwork signals interest to galleries.")
+        ).not.toBeInTheDocument()
+      })
     })
 
     it("should open the modal when `Add to a List` button was pressed", async () => {

--- a/src/Components/Artwork/useArtworkLists.ts
+++ b/src/Components/Artwork/useArtworkLists.ts
@@ -6,6 +6,7 @@ import {
 } from "Components/Artwork/SaveButton/useSaveArtworkToLists"
 import { useEffect } from "react"
 import { useTranslation } from "react-i18next"
+import { useFeatureFlag } from "System/useFeatureFlag"
 import { useAuthIntent } from "Utils/Hooks/useAuthIntent"
 
 export const useArtworkLists = (options: SaveArtworkToListsOptions) => {
@@ -18,6 +19,9 @@ export const useArtworkLists = (options: SaveArtworkToListsOptions) => {
     saveArtworkToLists: saveToLists,
     openSelectListsForArtworkModal,
   } = useSaveArtworkToLists(options)
+  const isPartnerOfferEnabled = useFeatureFlag(
+    "emerald_partner-offers-from-saves"
+  )
 
   useEffect(() => {
     if (
@@ -50,6 +54,11 @@ export const useArtworkLists = (options: SaveArtworkToListsOptions) => {
         message: t(
           `collectorSaves.saveArtworkToLists.toast.artworkSaved.message`
         ),
+        ...(isPartnerOfferEnabled && {
+          description: t(
+            `collectorSaves.saveArtworkToLists.toast.artworkSaved.description`
+          ),
+        }),
         action: {
           label: t(
             "collectorSaves.saveArtworkToLists.toast.artworkSaved.button"

--- a/src/System/i18n/locales/en-US/translation.json
+++ b/src/System/i18n/locales/en-US/translation.json
@@ -156,6 +156,7 @@
       "toast": {
         "artworkSaved": {
           "message": "Artwork saved",
+          "description": "Saving an artwork signals interest to galleries.",
           "button": "Add to a List"
         },
         "artworkRemoved": {


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-1594]

> [!Note]
> This change is behind the feature flag `emerald_partner-offers-from-saves`

### Description
This PR updates the Save artwork toast and adds a description for the Partner Offer


### Screenshots
| Before | After |
|---|---|
| ![image](https://github.com/artsy/force/assets/20655703/0edcae92-0459-4e80-bbf9-4137dc76fa06) | ![image](https://github.com/artsy/force/assets/20655703/dc08ef0a-a836-4c10-b810-076cc6fb61d1) |  

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EMI-1594]: https://artsyproduct.atlassian.net/browse/EMI-1594?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ