### PR TITLE
fix(deepzoom): works with new portal

### DIFF
--- a/src/Components/DeepZoom/DeepZoom.tsx
+++ b/src/Components/DeepZoom/DeepZoom.tsx
@@ -37,8 +37,10 @@ const DeepZoom: React.FC<DeepZoomProps> = ({ image, onClose }) => {
     }))
   }
 
+  const isMounted = useDidMount()
+
   useEffect(() => {
-    if (!deepZoomRef.current) return
+    if (!isMounted || !deepZoomRef.current) return
 
     import(/* webpackChunkName: "openseadragon" */ "openseadragon").then(
       OpenSeaDragon => {
@@ -92,7 +94,7 @@ const DeepZoom: React.FC<DeepZoomProps> = ({ image, onClose }) => {
       osdViewerRef.current.destroy()
       osdViewerRef.current = null
     }
-  }, [image.deepZoom])
+  }, [image.deepZoom, isMounted])
 
   const zoomBy = (amount: number) => {
     if (!osdViewerRef.current) return
@@ -127,8 +129,6 @@ const DeepZoom: React.FC<DeepZoomProps> = ({ image, onClose }) => {
 
   const { detectActivityProps, isActive } = useDetectActivity()
 
-  const isMounted = useDidMount()
-
   return (
     <ModalBase onClose={onClose} {...detectActivityProps}>
       <Box
@@ -140,6 +140,7 @@ const DeepZoom: React.FC<DeepZoomProps> = ({ image, onClose }) => {
       />
 
       <DeepZoomCloseButton
+        aria-label="Close"
         position="absolute"
         top={0}
         right={0}
@@ -158,6 +159,7 @@ const DeepZoom: React.FC<DeepZoomProps> = ({ image, onClose }) => {
         }}
       >
         <DeepZoomSlider
+          aria-label="Zoom level"
           onChange={handleSliderChanged}
           onZoomInClicked={handleZoomInClicked}
           onZoomOutClicked={handleZoomOutClicked}

--- a/src/Components/DeepZoom/__tests__/DeepZoom.jest.tsx
+++ b/src/Components/DeepZoom/__tests__/DeepZoom.jest.tsx
@@ -1,16 +1,23 @@
 import { graphql } from "react-relay"
-import { setupTestWrapper } from "DevTools/setupTestWrapper"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { DeepZoomFragmentContainer } from "Components/DeepZoom/DeepZoom"
 import { DeepZoom_Test_Query } from "__generated__/DeepZoom_Test_Query.graphql"
+import { screen } from "@testing-library/react"
 
 jest.unmock("react-relay")
 
+jest.mock("@artsy/palette", () => {
+  return {
+    ...jest.requireActual("@artsy/palette"),
+    ModalBase: ({ children }) => children,
+  }
+})
+
 const handleClose = jest.fn()
 
-const { getWrapper } = setupTestWrapper<DeepZoom_Test_Query>({
+const { renderWithRelay } = setupTestWrapperTL<DeepZoom_Test_Query>({
   Component: ({ artwork }) => {
     const image = artwork!.images![0]!
-
     return <DeepZoomFragmentContainer image={image} onClose={handleClose} />
   },
   query: graphql`
@@ -30,19 +37,18 @@ describe("DeepZoom", () => {
   })
 
   it("renders correctly", () => {
-    const { wrapper } = getWrapper()
+    renderWithRelay()
 
-    expect(wrapper.html()).toContain(
-      'input min="0" max="1" step="0.001" type="range"'
-    )
+    expect(screen.getByLabelText("Zoom level")).toBeInTheDocument()
   })
 
   it("calls onClose when the close button is clicked", () => {
-    const { wrapper } = getWrapper()
+    renderWithRelay()
 
     expect(handleClose).not.toBeCalled()
 
-    wrapper.find("button").first().simulate("click")
+    const button = screen.getByLabelText("Close")
+    button.click()
 
     expect(handleClose).toBeCalledTimes(1)
   })


### PR DESCRIPTION
Fixes the underlying issue that https://github.com/artsy/force/pull/13332 was going to revert.

`OpenSeadragon` wasn't initializing because of the way this component + effect was structured. The fact that Renovate auto-merged a failing branch is also concerning.