### PR TITLE
feat: update dead-code analysis

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "cypress:run": "./node_modules/.bin/cypress run",
     "cypress": "./node_modules/.bin/cypress open",
     "dead-code": "./scripts/check-dead-code.sh",
+    "dead-code:production": "./scripts/check-dead-code.sh production",
     "delete-review-app": "kubectl --context staging delete namespace",
     "detect-secrets:hook": "scripts/detect-secrets.sh hook",
     "detect-secrets:rebuild": "scripts/detect-secrets.sh rebuild",

--- a/scripts/check-dead-code.sh
+++ b/scripts/check-dead-code.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 
-npx knip --no-exit-code --include files \
+if [ "$1" = "production" ]; then
+    IS_PRODUCTION_MODE="--production"
+else
+    IS_PRODUCTION_MODE=""
+fi
+
+npx knip --no-exit-code --include files $IS_PRODUCTION_MODE \
   | grep -v '__generated__' \
   | grep -v '__mocks__' \
   | grep -v '__stories__'

--- a/scripts/check-dead-code.sh
+++ b/scripts/check-dead-code.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-npx ts-prune --project tsconfig.json \
-  | grep -v '(used in module)' \
+npx knip --no-exit-code --include files \
   | grep -v '__generated__' \
-  | grep -v '__stories__' \
-  | grep -v '.story.' \
-  | grep -v '__mocks__'
+  | grep -v '__mocks__' \
+  | grep -v '__stories__'

--- a/src/DevTools/mockReactI18n.tsx
+++ b/src/DevTools/mockReactI18n.tsx
@@ -3,14 +3,12 @@ import config from "System/i18n/config"
 
 i18n.init(config)
 
-// ts-prune-ignore-next
 export const useTranslation = () => {
   return {
     t: i18n.t,
   }
 }
 
-// ts-prune-ignore-next
 export const initReactI18next = {
   type: "3rdParty",
   init: () => {},

--- a/src/Server/asyncLocalWrapper/browser.ts
+++ b/src/Server/asyncLocalWrapper/browser.ts
@@ -3,7 +3,6 @@ import type { AsyncLocalStorage } from "async_hooks"
 const map = new Map()
 
 // A no-op stub in case this is accessed in the browser.
-// ts-prune-ignore-next
 export const asyncLocalStorage: AsyncLocalStorage<Map<any, any>> = {
   getStore: () => {
     return map

--- a/src/Server/asyncLocalWrapper/server.ts
+++ b/src/Server/asyncLocalWrapper/server.ts
@@ -1,4 +1,3 @@
 import { AsyncLocalStorage } from "async_hooks"
 
-// ts-prune-ignore-next
 export const asyncLocalStorage = new AsyncLocalStorage<Map<any, any>>()

--- a/src/Server/ip.ts
+++ b/src/Server/ip.ts
@@ -1,6 +1,5 @@
 const ipv6Regex = /^(::)?(((\d{1,3}\.){3}(\d{1,3}){1})?([0-9a-f]){0,4}:{0,2}){1,8}(::)?$/i
 
-// ts-prune-ignore-next
 export const isV6Format = ip => {
   return ipv6Regex.test(ip)
 }

--- a/src/Server/userPerformanceMetrics.ts
+++ b/src/Server/userPerformanceMetrics.ts
@@ -58,7 +58,6 @@ export function measure(
 /**
  * Aggregates all marks and measures into a single report
  */
-// ts-prune-ignore-next
 export function getUserTiming() {
   if (typeof PerformanceMark === "undefined") return null
 
@@ -123,7 +122,6 @@ export function getLoadEventEnd() {
  *
  * https://varvy.com/performance/dominteractive.html
  */
-// ts-prune-ignore-next
 export function getDomInteractive() {
   if (!timingAvailable) return null
   return sanitizedMetrics(perf.timing.requestStart, perf.timing.domInteractive)

--- a/webpack/sharedConfig.js
+++ b/webpack/sharedConfig.js
@@ -4,7 +4,6 @@ import path from "path"
 import TerserPlugin from "terser-webpack-plugin"
 import { basePath } from "./webpackEnv"
 
-// ts-prune-ignore-next
 export const productionDevtool = "source-map"
 export const devtool = process.env.WEBPACK_DEVTOOL || "eval"
 export const mode = process.env.NODE_ENV
@@ -23,7 +22,6 @@ export const cache = {
   type: "filesystem", // or 'memory'
 }
 
-// ts-prune-ignore-next
 export const minimizer = [
   new TerserPlugin({
     // Only use 4 cpus (default) in CircleCI, by default it will try using 36 and OOM


### PR DESCRIPTION
The type of this PR is: **Feat**

### Description

Dead-code analyis was added to Force in https://github.com/artsy/force/pull/11984, built on top of [`ts-prune`](https://github.com/nadeesha/ts-prune). 

That project has been archived and now recommends that its users adopt [Knip](https://knip.dev).

This PR changes the existing script to use Knip instead.

### `production` option

It also adds a `production` option that can used to do a deeper clean in  "[production mode](https://knip.dev/features/production-mode)" — i.e. will flag files that _are_ used, if they are _only_ used in tests.

Example:

```sh
yarn dead-code
# => finds 46 files

yarn dead-code:production
# => finds 131 files, now including files that are only used in tests, but otherwise unused
```

### Caveats

- I've only enable the unused file reporting (`--include files`), but Knip can report many other types of unused things, such as binaries or `package.json` dependencies. Definitely worth pursuing further.

- Perhaps goes without saying, but these should be treated as suggestions and reviewed and tested carefully when doing actual cleanups

- Knip is highly configurable and I have not gone all the way down the rabbit hole. It's possible this can be optimized even more by giving Knip a better understanding of our repo's various code entry points. Iteration is welcome, but this should certainly work as a good starting point.
