### PR TITLE
fix: fix long press on search dropdown items

### DIFF
--- a/src/Components/Search/SearchBarInput.tsx
+++ b/src/Components/Search/SearchBarInput.tsx
@@ -177,6 +177,7 @@ const SearchBarInput: FC<SearchBarInputProps> = ({
     })
 
     resetValue()
+    redirect(option.href)
   }
 
   const handleFocus = () => {
@@ -221,6 +222,7 @@ const SearchBarInput: FC<SearchBarInputProps> = ({
       defaultValue={value}
       onChange={handleChange}
       onClear={resetValue}
+      onSelect={handleSelect}
       onSubmit={handleSubmit}
       onClick={handleFocus}
       header={


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

When I press (long click) on search results in the dropdown - redirect doesn't happen. This PR fixes the issue.

| Before | After |
|---|---|
| <video src="https://github.com/artsy/force/assets/3934579/a627fea6-4641-4563-a211-e3269af39e3e" /> | <video src="https://github.com/artsy/force/assets/3934579/e00cde18-3383-4aae-9aed-7046ccb3b9af" /> |


