### PR TITLE
fix(artist): disable artist page jumpTo when coming from alert context

### DIFF
--- a/src/Apps/Artist/Routes/WorksForSale/ArtistWorksForSaleRoute.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/ArtistWorksForSaleRoute.tsx
@@ -1,11 +1,9 @@
-import React, { useEffect } from "react"
+import React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { ArtistArtworkFilterRefetchContainer } from "./Components/ArtistArtworkFilter"
 import { ArtistWorksForSaleRoute_artist$data } from "__generated__/ArtistWorksForSaleRoute_artist.graphql"
 import { SharedArtworkFilterContextProps } from "Components/ArtworkFilter/ArtworkFilterContext"
 import { Title, Meta } from "react-head"
-import { useRouter } from "System/Router/useRouter"
-import { useJump } from "Utils/Hooks/useJump"
 import { ArtistWorksForSaleEmptyFragmentContainer } from "Apps/Artist/Routes/WorksForSale/Components/ArtistWorksForSaleEmpty"
 
 interface ArtistWorksForSaleRouteProps {
@@ -15,23 +13,7 @@ interface ArtistWorksForSaleRouteProps {
 const ArtistWorksForSaleRoute: React.FC<ArtistWorksForSaleRouteProps> = ({
   artist,
 }) => {
-  const { match } = useRouter()
   const { title, description } = artist.meta
-
-  const { jumpTo } = useJump({ behavior: "smooth", offset: 10 })
-
-  useEffect(() => {
-    if (!match?.location?.query?.search_criteria_id) return
-
-    const timeout = setTimeout(() => {
-      jumpTo("artworkFilter")
-    }, 0)
-
-    return () => {
-      clearTimeout(timeout)
-    }
-  }, [jumpTo, match.location.query.search_criteria_id])
-
   const total = artist.sidebarAggregations?.counts?.total ?? 0
 
   return (


### PR DESCRIPTION
The type of this PR is: **Fix**

This follows up [a few failed attempts](https://github.com/artsy/force/pull/13405) to solve the alerts-related artist page scroll bug [ticketed here](https://artsyproduct.atlassian.net/browse/ONYX-665).

At this point we are getting rid of the bug by actually _disabling_ the automatic `jumpTo` behavior completely. (It seems to interact poorly with the new filter UI which was released in https://github.com/artsy/force/pull/13329)

I'll leave the bug ticket open, in case anyone wants to take another swing at this. For context, the discussion took place in [this thread](https://artsy.slack.com/archives/C05EQL4R5N0/p1706034210971619).
