### PR TITLE
feat: add pageview tracking to artwork error pages

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkErrorApp/ArtworkErrorApp.tsx
+++ b/src/Apps/Artwork/Components/ArtworkErrorApp/ArtworkErrorApp.tsx
@@ -5,6 +5,8 @@ import { graphql, useFragment } from "react-relay"
 import { OtherWorksQueryRenderer } from "Apps/Artwork/Components/ArtworkErrorApp/ArtworkErrorAppOtherWorks"
 import { RelatedWorksQueryRenderer } from "Apps/Artwork/Components/ArtworkErrorApp/ArtworkErrorAppRelatedWorks"
 import { RecentlyViewed } from "Components/RecentlyViewed"
+import { useCallback, useEffect } from "react"
+import { getENV } from "Utils/getENV"
 
 interface ArtworkErrorAppProps {
   artworkError: ArtworkErrorApp_artworkError$key
@@ -25,6 +27,30 @@ export const ArtworkErrorApp: React.FC<ArtworkErrorAppProps> = ({
       : ERROR_MESSAGES[statusCode] ?? "Internal Error"
 
   const artworkSlug = artwork?.slug
+
+  // Artwork paths are excluded from regular pageview tracking via
+  // `trackingMiddleware`, since `ArtworkApp` does some custom tracking.
+  // However, we still want to track pageviews for error pages.
+  // This is mostly cribbed from `ArtworkApp`.
+  const trackPageview = useCallback(() => {
+    const path = window.location.pathname
+
+    if (typeof window.analytics !== "undefined") {
+      const properties: any = {
+        path,
+        url: getENV("APP_URL") + path,
+        error: true,
+      }
+
+      window.analytics.page(properties, { integrations: { Marketo: false } })
+    }
+  }, [])
+
+  useEffect(() => {
+    trackPageview()
+
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   return (
     <Box>


### PR DESCRIPTION
@abhitip pointed out that our regular pageview tracking wasn't in effect for the artwork error app.

Looking into it, and this is b/c artwork pageview tracking is actually excluded in `trackingMiddleware`, otherwise we'd get that for free. That configuration is [here](https://github.com/artsy/force/blob/0c96a2f8313fcdb057604a29d4df803a3634d73c/src/System/Router/buildClientApp.tsx#L78).

So, this adds the same kind of raw pageview tracking (via `useEffect` with a good ol' `[]` dep. array), and `window.analytics`, as the `ArtworkApp` does [here](https://github.com/artsy/force/blob/0c96a2f8313fcdb057604a29d4df803a3634d73c/src/Apps/Artwork/ArtworkApp.tsx#L175).

Overall this is a bit messy and less than ideal, but is a consequence of the need to do custom analytics hooks on the artwork page (and thus is excluded from the 'free' tracking via middleware). And there is that need in `ArtworkApp` (and I don't see any obvious refactor or improvement), as additional data based on fetched data is required to be injected into the pageview tracking call [here](https://github.com/artsy/force/blob/0c96a2f8313fcdb057604a29d4df803a3634d73c/src/Apps/Artwork/ArtworkApp.tsx#L100), and there's no great way to access those additional properties from the middleware, so it has to happen in the component this way.

Separately, since `ArtworkApp` does some non-standard tracking (some of which will remain I'm sure), we may want to periodically double-check with analytics that these additional properties are useful. Perhaps for pageview tracking these additional properties aren't used and we could possibly consolidate to use the middleware and drop these additional properties.