### PR TITLE
fix: Use onyx_activity_panel_filter_pills for mark all as read panel

### DIFF
--- a/src/Components/Notifications/MarkAllAsReadPanel.tsx
+++ b/src/Components/Notifications/MarkAllAsReadPanel.tsx
@@ -19,7 +19,9 @@ export const MarkAllAsReadPanel: React.FC<MarkAllAsReadPanelProps> = ({
   const { relayEnvironment } = useSystemContext()
   const { t } = useTranslation()
   const hasUnreadNotifications = unreadCounts > 0
-  const enableNewActivityPanel = useFeatureFlag("onyx_new_notification_page")
+  const enableActivityPanelPills = useFeatureFlag(
+    "onyx_activity_panel_filter_pills"
+  )
 
   const markAllAsRead = async () => {
     if (!relayEnvironment) {
@@ -42,7 +44,7 @@ export const MarkAllAsReadPanel: React.FC<MarkAllAsReadPanelProps> = ({
 
   return (
     <Box>
-      {!enableNewActivityPanel ? (
+      {!enableActivityPanelPills ? (
         <Flex
           height={MARK_ALL_AS_READ_PANEL_HEIGHT}
           p={2}


### PR DESCRIPTION

## Description

Use the new `onyx_activity_panel_filter_pills` feature flag for the "Mark All as Read" panel to avoid this issue.

![Screenshot 2024-02-14 at 14 47 10](https://github.com/artsy/force/assets/4691889/aa67ab68-eb71-4fdd-b389-b3913ddca2bf)
