### PR TITLE
feat(ONYX-588): add tracking to the new edit alert screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "superagent": "3.8.3"
   },
   "dependencies": {
-    "@artsy/cohesion": "4.159.0",
+    "@artsy/cohesion": "4.160.0",
     "@artsy/commerce_helpers": "artsy/commerce_helpers",
     "@artsy/detect-responsive-traits": "^0.1.0",
     "@artsy/eigen-web-association": "^1.6.0",

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/NewSavedSearchAlertEditForm.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/NewSavedSearchAlertEditForm.tsx
@@ -34,6 +34,7 @@ import { Modal } from "Components/Alert/Components/Modal/Modal"
 import { NotificationPreferencesQueryRenderer } from "Components/Alert/Components/NotificationPreferences"
 import { SugggestedFiltersQueryRenderer } from "Components/Alert/Components/Form/SuggestedFilters"
 import { useFeatureFlag } from "System/useFeatureFlag"
+import { useAlertTracking } from "Components/Alert/Hooks/useAlertTracking"
 
 interface NewSavedSearchAlertEditFormQueryRendererProps {
   editAlertEntity: EditAlertEntity
@@ -119,6 +120,7 @@ const NewSavedSearchAlertEditForm: React.FC<NewSavedSearchAlertEditFormProps> = 
     "onyx_saved_searches_suggested_filters"
   )
   const { state, goToFilters, dispatch, onComplete } = useAlertContext()
+  const { clickedAddFilters } = useAlertTracking()
 
   const isMounted = useDidMount()
 
@@ -138,8 +140,9 @@ const NewSavedSearchAlertEditForm: React.FC<NewSavedSearchAlertEditFormProps> = 
           isSaveAlertButtonDisabled = false
         }
 
-        const transitionToFilters = () => {
+        const transitionToFiltersAndTrack = () => {
           goToFilters()
+          clickedAddFilters(state.isEditMode)
         }
 
         return (
@@ -168,10 +171,10 @@ const NewSavedSearchAlertEditForm: React.FC<NewSavedSearchAlertEditFormProps> = 
 
               {enableSuggestedFilters ? (
                 <SugggestedFiltersQueryRenderer
-                  transitionToFiltersAndTrack={transitionToFilters}
+                  transitionToFiltersAndTrack={transitionToFiltersAndTrack}
                 />
               ) : (
-                <Clickable onClick={transitionToFilters} width="100%">
+                <Clickable onClick={transitionToFiltersAndTrack} width="100%">
                   <Flex justifyContent="space-between" alignItems={"center"}>
                     <Box>
                       <Text variant="sm-display">Add Filters:</Text>

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp.tsx
@@ -37,6 +37,7 @@ import { useSystemContext } from "System/SystemContext"
 import { SavedSearchAlertsApp_Alert_Query } from "__generated__/SavedSearchAlertsApp_Alert_Query.graphql"
 import { NewSavedSearchAlertEditFormQueryRenderer } from "Apps/Settings/Routes/SavedSearchAlerts/Components/NewSavedSearchAlertEditForm"
 import { useFeatureFlag } from "System/useFeatureFlag"
+import { useAlertTracking } from "Components/Alert/Hooks/useAlertTracking"
 
 interface SavedSearchAlertsAppProps {
   me: SavedSearchAlertsApp_me$data
@@ -58,6 +59,7 @@ export const SavedSearchAlertsApp: React.FC<SavedSearchAlertsAppProps> = ({
   const { relayEnvironment } = useSystemContext()
   const { sendToast } = useToasts()
   const { trackEvent } = useTracking()
+  const { deletedAlert } = useAlertTracking()
   const newAlertModalEnabled = useFeatureFlag("onyx_artwork_alert_modal_v2")
   const [showDeleteModal, setShowDeleteModal] = useState(false)
   const [sort, setSort] = useState("CREATED_AT_DESC")
@@ -103,10 +105,12 @@ export const SavedSearchAlertsApp: React.FC<SavedSearchAlertsAppProps> = ({
   }
 
   const handleDeleted = () => {
-    trackEvent({
-      action: ActionType.deletedSavedSearch,
-      saved_search_id: editAlertEntity?.id,
-    })
+    newAlertModalEnabled
+      ? deletedAlert(editAlertEntity?.id)
+      : trackEvent({
+          action: ActionType.deletedSavedSearch,
+          saved_search_id: editAlertEntity?.id,
+        })
 
     closeEditFormAndRefetch()
     closeDeleteModal()

--- a/src/Components/Alert/AlertProvider.tsx
+++ b/src/Components/Alert/AlertProvider.tsx
@@ -53,7 +53,7 @@ export const AlertProvider: FC<AlertProviderProps> = ({
   isEditMode,
 }) => {
   const newAlertModalEnabled = useFeatureFlag("onyx_artwork_alert_modal_v2")
-  const { createdAlert } = useAlertTracking()
+  const { createdAlert, editedAlert } = useAlertTracking()
   const { showAuthDialog } = useAuthDialog()
   const { value, clearValue } = useAuthIntent()
   const { submitMutation } = useCreateAlert()
@@ -109,6 +109,8 @@ export const AlertProvider: FC<AlertProviderProps> = ({
           },
         },
       })
+
+      editedAlert(searchCriteriaID)
     } catch (error) {
       console.error("Alert/useAlertContext", error)
       logger.error(error)

--- a/src/Components/Alert/Components/Form/SuggestedFilters.tsx
+++ b/src/Components/Alert/Components/Form/SuggestedFilters.tsx
@@ -12,6 +12,7 @@ import {
 import { handleFieldsWithMultipleValues } from "Components/Alert/Helpers/handleFieldsWithMultipleValues"
 import { isValueSelected } from "Components/Alert/Helpers/isValueSelected"
 import { useAlertContext } from "Components/Alert/Hooks/useAlertContext"
+import { useAlertTracking } from "Components/Alert/Hooks/useAlertTracking"
 import { SearchCriteriaAttributeKeys } from "Components/SavedSearchAlert/types"
 import { SuggestedFiltersFetchQuery } from "__generated__/SuggestedFiltersFetchQuery.graphql"
 import { times } from "lodash"
@@ -24,6 +25,7 @@ export const SuggestedFilters: React.FC<SuggestedFiltersProps> = ({
   transitionToFiltersAndTrack,
 }) => {
   const { state, dispatch } = useAlertContext()
+  const { clickedSuggestedFilterOption } = useAlertTracking()
 
   const { artistIDs } = state.criteria
   const { currentArtworkID } = state
@@ -98,6 +100,10 @@ export const SuggestedFilters: React.FC<SuggestedFiltersProps> = ({
                     })
                     break
                 }
+                clickedSuggestedFilterOption(
+                  suggestedFilter.field,
+                  state.isEditMode
+                )
               }}
             >
               {suggestedFilter.displayValue}

--- a/src/Components/Alert/Hooks/useAlertTracking.ts
+++ b/src/Components/Alert/Hooks/useAlertTracking.ts
@@ -5,8 +5,10 @@ import {
   ClickedCreateAlert,
   ContextModule,
   DeletedSavedSearch,
+  EditedAlert,
   OwnerType,
   ScreenOwnerType,
+  SelectedSuggestedFilter,
   ToggledSavedSearch,
 } from "@artsy/cohesion"
 import { useTracking } from "react-tracking"
@@ -39,11 +41,22 @@ export const useAlertTracking = () => {
       trackEvent(payload)
     },
 
-    deletedAlert: () => {
+    editedAlert: (searchCriteriaID: string) => {
+      const payload: EditedAlert = {
+        action: ActionType.editedAlert,
+        saved_search_id: searchCriteriaID,
+        context_screen_owner_type: contextPageOwnerType as ScreenOwnerType,
+      }
+
+      trackEvent(payload)
+    },
+
+    deletedAlert: (searchCriteriaID: string) => {
       const payload: DeletedSavedSearch = {
         action: ActionType.deletedSavedSearch,
         context_screen_owner_id: contextPageOwnerId,
         context_screen_owner_type: contextPageOwnerType as ScreenOwnerType,
+        saved_search_id: searchCriteriaID,
       }
 
       trackEvent(payload)
@@ -60,10 +73,12 @@ export const useAlertTracking = () => {
       trackEvent(payload)
     },
 
-    clickedAddFilters: () => {
+    clickedAddFilters: (isEditMode?: boolean) => {
       const payload: ClickedAddFilters = {
         action: ActionType.clickedAddFilters,
-        context_module: ContextModule.alertFilters,
+        context_module: isEditMode
+          ? ContextModule.editAlert
+          : ContextModule.alertFilters,
       }
 
       trackEvent(payload)
@@ -78,6 +93,18 @@ export const useAlertTracking = () => {
         destination_page_owner_slug: slug,
         destination_page_owner_type: OwnerType.artwork,
         type: "thumbnail",
+      }
+
+      trackEvent(payload)
+    },
+
+    clickedSuggestedFilterOption: (criterion: string, isEditMode?: boolean) => {
+      const payload: SelectedSuggestedFilter = {
+        action: ActionType.selectedSuggestedFilter,
+        context_module: isEditMode
+          ? ContextModule.editAlert
+          : ContextModule.createAlert,
+        subject: criterion,
       }
 
       trackEvent(payload)

--- a/src/Components/Alert/Hooks/useAlertTracking.ts
+++ b/src/Components/Alert/Hooks/useAlertTracking.ts
@@ -51,7 +51,7 @@ export const useAlertTracking = () => {
       trackEvent(payload)
     },
 
-    deletedAlert: (searchCriteriaID: string) => {
+    deletedAlert: (searchCriteriaID?: string) => {
       const payload: DeletedSavedSearch = {
         action: ActionType.deletedSavedSearch,
         context_screen_owner_id: contextPageOwnerId,

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,10 +22,10 @@
   dependencies:
     tslib "~2.0.1"
 
-"@artsy/cohesion@4.159.0":
-  version "4.159.0"
-  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-4.159.0.tgz#ab3cf85cc1368488a8e4b6b2b7fd11ca30e90aec"
-  integrity sha512-oLxaAqcXnrXZPbE75ErnJZNDdtgoPSACIGdDAs0sunPKRVx5f/KFIbv26P+266l/tK0kPLdCUVUnBDOMKZ82Pw==
+"@artsy/cohesion@4.160.0":
+  version "4.160.0"
+  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-4.160.0.tgz#46bf602313efe02f36a24fd985fee86446587e87"
+  integrity sha512-8QhAd3vzoS4Oj3YMSfjQ+dAzjyfoCSxpxTOIprD/37UdWXgh2zjaVelJxmAw7K7bURO9bgCjfv3MaK7Vhr50NA==
   dependencies:
     core-js "3"
 


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [ONYX-588]

### Description

<!-- Implementation description -->

Add tracking to the new edit alert screen

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-588]: https://artsyproduct.atlassian.net/browse/ONYX-588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ