### PR TITLE
feat(MyC, SwA): present disambiguating info when selecting an artist

### DIFF
--- a/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtistAutocomplete.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtistAutocomplete.tsx
@@ -96,8 +96,8 @@ export const ArtistAutoComplete: React.FC<{
           const options = extractNodes(suggestions)
           setSuggestions(
             options.map((option: any) => ({
-              text: option.displayLabel!,
-              value: option.internalID!,
+              text: option.displayLabel,
+              value: option.internalID,
               option,
             }))
           )
@@ -167,9 +167,14 @@ export const ArtistAutoComplete: React.FC<{
         ) : (
           <Box width={44} height={44} backgroundColor="black10" />
         )}
-        <Text ml={1} variant="sm-display">
-          {option.text}
-        </Text>
+        <Flex flexDirection={"column"}>
+          <Text ml={1} variant="sm-display">
+            {option.text}
+          </Text>
+          <Text ml={1} lineHeight={1.5} variant="sm-display" color="black60">
+            {option.option?.formattedNationalityAndBirthday}
+          </Text>
+        </Flex>
       </Flex>
     )
   }
@@ -226,7 +231,7 @@ const fetchSuggestions = async (
                 internalID
                 isPersonalArtist
                 image {
-                  cropped(width: 44, height: 44) {
+                  cropped(width: 50, height: 50) {
                     height
                     src
                     srcSet

--- a/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtistAutocomplete.jest.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtistAutocomplete.jest.tsx
@@ -21,6 +21,7 @@ const results = {
         node: {
           displayLabel: "Banksy",
           internalID: "111",
+          formattedNationalityAndBirthday: "British, b. 1974",
           image: {
             cropped: {
               height: 44,
@@ -31,7 +32,13 @@ const results = {
           },
         },
       },
-      { node: { displayLabel: "Andy Warhol", internalID: "222" } },
+      {
+        node: {
+          displayLabel: "Andy Warhol",
+          formattedNationalityAndBirthday: "American, 1928–1987",
+          internalID: "222",
+        },
+      },
     ],
   },
 }
@@ -158,7 +165,21 @@ describe("ArtistAutocomplete", () => {
       const suggestions = wrapper.find(optionsSelector)
 
       suggestions.forEach((node, idx) => {
-        expect(node.text()).toBe(correctSuggestionsLabels[idx])
+        expect(node.text()).toContain(correctSuggestionsLabels[idx])
+      })
+    })
+
+    it("render disambiguating info", async () => {
+      const correctDisambiguatingInfo = [
+        "British, b. 1974",
+        "American, 1928–1987",
+      ]
+      await simulateTyping(wrapper, "Ban")
+
+      const suggestions = wrapper.find(optionsSelector)
+
+      suggestions.forEach((node, idx) => {
+        expect(node.text()).toContain(correctDisambiguatingInfo[idx])
       })
     })
 

--- a/src/__generated__/ArtistAutocomplete_SearchConnection_Query.graphql.ts
+++ b/src/__generated__/ArtistAutocomplete_SearchConnection_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f6113367e7a762f968731d67e891d39c>>
+ * @generated SignedSource<<aa3bff6dab434e3af2b2652e0bbd4f30>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -152,12 +152,12 @@ v3 = {
             {
               "kind": "Literal",
               "name": "height",
-              "value": 44
+              "value": 50
             },
             {
               "kind": "Literal",
               "name": "width",
-              "value": 44
+              "value": 50
             }
           ],
           "concreteType": "CroppedImageUrl",
@@ -194,7 +194,7 @@ v3 = {
               "storageKey": null
             }
           ],
-          "storageKey": "cropped(height:44,width:44)"
+          "storageKey": "cropped(height:50,width:50)"
         }
       ],
       "storageKey": null
@@ -332,16 +332,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ee6256efc8eabd5b60a0802259ae7d86",
+    "cacheID": "931ba7dbc4798dc45f8396a59f0defc9",
     "id": null,
     "metadata": {},
     "name": "ArtistAutocomplete_SearchConnection_Query",
     "operationKind": "query",
-    "text": "query ArtistAutocomplete_SearchConnection_Query(\n  $searchQuery: String!\n) {\n  searchConnection(query: $searchQuery, entities: ARTIST, mode: AUTOSUGGEST, first: 6) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        ... on Artist {\n          counts {\n            artworks\n          }\n          formattedNationalityAndBirthday\n          name\n          initials\n          internalID\n          isPersonalArtist\n          image {\n            cropped(width: 44, height: 44) {\n              height\n              src\n              srcSet\n              width\n            }\n          }\n          targetSupply {\n            isP1\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query ArtistAutocomplete_SearchConnection_Query(\n  $searchQuery: String!\n) {\n  searchConnection(query: $searchQuery, entities: ARTIST, mode: AUTOSUGGEST, first: 6) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        ... on Artist {\n          counts {\n            artworks\n          }\n          formattedNationalityAndBirthday\n          name\n          initials\n          internalID\n          isPersonalArtist\n          image {\n            cropped(width: 50, height: 50) {\n              height\n              src\n              srcSet\n              width\n            }\n          }\n          targetSupply {\n            isP1\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "c6318c01fb735a86d53e0671cc16bd24";
+(node as any).hash = "ac1f90f42bb270a699e1b608dba94473";
 
 export default node;


### PR DESCRIPTION
> [!IMPORTANT]  
> As a reminder, **any** time we present a list of artists from which a user will select, we should also display disambiguating info: nationality, birth date, death date.

This PR solves [ONYX-438]

### Description

(Counterpart to https://github.com/artsy/eigen/pull/10018)

This adds disambiguating information to the artist selection UI that is used in both My Collection and Sell with Artsy, for similar reasons as stated in the Eigen PR — to minimize the risk of misattributed works and duplicated artist data.

## My Collection

Before and after…

![myc](https://github.com/artsy/force/assets/140521/0c4ded28-2673-4b7b-8f1a-ca1a182d87da)

---

## Sell with Artsy

Before and after…

![swa](https://github.com/artsy/force/assets/140521/14e0d6dc-e707-46f0-9961-ac45996bde67)



[ONYX-438]: https://artsyproduct.atlassian.net/browse/ONYX-438?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ