### PR TITLE
feat(EMI-1595): add text and tooltip to saves list header

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves/Components/ArtworkListsHeader.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves/Components/ArtworkListsHeader.tsx
@@ -4,6 +4,9 @@ import { useToasts } from "@artsy/palette"
 import { useTranslation } from "react-i18next"
 import { CreateNewListModalWizard } from "./CreateNewListModal/CreateNewListModalWizard"
 import { ArtworkList } from "./CreateNewListModal/CreateNewListModal"
+import { ProgressiveOnboardingSaveTitle } from "Components/ProgressiveOnboarding/ProgressiveOnboardingSaveTitle"
+import { RouterLink } from "System/Router/RouterLink"
+import { useFeatureFlag } from "System/useFeatureFlag"
 
 interface ArtworkListsHeaderProps {
   savedArtworksCount: number
@@ -35,6 +38,10 @@ export const ArtworkListsHeader: FC<ArtworkListsHeaderProps> = ({
     setModalIsOpened(false)
   }
 
+  const isPartnerOfferEnabled = useFeatureFlag(
+    "emerald_partner-offers-from-saves"
+  )
+
   return (
     <>
       {modalIsOpened && (
@@ -57,7 +64,19 @@ export const ArtworkListsHeader: FC<ArtworkListsHeaderProps> = ({
           alignItems={["stretch", "center"]}
         >
           <Text variant="sm-display" color="black60">
-            {t("collectorSaves.artworkListsHeader.curateYourList")}
+            {isPartnerOfferEnabled ? (
+              <ProgressiveOnboardingSaveTitle>
+                {t("collectorSaves.artworkListsHeader.curateYourList") +
+                  " " +
+                  t("collectorSaves.artworkListsHeader.connector") +
+                  " "}
+                <RouterLink to="TODO.com">
+                  {t("collectorSaves.artworkListsHeader.signalInterest")}
+                </RouterLink>
+              </ProgressiveOnboardingSaveTitle>
+            ) : (
+              t("collectorSaves.artworkListsHeader.curateYourList")
+            )}
           </Text>
 
           <Button

--- a/src/Apps/CollectorProfile/Routes/Saves/Components/ArtworkListsHeader.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves/Components/ArtworkListsHeader.tsx
@@ -70,7 +70,7 @@ export const ArtworkListsHeader: FC<ArtworkListsHeaderProps> = ({
                   " " +
                   t("collectorSaves.artworkListsHeader.connector") +
                   " "}
-                <RouterLink to="TODO.com">
+                <RouterLink to="https://support.artsy.net/s/article/Offers-on-saved-works">
                   {t("collectorSaves.artworkListsHeader.signalInterest")}
                 </RouterLink>
               </ProgressiveOnboardingSaveTitle>

--- a/src/Components/ProgressiveOnboarding/ProgressiveOnboardingSaveTitle.tsx
+++ b/src/Components/ProgressiveOnboarding/ProgressiveOnboardingSaveTitle.tsx
@@ -36,7 +36,7 @@ export const __ProgressiveOnboardingSaveTitle__: FC<ProgressiveOnboardingSaveTit
       onClose={handleClose}
       popover={
         <Text variant="xs">
-          <>{t("collectorSaves.artworkListsHeader.curateYourList")}</>
+          {t("collectorSaves.artworkListsHeader.curateYourList")}
         </Text>
       }
     >

--- a/src/Components/ProgressiveOnboarding/ProgressiveOnboardingSaveTitle.tsx
+++ b/src/Components/ProgressiveOnboarding/ProgressiveOnboardingSaveTitle.tsx
@@ -1,0 +1,50 @@
+import { FC, useCallback } from "react"
+import { Text } from "@artsy/palette"
+import { ProgressiveOnboardingPopover } from "Components/ProgressiveOnboarding/ProgressiveOnboardingPopover"
+import {
+  withProgressiveOnboardingCounts,
+  WithProgressiveOnboardingCountsProps,
+} from "Components/ProgressiveOnboarding/withProgressiveOnboardingCounts"
+import { useDismissibleContext } from "@artsy/dismissible"
+import { PROGRESSIVE_ONBOARDING_ALERTS } from "Components/ProgressiveOnboarding/progressiveOnboardingAlerts"
+import { t } from "i18next"
+
+const ALERT_ID = PROGRESSIVE_ONBOARDING_ALERTS.saveTitle
+
+interface ProgressiveOnboardingSaveTitleProps
+  extends WithProgressiveOnboardingCountsProps {}
+
+export const __ProgressiveOnboardingSaveTitle__: FC<ProgressiveOnboardingSaveTitleProps> = ({
+  children,
+}) => {
+  const { dismiss, isDismissed } = useDismissibleContext()
+
+  const isDisplayble = !isDismissed(ALERT_ID).status
+
+  const handleClose = useCallback(() => {
+    dismiss(ALERT_ID)
+  }, [dismiss])
+
+  if (!isDisplayble) {
+    return <>{children}</>
+  }
+
+  return (
+    <ProgressiveOnboardingPopover
+      name={ALERT_ID}
+      placement="top-end"
+      onClose={handleClose}
+      popover={
+        <Text variant="xs">
+          <>{t("collectorSaves.artworkListsHeader.curateYourList")}</>
+        </Text>
+      }
+    >
+      {children}
+    </ProgressiveOnboardingPopover>
+  )
+}
+
+export const ProgressiveOnboardingSaveTitle = withProgressiveOnboardingCounts(
+  __ProgressiveOnboardingSaveTitle__
+)

--- a/src/Components/ProgressiveOnboarding/progressiveOnboardingAlerts.tsx
+++ b/src/Components/ProgressiveOnboarding/progressiveOnboardingAlerts.tsx
@@ -8,6 +8,7 @@ export const PROGRESSIVE_ONBOARDING_ALERTS = {
   saveArtwork: "save-artwork",
   saveFind: "save-find",
   saveHighlight: "save-highlight",
+  saveTitle: "save-title",
 
   // Alerts
   alertCreate: "alert-create",
@@ -35,6 +36,7 @@ export const PROGRESSIVE_ONBOARDING_SAVE_CHAIN = [
   PROGRESSIVE_ONBOARDING_ALERTS.saveArtwork,
   PROGRESSIVE_ONBOARDING_ALERTS.saveFind,
   PROGRESSIVE_ONBOARDING_ALERTS.saveHighlight,
+  PROGRESSIVE_ONBOARDING_ALERTS.saveTitle,
 ] as const
 
 export const getProgressiveOnboardingAlertKeys = () => {

--- a/src/System/i18n/locales/en-US/translation.json
+++ b/src/System/i18n/locales/en-US/translation.json
@@ -136,7 +136,10 @@
       "listCreated": "{{listName}} Created",
       "savedArtworks": "Saves",
       "curateYourList": "Curate your own lists of the works you love",
-      "createNewListButton": "Create New List"
+      "createNewListButton": "Create New List",
+      "connector": "and",
+      "signalInterest": "signal your interest to galleries",
+      "popover": "Learn more about saves and how to manage your preferences."
     },
     "createNewListModal": {
       "title": "Create a new list"


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [EMI-1595]

### Description

Inform users about the Partner Offer new project by showing a toast on the saves page.

### Mobile:
<img width="500" alt="Screenshot 2024-01-10 at 16 47 47" src="https://github.com/artsy/force/assets/7518671/ae0fec66-5925-4a16-a9ce-7c2763b9f724">

### Web:
<img width="605" alt="Screenshot 2024-01-10 at 16 48 03" src="https://github.com/artsy/force/assets/7518671/193f4be5-5b34-4ecc-a6b2-ba871ba41918">


#### Note: 
I found it hard to follow the designs perfectly. Tried having the ProgressiveOnborading only on the specific link but it generated issues in the responsive view, as it created a div that I couldn't wrap around and instead the text was displayed as 2 columns like so
<img width="605" alt="Screenshot 2024-01-11 at 14 59 32" src="https://github.com/artsy/force/assets/7518671/4bbd344d-313c-4316-b1d9-8d81dc8aa2b1">



[EMI-1595]: https://artsyproduct.atlassian.net/browse/EMI-1595?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ