### PR TITLE
fix: avoids remounting

### DIFF
--- a/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
@@ -67,8 +67,6 @@ const ArtistArtworkFilter: React.FC<ArtistArtworkFilterProps> = props => {
       ]}
       ZeroState={ZeroState}
       userPreferredMetric={userPreferences?.metric}
-      // Setting the key here to enforce a remount of the component when changing pages or query parameter filters within the query.
-      key={match.location.pathname + match.location.search}
     >
       <ArtworkFilterAlertContextProvider
         initialCriteria={{ artistIDs: [artist.internalID] }}


### PR DESCRIPTION
Closes [DIA-456](https://artsyproduct.atlassian.net/browse/DIA-456)

Re: https://github.com/artsy/force/pull/13214 — this bug needs to be fixed rather than papered over by constantly remounting the filter whenever the route changes.

It's actually pretty concerning that one can't drive the filters with a simple route change. One would think that would be the primary way we'd change filter state...

[DIA-456]: https://artsyproduct.atlassian.net/browse/DIA-456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ