### PR TITLE
ci(slack): Update slack notification to use circle context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -361,6 +361,7 @@ workflows:
           <<: *only_main
           name: deploy-staging
           project-name: force
+          context: slack-orb
           executor: hokusai/beta
           requires:
             - production-image-push
@@ -399,6 +400,7 @@ workflows:
 
       - validate_production_schema:
           <<: *only_release
+          context: slack-orb
 
       # Production
       - hokusai/deploy-production:


### PR DESCRIPTION
Related:
- https://github.com/artsy/volt/pull/7443

The type of this PR is: **CI**

### Description

This updates our CI config to take advantage of our slack-orb context for the SLACK_ACCESS_TOKEN key, vs a per-repo env config.
