### PR TITLE
fix: a cornucopia of terms and conditions changes

### DIFF
--- a/src/Apps/Auction/Components/Form/ConditionsOfSaleCheckbox.tsx
+++ b/src/Apps/Auction/Components/Form/ConditionsOfSaleCheckbox.tsx
@@ -23,7 +23,11 @@ export const ConditionsOfSaleCheckbox: React.FC = () => {
 
   return (
     <>
-      <Checkbox selected={values.agreeToTerms} onSelect={handleCheckboxSelect}>
+      <Checkbox
+        selected={values.agreeToTerms}
+        onSelect={handleCheckboxSelect}
+        data-testid="disclaimer"
+      >
         {showNewDisclaimer ? (
           <Text variant="sm-display" ml={0.5}>
             I agree to Artsy's{" "}
@@ -31,7 +35,7 @@ export const ConditionsOfSaleCheckbox: React.FC = () => {
               inline
               display="inline"
               color="black100"
-              to="/conditions-of-sale"
+              to="/terms"
               target="_blank"
             >
               General Terms and Conditions of Sale

--- a/src/Apps/Auction/Components/Form/ConditionsOfSaleCheckbox.tsx
+++ b/src/Apps/Auction/Components/Form/ConditionsOfSaleCheckbox.tsx
@@ -12,9 +12,7 @@ export const ConditionsOfSaleCheckbox: React.FC = () => {
     setFieldValue,
   } = useFormContext()
 
-  const newTermsAndConditionsEnabled = useFeatureFlag(
-    "diamond_new-terms-and-conditions"
-  )
+  const showNewDisclaimer = useFeatureFlag("diamond_new-terms-and-conditions")
 
   const showErrorMessage = !!(touched.agreeToTerms && errors.agreeToTerms)
 
@@ -26,7 +24,7 @@ export const ConditionsOfSaleCheckbox: React.FC = () => {
   return (
     <>
       <Checkbox selected={values.agreeToTerms} onSelect={handleCheckboxSelect}>
-        {newTermsAndConditionsEnabled ? (
+        {showNewDisclaimer ? (
           <Text variant="sm-display" ml={0.5}>
             I agree to Artsy's{" "}
             <RouterLink

--- a/src/Apps/Auction/Components/Form/__tests__/ConditionsOfSaleCheckbox.jest.tsx
+++ b/src/Apps/Auction/Components/Form/__tests__/ConditionsOfSaleCheckbox.jest.tsx
@@ -9,7 +9,6 @@ jest.mock("System/useFeatureFlag")
 
 describe("ConditionsOfSaleCheckbox", () => {
   const mockUseFormContext = useFormContext as jest.Mock
-  const mockUseFeatureFlag = useFeatureFlag as jest.Mock
   const setFieldTouched = jest.fn()
   const setFieldValue = jest.fn()
   const formProps = {
@@ -45,13 +44,13 @@ describe("ConditionsOfSaleCheckbox", () => {
 
   describe("when the new disclaimer is enabled", () => {
     beforeAll(() => {
-      mockUseFeatureFlag.mockImplementation(
+      ;(useFeatureFlag as jest.Mock).mockImplementation(
         (f: string) => f === "diamond_new-terms-and-conditions"
       )
     })
 
     afterAll(() => {
-      mockUseFeatureFlag.mockReset()
+      ;(useFeatureFlag as jest.Mock).mockReset()
     })
 
     it("renders the new disclaimer", () => {

--- a/src/Apps/Auction/Components/Form/__tests__/ConditionsOfSaleCheckbox.jest.tsx
+++ b/src/Apps/Auction/Components/Form/__tests__/ConditionsOfSaleCheckbox.jest.tsx
@@ -2,15 +2,14 @@ import { mount } from "enzyme"
 import { useFormContext } from "Apps/Auction/Hooks/useFormContext"
 import { ConditionsOfSaleCheckbox } from "Apps/Auction/Components/Form/ConditionsOfSaleCheckbox"
 import { useFeatureFlag } from "System/useFeatureFlag"
+import { render, screen } from "@testing-library/react"
 
 jest.mock("Apps/Auction/Hooks/useFormContext")
-
-jest.mock("System/useFeatureFlag", () => ({
-  useFeatureFlag: jest.fn(),
-}))
+jest.mock("System/useFeatureFlag")
 
 describe("ConditionsOfSaleCheckbox", () => {
   const mockUseFormContext = useFormContext as jest.Mock
+  const mockUseFeatureFlag = useFeatureFlag as jest.Mock
   const setFieldTouched = jest.fn()
   const setFieldValue = jest.fn()
   const formProps = {
@@ -31,27 +30,41 @@ describe("ConditionsOfSaleCheckbox", () => {
     })
   })
 
-  it("renders correct components", () => {
-    const wrapper = getWrapper()
-    expect(wrapper.find("Checkbox")).toHaveLength(1)
-    expect(wrapper.text()).toContain(
+  it("renders a disclaimer", () => {
+    render(<ConditionsOfSaleCheckbox />)
+
+    expect(screen.getByTestId("disclaimer")).toHaveTextContent(
       "I agree to the Conditions of Sale. I understand that all bids are binding and may not be retracted."
     )
+    expect(
+      screen.getByRole("link", {
+        name: "Conditions of Sale",
+      })
+    ).toHaveAttribute("href", "/conditions-of-sale")
   })
 
-  describe("new terms and conditions enabled", () => {
-    beforeEach(() => {
-      ;(useFeatureFlag as jest.Mock).mockImplementation(
+  describe("when the new disclaimer is enabled", () => {
+    beforeAll(() => {
+      mockUseFeatureFlag.mockImplementation(
         (f: string) => f === "diamond_new-terms-and-conditions"
       )
     })
 
-    it("renders correct components", () => {
-      const wrapper = getWrapper()
-      expect(wrapper.find("Checkbox")).toHaveLength(1)
-      expect(wrapper.text()).toContain(
+    afterAll(() => {
+      mockUseFeatureFlag.mockReset()
+    })
+
+    it("renders the new disclaimer", () => {
+      render(<ConditionsOfSaleCheckbox />)
+
+      expect(screen.getByTestId("disclaimer")).toHaveTextContent(
         "I agree to Artsy's General Terms and Conditions of Sale. I understand that all bids are binding and may not be retracted."
       )
+      expect(
+        screen.getByRole("link", {
+          name: "General Terms and Conditions of Sale",
+        })
+      ).toHaveAttribute("href", "/terms")
     })
   })
 
@@ -76,10 +89,5 @@ describe("ConditionsOfSaleCheckbox", () => {
     wrapper.find("Checkbox").simulate("click")
     expect(setFieldTouched).toHaveBeenCalledWith("agreeToTerms")
     expect(setFieldValue).toHaveBeenCalledWith("agreeToTerms", true)
-  })
-
-  it("links out to conditions of sale", () => {
-    const wrapper = getWrapper()
-    expect(wrapper.html()).toContain('href="/conditions-of-sale"')
   })
 })

--- a/src/Apps/Order/Components/ConditionsOfSaleDisclaimer.tsx
+++ b/src/Apps/Order/Components/ConditionsOfSaleDisclaimer.tsx
@@ -12,9 +12,7 @@ export const ConditionsOfSaleDisclaimer: React.FC<Props> = ({
   textProps,
   orderSource,
 }) => {
-  const newTermsAndConditionsEnabled = useFeatureFlag(
-    "diamond_new-terms-and-conditions"
-  )
+  const showNewDisclaimer = useFeatureFlag("diamond_new-terms-and-conditions")
 
   if (orderSource === "private_sale") {
     return (
@@ -36,7 +34,7 @@ export const ConditionsOfSaleDisclaimer: React.FC<Props> = ({
     )
   }
 
-  return newTermsAndConditionsEnabled ? (
+  return showNewDisclaimer ? (
     <Text variant="xs" color="black60" {...textProps}>
       By clicking Submit, I agree to Artsy’s{" "}
       <RouterLink inline to="/terms" target="_blank">

--- a/src/Apps/Order/Routes/__tests__/Reject.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Reject.jest.tsx
@@ -12,10 +12,12 @@ import { OrderAppTestPage } from "./Utils/OrderAppTestPage"
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
 import { MockBoot } from "DevTools/MockBoot"
 import { useFeatureFlag } from "System/useFeatureFlag"
+import { RouterLink } from "System/Router/RouterLink"
 
 jest.mock("Utils/getCurrentTimeAsIsoString")
 const NOW = "2018-12-05T13:47:16.446Z"
 require("Utils/getCurrentTimeAsIsoString").__setCurrentTime(NOW)
+jest.mock("System/useFeatureFlag")
 
 jest.mock("@artsy/palette", () => {
   return {
@@ -34,10 +36,6 @@ jest.mock("@artsy/palette", () => {
 })
 
 jest.unmock("react-relay")
-
-jest.mock("System/useFeatureFlag", () => ({
-  useFeatureFlag: jest.fn(),
-}))
 
 const realSetInterval = global.setInterval
 
@@ -121,20 +119,23 @@ describe("Buyer rejects seller offer", () => {
       expect(page.conditionsOfSaleDisclaimer.text()).toMatch(
         "By clicking Submit, I agree to Artsy’s Conditions of Sale."
       )
+      expect(
+        page.conditionsOfSaleDisclaimer.find(RouterLink).props().to
+      ).toEqual("/conditions-of-sale")
     })
 
-    describe("with new terms and conditions enabled", () => {
-      beforeEach(() => {
+    describe("when new disclaimers are enabled", () => {
+      beforeAll(() => {
         ;(useFeatureFlag as jest.Mock).mockImplementation(
           (f: string) => f === "diamond_new-terms-and-conditions"
         )
       })
 
-      afterEach(() => {
+      afterAll(() => {
         ;(useFeatureFlag as jest.Mock).mockReset()
       })
 
-      it("renders the new terms and conditions disclaimer", () => {
+      it("renders the new disclaimer", () => {
         const { wrapper } = getWrapper({
           CommerceOrder: () => testOrder,
         })
@@ -143,6 +144,9 @@ describe("Buyer rejects seller offer", () => {
         expect(page.conditionsOfSaleDisclaimer.text()).toMatch(
           "By clicking Submit, I agree to Artsy’s General Terms and Conditions of Sale."
         )
+        expect(
+          page.conditionsOfSaleDisclaimer.find(RouterLink).props().to
+        ).toEqual("/terms")
       })
     })
 

--- a/src/Apps/Order/Routes/__tests__/Review.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Review.jest.tsx
@@ -49,6 +49,7 @@ import {
   getErrorDialogCopy,
 } from "Apps/Order/Utils/getErrorDialogCopy"
 import { useFeatureFlag } from "System/useFeatureFlag"
+import { RouterLink } from "System/Router/RouterLink"
 
 jest.unmock("react-relay")
 
@@ -69,6 +70,7 @@ jest.mock("@stripe/stripe-js", () => {
   }
 })
 const { loadStripe, _mockStripe } = require("@stripe/stripe-js")
+jest.mock("System/useFeatureFlag")
 
 const mockShowErrorDialog = jest.fn()
 jest.mock("Apps/Order/Dialogs", () => ({
@@ -84,10 +86,6 @@ jest.mock("Apps/Order/Utils/commitMutation", () => ({
   injectCommitMutation: Component => props => (
     <Component {...props} commitMutation={mockCommitMutation} />
   ),
-}))
-
-jest.mock("System/useFeatureFlag", () => ({
-  useFeatureFlag: jest.fn(),
 }))
 
 const testOrder: ReviewTestQuery$rawResponse["order"] = {
@@ -203,20 +201,23 @@ describe("Review", () => {
       expect(page.conditionsOfSaleDisclaimer.text()).toMatch(
         "By clicking Submit, I agree to Artsy’s Conditions of Sale."
       )
+      expect(
+        page.conditionsOfSaleDisclaimer.find(RouterLink).props().to
+      ).toEqual("/conditions-of-sale")
     })
 
-    describe("with new terms and conditions enabled", () => {
-      beforeEach(() => {
+    describe("when the new disclaimer is enabled", () => {
+      beforeAll(() => {
         ;(useFeatureFlag as jest.Mock).mockImplementation(
           (f: string) => f === "diamond_new-terms-and-conditions"
         )
       })
 
-      afterEach(() => {
+      afterAll(() => {
         ;(useFeatureFlag as jest.Mock).mockReset()
       })
 
-      it("shows the new conditions of sale disclaimer", () => {
+      it("renders the new disclaimer", () => {
         const { wrapper } = getWrapper({
           CommerceOrder: () => testOrder,
         })
@@ -225,6 +226,9 @@ describe("Review", () => {
         expect(page.conditionsOfSaleDisclaimer.text()).toMatch(
           "By clicking Submit, I agree to Artsy’s General Terms and Conditions of Sale."
         )
+        expect(
+          page.conditionsOfSaleDisclaimer.find(RouterLink).props().to
+        ).toEqual("/terms")
       })
     })
 
@@ -484,18 +488,18 @@ describe("Review", () => {
       )
     })
 
-    describe("with new terms and conditions enabled", () => {
-      beforeEach(() => {
+    describe("when the new disclaimer is enabled", () => {
+      beforeAll(() => {
         ;(useFeatureFlag as jest.Mock).mockImplementation(
           (f: string) => f === "diamond_new-terms-and-conditions"
         )
       })
 
-      afterEach(() => {
+      afterAll(() => {
         ;(useFeatureFlag as jest.Mock).mockReset()
       })
 
-      it("shows the new conditions of sale disclaimer", () => {
+      it("renders the new disclaimer", () => {
         const { wrapper } = getWrapper({
           CommerceOrder: () => testOrder,
         })
@@ -504,6 +508,9 @@ describe("Review", () => {
         expect(page.conditionsOfSaleDisclaimer.text()).toMatch(
           "By clicking Submit, I agree to Artsy’s General Terms and Conditions of Sale."
         )
+        expect(
+          page.conditionsOfSaleDisclaimer.find(RouterLink).props().to
+        ).toEqual("/terms")
       })
     })
 

--- a/src/Components/AuthDialog/Views/__tests__/AuthDialogSignUp.jest.tsx
+++ b/src/Components/AuthDialog/Views/__tests__/AuthDialogSignUp.jest.tsx
@@ -29,23 +29,15 @@ jest.mock("Utils/device", () => ({
   },
 }))
 
-// mocks the country code hook to return a specific country code
-jest.mock("Components/AuthDialog/Hooks/useCountryCode", () => ({
-  useCountryCode: jest.fn(),
-}))
-
-// mocks the feature flag hook to enable the new disclaimer
-jest.mock("System/useFeatureFlag", () => ({
-  useFeatureFlag: jest.fn(),
-}))
+jest.mock("Components/AuthDialog/Hooks/useCountryCode")
+jest.mock("System/useFeatureFlag")
 
 describe("AuthDialogSignUp", () => {
-  beforeEach(() => {
-    const useCountryCodeMock = jest.fn().mockReturnValue({
+  beforeAll(() => {
+    ;(useCountryCode as jest.Mock).mockImplementation(() => ({
       loading: false,
       countryCode: "US",
-    })
-    ;(useCountryCode as jest.Mock).mockImplementation(useCountryCodeMock)
+    }))
   })
 
   it("renders correctly", () => {
@@ -96,20 +88,18 @@ describe("AuthDialogSignUp", () => {
   })
 
   describe("when the user is in a GDPR country", () => {
-    beforeEach(() => {
-      const useCountryCodeMock = jest.fn().mockReturnValue({
+    beforeAll(() => {
+      ;(useCountryCode as jest.Mock).mockImplementation(() => ({
         loading: false,
         countryCode: "DE",
-      })
-      ;(useCountryCode as jest.Mock).mockImplementation(useCountryCodeMock)
+      }))
     })
 
-    afterEach(() => {
-      const useCountryCodeMock = jest.fn().mockReturnValue({
+    afterAll(() => {
+      ;(useCountryCode as jest.Mock).mockImplementation(() => ({
         loading: false,
         countryCode: "US",
-      })
-      ;(useCountryCode as jest.Mock).mockImplementation(useCountryCodeMock)
+      }))
     })
 
     it("renders a disclaimer without the bit about receiving emails", () => {
@@ -122,12 +112,18 @@ describe("AuthDialogSignUp", () => {
   })
 
   describe("when the country code is loading", () => {
-    beforeEach(() => {
-      const useCountryCodeMock = jest.fn().mockReturnValue({
+    beforeAll(() => {
+      ;(useCountryCode as jest.Mock).mockImplementation(() => ({
         loading: true,
         countryCode: "US",
-      })
-      ;(useCountryCode as jest.Mock).mockImplementation(useCountryCodeMock)
+      }))
+    })
+
+    afterAll(() => {
+      ;(useCountryCode as jest.Mock).mockImplementation(() => ({
+        loading: false,
+        countryCode: "US",
+      }))
     })
 
     it("renders a skeleton disclaimer", () => {
@@ -139,10 +135,14 @@ describe("AuthDialogSignUp", () => {
     })
 
     describe("when the new disclaimer is enabled", () => {
-      beforeEach(() => {
+      beforeAll(() => {
         ;(useFeatureFlag as jest.Mock).mockImplementation(
           (f: string) => f === "diamond_new-terms-and-conditions"
         )
+      })
+
+      afterAll(() => {
+        ;(useFeatureFlag as jest.Mock).mockReset()
       })
 
       it("renders a disclaimer with the new text", () => {
@@ -156,10 +156,14 @@ describe("AuthDialogSignUp", () => {
   })
 
   describe("when the new disclaimer is enabled", () => {
-    beforeEach(() => {
+    beforeAll(() => {
       ;(useFeatureFlag as jest.Mock).mockImplementation(
         (f: string) => f === "diamond_new-terms-and-conditions"
       )
+    })
+
+    afterAll(() => {
+      ;(useFeatureFlag as jest.Mock).mockReset()
     })
 
     it("renders a disclaimer with the new text", () => {

--- a/src/Components/Footer/Footer.tsx
+++ b/src/Components/Footer/Footer.tsx
@@ -277,9 +277,7 @@ export const Footer: React.FC<FooterProps> = props => {
 
 const PolicyLinks = () => {
   const { CCPARequestComponent, showCCPARequest } = useCCPARequest()
-  const newTermsAndConditionsEnabled = useFeatureFlag(
-    "diamond_new-terms-and-conditions"
-  )
+  const showNewDisclaimer = useFeatureFlag("diamond_new-terms-and-conditions")
 
   return (
     <>
@@ -294,7 +292,7 @@ const PolicyLinks = () => {
       >
         <Flex mr={1}>© {new Date().getFullYear()} Artsy</Flex>
 
-        {newTermsAndConditionsEnabled ? (
+        {showNewDisclaimer ? (
           <>
             <FooterLink color="black60" mr={1} to="/terms">
               Terms and Conditions

--- a/src/Components/Footer/Footer.tsx
+++ b/src/Components/Footer/Footer.tsx
@@ -298,7 +298,7 @@ const PolicyLinks = () => {
               Terms and Conditions
             </FooterLink>
 
-            <FooterLink color="black60" mr={1} to="/supplemental-auction-COS">
+            <FooterLink color="black60" mr={1} to="/supplemental-cos">
               Auction Supplement
             </FooterLink>
 

--- a/src/Components/Footer/__tests__/Footer.jest.tsx
+++ b/src/Components/Footer/__tests__/Footer.jest.tsx
@@ -11,9 +11,7 @@ jest.mock("System/Router/useRouter", () => ({
   }),
 }))
 
-jest.mock("System/useFeatureFlag", () => ({
-  useFeatureFlag: jest.fn(),
-}))
+jest.mock("System/useFeatureFlag")
 
 describe("Footer", () => {
   const getWrapper = (breakpoint: Breakpoint) =>
@@ -104,14 +102,14 @@ describe("Footer", () => {
       expect(wrapper.html()).toContain("/buyer-guarantee")
     })
 
-    describe("when diamond_new-terms-and-conditions is enabled", () => {
-      beforeEach(() => {
+    describe("when new footer links are enabled", () => {
+      beforeAll(() => {
         ;(useFeatureFlag as jest.Mock).mockImplementation(
           (f: string) => f === "diamond_new-terms-and-conditions"
         )
       })
 
-      afterEach(() => {
+      afterAll(() => {
         ;(useFeatureFlag as jest.Mock).mockReset()
       })
 
@@ -122,7 +120,7 @@ describe("Footer", () => {
         expect(wrapper.html()).toContain("/terms")
 
         expect(wrapper.text()).toContain("Auction Supplement")
-        expect(wrapper.html()).toContain("/supplemental-auction-COS")
+        expect(wrapper.html()).toContain("/supplemental-cos")
 
         expect(wrapper.text()).toContain("Buyer Guarantee")
         expect(wrapper.html()).toContain("/buyer-guarantee")
@@ -172,13 +170,13 @@ describe("Footer", () => {
     })
 
     describe("when diamond_new-terms-and-conditions is enabled", () => {
-      beforeEach(() => {
+      beforeAll(() => {
         ;(useFeatureFlag as jest.Mock).mockImplementation(
           (f: string) => f === "diamond_new-terms-and-conditions"
         )
       })
 
-      afterEach(() => {
+      afterAll(() => {
         ;(useFeatureFlag as jest.Mock).mockReset()
       })
 
@@ -189,7 +187,7 @@ describe("Footer", () => {
         expect(wrapper.html()).toContain("/terms")
 
         expect(wrapper.text()).toContain("Auction Supplement")
-        expect(wrapper.html()).toContain("/supplemental-auction-COS")
+        expect(wrapper.html()).toContain("/supplemental-cos")
 
         expect(wrapper.text()).toContain("Buyer Guarantee")
         expect(wrapper.html()).toContain("/buyer-guarantee")

--- a/src/Components/Inquiry/__tests__/Views/InquirySignUp.jest.tsx
+++ b/src/Components/Inquiry/__tests__/Views/InquirySignUp.jest.tsx
@@ -78,10 +78,14 @@ describe("InquirySignUp", () => {
   })
 
   describe("when the new disclaimer is enabled", () => {
-    beforeEach(() => {
+    beforeAll(() => {
       ;(useFeatureFlag as jest.Mock).mockImplementation(
         (f: string) => f === "diamond_new-terms-and-conditions"
       )
+    })
+
+    afterAll(() => {
+      ;(useFeatureFlag as jest.Mock).mockReset()
     })
 
     it("renders the new disclaimer", () => {
@@ -96,6 +100,8 @@ describe("InquirySignUp", () => {
       expect(
         screen.getByRole("link", { name: "Privacy Policy" })
       ).toHaveAttribute("href", "/privacy")
+
+      // TODO: remove this assertion when deprecating diamond_new-terms-and-conditions
       expect(
         screen.queryByRole("link", { name: "Conditions of Sale" })
       ).not.toBeInTheDocument()


### PR DESCRIPTION
This PR addresses:

- https://artsyproduct.atlassian.net/browse/DIA-549
- https://artsyproduct.atlassian.net/browse/DIA-550

This PR changes:

1. Linking "General Terms and Conditions of Sale" to `/terms`
2. Linking "Auctions Supplement" to `/supplemental-cos`
3. Standardizing how tests are written