### PR TITLE
feat: update checkout conditions of sale copy (DIA-539)

### DIFF
--- a/src/Apps/Order/Components/ConditionsOfSaleDisclaimer.tsx
+++ b/src/Apps/Order/Components/ConditionsOfSaleDisclaimer.tsx
@@ -1,6 +1,7 @@
 import { Text, TextProps } from "@artsy/palette"
 import * as React from "react"
 import { RouterLink } from "System/Router/RouterLink"
+import { useFeatureFlag } from "System/useFeatureFlag"
 
 interface Props {
   textProps?: Partial<TextProps>
@@ -11,6 +12,10 @@ export const ConditionsOfSaleDisclaimer: React.FC<Props> = ({
   textProps,
   orderSource,
 }) => {
+  const newTermsAndConditionsEnabled = useFeatureFlag(
+    "diamond_new-terms-and-conditions"
+  )
+
   if (orderSource === "private_sale") {
     return (
       <Text variant="sm" color="black60" {...textProps}>
@@ -31,7 +36,14 @@ export const ConditionsOfSaleDisclaimer: React.FC<Props> = ({
     )
   }
 
-  return (
+  return newTermsAndConditionsEnabled ? (
+    <Text variant="xs" color="black60" {...textProps}>
+      By clicking Submit, I agree to Artsy’s{" "}
+      <RouterLink inline to="/terms" target="_blank">
+        General Terms and Conditions of Sale.
+      </RouterLink>
+    </Text>
+  ) : (
     <Text variant="xs" color="black60" {...textProps}>
       By clicking Submit, I agree to Artsy’s{" "}
       <RouterLink inline to="/conditions-of-sale" target="_blank">

--- a/src/Apps/Order/Routes/__tests__/Review.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Review.jest.tsx
@@ -48,6 +48,7 @@ import {
   ErrorDialogs,
   getErrorDialogCopy,
 } from "Apps/Order/Utils/getErrorDialogCopy"
+import { useFeatureFlag } from "System/useFeatureFlag"
 
 jest.unmock("react-relay")
 
@@ -83,6 +84,10 @@ jest.mock("Apps/Order/Utils/commitMutation", () => ({
   injectCommitMutation: Component => props => (
     <Component {...props} commitMutation={mockCommitMutation} />
   ),
+}))
+
+jest.mock("System/useFeatureFlag", () => ({
+  useFeatureFlag: jest.fn(),
 }))
 
 const testOrder: ReviewTestQuery$rawResponse["order"] = {
@@ -187,6 +192,40 @@ describe("Review", () => {
       const page = new ReviewTestPage(wrapper)
 
       expect(page.buyerGuarantee.length).toBe(1)
+    })
+
+    it("shows the conditions of sale disclaimer", () => {
+      const { wrapper } = getWrapper({
+        CommerceOrder: () => testOrder,
+      })
+      const page = new ReviewTestPage(wrapper)
+
+      expect(page.conditionsOfSaleDisclaimer.text()).toMatch(
+        "By clicking Submit, I agree to Artsy’s Conditions of Sale."
+      )
+    })
+
+    describe("with new terms and conditions enabled", () => {
+      beforeEach(() => {
+        ;(useFeatureFlag as jest.Mock).mockImplementation(
+          (f: string) => f === "diamond_new-terms-and-conditions"
+        )
+      })
+
+      afterEach(() => {
+        ;(useFeatureFlag as jest.Mock).mockReset()
+      })
+
+      it("shows the new conditions of sale disclaimer", () => {
+        const { wrapper } = getWrapper({
+          CommerceOrder: () => testOrder,
+        })
+        const page = new ReviewTestPage(wrapper)
+
+        expect(page.conditionsOfSaleDisclaimer.text()).toMatch(
+          "By clicking Submit, I agree to Artsy’s General Terms and Conditions of Sale."
+        )
+      })
     })
 
     it("shows an error modal when there is an error in submitOrderPayload", async () => {
@@ -432,6 +471,40 @@ describe("Review", () => {
       expect(pushMock).toBeCalledWith(
         "/artwork/artworkId?order-submitted=offer-order-id"
       )
+    })
+
+    it("shows the conditions of sale disclaimer", () => {
+      const { wrapper } = getWrapper({
+        CommerceOrder: () => testOrder,
+      })
+      const page = new ReviewTestPage(wrapper)
+
+      expect(page.conditionsOfSaleDisclaimer.text()).toMatch(
+        "By clicking Submit, I agree to Artsy’s Conditions of Sale."
+      )
+    })
+
+    describe("with new terms and conditions enabled", () => {
+      beforeEach(() => {
+        ;(useFeatureFlag as jest.Mock).mockImplementation(
+          (f: string) => f === "diamond_new-terms-and-conditions"
+        )
+      })
+
+      afterEach(() => {
+        ;(useFeatureFlag as jest.Mock).mockReset()
+      })
+
+      it("shows the new conditions of sale disclaimer", () => {
+        const { wrapper } = getWrapper({
+          CommerceOrder: () => testOrder,
+        })
+        const page = new ReviewTestPage(wrapper)
+
+        expect(page.conditionsOfSaleDisclaimer.text()).toMatch(
+          "By clicking Submit, I agree to Artsy’s General Terms and Conditions of Sale."
+        )
+      })
     })
 
     it("shows an error modal when there is an error in submitOrderPayload", async () => {


### PR DESCRIPTION
This PR updates the conditions of sale copy that can be seen at the bottom of the submit-button on the last step of the checkout flow.

| Surface | Screenshot |
|---------|------------|
| Review order | <img width="1502" alt="Screenshot 2024-03-28 at 1 14 16 PM" src="https://github.com/artsy/force/assets/44589599/682163a0-866e-4faf-a5d9-abf45eaaef48"> |
| Review offer | <img width="1251" alt="Screenshot 2024-03-28 at 1 15 48 PM" src="https://github.com/artsy/force/assets/44589599/827df33e-4658-4253-9e2a-d3f1ab4868d8"> |
| Counter counteroffer |  <img width="1502" alt="Screenshot 2024-03-28 at 1 18 44 PM" src="https://github.com/artsy/force/assets/44589599/cf4314ee-53e4-4b36-a618-d7ee7e0f8b7b"> |
| Accept counteroffer | <img width="1493" alt="Screenshot 2024-03-28 at 1 19 21 PM" src="https://github.com/artsy/force/assets/44589599/0d225e45-72ca-49e8-a1b2-a3db8e813216"> |
| Reject counteroffer | <img width="1499" alt="Screenshot 2024-03-28 at 1 19 36 PM" src="https://github.com/artsy/force/assets/44589599/47a95dd0-ef01-4c47-a7d3-5f59480c4808"> |

