### PR TITLE
fix: wrong relay connection key used to refresh artwork lists

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves/Components/Actions/Mutations/useCreateCollection.ts
+++ b/src/Apps/CollectorProfile/Routes/Saves/Components/Actions/Mutations/useCreateCollection.ts
@@ -17,7 +17,7 @@ const onListAdded = (
     return
   }
 
-  const key = "CollectorProfileSaves2Route_customArtworkLists"
+  const key = "CollectorProfileSavesRoute_customArtworkLists"
   const customArtworkListsConnection = ConnectionHandler.getConnection(me, key)
   const mutationPayload = store.getRootField("createCollection")
   const responseOrError = mutationPayload.getLinkedRecord("responseOrError")

--- a/src/Apps/CollectorProfile/Routes/Saves/Components/Actions/Mutations/useDeleteArtworkList.ts
+++ b/src/Apps/CollectorProfile/Routes/Saves/Components/Actions/Mutations/useDeleteArtworkList.ts
@@ -27,7 +27,7 @@ const deleteArtworkListUpdater = (
 
   const customArtworkListsConnection = ConnectionHandler.getConnection(
     me,
-    "CollectorProfileSaves2Route_customArtworkLists"
+    "CollectorProfileSavesRoute_customArtworkLists"
   )
 
   if (!customArtworkListsConnection) {


### PR DESCRIPTION
The type of this PR is: **fix**

This PR fixes a [bug reported in 🔒 slack](https://artsy.slack.com/archives/C02JHHHKP5K/p1707317247273669?thread_ts=1707317112.824079&cid=C02JHHHKP5K) where the artwork list list does not get updated after creating or deleting an artwork list. Looks like a tiny oversight after a migration on this page was completed.