### PR TITLE
feat: Implement notification pages for Alert and Follow notifications

### DIFF
--- a/src/Apps/Notifications/NotificationsApp.tsx
+++ b/src/Apps/Notifications/NotificationsApp.tsx
@@ -10,7 +10,7 @@ import { GridColumns, Column, Flex, FullBleed } from "@artsy/palette"
 import { DESKTOP_NAV_BAR_HEIGHT } from "Components/NavBar/constants"
 
 const DESKTOP_HEIGHT = `calc(100vh - ${DESKTOP_NAV_BAR_HEIGHT}px)`
-const MIN_LIST_WIDTH = 340
+const MIN_LIST_WIDTH = 350
 
 interface NotificationsAppProps {
   me: NotificationsApp_me$data

--- a/src/Components/Notifications/AlertNotification.tsx
+++ b/src/Components/Notifications/AlertNotification.tsx
@@ -1,0 +1,102 @@
+import { Flex, Spacer, Text, Box, Pill } from "@artsy/palette"
+import { RouterLink } from "System/Router/RouterLink"
+import { FC } from "react"
+import { useFragment, graphql } from "react-relay"
+import { NotificationTypeLabel } from "Components/Notifications/NotificationTypeLabel"
+import { NotificationArtworkList } from "Components/Notifications/NotificationArtworkList"
+import { AlertNotification_notification$key } from "__generated__/AlertNotification_notification.graphql"
+
+interface AlertNotificationProps {
+  notification: AlertNotification_notification$key
+}
+
+export const AlertNotification: FC<AlertNotificationProps> = ({
+  notification,
+}) => {
+  const notificationData = useFragment(AlertNotificationFragment, notification)
+
+  const { artworksConnection, headline, item } = notificationData
+
+  const alert = item?.alert
+  const artist = item?.alert?.artists?.[0]
+
+  if (!alert || !artist) {
+    return (
+      <Text variant="lg" m={4}>
+        Sorry, something went wrong.
+      </Text>
+    )
+  }
+
+  return (
+    <Box mx={4} my={4}>
+      <Flex width="100%" justifyContent="space-between">
+        <Flex flex={1}>
+          <Text fontWeight="bold" variant="xl">
+            {headline}
+          </Text>
+        </Flex>
+        <RouterLink to={`/settings/alerts/${alert.internalID}/edit`}>
+          <Text>Edit Alert</Text>
+        </RouterLink>
+      </Flex>
+
+      <Spacer y={1} />
+
+      <NotificationTypeLabel item={notificationData} />
+
+      <Spacer y={1} />
+
+      <Flex flexDirection="row" flexWrap="wrap">
+        {alert.labels.map(label => (
+          <Pill
+            variant="filter"
+            mr={1}
+            mb={1}
+            key={`filter-label-${label?.displayValue}`}
+            disabled
+            borderColor="black30"
+          >
+            {label?.displayValue}
+          </Pill>
+        ))}
+      </Flex>
+
+      <Spacer y={4} />
+
+      <NotificationArtworkList artworksConnection={artworksConnection} />
+
+      <Spacer y={4} />
+
+      <RouterLink to={`/artist/${artist?.slug}/works-for-sale`}>
+        <Text fontWeight="bold">View all works by {artist.name}</Text>
+      </RouterLink>
+    </Box>
+  )
+}
+
+export const AlertNotificationFragment = graphql`
+  fragment AlertNotification_notification on Notification {
+    artworksConnection(first: 10) {
+      ...NotificationArtworkList_artworksConnection
+      totalCount
+    }
+    headline
+    item {
+      ... on AlertNotificationItem {
+        alert {
+          internalID
+          artists {
+            name
+            slug
+          }
+          labels {
+            displayValue
+          }
+        }
+      }
+    }
+    notificationType
+    publishedAt(format: "RELATIVE")
+  }
+`

--- a/src/Components/Notifications/ArtworkPublishedNotification.tsx
+++ b/src/Components/Notifications/ArtworkPublishedNotification.tsx
@@ -1,0 +1,83 @@
+import { Flex, Spacer, Text, Box } from "@artsy/palette"
+import { FollowArtistButtonQueryRenderer } from "Components/FollowButton/FollowArtistButton"
+import { RouterLink } from "System/Router/RouterLink"
+import { FC } from "react"
+import { useFragment, graphql } from "react-relay"
+import { ArtworkPublishedNotification_notification$key } from "__generated__/ArtworkPublishedNotification_notification.graphql"
+import { NotificationTypeLabel } from "Components/Notifications/NotificationTypeLabel"
+import { NotificationArtworkList } from "Components/Notifications/NotificationArtworkList"
+
+interface ArtworkPublishedNotificationProps {
+  notification: ArtworkPublishedNotification_notification$key
+}
+
+export const ArtworkPublishedNotification: FC<ArtworkPublishedNotificationProps> = ({
+  notification,
+}) => {
+  const notificationData = useFragment(
+    ArtworkPublishedNotificationFragment,
+    notification
+  )
+
+  const { artworksConnection, headline, item } = notificationData
+
+  const artist = item?.artists?.[0]
+
+  if (!artist) {
+    return (
+      <Text variant="lg" m={4}>
+        Sorry, something went wrong.
+      </Text>
+    )
+  }
+
+  return (
+    <Box mx={4} my={4}>
+      <Text fontWeight="bold" variant="xl">
+        {headline}
+      </Text>
+
+      <Spacer y={1} />
+
+      <NotificationTypeLabel item={notificationData} />
+
+      <Spacer y={1} />
+
+      <FollowArtistButtonQueryRenderer id={artist.internalID} size="small" />
+
+      <Spacer y={4} />
+
+      <NotificationArtworkList artworksConnection={artworksConnection} />
+
+      <Spacer y={4} />
+
+      <RouterLink to={`/artist/${artist?.slug}/works-for-sale`}>
+        <Flex flexDirection="row">
+          <Text fontWeight="bold">View all works by {artist.name}</Text>
+        </Flex>
+      </RouterLink>
+    </Box>
+  )
+}
+
+export const ArtworkPublishedNotificationFragment = graphql`
+  fragment ArtworkPublishedNotification_notification on Notification {
+    artworksConnection(first: 10) {
+      ...NotificationArtworkList_artworksConnection
+      totalCount
+    }
+    headline
+    item {
+      ... on ArtworkPublishedNotificationItem {
+        artists {
+          internalID
+          isFollowed
+          name
+          slug
+        }
+      }
+    }
+    notificationType
+    publishedAt(format: "RELATIVE")
+  }
+`

--- a/src/Components/Notifications/Notification.tsx
+++ b/src/Components/Notifications/Notification.tsx
@@ -4,12 +4,14 @@ import {
   SkeletonBox,
   SkeletonText,
   Spacer,
-  Text,
 } from "@artsy/palette"
 import { graphql, useLazyLoadQuery } from "react-relay"
 import { NotificationQuery } from "__generated__/NotificationQuery.graphql"
 import { useNotificationsContext } from "Components/Notifications/useNotificationsContext"
-import { Suspense } from "react"
+import { Suspense, useEffect } from "react"
+import { ArtworkPublishedNotification } from "Components/Notifications/ArtworkPublishedNotification"
+import { AlertNotification } from "Components/Notifications/AlertNotification"
+import { useRouter } from "found"
 
 export const SUPPORTED_NOTIFICATION_TYPES = [
   "ARTWORK_ALERT",
@@ -21,34 +23,40 @@ interface NotificationProps {
 }
 
 const Notification: React.FC<NotificationProps> = ({ notificationId }) => {
-  const { me } = useLazyLoadQuery<NotificationQuery>(notificationQuery, {
-    id: notificationId,
+  const { router } = useRouter()
+
+  const data = useLazyLoadQuery<NotificationQuery>(notificationQuery, {
+    internalID: notificationId,
   })
 
-  if (!me) {
+  const notification = data.me?.notification
+
+  // Redirect user to the notifications targetHref if the notification type is not supported
+  useEffect(() => {
+    if (
+      !SUPPORTED_NOTIFICATION_TYPES.includes(
+        notification?.notificationType as string
+      )
+    ) {
+      router.push(notification?.targetHref as string)
+    }
+  }, [notification, router])
+
+  // TODO: Implement error handling
+  if (!data.me?.notification) {
     return null
   }
 
-  const { notification } = me
-
-  if (!notification) {
-    return (
-      <Text variant="sm-display" px={2} py={4}>
-        There is nothing to show.
-      </Text>
-    )
+  switch (notification?.notificationType) {
+    case "ARTWORK_ALERT":
+      return <AlertNotification notification={data.me?.notification} />
+    case "ARTWORK_PUBLISHED":
+      return (
+        <ArtworkPublishedNotification notification={data.me?.notification} />
+      )
+    default:
+      return null
   }
-
-  return (
-    <Flex flexDirection="column" m={4}>
-      <Text variant="xl" mb={2}>
-        {notification.title}
-      </Text>
-
-      {/* TODO: Please remove me. I'm just here to test scrolling. */}
-      <Flex height={2000} />
-    </Flex>
-  )
 }
 
 export const NotificationQueryRenderer: React.FC = props => {
@@ -66,10 +74,14 @@ export const NotificationQueryRenderer: React.FC = props => {
 }
 
 const notificationQuery = graphql`
-  query NotificationQuery($id: String!) {
+  query NotificationQuery($internalID: String!) {
     me {
-      notification(id: $id) {
-        title
+      notification(id: $internalID) {
+        notificationType
+        targetHref
+
+        ...AlertNotification_notification
+        ...ArtworkPublishedNotification_notification
       }
     }
   }

--- a/src/Components/Notifications/Notification.tsx
+++ b/src/Components/Notifications/Notification.tsx
@@ -12,7 +12,7 @@ import { useNotificationsContext } from "Components/Notifications/useNotificatio
 import { Suspense, useEffect } from "react"
 import { ArtworkPublishedNotification } from "Components/Notifications/ArtworkPublishedNotification"
 import { AlertNotification } from "Components/Notifications/AlertNotification"
-import { useRouter } from "found"
+import { useRouter } from "System/Router/useRouter"
 
 export const SUPPORTED_NOTIFICATION_TYPES = [
   "ARTWORK_ALERT",

--- a/src/Components/Notifications/Notification.tsx
+++ b/src/Components/Notifications/Notification.tsx
@@ -4,6 +4,7 @@ import {
   SkeletonBox,
   SkeletonText,
   Spacer,
+  Text,
 } from "@artsy/palette"
 import { graphql, useLazyLoadQuery } from "react-relay"
 import { NotificationQuery } from "__generated__/NotificationQuery.graphql"
@@ -38,13 +39,16 @@ const Notification: React.FC<NotificationProps> = ({ notificationId }) => {
         notification?.notificationType as string
       )
     ) {
-      router.push(notification?.targetHref as string)
+      router.replace(notification?.targetHref as string)
     }
   }, [notification, router])
 
-  // TODO: Implement error handling
   if (!data.me?.notification) {
-    return null
+    return (
+      <Text variant="lg" m={4}>
+        Sorry, something went wrong.
+      </Text>
+    )
   }
 
   switch (notification?.notificationType) {

--- a/src/Components/Notifications/NotificationArtwork.tsx
+++ b/src/Components/Notifications/NotificationArtwork.tsx
@@ -1,0 +1,108 @@
+import * as React from "react"
+import { graphql, useFragment } from "react-relay"
+import { RouterLink, RouterLinkProps } from "System/Router/RouterLink"
+import { NotificationArtwork_artwork$key } from "__generated__/NotificationArtwork_artwork.graphql"
+import Metadata from "Components/Artwork/Metadata"
+import { AuthContextModule } from "@artsy/cohesion"
+import { Box, Button, Image } from "@artsy/palette"
+import { ManageArtworkForSavesProvider } from "Components/Artwork/ManageArtworkForSaves"
+import { resized } from "Utils/resized"
+
+const MAX_WIDTH = 600
+
+export interface NotificationArtworkProps
+  extends Omit<RouterLinkProps, "to" | "width"> {
+  artwork: NotificationArtwork_artwork$key
+  contextModule?: AuthContextModule
+  onClick?: () => void
+}
+
+export const NotificationArtwork: React.FC<NotificationArtworkProps> = ({
+  artwork: artworkProp,
+  contextModule,
+  onClick,
+  ...rest
+}) => {
+  const artwork = useFragment(notificationArtworkFragment, artworkProp)
+
+  if (!artwork.image?.src) {
+    return null
+  }
+
+  const image = resized(artwork.image.src, { width: MAX_WIDTH })
+
+  const label =
+    (artwork.title ?? "Artwork") +
+    (artwork.artistNames ? ` by ${artwork.artistNames}` : "")
+
+  return (
+    <ManageArtworkForSavesProvider>
+      <RouterLink
+        to={artwork?.href}
+        onClick={onClick}
+        display="flex"
+        flexDirection="column"
+        textDecoration="none"
+        aria-label={label}
+        maxWidth={MAX_WIDTH}
+        overflow="hidden"
+        width="100%"
+        {...rest}
+        mb={2}
+      >
+        <Box
+          width="100%"
+          style={{
+            aspectRatio: `${artwork.image?.width ?? 1} / ${
+              artwork.image?.height ?? 1
+            }`,
+          }}
+          bg="black10"
+        >
+          <Image
+            src={image.src}
+            srcSet={image.srcSet}
+            width="100%"
+            height="100%"
+            lazyLoad
+            alt=""
+          />
+        </Box>
+
+        <Metadata
+          artwork={artwork}
+          contextModule={contextModule}
+          showSaveButton
+          disableRouterLinking
+          maxWidth="100%"
+        />
+      </RouterLink>
+
+      <Box mb={4} width="100%" maxWidth={MAX_WIDTH}>
+        <Button
+          // @ts-ignore
+          as={RouterLink}
+          to={artwork?.href}
+          onClick={onClick}
+        >
+          View Work
+        </Button>
+      </Box>
+    </ManageArtworkForSavesProvider>
+  )
+}
+
+const notificationArtworkFragment = graphql`
+  fragment NotificationArtwork_artwork on Artwork {
+    artistNames
+    href
+    image {
+      src: url(version: ["larger", "large"])
+      width
+      height
+    }
+    title
+
+    ...Metadata_artwork
+  }
+`

--- a/src/Components/Notifications/NotificationArtworkList.tsx
+++ b/src/Components/Notifications/NotificationArtworkList.tsx
@@ -1,0 +1,43 @@
+import { ContextModule } from "@artsy/cohesion"
+import { Flex } from "@artsy/palette"
+import { extractNodes } from "Utils/extractNodes"
+import { FC } from "react"
+import { useFragment, graphql } from "react-relay"
+import { NotificationArtworkList_artworksConnection$key } from "__generated__/NotificationArtworkList_artworksConnection.graphql"
+import { NotificationArtwork } from "Components/Notifications/NotificationArtwork"
+
+interface NotificationArtworkListProps {
+  artworksConnection?: NotificationArtworkList_artworksConnection$key | null
+}
+
+export const NotificationArtworkList: FC<NotificationArtworkListProps> = props => {
+  const artworksConnection = useFragment(
+    notificationArtworkListFragment,
+    props.artworksConnection
+  )
+
+  const artworks = extractNodes(artworksConnection)
+
+  return (
+    <Flex flexDirection="column" alignItems="center">
+      {artworks.map(artwork => (
+        <NotificationArtwork
+          key={artwork.internalID}
+          artwork={artwork}
+          contextModule={ContextModule.activity}
+        />
+      ))}
+    </Flex>
+  )
+}
+
+export const notificationArtworkListFragment = graphql`
+  fragment NotificationArtworkList_artworksConnection on ArtworkConnection {
+    edges {
+      node {
+        ...NotificationArtwork_artwork
+        internalID
+      }
+    }
+  }
+`

--- a/src/Components/Notifications/__tests__/Notification.jest.tsx
+++ b/src/Components/Notifications/__tests__/Notification.jest.tsx
@@ -1,4 +1,3 @@
-import { screen } from "@testing-library/react"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { NotificationQueryRenderer } from "Components/Notifications/Notification"
 import { NotificationsContextProvider } from "Components/Notifications/useNotificationsContext"

--- a/src/Components/Notifications/__tests__/Notification.jest.tsx
+++ b/src/Components/Notifications/__tests__/Notification.jest.tsx
@@ -4,11 +4,14 @@ import { NotificationQueryRenderer } from "Components/Notifications/Notification
 import { NotificationsContextProvider } from "Components/Notifications/useNotificationsContext"
 import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
 
+const mockRouterReplace = jest.fn()
+
 jest.unmock("react-relay")
 jest.mock("System/Router/useRouter", () => ({
-  useRouter: () => ({
+  useRouter: jest.fn(() => ({
     match: { params: { notificationId: "test-id" } },
-  }),
+    router: { replace: mockRouterReplace },
+  })),
 }))
 
 const { renderWithRelay } = setupTestWrapperTL({
@@ -22,17 +25,19 @@ const { renderWithRelay } = setupTestWrapperTL({
 })
 
 describe("Notification", () => {
-  it("should render notification items", async () => {
-    renderWithRelay({
-      Notification: () => notification,
+  describe("when the notification is not supported", () => {
+    it("should redirect to the notifications targetHref", async () => {
+      renderWithRelay({
+        Notification: () => notification,
+      })
+
+      await flushPromiseQueue()
+
+      expect(mockRouterReplace).toHaveBeenCalledWith("test-href")
     })
-
-    await flushPromiseQueue()
-
-    expect(screen.getByText("Notification One")).toBeInTheDocument()
   })
 })
 
 const notification = {
-  title: "Notification One",
+  targetHref: "test-href",
 }

--- a/src/__generated__/AlertNotification_notification.graphql.ts
+++ b/src/__generated__/AlertNotification_notification.graphql.ts
@@ -1,0 +1,189 @@
+/**
+ * @generated SignedSource<<94273a9b501b1c968a3de7dd60cc74f2>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { Fragment, ReaderFragment } from 'relay-runtime';
+export type NotificationTypesEnum = "ARTICLE_FEATURED_ARTIST" | "ARTWORK_ALERT" | "ARTWORK_PUBLISHED" | "PARTNER_OFFER_CREATED" | "PARTNER_SHOW_OPENED" | "VIEWING_ROOM_PUBLISHED" | "%future added value";
+import { FragmentRefs } from "relay-runtime";
+export type AlertNotification_notification$data = {
+  readonly artworksConnection: {
+    readonly totalCount: number | null | undefined;
+    readonly " $fragmentSpreads": FragmentRefs<"NotificationArtworkList_artworksConnection">;
+  } | null | undefined;
+  readonly headline: string;
+  readonly item: {
+    readonly alert?: {
+      readonly artists: ReadonlyArray<{
+        readonly name: string | null | undefined;
+        readonly slug: string;
+      }>;
+      readonly internalID: string;
+      readonly labels: ReadonlyArray<{
+        readonly displayValue: string;
+      } | null | undefined>;
+    } | null | undefined;
+  } | null | undefined;
+  readonly notificationType: NotificationTypesEnum;
+  readonly publishedAt: string;
+  readonly " $fragmentType": "AlertNotification_notification";
+};
+export type AlertNotification_notification$key = {
+  readonly " $data"?: AlertNotification_notification$data;
+  readonly " $fragmentSpreads": FragmentRefs<"AlertNotification_notification">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "AlertNotification_notification",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 10
+        }
+      ],
+      "concreteType": "ArtworkConnection",
+      "kind": "LinkedField",
+      "name": "artworksConnection",
+      "plural": false,
+      "selections": [
+        {
+          "args": null,
+          "kind": "FragmentSpread",
+          "name": "NotificationArtworkList_artworksConnection"
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "totalCount",
+          "storageKey": null
+        }
+      ],
+      "storageKey": "artworksConnection(first:10)"
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "headline",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": null,
+      "kind": "LinkedField",
+      "name": "item",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "InlineFragment",
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Alert",
+              "kind": "LinkedField",
+              "name": "alert",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "internalID",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "Artist",
+                  "kind": "LinkedField",
+                  "name": "artists",
+                  "plural": true,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "name",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "slug",
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "SearchCriteriaLabel",
+                  "kind": "LinkedField",
+                  "name": "labels",
+                  "plural": true,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "displayValue",
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "type": "AlertNotificationItem",
+          "abstractKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "notificationType",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "format",
+          "value": "RELATIVE"
+        }
+      ],
+      "kind": "ScalarField",
+      "name": "publishedAt",
+      "storageKey": "publishedAt(format:\"RELATIVE\")"
+    }
+  ],
+  "type": "Notification",
+  "abstractKey": null
+};
+
+(node as any).hash = "ab5d4566b3d0360fd46f6f8268c03426";
+
+export default node;

--- a/src/__generated__/ArtworkPublishedNotification_notification.graphql.ts
+++ b/src/__generated__/ArtworkPublishedNotification_notification.graphql.ts
@@ -1,0 +1,163 @@
+/**
+ * @generated SignedSource<<753a7e2f1f874da13bb489808804cbdc>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { Fragment, ReaderFragment } from 'relay-runtime';
+export type NotificationTypesEnum = "ARTICLE_FEATURED_ARTIST" | "ARTWORK_ALERT" | "ARTWORK_PUBLISHED" | "PARTNER_OFFER_CREATED" | "PARTNER_SHOW_OPENED" | "VIEWING_ROOM_PUBLISHED" | "%future added value";
+import { FragmentRefs } from "relay-runtime";
+export type ArtworkPublishedNotification_notification$data = {
+  readonly artworksConnection: {
+    readonly totalCount: number | null | undefined;
+    readonly " $fragmentSpreads": FragmentRefs<"NotificationArtworkList_artworksConnection">;
+  } | null | undefined;
+  readonly headline: string;
+  readonly item: {
+    readonly artists?: ReadonlyArray<{
+      readonly internalID: string;
+      readonly isFollowed: boolean | null | undefined;
+      readonly name: string | null | undefined;
+      readonly slug: string;
+    }>;
+  } | null | undefined;
+  readonly notificationType: NotificationTypesEnum;
+  readonly publishedAt: string;
+  readonly " $fragmentType": "ArtworkPublishedNotification_notification";
+};
+export type ArtworkPublishedNotification_notification$key = {
+  readonly " $data"?: ArtworkPublishedNotification_notification$data;
+  readonly " $fragmentSpreads": FragmentRefs<"ArtworkPublishedNotification_notification">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ArtworkPublishedNotification_notification",
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 10
+        }
+      ],
+      "concreteType": "ArtworkConnection",
+      "kind": "LinkedField",
+      "name": "artworksConnection",
+      "plural": false,
+      "selections": [
+        {
+          "args": null,
+          "kind": "FragmentSpread",
+          "name": "NotificationArtworkList_artworksConnection"
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "totalCount",
+          "storageKey": null
+        }
+      ],
+      "storageKey": "artworksConnection(first:10)"
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "headline",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": null,
+      "kind": "LinkedField",
+      "name": "item",
+      "plural": false,
+      "selections": [
+        {
+          "kind": "InlineFragment",
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Artist",
+              "kind": "LinkedField",
+              "name": "artists",
+              "plural": true,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "internalID",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "isFollowed",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "name",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "slug",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "type": "ArtworkPublishedNotificationItem",
+          "abstractKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "notificationType",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "format",
+          "value": "RELATIVE"
+        }
+      ],
+      "kind": "ScalarField",
+      "name": "publishedAt",
+      "storageKey": "publishedAt(format:\"RELATIVE\")"
+    }
+  ],
+  "type": "Notification",
+  "abstractKey": null
+};
+
+(node as any).hash = "8d5ed841bb2ead3bc900c0a6a2b58133";
+
+export default node;

--- a/src/__generated__/NotificationArtworkList_artworksConnection.graphql.ts
+++ b/src/__generated__/NotificationArtworkList_artworksConnection.graphql.ts
@@ -1,0 +1,74 @@
+/**
+ * @generated SignedSource<<92071011ba7c2193364cab11d6472d1d>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { Fragment, ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type NotificationArtworkList_artworksConnection$data = {
+  readonly edges: ReadonlyArray<{
+    readonly node: {
+      readonly internalID: string;
+      readonly " $fragmentSpreads": FragmentRefs<"NotificationArtwork_artwork">;
+    } | null | undefined;
+  } | null | undefined> | null | undefined;
+  readonly " $fragmentType": "NotificationArtworkList_artworksConnection";
+};
+export type NotificationArtworkList_artworksConnection$key = {
+  readonly " $data"?: NotificationArtworkList_artworksConnection$data;
+  readonly " $fragmentSpreads": FragmentRefs<"NotificationArtworkList_artworksConnection">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "NotificationArtworkList_artworksConnection",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "ArtworkEdge",
+      "kind": "LinkedField",
+      "name": "edges",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Artwork",
+          "kind": "LinkedField",
+          "name": "node",
+          "plural": false,
+          "selections": [
+            {
+              "args": null,
+              "kind": "FragmentSpread",
+              "name": "NotificationArtwork_artwork"
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "internalID",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "ArtworkConnection",
+  "abstractKey": null
+};
+
+(node as any).hash = "58123c4686453bf60a5a0d6fe107ae37";
+
+export default node;

--- a/src/__generated__/NotificationArtwork_artwork.graphql.ts
+++ b/src/__generated__/NotificationArtwork_artwork.graphql.ts
@@ -1,0 +1,110 @@
+/**
+ * @generated SignedSource<<7650ac6b2a95b6c7900a5cbc7cbaea35>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { Fragment, ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type NotificationArtwork_artwork$data = {
+  readonly artistNames: string | null | undefined;
+  readonly href: string | null | undefined;
+  readonly image: {
+    readonly height: number | null | undefined;
+    readonly src: string | null | undefined;
+    readonly width: number | null | undefined;
+  } | null | undefined;
+  readonly title: string | null | undefined;
+  readonly " $fragmentSpreads": FragmentRefs<"Metadata_artwork">;
+  readonly " $fragmentType": "NotificationArtwork_artwork";
+};
+export type NotificationArtwork_artwork$key = {
+  readonly " $data"?: NotificationArtwork_artwork$data;
+  readonly " $fragmentSpreads": FragmentRefs<"NotificationArtwork_artwork">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "NotificationArtwork_artwork",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "artistNames",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "href",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Image",
+      "kind": "LinkedField",
+      "name": "image",
+      "plural": false,
+      "selections": [
+        {
+          "alias": "src",
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "version",
+              "value": [
+                "larger",
+                "large"
+              ]
+            }
+          ],
+          "kind": "ScalarField",
+          "name": "url",
+          "storageKey": "url(version:[\"larger\",\"large\"])"
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "width",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "height",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "title",
+      "storageKey": null
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "Metadata_artwork"
+    }
+  ],
+  "type": "Artwork",
+  "abstractKey": null
+};
+
+(node as any).hash = "ea1790fa8c90a2e29d64de77fb5346fd";
+
+export default node;

--- a/src/__generated__/NotificationQuery.graphql.ts
+++ b/src/__generated__/NotificationQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<97cd82ab5cddb5cc2079fec20ca116e5>>
+ * @generated SignedSource<<1af21d0278831a264deb6d782111dc35>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,13 +9,17 @@
 // @ts-nocheck
 
 import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type NotificationTypesEnum = "ARTICLE_FEATURED_ARTIST" | "ARTWORK_ALERT" | "ARTWORK_PUBLISHED" | "PARTNER_OFFER_CREATED" | "PARTNER_SHOW_OPENED" | "VIEWING_ROOM_PUBLISHED" | "%future added value";
 export type NotificationQuery$variables = {
-  id: string;
+  internalID: string;
 };
 export type NotificationQuery$data = {
   readonly me: {
     readonly notification: {
-      readonly title: string;
+      readonly notificationType: NotificationTypesEnum;
+      readonly targetHref: string;
+      readonly " $fragmentSpreads": FragmentRefs<"AlertNotification_notification" | "ArtworkPublishedNotification_notification">;
     } | null | undefined;
   } | null | undefined;
 };
@@ -29,30 +33,92 @@ var v0 = [
   {
     "defaultValue": null,
     "kind": "LocalArgument",
-    "name": "id"
+    "name": "internalID"
   }
 ],
 v1 = [
   {
     "kind": "Variable",
     "name": "id",
-    "variableName": "id"
+    "variableName": "internalID"
   }
 ],
 v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "title",
+  "name": "notificationType",
   "storageKey": null
 },
 v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "targetHref",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
-};
+},
+v7 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true
+  }
+],
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "endAt",
+  "storageKey": null
+},
+v10 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+],
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v12 = [
+  (v8/*: any*/),
+  (v6/*: any*/)
+];
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -76,7 +142,18 @@ return {
             "name": "notification",
             "plural": false,
             "selections": [
-              (v2/*: any*/)
+              (v2/*: any*/),
+              (v3/*: any*/),
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "AlertNotification_notification"
+              },
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "ArtworkPublishedNotification_notification"
+              }
             ],
             "storageKey": null
           }
@@ -110,27 +187,552 @@ return {
             "plural": false,
             "selections": [
               (v2/*: any*/),
-              (v3/*: any*/)
+              (v3/*: any*/),
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 10
+                  }
+                ],
+                "concreteType": "ArtworkConnection",
+                "kind": "LinkedField",
+                "name": "artworksConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "ArtworkEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Artwork",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "artistNames",
+                            "storageKey": null
+                          },
+                          (v4/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Image",
+                            "kind": "LinkedField",
+                            "name": "image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": "src",
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "version",
+                                    "value": [
+                                      "larger",
+                                      "large"
+                                    ]
+                                  }
+                                ],
+                                "kind": "ScalarField",
+                                "name": "url",
+                                "storageKey": "url(version:[\"larger\",\"large\"])"
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "width",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "height",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "title",
+                            "storageKey": null
+                          },
+                          (v5/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "date",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "sale_message",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "saleMessage",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "cultural_maker",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "culturalMaker",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Artist",
+                            "kind": "LinkedField",
+                            "name": "artist",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "ArtistTargetSupply",
+                                "kind": "LinkedField",
+                                "name": "targetSupply",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isP1",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              },
+                              (v6/*: any*/)
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ArtworkPriceInsights",
+                            "kind": "LinkedField",
+                            "name": "marketPriceInsights",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "demandRank",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": (v7/*: any*/),
+                            "concreteType": "Artist",
+                            "kind": "LinkedField",
+                            "name": "artists",
+                            "plural": true,
+                            "selections": [
+                              (v6/*: any*/),
+                              (v4/*: any*/),
+                              (v8/*: any*/)
+                            ],
+                            "storageKey": "artists(shallow:true)"
+                          },
+                          {
+                            "alias": "collecting_institution",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "collectingInstitution",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": (v7/*: any*/),
+                            "concreteType": "Partner",
+                            "kind": "LinkedField",
+                            "name": "partner",
+                            "plural": false,
+                            "selections": [
+                              (v8/*: any*/),
+                              (v4/*: any*/),
+                              (v6/*: any*/)
+                            ],
+                            "storageKey": "partner(shallow:true)"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Sale",
+                            "kind": "LinkedField",
+                            "name": "sale",
+                            "plural": false,
+                            "selections": [
+                              (v9/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "cascadingEndTimeIntervalMinutes",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "extendedBiddingIntervalMinutes",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "startAt",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "is_auction",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isAuction",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "is_closed",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isClosed",
+                                "storageKey": null
+                              },
+                              (v6/*: any*/)
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "sale_artwork",
+                            "args": null,
+                            "concreteType": "SaleArtwork",
+                            "kind": "LinkedField",
+                            "name": "saleArtwork",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "lotID",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "lotLabel",
+                                "storageKey": null
+                              },
+                              (v9/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "extendedBiddingEndAt",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "formattedEndDateTime",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "SaleArtworkCounts",
+                                "kind": "LinkedField",
+                                "name": "counts",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": "bidder_positions",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "bidderPositions",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "highest_bid",
+                                "args": null,
+                                "concreteType": "SaleArtworkHighestBid",
+                                "kind": "LinkedField",
+                                "name": "highestBid",
+                                "plural": false,
+                                "selections": (v10/*: any*/),
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "opening_bid",
+                                "args": null,
+                                "concreteType": "SaleArtworkOpeningBid",
+                                "kind": "LinkedField",
+                                "name": "openingBid",
+                                "plural": false,
+                                "selections": (v10/*: any*/),
+                                "storageKey": null
+                              },
+                              (v6/*: any*/)
+                            ],
+                            "storageKey": null
+                          },
+                          (v6/*: any*/),
+                          (v11/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isSaved",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "preview",
+                            "args": null,
+                            "concreteType": "Image",
+                            "kind": "LinkedField",
+                            "name": "image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "version",
+                                    "value": "square"
+                                  }
+                                ],
+                                "kind": "ScalarField",
+                                "name": "url",
+                                "storageKey": "url(version:\"square\")"
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isSavedToList",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "AttributionClass",
+                            "kind": "LinkedField",
+                            "name": "attributionClass",
+                            "plural": false,
+                            "selections": (v12/*: any*/),
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ArtworkMedium",
+                            "kind": "LinkedField",
+                            "name": "mediumType",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Gene",
+                                "kind": "LinkedField",
+                                "name": "filterGene",
+                                "plural": false,
+                                "selections": (v12/*: any*/),
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "totalCount",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "artworksConnection(first:10)"
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "headline",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": null,
+                "kind": "LinkedField",
+                "name": "item",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "__typename",
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Alert",
+                        "kind": "LinkedField",
+                        "name": "alert",
+                        "plural": false,
+                        "selections": [
+                          (v5/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Artist",
+                            "kind": "LinkedField",
+                            "name": "artists",
+                            "plural": true,
+                            "selections": [
+                              (v8/*: any*/),
+                              (v11/*: any*/),
+                              (v6/*: any*/)
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "SearchCriteriaLabel",
+                            "kind": "LinkedField",
+                            "name": "labels",
+                            "plural": true,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "displayValue",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          (v6/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "type": "AlertNotificationItem",
+                    "abstractKey": null
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Artist",
+                        "kind": "LinkedField",
+                        "name": "artists",
+                        "plural": true,
+                        "selections": [
+                          (v5/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isFollowed",
+                            "storageKey": null
+                          },
+                          (v8/*: any*/),
+                          (v11/*: any*/),
+                          (v6/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "type": "ArtworkPublishedNotificationItem",
+                    "abstractKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "format",
+                    "value": "RELATIVE"
+                  }
+                ],
+                "kind": "ScalarField",
+                "name": "publishedAt",
+                "storageKey": "publishedAt(format:\"RELATIVE\")"
+              },
+              (v6/*: any*/)
             ],
             "storageKey": null
           },
-          (v3/*: any*/)
+          (v6/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "9ef897a3efbc4ea5ea1e5ffd42c4bb66",
+    "cacheID": "6d75da72476d63ebc4cc879d70c3d9c3",
     "id": null,
     "metadata": {},
     "name": "NotificationQuery",
     "operationKind": "query",
-    "text": "query NotificationQuery(\n  $id: String!\n) {\n  me {\n    notification(id: $id) {\n      title\n      id\n    }\n    id\n  }\n}\n"
+    "text": "query NotificationQuery(\n  $internalID: String!\n) {\n  me {\n    notification(id: $internalID) {\n      notificationType\n      targetHref\n      ...AlertNotification_notification\n      ...ArtworkPublishedNotification_notification\n      id\n    }\n    id\n  }\n}\n\nfragment AlertNotification_notification on Notification {\n  artworksConnection(first: 10) {\n    ...NotificationArtworkList_artworksConnection\n    totalCount\n  }\n  headline\n  item {\n    __typename\n    ... on AlertNotificationItem {\n      alert {\n        internalID\n        artists {\n          name\n          slug\n          id\n        }\n        labels {\n          displayValue\n        }\n        id\n      }\n    }\n  }\n  notificationType\n  publishedAt(format: \"RELATIVE\")\n}\n\nfragment ArtworkPublishedNotification_notification on Notification {\n  artworksConnection(first: 10) {\n    ...NotificationArtworkList_artworksConnection\n    totalCount\n  }\n  headline\n  item {\n    __typename\n    ... on ArtworkPublishedNotificationItem {\n      artists {\n        internalID\n        isFollowed\n        name\n        slug\n        id\n      }\n    }\n  }\n  notificationType\n  publishedAt(format: \"RELATIVE\")\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NotificationArtworkList_artworksConnection on ArtworkConnection {\n  edges {\n    node {\n      ...NotificationArtwork_artwork\n      internalID\n      id\n    }\n  }\n}\n\nfragment NotificationArtwork_artwork on Artwork {\n  artistNames\n  href\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n  }\n  title\n  ...Metadata_artwork\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isSavedToList\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n"
   }
 };
 })();
 
-(node as any).hash = "a82be41c0ee4f4061d4490dac0f76efc";
+(node as any).hash = "c11d44d16ae8fc41fa123d53ea3e23ba";
 
 export default node;


### PR DESCRIPTION
Addresses [ONYX-625] & [ONYX-626]

- [Figma Design](https://www.figma.com/file/PO3rjpDV29YOFR8kLI4InJ/Activity-Panel-%26-Alerts-Management?type=design&node-id=652-3067&mode=design&t=H6HRDnH8XJe5dsI0-0)

## Description

This PR implement notification pages for Alert and Follow notifications


**To Do:**

- The label is still missing but will be displayed correctly after merging https://github.com/artsy/force/pull/13419

| Follow | Alert |
| --- | --- |
|<img width="1182" alt="Screenshot 2024-01-25 at 17 06 12" src="https://github.com/artsy/force/assets/4691889/ab19d64a-bc74-45e1-bfb1-f6787f582467"> |<img width="1199" alt="Screenshot 2024-01-25 at 17 06 25" src="https://github.com/artsy/force/assets/4691889/aeff720b-5fdb-4c28-96e6-b822d6e304c4"> |







[ONYX-626]: https://artsyproduct.atlassian.net/browse/ONYX-626?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[ONYX-625]: https://artsyproduct.atlassian.net/browse/ONYX-625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ