### PR TITLE
fix(artist): Fix jump bug

### DIFF
--- a/src/Apps/Artist/Routes/WorksForSale/ArtistWorksForSaleRoute.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/ArtistWorksForSaleRoute.tsx
@@ -30,7 +30,8 @@ const ArtistWorksForSaleRoute: React.FC<ArtistWorksForSaleRouteProps> = ({
     return () => {
       clearTimeout(timeout)
     }
-  }, [jumpTo, match.location.query.search_criteria_id])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const total = artist.sidebarAggregations?.counts?.total ?? 0
 

--- a/src/Apps/Artist/Routes/WorksForSale/ArtistWorksForSaleRoute.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/ArtistWorksForSaleRoute.tsx
@@ -20,9 +20,24 @@ const ArtistWorksForSaleRoute: React.FC<ArtistWorksForSaleRouteProps> = ({
 
   const { jumpTo } = useJump({ behavior: "smooth", offset: 10 })
 
+  const lastSearchCriteriaID = React.useRef<string>(
+    match?.location?.query?.search_criteria_id
+  )
+
   useEffect(() => {
+    // bail unless we have a search criteria
     if (!match?.location?.query?.search_criteria_id) return
 
+    // bail unless the search criteria has *changed*
+    if (
+      match.location.query.search_criteria_id === lastSearchCriteriaID.current
+    ) {
+      return
+    }
+
+    lastSearchCriteriaID.current = match.location.query.search_criteria_id
+
+    // now, safe to jump
     const timeout = setTimeout(() => {
       jumpTo("artworkFilter")
     }, 0)
@@ -30,8 +45,7 @@ const ArtistWorksForSaleRoute: React.FC<ArtistWorksForSaleRouteProps> = ({
     return () => {
       clearTimeout(timeout)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [jumpTo, match.location.query])
 
   const total = artist.sidebarAggregations?.counts?.total ?? 0
 


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

This fixes an issue that was [observed here](https://artsyproduct.atlassian.net/browse/ONYX-665), where scrolling after jump was blowing up scrolling on the page.

The issue has to do with useEffect dependencies. If we want something to execute once _and only once_, we shouldn't pass dependencies. Ignore that bloody react-hooks linter when it doesn't make sense 😄.  
