### PR TITLE
fix(shows): Fix display of address

### DIFF
--- a/src/Apps/Show/Components/ShowInfoLocation.tsx
+++ b/src/Apps/Show/Components/ShowInfoLocation.tsx
@@ -14,7 +14,6 @@ export const ShowInfoLocation: React.FC<ShowInfoLocationProps> = ({
   const location = show.location ?? show.fair?.location
 
   const lines = [
-    location?.display,
     location?.address,
     location?.address2,
     [location?.city, location?.state, location?.country]


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Addresses an issue noted in #product-bugs-and-feedback around duplicate addresses showing up. Fixed it by removing reference to the summary, in favor of the better-formatted version:

Before:
<img width="423" alt="Screenshot 2024-02-22 at 12 52 45 PM" src="https://github.com/artsy/force/assets/236943/9fdc244a-8e26-436c-8158-b6512e8a1031">

After: 
<img width="230" alt="Screenshot 2024-02-22 at 12 52 50 PM" src="https://github.com/artsy/force/assets/236943/8c8f5a42-853b-4e68-98c3-90470fe9f0b7">

