### PR TITLE
fix(termsupdate): ignores integrity

### DIFF
--- a/src/Components/TermsUpdateDialog.tsx
+++ b/src/Components/TermsUpdateDialog.tsx
@@ -2,12 +2,15 @@ import Cookies from "cookies-js"
 import { Button, ModalDialog, Text } from "@artsy/palette"
 import { FC, useEffect, useState } from "react"
 import { useFeatureFlag } from "System/useFeatureFlag"
+import { getENV } from "Utils/getENV"
 
 const TERMS_UPDATE_DIALOG_KEY = "terms-update-2024-dismissed"
 
 interface TermsUpdateDialogProps {}
 
 export const TermsUpdateDialog: FC<TermsUpdateDialogProps> = () => {
+  const isIntegrity = getENV("USER_AGENT") === "ArtsyIntegrity"
+
   const isTermsUpdateActive = useFeatureFlag("diamond_new-terms-and-conditions")
 
   const [isDisplayable, setIsDisplayable] = useState(false)
@@ -18,13 +21,13 @@ export const TermsUpdateDialog: FC<TermsUpdateDialogProps> = () => {
   }
 
   useEffect(() => {
-    if (!isTermsUpdateActive) return
+    if (isIntegrity || !isTermsUpdateActive) return
 
     const isDismissed = Cookies.get(TERMS_UPDATE_DIALOG_KEY)
     if (isDismissed) return
 
     setIsDisplayable(true)
-  }, [isTermsUpdateActive])
+  }, [isIntegrity, isTermsUpdateActive])
 
   if (!isDisplayable) {
     return null

--- a/src/Typings/sharify.d.ts
+++ b/src/Typings/sharify.d.ts
@@ -110,6 +110,7 @@ declare module "sharify" {
       TARGET_CAMPAIGN_URL: string
       THIRD_PARTIES_DISABLED: boolean
       TRACK_PAGELOAD_PATHS: string
+      USER_AGENT: string
       USER_PREFERENCES: any
       VOLLEY_ENDPOINT: string
       WEBFONT_URL: string


### PR DESCRIPTION
If running as part of an Integrity spec, do not show the terms update dialog. Turns out it's tricky to globally accept within Integrity.