### PR TITLE
chore(artist series filter): retire Unleash feature flag

### DIFF
--- a/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters.tsx
@@ -21,9 +21,6 @@ interface ArtistArtworkFiltersProps {}
 
 export const ArtistArtworkFilters: React.FC<ArtistArtworkFiltersProps> = props => {
   const { user } = useSystemContext()
-  const isArtistSeriesFilterEnabled = useFeatureFlag(
-    "onyx_enable-artist-series-filter"
-  )
   const isAvailabilityFilterEnabled = useFeatureFlag("onyx_availability-filter")
 
   return (
@@ -33,7 +30,7 @@ export const ArtistArtworkFilters: React.FC<ArtistArtworkFiltersProps> = props =
       <AttributionClassFilter expanded />
       <MediumFilter expanded />
       <PriceRangeFilter expanded />
-      {isArtistSeriesFilterEnabled && <ArtistSeriesFilter expanded />}
+      <ArtistSeriesFilter expanded />
       <SizeFilter expanded />
       {isAvailabilityFilterEnabled && <AvailabilityFilter />}
       <WaysToBuyFilter expanded />

--- a/src/Apps/Artist/Routes/WorksForSale/Components/__tests__/ArtistArtworkFilters.jest.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/__tests__/ArtistArtworkFilters.jest.tsx
@@ -51,33 +51,14 @@ it("renders all expected filters", () => {
   expect(screen.getByText("Rarity")).toBeInTheDocument()
   expect(screen.getByText("Medium")).toBeInTheDocument()
   expect(screen.getByText("Price")).toBeInTheDocument()
+  expect(screen.getByText("Artist Series")).toBeInTheDocument()
+  expect(screen.getByText("Size")).toBeInTheDocument()
   expect(screen.getByText("Ways to Buy")).toBeInTheDocument()
   expect(screen.getByText("Material")).toBeInTheDocument()
   expect(screen.getByText("Artwork Location")).toBeInTheDocument()
   expect(screen.getByText("Time Period")).toBeInTheDocument()
   expect(screen.getByText("Color")).toBeInTheDocument()
   expect(screen.getByText("Galleries and Institutions")).toBeInTheDocument()
-})
-
-describe("feature flag: onyx_enable-artist-series-filter", () => {
-  describe("when the feature flag is enabled", () => {
-    beforeEach(() => {
-      ;(useFeatureFlag as jest.Mock).mockImplementation(() => true)
-    })
-    it("renders the Artist Series filter", () => {
-      render(<ArtistArtworkFilters />)
-      expect(screen.getByText("Artist Series")).toBeInTheDocument()
-    })
-  })
-  describe("when the feature flag is disabled", () => {
-    beforeEach(() => {
-      ;(useFeatureFlag as jest.Mock).mockImplementation(() => false)
-    })
-    it("does not render the Artist Series filter", () => {
-      render(<ArtistArtworkFilters />)
-      expect(screen.queryByText("Artist Series")).not.toBeInTheDocument()
-    })
-  })
 })
 
 describe("feature flag: onyx_availability", () => {

--- a/src/Components/ArtworkFilter/ArtworkFiltersQuick/ArtistSeriesFilterQuick.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFiltersQuick/ArtistSeriesFilterQuick.tsx
@@ -2,20 +2,15 @@ import { FC } from "react"
 import { useArtworkFilterContext } from "Components/ArtworkFilter/ArtworkFilterContext"
 import { DropdownProps } from "@artsy/palette"
 import { FilterQuick } from "Components/ArtworkFilter/ArtworkFiltersQuick/FilterQuick"
-import { useFeatureFlag } from "System/useFeatureFlag"
 
 export interface ArtistSeriesFilterQuickProps
   extends Omit<DropdownProps, "dropdown" | "children"> {}
 
 export const ArtistSeriesFilterQuick: FC<ArtistSeriesFilterQuickProps> = props => {
-  const isArtistSeriesFilterEnabled = useFeatureFlag(
-    "onyx_enable-artist-series-filter"
-  )
-
   const { aggregations } = useArtworkFilterContext()
   const aggregation = aggregations?.find(agg => agg.slice === "ARTIST_SERIES")
   const artistSeries = aggregation?.counts || []
-  const isDisplayable = isArtistSeriesFilterEnabled && artistSeries.length > 0
+  const isDisplayable = artistSeries.length > 0
 
   if (!isDisplayable) return null
 

--- a/src/Components/ArtworkFilter/ArtworkFiltersQuick/__tests__/ArtistSeriesFilterQuick.jest.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFiltersQuick/__tests__/ArtistSeriesFilterQuick.jest.tsx
@@ -2,7 +2,6 @@ import { screen } from "@testing-library/react"
 import { createArtworkFilterTestRenderer } from "Components/ArtworkFilter/ArtworkFilters/__tests__/Utils"
 import { ArtworkFilterContextProps } from "Components/ArtworkFilter/ArtworkFilterContext"
 import { ArtistSeriesFilterQuick } from "Components/ArtworkFilter/ArtworkFiltersQuick/ArtistSeriesFilterQuick"
-import { useFeatureFlag } from "System/useFeatureFlag"
 
 jest.mock("System/useFeatureFlag", () => ({
   useFeatureFlag: jest.fn(() => true),
@@ -27,40 +26,23 @@ describe(ArtistSeriesFilterQuick, () => {
     render = createArtworkFilterTestRenderer(artworkFilterContext)
   })
 
-  describe("when onyx_enable-artist-series-filter flag is enabled", () => {
-    beforeEach(() => {
-      ;(useFeatureFlag as jest.Mock).mockImplementation(() => true)
-    })
-
-    describe("when artist series aggregations are present", () => {
-      it("renders the artist series quick filter", () => {
-        render(<ArtistSeriesFilterQuick />)
-        expect(screen.getByText("Artist Series")).toBeInTheDocument()
-      })
-    })
-
-    describe("when artist series aggregations are absent", () => {
-      it("does not render the artist series quick filter", () => {
-        render = createArtworkFilterTestRenderer({
-          aggregations: [
-            {
-              slice: "ARTIST_SERIES",
-              counts: [],
-            },
-          ],
-        })
-        render(<ArtistSeriesFilterQuick />)
-        expect(screen.queryByText("Artist Series")).not.toBeInTheDocument()
-      })
+  describe("when artist series aggregations are present", () => {
+    it("renders the artist series quick filter", () => {
+      render(<ArtistSeriesFilterQuick />)
+      expect(screen.getByText("Artist Series")).toBeInTheDocument()
     })
   })
 
-  describe("when onyx_enable-artist-series-filter flag is disabled", () => {
-    beforeEach(() => {
-      ;(useFeatureFlag as jest.Mock).mockImplementation(() => false)
-    })
-
+  describe("when artist series aggregations are absent", () => {
     it("does not render the artist series quick filter", () => {
+      render = createArtworkFilterTestRenderer({
+        aggregations: [
+          {
+            slice: "ARTIST_SERIES",
+            counts: [],
+          },
+        ],
+      })
       render(<ArtistSeriesFilterQuick />)
       expect(screen.queryByText("Artist Series")).not.toBeInTheDocument()
     })


### PR DESCRIPTION
The type of this PR is: **Chore**

This PR solves [ONYX-800]

### Description

Feature has been fully launched for while, time to clean up the flag 🧹 

TODO

- [ ] After deploying, archive the Unleash flag [`onyx_enable-artist-series-filter`](https://unleash.artsy.net/projects/default/features/onyx_enable-artist-series-filter)

[ONYX-800]: https://artsyproduct.atlassian.net/browse/ONYX-800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ