### PR TITLE
chore: rename Saved Alerts to Alerts in settings

### DIFF
--- a/src/Apps/Settings/SettingsApp.tsx
+++ b/src/Apps/Settings/SettingsApp.tsx
@@ -47,7 +47,7 @@ const SettingsApp: React.FC<SettingsAppProps> = ({ me, children }) => {
         <RouteTab to="/settings/edit-profile">Edit Profile</RouteTab>
 
         <ProgressiveOnboardingAlertHighlight position="center">
-          <RouteTab to="/settings/alerts">Saved Alerts</RouteTab>
+          <RouteTab to="/settings/alerts">Alerts</RouteTab>
         </ProgressiveOnboardingAlertHighlight>
 
         <RouteTab to="/settings/edit-settings">Account Settings</RouteTab>

--- a/src/Components/NavBar/Menus/NavBarUserMenu.tsx
+++ b/src/Components/NavBar/Menus/NavBarUserMenu.tsx
@@ -120,7 +120,7 @@ export const NavBarUserMenu: React.FC = () => {
         position={{ top: "3.5px", left: "9.5px" }}
       >
         <NavBarMenuItemLink
-          aria-label="View your saved alerts"
+          aria-label="View your alerts"
           to="/settings/alerts"
           onClick={trackClick}
         >

--- a/src/Components/SavedSearchAlert/__tests__/SavedSearchAlertModal.jest.tsx
+++ b/src/Components/SavedSearchAlert/__tests__/SavedSearchAlertModal.jest.tsx
@@ -126,7 +126,7 @@ describe("SavedSearchAlertModal", () => {
     expect(screen.getAllByRole("checkbox")[1]).toBeChecked()
   })
 
-  it("saved alert button is disabled when no one notification option selected", () => {
+  it("save alert button is disabled when no one notification option selected", () => {
     render(
       <TestComponent initialValues={{ ...formInitialValues, email: false }} />
     )
@@ -135,7 +135,7 @@ describe("SavedSearchAlertModal", () => {
     expect(saveAlertButton).toBeDisabled()
   })
 
-  it("saved alert button is enabled when at least one notification option selected", () => {
+  it("save alert button is enabled when at least one notification option selected", () => {
     render(<TestComponent />)
 
     expect(screen.getByText("Save Alert")).toBeEnabled()


### PR DESCRIPTION
The type of this PR is: **Chore**

This PR solves [ONYX-564]

### Description

This is the only place I could find where alerts are still called "saved alerts"

[ONYX-564]: https://artsyproduct.atlassian.net/browse/ONYX-564?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ