### PR TITLE
fix: Typescript type checking error in ErrorPage component

### DIFF
--- a/src/Components/ErrorPage.tsx
+++ b/src/Components/ErrorPage.tsx
@@ -55,19 +55,23 @@ export const ErrorPage: React.FC<ErrorPageProps> = ({
         </Column>
       </GridColumns>
 
-      {(code >= 500 || typeof code === "string") && (detail || message) && (
-        <>
-          <Spacer y={4} />
+      {((typeof code === "number" && code >= 500) ||
+        typeof code === "string") &&
+        (detail || message) && (
+          <>
+            <Spacer y={4} />
 
-          {message && (
-            <Message color={detail ? "black100" : "black60"}>{message}</Message>
-          )}
+            {message && (
+              <Message color={detail ? "black100" : "black60"}>
+                {message}
+              </Message>
+            )}
 
-          {detail && (
-            <Detail {...(message ? { mt: "-1px" } : {})}>{detail}</Detail>
-          )}
-        </>
-      )}
+            {detail && (
+              <Detail {...(message ? { mt: "-1px" } : {})}>{detail}</Detail>
+            )}
+          </>
+        )}
     </Box>
   )
 }


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

<!-- Implementation description -->

Really small change to fix a type check error I came across while looking at the ErrorPage component. Implemented the co-pilot suggested fix to resolve:

<img width="593" alt="Screenshot 2024-01-17 at 2 26 59 PM" src="https://github.com/artsy/force/assets/29984068/fbc73586-3859-4544-a0d0-ca8979868844">


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ