### PR TITLE
fix: fixes unwanted redirect to a notification page from notifications list

### DIFF
--- a/src/Components/Notifications/NotificationsList.tsx
+++ b/src/Components/Notifications/NotificationsList.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, Join, Separator, Text } from "@artsy/palette"
+import { Box, Button, Flex, Join, Separator, THEME, Text } from "@artsy/palette"
 import {
   createPaginationContainer,
   graphql,
@@ -22,6 +22,7 @@ import { NotificationsListPlaceholder } from "./NotificationsListPlaceholder"
 import { useNotificationsContext } from "Components/Notifications/useNotificationsContext"
 import { NotificationListMode } from "Components/Notifications/NotificationsTabs"
 import { useRouter } from "System/Router/useRouter"
+import { __internal__useMatchMedia } from "Utils/Hooks/useMatchMedia"
 
 interface NotificationsListQueryRendererProps {
   mode: NotificationListMode
@@ -55,11 +56,18 @@ const NotificationsList: React.FC<NotificationsListProps> = ({
 
   const { state } = useNotificationsContext()
 
+  const xs = __internal__useMatchMedia(THEME.mediaQueries.xs)
+  const sm = __internal__useMatchMedia(THEME.mediaQueries.sm)
+  const isMobile = xs || sm
+
   // Set the current notification ID to the first one from the list in case no ID is selected.
   useEffect(() => {
+    if (isMobile === null) return
+
     const firstNotificationId = nodes[0]?.internalID
 
     if (
+      isMobile ||
       mode !== "page" ||
       state.currentNotificationId ||
       !firstNotificationId
@@ -69,7 +77,7 @@ const NotificationsList: React.FC<NotificationsListProps> = ({
 
     router.replace(`/notification/${firstNotificationId}`)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [isMobile])
 
   const handleLoadNext = () => {
     if (!relay.hasMore() || relay.isLoading()) {


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Fixes unwanted redirect for mWeb, when user opens `/notifications` page and gets redirected to a top notification page right away. See before and after (notice that only mWeb was broken, I've attached desktop video just to demo that it works after changes)

Before:

| mWeb | Desktop |
|---|---|
| <video src="https://github.com/artsy/force/assets/3934579/62abe90f-8df5-4688-baa8-b883901f0223" /> | <video src="https://github.com/artsy/force/assets/3934579/175c5369-6a73-4788-b6d9-6e95ba09dcd1" /> |

After:

| mWeb | Desktop |
|---|---|
| <video src="https://github.com/artsy/force/assets/3934579/7e3326fe-4a88-458e-a132-48cb838aad72" /> | <video src="https://github.com/artsy/force/assets/3934579/e05fd6d1-2486-4d2c-af3c-0961e74107e8" /> |




