### PR TITLE
fix: wandering artist follows popover (DIA-471)

### DIFF
--- a/src/Components/ProgressiveOnboarding/ProgressiveOnboardingFollowArtist.tsx
+++ b/src/Components/ProgressiveOnboarding/ProgressiveOnboardingFollowArtist.tsx
@@ -68,7 +68,7 @@ export const __ProgressiveOnboardingFollowArtist__: FC<ProgressiveOnboardingFoll
   return (
     <ProgressiveOnboardingPopover
       name={ALERT_ID}
-      placement="bottom"
+      placement="bottom-start"
       onClose={handleClose}
       popover={
         <Text variant="xs">

--- a/src/Components/ProgressiveOnboarding/ProgressiveOnboardingPopover.tsx
+++ b/src/Components/ProgressiveOnboarding/ProgressiveOnboardingPopover.tsx
@@ -29,7 +29,11 @@ export const ProgressiveOnboardingPopover: FC<ProgressiveOnboardingPopoverProps>
       {...rest}
     >
       {({ anchorRef }) => {
-        return <Box ref={anchorRef as any}>{children}</Box>
+        return (
+          <Box width="fit-content" ref={anchorRef as any}>
+            {children}
+          </Box>
+        )
       }}
     </Popover>
   )


### PR DESCRIPTION
This PR changes:

1. The horizontal position of the artist follows popover when the artist has no:
    - Cover artwork
    - Biography blurb
    - Verified representatives
    - Insights
1. The placement of the arrow on the artist follows popover

(1) was needed because the popover was appearing to the far right of the follows button:

<img width="1066" alt="Screenshot 2024-02-20 at 9 00 55 AM" src="https://github.com/artsy/force/assets/44589599/50638ece-e29c-4c05-be18-e80e1e1bfa53">

The solution was to fit the container that the popover is attached to to fit its content. However, (2) was needed because the popover was smooshed against the edge of the screen when there was no cover artwork:

<img width="1107" alt="Screenshot 2024-02-20 at 9 00 16 AM" src="https://github.com/artsy/force/assets/44589599/22ab0b8f-b224-48f5-b5c4-297e8d6eba07">

Here is the final result for artists with/without a cover artwork:

<img width="1672" alt="Screenshot 2024-02-20 at 8 59 13 AM" src="https://github.com/artsy/force/assets/44589599/e259f501-ccb9-42c6-81d7-dd38e34664db">

<img width="1069" alt="Screenshot 2024-02-20 at 8 58 12 AM" src="https://github.com/artsy/force/assets/44589599/04236423-48c2-4b3c-83d8-28a824f8c2b5">

