### PR TITLE
Feat: Address autocomplete for auction registration and user settings

### DIFF
--- a/src/Apps/Order/Routes/Shipping2/Components/FulfillmentDetailsForm.tsx
+++ b/src/Apps/Order/Routes/Shipping2/Components/FulfillmentDetailsForm.tsx
@@ -367,7 +367,8 @@ const FulfillmentDetailsFormLayout = (
                   }
                   data-testid="AddressForm_addressLine1"
                   onClear={function (): void {
-                    throw new Error("Function not implemented.")
+                    setFieldValue("attributes.addressLine1", "")
+                    setHasAutocompletedAddress(false)
                   }}
                 />
               </Column>


### PR DESCRIPTION
The type of this PR is: **feat**

This PR adds address autocomplete to the auction registration form and the settings > shipping address modal.
<details><summary>Screencap (UX is identical for both forms)</summary>

![2024-01-16 15 49 28](https://github.com/artsy/force/assets/9088720/3cd31058-8ae1-45fb-ae8d-207510dd0e83)

</details> 

TODOs if we wanted to merge one or both of these:
- the form layout is not logical for an autocompleted address field because the postal code comes first (see screencap).
- need to clarify analytics values - I did not immediately find a context module for auction registration.
- the auction registration address form is technically a billing address form. we may want to add an '...and also save to my shipping addresses' box. However this might impact auction ops.
- it might make sense to move the (now 3x duplicated) `trackAutocompleteEdits` helper somewhere. It makes sense to put it in the hook to me (for the future secondary address field search work, we would like to know if an address was already autocompleted) but that might require more thought. doesn't need to block this ticket.
- may impact integrity tests, but I hope not.
cc @dzucconi 
