### PR TITLE
fix: Adjust notification page Edit Alert font size

### DIFF
--- a/src/Components/Notifications/AlertNotification.tsx
+++ b/src/Components/Notifications/AlertNotification.tsx
@@ -31,7 +31,7 @@ export const AlertNotification: FC<AlertNotificationProps> = ({
           <Text variant="lg-display">{headline}</Text>
         </Flex>
         <RouterLink to={`/settings/alerts/${alert.internalID}/edit`}>
-          <Text variant="xs" mt={[0.5, 0.5]}>
+          <Text variant="xs" mt={0.5}>
             Edit Alert
           </Text>
         </RouterLink>

--- a/src/Components/Notifications/AlertNotification.tsx
+++ b/src/Components/Notifications/AlertNotification.tsx
@@ -31,7 +31,9 @@ export const AlertNotification: FC<AlertNotificationProps> = ({
           <Text variant="lg-display">{headline}</Text>
         </Flex>
         <RouterLink to={`/settings/alerts/${alert.internalID}/edit`}>
-          <Text mt={[0.5, 1]}>Edit Alert</Text>
+          <Text variant="xs" mt={[0.5, 0.5]}>
+            Edit Alert
+          </Text>
         </RouterLink>
       </Flex>
 


### PR DESCRIPTION
Addresses [ONYX-777]

## Description

This PR adjusts the notification page Edit Alert font size.

| | |
| --- | --- |
|<img width="796" alt="Screenshot 2024-02-22 at 16 06 43" src="https://github.com/artsy/force/assets/4691889/de95be50-067f-464d-b6fd-0646fb21b78d"> |<img width="801" alt="Screenshot 2024-02-22 at 16 06 48" src="https://github.com/artsy/force/assets/4691889/d6bb065c-9d4b-4861-a864-6c791d3492ea"> |




[ONYX-777]: https://artsyproduct.atlassian.net/browse/ONYX-777?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ