### PR TITLE
feat: adds an availability filter for use on artwork grids

### DIFF
--- a/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters.tsx
@@ -16,6 +16,7 @@ import { Join, Spacer } from "@artsy/palette"
 import { ProgressiveOnboardingAlertSelectFilter } from "Components/ProgressiveOnboarding/ProgressiveOnboardingAlertSelectFilter"
 import { ArtistSeriesFilter } from "Components/ArtworkFilter/ArtworkFilters/ArtistSeriesFilter"
 import { useFeatureFlag } from "System/useFeatureFlag"
+import { AvailabilityFilter } from "Components/ArtworkFilter/ArtworkFilters/AvailabilityFilter"
 
 interface ArtistArtworkFiltersProps {}
 
@@ -28,6 +29,7 @@ export const ArtistArtworkFilters: React.FC<ArtistArtworkFiltersProps> = props =
   return (
     <Join separator={<Spacer y={4} />}>
       <KeywordFilter />
+      <AvailabilityFilter />
       <ArtistsFilter user={user} expanded />
       <ProgressiveOnboardingAlertSelectFilter>
         <AttributionClassFilter expanded />

--- a/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters.tsx
@@ -25,11 +25,12 @@ export const ArtistArtworkFilters: React.FC<ArtistArtworkFiltersProps> = props =
   const isArtistSeriesFilterEnabled = useFeatureFlag(
     "onyx_enable-artist-series-filter"
   )
+  const isAvailabilityFilterEnabled = useFeatureFlag("onyx_availability-filter")
 
   return (
     <Join separator={<Spacer y={4} />}>
       <KeywordFilter />
-      <AvailabilityFilter />
+      {isAvailabilityFilterEnabled && <AvailabilityFilter />}
       <ArtistsFilter user={user} expanded />
       <ProgressiveOnboardingAlertSelectFilter>
         <AttributionClassFilter expanded />

--- a/src/Apps/Artist/Routes/WorksForSale/Components/__tests__/ArtistArtworkFilters.jest.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/__tests__/ArtistArtworkFilters.jest.tsx
@@ -81,9 +81,11 @@ describe("feature flag: onyx_enable-artist-series-filter", () => {
 })
 
 describe("feature flag: onyx_availability", () => {
+  const mockUseFeatureFlag = useFeatureFlag as jest.Mock
+
   describe("when the feature flag is enabled", () => {
     beforeEach(() => {
-      ;(useFeatureFlag as jest.Mock).mockImplementation(() => true)
+      mockUseFeatureFlag.mockImplementation(() => true)
     })
     it("renders the Availability filter", () => {
       render(<ArtistArtworkFilters />)
@@ -92,7 +94,7 @@ describe("feature flag: onyx_availability", () => {
   })
   describe("when the feature flag is disabled", () => {
     beforeEach(() => {
-      ;(useFeatureFlag as jest.Mock).mockImplementation(() => false)
+      mockUseFeatureFlag.mockImplementation(() => false)
     })
     it("does not render the Availability filter", () => {
       render(<ArtistArtworkFilters />)

--- a/src/Apps/Artist/Routes/WorksForSale/Components/__tests__/ArtistArtworkFilters.jest.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/__tests__/ArtistArtworkFilters.jest.tsx
@@ -79,3 +79,24 @@ describe("feature flag: onyx_enable-artist-series-filter", () => {
     })
   })
 })
+
+describe("feature flag: onyx_availability", () => {
+  describe("when the feature flag is enabled", () => {
+    beforeEach(() => {
+      ;(useFeatureFlag as jest.Mock).mockImplementation(() => true)
+    })
+    it("renders the Availability filter", () => {
+      render(<ArtistArtworkFilters />)
+      expect(screen.getByText("Availability")).toBeInTheDocument()
+    })
+  })
+  describe("when the feature flag is disabled", () => {
+    beforeEach(() => {
+      ;(useFeatureFlag as jest.Mock).mockImplementation(() => false)
+    })
+    it("does not render the Availability filter", () => {
+      render(<ArtistArtworkFilters />)
+      expect(screen.queryByText("Availability")).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/Components/ArtworkFilter/ArtworkFilters/AvailabilityFilter.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/AvailabilityFilter.tsx
@@ -1,0 +1,21 @@
+import { Checkbox } from "@artsy/palette"
+import { useArtworkFilterContext } from "Components/ArtworkFilter/ArtworkFilterContext"
+import { FilterExpandable } from "Components/ArtworkFilter/ArtworkFilters/FilterExpandable"
+
+export const AvailabilityFilter: React.FC = () => {
+  const { setFilter, unsetFilter, filters } = useArtworkFilterContext()
+
+  return (
+    <FilterExpandable label="Availability" expanded>
+      <Checkbox
+        selected={!!filters?.forSale}
+        onSelect={selected => {
+          selected ? setFilter("forSale", true) : unsetFilter("forSale")
+        }}
+        my={1}
+      >
+        Only works for sale
+      </Checkbox>
+    </FilterExpandable>
+  )
+}

--- a/src/Components/ArtworkFilter/ArtworkFilters/__tests__/AvailabilityFilter.jest.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/__tests__/AvailabilityFilter.jest.tsx
@@ -1,0 +1,44 @@
+import { screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import {
+  createArtworkFilterTestRenderer,
+  currentArtworkFilterContext,
+} from "Components/ArtworkFilter/ArtworkFilters/__tests__/Utils"
+import { ArtworkFilterContextProps } from "Components/ArtworkFilter/ArtworkFilterContext"
+import { AvailabilityFilter } from "Components/ArtworkFilter/ArtworkFilters/AvailabilityFilter"
+
+const artworkFilterContext: Partial<ArtworkFilterContextProps> = {
+  filters: {
+    forSale: undefined,
+  },
+}
+
+const render = createArtworkFilterTestRenderer(artworkFilterContext)
+
+describe(AvailabilityFilter, () => {
+  it("renders a for-sale toggle", () => {
+    render(<AvailabilityFilter />)
+    expect(screen.getByText("Only works for sale")).toBeInTheDocument()
+  })
+
+  it("updates context on filter change", () => {
+    render(<AvailabilityFilter />)
+    expect(currentArtworkFilterContext().filters?.forSale).toBeUndefined()
+
+    userEvent.click(screen.getAllByRole("checkbox")[0])
+    expect(currentArtworkFilterContext().filters?.forSale).toBeTruthy()
+
+    userEvent.click(screen.getAllByRole("checkbox")[0])
+    expect(currentArtworkFilterContext().filters?.forSale).toBeFalsy()
+  })
+
+  it("clears local input state after Clear All", () => {
+    render(<AvailabilityFilter />)
+    userEvent.click(screen.getAllByRole("checkbox")[0])
+    expect(currentArtworkFilterContext().filters?.forSale).toBeTruthy()
+
+    userEvent.click(screen.getByText("Clear all"))
+
+    expect(currentArtworkFilterContext().filters?.forSale).toBeFalsy()
+  })
+})


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [Hack13 - available filter](https://www.notion.so/artsy/Add-Sold-and-Available-filters-for-works-on-Artsy-net-so-it-makes-it-easier-to-send-inventories--167eb801582247acbee50db536bcba82) / [ONYX-698]

Review app example: https://availability-filter.artsy.net/artist/mike-gough

### Description

Adds a filter using our customary ux patterns that allows a collector to filter down to for-sale works only.

Quirky behavior at the moment:

- toggling it on shows `forsale: true` works only ✅ 
- toggling it off shows `forsale: false` works only, rather than _all_ works 🤔 


### Screencap
Notice how the count here goes from 46 (**all**) → 16 (**for-sale**) → 30 (**not-for-sale**) → 46 (back to **all**, by tweaking the url) →

https://github.com/artsy/force/assets/140521/08414b79-fb3d-43a6-b725-97aa2169b6e7



[ONYX-698]: https://artsyproduct.atlassian.net/browse/ONYX-698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ