### PR TITLE
chore: Rename "following" notification type to "follows"

### DIFF
--- a/src/Components/Notifications/NotificationsEmptyStateByType.tsx
+++ b/src/Components/Notifications/NotificationsEmptyStateByType.tsx
@@ -23,7 +23,7 @@ const emptyStateByType: Record<
     message:
       "Create alerts on an artist or artwork page and get notifications here when there’s a match.",
   },
-  following: {
+  follows: {
     title: "Follow artists and galleries to stay up to date",
     message:
       "Keep track of the art and events you love, and get recommendations based on who you follow.",

--- a/src/Components/Notifications/NotificationsList.tsx
+++ b/src/Components/Notifications/NotificationsList.tsx
@@ -247,7 +247,7 @@ const getNotificationTypes = (
   if (type === "alerts") {
     return ["ARTWORK_ALERT"]
   }
-  if (type === "following") {
+  if (type === "follows") {
     return ["ARTWORK_PUBLISHED"]
   }
   if (type === "offers") {

--- a/src/Components/Notifications/NotificationsPills.tsx
+++ b/src/Components/Notifications/NotificationsPills.tsx
@@ -24,7 +24,7 @@ export const NotificationsPills: React.FC = () => {
     { value: "All", name: "all" },
     hasPartnerOfferNotifications && { value: "Offers", name: "offers" },
     { value: "Alerts", name: "alerts" },
-    { value: "Follows", name: "following" },
+    { value: "Follows", name: "follows" },
   ])
 
   if (loading) return <Placeholder />

--- a/src/Components/Notifications/__tests__/NotificationsEmptyStateByType.jest.tsx
+++ b/src/Components/Notifications/__tests__/NotificationsEmptyStateByType.jest.tsx
@@ -33,13 +33,13 @@ describe("NotificationsEmptyStateByType", () => {
   })
 })
 
-describe("NotificationsEmptyStateByType Following alerts", () => {
+describe("NotificationsEmptyStateByType Follows alerts", () => {
   beforeEach(() => {
     ;(useFeatureFlag as jest.Mock).mockImplementation(() => true)
   })
 
-  it("should render correct state when type is 'Following'", () => {
-    render(<NotificationsEmptyStateByType type="following" />)
+  it("should render correct state when type is 'Follows'", () => {
+    render(<NotificationsEmptyStateByType type="follows" />)
 
     const title = "Follow artists and galleries to stay up to date"
     const message =

--- a/src/Components/Notifications/types.ts
+++ b/src/Components/Notifications/types.ts
@@ -1,2 +1,2 @@
-export type NotificationType = "all" | "alerts" | "following" | "offers"
+export type NotificationType = "all" | "alerts" | "follows" | "offers"
 export type NotificationPaginationType = "showMoreButton" | "infinite"


### PR DESCRIPTION
Context: https://github.com/artsy/force/pull/13532#discussion_r1506307872

## Description

Rename "following" notification type to "follows".