### PR TITLE
chore: (AMBER-367) Added modal for condition information in auction lots. 

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkDefinitionList.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDefinitionList.tsx
@@ -1,23 +1,32 @@
 import * as React from "react"
-import { BoxProps, Flex, Text } from "@artsy/palette"
-// import { useState } from "react"
-
+import { BoxProps, Clickable, Flex, Text } from "@artsy/palette"
 interface ArtworkDefinitionListProps extends BoxProps {
   term: string
   children: React.ReactNode
-  // modalComponent?: React.ReactNode
+  onTitleClick?: () => void
 }
 
 export const ArtworkDefinitionList: React.FC<ArtworkDefinitionListProps> = ({
   term,
   children,
+  onTitleClick,
   ...rest
 }) => {
   return (
     <Flex as="dl" flexDirection={["column", "row"]} {...rest}>
-      <Text as="dt" variant="xs" width={150} flexShrink={0} mr={2}>
-        {term}
-      </Text>
+      {onTitleClick ? (
+        <>
+          <Clickable textDecoration="underline" onClick={onTitleClick}>
+            <Text as="dt" variant="xs" width={150} flexShrink={0} mr={2}>
+              {term}
+            </Text>
+          </Clickable>
+        </>
+      ) : (
+        <Text as="dt" variant="xs" width={150} flexShrink={0} mr={2}>
+          {term}
+        </Text>
+      )}
 
       <Text as="dd" variant="xs" color="black60" flex={1}>
         {children}

--- a/src/Apps/Artwork/Components/ArtworkDefinitionList.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDefinitionList.tsx
@@ -1,9 +1,11 @@
-import * as React from "react";
-import { BoxProps, Flex, Text } from "@artsy/palette"
+import * as React from "react"
+import { BoxProps, Flex, Text, Clickable } from "@artsy/palette"
+// import { useState } from "react"
 
 interface ArtworkDefinitionListProps extends BoxProps {
   term: string
   children: React.ReactNode
+  // modalComponent?: React.ReactNode
 }
 
 export const ArtworkDefinitionList: React.FC<ArtworkDefinitionListProps> = ({
@@ -11,11 +13,15 @@ export const ArtworkDefinitionList: React.FC<ArtworkDefinitionListProps> = ({
   children,
   ...rest
 }) => {
+  // const [showModal, setShowModal] = useState(false)
+
   return (
     <Flex as="dl" flexDirection={["column", "row"]} {...rest}>
+      {/* <Clickable textDecoration="underline"> */}
       <Text as="dt" variant="xs" width={150} flexShrink={0} mr={2}>
         {term}
       </Text>
+      {/* </Clickable> */}
 
       <Text as="dd" variant="xs" color="black60" flex={1}>
         {children}

--- a/src/Apps/Artwork/Components/ArtworkDefinitionList.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDefinitionList.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { BoxProps, Flex, Text, Clickable } from "@artsy/palette"
+import { BoxProps, Flex, Text } from "@artsy/palette"
 // import { useState } from "react"
 
 interface ArtworkDefinitionListProps extends BoxProps {
@@ -13,15 +13,11 @@ export const ArtworkDefinitionList: React.FC<ArtworkDefinitionListProps> = ({
   children,
   ...rest
 }) => {
-  // const [showModal, setShowModal] = useState(false)
-
   return (
     <Flex as="dl" flexDirection={["column", "row"]} {...rest}>
-      {/* <Clickable textDecoration="underline"> */}
       <Text as="dt" variant="xs" width={150} flexShrink={0} mr={2}>
         {term}
       </Text>
-      {/* </Clickable> */}
 
       <Text as="dd" variant="xs" color="black60" flex={1}>
         {children}

--- a/src/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAdditionalInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAdditionalInfo.tsx
@@ -20,7 +20,7 @@ import { ArtworkDefinitionList } from "Apps/Artwork/Components/ArtworkDefinition
 import { useTracking } from "react-tracking"
 import { useArtworkDimensions } from "Apps/Artwork/useArtworkDimensions"
 import { ArtworkSidebarClassificationsModalQueryRenderer } from "Apps/Artwork/Components/ArtworkSidebarClassificationsModal"
-import { ConditionInfoModal } from "Apps/Auction/Routes/Bid/Components/ConditionInfoModal"
+import { ConditionInfoModal } from "Apps/Artwork/Components/ArtworkDetails/ConditionInfoModal"
 
 export interface ArtworkDetailsAdditionalInfoProps {
   artwork: ArtworkDetailsAdditionalInfo_artwork$data

--- a/src/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAdditionalInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAdditionalInfo.tsx
@@ -155,7 +155,6 @@ export const ArtworkDetailsAdditionalInfo: React.FC<ArtworkDetailsAdditionalInfo
         })
       },
       onTitleClick: () => {
-        console.log("clicked on title")
         setOpenConditionModal(true)
       },
     },

--- a/src/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAdditionalInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/ArtworkDetailsAdditionalInfo.tsx
@@ -20,6 +20,7 @@ import { ArtworkDefinitionList } from "Apps/Artwork/Components/ArtworkDefinition
 import { useTracking } from "react-tracking"
 import { useArtworkDimensions } from "Apps/Artwork/useArtworkDimensions"
 import { ArtworkSidebarClassificationsModalQueryRenderer } from "Apps/Artwork/Components/ArtworkSidebarClassificationsModal"
+import { ConditionInfoModal } from "Apps/Auction/Routes/Bid/Components/ConditionInfoModal"
 
 export interface ArtworkDetailsAdditionalInfoProps {
   artwork: ArtworkDetailsAdditionalInfo_artwork$data
@@ -47,6 +48,7 @@ export const ArtworkDetailsAdditionalInfo: React.FC<ArtworkDetailsAdditionalInfo
 
   const [openMediumModal, setOpenMediumModal] = useState(false)
   const [openRarityModal, setOpenRarityModal] = useState(false)
+  const [openConditionModal, setOpenConditionModal] = useState(false)
 
   const { dimensionsLabel } = useArtworkDimensions(dimensions)
 
@@ -152,6 +154,10 @@ export const ArtworkDetailsAdditionalInfo: React.FC<ArtworkDetailsAdditionalInfo
           subject: "Read more",
         })
       },
+      onTitleClick: () => {
+        console.log("clicked on title")
+        setOpenConditionModal(true)
+      },
     },
 
     {
@@ -179,26 +185,37 @@ export const ArtworkDetailsAdditionalInfo: React.FC<ArtworkDetailsAdditionalInfo
   }
 
   return (
-    <StackableBorderBox flexDirection="column">
-      <Join separator={<Spacer y={1} />}>
-        {displayItems.map(({ title, value, onReadMoreClicked }, index) => (
-          <ArtworkDefinitionList key={title + index} term={title}>
-            <HTML variant="xs" color="black60">
-              {/* TODO: not sure why this check is here */}
-              {React.isValidElement(value) ? (
-                value
-              ) : (
-                <ReadMore
-                  onReadMoreClicked={onReadMoreClicked}
-                  maxChars={140}
-                  content={value as string}
-                />
-              )}
-            </HTML>
-          </ArtworkDefinitionList>
-        ))}
-      </Join>
-    </StackableBorderBox>
+    <>
+      {openConditionModal && (
+        <ConditionInfoModal onClose={() => setOpenConditionModal(false)} />
+      )}
+      <StackableBorderBox flexDirection="column">
+        <Join separator={<Spacer y={1} />}>
+          {displayItems.map(
+            ({ title, value, onReadMoreClicked, onTitleClick }, index) => (
+              <ArtworkDefinitionList
+                key={title + index}
+                term={title}
+                onTitleClick={onTitleClick}
+              >
+                <HTML variant="xs" color="black60">
+                  {/* TODO: not sure why this check is here */}
+                  {React.isValidElement(value) ? (
+                    value
+                  ) : (
+                    <ReadMore
+                      onReadMoreClicked={onReadMoreClicked}
+                      maxChars={140}
+                      content={value as string}
+                    />
+                  )}
+                </HTML>
+              </ArtworkDefinitionList>
+            )
+          )}
+        </Join>
+      </StackableBorderBox>
+    </>
   )
 }
 

--- a/src/Apps/Artwork/Components/ArtworkDetails/ConditionInfoModal.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/ConditionInfoModal.tsx
@@ -14,9 +14,8 @@ export const ConditionInfoModal: React.FC<ConditionInfoModalProps> = ({
           Excellent Condition:
         </Text>
         <Text>
-          {" "}
           No signs of age or wear, undulation associated with hinging. Work may
-          be unsealed in original packaging.{" "}
+          be unsealed in original packaging.
         </Text>
         <Spacer y={2} />
         <Text fontWeight="bold">Very Good Condition:</Text>
@@ -28,7 +27,6 @@ export const ConditionInfoModal: React.FC<ConditionInfoModalProps> = ({
         <Spacer y={2} />
         <Text fontWeight="bold">Good Condition:</Text>
         <Text>
-          {" "}
           Overall good condition but with noticeable wear or age such as hard
           creases, scratches, indentations, water damage (associated buckling),
           foxing, discoloration, attenuation, material loss and tearing. May

--- a/src/Apps/Auction/Routes/Bid/Components/ConditionInfoModal.tsx
+++ b/src/Apps/Auction/Routes/Bid/Components/ConditionInfoModal.tsx
@@ -1,6 +1,4 @@
-import * as React from "react"
-import { ModalDialog, Clickable, Text, Box } from "@artsy/palette"
-import { useState } from "react"
+import { ModalDialog, Text, Spacer, Button } from "@artsy/palette"
 
 interface ConditionInfoModalProps {
   onClose: () => void
@@ -9,40 +7,25 @@ interface ConditionInfoModalProps {
 export const ConditionInfoModal: React.FC<ConditionInfoModalProps> = ({
   onClose,
 }) => {
-  const [showModal, setShowModal] = useState(false)
-
   return (
     <>
-      <Clickable
-        onClick={() => {
-          setShowModal(true)
-        }}
-      >
-        <Text> Condition </Text>
-      </Clickable>
-
-      {showModal && (
-        <ModalDialog onClose={() => setShowModal(false)}>
-          <Text>
-            <Box>Condition Definitions</Box>
-            <Box>
-              {" "}
-              Excellent Condition: No signs of age or wear, undulation
-              associated with hinging. Work may be unsealed in original
-              packaging. Very Good Condition: Overall very good condition, minor
-              signs of wear or age such as light handling creases, scuffing,
-              foxing, discoloration, buckling, and pinholes. Also includes works
-              that have been previously restored. Good Condition: Overall good
-              condition but with noticeable wear or age such as hard creases,
-              scratches, indentations, water damage (associated buckling),
-              foxing, discoloration, attenuation, material loss and tearing. May
-              require the attention of a conservator. Fair Condition: Overall
-              fair condition with significant wear and age that requires the
-              attention of a conservator.{" "}
-            </Box>
-          </Text>
-        </ModalDialog>
-      )}
+      <ModalDialog title="Condition Definitions" onClose={onClose}>
+        <Text variant="sm">
+          Excellent Condition: No signs of age or wear, undulation associated
+          with hinging. Work may be unsealed in original packaging. Very Good
+          Condition: Overall very good condition, minor signs of wear or age
+          such as light handling creases, scuffing, foxing, discoloration,
+          buckling, and pinholes. Also includes works that have been previously
+          restored. Good Condition: Overall good condition but with noticeable
+          wear or age such as hard creases, scratches, indentations, water
+          damage (associated buckling), foxing, discoloration, attenuation,
+          material loss and tearing. May require the attention of a conservator.
+          Fair Condition: Overall fair condition with significant wear and age
+          that requires the attention of a conservator.{" "}
+        </Text>
+        <Spacer y={2} />
+        <Button onClick={onClose}>Ok</Button>
+      </ModalDialog>
     </>
   )
 }

--- a/src/Apps/Auction/Routes/Bid/Components/ConditionInfoModal.tsx
+++ b/src/Apps/Auction/Routes/Bid/Components/ConditionInfoModal.tsx
@@ -1,5 +1,6 @@
 import * as React from "react"
 import { ModalDialog, Clickable, Text, Box } from "@artsy/palette"
+import { useState } from "react"
 
 interface ConditionInfoModalProps {
   onClose: () => void

--- a/src/Apps/Auction/Routes/Bid/Components/ConditionInfoModal.tsx
+++ b/src/Apps/Auction/Routes/Bid/Components/ConditionInfoModal.tsx
@@ -10,21 +10,40 @@ export const ConditionInfoModal: React.FC<ConditionInfoModalProps> = ({
   return (
     <>
       <ModalDialog title="Condition Definitions" onClose={onClose}>
-        <Text variant="sm">
-          Excellent Condition: No signs of age or wear, undulation associated
-          with hinging. Work may be unsealed in original packaging. Very Good
-          Condition: Overall very good condition, minor signs of wear or age
-          such as light handling creases, scuffing, foxing, discoloration,
-          buckling, and pinholes. Also includes works that have been previously
-          restored. Good Condition: Overall good condition but with noticeable
-          wear or age such as hard creases, scratches, indentations, water
-          damage (associated buckling), foxing, discoloration, attenuation,
-          material loss and tearing. May require the attention of a conservator.
-          Fair Condition: Overall fair condition with significant wear and age
-          that requires the attention of a conservator.{" "}
+        <Text variant="sm" fontWeight="bold">
+          Excellent Condition:
+        </Text>
+        <Text>
+          {" "}
+          No signs of age or wear, undulation associated with hinging. Work may
+          be unsealed in original packaging.{" "}
         </Text>
         <Spacer y={2} />
-        <Button onClick={onClose}>Ok</Button>
+        <Text fontWeight="bold">Very Good Condition:</Text>
+        <Text>
+          Overall very good condition, minor signs of wear or age such as light
+          handling creases, scuffing, foxing, discoloration, buckling, and
+          pinholes. Also includes works that have been previously restored.
+        </Text>
+        <Spacer y={2} />
+        <Text fontWeight="bold">Good Condition:</Text>
+        <Text>
+          {" "}
+          Overall good condition but with noticeable wear or age such as hard
+          creases, scratches, indentations, water damage (associated buckling),
+          foxing, discoloration, attenuation, material loss and tearing. May
+          require the attention of a conservator.
+        </Text>
+        <Spacer y={2} />
+        <Text fontWeight="bold">Fair Condition:</Text>
+        <Text>
+          Overall fair condition with significant wear and age that requires the
+          attention of a conservator.
+        </Text>
+        <Spacer y={2} />
+        <Button width="100%" onClick={onClose}>
+          Ok
+        </Button>
       </ModalDialog>
     </>
   )

--- a/src/Apps/Auction/Routes/Bid/Components/ConditionInfoModal.tsx
+++ b/src/Apps/Auction/Routes/Bid/Components/ConditionInfoModal.tsx
@@ -1,0 +1,47 @@
+import * as React from "react"
+import { ModalDialog, Clickable, Text, Box } from "@artsy/palette"
+
+interface ConditionInfoModalProps {
+  onClose: () => void
+}
+
+export const ConditionInfoModal: React.FC<ConditionInfoModalProps> = ({
+  onClose,
+}) => {
+  const [showModal, setShowModal] = useState(false)
+
+  return (
+    <>
+      <Clickable
+        onClick={() => {
+          setShowModal(true)
+        }}
+      >
+        <Text> Condition </Text>
+      </Clickable>
+
+      {showModal && (
+        <ModalDialog onClose={() => setShowModal(false)}>
+          <Text>
+            <Box>Condition Definitions</Box>
+            <Box>
+              {" "}
+              Excellent Condition: No signs of age or wear, undulation
+              associated with hinging. Work may be unsealed in original
+              packaging. Very Good Condition: Overall very good condition, minor
+              signs of wear or age such as light handling creases, scuffing,
+              foxing, discoloration, buckling, and pinholes. Also includes works
+              that have been previously restored. Good Condition: Overall good
+              condition but with noticeable wear or age such as hard creases,
+              scratches, indentations, water damage (associated buckling),
+              foxing, discoloration, attenuation, material loss and tearing. May
+              require the attention of a conservator. Fair Condition: Overall
+              fair condition with significant wear and age that requires the
+              attention of a conservator.{" "}
+            </Box>
+          </Text>
+        </ModalDialog>
+      )}
+    </>
+  )
+}


### PR DESCRIPTION
The type of this PR is: Chore

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [AMBER-376]

### Description

<!-- Implementation description -->

Bidders can now see a breakdown of what different condition levels mean and make an informed decision when bidding on an artwork by clicking "Condition" which opens a modal. 

[This design/copy might change? TBD. WIP.]

<img width="1761" alt="Screenshot 2024-01-22 at 5 23 28 PM" src="https://github.com/artsy/force/assets/66049063/b12b1c22-ebab-4590-8af9-8534dfe3cda2">




[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AMBER-376]: https://artsyproduct.atlassian.net/browse/AMBER-376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ