### PR TITLE
feat(alerts): source artist series suggestions from artwork

### DIFF
--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -331,7 +331,10 @@ const WrappedArtworkApp: React.FC<Props> = props => {
         }}
         enabled={websocketEnabled}
       >
-        <AlertProvider initialCriteria={initialAlertCriteria}>
+        <AlertProvider
+          initialCriteria={initialAlertCriteria}
+          currentArtworkID={internalID}
+        >
           <ArtworkApp
             {...props}
             routerPathname={pathname}

--- a/src/Components/Alert/Components/Form/SuggestedFilters.tsx
+++ b/src/Components/Alert/Components/Form/SuggestedFilters.tsx
@@ -26,11 +26,15 @@ export const SuggestedFilters: React.FC<SuggestedFiltersProps> = ({
   const { state, dispatch } = useAlertContext()
 
   const { artistIDs } = state.criteria
+  const { currentArtworkID } = state
 
   const data = useLazyLoadQuery<SuggestedFiltersFetchQuery>(
     suggestedFiltersFetchQuery,
     {
       attributes: { artistIDs },
+      source: currentArtworkID
+        ? { type: "ARTWORK", id: currentArtworkID }
+        : undefined,
     }
   )
 
@@ -115,9 +119,12 @@ export const SuggestedFilters: React.FC<SuggestedFiltersProps> = ({
 }
 
 const suggestedFiltersFetchQuery = graphql`
-  query SuggestedFiltersFetchQuery($attributes: PreviewSavedSearchAttributes!) {
+  query SuggestedFiltersFetchQuery(
+    $source: AlertSource
+    $attributes: PreviewSavedSearchAttributes!
+  ) {
     previewSavedSearch(attributes: $attributes) {
-      suggestedFilters {
+      suggestedFilters(source: $source) {
         displayValue
         field
         name

--- a/src/__generated__/SuggestedFiltersFetchQuery.graphql.ts
+++ b/src/__generated__/SuggestedFiltersFetchQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a10d7cd670a4463c5b6ab0c47ead96f9>>
+ * @generated SignedSource<<c335d5d81aef8b972e5b5f470f27e542>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,7 +9,12 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Query } from 'relay-runtime';
+export type AlertSourceType = "ARTIST" | "ARTWORK" | "%future added value";
 export type ArtworkSizes = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
+export type AlertSource = {
+  id?: string | null | undefined;
+  type?: AlertSourceType | null | undefined;
+};
 export type PreviewSavedSearchAttributes = {
   acquireable?: boolean | null | undefined;
   additionalGeneIDs?: ReadonlyArray<string | null | undefined> | null | undefined;
@@ -31,6 +36,7 @@ export type PreviewSavedSearchAttributes = {
 };
 export type SuggestedFiltersFetchQuery$variables = {
   attributes: PreviewSavedSearchAttributes;
+  source?: AlertSource | null | undefined;
 };
 export type SuggestedFiltersFetchQuery$data = {
   readonly previewSavedSearch: {
@@ -48,14 +54,17 @@ export type SuggestedFiltersFetchQuery = {
 };
 
 const node: ConcreteRequest = (function(){
-var v0 = [
-  {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "attributes"
-  }
-],
-v1 = [
+var v0 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "attributes"
+},
+v1 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
+  "name": "source"
+},
+v2 = [
   {
     "alias": null,
     "args": [
@@ -72,7 +81,13 @@ v1 = [
     "selections": [
       {
         "alias": null,
-        "args": null,
+        "args": [
+          {
+            "kind": "Variable",
+            "name": "source",
+            "variableName": "source"
+          }
+        ],
         "concreteType": "SearchCriteriaLabel",
         "kind": "LinkedField",
         "name": "suggestedFilters",
@@ -115,32 +130,38 @@ v1 = [
 ];
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [
+      (v0/*: any*/),
+      (v1/*: any*/)
+    ],
     "kind": "Fragment",
     "metadata": null,
     "name": "SuggestedFiltersFetchQuery",
-    "selections": (v1/*: any*/),
+    "selections": (v2/*: any*/),
     "type": "Query",
     "abstractKey": null
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [
+      (v1/*: any*/),
+      (v0/*: any*/)
+    ],
     "kind": "Operation",
     "name": "SuggestedFiltersFetchQuery",
-    "selections": (v1/*: any*/)
+    "selections": (v2/*: any*/)
   },
   "params": {
-    "cacheID": "97c50a13547a4c48ddcad4109ad833f8",
+    "cacheID": "55f3243863662916e0b9a80153e66417",
     "id": null,
     "metadata": {},
     "name": "SuggestedFiltersFetchQuery",
     "operationKind": "query",
-    "text": "query SuggestedFiltersFetchQuery(\n  $attributes: PreviewSavedSearchAttributes!\n) {\n  previewSavedSearch(attributes: $attributes) {\n    suggestedFilters {\n      displayValue\n      field\n      name\n      value\n    }\n  }\n}\n"
+    "text": "query SuggestedFiltersFetchQuery(\n  $source: AlertSource\n  $attributes: PreviewSavedSearchAttributes!\n) {\n  previewSavedSearch(attributes: $attributes) {\n    suggestedFilters(source: $source) {\n      displayValue\n      field\n      name\n      value\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "1e2ed90cb17c1db86c1e273c94d1dde0";
+(node as any).hash = "ce25b26f74071154884ace1ba36f703e";
 
 export default node;


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [ONYX-563]

### Description

Now that we suggest artist series criteria in the Create Alert UI, we want to make sure they are as relevant as possible.

This means that when we are creating an alert from an artwork, we want the artist series suggestion to be based on the artist series  which _that_ artwork belongs to (if any).

(This is made possible by https://github.com/artsy/metaphysics/pull/5471)

|Before|After|
|---|---|
|![artist](https://github.com/artsy/force/assets/140521/791bfe39-97ea-468d-ba4d-163c88270bfb)|![artwork](https://github.com/artsy/force/assets/140521/2b287d14-0813-456a-934e-b594f3d2f9ba)|


[ONYX-563]: https://artsyproduct.atlassian.net/browse/ONYX-563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ