### PR TITLE
fix(onyx-751): hide unpublished viewing room / activity panel notifications from activity panel

### DIFF
--- a/src/Components/Notifications/NotificationsList.tsx
+++ b/src/Components/Notifications/NotificationsList.tsx
@@ -177,6 +177,20 @@ export const NotificationsListFragmentContainer = createPaginationContainer(
                 totalCount
               }
               ...NotificationItem_item
+
+              item {
+                ... on ViewingRoomPublishedNotificationItem {
+                  viewingRoomsConnection(first: 1) {
+                    totalCount
+                  }
+                }
+
+                ... on ArticleFeaturedArtistNotificationItem {
+                  article {
+                    internalID
+                  }
+                }
+              }
             }
           }
         }

--- a/src/Components/Notifications/__tests__/NotificationsList.jest.tsx
+++ b/src/Components/Notifications/__tests__/NotificationsList.jest.tsx
@@ -57,16 +57,19 @@ const notifications = {
     {
       node: {
         title: "Notification One",
+        notificationType: "PARTNER_OFFER_CREATED",
       },
     },
     {
       node: {
         title: "Notification Two",
+        notificationType: "PARTNER_OFFER_CREATED",
       },
     },
     {
       node: {
         title: "Notification Three",
+        notificationType: "PARTNER_OFFER_CREATED",
       },
     },
   ],

--- a/src/Components/Notifications/__tests__/NotificationsList.jest.tsx
+++ b/src/Components/Notifications/__tests__/NotificationsList.jest.tsx
@@ -57,13 +57,13 @@ const notifications = {
     {
       node: {
         title: "Notification One",
-        notificationType: "PARTNER_OFFER_CREATED",
+        notificationType: "ARTWORK_ALERT",
       },
     },
     {
       node: {
         title: "Notification Two",
-        notificationType: "PARTNER_OFFER_CREATED",
+        notificationType: "ARTWORK_PUBLISHED",
       },
     },
     {

--- a/src/Components/Notifications/__tests__/util.jest.ts
+++ b/src/Components/Notifications/__tests__/util.jest.ts
@@ -1,14 +1,8 @@
 import { shouldDisplayNotification } from "Components/Notifications/util"
 
 describe("shouldDisplayNotification", () => {
-  it("returns true when notification is not artworks based", () => {
-    const result = shouldDisplayNotification({
-      notificationType: "VIEWING_ROOM_PUBLISHED",
-    })
-    expect(result).toEqual(true)
-  })
-
-  it("returns true when notification is artworks based, but has artworks", () => {
+  it("returns true when notification satisfies conditions", () => {
+    // artwork based notifications have artworks
     const result = shouldDisplayNotification({
       notificationType: "ARTWORK_ALERT",
       artworks: { totalCount: 1 },
@@ -26,9 +20,24 @@ describe("shouldDisplayNotification", () => {
       artworks: { totalCount: 1 },
     })
     expect(result3).toEqual(true)
+
+    // viewing room notification has viewing rooms
+    const result4 = shouldDisplayNotification({
+      notificationType: "VIEWING_ROOM_PUBLISHED",
+      item: { viewingRoomsConnection: { totalCount: 1 } },
+    })
+    expect(result4).toEqual(true)
+
+    // editorial notification has article
+    const result5 = shouldDisplayNotification({
+      notificationType: "ARTICLE_FEATURED_ARTIST",
+      item: { article: { internalID: 1 } },
+    })
+    expect(result5).toEqual(true)
   })
 
-  it("returns false when notification is artworks based, and has no artworks", () => {
+  it("returns false when notification does not satisfy conditions", () => {
+    // artwork based notifications have no artworks
     const result = shouldDisplayNotification({
       notificationType: "ARTWORK_ALERT",
       artworks: { totalCount: 0 },
@@ -46,5 +55,19 @@ describe("shouldDisplayNotification", () => {
       artworks: { totalCount: 0 },
     })
     expect(result3).toEqual(false)
+
+    // viewing room notification has no viewing rooms
+    const result4 = shouldDisplayNotification({
+      notificationType: "VIEWING_ROOM_PUBLISHED",
+      item: { viewingRoomsConnection: { totalCount: 0 } },
+    })
+    expect(result4).toEqual(false)
+
+    // editorial notification has no article
+    const result5 = shouldDisplayNotification({
+      notificationType: "ARTICLE_FEATURED_ARTIST",
+      item: {},
+    })
+    expect(result5).toEqual(false)
   })
 })

--- a/src/Components/Notifications/util.ts
+++ b/src/Components/Notifications/util.ts
@@ -1,12 +1,22 @@
 import { NotificationTypesEnum } from "__generated__/NotificationsList_viewer.graphql"
 
 export const shouldDisplayNotification = notification => {
-  if (!isArtworksBasedNotification(notification.notificationType)) {
-    return true
+  if (isArtworksBasedNotification(notification.notificationType)) {
+    const artworksCount = notification.artworks?.totalCount ?? 0
+    return artworksCount > 0
   }
 
-  const artworksCount = notification.artworks?.totalCount ?? 0
-  return artworksCount > 0
+  if (notification.notificationType === "VIEWING_ROOM_PUBLISHED") {
+    const viewingRoomsCount =
+      notification.item?.viewingRoomsConnection?.totalCount ?? 0
+    return viewingRoomsCount > 0
+  }
+
+  if (notification.notificationType === "ARTICLE_FEATURED_ARTIST") {
+    return !!notification.item?.article?.internalID
+  }
+
+  return true
 }
 
 export const isArtworksBasedNotification = (

--- a/src/__generated__/NotificationsListNextQuery.graphql.ts
+++ b/src/__generated__/NotificationsListNextQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<78c6ad435bc137020fc6e7065a3c1cc0>>
+ * @generated SignedSource<<28a22a653b6b675e85fbd422f6d46b1f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -75,21 +75,24 @@ v3 = {
   "name": "totalCount",
   "storageKey": null
 },
-v4 = {
+v4 = [
+  (v3/*: any*/)
+],
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -192,12 +195,10 @@ return {
                         "kind": "LinkedField",
                         "name": "artworksConnection",
                         "plural": false,
-                        "selections": [
-                          (v3/*: any*/)
-                        ],
+                        "selections": (v4/*: any*/),
                         "storageKey": null
                       },
-                      (v4/*: any*/),
+                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -254,7 +255,7 @@ return {
                         "name": "item",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/),
+                          (v6/*: any*/),
                           {
                             "kind": "InlineFragment",
                             "selections": [
@@ -274,6 +275,49 @@ return {
                               }
                             ],
                             "type": "PartnerOfferCreatedNotificationItem",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "first",
+                                    "value": 1
+                                  }
+                                ],
+                                "concreteType": "ViewingRoomsConnection",
+                                "kind": "LinkedField",
+                                "name": "viewingRoomsConnection",
+                                "plural": false,
+                                "selections": (v4/*: any*/),
+                                "storageKey": "viewingRoomsConnection(first:1)"
+                              }
+                            ],
+                            "type": "ViewingRoomPublishedNotificationItem",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Article",
+                                "kind": "LinkedField",
+                                "name": "article",
+                                "plural": false,
+                                "selections": [
+                                  (v2/*: any*/),
+                                  (v5/*: any*/)
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "ArticleFeaturedArtistNotificationItem",
                             "abstractKey": null
                           }
                         ],
@@ -311,7 +355,7 @@ return {
                                 "plural": false,
                                 "selections": [
                                   (v2/*: any*/),
-                                  (v6/*: any*/),
+                                  (v7/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -359,7 +403,7 @@ return {
                                     ],
                                     "storageKey": null
                                   },
-                                  (v4/*: any*/)
+                                  (v5/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -369,8 +413,8 @@ return {
                         ],
                         "storageKey": "artworksConnection(first:4)"
                       },
-                      (v6/*: any*/),
-                      (v5/*: any*/)
+                      (v7/*: any*/),
+                      (v6/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -427,12 +471,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1be58d0b7257af6b56fd8d3485f3d776",
+    "cacheID": "8da7cfa88f531eb34eb08f8f24f3df73",
     "id": null,
     "metadata": {},
     "name": "NotificationsListNextQuery",
     "operationKind": "query",
-    "text": "query NotificationsListNextQuery(\n  $count: Int!\n  $cursor: String\n  $types: [NotificationTypesEnum]\n) {\n  viewer {\n    ...NotificationsList_viewer_2TJroH\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  id\n  internalID\n  headline\n  message\n  publishedAt(format: \"RELATIVE\")\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  item {\n    __typename\n    ... on PartnerOfferCreatedNotificationItem {\n      available\n      expiresAt\n    }\n  }\n  artworksConnection(first: 4) {\n    totalCount\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n  title\n}\n\nfragment NotificationsList_viewer_2TJroH on Viewer {\n  notifications: notificationsConnection(first: $count, after: $cursor, notificationTypes: $types) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_item\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query NotificationsListNextQuery(\n  $count: Int!\n  $cursor: String\n  $types: [NotificationTypesEnum]\n) {\n  viewer {\n    ...NotificationsList_viewer_2TJroH\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  id\n  internalID\n  headline\n  message\n  publishedAt(format: \"RELATIVE\")\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  item {\n    __typename\n    ... on PartnerOfferCreatedNotificationItem {\n      available\n      expiresAt\n    }\n  }\n  artworksConnection(first: 4) {\n    totalCount\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n  title\n}\n\nfragment NotificationsList_viewer_2TJroH on Viewer {\n  notifications: notificationsConnection(first: $count, after: $cursor, notificationTypes: $types) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_item\n        item {\n          __typename\n          ... on ViewingRoomPublishedNotificationItem {\n            viewingRoomsConnection(first: 1) {\n              totalCount\n            }\n          }\n          ... on ArticleFeaturedArtistNotificationItem {\n            article {\n              internalID\n              id\n            }\n          }\n        }\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/NotificationsListQuery.graphql.ts
+++ b/src/__generated__/NotificationsListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<eb335923b122bb2e9c366533fb47c8a0>>
+ * @generated SignedSource<<307da507afc65f4c57ed047ab82916f3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -58,21 +58,24 @@ v3 = {
   "name": "totalCount",
   "storageKey": null
 },
-v4 = {
+v4 = [
+  (v3/*: any*/)
+],
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -165,12 +168,10 @@ return {
                         "kind": "LinkedField",
                         "name": "artworksConnection",
                         "plural": false,
-                        "selections": [
-                          (v3/*: any*/)
-                        ],
+                        "selections": (v4/*: any*/),
                         "storageKey": null
                       },
-                      (v4/*: any*/),
+                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -227,7 +228,7 @@ return {
                         "name": "item",
                         "plural": false,
                         "selections": [
-                          (v5/*: any*/),
+                          (v6/*: any*/),
                           {
                             "kind": "InlineFragment",
                             "selections": [
@@ -247,6 +248,49 @@ return {
                               }
                             ],
                             "type": "PartnerOfferCreatedNotificationItem",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "first",
+                                    "value": 1
+                                  }
+                                ],
+                                "concreteType": "ViewingRoomsConnection",
+                                "kind": "LinkedField",
+                                "name": "viewingRoomsConnection",
+                                "plural": false,
+                                "selections": (v4/*: any*/),
+                                "storageKey": "viewingRoomsConnection(first:1)"
+                              }
+                            ],
+                            "type": "ViewingRoomPublishedNotificationItem",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Article",
+                                "kind": "LinkedField",
+                                "name": "article",
+                                "plural": false,
+                                "selections": [
+                                  (v2/*: any*/),
+                                  (v5/*: any*/)
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "ArticleFeaturedArtistNotificationItem",
                             "abstractKey": null
                           }
                         ],
@@ -284,7 +328,7 @@ return {
                                 "plural": false,
                                 "selections": [
                                   (v2/*: any*/),
-                                  (v6/*: any*/),
+                                  (v7/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -332,7 +376,7 @@ return {
                                     ],
                                     "storageKey": null
                                   },
-                                  (v4/*: any*/)
+                                  (v5/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -342,8 +386,8 @@ return {
                         ],
                         "storageKey": "artworksConnection(first:4)"
                       },
-                      (v6/*: any*/),
-                      (v5/*: any*/)
+                      (v7/*: any*/),
+                      (v6/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -400,12 +444,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f1d4c6c0d4c862725aacdf0391a84564",
+    "cacheID": "69ed2653e1281e58dbcd320d167733c5",
     "id": null,
     "metadata": {},
     "name": "NotificationsListQuery",
     "operationKind": "query",
-    "text": "query NotificationsListQuery(\n  $types: [NotificationTypesEnum]\n) {\n  viewer {\n    ...NotificationsList_viewer_1OKkmt\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  id\n  internalID\n  headline\n  message\n  publishedAt(format: \"RELATIVE\")\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  item {\n    __typename\n    ... on PartnerOfferCreatedNotificationItem {\n      available\n      expiresAt\n    }\n  }\n  artworksConnection(first: 4) {\n    totalCount\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n  title\n}\n\nfragment NotificationsList_viewer_1OKkmt on Viewer {\n  notifications: notificationsConnection(first: 10, notificationTypes: $types) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_item\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query NotificationsListQuery(\n  $types: [NotificationTypesEnum]\n) {\n  viewer {\n    ...NotificationsList_viewer_1OKkmt\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  id\n  internalID\n  headline\n  message\n  publishedAt(format: \"RELATIVE\")\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  item {\n    __typename\n    ... on PartnerOfferCreatedNotificationItem {\n      available\n      expiresAt\n    }\n  }\n  artworksConnection(first: 4) {\n    totalCount\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n  title\n}\n\nfragment NotificationsList_viewer_1OKkmt on Viewer {\n  notifications: notificationsConnection(first: 10, notificationTypes: $types) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_item\n        item {\n          __typename\n          ... on ViewingRoomPublishedNotificationItem {\n            viewingRoomsConnection(first: 1) {\n              totalCount\n            }\n          }\n          ... on ArticleFeaturedArtistNotificationItem {\n            article {\n              internalID\n              id\n            }\n          }\n        }\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/NotificationsList_test_Query.graphql.ts
+++ b/src/__generated__/NotificationsList_test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1c7948196578716bd117fd15da4658a2>>
+ * @generated SignedSource<<f4619a2969790a323b409f037279a53d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -43,58 +43,61 @@ v2 = {
   "name": "totalCount",
   "storageKey": null
 },
-v3 = {
+v3 = [
+  (v2/*: any*/)
+],
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v4 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "title",
   "storageKey": null
 },
-v6 = {
+v7 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
-},
-v7 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "ArtworkConnection"
 },
 v8 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Int"
+  "type": "ArtworkConnection"
 },
 v9 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Int"
+},
+v10 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v10 = {
+v11 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v11 = {
+v12 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
@@ -180,12 +183,10 @@ return {
                         "kind": "LinkedField",
                         "name": "artworksConnection",
                         "plural": false,
-                        "selections": [
-                          (v2/*: any*/)
-                        ],
+                        "selections": (v3/*: any*/),
                         "storageKey": null
                       },
-                      (v3/*: any*/),
+                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -242,7 +243,7 @@ return {
                         "name": "item",
                         "plural": false,
                         "selections": [
-                          (v4/*: any*/),
+                          (v5/*: any*/),
                           {
                             "kind": "InlineFragment",
                             "selections": [
@@ -262,6 +263,49 @@ return {
                               }
                             ],
                             "type": "PartnerOfferCreatedNotificationItem",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": [
+                                  {
+                                    "kind": "Literal",
+                                    "name": "first",
+                                    "value": 1
+                                  }
+                                ],
+                                "concreteType": "ViewingRoomsConnection",
+                                "kind": "LinkedField",
+                                "name": "viewingRoomsConnection",
+                                "plural": false,
+                                "selections": (v3/*: any*/),
+                                "storageKey": "viewingRoomsConnection(first:1)"
+                              }
+                            ],
+                            "type": "ViewingRoomPublishedNotificationItem",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Article",
+                                "kind": "LinkedField",
+                                "name": "article",
+                                "plural": false,
+                                "selections": [
+                                  (v1/*: any*/),
+                                  (v4/*: any*/)
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "ArticleFeaturedArtistNotificationItem",
                             "abstractKey": null
                           }
                         ],
@@ -299,7 +343,7 @@ return {
                                 "plural": false,
                                 "selections": [
                                   (v1/*: any*/),
-                                  (v5/*: any*/),
+                                  (v6/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -347,7 +391,7 @@ return {
                                     ],
                                     "storageKey": null
                                   },
-                                  (v3/*: any*/)
+                                  (v4/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -357,8 +401,8 @@ return {
                         ],
                         "storageKey": "artworksConnection(first:4)"
                       },
-                      (v5/*: any*/),
-                      (v4/*: any*/)
+                      (v6/*: any*/),
+                      (v5/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -415,7 +459,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "2f4427b8d8485aa3711c1ad78a9fb046",
+    "cacheID": "6466902a61a975c6624912393e8cc8bb",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -437,17 +481,17 @@ return {
           "plural": true,
           "type": "NotificationEdge"
         },
-        "viewer.notifications.edges.cursor": (v6/*: any*/),
+        "viewer.notifications.edges.cursor": (v7/*: any*/),
         "viewer.notifications.edges.node": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Notification"
         },
-        "viewer.notifications.edges.node.__typename": (v6/*: any*/),
-        "viewer.notifications.edges.node.artworks": (v7/*: any*/),
-        "viewer.notifications.edges.node.artworks.totalCount": (v8/*: any*/),
-        "viewer.notifications.edges.node.artworksConnection": (v7/*: any*/),
+        "viewer.notifications.edges.node.__typename": (v7/*: any*/),
+        "viewer.notifications.edges.node.artworks": (v8/*: any*/),
+        "viewer.notifications.edges.node.artworks.totalCount": (v9/*: any*/),
+        "viewer.notifications.edges.node.artworksConnection": (v8/*: any*/),
         "viewer.notifications.edges.node.artworksConnection.edges": {
           "enumValues": null,
           "nullable": true,
@@ -460,7 +504,7 @@ return {
           "plural": false,
           "type": "Artwork"
         },
-        "viewer.notifications.edges.node.artworksConnection.edges.node.id": (v9/*: any*/),
+        "viewer.notifications.edges.node.artworksConnection.edges.node.id": (v10/*: any*/),
         "viewer.notifications.edges.node.artworksConnection.edges.node.image": {
           "enumValues": null,
           "nullable": true,
@@ -473,30 +517,45 @@ return {
           "plural": false,
           "type": "CroppedImageUrl"
         },
-        "viewer.notifications.edges.node.artworksConnection.edges.node.image.thumb.src": (v6/*: any*/),
-        "viewer.notifications.edges.node.artworksConnection.edges.node.image.thumb.srcSet": (v6/*: any*/),
-        "viewer.notifications.edges.node.artworksConnection.edges.node.internalID": (v9/*: any*/),
-        "viewer.notifications.edges.node.artworksConnection.edges.node.title": (v10/*: any*/),
-        "viewer.notifications.edges.node.artworksConnection.totalCount": (v8/*: any*/),
-        "viewer.notifications.edges.node.headline": (v6/*: any*/),
-        "viewer.notifications.edges.node.id": (v9/*: any*/),
-        "viewer.notifications.edges.node.internalID": (v9/*: any*/),
-        "viewer.notifications.edges.node.isUnread": (v11/*: any*/),
+        "viewer.notifications.edges.node.artworksConnection.edges.node.image.thumb.src": (v7/*: any*/),
+        "viewer.notifications.edges.node.artworksConnection.edges.node.image.thumb.srcSet": (v7/*: any*/),
+        "viewer.notifications.edges.node.artworksConnection.edges.node.internalID": (v10/*: any*/),
+        "viewer.notifications.edges.node.artworksConnection.edges.node.title": (v11/*: any*/),
+        "viewer.notifications.edges.node.artworksConnection.totalCount": (v9/*: any*/),
+        "viewer.notifications.edges.node.headline": (v7/*: any*/),
+        "viewer.notifications.edges.node.id": (v10/*: any*/),
+        "viewer.notifications.edges.node.internalID": (v10/*: any*/),
+        "viewer.notifications.edges.node.isUnread": (v12/*: any*/),
         "viewer.notifications.edges.node.item": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "NotificationItem"
         },
-        "viewer.notifications.edges.node.item.__typename": (v6/*: any*/),
+        "viewer.notifications.edges.node.item.__typename": (v7/*: any*/),
+        "viewer.notifications.edges.node.item.article": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Article"
+        },
+        "viewer.notifications.edges.node.item.article.id": (v10/*: any*/),
+        "viewer.notifications.edges.node.item.article.internalID": (v10/*: any*/),
         "viewer.notifications.edges.node.item.available": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Boolean"
         },
-        "viewer.notifications.edges.node.item.expiresAt": (v10/*: any*/),
-        "viewer.notifications.edges.node.message": (v6/*: any*/),
+        "viewer.notifications.edges.node.item.expiresAt": (v11/*: any*/),
+        "viewer.notifications.edges.node.item.viewingRoomsConnection": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ViewingRoomsConnection"
+        },
+        "viewer.notifications.edges.node.item.viewingRoomsConnection.totalCount": (v9/*: any*/),
+        "viewer.notifications.edges.node.message": (v7/*: any*/),
         "viewer.notifications.edges.node.notificationType": {
           "enumValues": [
             "ARTICLE_FEATURED_ARTIST",
@@ -516,22 +575,22 @@ return {
           "plural": false,
           "type": "Int"
         },
-        "viewer.notifications.edges.node.publishedAt": (v6/*: any*/),
-        "viewer.notifications.edges.node.targetHref": (v6/*: any*/),
-        "viewer.notifications.edges.node.title": (v6/*: any*/),
+        "viewer.notifications.edges.node.publishedAt": (v7/*: any*/),
+        "viewer.notifications.edges.node.targetHref": (v7/*: any*/),
+        "viewer.notifications.edges.node.title": (v7/*: any*/),
         "viewer.notifications.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "viewer.notifications.pageInfo.endCursor": (v10/*: any*/),
-        "viewer.notifications.pageInfo.hasNextPage": (v11/*: any*/)
+        "viewer.notifications.pageInfo.endCursor": (v11/*: any*/),
+        "viewer.notifications.pageInfo.hasNextPage": (v12/*: any*/)
       }
     },
     "name": "NotificationsList_test_Query",
     "operationKind": "query",
-    "text": "query NotificationsList_test_Query {\n  viewer {\n    ...NotificationsList_viewer\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  id\n  internalID\n  headline\n  message\n  publishedAt(format: \"RELATIVE\")\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  item {\n    __typename\n    ... on PartnerOfferCreatedNotificationItem {\n      available\n      expiresAt\n    }\n  }\n  artworksConnection(first: 4) {\n    totalCount\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n  title\n}\n\nfragment NotificationsList_viewer on Viewer {\n  notifications: notificationsConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_item\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query NotificationsList_test_Query {\n  viewer {\n    ...NotificationsList_viewer\n  }\n}\n\nfragment NotificationItem_item on Notification {\n  id\n  internalID\n  headline\n  message\n  publishedAt(format: \"RELATIVE\")\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  item {\n    __typename\n    ... on PartnerOfferCreatedNotificationItem {\n      available\n      expiresAt\n    }\n  }\n  artworksConnection(first: 4) {\n    totalCount\n    edges {\n      node {\n        internalID\n        title\n        image {\n          thumb: cropped(width: 58, height: 58) {\n            src\n            srcSet\n          }\n        }\n        id\n      }\n    }\n  }\n  title\n}\n\nfragment NotificationsList_viewer on Viewer {\n  notifications: notificationsConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_item\n        item {\n          __typename\n          ... on ViewingRoomPublishedNotificationItem {\n            viewingRoomsConnection(first: 1) {\n              totalCount\n            }\n          }\n          ... on ArticleFeaturedArtistNotificationItem {\n            article {\n              internalID\n              id\n            }\n          }\n        }\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/NotificationsList_viewer.graphql.ts
+++ b/src/__generated__/NotificationsList_viewer.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<83969e4293e3d58515588838a639cbf9>>
+ * @generated SignedSource<<76d41408a0d0f5180be5d12697997137>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -19,6 +19,14 @@ export type NotificationsList_viewer$data = {
           readonly totalCount: number | null | undefined;
         } | null | undefined;
         readonly internalID: string;
+        readonly item: {
+          readonly article?: {
+            readonly internalID: string;
+          } | null | undefined;
+          readonly viewingRoomsConnection?: {
+            readonly totalCount: number | null | undefined;
+          } | null | undefined;
+        } | null | undefined;
         readonly notificationType: NotificationTypesEnum;
         readonly " $fragmentSpreads": FragmentRefs<"NotificationItem_item">;
       } | null | undefined;
@@ -31,7 +39,24 @@ export type NotificationsList_viewer$key = {
   readonly " $fragmentSpreads": FragmentRefs<"NotificationsList_viewer">;
 };
 
-const node: ReaderFragment = {
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v1 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "totalCount",
+    "storageKey": null
+  }
+];
+return {
   "argumentDefinitions": [
     {
       "defaultValue": 10,
@@ -88,13 +113,7 @@ const node: ReaderFragment = {
               "name": "node",
               "plural": false,
               "selections": [
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "internalID",
-                  "storageKey": null
-                },
+                (v0/*: any*/),
                 {
                   "alias": null,
                   "args": null,
@@ -109,21 +128,66 @@ const node: ReaderFragment = {
                   "kind": "LinkedField",
                   "name": "artworksConnection",
                   "plural": false,
-                  "selections": [
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "totalCount",
-                      "storageKey": null
-                    }
-                  ],
+                  "selections": (v1/*: any*/),
                   "storageKey": null
                 },
                 {
                   "args": null,
                   "kind": "FragmentSpread",
                   "name": "NotificationItem_item"
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": null,
+                  "kind": "LinkedField",
+                  "name": "item",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "kind": "InlineFragment",
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": [
+                            {
+                              "kind": "Literal",
+                              "name": "first",
+                              "value": 1
+                            }
+                          ],
+                          "concreteType": "ViewingRoomsConnection",
+                          "kind": "LinkedField",
+                          "name": "viewingRoomsConnection",
+                          "plural": false,
+                          "selections": (v1/*: any*/),
+                          "storageKey": "viewingRoomsConnection(first:1)"
+                        }
+                      ],
+                      "type": "ViewingRoomPublishedNotificationItem",
+                      "abstractKey": null
+                    },
+                    {
+                      "kind": "InlineFragment",
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "concreteType": "Article",
+                          "kind": "LinkedField",
+                          "name": "article",
+                          "plural": false,
+                          "selections": [
+                            (v0/*: any*/)
+                          ],
+                          "storageKey": null
+                        }
+                      ],
+                      "type": "ArticleFeaturedArtistNotificationItem",
+                      "abstractKey": null
+                    }
+                  ],
+                  "storageKey": null
                 },
                 {
                   "alias": null,
@@ -177,7 +241,8 @@ const node: ReaderFragment = {
   "type": "Viewer",
   "abstractKey": null
 };
+})();
 
-(node as any).hash = "b1fc107a2fde16d8574ed621d4fe3abe";
+(node as any).hash = "00ed829ed7cade687cc38e132910031e";
 
 export default node;


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [ONYX-751]

### Description

Hides notifications which do not have published viewing rooms / article within them.

[ONYX-751]: https://artsyproduct.atlassian.net/browse/ONYX-751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ