### PR TITLE
fix(nav-menu): Close artist and artworks dropdowns on nav item click

### DIFF
--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -372,7 +372,7 @@ export const NavBar: React.FC = track(
                     />
                   )}
                 >
-                  {({ anchorRef, anchorProps, visible }) => (
+                  {({ anchorRef, anchorProps, visible, setVisible }) => (
                     <NavBarItemButton
                       ref={anchorRef as any}
                       px={0}
@@ -382,7 +382,14 @@ export const NavBar: React.FC = track(
                     >
                       <NavBarItemUnfocusableAnchor
                         href="/artists"
-                        onClick={handleClick}
+                        onClick={event => {
+                          handleClick(event)
+
+                          // Small timeout to avoid transition race condition
+                          setTimeout(() => {
+                            setVisible(false)
+                          }, 100)
+                        }}
                         data-label="Artists"
                       />
                       {t`navbar.artists`}
@@ -406,7 +413,7 @@ export const NavBar: React.FC = track(
                     />
                   )}
                 >
-                  {({ anchorRef, anchorProps, visible }) => (
+                  {({ anchorRef, anchorProps, visible, setVisible }) => (
                     <NavBarItemButton
                       ref={anchorRef as any}
                       active={visible}
@@ -414,7 +421,14 @@ export const NavBar: React.FC = track(
                     >
                       <NavBarItemUnfocusableAnchor
                         href="/collect"
-                        onClick={handleClick}
+                        onClick={event => {
+                          handleClick(event)
+
+                          // Small timeout to avoid transition race condition
+                          setTimeout(() => {
+                            setVisible(false)
+                          }, 100)
+                        }}
                         data-label="Artworks"
                       />
                       {t`navbar.artworks`}


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Fixes an long-standing issue where top-nav clicks don't close the drop down, leading to some page confusion. Discussed with Jimi [in here](https://artsy.slack.com/archives/C9XJKPY9W/p1709241670001359). 

https://github.com/artsy/force/assets/236943/cdc8d5f4-aee4-432c-9ce1-65165f92fb47

