### PR TITLE
fix: failing test after palette upgrade

### DIFF
--- a/src/Apps/Order/Routes/Shipping2/__tests__/Shipping2.jest.tsx
+++ b/src/Apps/Order/Routes/Shipping2/__tests__/Shipping2.jest.tsx
@@ -345,7 +345,7 @@ describe("Shipping", () => {
           relayEnv
         )
 
-        expect(screen.getAllByRole("button", { name: "Offer" }).length).toBe(2)
+        expect(screen.getAllByRole("button", { name: "Offer" }).length).toBe(1)
       })
 
       it("renders fulfillment selection if artwork is available for pickup", async () => {

--- a/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Shipping.jest.tsx
@@ -293,7 +293,7 @@ describe("Shipping", () => {
           Me: () => meWithoutAddress,
         })
 
-        expect(screen.getAllByRole("button", { name: "Offer" }).length).toBe(2)
+        expect(screen.getAllByRole("button", { name: "Offer" }).length).toBe(1)
       })
 
       it("renders fulfillment selection if artwork is available for pickup", async () => {


### PR DESCRIPTION
We noticed that Force's test suite was failing after some dependency updates were auto-merged. We believe that the following updates could have changed something that caused these tests to fail:

- https://github.com/artsy/force/pull/13360
- https://github.com/artsy/force/pull/13363

The existing tests were failing because the "Offer" stepper button in the checkout flow was wrapped inside another button, like this:

```
<button>
  <div>
    <button>
      Offer
    </button>
  </div>
<button>
```

And the testing library was recognizing this as two buttons with the same text, so the tests were asserting the existence of 2 buttons. Whatever caused these tests to fail was a blessing in disguise because this allows the test to assert the existence of 1 button.