### PR TITLE
feat(ONYX-742): notifications empty state redesign

### DIFF
--- a/src/Components/Notifications/NotificationsContextualMenu.tsx
+++ b/src/Components/Notifications/NotificationsContextualMenu.tsx
@@ -2,7 +2,6 @@ import { ContextualMenu, ContextualMenuItem } from "Components/ContextualMenu"
 import { MarkAllAsReadPanel } from "Components/Notifications/MarkAllAsReadPanel"
 import { Z } from "Apps/Components/constants"
 import { RouterLink } from "System/Router/RouterLink"
-import { BASE_SAVES_PATH } from "Apps/CollectorProfile/constants"
 
 interface NotificationsContextualMenuProps {
   onHide?: () => void
@@ -21,13 +20,13 @@ export const NotificationsContextualMenu: React.FC<NotificationsContextualMenuPr
       <ContextualMenuItem p={0}>
         <RouterLink
           onClick={onHide}
-          to={BASE_SAVES_PATH}
+          to={"/settings/alerts"}
           textDecoration="none"
           color="black100"
           display="block"
           p={2}
         >
-          Manage Saves
+          Manage Alerts
         </RouterLink>
       </ContextualMenuItem>
       <ContextualMenuItem p={0}>

--- a/src/Components/Notifications/NotificationsEmptyStateByType.tsx
+++ b/src/Components/Notifications/NotificationsEmptyStateByType.tsx
@@ -51,7 +51,7 @@ export const NotificationsEmptyStateByType: React.FC<NotificationsEmptyStateByTy
         <RouterLink to={"/artists"} color="black100" mx={1}>
           Artists
         </RouterLink>
-        {type == "following" && (
+        {type !== "alerts" && (
           <RouterLink to={"/galleries"} color="black100">
             Galleries
           </RouterLink>

--- a/src/Components/Notifications/NotificationsEmptyStateByType.tsx
+++ b/src/Components/Notifications/NotificationsEmptyStateByType.tsx
@@ -38,7 +38,7 @@ export const NotificationsEmptyStateByType: React.FC<NotificationsEmptyStateByTy
 
   return (
     <Box p={4} aria-label="There is nothing to show">
-      <Text variant="sm-display" textAlign={"left"}>
+      <Text variant="sm-display" textAlign="left">
         {state.title}
       </Text>
       <Spacer y={1} />

--- a/src/Components/Notifications/NotificationsEmptyStateByType.tsx
+++ b/src/Components/Notifications/NotificationsEmptyStateByType.tsx
@@ -1,5 +1,6 @@
 import { Box, Spacer, Text } from "@artsy/palette"
 import { NotificationType } from "./types"
+import { RouterLink } from "System/Router/RouterLink"
 
 interface NotificationsEmptyStateByTypeProps {
   type: NotificationType
@@ -13,10 +14,9 @@ const emptyStateByType: Record<
   }
 > = {
   all: {
-    //TODO: add new copy for "all" notifications
-    title: "Follow artists and galleries to stay up to date",
+    title: "Stay up to date with the artists and artworks you love",
     message:
-      "Keep track of the art and events you love, and get recommendations based on who you follow.",
+      "Follow artists and galleries to keep track of their latest updates. Or create an alert and we’ll let you know when there’s a matching work.",
   },
   alerts: {
     title: "Hunting for a particular artwork?",
@@ -37,13 +37,25 @@ export const NotificationsEmptyStateByType: React.FC<NotificationsEmptyStateByTy
   const state = emptyStateByType[type]
 
   return (
-    <Box px={2} py={4} aria-label="There is nothing to show">
-      <Text variant="sm-display" textAlign="center">
+    <Box p={4} aria-label="There is nothing to show">
+      <Text variant="sm-display" textAlign={"left"}>
         {state.title}
       </Text>
-      <Spacer y={2} />
-      <Text variant="xs" color="black60" textAlign="center">
+      <Spacer y={1} />
+      <Text variant="xs" color="black60" textAlign="left">
         {state.message}
+      </Text>
+      <Spacer y={1} />
+      <Text color="black60" variant="xs">
+        Get started with:
+        <RouterLink to={"/artists"} color="black100" mx={1}>
+          Artists
+        </RouterLink>
+        {type == "following" && (
+          <RouterLink to={"/galleries"} color="black100">
+            Galleries
+          </RouterLink>
+        )}
       </Text>
     </Box>
   )

--- a/src/Components/Notifications/NotificationsPills.tsx
+++ b/src/Components/Notifications/NotificationsPills.tsx
@@ -19,16 +19,12 @@ export const NotificationsPills: React.FC = () => {
 
   const hasPartnerOfferNotifications =
     extractNodes(data?.viewer?.partnerOfferNotifications).length > 0
-  const hasAlertNotifications =
-    extractNodes(data?.viewer?.alertNotifications).length > 0
-  const hasFollowNotifications =
-    extractNodes(data?.viewer?.followNotifications).length > 0
 
   const notificationPills = compact([
     { value: "All", name: "all" },
     hasPartnerOfferNotifications && { value: "Offers", name: "offers" },
-    hasAlertNotifications && { value: "Alerts", name: "alerts" },
-    hasFollowNotifications && { value: "Following", name: "following" },
+    { value: "Alerts", name: "alerts" },
+    { value: "Following", name: "following" },
   ])
 
   if (loading) return <Placeholder />

--- a/src/Components/Notifications/__tests__/NotificationsEmptyStateByType.jest.tsx
+++ b/src/Components/Notifications/__tests__/NotificationsEmptyStateByType.jest.tsx
@@ -13,9 +13,9 @@ describe("NotificationsEmptyStateByType", () => {
   it("should render correct state when type is 'All'", () => {
     render(<NotificationsEmptyStateByType type="all" />)
 
-    const title = "Follow artists and galleries to stay up to date"
+    const title = "Stay up to date with the artists and artworks you love"
     const message =
-      "Keep track of the art and events you love, and get recommendations based on who you follow."
+      "Follow artists and galleries to keep track of their latest updates. Or create an alert and we’ll let you know when there’s a matching work."
 
     expect(screen.getByText(title)).toBeInTheDocument()
     expect(screen.getByText(message)).toBeInTheDocument()


### PR DESCRIPTION
The type of this PR is: Feat

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [ONYX-742](https://artsyproduct.atlassian.net/browse/ONYX-742)

### Description
Update Notifications empty state design, added links "Artists" and "Galleries" that lead to their pages.

https://github.com/artsy/force/assets/17580625/5badc5dd-2329-44f8-8d04-ccf05784ed1f

https://github.com/artsy/force/assets/17580625/0b3a7ad3-bee5-4ff2-88b8-89e9cddd18ee





[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-742]: https://artsyproduct.atlassian.net/browse/ONYX-742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ