### PR TITLE
fix: Notification list scroll behaviour

### DIFF
--- a/src/Components/Notifications/NotificationsWrapper.tsx
+++ b/src/Components/Notifications/NotificationsWrapper.tsx
@@ -47,6 +47,7 @@ export const NotificationsWrapper: React.FC<NotificationsWrapperProps> = ({
           </Sticky>
 
           <Box
+            // The notification list needs a maximum height to be independently scrollable.
             overflow="scroll"
             maxHeight={`calc(100vh - ${DROPDOWN_CONTENT_HEIGHT}px)`}
             pb={2}

--- a/src/Components/Notifications/NotificationsWrapper.tsx
+++ b/src/Components/Notifications/NotificationsWrapper.tsx
@@ -47,8 +47,8 @@ export const NotificationsWrapper: React.FC<NotificationsWrapperProps> = ({
           </Sticky>
 
           <Box
-            // The notification list needs a maximum height to be independently scrollable.
             overflow="scroll"
+            // The notification list needs a maximum height to be independently scrollable.
             maxHeight={`calc(100vh - ${DROPDOWN_CONTENT_HEIGHT}px)`}
             pb={2}
           >

--- a/src/Components/Notifications/NotificationsWrapper.tsx
+++ b/src/Components/Notifications/NotificationsWrapper.tsx
@@ -44,9 +44,13 @@ export const NotificationsWrapper: React.FC<NotificationsWrapperProps> = ({
             <Separator />
           </Sticky>
 
-          <Flex overflow="scroll" flexDirection="column">
+          <Box
+            overflow="scroll"
+            maxHeight={`calc(100vh - ${DROPDOWN_CONTENT_HEIGHT}px)`}
+            pb={2}
+          >
             <NotificationsListQueryRenderer mode={mode} />
-          </Flex>
+          </Box>
           <Separator />
         </>
       )}


### PR DESCRIPTION

## Description

This PR fixes the scrolling behavior of the Activity list in the split view, which was broken after updating the design of the activity list (https://github.com/artsy/force/issues/13392).

Basically, it wasn't possible to scroll the list independently.

