### PR TITLE
feat(alerts): allow artist series suggestion to be accepted

### DIFF
--- a/src/Components/Alert/Components/Form/SuggestedFilters.tsx
+++ b/src/Components/Alert/Components/Form/SuggestedFilters.tsx
@@ -83,6 +83,7 @@ export const SuggestedFilters: React.FC<SuggestedFiltersProps> = ({
                 switch (suggestedFilter.field) {
                   case "additionalGeneIDs":
                   case "attributionClass":
+                  case "artistSeriesIDs":
                     handleFieldsWithMultipleValues({
                       selectedValue:
                         state.criteria[suggestedFilter.field] || [],

--- a/src/Components/Alert/Components/Form/__tests__/SuggestedFilters.jest.tsx
+++ b/src/Components/Alert/Components/Form/__tests__/SuggestedFilters.jest.tsx
@@ -83,4 +83,10 @@ const mockSuggestedFilters = [
     name: "Price",
     value: "*-10000",
   },
+  {
+    displayValue: "Toys",
+    field: "artistSeriesIDs",
+    name: "Artist Series",
+    value: "kaws-toys",
+  },
 ]


### PR DESCRIPTION
The type of this PR is: **Fix**

Solves this QA item: https://www.notion.so/artsy/I-ve-found-a-case-where-one-suggested-filter-is-clicked-but-isn-t-added-a4f52b3dbe7c4f0ba13e65cb85856e31

### Description

Now that Artist Series suggestions have landed in Metaphysics we need to make sure Force can accept them.
