### PR TITLE
feat: redirect conditions of sale

### DIFF
--- a/src/Server/middleware/hardcodedRedirects.ts
+++ b/src/Server/middleware/hardcodedRedirects.ts
@@ -154,6 +154,7 @@ const PERMANENT_REDIRECTS = {
   "/log_in": "/login",
   "/sign_up": "/signup",
   "/meet-the-specialists": "/sell",
+  "/conditions-of-sale": "/supplemental-cos",
 }
 
 const router = express.Router()


### PR DESCRIPTION
This PR adds a permanent redirect from /conditions-of-sale to /supplemental-cos. This PR has a "Do not merge" label because the redirect destination has not yet been created. It is planned to be ready to launch by April 17, 2024.