### PR TITLE
feat: new disclaimer in signup dialog (DIA-533)

### DIFF
--- a/src/Components/AuthDialog/Components/AuthDialogSignUpPlaceholder.tsx
+++ b/src/Components/AuthDialog/Components/AuthDialogSignUpPlaceholder.tsx
@@ -7,9 +7,12 @@ import {
   SkeletonText,
   Spacer,
 } from "@artsy/palette"
+import { useFeatureFlag } from "System/useFeatureFlag"
 import { FC } from "react"
 
 export const AuthDialogSignUpPlaceholder: FC = () => {
+  const showNewDisclaimer = useFeatureFlag("diamond_new-terms-and-conditions")
+
   return (
     <Skeleton>
       <Join separator={<Spacer y={2} />}>
@@ -47,9 +50,9 @@ export const AuthDialogSignUpPlaceholder: FC = () => {
           textAlign="center"
           data-testid="skeleton-disclaimer"
         >
-          By clicking Sign Up or Continue with Email, Apple, Google, or
-          Facebook, you agree to Artsy’s Terms and Conditions and Privacy Policy
-          and to receiving emails from Artsy.
+          {showNewDisclaimer
+            ? "By clicking Sign Up or Continue with Email, Apple, Google, or Facebook, you agree to Artsy’s Terms and Conditions and Privacy Policy and to receiving emails from Artsy."
+            : "By clicking Sign Up or Continue with Apple, Google, or Facebook, you agree to Artsy’s Terms of Use and Privacy Policy and to receiving emails from Artsy."}
         </SkeletonText>
 
         <SkeletonText variant="xs" textAlign="center">

--- a/src/Components/AuthDialog/Components/AuthDialogSignUpPlaceholder.tsx
+++ b/src/Components/AuthDialog/Components/AuthDialogSignUpPlaceholder.tsx
@@ -42,10 +42,14 @@ export const AuthDialogSignUpPlaceholder: FC = () => {
           Already have an account? Log in.
         </SkeletonText>
 
-        <SkeletonText variant="xs" textAlign="center">
-          By clicking Sign Up or Continue with Apple, Google, or Facebook, you
-          agree to Artsy’s Terms of Use and Privacy Policy and to receiving
-          emails from Artsy.
+        <SkeletonText
+          variant="xs"
+          textAlign="center"
+          data-testid="skeleton-disclaimer"
+        >
+          By clicking Sign Up or Continue with Email, Apple, Google, or
+          Facebook, you agree to Artsy’s Terms and Conditions and Privacy Policy
+          and to receiving emails from Artsy.
         </SkeletonText>
 
         <SkeletonText variant="xs" textAlign="center">

--- a/src/Components/AuthDialog/Views/AuthDialogSignUp.tsx
+++ b/src/Components/AuthDialog/Views/AuthDialogSignUp.tsx
@@ -187,7 +187,12 @@ export const AuthDialogSignUp: FC = () => {
                 </Clickable>
               </Text>
 
-              <Text variant="xs" color="black60" textAlign="center">
+              <Text
+                variant="xs"
+                color="black60"
+                textAlign="center"
+                data-testid="disclaimer"
+              >
                 By {isTouch ? "tapping" : "clicking"} Sign Up or Continue with
                 Apple, Google, or Facebook, you agree to Artsy’s{" "}
                 <RouterLink inline to="/terms" target="_blank">

--- a/src/Components/AuthDialog/Views/AuthDialogSignUp.tsx
+++ b/src/Components/AuthDialog/Views/AuthDialogSignUp.tsx
@@ -23,6 +23,7 @@ import { useAuthDialogTracking } from "Components/AuthDialog/Hooks/useAuthDialog
 import { AuthDialogSignUpPlaceholder } from "Components/AuthDialog/Components/AuthDialogSignUpPlaceholder"
 import { useCountryCode } from "Components/AuthDialog/Hooks/useCountryCode"
 import { RouterLink } from "System/Router/RouterLink"
+import { useFeatureFlag } from "System/useFeatureFlag"
 
 export const AuthDialogSignUp: FC = () => {
   const {
@@ -35,6 +36,8 @@ export const AuthDialogSignUp: FC = () => {
   const track = useAuthDialogTracking()
 
   const { loading, countryCode } = useCountryCode()
+
+  const showNewDisclaimer = useFeatureFlag("diamond_new-terms-and-conditions")
 
   const isAutomaticallySubscribed = !!(
     countryCode && !GDPR_COUNTRY_CODES.includes(countryCode)
@@ -194,9 +197,10 @@ export const AuthDialogSignUp: FC = () => {
                 data-testid="disclaimer"
               >
                 By {isTouch ? "tapping" : "clicking"} Sign Up or Continue with
+                {showNewDisclaimer ? " Email, " : " "}
                 Apple, Google, or Facebook, you agree to Artsy’s{" "}
                 <RouterLink inline to="/terms" target="_blank">
-                  Terms of Use
+                  {showNewDisclaimer ? "Terms and Conditions" : "Terms of Use"}
                 </RouterLink>{" "}
                 and{" "}
                 <RouterLink inline to="/privacy" target="_blank">

--- a/src/Components/AuthDialog/Views/__tests__/AuthDialogSignUp.jest.tsx
+++ b/src/Components/AuthDialog/Views/__tests__/AuthDialogSignUp.jest.tsx
@@ -68,6 +68,13 @@ describe("AuthDialogSignUp", () => {
     expect(screen.getByTestId("disclaimer")).toHaveTextContent(
       "By clicking Sign Up or Continue with Apple, Google, or Facebook, you agree to Artsy’s Terms of Use and Privacy Policy and to receiving emails from Artsy."
     )
+    expect(screen.getByRole("link", { name: "Terms of Use" })).toHaveAttribute(
+      "href",
+      "/terms"
+    )
+    expect(
+      screen.getByRole("link", { name: "Privacy Policy" })
+    ).toHaveAttribute("href", "/privacy")
   })
 
   describe("when the user is on a touch device", () => {
@@ -161,6 +168,12 @@ describe("AuthDialogSignUp", () => {
       expect(screen.getByTestId("disclaimer")).toHaveTextContent(
         "By clicking Sign Up or Continue with Email, Apple, Google, or Facebook, you agree to Artsy’s Terms and Conditions and Privacy Policy and to receiving emails from Artsy."
       )
+      expect(
+        screen.getByRole("link", { name: "Terms and Conditions" })
+      ).toHaveAttribute("href", "/terms")
+      expect(
+        screen.getByRole("link", { name: "Privacy Policy" })
+      ).toHaveAttribute("href", "/privacy")
     })
   })
 

--- a/src/Components/AuthDialog/Views/__tests__/AuthDialogSignUp.jest.tsx
+++ b/src/Components/AuthDialog/Views/__tests__/AuthDialogSignUp.jest.tsx
@@ -127,8 +127,24 @@ describe("AuthDialogSignUp", () => {
       render(<AuthDialogSignUp />)
 
       expect(screen.getByTestId("skeleton-disclaimer")).toHaveTextContent(
-        "By clicking Sign Up or Continue with Email, Apple, Google, or Facebook, you agree to Artsy’s Terms and Conditions and Privacy Policy and to receiving emails from Artsy."
+        "By clicking Sign Up or Continue with Apple, Google, or Facebook, you agree to Artsy’s Terms of Use and Privacy Policy and to receiving emails from Artsy."
       )
+    })
+
+    describe("when the new disclaimer is enabled", () => {
+      beforeEach(() => {
+        ;(useFeatureFlag as jest.Mock).mockImplementation(
+          (f: string) => f === "diamond_new-terms-and-conditions"
+        )
+      })
+
+      it("renders a disclaimer with the new text", () => {
+        render(<AuthDialogSignUp />)
+
+        expect(screen.getByTestId("skeleton-disclaimer")).toHaveTextContent(
+          "By clicking Sign Up or Continue with Email, Apple, Google, or Facebook, you agree to Artsy’s Terms and Conditions and Privacy Policy and to receiving emails from Artsy."
+        )
+      })
     })
   })
 

--- a/src/Components/AuthDialog/Views/__tests__/AuthDialogSignUp.jest.tsx
+++ b/src/Components/AuthDialog/Views/__tests__/AuthDialogSignUp.jest.tsx
@@ -114,6 +114,24 @@ describe("AuthDialogSignUp", () => {
     })
   })
 
+  describe("when the country code is loading", () => {
+    beforeEach(() => {
+      const useCountryCodeMock = jest.fn().mockReturnValue({
+        loading: true,
+        countryCode: "US",
+      })
+      ;(useCountryCode as jest.Mock).mockImplementation(useCountryCodeMock)
+    })
+
+    it("renders a skeleton disclaimer", () => {
+      render(<AuthDialogSignUp />)
+
+      expect(screen.getByTestId("skeleton-disclaimer")).toHaveTextContent(
+        "By clicking Sign Up or Continue with Email, Apple, Google, or Facebook, you agree to Artsy’s Terms and Conditions and Privacy Policy and to receiving emails from Artsy."
+      )
+    })
+  })
+
   describe("when the new disclaimer is enabled", () => {
     beforeEach(() => {
       ;(useFeatureFlag as jest.Mock).mockImplementation(

--- a/src/Components/Inquiry/Views/InquirySignUp.tsx
+++ b/src/Components/Inquiry/Views/InquirySignUp.tsx
@@ -32,6 +32,7 @@ import {
   useInquiryAccountContext,
 } from "Components/Inquiry/Views/InquiryAccount"
 import { formatErrorMessage } from "Components/AuthDialog/Utils/formatErrorMessage"
+import { useFeatureFlag } from "System/useFeatureFlag"
 
 type Mode = "Pending" | "Loading" | "Error" | "Done" | "Success"
 
@@ -58,6 +59,8 @@ export const InquirySignUp: React.FC = () => {
   } = useInquiryContext()
 
   const { submitArtworkInquiryRequest } = useArtworkInquiryRequest()
+
+  const showNewDisclaimer = useFeatureFlag("diamond_new-terms-and-conditions")
 
   const [state, setState] = useState<InquirySignUpState>({
     name: "",
@@ -200,18 +203,22 @@ export const InquirySignUp: React.FC = () => {
         <Spacer y={2} />
 
         <Text variant="xs" color="black60" data-testid="disclaimer">
-          By signing up, you agree to our{" "}
+          By signing up, you agree to {showNewDisclaimer ? "Artsy's" : "our"}{" "}
           <RouterLink inline to="/terms" target="_blank">
-            Terms of Use
+            {showNewDisclaimer ? "Terms and Conditions" : "Terms of Use"}
           </RouterLink>
           ,{" "}
           <RouterLink inline to="/privacy" target="_blank">
             Privacy Policy
           </RouterLink>
-          ,{" "}
-          <RouterLink inline to="/conditions-of-sale" target="_blank">
-            Conditions of Sale
-          </RouterLink>{" "}
+          {!showNewDisclaimer && (
+            <>
+              {", "}
+              <RouterLink inline to="/conditions-of-sale" target="_blank">
+                Conditions of Sale
+              </RouterLink>
+            </>
+          )}{" "}
           and to receiving emails from Artsy.
         </Text>
 

--- a/src/Components/Inquiry/Views/InquirySignUp.tsx
+++ b/src/Components/Inquiry/Views/InquirySignUp.tsx
@@ -199,7 +199,7 @@ export const InquirySignUp: React.FC = () => {
 
         <Spacer y={2} />
 
-        <Text variant="xs" color="black60">
+        <Text variant="xs" color="black60" data-testid="disclaimer">
           By signing up, you agree to our{" "}
           <RouterLink inline to="/terms" target="_blank">
             Terms of Use

--- a/src/Components/Inquiry/__tests__/Views/InquirySignUp.jest.tsx
+++ b/src/Components/Inquiry/__tests__/Views/InquirySignUp.jest.tsx
@@ -7,12 +7,14 @@ import { useInquiryContext } from "Components/Inquiry/Hooks/useInquiryContext"
 import { fill } from "Components/Inquiry/__tests__/util"
 import { useTracking } from "react-tracking"
 import { render, screen } from "@testing-library/react"
+import { useFeatureFlag } from "System/useFeatureFlag"
 
 jest.mock("Utils/auth")
 jest.mock("../../Hooks/useArtworkInquiryRequest")
 jest.mock("../../Hooks/useInquiryContext")
 jest.mock("Utils/wait", () => ({ wait: () => Promise.resolve() }))
 jest.mock("react-tracking")
+jest.mock("System/useFeatureFlag")
 
 describe("InquirySignUp", () => {
   const next = jest.fn()
@@ -63,6 +65,41 @@ describe("InquirySignUp", () => {
     expect(screen.getByTestId("disclaimer")).toHaveTextContent(
       "By signing up, you agree to our Terms of Use, Privacy Policy, Conditions of Sale and to receiving emails from Artsy."
     )
+    expect(screen.getByRole("link", { name: "Terms of Use" })).toHaveAttribute(
+      "href",
+      "/terms"
+    )
+    expect(
+      screen.getByRole("link", { name: "Privacy Policy" })
+    ).toHaveAttribute("href", "/privacy")
+    expect(
+      screen.getByRole("link", { name: "Conditions of Sale" })
+    ).toHaveAttribute("href", "/conditions-of-sale")
+  })
+
+  describe("when the new disclaimer is enabled", () => {
+    beforeEach(() => {
+      ;(useFeatureFlag as jest.Mock).mockImplementation(
+        (f: string) => f === "diamond_new-terms-and-conditions"
+      )
+    })
+
+    it("renders the new disclaimer", () => {
+      render(<InquirySignUp />)
+
+      expect(screen.getByTestId("disclaimer")).toHaveTextContent(
+        "By signing up, you agree to Artsy's Terms and Conditions, Privacy Policy and to receiving emails from Artsy."
+      )
+      expect(
+        screen.getByRole("link", { name: "Terms and Conditions" })
+      ).toHaveAttribute("href", "/terms")
+      expect(
+        screen.getByRole("link", { name: "Privacy Policy" })
+      ).toHaveAttribute("href", "/privacy")
+      expect(
+        screen.queryByRole("link", { name: "Conditions of Sale" })
+      ).not.toBeInTheDocument()
+    })
   })
 
   describe("success", () => {

--- a/src/Components/Inquiry/__tests__/Views/InquirySignUp.jest.tsx
+++ b/src/Components/Inquiry/__tests__/Views/InquirySignUp.jest.tsx
@@ -6,6 +6,7 @@ import { signUp } from "Utils/auth"
 import { useInquiryContext } from "Components/Inquiry/Hooks/useInquiryContext"
 import { fill } from "Components/Inquiry/__tests__/util"
 import { useTracking } from "react-tracking"
+import { render, screen } from "@testing-library/react"
 
 jest.mock("Utils/auth")
 jest.mock("../../Hooks/useArtworkInquiryRequest")
@@ -54,6 +55,14 @@ describe("InquirySignUp", () => {
     const wrapper = mount(<InquirySignUp />)
 
     expect(wrapper.html()).toContain("Sign up to send your message")
+  })
+
+  it("renders a disclaimer", () => {
+    render(<InquirySignUp />)
+
+    expect(screen.getByTestId("disclaimer")).toHaveTextContent(
+      "By signing up, you agree to our Terms of Use, Privacy Policy, Conditions of Sale and to receiving emails from Artsy."
+    )
   })
 
   describe("success", () => {


### PR DESCRIPTION
This PR updates the disclaimer at the bottom of the signup dialog behind a feature flag. In addition to the default signup dialog, there is a skeleton loader for that dialog, as well as a signup dialog in the inquiry flow that needs to be updated.

| Before | After |
|-------|------|
| <img width="1436" alt="before_auth_signup" src="https://github.com/artsy/force/assets/44589599/35a680a1-c81a-4d70-bb7f-155a99a1448e"> | <img width="1436" alt="after_auth_signup" src="https://github.com/artsy/force/assets/44589599/1eb44634-de6e-4825-b5f2-5c3ece2973ff"> |
| <img width="1436" alt="before_inquiry_signup" src="https://github.com/artsy/force/assets/44589599/e08e62b5-63cc-4cb6-84e7-e13a7d428134"> | <img width="1436" alt="after_inquiry_signup" src="https://github.com/artsy/force/assets/44589599/02817888-6977-48b4-8787-0abf15ec9afb"> |

