### PR TITLE
feat: Implement app preferences + theme select

### DIFF
--- a/src/Apps/AppPreferences/__tests__/appPreferencesServerRoutes.jest.ts
+++ b/src/Apps/AppPreferences/__tests__/appPreferencesServerRoutes.jest.ts
@@ -1,0 +1,111 @@
+import {
+  appPreferencesPost,
+  getAppPreferences,
+} from "Apps/AppPreferences/appPreferencesServerRoutes"
+import { ArtsyRequest } from "Server/middleware/artsyExpress"
+
+describe("getAppPreferences", () => {
+  it("returns the default app preferences if there are none", () => {
+    const preferences = getAppPreferences({
+      cookies: {},
+    } as ArtsyRequest)
+
+    expect(preferences).toEqual({ theme: "light" })
+  })
+
+  it("returns the app preferences from the cookies", () => {
+    const preferences = getAppPreferences({
+      cookies: {
+        APP_PREFERENCES: JSON.stringify({ theme: "dark" }),
+      },
+    } as ArtsyRequest)
+
+    expect(preferences).toEqual({ theme: "dark" })
+  })
+
+  it("returns the default app preferences if the cookies are invalid", () => {
+    const preferences = getAppPreferences({
+      cookies: {
+        APP_PREFERENCES: "invalid",
+      },
+    } as ArtsyRequest)
+
+    expect(preferences).toEqual({ theme: "light" })
+  })
+})
+
+describe("appPreferencesPost", () => {
+  it("returns an error if no preferences are provided", () => {
+    const req = {
+      body: {},
+      cookies: {},
+    } as ArtsyRequest
+
+    const send = jest.fn()
+
+    const res = {
+      status: jest.fn().mockReturnValue({ send }),
+      cookie: jest.fn(),
+    } as any
+
+    appPreferencesPost(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(send).toHaveBeenCalledWith({
+      error: "No preferences provided",
+    })
+  })
+
+  it("returns an error if the preferences are invalid", () => {
+    const req = {
+      body: {
+        theme: "invalid",
+      },
+      cookies: {},
+    } as ArtsyRequest
+
+    const send = jest.fn()
+
+    const res = {
+      status: jest.fn().mockReturnValue({ send }),
+      cookie: jest.fn(),
+    } as any
+
+    appPreferencesPost(req, res)
+
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(send).toHaveBeenCalledWith({
+      error: "Invalid preferences provided",
+    })
+  })
+
+  it("updates the app preferences in the cookies", () => {
+    const req = {
+      body: {
+        theme: "dark",
+      },
+      cookies: {},
+    } as ArtsyRequest
+
+    const send = jest.fn()
+
+    const res = {
+      status: jest.fn(),
+      send,
+      cookie: jest.fn(),
+    } as any
+
+    appPreferencesPost(req, res)
+
+    expect(res.cookie).toHaveBeenCalledWith(
+      "APP_PREFERENCES",
+      JSON.stringify({ theme: "dark" }),
+      {
+        maxAge: 31536000000,
+        httpOnly: false,
+        secure: true,
+      }
+    )
+    expect(send).toHaveBeenCalledWith({ theme: "dark" })
+  })
+})

--- a/src/Apps/AppPreferences/appPreferencesMiddleware.ts
+++ b/src/Apps/AppPreferences/appPreferencesMiddleware.ts
@@ -1,0 +1,15 @@
+import { getAppPreferences } from "Apps/AppPreferences/appPreferencesServerRoutes"
+import { APP_PREFERENCES_SHARIFY_KEY } from "Apps/AppPreferences/useAppPreferences"
+import { ArtsyRequest, ArtsyResponse } from "Server/middleware/artsyExpress"
+import { updateSharifyAndContext } from "Server/middleware/bootstrapSharifyAndContextLocalsMiddleware"
+import { NextFunction } from "express"
+
+export const appPreferencesMiddleware = async (
+  req: ArtsyRequest,
+  res: ArtsyResponse,
+  next: NextFunction
+) => {
+  const preferences = getAppPreferences(req)
+  updateSharifyAndContext(res, APP_PREFERENCES_SHARIFY_KEY, preferences)
+  next()
+}

--- a/src/Apps/AppPreferences/appPreferencesServerRoutes.ts
+++ b/src/Apps/AppPreferences/appPreferencesServerRoutes.ts
@@ -1,0 +1,74 @@
+import {
+  AppPreferences,
+  appPreferencesSchema,
+  DEFAULT_PREFERENCES,
+} from "Apps/AppPreferences/useAppPreferences"
+import { Router } from "express"
+import { ArtsyRequest, ArtsyResponse } from "Server/middleware/artsyExpress"
+
+const APP_PREFERENCES_COOKIE_NAME = "APP_PREFERENCES"
+const APP_PREFERENCES_COOKIE_CONFIGURATION = {
+  maxAge: 1000 * 60 * 60 * 24 * 365,
+  httpOnly: false,
+  secure: true,
+}
+
+const appPreferencesServerRoutes = Router()
+
+export const appPreferencesGet = (req: ArtsyRequest, res: ArtsyResponse) => {
+  const preferences = getAppPreferences(req)
+  res.send(preferences)
+}
+
+export const appPreferencesPost = (req: ArtsyRequest, res: ArtsyResponse) => {
+  const body = req.body
+
+  if (Object.keys(body).length === 0) {
+    res.status(400).send({
+      error: "No preferences provided",
+    })
+    return
+  }
+
+  try {
+    const previousPreferences = getAppPreferences(req)
+
+    const updatedPreferences = appPreferencesSchema.validateSync(
+      { ...previousPreferences, ...body },
+      { stripUnknown: true }
+    )
+
+    const payload = JSON.stringify(updatedPreferences)
+
+    res.cookie(
+      APP_PREFERENCES_COOKIE_NAME,
+      payload,
+      APP_PREFERENCES_COOKIE_CONFIGURATION
+    )
+
+    res.send(body)
+  } catch (error) {
+    console.error(error)
+    res.status(400).send({
+      error: "Invalid preferences provided",
+    })
+  }
+}
+
+appPreferencesServerRoutes
+  .get("/api/app-preferences", appPreferencesGet)
+  .post("/api/app-preferences", appPreferencesPost)
+
+export { appPreferencesServerRoutes }
+
+export const getAppPreferences = (req: ArtsyRequest): AppPreferences => {
+  try {
+    const value = req.cookies[APP_PREFERENCES_COOKIE_NAME]
+
+    return appPreferencesSchema.validateSync(value, {
+      stripUnknown: true,
+    })
+  } catch (error) {
+    return DEFAULT_PREFERENCES
+  }
+}

--- a/src/Apps/AppPreferences/useAppPreferences.tsx
+++ b/src/Apps/AppPreferences/useAppPreferences.tsx
@@ -1,0 +1,96 @@
+import { getENV } from "Utils/getENV"
+import {
+  FC,
+  ReactNode,
+  createContext,
+  useCallback,
+  useState,
+  useContext,
+  useRef,
+} from "react"
+import * as Yup from "yup"
+
+export const appPreferencesSchema = Yup.object({
+  theme: Yup.string().oneOf(["light", "dark"]).required() as Yup.StringSchema<
+    "light" | "dark"
+  >,
+})
+
+export type AppPreferences = Yup.InferType<typeof appPreferencesSchema>
+
+export const DEFAULT_PREFERENCES: AppPreferences = {
+  theme: "light",
+}
+
+const AppPreferencesContext = createContext<{
+  preferences: AppPreferences
+  updatePreferences: (newPreferences: Partial<AppPreferences>) => void
+}>({
+  preferences: DEFAULT_PREFERENCES,
+  updatePreferences: () => {},
+})
+
+interface AppPreferencesProviderProps {
+  children: ReactNode
+}
+
+export const APP_PREFERENCES_SHARIFY_KEY = "APP_PREFERENCES"
+
+export const AppPreferencesProvider: FC<AppPreferencesProviderProps> = ({
+  children,
+}) => {
+  const initialPreferences =
+    getENV(APP_PREFERENCES_SHARIFY_KEY) || DEFAULT_PREFERENCES
+
+  const [preferences, setPreferences] = useState<AppPreferences>(
+    initialPreferences
+  )
+
+  const restoredPreferences = useRef(preferences)
+  const isUpdating = useRef(false)
+
+  const updatePreferences = useCallback(
+    (newPreferences: Partial<AppPreferences>) => {
+      if (isUpdating.current) {
+        return
+      }
+
+      isUpdating.current = true
+
+      // Optimistically update preferences
+      setPreferences(prevPreferences => ({
+        ...prevPreferences,
+        ...newPreferences,
+      }))
+
+      fetch("/api/app-preferences", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(newPreferences),
+      })
+        .then(response => response.json())
+        .then(data => {
+          restoredPreferences.current = data
+        })
+        .finally(() => {
+          isUpdating.current = false
+        })
+        .catch(error => {
+          console.error(error)
+          // Rollback to previous preferences on error
+          setPreferences(restoredPreferences.current)
+        })
+    },
+    []
+  )
+
+  return (
+    <AppPreferencesContext.Provider value={{ preferences, updatePreferences }}>
+      {children}
+    </AppPreferencesContext.Provider>
+  )
+}
+
+export const useAppPreferences = () => {
+  return useContext(AppPreferencesContext)
+}

--- a/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsThemeSelect.tsx
+++ b/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsThemeSelect.tsx
@@ -1,0 +1,27 @@
+import { Button, Text } from "@artsy/palette"
+import { useAppPreferences } from "Apps/AppPreferences/useAppPreferences"
+import { FC } from "react"
+
+interface SettingsEditSettingsThemeSelectProps {}
+
+export const SettingsEditSettingsThemeSelect: FC<SettingsEditSettingsThemeSelectProps> = props => {
+  const { updatePreferences, preferences } = useAppPreferences()
+
+  return (
+    <>
+      <Text color="black100" variant={["md", "lg"]} mb={4}>
+        Theme
+      </Text>
+
+      <Button
+        onClick={() => {
+          updatePreferences({
+            theme: preferences.theme === "light" ? "dark" : "light",
+          })
+        }}
+      >
+        Dark mode: {preferences.theme === "light" ? "Off" : "On"}
+      </Button>
+    </>
+  )
+}

--- a/src/Apps/Settings/Routes/EditSettings/SettingsEditSettingsRoute.tsx
+++ b/src/Apps/Settings/Routes/EditSettings/SettingsEditSettingsRoute.tsx
@@ -8,12 +8,16 @@ import { SettingsEditSettingsDeleteAccount } from "./Components/SettingsEditSett
 import { SettingsEditSettingsLinkedAccountsFragmentContainer } from "./Components/SettingsEditSettingsLinkedAccounts"
 import { SettingsEditSettingsEmailPreferences } from "./Components/SettingsEditSettingsEmailPreferences/SettingsEditSettingsEmailPreferences"
 import { SettingsEditSettingsInformationFragmentContainer } from "Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsInformation"
+import { SettingsEditSettingsThemeSelect } from "Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsThemeSelect"
+import { useFeatureFlag } from "System/useFeatureFlag"
 
 interface SettingsEditRouteProps {
   me: SettingsEditSettingsRoute_me$data
 }
 
 const SettingsEditRoute: React.FC<SettingsEditRouteProps> = ({ me }) => {
+  const isDarkModeEnabled = useFeatureFlag("diamond_dark-mode")
+
   return (
     <GridColumns>
       <Column span={8}>
@@ -27,6 +31,8 @@ const SettingsEditRoute: React.FC<SettingsEditRouteProps> = ({ me }) => {
           <SettingsEditSettingsLinkedAccountsFragmentContainer me={me} />
 
           <SettingsEditSettingsEmailPreferences />
+
+          {isDarkModeEnabled && <SettingsEditSettingsThemeSelect />}
 
           <SettingsEditSettingsDeleteAccount />
         </Join>

--- a/src/System/Router/Boot.tsx
+++ b/src/System/Router/Boot.tsx
@@ -6,7 +6,7 @@ import {
 } from "@artsy/palette"
 import { SystemContextProvider } from "System/SystemContext"
 import { AppRouteConfig } from "System/Router/Route"
-import { useEffect, useState } from "react"
+import { FC, useEffect } from "react"
 import * as React from "react"
 import { HeadProvider } from "react-head"
 import { Environment } from "react-relay"
@@ -34,6 +34,10 @@ import { AuthDialogProvider } from "Components/AuthDialog/AuthDialogContext"
 import { CookieConsentManager } from "Components/CookieConsentManager/CookieConsentManager"
 import { DismissibleProvider } from "@artsy/dismissible"
 import { PROGRESSIVE_ONBOARDING_KEYS } from "Components/ProgressiveOnboarding/progressiveOnboardingKeys"
+import {
+  AppPreferencesProvider,
+  useAppPreferences,
+} from "Apps/AppPreferences/useAppPreferences"
 
 export interface BootProps {
   children: React.ReactNode
@@ -75,64 +79,51 @@ export const Boot = track(undefined, {
     ...context,
   }
 
-  const [theme, setTheme] = useState<"light" | "dark">("light")
-
-  const user = props.user
-
-  useEffect(() => {
-    if (!user?.email?.endsWith("artsymail.com")) return
-
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.metaKey && e.key === "i") {
-        setTheme(prevTheme => (prevTheme === "light" ? "dark" : "light"))
-      }
-    }
-
-    document.addEventListener("keydown", handleKeyDown)
-
-    return () => {
-      document.removeEventListener("keydown", handleKeyDown)
-    }
-  }, [user])
-
   return (
-    <Theme theme={theme}>
-      <GlobalStyles />
+    <AppPreferencesProvider>
+      <ThemeProvider>
+        <GlobalStyles />
 
-      <HeadProvider headTags={headTags}>
-        <StateProvider>
-          <SystemContextProvider {...contextProps}>
-            <ErrorBoundary>
-              <MediaContextProvider onlyMatch={onlyMatchMediaQueries}>
-                <ResponsiveProvider
-                  mediaQueries={THEME.mediaQueries}
-                  initialMatchingMediaQueries={onlyMatchMediaQueries as any}
-                >
-                  <ToastsProvider>
-                    <StickyProvider>
-                      <AuthIntentProvider>
-                        <AuthDialogProvider>
-                          <DismissibleProvider
-                            userID={props.user?.id}
-                            keys={PROGRESSIVE_ONBOARDING_KEYS}
-                          >
-                            <CookieConsentManager>
-                              <FocusVisible />
-                              <SiftContainer />
+        <HeadProvider headTags={headTags}>
+          <StateProvider>
+            <SystemContextProvider {...contextProps}>
+              <ErrorBoundary>
+                <MediaContextProvider onlyMatch={onlyMatchMediaQueries}>
+                  <ResponsiveProvider
+                    mediaQueries={THEME.mediaQueries}
+                    initialMatchingMediaQueries={onlyMatchMediaQueries as any}
+                  >
+                    <ToastsProvider>
+                      <StickyProvider>
+                        <AuthIntentProvider>
+                          <AuthDialogProvider>
+                            <DismissibleProvider
+                              userID={props.user?.id}
+                              keys={PROGRESSIVE_ONBOARDING_KEYS}
+                            >
+                              <CookieConsentManager>
+                                <FocusVisible />
+                                <SiftContainer />
 
-                              {children}
-                            </CookieConsentManager>
-                          </DismissibleProvider>
-                        </AuthDialogProvider>
-                      </AuthIntentProvider>
-                    </StickyProvider>
-                  </ToastsProvider>
-                </ResponsiveProvider>
-              </MediaContextProvider>
-            </ErrorBoundary>
-          </SystemContextProvider>
-        </StateProvider>
-      </HeadProvider>
-    </Theme>
+                                {children}
+                              </CookieConsentManager>
+                            </DismissibleProvider>
+                          </AuthDialogProvider>
+                        </AuthIntentProvider>
+                      </StickyProvider>
+                    </ToastsProvider>
+                  </ResponsiveProvider>
+                </MediaContextProvider>
+              </ErrorBoundary>
+            </SystemContextProvider>
+          </StateProvider>
+        </HeadProvider>
+      </ThemeProvider>
+    </AppPreferencesProvider>
   )
 })
+
+const ThemeProvider: FC = ({ children }) => {
+  const { preferences } = useAppPreferences()
+  return <Theme theme={preferences.theme}>{children}</Theme>
+}

--- a/src/System/Router/buildServerApp.tsx
+++ b/src/System/Router/buildServerApp.tsx
@@ -154,13 +154,13 @@ export function buildServerApp(
           return (
             <Boot
               context={serverContext}
-              user={user}
               headTags={tags}
+              relayEnvironment={relayEnvironment}
+              routes={routes}
+              user={user}
               // FIXME:
               // @ts-ignore
               onlyMatchMediaQueries={matchingMediaQueries}
-              relayEnvironment={relayEnvironment}
-              routes={routes}
             >
               {farceResults.element}
             </Boot>

--- a/src/Typings/sharify.d.ts
+++ b/src/Typings/sharify.d.ts
@@ -23,6 +23,7 @@ declare module "sharify" {
       ALLOWED_REDIRECT_HOSTS: string
       API_REQUEST_TIMEOUT?: number
       API_URL: string
+      APP_PREFERENCES: AppPreferences
       APP_URL: string
       APPLICATION_NAME: string
       ARTIST_COLLECTIONS_RAIL?: string // TODO: remove after CollectionsRail a/b test

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -68,6 +68,7 @@ import {
 } from "./Server/featureFlags/unleashService"
 import { registerFeatureFlagService } from "./Server/featureFlags/featureFlagService"
 import { userPreferencesMiddleware } from "./Server/middleware/userPreferencesMiddleware"
+import { appPreferencesMiddleware } from "Apps/AppPreferences/appPreferencesMiddleware"
 
 // Find the v2 routes, we will not be testing memory caching for legacy pages.
 
@@ -174,7 +175,7 @@ function applySecurityMiddleware(app) {
   // because `local.asset` is required to render the error page.
   app.use(assetMiddleware())
 
-  // // Passport middleware for authentication.
+  // Passport middleware for authentication.
   app.use(
     artsyPassport({
       APP_URL,
@@ -215,6 +216,9 @@ function applySecurityMiddleware(app) {
 
   // Get user preferences (e.g. metric, currency)
   app.use(userPreferencesMiddleware)
+
+  // Get app preferences (e.g. theme)
+  app.use(appPreferencesMiddleware)
 }
 
 function applyStaticAssetMiddlewares(app) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,7 @@ import { sitemapsServerApp } from "Apps/Sitemaps/sitemapsServerApp"
 import { rssServerApp } from "Apps/RSS/rssServerApp"
 import { redirectsServerRoutes } from "Apps/Redirects/redirectsServerRoutes"
 import { cookieConsentManagerServerRoutes } from "Components/CookieConsentManager/cookieConsentManagerServerRoutes"
+import { appPreferencesServerRoutes } from "Apps/AppPreferences/appPreferencesServerRoutes"
 
 const app = express()
 const { routes, routePaths } = getRouteConfig()
@@ -51,6 +52,7 @@ app.get(
  */
 
 app
+  .use(appPreferencesServerRoutes)
   .use(cookieConsentManagerServerRoutes)
   .use(adminServerRoutes)
   .use(sitemapsServerApp)


### PR DESCRIPTION
Re: [DIA-415](https://artsyproduct.atlassian.net/browse/DIA-415)

The idea here is that we set preferences in a server side cookie, then parse and cast using a Yup schema and load it into sharify. A context provider pulls it out of sharify and into state for the client. You can then update both the client-side state and the cookie simultaneously. This provides a stable value for the server-side render + client-side mount.

The toggle for dark mode is located on the account settings page and hidden behind the feature flag `diamond_dark-mode`.

![](https://capture.static.damonzucconi.com/Screen-Shot-2024-03-21-08-35-05.13-1tOEkDvxbpqEwlGQ7fvQOBJqdni9OUB6aNWgWheZ8U4k0DzE79SfaMaMPZBy2JDfTw21t3dna3K70lMAF5XEYU8EUhFeyakk879r.png)

[DIA-415]: https://artsyproduct.atlassian.net/browse/DIA-415?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ