### PR TITLE
fix: Editorial notification artist line breaks

### DIFF
--- a/src/Components/Notifications/ArticleFeaturedArtistNotification.tsx
+++ b/src/Components/Notifications/ArticleFeaturedArtistNotification.tsx
@@ -64,22 +64,21 @@ export const ArticleFeaturedArtistNotification: FC<ArticleFeaturedArtistNotifica
           />
         )}
 
-        <Flex flexDirection="row">
+        <Text variant="xs">
           {artists.map((artist, index) => {
             return (
               <RouterLink
                 to={artist.href}
                 key={artist.internalID}
                 textDecoration="none"
+                inline
               >
-                <Text variant="xs">
-                  {index > 0 && ", "}
-                  {artist.name}
-                </Text>
+                {index > 0 && ", "}
+                {artist.name}
               </RouterLink>
             )
           })}
-        </Flex>
+        </Text>
       </Flex>
 
       <Spacer y={4} />


### PR DESCRIPTION
Addresses [ONYX-754]

## Description

Removing the editorial notification page artist name line breaks that don't look so good.

| Before | After |
| --- | --- |
|<img width="396" alt="Screenshot 2024-02-13 at 14 22 12" src="https://github.com/artsy/force/assets/4691889/1e68c4c6-f0dc-4844-8ecd-df878fb222e7"> |<img width="389" alt="Screenshot 2024-02-13 at 14 20 40" src="https://github.com/artsy/force/assets/4691889/732a031c-e12c-43f7-8f93-8955fe4b4519"> |


[ONYX-754]: https://artsyproduct.atlassian.net/browse/ONYX-754?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ