### PR TITLE
fix: Adjust Alerts notification page header on mWeb

### DIFF
--- a/src/Components/Notifications/AlertNotification.tsx
+++ b/src/Components/Notifications/AlertNotification.tsx
@@ -31,11 +31,11 @@ export const AlertNotification: FC<AlertNotificationProps> = ({
   return (
     <Box m={4}>
       <Flex width="100%" justifyContent="space-between">
-        <Flex flex={1}>
+        <Flex flex={1} mr={1}>
           <Text variant="lg-display">{headline}</Text>
         </Flex>
         <RouterLink to={`/settings/alerts/${alert.internalID}/edit`}>
-          <Text>Edit Alert</Text>
+          <Text mt={[0.5, 1]}>Edit Alert</Text>
         </RouterLink>
       </Flex>
 


### PR DESCRIPTION
Addresses [ONYX-759]

## Description

Adjust Alerts notification page header on mWeb.

| Before | After |
| --- | --- |
|<img width="467" alt="Screenshot 2024-02-15 at 08 32 58" src="https://github.com/artsy/force/assets/4691889/cefa9193-1a32-485d-a90d-488cbbb0c4fe"> | <img width="464" alt="Screenshot 2024-02-15 at 08 33 07" src="https://github.com/artsy/force/assets/4691889/136ac352-617a-4e18-bf0a-b6bf546d4b05">|





[ONYX-759]: https://artsyproduct.atlassian.net/browse/ONYX-759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ