### PR TITLE
chore: add required label and field errors to consignment artwork-details

### DIFF
--- a/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtworkDetailsForm.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtworkDetailsForm.tsx
@@ -231,6 +231,7 @@ export const ArtworkDetailsForm: React.FC = () => {
             onSelect={artist => setFieldValue("artistId", artist?.internalID)}
             onError={() => handleAutosuggestError(true)}
             title="Artist"
+            required
           />
         </Column>
         <Column span={6} mt={[4, 0]}>
@@ -242,6 +243,8 @@ export const ArtworkDetailsForm: React.FC = () => {
             onBlur={handleBlur}
             onChange={handleChange}
             value={values.year}
+            required
+            error={touched.year && errors.year}
           />
         </Column>
       </GridColumns>
@@ -255,6 +258,8 @@ export const ArtworkDetailsForm: React.FC = () => {
             onBlur={handleBlur}
             onChange={handleChange}
             value={values.title}
+            required
+            error={touched.title && errors.title}
           />
         </Column>
         <Column span={6} mt={[4, 0]}>
@@ -266,6 +271,8 @@ export const ArtworkDetailsForm: React.FC = () => {
             onBlur={handleBlur}
             onChange={handleChange}
             onSelect={selected => setFieldValue("category", selected)}
+            required
+            error={touched.category && errors.category}
           />
         </Column>
       </GridColumns>
@@ -279,6 +286,8 @@ export const ArtworkDetailsForm: React.FC = () => {
             onBlur={handleBlur}
             onChange={handleChange}
             value={values.materials}
+            required
+            error={touched.materials && errors.materials}
           />
         </Column>
       </GridColumns>
@@ -302,6 +311,8 @@ export const ArtworkDetailsForm: React.FC = () => {
             onBlur={handleBlur}
             onChange={handleChange}
             onSelect={selected => setFieldValue("rarity", selected)}
+            required
+            error={touched.rarity && errors.rarity}
           />
         </Column>
         <Column display="flex" span={6}>
@@ -321,6 +332,8 @@ export const ArtworkDetailsForm: React.FC = () => {
                 onBlur={handleBlur}
                 onChange={handleChange}
                 value={values.editionNumber}
+                required
+                error={touched.editionNumber && errors.editionNumber}
               />
               <Box px={[0.5, 2]} mt={2}>
                 /
@@ -333,6 +346,8 @@ export const ArtworkDetailsForm: React.FC = () => {
                 onBlur={handleBlur}
                 onChange={handleChange}
                 value={values.editionSize}
+                required
+                error={touched.editionSize && errors.editionSize}
               />
             </Flex>
           )}
@@ -351,6 +366,8 @@ export const ArtworkDetailsForm: React.FC = () => {
               onBlur={handleBlur}
               onChange={handleChange}
               value={values.height}
+              required
+              error={touched.height && errors.height}
             />
 
             <LabeledInput
@@ -362,6 +379,8 @@ export const ArtworkDetailsForm: React.FC = () => {
               onBlur={handleBlur}
               onChange={handleChange}
               value={values.width}
+              required
+              error={touched.width && errors.width}
             />
           </Flex>
         </Column>
@@ -413,6 +432,8 @@ export const ArtworkDetailsForm: React.FC = () => {
             onBlur={handleBlur}
             onChange={handleChange}
             value={values.provenance}
+            required
+            error={touched.provenance && errors.provenance}
           />
         </Column>
         <Column display="flex" alignItems="flex-end" span={6} mt={[4, 0]}>
@@ -429,6 +450,7 @@ export const ArtworkDetailsForm: React.FC = () => {
             onSelect={handleLocationSelect}
             onChange={handleLocationChange}
             onClick={handleLocationClick}
+            required
           />
         </Column>
       </GridColumns>

--- a/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtworkDetails.jest.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtworkDetails.jest.tsx
@@ -18,7 +18,7 @@ const validForm = {
     internalID: "artistId",
     name: "Banksy",
   },
-  category: null,
+  category: "Painting",
   locationCity: "NY, USA",
   locationCountry: null,
   locationState: null,
@@ -354,7 +354,7 @@ describe("ArtworkDetails", () => {
           {
             artistID: "artistId",
             attributionClass: "LIMITED_EDITION",
-            category: null,
+            category: "Painting",
             depth: "5",
             dimensionsMetric: "cm",
             editionNumber: "1",
@@ -404,7 +404,7 @@ describe("ArtworkDetails", () => {
           {
             artistID: "artistId",
             attributionClass: "LIMITED_EDITION",
-            category: null,
+            category: "Painting",
             depth: "5",
             dimensionsMetric: "cm",
             editionNumber: "1",

--- a/src/Apps/Consign/Routes/SubmissionFlow/Utils/validation.ts
+++ b/src/Apps/Consign/Routes/SubmissionFlow/Utils/validation.ts
@@ -7,27 +7,23 @@ export const artworkDetailsValidationSchema = yup.object().shape({
     .required(
       "Please select an artist from the list. Other artists cannot be submitted due to limited demand."
     ),
-  year: yup.string().required().trim(),
-  title: yup.string().required().trim(),
-  materials: yup.string().required().trim(),
+  year: yup.string().required("Please enter the year").trim(),
+  title: yup.string().required("Please enter the title").trim(),
+  materials: yup.string().required("Please enter materials").trim(),
   rarity: yup
     .string()
-    .required()
-    .test(
-      "isDefault",
-      "Rarity field not selected",
-      rarity => rarity !== "default"
-    ),
+    .required("Please select a rarity")
+    .test("isDefault", "", rarity => rarity !== "default"),
   editionNumber: yup.string().when("rarity", {
     is: "limited edition",
-    then: yup.string().required().trim(),
+    then: yup.string().required("Please enter the edition number").trim(),
   }),
   editionSize: yup.string().when("rarity", {
     is: "limited edition",
-    then: yup.string().required().trim(),
+    then: yup.string().required("Please enter the edition size").trim(),
   }),
-  height: yup.string().required().trim(),
-  width: yup.string().required().trim(),
+  height: yup.string().required("Please enter the height").trim(),
+  width: yup.string().required("Please enter the width").trim(),
   depth: yup
     .string()
     .transform((value, originalValue) =>
@@ -35,7 +31,7 @@ export const artworkDetailsValidationSchema = yup.object().shape({
     )
     .trim(),
   units: yup.string().required(),
-  provenance: yup.string().required().trim(),
+  provenance: yup.string().required("Please enter the provenance").trim(),
   location: yup
     .object()
     .shape({
@@ -47,6 +43,10 @@ export const artworkDetailsValidationSchema = yup.object().shape({
       coordinates: yup.array(yup.number()),
     })
     .required(),
+  category: yup
+    .string()
+    .required("Please select a medium")
+    .test("isDefault", "", category => category !== "default"),
 })
 
 export const uploadPhotosValidationSchema = yup.object().shape({


### PR DESCRIPTION
Fixes https://artsyproduct.atlassian.net/browse/ONYX-870

This adds in our 'standard' form best practices -> using the `required` label, and also informative validation errors (to be displayed after a user has interacted with a field, and then focused away w/ the field still being invalid).

Winds up looking something like -
![Screen Shot 2024-04-03 at 4 54 30 PM](https://github.com/artsy/force/assets/1457859/408adc9e-f605-49a4-a4ca-10bc5749951a)


I think this is an improvement of the current experience, where it's more subtle that all fields are required, _and_ there were no validation errors being displayed (besides the auto-completes which have their own).