### PR TITLE
refactor: password reset copy

### DIFF
--- a/src/Components/AuthDialog/Views/AuthDialogForgotPassword.tsx
+++ b/src/Components/AuthDialog/Views/AuthDialogForgotPassword.tsx
@@ -81,8 +81,8 @@ export const AuthDialogForgotPassword: FC = () => {
 
               {values.mode === "Success" && (
                 <Message variant="success">
-                  If an Artsy account is associated with this email, we've sent
-                  a password reset link to its inbox.
+                  We've sent a link to reset your password if an account is
+                  associated with this email.
                 </Message>
               )}
 

--- a/src/Components/AuthDialog/Views/AuthDialogForgotPassword.tsx
+++ b/src/Components/AuthDialog/Views/AuthDialogForgotPassword.tsx
@@ -81,7 +81,8 @@ export const AuthDialogForgotPassword: FC = () => {
 
               {values.mode === "Success" && (
                 <Message variant="success">
-                  We’ve sent you an email with a link to reset your password.
+                  If an Artsy account is associated with this email, we've sent
+                  a password reset link to its inbox.
                 </Message>
               )}
 

--- a/src/Components/AuthDialog/Views/__tests__/AuthDialogForgotPassword.jest.tsx
+++ b/src/Components/AuthDialog/Views/__tests__/AuthDialogForgotPassword.jest.tsx
@@ -44,7 +44,7 @@ describe("AuthDialogForgotPassword", () => {
 
     expect(
       screen.queryByText(
-        "We’ve sent you an email with a link to reset your password."
+        "If an Artsy account is associated with this email, we've sent a password reset link to its inbox."
       )
     ).not.toBeInTheDocument()
 
@@ -57,7 +57,7 @@ describe("AuthDialogForgotPassword", () => {
 
       expect(
         screen.getByText(
-          "We’ve sent you an email with a link to reset your password."
+          "If an Artsy account is associated with this email, we've sent a password reset link to its inbox."
         )
       ).toBeInTheDocument()
     })

--- a/src/Components/AuthDialog/Views/__tests__/AuthDialogForgotPassword.jest.tsx
+++ b/src/Components/AuthDialog/Views/__tests__/AuthDialogForgotPassword.jest.tsx
@@ -44,7 +44,7 @@ describe("AuthDialogForgotPassword", () => {
 
     expect(
       screen.queryByText(
-        "We've sent a link to reset your password if an account is associated with this email.."
+        "We've sent a link to reset your password if an account is associated with this email."
       )
     ).not.toBeInTheDocument()
 
@@ -57,7 +57,7 @@ describe("AuthDialogForgotPassword", () => {
 
       expect(
         screen.getByText(
-          "We've sent a link to reset your password if an account is associated with this email.."
+          "We've sent a link to reset your password if an account is associated with this email."
         )
       ).toBeInTheDocument()
     })

--- a/src/Components/AuthDialog/Views/__tests__/AuthDialogForgotPassword.jest.tsx
+++ b/src/Components/AuthDialog/Views/__tests__/AuthDialogForgotPassword.jest.tsx
@@ -44,7 +44,7 @@ describe("AuthDialogForgotPassword", () => {
 
     expect(
       screen.queryByText(
-        "If an Artsy account is associated with this email, we've sent a password reset link to its inbox."
+        "We've sent a link to reset your password if an account is associated with this email.."
       )
     ).not.toBeInTheDocument()
 
@@ -57,7 +57,7 @@ describe("AuthDialogForgotPassword", () => {
 
       expect(
         screen.getByText(
-          "If an Artsy account is associated with this email, we've sent a password reset link to its inbox."
+          "We've sent a link to reset your password if an account is associated with this email.."
         )
       ).toBeInTheDocument()
     })


### PR DESCRIPTION
The type of this PR is: refactor

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PHIRE-681]

### Description

<!-- Implementation description -->
This PR refactors the copy a user sees when triggering a password reset email. The new copy includes a gentle reminder that they should only expect an email if we have an artsy account associated with the email they have input. 

👉 **Please feel free to suggest copy edits**

Old: 
<img width="429" alt="Screenshot 2024-03-07 at 1 05 33 PM" src="https://github.com/artsy/force/assets/38149304/2bd2b7c7-d3fe-410c-a5f4-f14b574c0d1e">

New:
<img width="426" alt="Screenshot 2024-03-07 at 1 12 02 PM" src="https://github.com/artsy/force/assets/38149304/feb9f0cd-f1aa-48d4-a052-fdbe0ea76aef">



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PHIRE-681]: https://artsyproduct.atlassian.net/browse/PHIRE-681?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ