### PR TITLE
fix(images): increase quality of install shots

### DIFF
--- a/src/Apps/Show/Components/ShowInstallShots.tsx
+++ b/src/Apps/Show/Components/ShowInstallShots.tsx
@@ -147,6 +147,7 @@ export const ShowInstallShotsFragmentContainer = createFragmentContainer(
           internalID
           caption
           mobile: resized(
+            quality: 85
             width: 200
             version: ["main", "normalized", "larger", "large"]
           ) {
@@ -154,6 +155,7 @@ export const ShowInstallShotsFragmentContainer = createFragmentContainer(
             height
           }
           desktop: resized(
+            quality: 85
             width: 325
             version: ["main", "normalized", "larger", "large"]
           ) {
@@ -163,6 +165,7 @@ export const ShowInstallShotsFragmentContainer = createFragmentContainer(
             height
           }
           zoom: resized(
+            quality: 85
             width: 900
             height: 900
             version: ["main", "normalized", "larger", "large"]

--- a/src/__generated__/ShowApp_Test_Query.graphql.ts
+++ b/src/__generated__/ShowApp_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e83d86dfafa3c7b59b8d940968e595d9>>
+ * @generated SignedSource<<d29fd95592eace640ef5820b1c98f649>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -122,6 +122,11 @@ v13 = {
 },
 v14 = {
   "kind": "Literal",
+  "name": "quality",
+  "value": 85
+},
+v15 = {
+  "kind": "Literal",
   "name": "version",
   "value": [
     "main",
@@ -130,56 +135,56 @@ v14 = {
     "large"
   ]
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "width",
   "storageKey": null
 },
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "height",
   "storageKey": null
 },
-v17 = [
+v18 = [
   (v12/*: any*/),
   (v13/*: any*/),
-  (v15/*: any*/),
-  (v16/*: any*/)
+  (v16/*: any*/),
+  (v17/*: any*/)
 ],
-v18 = [
+v19 = [
   (v1/*: any*/),
   (v9/*: any*/)
 ],
-v19 = [
+v20 = [
   (v9/*: any*/)
 ],
-v20 = {
+v21 = {
   "kind": "InlineFragment",
-  "selections": (v19/*: any*/),
+  "selections": (v20/*: any*/),
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v21 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v22 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "page",
   "storageKey": null
 },
-v23 = [
-  (v21/*: any*/),
+v24 = [
   (v22/*: any*/),
+  (v23/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -188,7 +193,7 @@ v23 = [
     "storageKey": null
   }
 ],
-v24 = {
+v25 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -196,28 +201,28 @@ v24 = {
     "large"
   ]
 },
-v25 = [
+v26 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v26 = {
+v27 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v27 = {
+v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v28 = [
+v29 = [
   {
     "alias": null,
     "args": null,
@@ -226,91 +231,91 @@ v28 = [
     "storageKey": null
   }
 ],
-v29 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "String"
-},
 v30 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "FormattedNumber"
+  "type": "String"
 },
 v31 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Boolean"
+  "type": "FormattedNumber"
 },
 v32 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Boolean"
+},
+v33 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v33 = {
+v34 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Image"
 },
-v34 = {
+v35 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v35 = {
+v36 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FilterArtworksConnection"
 },
-v36 = {
+v37 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Artwork"
 },
-v37 = {
+v38 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "ID"
 },
-v38 = {
+v39 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "ResizedImageUrl"
 },
-v39 = {
+v40 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v40 = {
+v41 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Boolean"
 },
-v41 = {
+v42 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "SaleArtwork"
 },
-v42 = {
+v43 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Int"
 },
-v43 = {
+v44 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -654,6 +659,7 @@ return {
                 "alias": "mobile",
                 "args": [
                   (v14/*: any*/),
+                  (v15/*: any*/),
                   {
                     "kind": "Literal",
                     "name": "width",
@@ -665,15 +671,16 @@ return {
                 "name": "resized",
                 "plural": false,
                 "selections": [
-                  (v15/*: any*/),
-                  (v16/*: any*/)
+                  (v16/*: any*/),
+                  (v17/*: any*/)
                 ],
-                "storageKey": "resized(version:[\"main\",\"normalized\",\"larger\",\"large\"],width:200)"
+                "storageKey": "resized(quality:85,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:200)"
               },
               {
                 "alias": "desktop",
                 "args": [
                   (v14/*: any*/),
+                  (v15/*: any*/),
                   {
                     "kind": "Literal",
                     "name": "width",
@@ -684,8 +691,8 @@ return {
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v17/*: any*/),
-                "storageKey": "resized(version:[\"main\",\"normalized\",\"larger\",\"large\"],width:325)"
+                "selections": (v18/*: any*/),
+                "storageKey": "resized(quality:85,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:325)"
               },
               {
                 "alias": "zoom",
@@ -696,6 +703,7 @@ return {
                     "value": 900
                   },
                   (v14/*: any*/),
+                  (v15/*: any*/),
                   {
                     "kind": "Literal",
                     "name": "width",
@@ -706,8 +714,8 @@ return {
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v17/*: any*/),
-                "storageKey": "resized(height:900,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:900)"
+                "selections": (v18/*: any*/),
+                "storageKey": "resized(height:900,quality:85,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:900)"
               }
             ],
             "storageKey": "images(default:false,size:100)"
@@ -858,11 +866,11 @@ return {
               },
               {
                 "kind": "InlineFragment",
-                "selections": (v18/*: any*/),
+                "selections": (v19/*: any*/),
                 "type": "ExternalPartner",
                 "abstractKey": null
               },
-              (v20/*: any*/)
+              (v21/*: any*/)
             ],
             "storageKey": null
           },
@@ -884,7 +892,7 @@ return {
               {
                 "alias": "src",
                 "args": [
-                  (v14/*: any*/)
+                  (v15/*: any*/)
                 ],
                 "kind": "ScalarField",
                 "name": "url",
@@ -972,7 +980,7 @@ return {
                     "kind": "LinkedField",
                     "name": "around",
                     "plural": true,
-                    "selections": (v23/*: any*/),
+                    "selections": (v24/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -982,7 +990,7 @@ return {
                     "kind": "LinkedField",
                     "name": "first",
                     "plural": false,
-                    "selections": (v23/*: any*/),
+                    "selections": (v24/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -992,7 +1000,7 @@ return {
                     "kind": "LinkedField",
                     "name": "last",
                     "plural": false,
-                    "selections": (v23/*: any*/),
+                    "selections": (v24/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -1003,8 +1011,8 @@ return {
                     "name": "previous",
                     "plural": false,
                     "selections": [
-                      (v21/*: any*/),
-                      (v22/*: any*/)
+                      (v22/*: any*/),
+                      (v23/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1026,7 +1034,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": (v19/*: any*/),
+                    "selections": (v20/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -1087,7 +1095,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v24/*: any*/)
+                                  (v25/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -1103,7 +1111,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v24/*: any*/),
+                                  (v25/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -1114,7 +1122,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "resized",
                                 "plural": false,
-                                "selections": (v17/*: any*/),
+                                "selections": (v18/*: any*/),
                                 "storageKey": "resized(version:[\"larger\",\"large\"],width:445)"
                               }
                             ],
@@ -1206,7 +1214,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v25/*: any*/),
+                            "args": (v26/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
@@ -1227,7 +1235,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v25/*: any*/),
+                            "args": (v26/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
@@ -1310,7 +1318,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v26/*: any*/),
+                              (v27/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1319,7 +1327,7 @@ return {
                                 "storageKey": null
                               },
                               (v11/*: any*/),
-                              (v27/*: any*/),
+                              (v28/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1352,7 +1360,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v28/*: any*/),
+                                "selections": (v29/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -1362,7 +1370,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v28/*: any*/),
+                                "selections": (v29/*: any*/),
                                 "storageKey": null
                               },
                               (v9/*: any*/)
@@ -1414,7 +1422,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v18/*: any*/),
+                            "selections": (v19/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1432,7 +1440,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v18/*: any*/),
+                                "selections": (v19/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -1454,8 +1462,8 @@ return {
                             "plural": false,
                             "selections": [
                               (v11/*: any*/),
+                              (v28/*: any*/),
                               (v27/*: any*/),
-                              (v26/*: any*/),
                               (v9/*: any*/)
                             ],
                             "storageKey": null
@@ -1470,7 +1478,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v20/*: any*/)
+                      (v21/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1488,7 +1496,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "fd0db32a425ff5a1a0c0c873e70fed60",
+    "cacheID": "03eb926dc82e63ea5757a2495216673a",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -1498,123 +1506,123 @@ return {
           "plural": false,
           "type": "Show"
         },
-        "show.about": (v29/*: any*/),
+        "show.about": (v30/*: any*/),
         "show.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ShowCounts"
         },
-        "show.counts.eligibleArtworks": (v30/*: any*/),
-        "show.endAt": (v29/*: any*/),
+        "show.counts.eligibleArtworks": (v31/*: any*/),
+        "show.endAt": (v30/*: any*/),
         "show.fair": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Fair"
         },
-        "show.fair.endAt": (v29/*: any*/),
-        "show.fair.exhibitionPeriod": (v29/*: any*/),
-        "show.fair.hasFullFeature": (v31/*: any*/),
-        "show.fair.href": (v29/*: any*/),
-        "show.fair.id": (v32/*: any*/),
-        "show.fair.image": (v33/*: any*/),
+        "show.fair.endAt": (v30/*: any*/),
+        "show.fair.exhibitionPeriod": (v30/*: any*/),
+        "show.fair.hasFullFeature": (v32/*: any*/),
+        "show.fair.href": (v30/*: any*/),
+        "show.fair.id": (v33/*: any*/),
+        "show.fair.image": (v34/*: any*/),
         "show.fair.image.cropped": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "CroppedImageUrl"
         },
-        "show.fair.image.cropped.src": (v34/*: any*/),
-        "show.fair.image.cropped.srcSet": (v34/*: any*/),
-        "show.fair.internalID": (v32/*: any*/),
-        "show.fair.isActive": (v31/*: any*/),
-        "show.fair.name": (v29/*: any*/),
-        "show.fair.slug": (v32/*: any*/),
-        "show.fair.startAt": (v29/*: any*/),
-        "show.filtered_artworks": (v35/*: any*/),
-        "show.filtered_artworks.__isArtworkConnectionInterface": (v34/*: any*/),
+        "show.fair.image.cropped.src": (v35/*: any*/),
+        "show.fair.image.cropped.srcSet": (v35/*: any*/),
+        "show.fair.internalID": (v33/*: any*/),
+        "show.fair.isActive": (v32/*: any*/),
+        "show.fair.name": (v30/*: any*/),
+        "show.fair.slug": (v33/*: any*/),
+        "show.fair.startAt": (v30/*: any*/),
+        "show.filtered_artworks": (v36/*: any*/),
+        "show.filtered_artworks.__isArtworkConnectionInterface": (v35/*: any*/),
         "show.filtered_artworks.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "FilterArtworksCounts"
         },
-        "show.filtered_artworks.counts.total": (v30/*: any*/),
+        "show.filtered_artworks.counts.total": (v31/*: any*/),
         "show.filtered_artworks.edges": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "ArtworkEdgeInterface"
         },
-        "show.filtered_artworks.edges.__isNode": (v34/*: any*/),
-        "show.filtered_artworks.edges.__typename": (v34/*: any*/),
-        "show.filtered_artworks.edges.id": (v32/*: any*/),
-        "show.filtered_artworks.edges.node": (v36/*: any*/),
+        "show.filtered_artworks.edges.__isNode": (v35/*: any*/),
+        "show.filtered_artworks.edges.__typename": (v35/*: any*/),
+        "show.filtered_artworks.edges.id": (v33/*: any*/),
+        "show.filtered_artworks.edges.node": (v37/*: any*/),
         "show.filtered_artworks.edges.node.artist": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Artist"
         },
-        "show.filtered_artworks.edges.node.artist.id": (v32/*: any*/),
+        "show.filtered_artworks.edges.node.artist.id": (v33/*: any*/),
         "show.filtered_artworks.edges.node.artist.targetSupply": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "ArtistTargetSupply"
         },
-        "show.filtered_artworks.edges.node.artist.targetSupply.isP1": (v31/*: any*/),
-        "show.filtered_artworks.edges.node.artistNames": (v29/*: any*/),
+        "show.filtered_artworks.edges.node.artist.targetSupply.isP1": (v32/*: any*/),
+        "show.filtered_artworks.edges.node.artistNames": (v30/*: any*/),
         "show.filtered_artworks.edges.node.artists": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Artist"
         },
-        "show.filtered_artworks.edges.node.artists.href": (v29/*: any*/),
-        "show.filtered_artworks.edges.node.artists.id": (v32/*: any*/),
-        "show.filtered_artworks.edges.node.artists.name": (v29/*: any*/),
+        "show.filtered_artworks.edges.node.artists.href": (v30/*: any*/),
+        "show.filtered_artworks.edges.node.artists.id": (v33/*: any*/),
+        "show.filtered_artworks.edges.node.artists.name": (v30/*: any*/),
         "show.filtered_artworks.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "show.filtered_artworks.edges.node.attributionClass.id": (v32/*: any*/),
-        "show.filtered_artworks.edges.node.attributionClass.name": (v29/*: any*/),
-        "show.filtered_artworks.edges.node.collecting_institution": (v29/*: any*/),
-        "show.filtered_artworks.edges.node.cultural_maker": (v29/*: any*/),
-        "show.filtered_artworks.edges.node.date": (v29/*: any*/),
-        "show.filtered_artworks.edges.node.href": (v29/*: any*/),
-        "show.filtered_artworks.edges.node.id": (v32/*: any*/),
-        "show.filtered_artworks.edges.node.image": (v33/*: any*/),
+        "show.filtered_artworks.edges.node.attributionClass.id": (v33/*: any*/),
+        "show.filtered_artworks.edges.node.attributionClass.name": (v30/*: any*/),
+        "show.filtered_artworks.edges.node.collecting_institution": (v30/*: any*/),
+        "show.filtered_artworks.edges.node.cultural_maker": (v30/*: any*/),
+        "show.filtered_artworks.edges.node.date": (v30/*: any*/),
+        "show.filtered_artworks.edges.node.href": (v30/*: any*/),
+        "show.filtered_artworks.edges.node.id": (v33/*: any*/),
+        "show.filtered_artworks.edges.node.image": (v34/*: any*/),
         "show.filtered_artworks.edges.node.image.aspectRatio": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "Float"
         },
-        "show.filtered_artworks.edges.node.image.internalID": (v37/*: any*/),
-        "show.filtered_artworks.edges.node.image.placeholder": (v29/*: any*/),
-        "show.filtered_artworks.edges.node.image.resized": (v38/*: any*/),
-        "show.filtered_artworks.edges.node.image.resized.height": (v39/*: any*/),
-        "show.filtered_artworks.edges.node.image.resized.src": (v34/*: any*/),
-        "show.filtered_artworks.edges.node.image.resized.srcSet": (v34/*: any*/),
-        "show.filtered_artworks.edges.node.image.resized.width": (v39/*: any*/),
-        "show.filtered_artworks.edges.node.image.url": (v29/*: any*/),
+        "show.filtered_artworks.edges.node.image.internalID": (v38/*: any*/),
+        "show.filtered_artworks.edges.node.image.placeholder": (v30/*: any*/),
+        "show.filtered_artworks.edges.node.image.resized": (v39/*: any*/),
+        "show.filtered_artworks.edges.node.image.resized.height": (v40/*: any*/),
+        "show.filtered_artworks.edges.node.image.resized.src": (v35/*: any*/),
+        "show.filtered_artworks.edges.node.image.resized.srcSet": (v35/*: any*/),
+        "show.filtered_artworks.edges.node.image.resized.width": (v40/*: any*/),
+        "show.filtered_artworks.edges.node.image.url": (v30/*: any*/),
         "show.filtered_artworks.edges.node.image.versions": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "String"
         },
-        "show.filtered_artworks.edges.node.imageTitle": (v29/*: any*/),
-        "show.filtered_artworks.edges.node.image_title": (v29/*: any*/),
-        "show.filtered_artworks.edges.node.internalID": (v32/*: any*/),
-        "show.filtered_artworks.edges.node.isSaved": (v31/*: any*/),
-        "show.filtered_artworks.edges.node.isSavedToList": (v40/*: any*/),
-        "show.filtered_artworks.edges.node.is_biddable": (v31/*: any*/),
+        "show.filtered_artworks.edges.node.imageTitle": (v30/*: any*/),
+        "show.filtered_artworks.edges.node.image_title": (v30/*: any*/),
+        "show.filtered_artworks.edges.node.internalID": (v33/*: any*/),
+        "show.filtered_artworks.edges.node.isSaved": (v32/*: any*/),
+        "show.filtered_artworks.edges.node.isSavedToList": (v41/*: any*/),
+        "show.filtered_artworks.edges.node.is_biddable": (v32/*: any*/),
         "show.filtered_artworks.edges.node.marketPriceInsights": {
           "enumValues": null,
           "nullable": true,
@@ -1639,72 +1647,72 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "show.filtered_artworks.edges.node.mediumType.filterGene.id": (v32/*: any*/),
-        "show.filtered_artworks.edges.node.mediumType.filterGene.name": (v29/*: any*/),
+        "show.filtered_artworks.edges.node.mediumType.filterGene.id": (v33/*: any*/),
+        "show.filtered_artworks.edges.node.mediumType.filterGene.name": (v30/*: any*/),
         "show.filtered_artworks.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "show.filtered_artworks.edges.node.partner.href": (v29/*: any*/),
-        "show.filtered_artworks.edges.node.partner.id": (v32/*: any*/),
-        "show.filtered_artworks.edges.node.partner.name": (v29/*: any*/),
-        "show.filtered_artworks.edges.node.preview": (v33/*: any*/),
-        "show.filtered_artworks.edges.node.preview.url": (v29/*: any*/),
+        "show.filtered_artworks.edges.node.partner.href": (v30/*: any*/),
+        "show.filtered_artworks.edges.node.partner.id": (v33/*: any*/),
+        "show.filtered_artworks.edges.node.partner.name": (v30/*: any*/),
+        "show.filtered_artworks.edges.node.preview": (v34/*: any*/),
+        "show.filtered_artworks.edges.node.preview.url": (v30/*: any*/),
         "show.filtered_artworks.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "show.filtered_artworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v39/*: any*/),
-        "show.filtered_artworks.edges.node.sale.display_timely_at": (v29/*: any*/),
-        "show.filtered_artworks.edges.node.sale.endAt": (v29/*: any*/),
-        "show.filtered_artworks.edges.node.sale.extendedBiddingIntervalMinutes": (v39/*: any*/),
-        "show.filtered_artworks.edges.node.sale.extendedBiddingPeriodMinutes": (v39/*: any*/),
-        "show.filtered_artworks.edges.node.sale.id": (v32/*: any*/),
-        "show.filtered_artworks.edges.node.sale.is_auction": (v31/*: any*/),
-        "show.filtered_artworks.edges.node.sale.is_closed": (v31/*: any*/),
-        "show.filtered_artworks.edges.node.sale.is_preview": (v31/*: any*/),
-        "show.filtered_artworks.edges.node.sale.startAt": (v29/*: any*/),
-        "show.filtered_artworks.edges.node.saleArtwork": (v41/*: any*/),
-        "show.filtered_artworks.edges.node.saleArtwork.endAt": (v29/*: any*/),
-        "show.filtered_artworks.edges.node.saleArtwork.extendedBiddingEndAt": (v29/*: any*/),
-        "show.filtered_artworks.edges.node.saleArtwork.id": (v32/*: any*/),
-        "show.filtered_artworks.edges.node.saleArtwork.lotID": (v29/*: any*/),
-        "show.filtered_artworks.edges.node.sale_artwork": (v41/*: any*/),
+        "show.filtered_artworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v40/*: any*/),
+        "show.filtered_artworks.edges.node.sale.display_timely_at": (v30/*: any*/),
+        "show.filtered_artworks.edges.node.sale.endAt": (v30/*: any*/),
+        "show.filtered_artworks.edges.node.sale.extendedBiddingIntervalMinutes": (v40/*: any*/),
+        "show.filtered_artworks.edges.node.sale.extendedBiddingPeriodMinutes": (v40/*: any*/),
+        "show.filtered_artworks.edges.node.sale.id": (v33/*: any*/),
+        "show.filtered_artworks.edges.node.sale.is_auction": (v32/*: any*/),
+        "show.filtered_artworks.edges.node.sale.is_closed": (v32/*: any*/),
+        "show.filtered_artworks.edges.node.sale.is_preview": (v32/*: any*/),
+        "show.filtered_artworks.edges.node.sale.startAt": (v30/*: any*/),
+        "show.filtered_artworks.edges.node.saleArtwork": (v42/*: any*/),
+        "show.filtered_artworks.edges.node.saleArtwork.endAt": (v30/*: any*/),
+        "show.filtered_artworks.edges.node.saleArtwork.extendedBiddingEndAt": (v30/*: any*/),
+        "show.filtered_artworks.edges.node.saleArtwork.id": (v33/*: any*/),
+        "show.filtered_artworks.edges.node.saleArtwork.lotID": (v30/*: any*/),
+        "show.filtered_artworks.edges.node.sale_artwork": (v42/*: any*/),
         "show.filtered_artworks.edges.node.sale_artwork.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkCounts"
         },
-        "show.filtered_artworks.edges.node.sale_artwork.counts.bidder_positions": (v30/*: any*/),
-        "show.filtered_artworks.edges.node.sale_artwork.endAt": (v29/*: any*/),
-        "show.filtered_artworks.edges.node.sale_artwork.extendedBiddingEndAt": (v29/*: any*/),
-        "show.filtered_artworks.edges.node.sale_artwork.formattedEndDateTime": (v29/*: any*/),
+        "show.filtered_artworks.edges.node.sale_artwork.counts.bidder_positions": (v31/*: any*/),
+        "show.filtered_artworks.edges.node.sale_artwork.endAt": (v30/*: any*/),
+        "show.filtered_artworks.edges.node.sale_artwork.extendedBiddingEndAt": (v30/*: any*/),
+        "show.filtered_artworks.edges.node.sale_artwork.formattedEndDateTime": (v30/*: any*/),
         "show.filtered_artworks.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "show.filtered_artworks.edges.node.sale_artwork.highest_bid.display": (v29/*: any*/),
-        "show.filtered_artworks.edges.node.sale_artwork.id": (v32/*: any*/),
-        "show.filtered_artworks.edges.node.sale_artwork.lotID": (v29/*: any*/),
-        "show.filtered_artworks.edges.node.sale_artwork.lotLabel": (v29/*: any*/),
+        "show.filtered_artworks.edges.node.sale_artwork.highest_bid.display": (v30/*: any*/),
+        "show.filtered_artworks.edges.node.sale_artwork.id": (v33/*: any*/),
+        "show.filtered_artworks.edges.node.sale_artwork.lotID": (v30/*: any*/),
+        "show.filtered_artworks.edges.node.sale_artwork.lotLabel": (v30/*: any*/),
         "show.filtered_artworks.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "show.filtered_artworks.edges.node.sale_artwork.opening_bid.display": (v29/*: any*/),
-        "show.filtered_artworks.edges.node.sale_message": (v29/*: any*/),
-        "show.filtered_artworks.edges.node.slug": (v32/*: any*/),
-        "show.filtered_artworks.edges.node.title": (v29/*: any*/),
-        "show.filtered_artworks.id": (v32/*: any*/),
+        "show.filtered_artworks.edges.node.sale_artwork.opening_bid.display": (v30/*: any*/),
+        "show.filtered_artworks.edges.node.sale_message": (v30/*: any*/),
+        "show.filtered_artworks.edges.node.slug": (v33/*: any*/),
+        "show.filtered_artworks.edges.node.title": (v30/*: any*/),
+        "show.filtered_artworks.id": (v33/*: any*/),
         "show.filtered_artworks.pageCursors": {
           "enumValues": null,
           "nullable": false,
@@ -1717,68 +1725,68 @@ return {
           "plural": true,
           "type": "PageCursor"
         },
-        "show.filtered_artworks.pageCursors.around.cursor": (v34/*: any*/),
-        "show.filtered_artworks.pageCursors.around.isCurrent": (v40/*: any*/),
-        "show.filtered_artworks.pageCursors.around.page": (v42/*: any*/),
-        "show.filtered_artworks.pageCursors.first": (v43/*: any*/),
-        "show.filtered_artworks.pageCursors.first.cursor": (v34/*: any*/),
-        "show.filtered_artworks.pageCursors.first.isCurrent": (v40/*: any*/),
-        "show.filtered_artworks.pageCursors.first.page": (v42/*: any*/),
-        "show.filtered_artworks.pageCursors.last": (v43/*: any*/),
-        "show.filtered_artworks.pageCursors.last.cursor": (v34/*: any*/),
-        "show.filtered_artworks.pageCursors.last.isCurrent": (v40/*: any*/),
-        "show.filtered_artworks.pageCursors.last.page": (v42/*: any*/),
-        "show.filtered_artworks.pageCursors.previous": (v43/*: any*/),
-        "show.filtered_artworks.pageCursors.previous.cursor": (v34/*: any*/),
-        "show.filtered_artworks.pageCursors.previous.page": (v42/*: any*/),
+        "show.filtered_artworks.pageCursors.around.cursor": (v35/*: any*/),
+        "show.filtered_artworks.pageCursors.around.isCurrent": (v41/*: any*/),
+        "show.filtered_artworks.pageCursors.around.page": (v43/*: any*/),
+        "show.filtered_artworks.pageCursors.first": (v44/*: any*/),
+        "show.filtered_artworks.pageCursors.first.cursor": (v35/*: any*/),
+        "show.filtered_artworks.pageCursors.first.isCurrent": (v41/*: any*/),
+        "show.filtered_artworks.pageCursors.first.page": (v43/*: any*/),
+        "show.filtered_artworks.pageCursors.last": (v44/*: any*/),
+        "show.filtered_artworks.pageCursors.last.cursor": (v35/*: any*/),
+        "show.filtered_artworks.pageCursors.last.isCurrent": (v41/*: any*/),
+        "show.filtered_artworks.pageCursors.last.page": (v43/*: any*/),
+        "show.filtered_artworks.pageCursors.previous": (v44/*: any*/),
+        "show.filtered_artworks.pageCursors.previous.cursor": (v35/*: any*/),
+        "show.filtered_artworks.pageCursors.previous.page": (v43/*: any*/),
         "show.filtered_artworks.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "show.filtered_artworks.pageInfo.endCursor": (v29/*: any*/),
-        "show.filtered_artworks.pageInfo.hasNextPage": (v40/*: any*/),
-        "show.formattedEndAt": (v29/*: any*/),
-        "show.formattedStartAt": (v29/*: any*/),
-        "show.href": (v29/*: any*/),
-        "show.id": (v32/*: any*/),
+        "show.filtered_artworks.pageInfo.endCursor": (v30/*: any*/),
+        "show.filtered_artworks.pageInfo.hasNextPage": (v41/*: any*/),
+        "show.formattedEndAt": (v30/*: any*/),
+        "show.formattedStartAt": (v30/*: any*/),
+        "show.href": (v30/*: any*/),
+        "show.id": (v33/*: any*/),
         "show.images": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Image"
         },
-        "show.images.caption": (v29/*: any*/),
-        "show.images.desktop": (v38/*: any*/),
-        "show.images.desktop.height": (v39/*: any*/),
-        "show.images.desktop.src": (v34/*: any*/),
-        "show.images.desktop.srcSet": (v34/*: any*/),
-        "show.images.desktop.width": (v39/*: any*/),
-        "show.images.internalID": (v37/*: any*/),
-        "show.images.mobile": (v38/*: any*/),
-        "show.images.mobile.height": (v39/*: any*/),
-        "show.images.mobile.width": (v39/*: any*/),
-        "show.images.url": (v29/*: any*/),
-        "show.images.zoom": (v38/*: any*/),
-        "show.images.zoom.height": (v39/*: any*/),
-        "show.images.zoom.src": (v34/*: any*/),
-        "show.images.zoom.srcSet": (v34/*: any*/),
-        "show.images.zoom.width": (v39/*: any*/),
-        "show.internalID": (v32/*: any*/),
-        "show.isFairBooth": (v31/*: any*/),
-        "show.metaDescription": (v29/*: any*/),
-        "show.metaImage": (v33/*: any*/),
-        "show.metaImage.src": (v29/*: any*/),
-        "show.name": (v29/*: any*/),
+        "show.images.caption": (v30/*: any*/),
+        "show.images.desktop": (v39/*: any*/),
+        "show.images.desktop.height": (v40/*: any*/),
+        "show.images.desktop.src": (v35/*: any*/),
+        "show.images.desktop.srcSet": (v35/*: any*/),
+        "show.images.desktop.width": (v40/*: any*/),
+        "show.images.internalID": (v38/*: any*/),
+        "show.images.mobile": (v39/*: any*/),
+        "show.images.mobile.height": (v40/*: any*/),
+        "show.images.mobile.width": (v40/*: any*/),
+        "show.images.url": (v30/*: any*/),
+        "show.images.zoom": (v39/*: any*/),
+        "show.images.zoom.height": (v40/*: any*/),
+        "show.images.zoom.src": (v35/*: any*/),
+        "show.images.zoom.srcSet": (v35/*: any*/),
+        "show.images.zoom.width": (v40/*: any*/),
+        "show.internalID": (v33/*: any*/),
+        "show.isFairBooth": (v32/*: any*/),
+        "show.metaDescription": (v30/*: any*/),
+        "show.metaImage": (v34/*: any*/),
+        "show.metaImage.src": (v30/*: any*/),
+        "show.name": (v30/*: any*/),
         "show.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "PartnerTypes"
         },
-        "show.partner.__isNode": (v34/*: any*/),
-        "show.partner.__typename": (v34/*: any*/),
+        "show.partner.__isNode": (v35/*: any*/),
+        "show.partner.__typename": (v35/*: any*/),
         "show.partner.artworksConnection": {
           "enumValues": null,
           "nullable": true,
@@ -1791,25 +1799,25 @@ return {
           "plural": true,
           "type": "ArtworkEdge"
         },
-        "show.partner.artworksConnection.edges.node": (v36/*: any*/),
-        "show.partner.artworksConnection.edges.node.id": (v32/*: any*/),
-        "show.partner.artworksConnection.edges.node.image": (v33/*: any*/),
-        "show.partner.artworksConnection.edges.node.image.url": (v29/*: any*/),
-        "show.partner.href": (v29/*: any*/),
-        "show.partner.id": (v32/*: any*/),
-        "show.partner.internalID": (v32/*: any*/),
-        "show.partner.isLinkable": (v31/*: any*/),
+        "show.partner.artworksConnection.edges.node": (v37/*: any*/),
+        "show.partner.artworksConnection.edges.node.id": (v33/*: any*/),
+        "show.partner.artworksConnection.edges.node.image": (v34/*: any*/),
+        "show.partner.artworksConnection.edges.node.image.url": (v30/*: any*/),
+        "show.partner.href": (v30/*: any*/),
+        "show.partner.id": (v33/*: any*/),
+        "show.partner.internalID": (v33/*: any*/),
+        "show.partner.isLinkable": (v32/*: any*/),
         "show.partner.locations": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Location"
         },
-        "show.partner.locations.city": (v29/*: any*/),
-        "show.partner.locations.id": (v32/*: any*/),
-        "show.partner.name": (v29/*: any*/),
-        "show.partner.slug": (v32/*: any*/),
-        "show.sidebar": (v35/*: any*/),
+        "show.partner.locations.city": (v30/*: any*/),
+        "show.partner.locations.id": (v33/*: any*/),
+        "show.partner.name": (v30/*: any*/),
+        "show.partner.slug": (v33/*: any*/),
+        "show.sidebar": (v36/*: any*/),
         "show.sidebar.aggregations": {
           "enumValues": null,
           "nullable": true,
@@ -1822,9 +1830,9 @@ return {
           "plural": true,
           "type": "AggregationCount"
         },
-        "show.sidebar.aggregations.counts.count": (v42/*: any*/),
-        "show.sidebar.aggregations.counts.name": (v34/*: any*/),
-        "show.sidebar.aggregations.counts.value": (v34/*: any*/),
+        "show.sidebar.aggregations.counts.count": (v43/*: any*/),
+        "show.sidebar.aggregations.counts.name": (v35/*: any*/),
+        "show.sidebar.aggregations.counts.value": (v35/*: any*/),
         "show.sidebar.aggregations.slice": {
           "enumValues": [
             "ARTIST",
@@ -1852,10 +1860,10 @@ return {
           "plural": false,
           "type": "ArtworkAggregation"
         },
-        "show.sidebar.id": (v32/*: any*/),
-        "show.slug": (v32/*: any*/),
-        "show.startAt": (v29/*: any*/),
-        "show.status": (v29/*: any*/),
+        "show.sidebar.id": (v33/*: any*/),
+        "show.slug": (v33/*: any*/),
+        "show.startAt": (v30/*: any*/),
+        "show.status": (v30/*: any*/),
         "show.viewingRoomsConnection": {
           "enumValues": null,
           "nullable": true,
@@ -1868,16 +1876,16 @@ return {
           "plural": true,
           "type": "ViewingRoomsEdge"
         },
-        "show.viewingRoomsConnection.edges.__typename": (v34/*: any*/),
+        "show.viewingRoomsConnection.edges.__typename": (v35/*: any*/),
         "show.viewingRoomsConnection.edges.node": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ViewingRoom"
         },
-        "show.viewingRoomsConnection.edges.node.distanceToClose": (v29/*: any*/),
-        "show.viewingRoomsConnection.edges.node.distanceToOpen": (v29/*: any*/),
-        "show.viewingRoomsConnection.edges.node.href": (v29/*: any*/),
+        "show.viewingRoomsConnection.edges.node.distanceToClose": (v30/*: any*/),
+        "show.viewingRoomsConnection.edges.node.distanceToOpen": (v30/*: any*/),
+        "show.viewingRoomsConnection.edges.node.href": (v30/*: any*/),
         "show.viewingRoomsConnection.edges.node.image": {
           "enumValues": null,
           "nullable": true,
@@ -1890,16 +1898,16 @@ return {
           "plural": false,
           "type": "ImageURLs"
         },
-        "show.viewingRoomsConnection.edges.node.image.imageURLs.normalized": (v29/*: any*/),
-        "show.viewingRoomsConnection.edges.node.internalID": (v32/*: any*/),
-        "show.viewingRoomsConnection.edges.node.slug": (v34/*: any*/),
-        "show.viewingRoomsConnection.edges.node.status": (v34/*: any*/),
-        "show.viewingRoomsConnection.edges.node.title": (v34/*: any*/)
+        "show.viewingRoomsConnection.edges.node.image.imageURLs.normalized": (v30/*: any*/),
+        "show.viewingRoomsConnection.edges.node.internalID": (v33/*: any*/),
+        "show.viewingRoomsConnection.edges.node.slug": (v35/*: any*/),
+        "show.viewingRoomsConnection.edges.node.status": (v35/*: any*/),
+        "show.viewingRoomsConnection.edges.node.title": (v35/*: any*/)
       }
     },
     "name": "ShowApp_Test_Query",
     "operationKind": "query",
-    "text": "query ShowApp_Test_Query {\n  show(id: \"xxx\") {\n    ...ShowApp_show\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork\n      ...FlatGridItem_artwork\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BackToFairBanner_show on Show {\n  fair {\n    name\n    href\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment DeprecatedSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FairCard_fair on Fair {\n  name\n  image {\n    cropped(width: 768, height: 512, version: \"wide\") {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment FlatGridItem_artwork on Artwork {\n  ...Metadata_artwork\n  ...DeprecatedSaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n  isSaved\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isSavedToList\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n\nfragment ShowAbout_show on Show {\n  about: description\n}\n\nfragment ShowApp_show on Show {\n  name\n  href\n  internalID\n  slug\n  about: description\n  isFairBooth\n  viewingRoomsConnection {\n    edges {\n      __typename\n    }\n  }\n  counts {\n    eligibleArtworks\n  }\n  fair {\n    hasFullFeature\n    id\n  }\n  sidebar: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  images(default: false, size: 100) {\n    url\n  }\n  ...BackToFairBanner_show\n  ...ShowHeader_show\n  ...ShowAbout_show\n  ...ShowMeta_show\n  ...ShowInstallShots_show\n  ...ShowViewingRoom_show\n  ...ShowArtworksEmptyState_show\n  ...ShowArtworks_show_4g78v5\n  ...ShowContextCard_show\n}\n\nfragment ShowArtworksEmptyState_show on Show {\n  isFairBooth\n  status\n}\n\nfragment ShowArtworks_show_4g78v5 on Show {\n  filtered_artworks: filterArtworksConnection(first: 30) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment ShowContextCard_show on Show {\n  isFairBooth\n  partner {\n    __typename\n    ... on Partner {\n      internalID\n      slug\n      href\n      name\n      locations {\n        city\n        id\n      }\n      artworksConnection(first: 3, sort: MERCHANDISABILITY_DESC) {\n        edges {\n          node {\n            image {\n              url(version: \"larger\")\n            }\n            id\n          }\n        }\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  fair {\n    internalID\n    isActive\n    slug\n    href\n    name\n    ...FairTiming_fair\n    ...FairCard_fair\n    id\n  }\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  fair {\n    href\n    isActive\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowHeader_show on Show {\n  name\n  startAt\n  endAt\n  status\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  ...ShowContextualLink_show\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images(default: false, size: 100) {\n    internalID\n    caption\n    mobile: resized(width: 200, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n    }\n    desktop: resized(width: 325, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    zoom: resized(width: 900, height: 900, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  href\n  metaDescription: description\n  metaImage {\n    src: url(version: [\"main\", \"normalized\", \"larger\", \"large\"])\n  }\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n}\n\nfragment ShowViewingRoom_show on Show {\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  viewingRoomsConnection {\n    edges {\n      node {\n        internalID\n        slug\n        status\n        distanceToOpen(short: true)\n        distanceToClose(short: true)\n        title\n        href\n        image {\n          imageURLs {\n            normalized\n          }\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query ShowApp_Test_Query {\n  show(id: \"xxx\") {\n    ...ShowApp_show\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork\n      ...FlatGridItem_artwork\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BackToFairBanner_show on Show {\n  fair {\n    name\n    href\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment DeprecatedSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FairCard_fair on Fair {\n  name\n  image {\n    cropped(width: 768, height: 512, version: \"wide\") {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment FlatGridItem_artwork on Artwork {\n  ...Metadata_artwork\n  ...DeprecatedSaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n  isSaved\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isSavedToList\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n\nfragment ShowAbout_show on Show {\n  about: description\n}\n\nfragment ShowApp_show on Show {\n  name\n  href\n  internalID\n  slug\n  about: description\n  isFairBooth\n  viewingRoomsConnection {\n    edges {\n      __typename\n    }\n  }\n  counts {\n    eligibleArtworks\n  }\n  fair {\n    hasFullFeature\n    id\n  }\n  sidebar: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  images(default: false, size: 100) {\n    url\n  }\n  ...BackToFairBanner_show\n  ...ShowHeader_show\n  ...ShowAbout_show\n  ...ShowMeta_show\n  ...ShowInstallShots_show\n  ...ShowViewingRoom_show\n  ...ShowArtworksEmptyState_show\n  ...ShowArtworks_show_4g78v5\n  ...ShowContextCard_show\n}\n\nfragment ShowArtworksEmptyState_show on Show {\n  isFairBooth\n  status\n}\n\nfragment ShowArtworks_show_4g78v5 on Show {\n  filtered_artworks: filterArtworksConnection(first: 30) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment ShowContextCard_show on Show {\n  isFairBooth\n  partner {\n    __typename\n    ... on Partner {\n      internalID\n      slug\n      href\n      name\n      locations {\n        city\n        id\n      }\n      artworksConnection(first: 3, sort: MERCHANDISABILITY_DESC) {\n        edges {\n          node {\n            image {\n              url(version: \"larger\")\n            }\n            id\n          }\n        }\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  fair {\n    internalID\n    isActive\n    slug\n    href\n    name\n    ...FairTiming_fair\n    ...FairCard_fair\n    id\n  }\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  fair {\n    href\n    isActive\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowHeader_show on Show {\n  name\n  startAt\n  endAt\n  status\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  ...ShowContextualLink_show\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images(default: false, size: 100) {\n    internalID\n    caption\n    mobile: resized(quality: 85, width: 200, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n    }\n    desktop: resized(quality: 85, width: 325, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    zoom: resized(quality: 85, width: 900, height: 900, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  href\n  metaDescription: description\n  metaImage {\n    src: url(version: [\"main\", \"normalized\", \"larger\", \"large\"])\n  }\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n}\n\nfragment ShowViewingRoom_show on Show {\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  viewingRoomsConnection {\n    edges {\n      node {\n        internalID\n        slug\n        status\n        distanceToOpen(short: true)\n        distanceToClose(short: true)\n        title\n        href\n        image {\n          imageURLs {\n            normalized\n          }\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ShowInstallShots_Test_Query.graphql.ts
+++ b/src/__generated__/ShowInstallShots_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5f4ca2a7d9299b7b84e8b145a5c9368c>>
+ * @generated SignedSource<<0360038801192f94a0f32e3a93087363>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -31,6 +31,11 @@ var v0 = [
 ],
 v1 = {
   "kind": "Literal",
+  "name": "quality",
+  "value": 85
+},
+v2 = {
+  "kind": "Literal",
   "name": "version",
   "value": [
     "main",
@@ -39,21 +44,21 @@ v1 = {
     "large"
   ]
 },
-v2 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "width",
   "storageKey": null
 },
-v3 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "height",
   "storageKey": null
 },
-v4 = [
+v5 = [
   {
     "alias": null,
     "args": null,
@@ -68,28 +73,28 @@ v4 = [
     "name": "srcSet",
     "storageKey": null
   },
-  (v2/*: any*/),
-  (v3/*: any*/)
+  (v3/*: any*/),
+  (v4/*: any*/)
 ],
-v5 = {
+v6 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v6 = {
+v7 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "ResizedImageUrl"
 },
-v7 = {
+v8 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v8 = {
+v9 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
@@ -180,6 +185,7 @@ return {
                 "alias": "mobile",
                 "args": [
                   (v1/*: any*/),
+                  (v2/*: any*/),
                   {
                     "kind": "Literal",
                     "name": "width",
@@ -191,15 +197,16 @@ return {
                 "name": "resized",
                 "plural": false,
                 "selections": [
-                  (v2/*: any*/),
-                  (v3/*: any*/)
+                  (v3/*: any*/),
+                  (v4/*: any*/)
                 ],
-                "storageKey": "resized(version:[\"main\",\"normalized\",\"larger\",\"large\"],width:200)"
+                "storageKey": "resized(quality:85,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:200)"
               },
               {
                 "alias": "desktop",
                 "args": [
                   (v1/*: any*/),
+                  (v2/*: any*/),
                   {
                     "kind": "Literal",
                     "name": "width",
@@ -210,8 +217,8 @@ return {
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v4/*: any*/),
-                "storageKey": "resized(version:[\"main\",\"normalized\",\"larger\",\"large\"],width:325)"
+                "selections": (v5/*: any*/),
+                "storageKey": "resized(quality:85,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:325)"
               },
               {
                 "alias": "zoom",
@@ -222,6 +229,7 @@ return {
                     "value": 900
                   },
                   (v1/*: any*/),
+                  (v2/*: any*/),
                   {
                     "kind": "Literal",
                     "name": "width",
@@ -232,8 +240,8 @@ return {
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v4/*: any*/),
-                "storageKey": "resized(height:900,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:900)"
+                "selections": (v5/*: any*/),
+                "storageKey": "resized(height:900,quality:85,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:900)"
               }
             ],
             "storageKey": "images(default:false,size:100)"
@@ -251,7 +259,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ac2c7fc55709e1fbe7df63f360922776",
+    "cacheID": "90b7fae04cb63ae9411297f879fd8a5a",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -273,32 +281,32 @@ return {
           "plural": true,
           "type": "Image"
         },
-        "show.images.caption": (v5/*: any*/),
-        "show.images.desktop": (v6/*: any*/),
-        "show.images.desktop.height": (v7/*: any*/),
-        "show.images.desktop.src": (v8/*: any*/),
-        "show.images.desktop.srcSet": (v8/*: any*/),
-        "show.images.desktop.width": (v7/*: any*/),
+        "show.images.caption": (v6/*: any*/),
+        "show.images.desktop": (v7/*: any*/),
+        "show.images.desktop.height": (v8/*: any*/),
+        "show.images.desktop.src": (v9/*: any*/),
+        "show.images.desktop.srcSet": (v9/*: any*/),
+        "show.images.desktop.width": (v8/*: any*/),
         "show.images.internalID": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ID"
         },
-        "show.images.mobile": (v6/*: any*/),
-        "show.images.mobile.height": (v7/*: any*/),
-        "show.images.mobile.width": (v7/*: any*/),
-        "show.images.zoom": (v6/*: any*/),
-        "show.images.zoom.height": (v7/*: any*/),
-        "show.images.zoom.src": (v8/*: any*/),
-        "show.images.zoom.srcSet": (v8/*: any*/),
-        "show.images.zoom.width": (v7/*: any*/),
-        "show.name": (v5/*: any*/)
+        "show.images.mobile": (v7/*: any*/),
+        "show.images.mobile.height": (v8/*: any*/),
+        "show.images.mobile.width": (v8/*: any*/),
+        "show.images.zoom": (v7/*: any*/),
+        "show.images.zoom.height": (v8/*: any*/),
+        "show.images.zoom.src": (v9/*: any*/),
+        "show.images.zoom.srcSet": (v9/*: any*/),
+        "show.images.zoom.width": (v8/*: any*/),
+        "show.name": (v6/*: any*/)
       }
     },
     "name": "ShowInstallShots_Test_Query",
     "operationKind": "query",
-    "text": "query ShowInstallShots_Test_Query {\n  show(id: \"xxx\") {\n    ...ShowInstallShots_show\n    id\n  }\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images(default: false, size: 100) {\n    internalID\n    caption\n    mobile: resized(width: 200, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n    }\n    desktop: resized(width: 325, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    zoom: resized(width: 900, height: 900, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n"
+    "text": "query ShowInstallShots_Test_Query {\n  show(id: \"xxx\") {\n    ...ShowInstallShots_show\n    id\n  }\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images(default: false, size: 100) {\n    internalID\n    caption\n    mobile: resized(quality: 85, width: 200, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n    }\n    desktop: resized(quality: 85, width: 325, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    zoom: resized(quality: 85, width: 900, height: 900, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ShowInstallShots_show.graphql.ts
+++ b/src/__generated__/ShowInstallShots_show.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c62ffcee351e4aefc3d6c3636f55dbb0>>
+ * @generated SignedSource<<2a2d5fc60ea1e7c1df2dfe0991f25150>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -42,6 +42,11 @@ export type ShowInstallShots_show$key = {
 const node: ReaderFragment = (function(){
 var v0 = {
   "kind": "Literal",
+  "name": "quality",
+  "value": 85
+},
+v1 = {
+  "kind": "Literal",
   "name": "version",
   "value": [
     "main",
@@ -50,21 +55,21 @@ var v0 = {
     "large"
   ]
 },
-v1 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "width",
   "storageKey": null
 },
-v2 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "height",
   "storageKey": null
 },
-v3 = [
+v4 = [
   {
     "alias": null,
     "args": null,
@@ -79,8 +84,8 @@ v3 = [
     "name": "srcSet",
     "storageKey": null
   },
-  (v1/*: any*/),
-  (v2/*: any*/)
+  (v2/*: any*/),
+  (v3/*: any*/)
 ];
 return {
   "argumentDefinitions": [],
@@ -132,6 +137,7 @@ return {
           "alias": "mobile",
           "args": [
             (v0/*: any*/),
+            (v1/*: any*/),
             {
               "kind": "Literal",
               "name": "width",
@@ -143,15 +149,16 @@ return {
           "name": "resized",
           "plural": false,
           "selections": [
-            (v1/*: any*/),
-            (v2/*: any*/)
+            (v2/*: any*/),
+            (v3/*: any*/)
           ],
-          "storageKey": "resized(version:[\"main\",\"normalized\",\"larger\",\"large\"],width:200)"
+          "storageKey": "resized(quality:85,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:200)"
         },
         {
           "alias": "desktop",
           "args": [
             (v0/*: any*/),
+            (v1/*: any*/),
             {
               "kind": "Literal",
               "name": "width",
@@ -162,8 +169,8 @@ return {
           "kind": "LinkedField",
           "name": "resized",
           "plural": false,
-          "selections": (v3/*: any*/),
-          "storageKey": "resized(version:[\"main\",\"normalized\",\"larger\",\"large\"],width:325)"
+          "selections": (v4/*: any*/),
+          "storageKey": "resized(quality:85,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:325)"
         },
         {
           "alias": "zoom",
@@ -174,6 +181,7 @@ return {
               "value": 900
             },
             (v0/*: any*/),
+            (v1/*: any*/),
             {
               "kind": "Literal",
               "name": "width",
@@ -184,8 +192,8 @@ return {
           "kind": "LinkedField",
           "name": "resized",
           "plural": false,
-          "selections": (v3/*: any*/),
-          "storageKey": "resized(height:900,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:900)"
+          "selections": (v4/*: any*/),
+          "storageKey": "resized(height:900,quality:85,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:900)"
         }
       ],
       "storageKey": "images(default:false,size:100)"
@@ -196,6 +204,6 @@ return {
 };
 })();
 
-(node as any).hash = "fc65edc203f2de1cd4bc91a269d92366";
+(node as any).hash = "3439e5399514191f97f1b0403e53f6cf";
 
 export default node;

--- a/src/__generated__/showRoutes_ShowQuery.graphql.ts
+++ b/src/__generated__/showRoutes_ShowQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bf7bce8501682a1e04c185d8a6fb1af0>>
+ * @generated SignedSource<<24192e71dadf03977f35dddafc760aa1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -210,6 +210,11 @@ v19 = {
 },
 v20 = {
   "kind": "Literal",
+  "name": "quality",
+  "value": 85
+},
+v21 = {
+  "kind": "Literal",
   "name": "version",
   "value": [
     "main",
@@ -218,56 +223,56 @@ v20 = {
     "large"
   ]
 },
-v21 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "width",
   "storageKey": null
 },
-v22 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "height",
   "storageKey": null
 },
-v23 = [
+v24 = [
   (v18/*: any*/),
   (v19/*: any*/),
-  (v21/*: any*/),
-  (v22/*: any*/)
+  (v22/*: any*/),
+  (v23/*: any*/)
 ],
-v24 = [
+v25 = [
   (v7/*: any*/),
   (v15/*: any*/)
 ],
-v25 = [
+v26 = [
   (v15/*: any*/)
 ],
-v26 = {
+v27 = {
   "kind": "InlineFragment",
-  "selections": (v25/*: any*/),
+  "selections": (v26/*: any*/),
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v27 = {
+v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v28 = {
+v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "page",
   "storageKey": null
 },
-v29 = [
-  (v27/*: any*/),
+v30 = [
   (v28/*: any*/),
+  (v29/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -276,7 +281,7 @@ v29 = [
     "storageKey": null
   }
 ],
-v30 = {
+v31 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -284,28 +289,28 @@ v30 = {
     "large"
   ]
 },
-v31 = [
+v32 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v32 = {
+v33 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v33 = {
+v34 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v34 = [
+v35 = [
   {
     "alias": null,
     "args": null,
@@ -696,6 +701,7 @@ return {
                 "alias": "mobile",
                 "args": [
                   (v20/*: any*/),
+                  (v21/*: any*/),
                   {
                     "kind": "Literal",
                     "name": "width",
@@ -707,15 +713,16 @@ return {
                 "name": "resized",
                 "plural": false,
                 "selections": [
-                  (v21/*: any*/),
-                  (v22/*: any*/)
+                  (v22/*: any*/),
+                  (v23/*: any*/)
                 ],
-                "storageKey": "resized(version:[\"main\",\"normalized\",\"larger\",\"large\"],width:200)"
+                "storageKey": "resized(quality:85,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:200)"
               },
               {
                 "alias": "desktop",
                 "args": [
                   (v20/*: any*/),
+                  (v21/*: any*/),
                   {
                     "kind": "Literal",
                     "name": "width",
@@ -726,8 +733,8 @@ return {
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v23/*: any*/),
-                "storageKey": "resized(version:[\"main\",\"normalized\",\"larger\",\"large\"],width:325)"
+                "selections": (v24/*: any*/),
+                "storageKey": "resized(quality:85,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:325)"
               },
               {
                 "alias": "zoom",
@@ -738,6 +745,7 @@ return {
                     "value": 900
                   },
                   (v20/*: any*/),
+                  (v21/*: any*/),
                   {
                     "kind": "Literal",
                     "name": "width",
@@ -748,8 +756,8 @@ return {
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v23/*: any*/),
-                "storageKey": "resized(height:900,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:900)"
+                "selections": (v24/*: any*/),
+                "storageKey": "resized(height:900,quality:85,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:900)"
               }
             ],
             "storageKey": "images(default:false,size:100)"
@@ -900,11 +908,11 @@ return {
               },
               {
                 "kind": "InlineFragment",
-                "selections": (v24/*: any*/),
+                "selections": (v25/*: any*/),
                 "type": "ExternalPartner",
                 "abstractKey": null
               },
-              (v26/*: any*/)
+              (v27/*: any*/)
             ],
             "storageKey": null
           },
@@ -926,7 +934,7 @@ return {
               {
                 "alias": "src",
                 "args": [
-                  (v20/*: any*/)
+                  (v21/*: any*/)
                 ],
                 "kind": "ScalarField",
                 "name": "url",
@@ -1015,7 +1023,7 @@ return {
                     "kind": "LinkedField",
                     "name": "around",
                     "plural": true,
-                    "selections": (v29/*: any*/),
+                    "selections": (v30/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -1025,7 +1033,7 @@ return {
                     "kind": "LinkedField",
                     "name": "first",
                     "plural": false,
-                    "selections": (v29/*: any*/),
+                    "selections": (v30/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -1035,7 +1043,7 @@ return {
                     "kind": "LinkedField",
                     "name": "last",
                     "plural": false,
-                    "selections": (v29/*: any*/),
+                    "selections": (v30/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -1046,8 +1054,8 @@ return {
                     "name": "previous",
                     "plural": false,
                     "selections": [
-                      (v27/*: any*/),
-                      (v28/*: any*/)
+                      (v28/*: any*/),
+                      (v29/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1069,7 +1077,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": (v25/*: any*/),
+                    "selections": (v26/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -1130,7 +1138,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v30/*: any*/)
+                                  (v31/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -1146,7 +1154,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v30/*: any*/),
+                                  (v31/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -1157,7 +1165,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "resized",
                                 "plural": false,
-                                "selections": (v23/*: any*/),
+                                "selections": (v24/*: any*/),
                                 "storageKey": "resized(version:[\"larger\",\"large\"],width:445)"
                               }
                             ],
@@ -1249,7 +1257,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v31/*: any*/),
+                            "args": (v32/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
@@ -1270,7 +1278,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v31/*: any*/),
+                            "args": (v32/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
@@ -1353,7 +1361,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v32/*: any*/),
+                              (v33/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1362,7 +1370,7 @@ return {
                                 "storageKey": null
                               },
                               (v17/*: any*/),
-                              (v33/*: any*/),
+                              (v34/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1395,7 +1403,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v34/*: any*/),
+                                "selections": (v35/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -1405,7 +1413,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v34/*: any*/),
+                                "selections": (v35/*: any*/),
                                 "storageKey": null
                               },
                               (v15/*: any*/)
@@ -1457,7 +1465,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v24/*: any*/),
+                            "selections": (v25/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1475,7 +1483,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v24/*: any*/),
+                                "selections": (v25/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -1497,8 +1505,8 @@ return {
                             "plural": false,
                             "selections": [
                               (v17/*: any*/),
+                              (v34/*: any*/),
                               (v33/*: any*/),
-                              (v32/*: any*/),
                               (v15/*: any*/)
                             ],
                             "storageKey": null
@@ -1513,7 +1521,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v26/*: any*/)
+                      (v27/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -1531,12 +1539,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "456739f31559793c59735c1a63d29fe6",
+    "cacheID": "1eab026afc9a0b9f19d28ec16c019be6",
     "id": null,
     "metadata": {},
     "name": "showRoutes_ShowQuery",
     "operationKind": "query",
-    "text": "query showRoutes_ShowQuery(\n  $slug: String!\n  $input: FilterArtworksInput\n  $aggregations: [ArtworkAggregation]\n  $shouldFetchCounts: Boolean!\n) {\n  show(id: $slug) @principalField {\n    ...ShowApp_show_3TMxyn\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork\n      ...FlatGridItem_artwork\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BackToFairBanner_show on Show {\n  fair {\n    name\n    href\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment DeprecatedSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FairCard_fair on Fair {\n  name\n  image {\n    cropped(width: 768, height: 512, version: \"wide\") {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment FlatGridItem_artwork on Artwork {\n  ...Metadata_artwork\n  ...DeprecatedSaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n  isSaved\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isSavedToList\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n\nfragment ShowAbout_show on Show {\n  about: description\n}\n\nfragment ShowApp_show_3TMxyn on Show {\n  name\n  href\n  internalID\n  slug\n  about: description\n  isFairBooth\n  viewingRoomsConnection {\n    edges {\n      __typename\n    }\n  }\n  counts {\n    eligibleArtworks\n  }\n  fair {\n    hasFullFeature\n    id\n  }\n  sidebar: filterArtworksConnection(aggregations: $aggregations, first: 1) {\n    counts @include(if: $shouldFetchCounts) {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  images(default: false, size: 100) {\n    url\n  }\n  ...BackToFairBanner_show\n  ...ShowHeader_show\n  ...ShowAbout_show\n  ...ShowMeta_show\n  ...ShowInstallShots_show\n  ...ShowViewingRoom_show\n  ...ShowArtworksEmptyState_show\n  ...ShowArtworks_show_2VV6jB\n  ...ShowContextCard_show\n}\n\nfragment ShowArtworksEmptyState_show on Show {\n  isFairBooth\n  status\n}\n\nfragment ShowArtworks_show_2VV6jB on Show {\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment ShowContextCard_show on Show {\n  isFairBooth\n  partner {\n    __typename\n    ... on Partner {\n      internalID\n      slug\n      href\n      name\n      locations {\n        city\n        id\n      }\n      artworksConnection(first: 3, sort: MERCHANDISABILITY_DESC) {\n        edges {\n          node {\n            image {\n              url(version: \"larger\")\n            }\n            id\n          }\n        }\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  fair {\n    internalID\n    isActive\n    slug\n    href\n    name\n    ...FairTiming_fair\n    ...FairCard_fair\n    id\n  }\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  fair {\n    href\n    isActive\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowHeader_show on Show {\n  name\n  startAt\n  endAt\n  status\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  ...ShowContextualLink_show\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images(default: false, size: 100) {\n    internalID\n    caption\n    mobile: resized(width: 200, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n    }\n    desktop: resized(width: 325, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    zoom: resized(width: 900, height: 900, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  href\n  metaDescription: description\n  metaImage {\n    src: url(version: [\"main\", \"normalized\", \"larger\", \"large\"])\n  }\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n}\n\nfragment ShowViewingRoom_show on Show {\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  viewingRoomsConnection {\n    edges {\n      node {\n        internalID\n        slug\n        status\n        distanceToOpen(short: true)\n        distanceToClose(short: true)\n        title\n        href\n        image {\n          imageURLs {\n            normalized\n          }\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query showRoutes_ShowQuery(\n  $slug: String!\n  $input: FilterArtworksInput\n  $aggregations: [ArtworkAggregation]\n  $shouldFetchCounts: Boolean!\n) {\n  show(id: $slug) @principalField {\n    ...ShowApp_show_3TMxyn\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork\n      ...FlatGridItem_artwork\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BackToFairBanner_show on Show {\n  fair {\n    name\n    href\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment DeprecatedSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment FairCard_fair on Fair {\n  name\n  image {\n    cropped(width: 768, height: 512, version: \"wide\") {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment FlatGridItem_artwork on Artwork {\n  ...Metadata_artwork\n  ...DeprecatedSaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n  isSaved\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isSavedToList\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n\nfragment ShowAbout_show on Show {\n  about: description\n}\n\nfragment ShowApp_show_3TMxyn on Show {\n  name\n  href\n  internalID\n  slug\n  about: description\n  isFairBooth\n  viewingRoomsConnection {\n    edges {\n      __typename\n    }\n  }\n  counts {\n    eligibleArtworks\n  }\n  fair {\n    hasFullFeature\n    id\n  }\n  sidebar: filterArtworksConnection(aggregations: $aggregations, first: 1) {\n    counts @include(if: $shouldFetchCounts) {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  images(default: false, size: 100) {\n    url\n  }\n  ...BackToFairBanner_show\n  ...ShowHeader_show\n  ...ShowAbout_show\n  ...ShowMeta_show\n  ...ShowInstallShots_show\n  ...ShowViewingRoom_show\n  ...ShowArtworksEmptyState_show\n  ...ShowArtworks_show_2VV6jB\n  ...ShowContextCard_show\n}\n\nfragment ShowArtworksEmptyState_show on Show {\n  isFairBooth\n  status\n}\n\nfragment ShowArtworks_show_2VV6jB on Show {\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment ShowContextCard_show on Show {\n  isFairBooth\n  partner {\n    __typename\n    ... on Partner {\n      internalID\n      slug\n      href\n      name\n      locations {\n        city\n        id\n      }\n      artworksConnection(first: 3, sort: MERCHANDISABILITY_DESC) {\n        edges {\n          node {\n            image {\n              url(version: \"larger\")\n            }\n            id\n          }\n        }\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  fair {\n    internalID\n    isActive\n    slug\n    href\n    name\n    ...FairTiming_fair\n    ...FairCard_fair\n    id\n  }\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  fair {\n    href\n    isActive\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowHeader_show on Show {\n  name\n  startAt\n  endAt\n  status\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  ...ShowContextualLink_show\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images(default: false, size: 100) {\n    internalID\n    caption\n    mobile: resized(quality: 85, width: 200, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n    }\n    desktop: resized(quality: 85, width: 325, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    zoom: resized(quality: 85, width: 900, height: 900, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  href\n  metaDescription: description\n  metaImage {\n    src: url(version: [\"main\", \"normalized\", \"larger\", \"large\"])\n  }\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n}\n\nfragment ShowViewingRoom_show on Show {\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  viewingRoomsConnection {\n    edges {\n      node {\n        internalID\n        slug\n        status\n        distanceToOpen(short: true)\n        distanceToClose(short: true)\n        title\n        href\n        image {\n          imageURLs {\n            normalized\n          }\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

In response to [this complaint](https://artsy.slack.com/archives/C03N12SR0RK/p1702895145151689) we learned that shows’ install shots are another case where our `quality: 50` setting bites us.

(Which makes sense since [white- or light-colored walls](https://observablehq.com/@anandaroop/artwork-color-casts) predominate in these photos.)

So this adds another targeted fix — very similar to https://github.com/artsy/force/pull/12913 — this time focusing on install shots.

The effect is subtle, but hopefully this gif (artifacts notwithstanding) makes the change clearer:

![q50-q85-2](https://github.com/artsy/force/assets/140521/e08db660-5419-4c38-867e-e4004f92d174)


