### PR TITLE
fix: spacing on new alert counts

### DIFF
--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertListItem.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertListItem.tsx
@@ -95,6 +95,7 @@ export const SavedSearchAlertListItem: React.FC<SavedSearchAlertListItemProps> =
             <RouterLink to={viewAllHref} textDecoration="underline">
               View Artworks
             </RouterLink>
+            &nbsp;
             <Sup color="brand">{matchingArtworksCount}</Sup>
           </Text>
         </Flex>


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [ONYX-827]

### Description

Adds a space between the superscript count and its preceding word, as we do elsewhere.

![sup](https://github.com/artsy/force/assets/140521/8bfa88b5-9be3-49ce-a678-e189df4ac47a)



[ONYX-827]: https://artsyproduct.atlassian.net/browse/ONYX-827?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ