### PR TITLE
fix: fixes failing LocationAutocompleteInput spec

### DIFF
--- a/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtistAutocomplete.jest.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtistAutocomplete.jest.tsx
@@ -89,7 +89,7 @@ const simulateTyping = async (wrapper: ReactWrapper, text: string) => {
 const simulateSelectSuggestion = async (wrapper: ReactWrapper, idx: number) => {
   wrapper.find(inputSelector).simulate("focus")
   const suggestion = wrapper.find(optionsSelector).at(idx)
-  suggestion.simulate("mouseenter").simulate("mousedown").simulate("mouseup")
+  suggestion.simulate("click")
   await flushPromiseQueue()
   wrapper.update()
 }

--- a/src/Components/__tests__/LocationAutocompleteInput.jest.tsx
+++ b/src/Components/__tests__/LocationAutocompleteInput.jest.tsx
@@ -44,7 +44,7 @@ const simulateTyping = async (wrapper: ReactWrapper, text: string) => {
 const simulateSelectSuggestion = async (wrapper: ReactWrapper, idx: number) => {
   wrapper.find(inputSelector).simulate("focus")
   const suggestion = wrapper.find(optionsSelector).at(idx)
-  suggestion.simulate("mouseenter").simulate("mousedown").simulate("mouseup")
+  suggestion.simulate("click")
   await flushPromiseQueue()
   wrapper.update()
 }


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Fixes [this failing test](https://app.circleci.com/pipelines/github/artsy/force/57761/workflows/a595a2db-bb43-4c09-b279-8e6aec8af35d/jobs/432033) cause by [this palette update](https://github.com/artsy/palette/pull/1361).

Not sure why `.simulate("mouseenter").simulate("mousedown").simulate("mouseup")` is not the same as `.simulate("click")` though 🤷 