### PR TITLE
fix: Update Alerts screen page to use split view

### DIFF
--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditForm.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditForm.tsx
@@ -137,7 +137,6 @@ const SavedSearchAlertEditForm: React.FC<SavedSearchAlertEditFormProps> = ({
 
         const transitionToFilters = () => {
           goToFilters()
-          jumpTo("SavedSearchAlertEditForm")
         }
 
         return (

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditForm.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditForm.tsx
@@ -30,7 +30,6 @@ import { Modal } from "Components/Alert/Components/Modal/Modal"
 import { NotificationPreferencesQueryRenderer } from "Components/Alert/Components/NotificationPreferences"
 import { SugggestedFiltersQueryRenderer } from "Components/Alert/Components/Form/SuggestedFilters"
 import { Sticky } from "Components/Sticky"
-import { useJump } from "Utils/Hooks/useJump"
 
 interface SavedSearchAlertEditFormQueryRendererProps {
   editAlertEntity: EditAlertEntity
@@ -113,7 +112,6 @@ const SavedSearchAlertEditForm: React.FC<SavedSearchAlertEditFormProps> = ({
   onCompleted,
 }) => {
   const { state, goToFilters, dispatch, onComplete } = useAlertContext()
-  const { jumpTo } = useJump()
 
   const isMounted = useDidMount()
 

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditFormPlaceholder.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditFormPlaceholder.tsx
@@ -5,7 +5,9 @@ import {
   SkeletonText,
   SkeletonBox,
   Skeleton,
+  Box,
 } from "@artsy/palette"
+import { ALERTS_APP_DESKTOP_HEIGHT } from "Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp"
 import { AlertProvider } from "Components/Alert/AlertProvider"
 import { CriteriaPillsPlaceholder } from "Components/Alert/Components/CriteriaPills"
 import { Modal } from "Components/Alert/Components/Modal/Modal"
@@ -15,7 +17,11 @@ export const SavedSearchAlertEditFormPlaceholder: React.FC<{
   onCloseClick?: () => void
 }> = ({ onCloseClick }) => {
   return (
-    <>
+    <Box
+      maxHeight={ALERTS_APP_DESKTOP_HEIGHT}
+      overflow="hidden"
+      flexDirection="column"
+    >
       <Media greaterThanOrEqual="md">
         <Skeleton flex={1} p={4}>
           <SavedSearchAlertEditFormPlaceholderContext />
@@ -32,7 +38,7 @@ export const SavedSearchAlertEditFormPlaceholder: React.FC<{
           </Skeleton>
         </AlertProvider>
       </Media>
-    </>
+    </Box>
   )
 }
 

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertsArtworks.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertsArtworks.tsx
@@ -31,8 +31,7 @@ import {
   CriteriaPillsPlaceholder,
 } from "Components/Alert/Components/CriteriaPills"
 import { ModalHeader } from "Components/Alert/Components/Modal/ModalHeader"
-
-const PLACEHOLDER_MAX_HEIGHT = 500
+import { ALERTS_APP_DESKTOP_HEIGHT } from "Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp"
 
 interface AlertArtworksProps {
   alert: NonNullable<SavedSearchAlertsArtworksQuery["response"]["me"]>["alert"]
@@ -286,11 +285,7 @@ export const SavedSearchAlertsArtworksQueryRenderer: React.FC<SavedSearchAlertsA
 const SavedSearchAlertsArtworksPlaseholderContext: React.FC = () => {
   return (
     // Setting a max height to force scrolling to top when the content changes.
-    <Flex
-      maxHeight={PLACEHOLDER_MAX_HEIGHT}
-      overflow="hidden"
-      flexDirection="column"
-    >
+    <>
       <Join separator={<Spacer y={2} />}>
         <CriteriaPillsPlaceholder />
         <SkeletonBox display={["none", "block"]}>
@@ -307,7 +302,7 @@ const SavedSearchAlertsArtworksPlaseholderContext: React.FC = () => {
         </Flex>
         <ArtworkGridPlaceholder columnCount={2} amount={2} />
       </Join>
-    </Flex>
+    </>
   )
 }
 
@@ -317,8 +312,13 @@ const SavedSearchAlertsArtworksPlaseholder: React.FC<{
   return (
     <>
       <Media greaterThanOrEqual="md">
-        <Skeleton p={4}>
-          <Text variant="lg" mb={2}>
+        <Skeleton
+          p={4}
+          maxHeight={ALERTS_APP_DESKTOP_HEIGHT}
+          overflow="hidden"
+          flexDirection="column"
+        >
+          <Text variant="lg" pb={2}>
             View Artworks
           </Text>
           <SavedSearchAlertsArtworksPlaseholderContext />

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertsArtworks.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertsArtworks.tsx
@@ -284,7 +284,6 @@ export const SavedSearchAlertsArtworksQueryRenderer: React.FC<SavedSearchAlertsA
 
 const SavedSearchAlertsArtworksPlaseholderContext: React.FC = () => {
   return (
-    // Setting a max height to force scrolling to top when the content changes.
     <>
       <Join separator={<Spacer y={2} />}>
         <CriteriaPillsPlaceholder />
@@ -314,6 +313,7 @@ const SavedSearchAlertsArtworksPlaseholder: React.FC<{
       <Media greaterThanOrEqual="md">
         <Skeleton
           p={4}
+          // Setting a max height to force scrolling to top when the content changes.
           maxHeight={ALERTS_APP_DESKTOP_HEIGHT}
           overflow="hidden"
           flexDirection="column"

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertsArtworks.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertsArtworks.tsx
@@ -32,6 +32,8 @@ import {
 } from "Components/Alert/Components/CriteriaPills"
 import { ModalHeader } from "Components/Alert/Components/Modal/ModalHeader"
 
+const PLACEHOLDER_MAX_HEIGHT = 500
+
 interface AlertArtworksProps {
   alert: NonNullable<SavedSearchAlertsArtworksQuery["response"]["me"]>["alert"]
   onCloseClick?: () => void
@@ -283,7 +285,12 @@ export const SavedSearchAlertsArtworksQueryRenderer: React.FC<SavedSearchAlertsA
 
 const SavedSearchAlertsArtworksPlaseholderContext: React.FC = () => {
   return (
-    <Flex maxHeight={500} overflow="hidden" flexDirection="column">
+    // Setting a max height to force scrolling to top when the content changes.
+    <Flex
+      maxHeight={PLACEHOLDER_MAX_HEIGHT}
+      overflow="hidden"
+      flexDirection="column"
+    >
       <Join separator={<Spacer y={2} />}>
         <CriteriaPillsPlaceholder />
         <SkeletonBox display={["none", "block"]}>

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertsArtworks.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertsArtworks.tsx
@@ -31,7 +31,6 @@ import {
   CriteriaPillsPlaceholder,
 } from "Components/Alert/Components/CriteriaPills"
 import { ModalHeader } from "Components/Alert/Components/Modal/ModalHeader"
-import { useJump } from "Utils/Hooks/useJump"
 
 interface AlertArtworksProps {
   alert: NonNullable<SavedSearchAlertsArtworksQuery["response"]["me"]>["alert"]
@@ -44,8 +43,6 @@ export const AlertArtworks: React.FC<AlertArtworksProps> = ({
   onCloseClick,
   onEditAlertClick,
 }) => {
-  const { jumpTo } = useJump()
-
   if (!alert || !alert.artworksConnection)
     return <SavedSearchAlertsArtworksPlaseholder onCloseClick={onCloseClick} />
 

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertsArtworks.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertsArtworks.tsx
@@ -100,7 +100,6 @@ export const AlertArtworks: React.FC<AlertArtworksProps> = ({
                       variant="secondaryBlack"
                       onClick={() => {
                         onEditAlertClick()
-                        jumpTo("SavedSearchAlertEditForm")
                       }}
                     >
                       Edit Alert
@@ -117,7 +116,6 @@ export const AlertArtworks: React.FC<AlertArtworksProps> = ({
                   variant="secondaryBlack"
                   onClick={() => {
                     onEditAlertClick()
-                    jumpTo("SavedSearchAlertEditForm")
                   }}
                 >
                   Edit Alert
@@ -288,22 +286,24 @@ export const SavedSearchAlertsArtworksQueryRenderer: React.FC<SavedSearchAlertsA
 
 const SavedSearchAlertsArtworksPlaseholderContext: React.FC = () => {
   return (
-    <Join separator={<Spacer y={2} />}>
-      <CriteriaPillsPlaceholder />
-      <SkeletonBox display={["none", "block"]}>
-        <Separator />
-      </SkeletonBox>
-      <Flex flexDirection="column">
-        <SkeletonText variant="sm-display">
-          20 works currently on Artsy match your criteria.
-        </SkeletonText>
-        <SkeletonText variant="sm-display">
-          See our top picks for you:
-        </SkeletonText>
-        <Spacer y={[4, 2]} />
-      </Flex>
-      <ArtworkGridPlaceholder columnCount={2} />
-    </Join>
+    <Flex maxHeight={500} overflow="hidden" flexDirection="column">
+      <Join separator={<Spacer y={2} />}>
+        <CriteriaPillsPlaceholder />
+        <SkeletonBox display={["none", "block"]}>
+          <Separator />
+        </SkeletonBox>
+        <Flex flexDirection="column">
+          <SkeletonText variant="sm-display">
+            20 works currently on Artsy match your criteria.
+          </SkeletonText>
+          <SkeletonText variant="sm-display">
+            See our top picks for you:
+          </SkeletonText>
+          <Spacer y={[4, 2]} />
+        </Flex>
+        <ArtworkGridPlaceholder columnCount={2} amount={2} />
+      </Join>
+    </Flex>
   )
 }
 

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp.tsx
@@ -38,7 +38,6 @@ import { __internal__useMatchMedia } from "Utils/Hooks/useMatchMedia"
 import { getENV } from "Utils/getENV"
 import { DESKTOP_NAV_BAR_HEIGHT } from "Components/NavBar/constants"
 import { SavedSearchAlertsArtworksQueryRenderer } from "Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertsArtworks"
-import { Jump } from "Utils/Hooks/useJump"
 
 const SETTINGS_NAVIGATION_BAR_HEIGHT = 300
 const DESKTOP_HEIGHT = `calc(100vh - ${
@@ -345,8 +344,6 @@ export const SavedSearchAlertsApp: React.FC<SavedSearchAlertsAppProps> = ({
                       overflow="auto"
                       paddingBottom={2}
                     >
-                      <Jump id="SavedSearchAlertEditForm" />
-
                       {viewOption === "EDIT" && editAlertEntity && (
                         <SavedSearchAlertEditFormQueryRenderer
                           editAlertEntity={editAlertEntity}

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp.tsx
@@ -315,8 +315,9 @@ export const SavedSearchAlertsApp: React.FC<SavedSearchAlertsAppProps> = ({
             />
             <Box mx={-4}>
               <Separator color="black15" />
+
               <Media greaterThanOrEqual="md">
-                <GridColumns>
+                <GridColumns gridColumnGap={0}>
                   <Column span={6}>
                     <Flex height={DESKTOP_HEIGHT} flexDirection="column">
                       <Flex

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp.tsx
@@ -6,6 +6,7 @@ import {
   Join,
   useToasts,
   Button,
+  Flex,
 } from "@artsy/palette"
 import {
   createPaginationContainer,
@@ -39,7 +40,10 @@ import { DESKTOP_NAV_BAR_HEIGHT } from "Components/NavBar/constants"
 import { SavedSearchAlertsArtworksQueryRenderer } from "Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertsArtworks"
 import { Jump } from "Utils/Hooks/useJump"
 
-const DESKTOP_HEIGHT = `calc(100vh - ${DESKTOP_NAV_BAR_HEIGHT}px)`
+const SETTINGS_NAVIGATION_BAR_HEIGHT = 300
+const DESKTOP_HEIGHT = `calc(100vh - ${
+  DESKTOP_NAV_BAR_HEIGHT + SETTINGS_NAVIGATION_BAR_HEIGHT
+}px)`
 
 interface SavedSearchAlertsAppProps {
   me: SavedSearchAlertsApp_me$data
@@ -252,7 +256,12 @@ export const SavedSearchAlertsApp: React.FC<SavedSearchAlertsAppProps> = ({
   }, [alertID, relayEnvironment])
 
   const list = (
-    <>
+    <Box
+      overflow="scroll"
+      // The notification list needs a maximum height to be independently scrollable.
+      maxHeight={[null, DESKTOP_HEIGHT]}
+      pb={2}
+    >
       <Join separator={<Separator borderColor="black5" />}>
         {alerts.map(node => {
           const isCurrentEdgeSelected = editAlertEntity?.id === node.internalID
@@ -291,7 +300,7 @@ export const SavedSearchAlertsApp: React.FC<SavedSearchAlertsAppProps> = ({
           </Button>
         </Box>
       )}
-    </>
+    </Box>
   )
 
   return (
@@ -310,8 +319,19 @@ export const SavedSearchAlertsApp: React.FC<SavedSearchAlertsAppProps> = ({
             <Box mx={-4}>
               <Separator color="black15" />
               <Media greaterThanOrEqual="md">
-                <GridColumns gridColumnGap={0}>
-                  <Column span={6}>{list}</Column>
+                <GridColumns>
+                  <Column span={6}>
+                    <Flex height={DESKTOP_HEIGHT} flexDirection="column">
+                      <Flex
+                        overflow="hidden"
+                        maxHeight={DESKTOP_HEIGHT}
+                        flexDirection="column"
+                      >
+                        {list}
+                      </Flex>
+                    </Flex>
+                  </Column>
+
                   <Column
                     span={6}
                     borderLeft="1px solid"
@@ -319,21 +339,28 @@ export const SavedSearchAlertsApp: React.FC<SavedSearchAlertsAppProps> = ({
                     borderRightColor="black15"
                     minHeight={DESKTOP_HEIGHT}
                   >
-                    <Jump id="SavedSearchAlertEditForm" />
+                    <Flex
+                      flexDirection="column"
+                      height={DESKTOP_HEIGHT}
+                      overflow="auto"
+                      paddingBottom={2}
+                    >
+                      <Jump id="SavedSearchAlertEditForm" />
 
-                    {viewOption === "EDIT" && editAlertEntity && (
-                      <SavedSearchAlertEditFormQueryRenderer
-                        editAlertEntity={editAlertEntity}
-                        onCompleted={handleCompleted}
-                        onDeleteClick={handleDeleteClick}
-                      />
-                    )}
-                    {viewOption === "ARTWORKS" && editAlertEntity && (
-                      <SavedSearchAlertsArtworksQueryRenderer
-                        editAlertEntity={editAlertEntity}
-                        onEditAlertClick={handleOpenEditForm}
-                      />
-                    )}
+                      {viewOption === "EDIT" && editAlertEntity && (
+                        <SavedSearchAlertEditFormQueryRenderer
+                          editAlertEntity={editAlertEntity}
+                          onCompleted={handleCompleted}
+                          onDeleteClick={handleDeleteClick}
+                        />
+                      )}
+                      {viewOption === "ARTWORKS" && editAlertEntity && (
+                        <SavedSearchAlertsArtworksQueryRenderer
+                          editAlertEntity={editAlertEntity}
+                          onEditAlertClick={handleOpenEditForm}
+                        />
+                      )}
+                    </Flex>
                   </Column>
                 </GridColumns>
 

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp.tsx
@@ -41,7 +41,7 @@ import { SavedSearchAlertsArtworksQueryRenderer } from "Apps/Settings/Routes/Sav
 import { InfiniteScrollSentinel } from "Components/InfiniteScrollSentinel"
 
 const SETTINGS_NAVIGATION_BAR_HEIGHT = 300
-const DESKTOP_HEIGHT = `calc(100vh - ${
+export const ALERTS_APP_DESKTOP_HEIGHT = `calc(100vh - ${
   DESKTOP_NAV_BAR_HEIGHT + SETTINGS_NAVIGATION_BAR_HEIGHT
 }px)`
 
@@ -254,7 +254,7 @@ export const SavedSearchAlertsApp: React.FC<SavedSearchAlertsAppProps> = ({
     <Box
       overflow="scroll"
       // The notification list needs a maximum height to be independently scrollable.
-      maxHeight={[null, DESKTOP_HEIGHT]}
+      maxHeight={[null, ALERTS_APP_DESKTOP_HEIGHT]}
       pb={2}
     >
       <Join separator={<Separator borderColor="black5" />}>
@@ -319,10 +319,13 @@ export const SavedSearchAlertsApp: React.FC<SavedSearchAlertsAppProps> = ({
               <Media greaterThanOrEqual="md">
                 <GridColumns gridColumnGap={0}>
                   <Column span={6}>
-                    <Flex height={DESKTOP_HEIGHT} flexDirection="column">
+                    <Flex
+                      height={ALERTS_APP_DESKTOP_HEIGHT}
+                      flexDirection="column"
+                    >
                       <Flex
                         overflow="hidden"
-                        maxHeight={DESKTOP_HEIGHT}
+                        maxHeight={ALERTS_APP_DESKTOP_HEIGHT}
                         flexDirection="column"
                       >
                         {list}
@@ -335,11 +338,11 @@ export const SavedSearchAlertsApp: React.FC<SavedSearchAlertsAppProps> = ({
                     borderLeft="1px solid"
                     borderLeftColor="black15"
                     borderRightColor="black15"
-                    minHeight={DESKTOP_HEIGHT}
+                    minHeight={ALERTS_APP_DESKTOP_HEIGHT}
                   >
                     <Flex
                       flexDirection="column"
-                      height={DESKTOP_HEIGHT}
+                      height={ALERTS_APP_DESKTOP_HEIGHT}
                       overflow="auto"
                       paddingBottom={2}
                     >

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp.tsx
@@ -5,7 +5,6 @@ import {
   Box,
   Join,
   useToasts,
-  Button,
   Flex,
   Spinner,
 } from "@artsy/palette"
@@ -65,7 +64,6 @@ export const SavedSearchAlertsApp: React.FC<SavedSearchAlertsAppProps> = ({
   const { match, silentPush } = useRouter()
   const [showDeleteModal, setShowDeleteModal] = useState(false)
   const [sort, setSort] = useState("ENABLED_AT_DESC")
-  const [loading, setLoading] = useState(false)
   const alerts = extractNodes(me.alertsConnection)
   const isMobile = getENV("IS_MOBILE")
 
@@ -188,14 +186,10 @@ export const SavedSearchAlertsApp: React.FC<SavedSearchAlertsAppProps> = ({
       return
     }
 
-    setLoading(true)
-
     relay.loadMore(10, err => {
       if (err) {
         console.error(err)
       }
-
-      setLoading(false)
     })
   }
 

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp.tsx
@@ -7,6 +7,7 @@ import {
   useToasts,
   Button,
   Flex,
+  Spinner,
 } from "@artsy/palette"
 import {
   createPaginationContainer,
@@ -38,6 +39,7 @@ import { __internal__useMatchMedia } from "Utils/Hooks/useMatchMedia"
 import { getENV } from "Utils/getENV"
 import { DESKTOP_NAV_BAR_HEIGHT } from "Components/NavBar/constants"
 import { SavedSearchAlertsArtworksQueryRenderer } from "Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertsArtworks"
+import { InfiniteScrollSentinel } from "Components/InfiniteScrollSentinel"
 
 const SETTINGS_NAVIGATION_BAR_HEIGHT = 300
 const DESKTOP_HEIGHT = `calc(100vh - ${
@@ -293,11 +295,13 @@ export const SavedSearchAlertsApp: React.FC<SavedSearchAlertsAppProps> = ({
       </Join>
 
       {relay.hasMore() && (
-        <Box textAlign="center" mt={4}>
-          <Button onClick={handleLoadMore} loading={loading}>
-            Show More
-          </Button>
-        </Box>
+        <>
+          <InfiniteScrollSentinel onNext={handleLoadMore} once={false} />
+
+          <Flex width="100%" my={4} alignItems="center">
+            <Spinner position="relative" />
+          </Flex>
+        </>
       )}
     </Box>
   )

--- a/src/Apps/Settings/settingsRoutes.tsx
+++ b/src/Apps/Settings/settingsRoutes.tsx
@@ -213,6 +213,7 @@ export const settingsRoutes: AppRouteConfig[] = [
       {
         path: "alerts",
         getComponent: () => AlertsRoute,
+        layout: "NavOnly",
         onClientSideRender: () => {
           AlertsRoute.preload()
         },
@@ -228,6 +229,8 @@ export const settingsRoutes: AppRouteConfig[] = [
       {
         path: "alerts/:alertID/edit",
         getComponent: () => AlertsRoute,
+        layout: "NavOnly",
+
         onClientSideRender: () => {
           AlertsRoute.preload()
         },
@@ -242,6 +245,8 @@ export const settingsRoutes: AppRouteConfig[] = [
       },
       {
         path: "alerts/:alertID/artworks",
+        layout: "NavOnly",
+
         getComponent: () => AlertsRoute,
         onClientSideRender: () => {
           AlertsRoute.preload()


### PR DESCRIPTION
Addresses [ONYX-823]

## Description

This PR updates the Alerts screen page layout to use a split view with independent scrollable views. We already use this layout for https://www.artsy.net/notifications and https://www.artsy.net/user/conversation. 

Using the split view instead of a sticky right panel resolves a couple of scrolling issues that we experienced (for example [ONYX-823] & https://github.com/artsy/force/pull/13599).

## Open Questions

- The split screen isn't usable with a browser window hight below 500px. Should we fix it?
- Should we make the whole row in the list on the left clickable?
- Should we adjust the ratio between list and detail view to match the 1:3 ratio from `/notifications`?

https://github.com/artsy/force/assets/4691889/ecde8919-2574-4484-bc5f-857b6bbaeb94


[ONYX-823]: https://artsyproduct.atlassian.net/browse/ONYX-823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ