### PR TITLE
feat: Always enable email notifications when creating alerts

### DIFF
--- a/src/Components/Alert/Components/Filters/__tests__/NotificationPreferences.jest.tsx
+++ b/src/Components/Alert/Components/Filters/__tests__/NotificationPreferences.jest.tsx
@@ -96,7 +96,7 @@ describe("NotificationPreferences", () => {
 
         const checkboxes = screen.getAllByRole("checkbox")
 
-        expect(checkboxes[0]).not.toBeChecked()
+        expect(checkboxes[0]).toBeChecked()
         expect(checkboxes[1]).not.toBeChecked()
       })
 
@@ -129,7 +129,7 @@ describe("NotificationPreferences", () => {
 
         expect(
           screen.queryByText("Change your email preferences")
-        ).not.toBeInTheDocument()
+        ).toBeInTheDocument()
 
         const checkboxes = screen.getAllByRole("checkbox")
 
@@ -137,8 +137,8 @@ describe("NotificationPreferences", () => {
         fireEvent.click(checkboxes[0])
 
         expect(
-          screen.getByText("Change your email preferences")
-        ).toBeInTheDocument()
+          screen.queryByText("Change your email preferences")
+        ).not.toBeInTheDocument()
       })
     })
   })
@@ -211,7 +211,7 @@ describe("NotificationPreferences", () => {
         expect(checkboxes[1]).not.toBeChecked()
       })
 
-      it("shows warning message when checkbox is checked", async () => {
+      it("shows warning message only when checkbox is checked", async () => {
         renderNotificationPreferences({ mode: "create" })
 
         environment.mock.resolveMostRecentOperation(operation =>
@@ -240,16 +240,18 @@ describe("NotificationPreferences", () => {
 
         expect(
           screen.queryByText("Change your email preferences")
-        ).not.toBeInTheDocument()
+        ).toBeInTheDocument()
 
         const checkboxes = screen.getAllByRole("checkbox")
 
         // Check the email checkbox
         fireEvent.click(checkboxes[0])
 
+        await flushPromiseQueue()
+
         expect(
-          screen.getByText("Change your email preferences")
-        ).toBeInTheDocument()
+          screen.queryByText("Change your email preferences")
+        ).not.toBeInTheDocument()
       })
     })
   })

--- a/src/Components/Alert/Components/Filters/__tests__/NotificationPreferences.jest.tsx
+++ b/src/Components/Alert/Components/Filters/__tests__/NotificationPreferences.jest.tsx
@@ -178,7 +178,7 @@ describe("NotificationPreferences", () => {
     })
 
     describe("when custom alert email notifications are disabled", () => {
-      it("email checkbox is disabled by default", async () => {
+      it("email checkbox is enabled by default", async () => {
         renderNotificationPreferences({ mode: "create" })
 
         environment.mock.resolveMostRecentOperation(operation =>
@@ -207,7 +207,7 @@ describe("NotificationPreferences", () => {
 
         const checkboxes = screen.getAllByRole("checkbox")
 
-        expect(checkboxes[0]).not.toBeChecked()
+        expect(checkboxes[0]).toBeChecked()
         expect(checkboxes[1]).not.toBeChecked()
       })
 

--- a/src/Components/Alert/Components/NotificationPreferences.tsx
+++ b/src/Components/Alert/Components/NotificationPreferences.tsx
@@ -9,7 +9,7 @@ import {
 } from "@artsy/palette"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { RouterLink } from "System/Router/RouterLink"
-import { FC, useEffect } from "react"
+import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { NotificationPreferences_viewer$data } from "__generated__/NotificationPreferences_viewer.graphql"
 import { NotificationPreferencesQuery } from "__generated__/NotificationPreferencesQuery.graphql"
@@ -38,14 +38,6 @@ export const NotificationPreferences: FC<NotificationPreferencesProps> = ({
       )
     }
   )
-
-  useEffect(() => {
-    // Don't want to override the user's email preference when in edit mode
-    if (mode === "edit") return
-
-    setFieldValue("email", areCustomAlertsEmailNotificationsEnabled)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
 
   const showEmailPreferenceWarning =
     values.email && !areCustomAlertsEmailNotificationsEnabled


### PR DESCRIPTION
## Description

Always enable email notifications when creating alerts. Previously, it was disabled if the user had unsubscribed from Custom Alerts emails.

<img width="526" alt="Screenshot 2023-12-14 at 17 03 53" src="https://github.com/artsy/force/assets/4691889/e763d101-dfaa-47a6-aee3-647eb3c595e3">

Addresses [ONYX-607](https://artsyproduct.atlassian.net/browse/ONYX-607)


[ONYX-607]: https://artsyproduct.atlassian.net/browse/ONYX-607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ