### PR TITLE
fix(ONYX-606): add underline to showmore on filter pills

### DIFF
--- a/src/Components/Alert/Components/CriteriaPills.tsx
+++ b/src/Components/Alert/Components/CriteriaPills.tsx
@@ -20,7 +20,11 @@ export const CriteriaPills: FC<CriteriaPillsProps> = ({ editable = true }) => {
   const showMorePillsText = `+${countPills - PILLS_TO_DISPLAY} more`
 
   return (
-    <ShowMore initial={PILLS_TO_DISPLAY} showMoreText={showMorePillsText}>
+    <ShowMore
+      initial={PILLS_TO_DISPLAY}
+      showMoreText={showMorePillsText}
+      textDecoration="underline"
+    >
       {labels.map(label => {
         if (!label) return null
 


### PR DESCRIPTION
The type of this PR is: Fix

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [ONYX-606](https://artsyproduct.atlassian.net/browse/ONYX-606)

### Description

Add underline to ShowMore on filter pills.
<img width="759" alt="Screenshot 2023-12-14 at 17 32 16" src="https://github.com/artsy/force/assets/17580625/31ff1b44-a0f3-4db4-9ddb-6e6ee02e5d99">
<img width="606" alt="Screenshot 2023-12-14 at 17 23 41" src="https://github.com/artsy/force/assets/17580625/be17e195-618a-4f48-98c7-20d7c1646357">

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-606]: https://artsyproduct.atlassian.net/browse/ONYX-606?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ