### PR TITLE
fix: Open first notification correctly

### DIFF
--- a/src/Components/Notifications/NotificationsList.tsx
+++ b/src/Components/Notifications/NotificationsList.tsx
@@ -21,6 +21,7 @@ import { shouldDisplayNotification } from "./util"
 import { NotificationsListPlaceholder } from "./NotificationsListPlaceholder"
 import { useNotificationsContext } from "Components/Notifications/useNotificationsContext"
 import { NotificationListMode } from "Components/Notifications/NotificationsTabs"
+import { useRouter } from "System/Router/useRouter"
 
 interface NotificationsListQueryRendererProps {
   mode: NotificationListMode
@@ -43,6 +44,7 @@ const NotificationsList: React.FC<NotificationsListProps> = ({
   type,
   paginationType = "showMoreButton",
 }) => {
+  const { router } = useRouter()
   const [loading, setLoading] = useState(false)
   const [currentPaginationType, setCurrentPaginationType] = useState(
     paginationType
@@ -51,7 +53,7 @@ const NotificationsList: React.FC<NotificationsListProps> = ({
     shouldDisplayNotification(node)
   )
 
-  const { state, setCurrentNotificationId } = useNotificationsContext()
+  const { state } = useNotificationsContext()
 
   // Set the current notification ID to the first one from the list in case no ID is selected.
   useEffect(() => {
@@ -65,8 +67,9 @@ const NotificationsList: React.FC<NotificationsListProps> = ({
       return
     }
 
-    setCurrentNotificationId(firstNotificationId)
-  })
+    router.replace(`/notification/${firstNotificationId}`)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const handleLoadNext = () => {
     if (!relay.hasMore() || relay.isLoading()) {

--- a/src/Components/Notifications/useNotificationsContext.tsx
+++ b/src/Components/Notifications/useNotificationsContext.tsx
@@ -38,6 +38,8 @@ export const NotificationsContextProvider: FC<NotificationsContextProviderProps>
   ] = useState<NotificationType>("all")
 
   useEffect(() => {
+    if (!match.params.notificationId) return
+
     setCurrentNotificationId(match.params.notificationId)
   }, [match.params.notificationId, setCurrentNotificationId])
 


### PR DESCRIPTION
## Description

When navigating to `/notifications` the first notification in the list should open, but for some reason, it is not happening. This fix solves the issue. With this change also the URL is correctly replaced with `/notification/${firstNotificationID}`.



| Before | After |
| --- | --- |
|<img width="1042" alt="Screenshot 2024-01-26 at 16 15 42" src="https://github.com/artsy/force/assets/4691889/57a0767c-bfc7-4f30-98b9-fe31ee151b90"> |<img width="1040" alt="Screenshot 2024-01-26 at 16 15 53" src="https://github.com/artsy/force/assets/4691889/b1c83bd2-e695-4af5-a942-ba6acc8bd33d"> |