### PR TITLE
refactor: do not throttle experiment_viewed tracking events

### DIFF
--- a/docs/unleash_a-b_testing.md
+++ b/docs/unleash_a-b_testing.md
@@ -1,11 +1,12 @@
 # A/B Testing with Unleash
 
-### Create an A/B test via our Internal Tools app: 
+### Create an A/B test via our Internal Tools app:
+
 - Login to https://tools.artsy.net/feature-flags
-- Select `Create` 
+- Select `Create`
 - Give your A/B test a name
-- Select `Experiment` checkbox 
-- Assign weights to each `control` and `experiment` (eg, 50-50; 50% of users will see control and 50% of users will see experiment) 
+- Select `Experiment` checkbox
+- Assign weights to each `control` and `experiment` (eg, 50-50; 50% of users will see control and 50% of users will see experiment)
 - Add additional variants if necessary
 - Hit `Create`
 
@@ -118,8 +119,6 @@ function MyComponent() {
 
 }
 ```
-
-The number of segment events sent for an experiment is [throttled](https://github.com/artsy/force/blob/main/src/System/useFeatureFlag.tsx#L65) to one event per user, per variant view.
 
 ### Accessing flags on the server
 

--- a/src/System/useFeatureFlag.tsx
+++ b/src/System/useFeatureFlag.tsx
@@ -92,7 +92,7 @@ export function useTrackFeatureVariant({
     const pageSlug = pageParts[2]
     const pageType = pathToOwnerType(path)
 
-    if (experimentViewTracked.current !== true && variantName !== "disabled") {
+    if (!experimentViewTracked.current && variantName !== "disabled") {
       // HACK: We are using window.analytics.track over trackEvent from useTracking because
       // the trackEvent wasn't behaving as expected, it was never firing the event and
       // moving to using the solution below fixed the issue.


### PR DESCRIPTION
The type of this PR is: refactor

This PR solves [PHIRE-533]

### Description
This PR refactors the `useFeatureFlag` hook to no longer throttle segment events when `trackFeatureView` is called.  

### Problem
Currently, we throttle the number of segment events to one event per user, per variant view (i.e., if a user sees an experiment multiple times, only the first view sends a segment event), using `localStorage` to track if an experiment was viewed or not. This implementation makes it difficult to analyze and accurately report on the outcome of our experiments and creates extra work for the data team. This was discussed in more detail in this [Slack thread](https://artsy.slack.com/archives/C0KEQD4B0/p1702548231405999) and the recommendation was made to change the implementation.

### Solution
With these changes, we will send a segment event each time a user views an experiment. In other words, if a user sees an experiment 10 times, we send 10 `experiment_viewed` events, one for each view. 

### TODO
- [x] Do some quick smoke testing locally, using the segment dashboard to verify. 

### Migration
Merge this PR when we no longer have an [experiment running ](https://unleash.artsy.net/features?sort=type)in `unleash`.

[PHIRE-533]: https://artsyproduct.atlassian.net/browse/PHIRE-533?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ