### PR TITLE
revert: revert the palette version to 37.2.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@artsy/icons": "3.11.0",
     "@artsy/img": "1.0.3",
     "@artsy/multienv": "^1.2.0",
-    "@artsy/palette": "37.3.0",
+    "@artsy/palette": "37.2.2",
     "@artsy/palette-charts": "36.3.0",
     "@artsy/react-html-parser": "^3.0.2",
     "@artsy/to-title-case": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -103,12 +103,30 @@
     d3-shape "^1.3.5"
     styled-system "^5.1.5"
 
-"@artsy/palette-tokens@^5.1.0":
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/@artsy/palette-tokens/-/palette-tokens-5.1.0.tgz#df546dda1aec2dbf631a816b047301333459aa2a"
-  integrity sha512-dBx1hkjTBQ460L8DTMou+vXNOaD1DAApt6UYGTSMVSfXX0/AE8ZJpPx0U3y2t20wNBPzIoYpDBusJ3vRFKrZzQ==
+"@artsy/palette-tokens@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@artsy/palette-tokens/-/palette-tokens-5.0.0.tgz#d1e1917d8163d88e7a9f877cf06b609fa8c8178c"
+  integrity sha512-nloC0ubH5XDVNiplehwTtDLEgY0vjeE3l8QUYppEIHFCgadntXm6aVlmEC79inO7L3lDYN7JckYlIYRrTJg3vw==
 
-"@artsy/palette@37.3.0", "@artsy/palette@^37.3.0":
+"@artsy/palette@37.2.2":
+  version "37.2.2"
+  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-37.2.2.tgz#529fc66cd1a32701c7360e7c33add924ab9a01c9"
+  integrity sha512-Rd9JOyGcF9GqwY070m6n9s0RcbEclnv7j/7BC11v+ShqnMiIHabTXx0MzPpgyDexesNfrAGeK35zy8fBu+ezsw==
+  dependencies:
+    "@artsy/icons" "^3.2.2"
+    "@artsy/palette-tokens" "^5.0.0"
+    "@seznam/compose-react-refs" "^1.0.6"
+    "@styled-system/theme-get" "^5.1.2"
+    lodash "^4.17.21"
+    proportional-scale "^4.0.0"
+    react-focus-on "^3.7.0"
+    react-lazy-load-image-component "1.5.5"
+    styled-system "^5.1.5"
+    trunc-html "^1.1.2"
+    use-cursor "^1.2.3"
+    use-keyboard-list-navigation "2.4.2"
+
+"@artsy/palette@^37.3.0":
   version "37.3.0"
   resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-37.3.0.tgz#930df3d9697800c0aa8e7b01a47cfb56c84b9245"
   integrity sha512-DZXE7ili3g73cOAG+XXDQZyWx+bBjOjWg5Bkt77+BhBdSems/jHBcJ8vGvvZ0l7heVcYvU7B8W11NNYBSCkhAw==


### PR DESCRIPTION
The type of this PR is: **Revert**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->


### Description

Since upgrading the palette version to 37.2.3  was [merged](https://github.com/artsy/force/commit/b87756920b6fd9e8ca0d99da5cf94b18d7521c2a), [two tests](https://app.circleci.com/pipelines/github/artsy/force/56771/workflows/21833c23-7908-4f45-97e2-f54aaf6feadf/jobs/424662) have been failing. To unblock other works, this PR reverts the change:  https://github.com/artsy/force/pull/13318

<!-- Implementation description -->

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ