### PR TITLE
feat: move availability filter to correct position

### DIFF
--- a/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters.tsx
@@ -29,13 +29,13 @@ export const ArtistArtworkFilters: React.FC<ArtistArtworkFiltersProps> = props =
   return (
     <Join separator={<Spacer y={4} />}>
       <KeywordFilter />
-      {isAvailabilityFilterEnabled && <AvailabilityFilter />}
       <ArtistsFilter user={user} expanded />
       <AttributionClassFilter expanded />
       <MediumFilter expanded />
       <PriceRangeFilter expanded />
       {isArtistSeriesFilterEnabled && <ArtistSeriesFilter expanded />}
       <SizeFilter expanded />
+      {isAvailabilityFilterEnabled && <AvailabilityFilter />}
       <WaysToBuyFilter expanded />
       <MaterialsFilter />
       <ArtistNationalityFilter />


### PR DESCRIPTION
The type of this PR is: **Feat**

### Description

As discussed in Onyx KS, this is a quick change to move the Availability filter closer to Ways to Buy, since these facets are kind of related thematically.

![avail](https://github.com/artsy/force/assets/140521/7ca9ee5a-7277-445a-bc0c-9e7aeb9b2391)
