### PR TITLE
fix: conditionally display subtitle in notification panel partner offers

### DIFF
--- a/src/Components/Notifications/PartnerOfferArtwork.tsx
+++ b/src/Components/Notifications/PartnerOfferArtwork.tsx
@@ -154,13 +154,13 @@ export const PartnerOfferArtwork: FC<PartnerOfferArtworkProps> = ({
         justifyContent="space-between"
         width="100%"
         maxWidth={CARD_MAX_WIDTH}
+        gap={2}
       >
         <Button
           // @ts-ignore
           as={RouterLink}
           to={href}
           data-testid="partner-offer-artwork-button"
-          mr={partnerOfferVisibilityEnabled && fullyAvailable ? 2 : 0}
           flex={partnerOfferVisibilityEnabled && fullyAvailable ? 1 : [1, 0.5]}
         >
           {buttonText}

--- a/src/Components/Notifications/PartnerOfferCreatedNotification.tsx
+++ b/src/Components/Notifications/PartnerOfferCreatedNotification.tsx
@@ -8,6 +8,7 @@ import { ExpiresInTimer } from "Components/Notifications/ExpiresInTimer"
 import { BASE_SAVES_PATH } from "Apps/CollectorProfile/constants"
 import { PartnerOfferArtwork } from "Components/Notifications/PartnerOfferArtwork"
 import { NotificationErrorMessage } from "Components/Notifications/NotificationErrorMessage"
+import { useTimer } from "Utils/Hooks/useTimer"
 
 interface PartnerOfferCreatedNotificationProps {
   notification: PartnerOfferCreatedNotification_notification$key
@@ -28,12 +29,20 @@ export const PartnerOfferCreatedNotification: FC<PartnerOfferCreatedNotification
     offerArtworksConnection,
   } = notificationData
 
+  const partnerOffer = item?.partnerOffer
+  const artwork = extractNodes(offerArtworksConnection)[0]
+  const { hasEnded } = useTimer(partnerOffer?.endAt || "")
+  let subtitle = "Review the offer on your saved artwork"
+  if (hasEnded)
+    subtitle =
+      "This offer has expired. View Work to make an offer, purchase or contact the gallery"
+  if (!partnerOffer?.isAvailable)
+    subtitle =
+      "Sorry, this artwork is sold or no longer available. Please create an alert or contact orders@artsy.net to find similar artworks"
+
   if (!item || !offerArtworksConnection || !item.partnerOffer) {
     return <NotificationErrorMessage />
   }
-
-  const partnerOffer = item.partnerOffer
-  const artwork = extractNodes(offerArtworksConnection)[0]
 
   return (
     <Box>
@@ -51,7 +60,7 @@ export const PartnerOfferCreatedNotification: FC<PartnerOfferCreatedNotification
         </Flex>
       </Flex>
 
-      <Text variant="sm-display">Review the offer on your saved artwork</Text>
+      <Text variant="sm-display">{subtitle}</Text>
 
       <Spacer y={0.5} />
 
@@ -67,8 +76,8 @@ export const PartnerOfferCreatedNotification: FC<PartnerOfferCreatedNotification
         </>
 
         <ExpiresInTimer
-          expiresAt={partnerOffer.endAt}
-          available={partnerOffer.isAvailable}
+          expiresAt={partnerOffer?.endAt}
+          available={partnerOffer?.isAvailable}
         />
       </Flex>
 
@@ -78,11 +87,11 @@ export const PartnerOfferCreatedNotification: FC<PartnerOfferCreatedNotification
         <PartnerOfferArtwork
           artwork={artwork}
           targetHref={targetHref}
-          endAt={partnerOffer.endAt}
-          note={partnerOffer.note}
-          available={partnerOffer.isAvailable}
-          partnerOfferID={partnerOffer.internalID}
-          priceWithDiscount={partnerOffer.priceWithDiscount?.display}
+          endAt={partnerOffer?.endAt}
+          note={partnerOffer?.note}
+          available={partnerOffer?.isAvailable}
+          partnerOfferID={partnerOffer?.internalID}
+          priceWithDiscount={partnerOffer?.priceWithDiscount?.display}
         />
       </Flex>
     </Box>


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Adjusting for scenarios where partner offer is not available, according to the original design handoff https://www.figma.com/file/PO3rjpDV29YOFR8kLI4InJ/Activity-Panel-%26-Alerts-Management?type=design&node-id=1001-21830&mode=design&t=tuZwYYFoPc7jjniE-0
