### PR TITLE
feat(alerts): allow selection of artist series from "more filters" UI

### DIFF
--- a/src/Components/Alert/Components/Filters/ArtistSeries.tsx
+++ b/src/Components/Alert/Components/Filters/ArtistSeries.tsx
@@ -1,0 +1,97 @@
+import { FC, Suspense } from "react"
+import { QuickMultipleSelectAlertFilter } from "Components/Alert/Components/Filters/QuickMultipleSelectAlertFilter"
+import { ArtistSeriesOptionsQuery } from "__generated__/ArtistSeriesOptionsQuery.graphql"
+import { graphql, useLazyLoadQuery } from "react-relay"
+import { useAlertContext } from "Components/Alert/Hooks/useAlertContext"
+import {
+  Flex,
+  Skeleton,
+  SkeletonBox,
+  SkeletonText,
+} from "@artsy/palette"
+import { compact, times } from "lodash"
+
+const artistSeriesOptionsQuery = graphql`
+  query ArtistSeriesOptionsQuery($input: FilterArtworksInput!) {
+    artworksConnection(size: 0, input: $input) {
+      aggregations {
+        counts {
+          count
+          name
+          value
+        }
+        slice
+      }
+    }
+  }
+`
+
+export const ArtistSeries: FC = () => {
+  const { state } = useAlertContext()
+  const artistIDs = state?.criteria?.artistIDs
+
+  const data = useLazyLoadQuery<ArtistSeriesOptionsQuery>(
+    artistSeriesOptionsQuery,
+    {
+      input: { artistIDs, aggregations: ["ARTIST_SERIES"] },
+    }
+  )
+  const artistSeries = (data.artworksConnection?.aggregations || []).find(
+    aggs => aggs?.slice === "ARTIST_SERIES"
+  )
+
+  const options = compact(
+    (artistSeries?.counts ?? []).map(count => {
+      if (!count) return null
+
+      return {
+        name: count.name,
+        value: count.value,
+      }
+    })
+  )
+
+  if (!options.length) return null
+
+  return (
+    <>
+      <QuickMultipleSelectAlertFilter
+        label="Artist Series"
+        // description="Optionally narrow down your alert to one or more of these series within this artist’s body of work"
+        criteriaKey="artistSeriesIDs"
+        options={options}
+        truncate={8}
+      />
+    </>
+  )
+}
+
+export const ArtistSeriesQueryRenderer: React.FC = props => {
+  return (
+    <Suspense fallback={<ArtistSeriesPlaceholder />}>
+      <ArtistSeries {...props} />
+    </Suspense>
+  )
+}
+
+const ArtistSeriesPlaceholder: React.FC = () => {
+  return (
+    <Skeleton>
+      <SkeletonText variant="xs" mb={2}>
+        Artist Series
+      </SkeletonText>
+
+      <Flex mb={4}>
+        {times(5).map(index => (
+          <SkeletonBox
+            key={`filter-${index}`}
+            width={70}
+            height={30}
+            mr={1}
+            mb={1}
+          />
+        ))}
+      </Flex>
+    </Skeleton>
+  )
+}

--- a/src/Components/Alert/Components/Filters/ArtistSeries.tsx
+++ b/src/Components/Alert/Components/Filters/ArtistSeries.tsx
@@ -5,6 +5,7 @@ import { graphql, useLazyLoadQuery } from "react-relay"
 import { useAlertContext } from "Components/Alert/Hooks/useAlertContext"
 import {
   Flex,
+  Separator,
   Skeleton,
   SkeletonBox,
   SkeletonText,
@@ -55,6 +56,8 @@ export const ArtistSeries: FC = () => {
 
   return (
     <>
+      <Separator my={2} />
+
       <QuickMultipleSelectAlertFilter
         label="Artist Series"
         // description="Optionally narrow down your alert to one or more of these series within this artist’s body of work"

--- a/src/Components/Alert/Components/Filters/QuickMultipleSelectAlertFilter.story.tsx
+++ b/src/Components/Alert/Components/Filters/QuickMultipleSelectAlertFilter.story.tsx
@@ -1,0 +1,53 @@
+import type { Meta } from "@storybook/react"
+import { QuickMultipleSelectAlertFilter } from "./QuickMultipleSelectAlertFilter"
+import { AlertProvider } from "Components/Alert/AlertProvider"
+import { Box } from "@artsy/palette"
+import { ComponentStory } from "@storybook/react"
+
+export const Basic: ComponentStory<typeof QuickMultipleSelectAlertFilter> = () => {
+  return (
+    <AlertProvider>
+      <QuickMultipleSelectAlertFilter
+        label="Colors"
+        criteriaKey="colors"
+        options={options}
+      />
+    </AlertProvider>
+  )
+}
+
+export const WithDescription = () => {
+  return (
+    <AlertProvider>
+      <QuickMultipleSelectAlertFilter
+        label="Colors"
+        description="Choose one or more of these colors for maximal colorfulness."
+        criteriaKey="colors"
+        options={options}
+      />
+    </AlertProvider>
+  )
+}
+
+const options = [
+  { name: "Red", value: "red" },
+  { name: "Orange", value: "orange" },
+  { name: "Yellow", value: "yellow" },
+  { name: "Green", value: "green" },
+  { name: "Blue", value: "blue" },
+  { name: "Indigo", value: "indigo" },
+  { name: "Violet", value: "violet" },
+]
+
+const meta: Meta<typeof QuickMultipleSelectAlertFilter> = {
+  title: "Components/QuickMultipleSelectAlertFilter",
+  decorators: [
+    Story => (
+      <Box width={[1.0, 400]}>
+        <Story />
+      </Box>
+    ),
+  ],
+}
+
+export default meta

--- a/src/Components/Alert/Components/Filters/QuickMultipleSelectAlertFilter.story.tsx
+++ b/src/Components/Alert/Components/Filters/QuickMultipleSelectAlertFilter.story.tsx
@@ -29,6 +29,19 @@ export const WithDescription = () => {
   )
 }
 
+export const WithTruncation = () => {
+  return (
+    <AlertProvider>
+      <QuickMultipleSelectAlertFilter
+        label="Colors"
+        criteriaKey="colors"
+        options={options}
+        truncate={4}
+      />
+    </AlertProvider>
+  )
+}
+
 const options = [
   { name: "Red", value: "red" },
   { name: "Orange", value: "orange" },

--- a/src/Components/Alert/Components/Filters/QuickMultipleSelectAlertFilter.tsx
+++ b/src/Components/Alert/Components/Filters/QuickMultipleSelectAlertFilter.tsx
@@ -1,5 +1,12 @@
-import { Checkbox, Column, GridColumns, Spacer, Text } from "@artsy/palette"
-import { FC } from "react"
+import {
+  Checkbox,
+  Clickable,
+  Column,
+  GridColumns,
+  Spacer,
+  Text,
+} from "@artsy/palette"
+import { FC, useState } from "react"
 import { useAlertContext } from "Components/Alert/Hooks/useAlertContext"
 import { SearchCriteriaAttributeKeys } from "Components/SavedSearchAlert/types"
 import { handleFieldsWithMultipleValues } from "Components/Alert/Helpers/handleFieldsWithMultipleValues"
@@ -9,6 +16,9 @@ interface QuickMultipleSelectAlertFilterProps {
   description?: string
   label: string
   options: { value: string; name: string }[]
+
+  /** Optionally truncate the list of options to this size, and display a Show/Hide toggle to disclose the full list. */
+  truncate?: number
 }
 
 export const QuickMultipleSelectAlertFilter: FC<QuickMultipleSelectAlertFilterProps> = ({
@@ -16,8 +26,13 @@ export const QuickMultipleSelectAlertFilter: FC<QuickMultipleSelectAlertFilterPr
   description,
   label,
   options,
+  truncate = Infinity,
 }) => {
   const { state, dispatch } = useAlertContext()
+
+  const [isExpanded, setExpanded] = useState(false)
+  const hasMore = options.length > truncate
+  const displayedOptions = isExpanded ? options : options.slice(0, truncate)
 
   const toggleSelection = (selected, value) => {
     handleFieldsWithMultipleValues({
@@ -42,7 +57,7 @@ export const QuickMultipleSelectAlertFilter: FC<QuickMultipleSelectAlertFilterPr
       <Spacer y={2} />
 
       <GridColumns>
-        {options.map(({ name, value }, index) => {
+        {displayedOptions.map(({ name, value }, index) => {
           return (
             <Column span={6} key={index}>
               <Checkbox
@@ -57,6 +72,16 @@ export const QuickMultipleSelectAlertFilter: FC<QuickMultipleSelectAlertFilterPr
           )
         })}
       </GridColumns>
+
+      {hasMore && (
+        <Clickable
+          mt={2}
+          onClick={() => setExpanded(visibility => !visibility)}
+          textDecoration={"underline"}
+        >
+          {isExpanded ? "Hide" : "Show more"}
+        </Clickable>
+      )}
     </>
   )
 }

--- a/src/Components/Alert/Components/Filters/QuickMultipleSelectAlertFilter.tsx
+++ b/src/Components/Alert/Components/Filters/QuickMultipleSelectAlertFilter.tsx
@@ -7,7 +7,6 @@ import { handleFieldsWithMultipleValues } from "Components/Alert/Helpers/handleF
 interface QuickMultipleSelectAlertFilterProps {
   criteriaKey: SearchCriteriaAttributeKeys
   description?: string
-  expanded?: boolean
   label: string
   options: { value: string; name: string }[]
 }

--- a/src/Components/Alert/Components/Filters/__tests__/ArtistSeries.jest.tsx
+++ b/src/Components/Alert/Components/Filters/__tests__/ArtistSeries.jest.tsx
@@ -1,0 +1,62 @@
+import { screen } from "@testing-library/react"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
+import { ArtistSeriesQueryRenderer } from "Components/Alert/Components/Filters/ArtistSeries"
+import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
+import { ArtistSeriesOptionsQuery$data } from "__generated__/ArtistSeriesOptionsQuery.graphql"
+import { AlertProvider } from "Components/Alert/AlertProvider"
+import userEvent from "@testing-library/user-event"
+
+jest.unmock("react-relay")
+
+describe("ArtistSeries", () => {
+  it("renders artist series options", async () => {
+    const { renderWithRelay } = setupTestWrapperTL({
+      Component: () => {
+        return (
+          <AlertProvider>
+            <ArtistSeriesQueryRenderer />
+          </AlertProvider>
+        )
+      },
+    })
+
+    renderWithRelay({
+      FilterArtworksConnection: () => mockArtistSeries.artworksConnection,
+    })
+
+    await flushPromiseQueue()
+
+    expect(screen.getByText("Artist Series")).toBeInTheDocument()
+
+    // 1st through 8th options are displayed
+    expect(screen.getByText("Posters")).toBeInTheDocument()
+    expect(screen.getByText("A Bigger Book")).toBeInTheDocument()
+
+    // 8th and later are truncated until "Show More" is clicked
+    expect(screen.queryByText("iPad Drawings")).not.toBeInTheDocument()
+    userEvent.click(screen.getByText("Show more"))
+    expect(screen.getByText("iPad Drawings")).toBeInTheDocument()
+  })
+})
+
+const mockArtistSeries: ArtistSeriesOptionsQuery$data = {
+  artworksConnection: {
+    aggregations: [
+      {
+        counts: [
+          { count: 42, name: "Posters", value: "posters" },
+          { count: 42, name: "Lithographs", value: "lithographs" },
+          { count: 42, name: "Flowers", value: "flowers" },
+          { count: 42, name: "Portraits", value: "portraits" },
+          { count: 42, name: "Pools", value: "pools" },
+          { count: 42, name: "Interiors", value: "interiors" },
+          { count: 42, name: "Celia", value: "celia" },
+          { count: 42, name: "A Bigger Book", value: "a-bigger-book" },
+          { count: 42, name: "iPad Drawings", value: "ipad-drawings" },
+          { count: 42, name: "The Blue Guitar", value: "the-blue-guitar" },
+        ],
+        slice: "ARTIST_SERIES",
+      },
+    ],
+  },
+}

--- a/src/Components/Alert/Components/Filters/__tests__/QuickMultipleSelectAlertFilter.jest.tsx
+++ b/src/Components/Alert/Components/Filters/__tests__/QuickMultipleSelectAlertFilter.jest.tsx
@@ -1,0 +1,104 @@
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { AlertContextProps } from "Components/Alert/AlertContext"
+import { AlertProvider } from "Components/Alert/AlertProvider"
+import { QuickMultipleSelectAlertFilter } from "Components/Alert/Components/Filters/QuickMultipleSelectAlertFilter"
+import { useAlertContext } from "Components/Alert/Hooks/useAlertContext"
+
+describe(QuickMultipleSelectAlertFilter, () => {
+  it("renders a label, description and options", () => {
+    renderWithWrapper(
+      <QuickMultipleSelectAlertFilter
+        label="Custom Label"
+        description="Custom description text"
+        criteriaKey="colors"
+        options={someOptions}
+      />
+    )
+
+    expect(screen.getByText("Custom Label")).toBeInTheDocument()
+    expect(screen.getByText("Custom description text")).toBeInTheDocument()
+    expect(screen.getByText("Name 1")).toBeInTheDocument()
+    expect(screen.getByText("Name 6")).toBeInTheDocument()
+  })
+
+  it("updates alert context when options are toggled", () => {
+    renderWithWrapper(
+      <QuickMultipleSelectAlertFilter
+        label="Custom Label"
+        criteriaKey="colors"
+        options={someOptions}
+      />
+    )
+
+    expect(screen.getByText("Custom Label")).toBeInTheDocument()
+    expect(currentAlertContext().state.criteria.colors).toBeUndefined()
+
+    // toggle on
+    userEvent.click(screen.getByText("Name 1"))
+    expect(currentAlertContext().state.criteria.colors).toEqual(["value-1"])
+
+    // toggle off
+    userEvent.click(screen.getByText("Name 1"))
+    expect(currentAlertContext().state.criteria.colors).toEqual([])
+  })
+})
+
+// fixtures
+
+const someOptions = [
+  { name: "Name 1", value: "value-1" },
+  { name: "Name 2", value: "value-2" },
+  { name: "Name 3", value: "value-3" },
+  { name: "Name 4", value: "value-4" },
+  { name: "Name 5", value: "value-5" },
+  { name: "Name 6", value: "value-6" },
+]
+
+// helpers
+
+/**
+ * Custom renderer with context and inspectable alert state
+ */
+const renderWithWrapper = (ui: React.ReactElement, options = {}) =>
+  render(ui, { wrapper: Wrapper, ...options })
+
+/**
+ * Dumps the AlertContext to the DOM for inspection
+ */
+const AlertStateInspector = () => {
+  const state = useAlertContext()
+  return (
+    <pre data-testid="alert-state-inspector">
+      {JSON.stringify(state, null, 2)}
+    </pre>
+  )
+}
+
+/**
+ * @returns An object representing the current state of the `AlertContext`
+ */
+function currentAlertContext(): AlertContextProps {
+  let contextInspector: HTMLElement
+  try {
+    contextInspector = screen.getByTestId("alert-state-inspector")
+  } catch (error) {
+    if (error.name === "TestingLibraryElementError")
+      throw new Error(
+        `The currentAlertContext() helper function requires an <AlertStateInspector /> to be mounted in the current DOM.`
+      )
+  }
+  return JSON.parse(contextInspector!.textContent!)
+}
+
+/**
+ * Render a component, along with context and inspector
+ */
+const Wrapper = ({ children }) => {
+  return (
+    <AlertProvider>
+      <AlertStateInspector />
+      {children}
+    </AlertProvider>
+  )
+}

--- a/src/Components/Alert/Components/Filters/__tests__/QuickMultipleSelectAlertFilter.jest.tsx
+++ b/src/Components/Alert/Components/Filters/__tests__/QuickMultipleSelectAlertFilter.jest.tsx
@@ -42,6 +42,35 @@ describe(QuickMultipleSelectAlertFilter, () => {
     userEvent.click(screen.getByText("Name 1"))
     expect(currentAlertContext().state.criteria.colors).toEqual([])
   })
+
+  it("can truncate and then expand the list of options", () => {
+    renderWithWrapper(
+      <QuickMultipleSelectAlertFilter
+        label="Custom Label"
+        description="Custom description text"
+        criteriaKey="colors"
+        options={someOptions}
+        truncate={4}
+      />
+    )
+
+    // truncate initially
+    expect(screen.queryByText("Name 1")).toBeInTheDocument()
+    expect(screen.queryByText("Name 4")).toBeInTheDocument()
+
+    expect(screen.queryByText("Name 5")).not.toBeInTheDocument()
+    expect(screen.queryByText("Name 6")).not.toBeInTheDocument()
+
+    // expand by clicking "Show more"
+    userEvent.click(screen.getByText("Show more"))
+    expect(screen.queryByText("Name 5")).toBeInTheDocument()
+    expect(screen.queryByText("Name 6")).toBeInTheDocument()
+
+    // collapse by clicking "Hide"
+    userEvent.click(screen.getByText("Hide"))
+    expect(screen.queryByText("Name 5")).not.toBeInTheDocument()
+    expect(screen.queryByText("Name 6")).not.toBeInTheDocument()
+  })
 })
 
 // fixtures

--- a/src/Components/Alert/Components/Steps/Filters.tsx
+++ b/src/Components/Alert/Components/Steps/Filters.tsx
@@ -7,6 +7,7 @@ import { WaysToBuy } from "Components/Alert/Components/Filters/WaysToBuy"
 import { Color } from "Components/Alert/Components/Filters/Color"
 import { useDidMount } from "Utils/Hooks/useDidMount"
 import { useAlertContext } from "Components/Alert/Hooks/useAlertContext"
+import { ArtistSeriesQueryRenderer } from "Components/Alert/Components/Filters/ArtistSeries"
 
 export const Filters: FC = () => {
   const isMounted = useDidMount()
@@ -34,6 +35,7 @@ export const Filters: FC = () => {
           <Medium />
           <Rarity />
           <PriceQueryRenderer />
+          <ArtistSeriesQueryRenderer />
           <WaysToBuy />
           <Color />
         </Join>

--- a/src/Components/Alert/Components/Steps/Filters.tsx
+++ b/src/Components/Alert/Components/Steps/Filters.tsx
@@ -1,5 +1,5 @@
-import { Box, Flex, Join, Separator, Spacer, Text } from "@artsy/palette"
-import { FC } from "react"
+import { Box, Flex, Separator, Spacer, Text } from "@artsy/palette"
+import React, { FC } from "react"
 import { Rarity } from "Components/Alert/Components/Filters/Rarity"
 import { Medium } from "Components/Alert/Components/Filters/Medium"
 import { PriceQueryRenderer } from "Components/Alert/Components/Filters/Price"
@@ -30,15 +30,25 @@ export const Filters: FC = () => {
     >
       <Flex flexDirection="column" width="auto">
         <Text variant="lg">Filters</Text>
+
         <Separator my={2} />
-        <Join separator={<Separator my={2} />}>
-          <Medium />
-          <Rarity />
-          <PriceQueryRenderer />
-          <ArtistSeriesQueryRenderer />
-          <WaysToBuy />
-          <Color />
-        </Join>
+        <Medium />
+
+        <Separator my={2} />
+        <Rarity />
+
+        <Separator my={2} />
+        <PriceQueryRenderer />
+
+        {/* no separator, in case null */}
+        <ArtistSeriesQueryRenderer />
+
+        <Separator my={2} />
+        <WaysToBuy />
+
+        <Separator my={2} />
+        <Color />
+
         <Spacer y={2} />
       </Flex>
     </Box>

--- a/src/__generated__/ArtistSeriesOptionsQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesOptionsQuery.graphql.ts
@@ -1,0 +1,218 @@
+/**
+ * @generated SignedSource<<4944d4ef6950c20adc572745e915c9ad>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ARTIST_SERIES" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "LOCATION_CITY" | "MAJOR_PERIOD" | "MATERIALS_TERMS" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "SIMPLE_PRICE_HISTOGRAM" | "TOTAL" | "%future added value";
+export type ArtworkSizes = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
+export type FilterArtworksInput = {
+  acquireable?: boolean | null | undefined;
+  additionalGeneIDs?: ReadonlyArray<string | null | undefined> | null | undefined;
+  after?: string | null | undefined;
+  aggregationPartnerCities?: ReadonlyArray<string | null | undefined> | null | undefined;
+  aggregations?: ReadonlyArray<ArtworkAggregation | null | undefined> | null | undefined;
+  artistID?: string | null | undefined;
+  artistIDs?: ReadonlyArray<string | null | undefined> | null | undefined;
+  artistNationalities?: ReadonlyArray<string | null | undefined> | null | undefined;
+  artistSeriesID?: string | null | undefined;
+  artistSeriesIDs?: ReadonlyArray<string | null | undefined> | null | undefined;
+  atAuction?: boolean | null | undefined;
+  attributionClass?: ReadonlyArray<string | null | undefined> | null | undefined;
+  before?: string | null | undefined;
+  color?: string | null | undefined;
+  colors?: ReadonlyArray<string | null | undefined> | null | undefined;
+  dimensionRange?: string | null | undefined;
+  excludeArtworkIDs?: ReadonlyArray<string | null | undefined> | null | undefined;
+  extraAggregationGeneIDs?: ReadonlyArray<string | null | undefined> | null | undefined;
+  first?: number | null | undefined;
+  forSale?: boolean | null | undefined;
+  geneID?: string | null | undefined;
+  geneIDs?: ReadonlyArray<string | null | undefined> | null | undefined;
+  height?: string | null | undefined;
+  includeArtworksByFollowedArtists?: boolean | null | undefined;
+  includeMediumFilterInAggregation?: boolean | null | undefined;
+  inquireableOnly?: boolean | null | undefined;
+  keyword?: string | null | undefined;
+  keywordMatchExact?: boolean | null | undefined;
+  last?: number | null | undefined;
+  locationCities?: ReadonlyArray<string | null | undefined> | null | undefined;
+  majorPeriods?: ReadonlyArray<string | null | undefined> | null | undefined;
+  marketable?: boolean | null | undefined;
+  marketingCollectionID?: string | null | undefined;
+  materialsTerms?: ReadonlyArray<string | null | undefined> | null | undefined;
+  medium?: string | null | undefined;
+  offerable?: boolean | null | undefined;
+  page?: number | null | undefined;
+  partnerCities?: ReadonlyArray<string | null | undefined> | null | undefined;
+  partnerID?: string | null | undefined;
+  partnerIDs?: ReadonlyArray<string | null | undefined> | null | undefined;
+  period?: string | null | undefined;
+  periods?: ReadonlyArray<string | null | undefined> | null | undefined;
+  priceRange?: string | null | undefined;
+  saleID?: string | null | undefined;
+  size?: number | null | undefined;
+  sizes?: ReadonlyArray<ArtworkSizes | null | undefined> | null | undefined;
+  sort?: string | null | undefined;
+  tagID?: string | null | undefined;
+  width?: string | null | undefined;
+};
+export type ArtistSeriesOptionsQuery$variables = {
+  input: FilterArtworksInput;
+};
+export type ArtistSeriesOptionsQuery$data = {
+  readonly artworksConnection: {
+    readonly aggregations: ReadonlyArray<{
+      readonly counts: ReadonlyArray<{
+        readonly count: number;
+        readonly name: string;
+        readonly value: string;
+      } | null | undefined> | null | undefined;
+      readonly slice: ArtworkAggregation | null | undefined;
+    } | null | undefined> | null | undefined;
+  } | null | undefined;
+};
+export type ArtistSeriesOptionsQuery = {
+  response: ArtistSeriesOptionsQuery$data;
+  variables: ArtistSeriesOptionsQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  },
+  {
+    "kind": "Literal",
+    "name": "size",
+    "value": 0
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "ArtworksAggregationResults",
+  "kind": "LinkedField",
+  "name": "aggregations",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "AggregationCount",
+      "kind": "LinkedField",
+      "name": "counts",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "count",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "value",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slice",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ArtistSeriesOptionsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "FilterArtworksConnection",
+        "kind": "LinkedField",
+        "name": "artworksConnection",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ArtistSeriesOptionsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "FilterArtworksConnection",
+        "kind": "LinkedField",
+        "name": "artworksConnection",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "ff534b3733d456106110eb8392488fd7",
+    "id": null,
+    "metadata": {},
+    "name": "ArtistSeriesOptionsQuery",
+    "operationKind": "query",
+    "text": "query ArtistSeriesOptionsQuery(\n  $input: FilterArtworksInput!\n) {\n  artworksConnection(size: 0, input: $input) {\n    aggregations {\n      counts {\n        count\n        name\n        value\n      }\n      slice\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "f66ff14062807fb9fd2d08191b289152";
+
+export default node;


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [ONYX-610]

### Description

Allows selection of arbitrary artist series belonging to the current artist.

Introduces a slightly new UX for doing so (long lists of options that can optionally be collapsed)


https://github.com/artsy/force/assets/140521/f936df74-a78d-439f-804d-546439422c9e



[ONYX-610]: https://artsyproduct.atlassian.net/browse/ONYX-610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ