### PR TITLE
fix: Remove spacing below notification list item title

### DIFF
--- a/src/Components/Notifications/NotificationItem.tsx
+++ b/src/Components/Notifications/NotificationItem.tsx
@@ -136,7 +136,7 @@ const NotificationItem: FC<NotificationItemProps> = ({ item }) => {
             {getNotificationPrelude(item)}
           </Text>
 
-          <Text fontWeight="bold" variant="sm">
+          <Text fontWeight="bold" variant="sm-display">
             {item.headline}
           </Text>
 


### PR DESCRIPTION


## Description

Remove spacing below notification list item title.