### PR TITLE
feat: enable pills and counts for the availability filter

### DIFF
--- a/src/Components/Alert/AlertProvider.tsx
+++ b/src/Components/Alert/AlertProvider.tsx
@@ -93,6 +93,12 @@ export const AlertProvider: FC<AlertProviderProps> = ({
     if (isEditMode || isAlertArtworksView) return
     const criteria = getAllowedSearchCriteria(initialCriteria ?? {})
 
+    // `forSale` is allowed as a filter criterion,
+    // but NOT as an alert criterion, so we remove it.
+    // (Alerts, by definition, stipulate forSale=true
+    // when they are created in Gravity.)
+    delete criteria.forSale
+
     dispatch({ type: "SET_CRITERIA", payload: criteria })
   }, [initialCriteria, isEditMode, isAlertArtworksView])
 

--- a/src/Components/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilterContext.tsx
@@ -45,6 +45,7 @@ export enum FilterParamName {
   artistsIFollow = "includeArtworksByFollowedArtists",
   attributionClass = "attributionClass",
   colors = "colors",
+  forSale = "forSale",
   height = "height",
   keyword = "keyword",
   locationCities = "locationCities",
@@ -177,6 +178,7 @@ export enum SelectedFiltersCountsLabels {
   artistNationalities = "artistNationalities",
   attributionClass = "attributionClass",
   colors = "colors",
+  forSale = "forSale",
   locationCities = "locationCities",
   materialsTerms = "materialsTerms",
   medium = "medium",
@@ -677,6 +679,12 @@ export const getSelectedFiltersCounts = (
       }
       case paramName === FilterParamName.keyword: {
         if (paramValue?.length) {
+          counts[paramName] = 1
+        }
+        break
+      }
+      case paramName === FilterParamName.forSale: {
+        if (paramValue) {
           counts[paramName] = 1
         }
         break

--- a/src/Components/ArtworkFilter/ArtworkFilters/AvailabilityFilter.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/AvailabilityFilter.tsx
@@ -1,17 +1,26 @@
 import { Checkbox } from "@artsy/palette"
-import { useArtworkFilterContext } from "Components/ArtworkFilter/ArtworkFilterContext"
+import {
+  SelectedFiltersCountsLabels,
+  useArtworkFilterContext,
+  useCurrentlySelectedFilters,
+} from "Components/ArtworkFilter/ArtworkFilterContext"
 import { FilterExpandable } from "Components/ArtworkFilter/ArtworkFilters/FilterExpandable"
+import { useFilterLabelCountByKey } from "Components/ArtworkFilter/Utils/useFilterLabelCountByKey"
 
 export const AvailabilityFilter: React.FC = () => {
-  const { setFilter, unsetFilter, filters } = useArtworkFilterContext()
+  const { setFilter } = useArtworkFilterContext()
+  const currentSelectedFilters = useCurrentlySelectedFilters()
+
+  const filtersCount = useFilterLabelCountByKey(
+    SelectedFiltersCountsLabels.forSale
+  )
+  const label = `Availability${filtersCount}`
 
   return (
-    <FilterExpandable label="Availability" expanded>
+    <FilterExpandable label={label} expanded>
       <Checkbox
-        selected={!!filters?.forSale}
-        onSelect={selected => {
-          selected ? setFilter("forSale", true) : unsetFilter("forSale")
-        }}
+        selected={!!currentSelectedFilters?.forSale}
+        onSelect={selected => setFilter("forSale", selected)}
         my={1}
       >
         Only works for sale

--- a/src/Components/ArtworkFilter/Utils/__tests__/countChangedFilters.jest.ts
+++ b/src/Components/ArtworkFilter/Utils/__tests__/countChangedFilters.jest.ts
@@ -96,9 +96,24 @@ describe("countChangedFilters", () => {
     ).toBe(0)
 
     expect(
+      countChangedFilters(EMPTY_FILTER, { ...EMPTY_FILTER, forSale: true })
+    ).toBe(1)
+
+    expect(
+      countChangedFilters(EMPTY_FILTER, { ...EMPTY_FILTER, forSale: false })
+    ).toBe(0)
+
+    expect(
       countChangedFilters(
         { ...EMPTY_FILTER, acquireable: false },
         { ...EMPTY_FILTER, acquireable: true }
+      )
+    ).toBe(1)
+
+    expect(
+      countChangedFilters(
+        { ...EMPTY_FILTER, forSale: false },
+        { ...EMPTY_FILTER, forSale: true }
       )
     ).toBe(1)
   })

--- a/src/Components/ArtworkFilter/Utils/countChangedFilters.ts
+++ b/src/Components/ArtworkFilter/Utils/countChangedFilters.ts
@@ -1,4 +1,4 @@
-import { ArtworkFilters } from "../ArtworkFilterContext"
+import { ArtworkFilters } from "Components/ArtworkFilter/ArtworkFilterContext"
 import { isEqual, transform, isObject } from "lodash"
 
 const difference = (initial: {}, next: {}) => {
@@ -24,6 +24,7 @@ export const countChangedFilters = (
     acquireable: false,
     atAuction: false,
     inquireableOnly: false,
+    forSale: false,
     ...filtersBefore,
   }
 

--- a/src/Components/SavedSearchAlert/Utils/__tests__/extractPills.jest.ts
+++ b/src/Components/SavedSearchAlert/Utils/__tests__/extractPills.jest.ts
@@ -2,12 +2,12 @@ import { Aggregations } from "Components/ArtworkFilter/ArtworkFilterContext"
 import {
   SavedSearchDefaultCriteria,
   SearchCriteriaAttributes,
-} from "../../types"
+} from "Components/SavedSearchAlert/types"
 import {
   extractPillsFromDefaultCriteria,
   excludeDefaultCriteria,
   extractPillFromAggregation,
-} from "../extractPills"
+} from "Components/SavedSearchAlert/Utils/extractPills"
 
 describe("extractPillFromAggregation", () => {
   it("returns pills", () => {
@@ -155,6 +155,24 @@ describe("extractPillsFromDefaultCriteria", () => {
         value: "limited edition",
         displayValue: "Limited Edition",
         field: "attributionClass",
+      },
+    ])
+  })
+
+  it("should support forSale", () => {
+    const result = extractPillsFromDefaultCriteria({
+      forSale: {
+        displayValue: "For sale",
+        value: true,
+      },
+    })
+
+    expect(result).toEqual([
+      {
+        isDefault: true,
+        displayValue: "For sale",
+        value: "true",
+        field: "forSale",
       },
     ])
   })

--- a/src/Components/SavedSearchAlert/Utils/extractPills.ts
+++ b/src/Components/SavedSearchAlert/Utils/extractPills.ts
@@ -204,6 +204,14 @@ export const extractPillsFromCriteria = ({
         }
         break
       }
+      case "forSale": {
+        result = {
+          field: paramName,
+          value: paramValue,
+          displayValue: "For sale",
+        }
+        break
+      }
       default: {
         result = null
       }

--- a/src/Components/SavedSearchAlert/constants.ts
+++ b/src/Components/SavedSearchAlert/constants.ts
@@ -31,6 +31,7 @@ export const allowedSearchCriteriaKeys = [
   "atAuction",
   "attributionClass",
   "colors",
+  "forSale",
   "height",
   "includeArtworksByFollowedArtists",
   "inquireableOnly",

--- a/src/Components/SavedSearchAlert/types.ts
+++ b/src/Components/SavedSearchAlert/types.ts
@@ -20,6 +20,7 @@ export interface SearchCriteriaAttributes {
   materialsTerms?: string[] | null
   priceRange?: string | null
   sizes?: string[] | null
+  forSale?: boolean | null
 }
 
 export type SearchCriteriaAttributeKeys = keyof SearchCriteriaAttributes


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [ONYX-702] and [ONYX-703]

### Description

This wraps up the Hackathon request that got stalled for a bit on the filter param logic (KS'd [here](https://www.notion.so/artsy/Boolean-filters-on-the-artwork-grid-0ccf4af13df54712b7c88b0480d377f8) and addressed in https://github.com/artsy/gravity/pull/17446)

Now that the for-sale toggle is filtering results correctly, we want to ensure the rest of the search UI works accordingly as well.

- A **pill** corresponding to the for-sale filter selection should be displayed, and allow for dismissal
- The **count** of active filters should account for the for-sale filter

Addressing the counts also turned up some gaps in the mWeb behavior, which should be addressed now.

Remains staging-only behind [an Unleash flag](https://unleash.artsy.net/projects/default/features/onyx_availability-filter) — but ready for final QA now I believe.

|Web|mWeb|
|---|---|
|<img src="https://github.com/artsy/force/assets/140521/866086a6-eea7-4317-8c93-108445525992" />|<img src="https://github.com/artsy/force/assets/140521/2a9c23aa-91df-4733-8f36-e34611975311" />|



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-702]: https://artsyproduct.atlassian.net/browse/ONYX-702?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-703]: https://artsyproduct.atlassian.net/browse/ONYX-703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ