### PR TITLE
feat: update footer links (DIA-123)

### DIFF
--- a/src/Components/Footer/Footer.tsx
+++ b/src/Components/Footer/Footer.tsx
@@ -28,6 +28,7 @@ import TikTokIcon from "@artsy/icons/TikTokIcon"
 import SpotifyIcon from "@artsy/icons/SpotifyIcon"
 import { useSystemContext } from "System/useSystemContext"
 import ArtsyMarkIcon from "@artsy/icons/ArtsyMarkIcon"
+import { useFeatureFlag } from "System/useFeatureFlag"
 
 interface FooterProps extends BoxProps {}
 
@@ -276,6 +277,9 @@ export const Footer: React.FC<FooterProps> = props => {
 
 const PolicyLinks = () => {
   const { CCPARequestComponent, showCCPARequest } = useCCPARequest()
+  const newTermsAndConditionsEnabled = useFeatureFlag(
+    "diamond_new-terms-and-conditions"
+  )
 
   return (
     <>
@@ -290,33 +294,59 @@ const PolicyLinks = () => {
       >
         <Flex mr={1}>© {new Date().getFullYear()} Artsy</Flex>
 
-        <FooterLink color="black60" mr={1} to="/terms">
-          Terms of Use
-        </FooterLink>
+        {newTermsAndConditionsEnabled ? (
+          <>
+            <FooterLink color="black60" mr={1} to="/terms">
+              Terms and Conditions
+            </FooterLink>
 
-        <FooterLink color="black60" mr={1} to="/privacy">
-          Privacy Policy
-        </FooterLink>
+            <FooterLink color="black60" mr={1} to="/supplemental-COS">
+              Auction Supplement
+            </FooterLink>
 
-        <FooterLink color="black60" mr={1} to="/security">
-          Security
-        </FooterLink>
+            <FooterLink color="black60" mr={1} to="/buyer-guarantee">
+              Buyer Guarantee
+            </FooterLink>
 
-        <FooterLink color="black60" mr={1} to="/conditions-of-sale">
-          Conditions of Sale
-        </FooterLink>
+            <FooterLink color="black60" mr={1} to="/privacy">
+              Privacy Policy
+            </FooterLink>
 
-        <FooterLink
-          color="black60"
-          mr={1}
-          to="/page/artsy-curated-auctions-listing-agreement"
-        >
-          ACA Seller’s Agreement
-        </FooterLink>
+            <FooterLink color="black60" mr={1} to="/security">
+              Security
+            </FooterLink>
+          </>
+        ) : (
+          <>
+            <FooterLink color="black60" mr={1} to="/terms">
+              Terms of Use
+            </FooterLink>
 
-        <FooterLink color="black60" mr={1} to="/buyer-guarantee">
-          Buyer Guarantee
-        </FooterLink>
+            <FooterLink color="black60" mr={1} to="/privacy">
+              Privacy Policy
+            </FooterLink>
+
+            <FooterLink color="black60" mr={1} to="/security">
+              Security
+            </FooterLink>
+
+            <FooterLink color="black60" mr={1} to="/conditions-of-sale">
+              Conditions of Sale
+            </FooterLink>
+
+            <FooterLink
+              color="black60"
+              mr={1}
+              to="/page/artsy-curated-auctions-listing-agreement"
+            >
+              ACA Seller’s Agreement
+            </FooterLink>
+
+            <FooterLink color="black60" mr={1} to="/buyer-guarantee">
+              Buyer Guarantee
+            </FooterLink>
+          </>
+        )}
 
         <Clickable onClick={showCCPARequest}>
           Do not sell my personal information

--- a/src/Components/Footer/Footer.tsx
+++ b/src/Components/Footer/Footer.tsx
@@ -300,7 +300,7 @@ const PolicyLinks = () => {
               Terms and Conditions
             </FooterLink>
 
-            <FooterLink color="black60" mr={1} to="/supplemental-COS">
+            <FooterLink color="black60" mr={1} to="/supplemental-auction-COS">
               Auction Supplement
             </FooterLink>
 

--- a/src/Components/Footer/__tests__/Footer.jest.tsx
+++ b/src/Components/Footer/__tests__/Footer.jest.tsx
@@ -122,7 +122,7 @@ describe("Footer", () => {
         expect(wrapper.html()).toContain("/terms")
 
         expect(wrapper.text()).toContain("Auction Supplement")
-        expect(wrapper.html()).toContain("/supplemental-COS")
+        expect(wrapper.html()).toContain("/supplemental-auction-COS")
 
         expect(wrapper.text()).toContain("Buyer Guarantee")
         expect(wrapper.html()).toContain("/buyer-guarantee")
@@ -189,7 +189,7 @@ describe("Footer", () => {
         expect(wrapper.html()).toContain("/terms")
 
         expect(wrapper.text()).toContain("Auction Supplement")
-        expect(wrapper.html()).toContain("/supplemental-COS")
+        expect(wrapper.html()).toContain("/supplemental-auction-COS")
 
         expect(wrapper.text()).toContain("Buyer Guarantee")
         expect(wrapper.html()).toContain("/buyer-guarantee")

--- a/src/Components/Footer/__tests__/Footer.jest.tsx
+++ b/src/Components/Footer/__tests__/Footer.jest.tsx
@@ -3,11 +3,16 @@ import { mount } from "enzyme"
 import { Footer } from "Components/Footer/Footer"
 import { Breakpoint } from "@artsy/palette/dist/themes/types"
 import { useRouter } from "System/Router/useRouter"
+import { useFeatureFlag } from "System/useFeatureFlag"
 
 jest.mock("System/Router/useRouter", () => ({
   useRouter: jest.fn().mockReturnValue({
     match: { location: { pathname: "/" } },
   }),
+}))
+
+jest.mock("System/useFeatureFlag", () => ({
+  useFeatureFlag: jest.fn(),
 }))
 
 describe("Footer", () => {
@@ -74,6 +79,61 @@ describe("Footer", () => {
       const wrapper = getWrapper("lg")
       expect(wrapper.text()).not.toContain("Meet your new art advisor.")
     })
+
+    it("renders footer links", () => {
+      const wrapper = getWrapper("lg")
+
+      expect(wrapper.text()).toContain("Terms of Use")
+      expect(wrapper.html()).toContain("/terms")
+
+      expect(wrapper.text()).toContain("Privacy Policy")
+      expect(wrapper.html()).toContain("/privacy")
+
+      expect(wrapper.text()).toContain("Security")
+      expect(wrapper.html()).toContain("/security")
+
+      expect(wrapper.text()).toContain("Conditions of Sale")
+      expect(wrapper.html()).toContain("/conditions-of-sale")
+
+      expect(wrapper.text()).toContain("ACA Seller’s Agreement")
+      expect(wrapper.html()).toContain(
+        "/page/artsy-curated-auctions-listing-agreement"
+      )
+
+      expect(wrapper.text()).toContain("Buyer Guarantee")
+      expect(wrapper.html()).toContain("/buyer-guarantee")
+    })
+
+    describe("when diamond_new-terms-and-conditions is enabled", () => {
+      beforeEach(() => {
+        ;(useFeatureFlag as jest.Mock).mockImplementation(
+          (f: string) => f === "diamond_new-terms-and-conditions"
+        )
+      })
+
+      afterEach(() => {
+        ;(useFeatureFlag as jest.Mock).mockReset()
+      })
+
+      it("renders the new footer links", () => {
+        const wrapper = getWrapper("lg")
+
+        expect(wrapper.text()).toContain("Terms and Conditions")
+        expect(wrapper.html()).toContain("/terms")
+
+        expect(wrapper.text()).toContain("Auction Supplement")
+        expect(wrapper.html()).toContain("/supplemental-COS")
+
+        expect(wrapper.text()).toContain("Buyer Guarantee")
+        expect(wrapper.html()).toContain("/buyer-guarantee")
+
+        expect(wrapper.text()).toContain("Privacy Policy")
+        expect(wrapper.html()).toContain("/privacy")
+
+        expect(wrapper.text()).toContain("Security")
+        expect(wrapper.html()).toContain("/security")
+      })
+    })
   })
 
   describe("small screen size", () => {
@@ -85,6 +145,61 @@ describe("Footer", () => {
     it("renders the CCPA request button", () => {
       const wrapper = getWrapper("xs")
       expect(wrapper.find("button").length).toEqual(1)
+    })
+
+    it("renders footer links", () => {
+      const wrapper = getWrapper("xs")
+
+      expect(wrapper.text()).toContain("Terms of Use")
+      expect(wrapper.html()).toContain("/terms")
+
+      expect(wrapper.text()).toContain("Privacy Policy")
+      expect(wrapper.html()).toContain("/privacy")
+
+      expect(wrapper.text()).toContain("Security")
+      expect(wrapper.html()).toContain("/security")
+
+      expect(wrapper.text()).toContain("Conditions of Sale")
+      expect(wrapper.html()).toContain("/conditions-of-sale")
+
+      expect(wrapper.text()).toContain("ACA Seller’s Agreement")
+      expect(wrapper.html()).toContain(
+        "/page/artsy-curated-auctions-listing-agreement"
+      )
+
+      expect(wrapper.text()).toContain("Buyer Guarantee")
+      expect(wrapper.html()).toContain("/buyer-guarantee")
+    })
+
+    describe("when diamond_new-terms-and-conditions is enabled", () => {
+      beforeEach(() => {
+        ;(useFeatureFlag as jest.Mock).mockImplementation(
+          (f: string) => f === "diamond_new-terms-and-conditions"
+        )
+      })
+
+      afterEach(() => {
+        ;(useFeatureFlag as jest.Mock).mockReset()
+      })
+
+      it("renders the new footer links", () => {
+        const wrapper = getWrapper("xs")
+
+        expect(wrapper.text()).toContain("Terms and Conditions")
+        expect(wrapper.html()).toContain("/terms")
+
+        expect(wrapper.text()).toContain("Auction Supplement")
+        expect(wrapper.html()).toContain("/supplemental-COS")
+
+        expect(wrapper.text()).toContain("Buyer Guarantee")
+        expect(wrapper.html()).toContain("/buyer-guarantee")
+
+        expect(wrapper.text()).toContain("Privacy Policy")
+        expect(wrapper.html()).toContain("/privacy")
+
+        expect(wrapper.text()).toContain("Security")
+        expect(wrapper.html()).toContain("/security")
+      })
     })
   })
 })


### PR DESCRIPTION
This PR reshuffles the footer links behind a feature flag. In addition to a new ordering, the following changes have been made:

1. "Terms of Use" becomes "Terms and Conditions"
2. "Conditions of Sale" becomes "Auction Supplement" and has a new URL
3. "ACA Seller Conditions" is removed

This PR also sneaks in a refactor of the footer link layout. Thanks to @araujobarret, we were able to remove the margin properties (which can cause layout problems when the parent component is updated in Palette) and space out each footer link using a [Flex gap](https://developer.mozilla.org/en-US/docs/Web/CSS/gap).

One side-effect of this change is that the footer links have a vertical gap on mobile web (see screenshots below). We decided that this was a good thing because it now gives users more space to actually tap on those links.

| Before | After |
|--------|------|
| <img width="1367" alt="Screenshot 2024-03-28 at 7 33 20 AM" src="https://github.com/artsy/force/assets/44589599/6c05ffe8-1363-450a-b8ab-629b5014f25b"> | <img width="1367" alt="Screenshot 2024-03-28 at 7 33 41 AM" src="https://github.com/artsy/force/assets/44589599/c8eb00e0-089a-460c-86fe-06d66cc7c6d2"> |
| ![localhost_4000_(iPhone SE) (1)](https://github.com/artsy/force/assets/44589599/3a71f45a-5d5e-4f55-88b8-f134f54fe7d9) | ![localhost_4000_(iPhone SE)](https://github.com/artsy/force/assets/44589599/3e61846a-c3d0-430e-9bdc-f91be90d58cd) |
