### PR TITLE
chore: add relay environment to MockBoot

### DIFF
--- a/src/DevTools/setupTestWrapper.tsx
+++ b/src/DevTools/setupTestWrapper.tsx
@@ -2,17 +2,12 @@ import { act, render, RenderResult } from "@testing-library/react"
 import { MockBoot } from "DevTools/MockBoot"
 import { mount } from "enzyme"
 import * as React from "react"
-import {
-  GraphQLTaggedNode,
-  QueryRenderer,
-  RelayEnvironmentProvider,
-  Variables,
-} from "react-relay"
+import { GraphQLTaggedNode, QueryRenderer, Variables } from "react-relay"
 import { OperationDescriptor, OperationType } from "relay-runtime"
 import {
   createMockEnvironment,
-  MockPayloadGenerator,
   MockEnvironment,
+  MockPayloadGenerator,
 } from "relay-test-utils"
 import { MockResolvers } from "relay-test-utils/lib/RelayMockPayloadGenerator"
 
@@ -127,9 +122,7 @@ export const setupTestWrapperTL = <T extends OperationType>({
         </MockBoot>
       ) : (
         <MockBoot relayEnvironment={env}>
-          <RelayEnvironmentProvider environment={env}>
-            <Component {...componentProps} />
-          </RelayEnvironmentProvider>
+          <Component {...componentProps} />
         </MockBoot>
       )
 

--- a/src/System/Router/Boot.tsx
+++ b/src/System/Router/Boot.tsx
@@ -4,12 +4,15 @@ import {
   THEME,
   ToastsProvider,
 } from "@artsy/palette"
-import { SystemContextProvider } from "System/SystemContext"
+import {
+  SystemContextConsumer,
+  SystemContextProvider,
+} from "System/SystemContext"
 import { AppRouteConfig } from "System/Router/Route"
 import { useEffect, useState } from "react"
 import * as React from "react"
 import { HeadProvider } from "react-head"
-import { Environment } from "react-relay"
+import { Environment, RelayEnvironmentProvider } from "react-relay"
 // eslint-disable-next-line no-restricted-imports
 import { data as sd } from "sharify"
 // eslint-disable-next-line no-restricted-imports
@@ -102,34 +105,46 @@ export const Boot = track(undefined, {
       <HeadProvider headTags={headTags}>
         <StateProvider>
           <SystemContextProvider {...contextProps}>
-            <ErrorBoundary>
-              <MediaContextProvider onlyMatch={onlyMatchMediaQueries}>
-                <ResponsiveProvider
-                  mediaQueries={THEME.mediaQueries}
-                  initialMatchingMediaQueries={onlyMatchMediaQueries as any}
-                >
-                  <ToastsProvider>
-                    <StickyProvider>
-                      <AuthIntentProvider>
-                        <AuthDialogProvider>
-                          <DismissibleProvider
-                            userID={props.user?.id}
-                            keys={getProgressiveOnboardingAlertKeys()}
-                          >
-                            <CookieConsentManager>
-                              <FocusVisible />
-                              <SiftContainer />
+            <SystemContextConsumer>
+              {contextValues => {
+                return (
+                  <RelayEnvironmentProvider
+                    environment={contextValues.relayEnvironment}
+                  >
+                    <ErrorBoundary>
+                      <MediaContextProvider onlyMatch={onlyMatchMediaQueries}>
+                        <ResponsiveProvider
+                          mediaQueries={THEME.mediaQueries}
+                          initialMatchingMediaQueries={
+                            onlyMatchMediaQueries as any
+                          }
+                        >
+                          <ToastsProvider>
+                            <StickyProvider>
+                              <AuthIntentProvider>
+                                <AuthDialogProvider>
+                                  <DismissibleProvider
+                                    userID={props.user?.id}
+                                    keys={getProgressiveOnboardingAlertKeys()}
+                                  >
+                                    <CookieConsentManager>
+                                      <FocusVisible />
+                                      <SiftContainer />
 
-                              {children}
-                            </CookieConsentManager>
-                          </DismissibleProvider>
-                        </AuthDialogProvider>
-                      </AuthIntentProvider>
-                    </StickyProvider>
-                  </ToastsProvider>
-                </ResponsiveProvider>
-              </MediaContextProvider>
-            </ErrorBoundary>
+                                      {children}
+                                    </CookieConsentManager>
+                                  </DismissibleProvider>
+                                </AuthDialogProvider>
+                              </AuthIntentProvider>
+                            </StickyProvider>
+                          </ToastsProvider>
+                        </ResponsiveProvider>
+                      </MediaContextProvider>
+                    </ErrorBoundary>
+                  </RelayEnvironmentProvider>
+                )
+              }}
+            </SystemContextConsumer>
           </SystemContextProvider>
         </StateProvider>
       </HeadProvider>

--- a/src/System/Router/ErrorBoundary.tsx
+++ b/src/System/Router/ErrorBoundary.tsx
@@ -41,6 +41,11 @@ export class ErrorBoundary extends React.Component<Props, State> {
   }
 
   static getDerivedStateFromError(error: Error | HttpError) {
+    // This adds a useful stacktrace that can make debugging easier when writing tests
+    if (window.__TEST__) {
+      console.log(error)
+    }
+
     if (error instanceof HttpError) {
       return {
         kind: "RouterError",

--- a/src/Typings/global.d.ts
+++ b/src/Typings/global.d.ts
@@ -50,6 +50,7 @@ declare global {
     // Zendesk properties
     zEmbed: { show: () => void; hide: () => void }
     zESettings: object
+    __TEST__?: boolean
   }
 }
 

--- a/src/tests.ts
+++ b/src/tests.ts
@@ -72,6 +72,7 @@ if (typeof window !== "undefined") {
   // Needed for new tests
   // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
   window.matchMedia = undefined
+  ;(window as Window).__TEST__ = true
 
   window.grecaptcha = {
     ready: jest.fn(cb => cb()),


### PR DESCRIPTION
The type of this PR is: **chore**

This PR makes the following change:
- Add relay environment to Mockboot to make sure components using relay hooks, can find a valid relay environment.


**Bonus:** The error stack trace was inexistent and that made finding out why [some tests](https://github.com/artsy/force/pull/13489/files) broke not trivial. I made a small adjustment to our error boundary to log the full error stack trace when running tests. 

_[The video below shows what it is like after the changes and how it was before them]_

https://github.com/artsy/force/assets/11945712/d7b59a2e-f099-4a74-b55e-8ef29d03f4a6



<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PROJECT-XX]

### Description

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ