### PR TITLE
fix: fixes sup colors for desktop on your alerts screen

### DIFF
--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertListItem.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertListItem.tsx
@@ -105,7 +105,11 @@ export const SavedSearchAlertListItem: React.FC<SavedSearchAlertListItemProps> =
               View Artworks
             </Clickable>
             &nbsp;
-            <Sup color="brand">{matchingArtworksCount}</Sup>
+            <Sup
+              textColor={["brand", variant === "active" ? "brand" : "black60"]}
+            >
+              {matchingArtworksCount}
+            </Sup>
           </Text>
         </Flex>
       </Flex>


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Fixes [this bug feedback](https://www.notion.so/artsy/Artwork-counts-colors-should-depend-on-whether-selected-or-not-95ac5f4014e4436fb4d5f6067ffdb8c5?pvs=4). Artwork counts’ colors should be blue only for selected item on Desktop:

<img width="1509" alt="Screenshot 2024-04-02 at 15 50 52" src="https://github.com/artsy/force/assets/3934579/f3c04b69-1ba2-4a0a-be6b-62ace11c9831">
