### PR TITLE
feat(EMI-1773): update copy for saves page tooltips and modals

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves/Components/ArtworkListContent.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves/Components/ArtworkListContent.tsx
@@ -98,9 +98,9 @@ const ArtworkListContent: FC<ArtworkListContentProps> = ({ me, relay }) => {
       >
         <Join separator={<Spacer x={2} />}>
           <Flex alignItems="center">
-            <Text variant="lg-display">{artworkList.name}</Text>
+            <Text variant="lg-display">{artworkList?.name}</Text>
             {shareableWithPartnersEnabled &&
-              !artworkList.shareableWithPartners && (
+              !artworkList?.shareableWithPartners && (
                 <Tooltip
                   pointer
                   variant="defaultDark"
@@ -121,7 +121,7 @@ const ArtworkListContent: FC<ArtworkListContentProps> = ({ me, relay }) => {
                 </Tooltip>
               )}
           </Flex>
-          {!artworkList.default && (
+          {!artworkList?.default && artworkList && (
             <ArtworkListContextualMenu artworkList={artworkList} />
           )}
         </Join>

--- a/src/Apps/CollectorProfile/Routes/Saves/Components/ArtworkListContent.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves/Components/ArtworkListContent.tsx
@@ -13,15 +13,16 @@ import { FC, useEffect } from "react"
 import { createRefetchContainer, graphql, RelayRefetchProp } from "react-relay"
 import { useRouter } from "System/Router/useRouter"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
-import { Flex, Join, Spacer, Text } from "@artsy/palette"
+import { Clickable, Flex, Join, Spacer, Text, Tooltip } from "@artsy/palette"
 import { updateUrl } from "Components/ArtworkFilter/Utils/urlBuilder"
 import { ArtworkListArtworksGridPlaceholder } from "./ArtworkListPlaceholders"
 import { ArtworkListContextualMenu } from "./Actions/ArtworkListContextualMenu"
 import { useJump } from "Utils/Hooks/useJump"
 import { useArtworkListVisibilityContext } from "Apps/CollectorProfile/Routes/Saves/Utils/useArtworkListVisibility"
 import { ARTWORK_LIST_SCROLL_TARGET_ID } from "Apps/CollectorProfile/Routes/Saves/CollectorProfileSavesRoute"
-import LockIcon from "@artsy/icons/LockIcon"
+import HideIcon from "@artsy/icons/HideIcon"
 import { useFeatureFlag } from "System/useFeatureFlag"
+import { useTranslation } from "react-i18next"
 
 interface ArtworkListContentQueryRendererProps {
   listID: string
@@ -55,11 +56,12 @@ function isContentOutOfView() {
 }
 
 const ArtworkListContent: FC<ArtworkListContentProps> = ({ me, relay }) => {
+  const { t } = useTranslation()
   const { match } = useRouter()
 
   const { jumpTo } = useJump()
   const { artworkListItemHasBeenTouched } = useArtworkListVisibilityContext()
-
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
   const artworkList = me.artworkList!
   const counts: Counts = {
     artworks: artworkList.artworks?.totalCount ?? 0,
@@ -96,29 +98,35 @@ const ArtworkListContent: FC<ArtworkListContentProps> = ({ me, relay }) => {
         justifyContent="space-between"
       >
         <Join separator={<Spacer x={2} />}>
-          <Text variant="lg-display">{artworkList.name}</Text>
+          <Flex alignItems="center">
+            <Text variant="lg-display">{artworkList.name}</Text>
+            {shareableWithPartnersEnabled &&
+              !artworkList.shareableWithPartners && (
+                <Tooltip
+                  pointer
+                  variant="defaultDark"
+                  placement="bottom-start"
+                  content={
+                    <Text variant="xs">
+                      {t("collectorSaves.artworkListsHeader.hideIconTooltip")}
+                    </Text>
+                  }
+                >
+                  <Clickable style={{ lineHeight: 0 }}>
+                    <HideIcon
+                      minWidth="18px"
+                      data-testid="hide-icon"
+                      ml={0.5}
+                    />
+                  </Clickable>
+                </Tooltip>
+              )}
+          </Flex>
           {!artworkList.default && (
             <ArtworkListContextualMenu artworkList={artworkList} />
           )}
         </Join>
       </Flex>
-      {shareableWithPartnersEnabled &&
-        (artworkList.shareableWithPartners ? (
-          <Text variant={["xs", "sm-display"]} color="black60" paddingTop={1}>
-            Shared
-          </Text>
-        ) : (
-          <Flex paddingTop={1}>
-            <LockIcon
-              marginRight={0.5}
-              minWidth="18px"
-              data-testid="lock-icon"
-            />
-            <Text variant={["xs", "sm-display"]} color="black60">
-              Private
-            </Text>
-          </Flex>
-        ))}
 
       <Spacer y={4} />
 

--- a/src/Apps/CollectorProfile/Routes/Saves/Components/ArtworkListContent.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves/Components/ArtworkListContent.tsx
@@ -61,10 +61,9 @@ const ArtworkListContent: FC<ArtworkListContentProps> = ({ me, relay }) => {
 
   const { jumpTo } = useJump()
   const { artworkListItemHasBeenTouched } = useArtworkListVisibilityContext()
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  const artworkList = me.artworkList!
+  const artworkList = me.artworkList
   const counts: Counts = {
-    artworks: artworkList.artworks?.totalCount ?? 0,
+    artworks: artworkList?.artworks?.totalCount ?? 0,
   }
 
   useEffect(() => {

--- a/src/Apps/CollectorProfile/Routes/Saves/Components/ArtworkListForm/ArtworkListForm.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves/Components/ArtworkListForm/ArtworkListForm.tsx
@@ -69,9 +69,9 @@ export const ArtworkListForm: React.FC<ArtworkListFormProps> = props => {
           <Spacer y={1} />
           <Flex>
             <Text variant="xs" color="black60">
-              Share your interest in artworks with their respective galleries.
-              Switching lists to private will make them visible only to you and
-              opt them out of offers. List names are always private.
+              Shared lists are eligible to receive offers from galleries.
+              Switching sharing off will make them visible only to you, and you
+              won't receive offers. List names are always private.
             </Text>
             <Spacer x={1} />
             <Toggle

--- a/src/Apps/CollectorProfile/Routes/Saves/Components/ArtworkListItem.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves/Components/ArtworkListItem.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Text } from "@artsy/palette"
+import { Box, Clickable, Flex, Text, Tooltip } from "@artsy/palette"
 import { FourUpImageLayout } from "./Images/FourUpImageLayout"
 import { StackedImageLayout } from "./Images/StackedImageLayout"
 import { FC } from "react"
@@ -11,7 +11,7 @@ import { BASE_SAVES_PATH } from "Apps/CollectorProfile/constants"
 import styled, { css } from "styled-components"
 import { useArtworkListVisibilityContext } from "Apps/CollectorProfile/Routes/Saves/Utils/useArtworkListVisibility"
 import { themeGet } from "@styled-system/theme-get"
-import LockIcon from "@artsy/icons/LockIcon"
+import HideIcon from "@artsy/icons/HideIcon"
 import { useFeatureFlag } from "System/useFeatureFlag"
 
 interface ArtworkListItemProps {
@@ -66,11 +66,24 @@ const ArtworkListItem: FC<ArtworkListItemProps> = props => {
               {item.name}
             </Text>
             {shareableWithPartnersEnabled && !item.shareableWithPartners && (
-              <LockIcon
-                marginLeft={0.5}
-                minWidth="18px"
-                data-testid="lock-icon"
-              />
+              <Tooltip
+                pointer
+                variant="defaultDark"
+                placement="bottom-start"
+                content={
+                  <Text variant="xs">
+                    {t("collectorSaves.artworkListsHeader.hideIconTooltip")}
+                  </Text>
+                }
+              >
+                <Clickable style={{ lineHeight: 0 }}>
+                  <HideIcon
+                    marginLeft={0.5}
+                    minWidth="18px"
+                    data-testid="hide-icon"
+                  />
+                </Clickable>
+              </Tooltip>
             )}
           </Flex>
 

--- a/src/Apps/CollectorProfile/Routes/Saves/Components/SelectArtworkListsModal/SelectArtworkListItem.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves/Components/SelectArtworkListsModal/SelectArtworkListItem.tsx
@@ -7,7 +7,7 @@ import { SelectArtworkListItem_item$data } from "__generated__/SelectArtworkList
 import { extractNodes } from "Utils/extractNodes"
 import { SavesEntityImage } from "Apps/CollectorProfile/Routes/Saves/Components/SavesEntityImage"
 import CheckmarkStrokeIcon from "@artsy/icons/CheckmarkStrokeIcon"
-import LockIcon from "@artsy/icons/LockIcon"
+import HideIcon from "@artsy/icons/HideIcon"
 import { useFeatureFlag } from "System/useFeatureFlag"
 
 const ICON_SIZE = 24
@@ -53,10 +53,10 @@ const SelectArtworkListItem: FC<SelectArtworkListItemProps> = ({
         <Flex>
           <Text variant="sm-display">{item.name}</Text>
           {shareableWithPartnersEnabled && !item.shareableWithPartners && (
-            <LockIcon
+            <HideIcon
               marginLeft={0.5}
               minWidth="18px"
-              data-testid="lock-icon"
+              data-testid="hide-icon"
             />
           )}
         </Flex>

--- a/src/Apps/CollectorProfile/Routes/Saves/Components/__tests__/ArtworkListContent.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves/Components/__tests__/ArtworkListContent.jest.tsx
@@ -53,15 +53,13 @@ describe("ArtworkListContent", () => {
     const title = "Keep track of artworks you love"
     const description =
       "Select the heart on an artwork to save it or add it to a list."
-    const shareStatus = "Shared"
 
     expect(screen.getByText(title)).toBeInTheDocument()
     expect(screen.getByText(description)).toBeInTheDocument()
-    expect(screen.getByText(shareStatus)).toBeInTheDocument()
     expect(screen.queryByTestId("hide-icon")).not.toBeInTheDocument()
   })
 
-  it("should render a private note if list is not shared with partners", () => {
+  it("should render a hide icon if list is not shared with partners", () => {
     renderWithRelay({
       Me: () => ({
         artworkList: {
@@ -75,8 +73,6 @@ describe("ArtworkListContent", () => {
       }),
     })
 
-    const shareStatus = "Private"
-    expect(screen.getByText(shareStatus)).toBeInTheDocument()
     expect(screen.getByTestId("hide-icon")).toBeInTheDocument()
   })
 

--- a/src/Apps/CollectorProfile/Routes/Saves/Components/__tests__/ArtworkListContent.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves/Components/__tests__/ArtworkListContent.jest.tsx
@@ -58,7 +58,7 @@ describe("ArtworkListContent", () => {
     expect(screen.getByText(title)).toBeInTheDocument()
     expect(screen.getByText(description)).toBeInTheDocument()
     expect(screen.getByText(shareStatus)).toBeInTheDocument()
-    expect(screen.queryByTestId("lock-icon")).not.toBeInTheDocument()
+    expect(screen.queryByTestId("hide-icon")).not.toBeInTheDocument()
   })
 
   it("should render a private note if list is not shared with partners", () => {
@@ -77,7 +77,7 @@ describe("ArtworkListContent", () => {
 
     const shareStatus = "Private"
     expect(screen.getByText(shareStatus)).toBeInTheDocument()
-    expect(screen.getByTestId("lock-icon")).toBeInTheDocument()
+    expect(screen.getByTestId("hide-icon")).toBeInTheDocument()
   })
 
   describe("Actions contextual menu", () => {

--- a/src/System/i18n/locales/en-US/translation.json
+++ b/src/System/i18n/locales/en-US/translation.json
@@ -139,7 +139,8 @@
       "createNewListButton": "Create New List",
       "connector": "and",
       "signalInterest": "signal your interest to galleries",
-      "popover": "Learn more about saves and how to manage your preferences."
+      "popover": "Learn more about saves and how to manage your preferences.",
+      "hideIconTooltip": "Artworks in this list are only visible to you and not eligible to receive offers."
     },
     "createNewListModal": {
       "title": "Create a new list"


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-1773]

### Description

- Update the "Create a new list" description copy
![SCR-20240326-v9c](https://github.com/artsy/force/assets/554507/8da5fdb6-0314-4845-b73f-479882aa6735)

- Replace the lock icon for a hide icon
- Update the list header to remove the list privacy (Shared or Private) and move the icon to the title itself
- Add tooltips for both icons
![SCR-20240326-v9x](https://github.com/artsy/force/assets/554507/dcf35474-40f7-4c88-b904-badae2613ef2)
![SCR-20240326-v9n](https://github.com/artsy/force/assets/554507/6a49012e-2647-4d74-9883-0efe15955aeb)

- Replace the lock icon in the SelectArtworkListItem modal
![SCR-20240327-oug](https://github.com/artsy/force/assets/554507/b7996804-ae0f-4d6e-a402-39ad08760f6b)


This will have merge conflicts with https://github.com/artsy/force/pull/13641, so we should merge that first.
@artsy/emerald-devs 

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EMI-1773]: https://artsyproduct.atlassian.net/browse/EMI-1773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ