### PR TITLE
fix(onyx-560): fixes broken search page when searching by a number

### DIFF
--- a/src/Components/Search/SearchBarInput.tsx
+++ b/src/Components/Search/SearchBarInput.tsx
@@ -109,7 +109,7 @@ const SearchBarInput: FC<SearchBarInputProps> = ({
       relay.refetch(
         {
           hasTerm: true,
-          term: value,
+          term: String(value),
           entities: entities,
         },
         null,
@@ -341,7 +341,7 @@ export const SearchBarInputQueryRenderer: FC<SearchBarInputQueryRendererProps> =
       `}
       variables={{
         hasTerm: shouldStartSearching(term ?? ""),
-        term: term ?? "",
+        term: term ? String(term) : "",
         entities: [],
       }}
       render={({ props }) => {


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [ONYX-560]

### Description

Another bug related to search by a number: when searching by a number, search input becomes unresponsive. This happens because `SearchBarInputSuggestQuery` fails because it sends term as a number, but schema expects a string.

[ONYX-560]: https://artsyproduct.atlassian.net/browse/ONYX-560?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ