### PR TITLE
fix(partner): Fix scrollTo on partner/artist section

### DIFF
--- a/src/Apps/Partner/Routes/Artists/ArtistsRoute.tsx
+++ b/src/Apps/Partner/Routes/Artists/ArtistsRoute.tsx
@@ -29,7 +29,8 @@ export const ArtistsRoute: React.FC<ArtistsRouteProps> = ({
     if (match.params.artistId && isLoaded && isMobile !== null) {
       jumpTo("PartnerArtistDetails")
     }
-  }, [isLoaded, isMobile, jumpTo, match.params.artistId])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isLoaded, isMobile, match.params.artistId])
 
   return (
     <Box mt={4}>


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Fixes issue noted [here](https://artsy.slack.com/archives/C05F8TNKGAV/p1710452735521909) where adding `jumpTo` to the dependencies array seems to "capture" the behavior and always scroll. Seems like `jumpTo` is rerendering in a weird way. 

Will file ticket on Diamond board, cc @dzucconi 
