### PR TITLE
fix(EMI-1640): Update ask specialist workflow engine config

### DIFF
--- a/src/Components/Inquiry/Views/InquirySpecialist.tsx
+++ b/src/Components/Inquiry/Views/InquirySpecialist.tsx
@@ -59,7 +59,7 @@ export const InquirySpecialist: React.FC = () => {
         contactGallery: false,
       })
       setMode("Success")
-      await wait(500)
+      await wait(1500)
       next()
     } catch (err) {
       logger.error(err)

--- a/src/Components/Inquiry/Views/InquirySpecialist.tsx
+++ b/src/Components/Inquiry/Views/InquirySpecialist.tsx
@@ -6,6 +6,7 @@ import {
   Spacer,
   Text,
   TextArea,
+  useToasts,
 } from "@artsy/palette"
 import * as React from "react"
 import { useSystemContext } from "System/useSystemContext"
@@ -23,6 +24,7 @@ type Mode = "Pending" | "Sending" | "Error" | "Success"
 
 export const InquirySpecialist: React.FC = () => {
   const { user } = useSystemContext()
+  const { sendToast } = useToasts()
 
   const { next, setInquiry, inquiry, artworkID } = useInquiryContext()
 
@@ -59,7 +61,11 @@ export const InquirySpecialist: React.FC = () => {
         contactGallery: false,
       })
       setMode("Success")
-      await wait(1500)
+      await wait(500)
+      sendToast({
+        variant: "success",
+        message: "Your message has been sent",
+      })
       next()
     } catch (err) {
       logger.error(err)

--- a/src/Components/Inquiry/config.ts
+++ b/src/Components/Inquiry/config.ts
@@ -31,14 +31,7 @@ export const useEngine = ({ context, onDone }: UseEngine) => {
       workflow: [
         {
           askSpecialist: {
-            true: [
-              "Specialist",
-              {
-                isLoggedOut: {
-                  true: ["Account"],
-                },
-              },
-            ],
+            true: ["Specialist"],
             false: [
               "Inquiry",
               {


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-1640]

### Description
This PR updates the Ask Specialist inquiry modal config to fix showing the Error status in the button.
~~We also updated the waiting period from `0.5s` to `1.5s` so users don't feel surprised when the modal suddenly disappears~~
We also added a toast when the message gets sent.


#### The motive behind the solution:
The fix here was to remove the `isLoggedOut` check from the `AskSpecialist` config for two reasons:
- We simplified the workflow a while ago in #11399. In the previous workflow, we used to have a confirmation modal at the end of the steps, so if the user was already logged in, it would skip the `isLoggedOut` check and move on to the confirmation modal.
- We don't have an Ask Specialist inquiry flow anymore, and if the user was logged in, the `isLoggedOut` check doesn't have a next step to go to, and it breaks

Due to these reasons, removing the check made sense

### Screenshots & Videos
| Before | After |
|---|---|
| <video src="https://github.com/artsy/force/assets/20655703/5f0f4ef8-3666-4b63-be5b-1ff3b9ad7c2a" /> | <video src="https://github.com/artsy/force/assets/20655703/78e66bfd-f801-491f-a726-6d558696d484" /> |


| New Toast |
|---|
| <img width="588" alt="image" src="https://github.com/artsy/force/assets/20655703/4cf00b85-e376-4d78-abe5-c97529757de0"> |

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EMI-1640]: https://artsyproduct.atlassian.net/browse/EMI-1640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ