### PR TITLE
fix: Show authentication dialog on the Notifications app when not logged in

### DIFF
--- a/src/Apps/Notifications/NotificationsApp.tsx
+++ b/src/Apps/Notifications/NotificationsApp.tsx
@@ -8,6 +8,10 @@ import { NotificationQueryRenderer } from "Components/Notifications/Notification
 import { useRouter } from "found"
 import { GridColumns, Column, Flex, FullBleed } from "@artsy/palette"
 import { DESKTOP_NAV_BAR_HEIGHT } from "Components/NavBar/constants"
+import { ContextModule, Intent } from "@artsy/cohesion"
+import { useAuthDialog } from "Components/AuthDialog"
+import { useSystemContext } from "System/SystemContext"
+import { useEffect } from "react"
 
 const DESKTOP_HEIGHT = `calc(100vh - ${DESKTOP_NAV_BAR_HEIGHT}px)`
 const MIN_LIST_WIDTH = 370
@@ -18,6 +22,27 @@ interface NotificationsAppProps {
 
 const NotificationsApp: React.FC<NotificationsAppProps> = ({ me }) => {
   const { match } = useRouter()
+  const { showAuthDialog } = useAuthDialog()
+  const { isLoggedIn } = useSystemContext()
+
+  useEffect(() => {
+    if (!isLoggedIn) {
+      showAuthDialog({
+        mode: "Login",
+        options: {
+          title: mode => {
+            const action = mode === "Login" ? "Log in" : "Sign up"
+            return `${action} to view your notifications.`
+          },
+        },
+        analytics: {
+          contextModule: ContextModule.activity,
+          intent: Intent.login,
+        },
+      })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
 
   const isNotificationsPage = match.location.pathname.startsWith(
     "/notifications"
@@ -42,7 +67,7 @@ const NotificationsApp: React.FC<NotificationsAppProps> = ({ me }) => {
               <Flex height={DESKTOP_HEIGHT} flexDirection="column">
                 <Notifications
                   mode="page"
-                  unreadCounts={me.unreadNotificationsCount ?? 0}
+                  unreadCounts={me?.unreadNotificationsCount ?? 0}
                 />
               </Flex>
             </Column>

--- a/src/Components/Notifications/Notification.tsx
+++ b/src/Components/Notifications/Notification.tsx
@@ -96,7 +96,8 @@ const Notification: React.FC<NotificationProps> = ({ notificationId }) => {
   }
 
   if (error || !notification) {
-    // logger.error(error)
+    logger.error(error)
+
     return <NotificationErrorMessage />
   }
 

--- a/src/Components/Notifications/NotificationErrorMessage.tsx
+++ b/src/Components/Notifications/NotificationErrorMessage.tsx
@@ -1,8 +1,18 @@
 import { Text, Box, Spacer } from "@artsy/palette"
 import { RouterLink } from "System/Router/RouterLink"
+import { useSystemContext } from "System/SystemContext"
 import { FC } from "react"
 
 export const NotificationErrorMessage: FC = () => {
+  const { isLoggedIn } = useSystemContext()
+
+  if (!isLoggedIn)
+    return (
+      <Box maxWidth={800}>
+        <Text variant="lg">Please log in to view your notifications.</Text>
+      </Box>
+    )
+
   return (
     <Box maxWidth={800}>
       <Text variant="lg">


### PR DESCRIPTION
Addresses [ONYX-769]

## Description

Show authentication dialog on the Notifications app (`/notifications` or `/notification/123`) when the user is not logged in.

<details><summary>Screenshots</summary>
<p>




| Before | After |
| --- | --- |
|<img width="1800" alt="Screenshot 2024-03-06 at 13 25 36" src="https://github.com/artsy/force/assets/4691889/e6c94275-6803-4a0c-8f93-d3cd10853c35"> | <img width="1800" alt="Screenshot 2024-03-06 at 13 25 15" src="https://github.com/artsy/force/assets/4691889/5b04d501-e366-41f9-99df-492d4e7d97f6">|
</p>
</details> 




[ONYX-769]: https://artsyproduct.atlassian.net/browse/ONYX-769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ