### PR TITLE
feat: pass e2e unleash experiments as a header to Metaphysics

### DIFF
--- a/src/Server/middleware/featureFlagMiddleware.ts
+++ b/src/Server/middleware/featureFlagMiddleware.ts
@@ -43,7 +43,14 @@ export function featureFlagMiddleware(serviceType: symbol) {
           }
         }, {})
 
+        const e2eFeatureFlags = Object.fromEntries(
+          Object.entries(featureFlags).filter(
+            ([key, value]) => key.startsWith("e2e_") && value.flagEnabled
+          )
+        )
+
         updateSharifyAndContext(res, "FEATURE_FLAGS", featureFlags)
+        updateSharifyAndContext(res, "E2E_FEATURE_FLAGS", e2eFeatureFlags)
 
         next()
       })

--- a/src/System/Relay/createRelaySSREnvironment.ts
+++ b/src/System/Relay/createRelaySSREnvironment.ts
@@ -90,6 +90,12 @@ export function createRelaySSREnvironment(config: Config = {}) {
     logger.warn("Browser does not support i18n API, not setting TZ header.")
   }
 
+  const e2eFeatureFlags = getENV("E2E_FEATURE_FLAGS")
+
+  if (e2eFeatureFlags) {
+    headers["X-Variants"] = JSON.stringify(e2eFeatureFlags)
+  }
+
   const authenticatedHeaders = !!user
     ? {
         ...headers,

--- a/src/Typings/sharify.d.ts
+++ b/src/Typings/sharify.d.ts
@@ -42,6 +42,7 @@ declare module "sharify" {
       CSRF_TOKEN: string
       CURRENT_PATH: string
       CURRENT_USER: User
+      E2E_FEATURE_FLAGS: any
       EIGEN: boolean
       ENABLE_CONVERSATIONS_MESSAGES_AUTO_REFRESH: boolean
       ENABLE_I18N_DEBUG: boolean


### PR DESCRIPTION
The type of this PR is: **Feat**

### Description

This PR is a proof-of-concept and one of a few moving parts for the "[Share split-test assignments with back-ends, for safer data/API roll-outs](https://www.notion.so/artsy/Share-split-test-assignments-with-back-ends-for-safer-data-API-roll-outs-7dcfb3401f1d4fb3b26af6dc70a3315b#42f1b1213b8f4ffaa89258ab0444840a)" technical plan.

The idea is that Force and Eigen detect e2e experiments (by "e2e_" prefix in their name) and sends such experiments in "X-Variants" header to Metaphysics.

For demo and testing purposes, I've created two Unleash experiments, they are enabled for dev/staging:

- [One](https://unleash.artsy.net/projects/default/features/e2e_test_nikita)
- [Two](https://unleash.artsy.net/projects/default/features/e2e_test_2_nikita)

You can test it in action in the [review app](https://e2e-unleash-experiments.artsy.net/).