### PR TITLE
chore: reenable terms dialog w/ opt-out for smoke test

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "cypress"
 
 export default defineConfig({
   retries: 5,
+  userAgent: "ForceSmokeTest",
   e2e: {
     baseUrl: "http://localhost:5000",
     supportFile: false,

--- a/src/Components/TermsUpdateDialog.tsx
+++ b/src/Components/TermsUpdateDialog.tsx
@@ -10,6 +10,7 @@ interface TermsUpdateDialogProps {}
 
 export const TermsUpdateDialog: FC<TermsUpdateDialogProps> = () => {
   const isIntegrity = getENV("USER_AGENT") === "ArtsyIntegrity"
+  const isSmokeTest = getENV("USER_AGENT") === "ForceSmokeTest"
 
   const isTermsUpdateActive = useFeatureFlag("diamond_new-terms-and-conditions")
 
@@ -21,13 +22,13 @@ export const TermsUpdateDialog: FC<TermsUpdateDialogProps> = () => {
   }
 
   useEffect(() => {
-    if (isIntegrity || !isTermsUpdateActive) return
+    if (isSmokeTest || isIntegrity || !isTermsUpdateActive) return
 
     const isDismissed = Cookies.get(TERMS_UPDATE_DIALOG_KEY)
     if (isDismissed) return
 
     setIsDisplayable(true)
-  }, [isIntegrity, isTermsUpdateActive])
+  }, [isSmokeTest, isIntegrity, isTermsUpdateActive])
 
   if (!isDisplayable) {
     return null

--- a/src/System/Router/Boot.tsx
+++ b/src/System/Router/Boot.tsx
@@ -38,6 +38,7 @@ import {
   AppPreferencesProvider,
   useAppPreferences,
 } from "Apps/AppPreferences/useAppPreferences"
+import { TermsUpdateDialog } from "Components/TermsUpdateDialog"
 
 export interface BootProps {
   children: React.ReactNode
@@ -104,6 +105,8 @@ export const Boot = track(undefined, {
                               <CookieConsentManager>
                                 <FocusVisible />
                                 <SiftContainer />
+
+                                <TermsUpdateDialog />
 
                                 {children}
                               </CookieConsentManager>


### PR DESCRIPTION
Similar to the Integrity user-agent check, do something similar for smoke tests (to opt those out of this dialog).