### PR TITLE
fix: fixes View Artworks link alignment on Your Alerts page

### DIFF
--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertListItem.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertListItem.tsx
@@ -24,6 +24,7 @@ export const SavedSearchAlertListItem: React.FC<SavedSearchAlertListItemProps> =
     <Box
       key={item.internalID}
       px={[2, 4]}
+      pr={[2, 2]}
       py={4}
       bg={variant === "active" ? "black5" : "white100"}
     >
@@ -63,7 +64,11 @@ export const SavedSearchAlertListItem: React.FC<SavedSearchAlertListItemProps> =
           </Flex>
           <Spacer x={2} y={2} />
         </Flex>
-        <Flex flexDirection="row" alignItems={["flex-start", "center"]}>
+        <Flex
+          flexDirection="row"
+          alignItems={["flex-start", "center"]}
+          minWidth="200px"
+        >
           <Text
             variant="sm"
             textColor={[


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Aligns links evenly depending on different artwork count:

| Before | After |
|---|---|
| <img width="300px" alt="Screenshot 2024-04-02 at 15 41 28" src="https://github.com/artsy/force/assets/3934579/b47f699c-1c4d-4cd2-8e45-525470fc5171"> | <img width="300px" alt="Screenshot 2024-04-02 at 15 41 39" src="https://github.com/artsy/force/assets/3934579/69d8d74c-9b64-4768-bd53-d326c4385bfe"> |
