### PR TITLE
fix: Add error boundary around notification pane in Activity panel

### DIFF
--- a/src/Components/Notifications/Notification.tsx
+++ b/src/Components/Notifications/Notification.tsx
@@ -6,10 +6,10 @@ import {
   SkeletonText,
   Spacer,
 } from "@artsy/palette"
-import { graphql, useLazyLoadQuery } from "react-relay"
+import { graphql } from "react-relay"
 import { NotificationQuery } from "__generated__/NotificationQuery.graphql"
 import { useNotificationsContext } from "Components/Notifications/useNotificationsContext"
-import { Suspense, useEffect } from "react"
+import { useEffect } from "react"
 import { ArtworkPublishedNotification } from "Components/Notifications/ArtworkPublishedNotification"
 import { AlertNotification } from "Components/Notifications/AlertNotification"
 import { useRouter } from "System/Router/useRouter"
@@ -21,7 +21,7 @@ import { markNotificationAsRead } from "Components/Notifications/Mutations/markN
 import { useSystemContext } from "System/SystemContext"
 import createLogger from "Utils/logger"
 import { NotificationErrorMessage } from "Components/Notifications/NotificationErrorMessage"
-import { ErrorBoundary } from "System/Router/ErrorBoundary"
+import { useClientQuery } from "Utils/Hooks/useClientQuery"
 
 const logger = createLogger("NotificationItem")
 
@@ -41,15 +41,17 @@ const Notification: React.FC<NotificationProps> = ({ notificationId }) => {
   const { relayEnvironment } = useSystemContext()
   const { router } = useRouter()
 
-  const data = useLazyLoadQuery<NotificationQuery>(notificationQuery, {
-    internalID: notificationId,
+  const { data, loading, error } = useClientQuery<NotificationQuery>({
+    query: notificationQuery,
+    variables: { internalID: notificationId },
   })
 
-  const notification = data.me?.notification
+  const notification = data?.me?.notification
 
   // Redirect user to the notifications targetHref if the notification type is not supported
   useEffect(() => {
     if (
+      notification &&
       !SUPPORTED_NOTIFICATION_TYPES.includes(
         notification?.notificationType as string
       )
@@ -59,6 +61,10 @@ const Notification: React.FC<NotificationProps> = ({ notificationId }) => {
   }, [notification, router])
 
   useEffect(() => {
+    if (!notification) {
+      return
+    }
+
     markAsRead()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [notification])
@@ -85,7 +91,12 @@ const Notification: React.FC<NotificationProps> = ({ notificationId }) => {
     }
   }
 
-  if (!data.me?.notification) {
+  if (loading) {
+    return <Placeholder />
+  }
+
+  if (error || !notification) {
+    // logger.error(error)
     return <NotificationErrorMessage />
   }
 
@@ -126,14 +137,7 @@ export const NotificationQueryRenderer: React.FC = props => {
 
   return (
     <Box mx={[2, 4]} my={2}>
-      <ErrorBoundary>
-        <Suspense fallback={<Placeholder />}>
-          <Notification
-            notificationId={state.currentNotificationId}
-            {...props}
-          />
-        </Suspense>
-      </ErrorBoundary>
+      <Notification notificationId={state.currentNotificationId} {...props} />
     </Box>
   )
 }

--- a/src/Components/Notifications/Notification.tsx
+++ b/src/Components/Notifications/Notification.tsx
@@ -21,6 +21,7 @@ import { markNotificationAsRead } from "Components/Notifications/Mutations/markN
 import { useSystemContext } from "System/SystemContext"
 import createLogger from "Utils/logger"
 import { NotificationErrorMessage } from "Components/Notifications/NotificationErrorMessage"
+import { ErrorBoundary } from "System/Router/ErrorBoundary"
 
 const logger = createLogger("NotificationItem")
 
@@ -125,9 +126,14 @@ export const NotificationQueryRenderer: React.FC = props => {
 
   return (
     <Box mx={[2, 4]} my={2}>
-      <Suspense fallback={<Placeholder />}>
-        <Notification notificationId={state.currentNotificationId} {...props} />
-      </Suspense>
+      <ErrorBoundary>
+        <Suspense fallback={<Placeholder />}>
+          <Notification
+            notificationId={state.currentNotificationId}
+            {...props}
+          />
+        </Suspense>
+      </ErrorBoundary>
     </Box>
   )
 }


### PR DESCRIPTION
https://www.notion.so/artsy/Navigating-to-a-missing-unknown-notification-throws-a-500-internal-error-Maybe-we-redirect-to--adcf2e8c8868423591987955477fa511?pvs=4

## Description

Add error boundary around notification pane in Activity panel to display the list if loading the notification fails (e.g. if the id is wrong).





| Before | After |
| --- | --- |
|<img width="1492" alt="Screenshot 2024-02-27 at 16 20 06" src="https://github.com/artsy/force/assets/4691889/5d77c687-6f23-420d-a436-f533f678db94"> | <img width="1490" alt="Screenshot 2024-02-27 at 16 19 55" src="https://github.com/artsy/force/assets/4691889/2e648447-b31f-4dc4-9b6a-07b8c46e7c63">|