### PR TITLE
fix: Adjust Activity panel max height and placeholder image width for mWeb

### DIFF
--- a/src/Components/Notifications/Notification.tsx
+++ b/src/Components/Notifications/Notification.tsx
@@ -165,9 +165,21 @@ export const Placeholder: React.FC = () => (
       <Spacer y={4} />
 
       <Flex flexDirection="column" alignItems="center">
-        <SkeletonBox width={CARD_MAX_WIDTH} height={CARD_MAX_WIDTH} mb={4} />
-        <SkeletonBox width={CARD_MAX_WIDTH} height={CARD_MAX_WIDTH} mb={4} />
-        <SkeletonBox width={CARD_MAX_WIDTH} height={CARD_MAX_WIDTH} mb={4} />
+        <SkeletonBox
+          width={["100%", CARD_MAX_WIDTH]}
+          height={CARD_MAX_WIDTH}
+          mb={4}
+        />
+        <SkeletonBox
+          width={["100%", CARD_MAX_WIDTH]}
+          height={CARD_MAX_WIDTH}
+          mb={4}
+        />
+        <SkeletonBox
+          width={["100%", CARD_MAX_WIDTH]}
+          height={CARD_MAX_WIDTH}
+          mb={4}
+        />
       </Flex>
     </Skeleton>
   </Flex>

--- a/src/Components/Notifications/NotificationsWrapper.tsx
+++ b/src/Components/Notifications/NotificationsWrapper.tsx
@@ -36,7 +36,7 @@ export const NotificationsWrapper: React.FC<NotificationsWrapperProps> = ({
             />
           </Flex>
 
-          <Separator />
+          <Separator borderColor="black5" />
 
           <Box
             maxHeight={`calc(100vh - ${DROPDOWN_CONTENT_HEIGHT}px)`}
@@ -53,7 +53,7 @@ export const NotificationsWrapper: React.FC<NotificationsWrapperProps> = ({
               onHide={onHide}
               unreadCounts={unreadCounts}
             />
-            <Separator />
+            <Separator borderColor="black5" />
           </Sticky>
 
           <Box

--- a/src/Components/Notifications/NotificationsWrapper.tsx
+++ b/src/Components/Notifications/NotificationsWrapper.tsx
@@ -59,7 +59,7 @@ export const NotificationsWrapper: React.FC<NotificationsWrapperProps> = ({
           <Box
             overflow="scroll"
             // The notification list needs a maximum height to be independently scrollable.
-            maxHeight={`calc(100vh - ${DROPDOWN_CONTENT_HEIGHT}px)`}
+            maxHeight={[null, `calc(100vh - ${DROPDOWN_CONTENT_HEIGHT}px)`]}
             pb={2}
           >
             <NotificationsListQueryRenderer mode={mode} />


### PR DESCRIPTION
https://www.notion.so/artsy/mWeb-The-image-placeholder-on-the-notification-page-e-g-alert-and-follow-is-to-wide-and-doesn-t--e9c00ff9529b425382956838e401427c?pvs=4
https://www.notion.so/artsy/All-lines-should-be-same-light-grey-in-the-build-the-top-one-is-darker-80559cfdbef64d22a74b481d04580669?pvs=4

## Description

This PR fixes the Activity panel max height and placeholder image width for mobile web and the line color below the Activity panel header.

| Before | After |
| --- | --- |
|<img width="376" alt="Screenshot 2024-02-26 at 16 47 16" src="https://github.com/artsy/force/assets/4691889/c2057663-1996-4b90-a7e5-99d3128d3f3d"> |<img width="379" alt="Screenshot 2024-02-26 at 16 47 09" src="https://github.com/artsy/force/assets/4691889/0af5beae-30c4-4ff2-8a01-5abe54ddd50c"> |
| --- | --- |
|<img width="379" alt="Screenshot 2024-02-26 at 16 46 28" src="https://github.com/artsy/force/assets/4691889/cd165e26-c74b-4c7d-a2a5-cf4260f52116"> | <img width="376" alt="Screenshot 2024-02-26 at 16 46 40" src="https://github.com/artsy/force/assets/4691889/51be2e0d-3802-4569-9783-834427c7437b">|





