### PR TITLE
fix: NavBar categories menu links to emerging-art collection

### DIFF
--- a/src/Components/NavBar/menuData.ts
+++ b/src/Components/NavBar/menuData.ts
@@ -176,7 +176,7 @@ export const ARTWORKS_SUBMENU_DATA: MenuLinkData = {
             },
             {
               text: "Emerging Art",
-              href: "/gene/emerging-art",
+              href: "/collection/emerging-art",
             },
             {
               text: "Street Art",


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves an inconsistency in the NavBar menu Categories list where item _Emerging Art_ [links to a gene](https://github.com/artsy/force/blob/83e5cf4561d21a2653621aaeb497abf628ed8092/src/Components/NavBar/menuData.ts#L178-L180) while the rest of the items in the list link to a collection. This corrects that inconsistency so that all list items link to collections.

### Description

<!-- Implementation description -->

Update the Categories menu Emerging Art item to link to [emerging-art _collection_](https://staging.artsy.net/collection/emerging-art).


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ