### PR TITLE
Chore/amber 522/remove rotating conversation messages

### DIFF
--- a/src/Components/Inquiry/Hooks/useInquiryContext.tsx
+++ b/src/Components/Inquiry/Hooks/useInquiryContext.tsx
@@ -45,54 +45,8 @@ export const DEFAULT_CONTEXT: Context = {
   shareFollows: false,
 }
 
-export const AUTOMATED_MESSAGES = [
-  "Hi, I’m interested in purchasing this work. Could you please provide more information about the piece?",
-  "Hello, I'm interested in this artwork. Could you provide more details about it?",
-  "Hi, I came across this piece and would love to learn more about it. Can you provide additional information?",
-  "Hi there, I'm interested in buying this work. Could you please share some more information about it?",
-  "Hello, I'm interested in this piece. Could you please provide me with more information about it?",
-  "Hi, I would love to add this artwork to my collection. Could you please provide me with more details?",
-  "Hi there, I'm interested in this piece. Could you please provide me with additional details?",
-  "Hello, I'm interested in purchasing this artwork. Can you provide me with more information about it?",
-  "Hi, I'm interested in this piece and would love to know more about it. Could you please provide additional information?",
-  "Hi there, I'm interested in this piece and would like to learn more about it. Could you please provide additional details?",
-  "Hello, I'm considering purchasing this artwork. Can you provide me with more information about the piece?",
-  "Hi, I'm interested in this work and would love to know more about it. Could you please provide additional information?",
-  "Hi there! Can you tell me more about this artwork? I'm very interested in it.",
-  "Hello, this artwork caught my eye. Any chance you could provide me with more details about it?",
-  "Hi, I'd love to learn more about this artwork! Could you tell me more about it?",
-  "Hello! Could you give me some additional information about this artwork? I'm really interested in it.",
-  "I'm very interested in this artwork. Could you please provide me with more details about it?",
-  "This artwork is fascinating! Could you please share some additional information about it?",
-  "Hi there! I'd like to know more about this piece. Could you tell me about it?",
-  "I'm very interested in this artwork. Would you mind providing me with more information about it?",
-  "I'd like to know more about this work. Could you share some additional information with me?",
-  "Hello! I was intrigued by this artwork. Could you please provide me with more details about it?",
-  "I'm very interested in this artwork. Can you give me more information about it?",
-  "Hi there! I saw this artwork and thought it was captivating. Could you tell me more about it?",
-  "I'm intrigued by this artwork. Could you please tell me more about it?",
-  "Hello, I'm interested in learning more about this artwork. Could you provide me with additional details?",
-  "Hi there! This artwork is stunning. Can you tell me more about it?",
-  "I'm very interested in this artwork. Would you mind giving me more details about it?",
-  "Hello! Could you please provide me with more details about this artwork? I'm quite interested in it.",
-  "Hello, I'm interested in this work. Could you share some additional information with me about it?",
-  "I'm interested in learning more about this piece. Can you tell me more about it?",
-  "Hi there. I came across this artwork today. Could you please provide me with more information about it?",
-  "Hello, I'm interested in this artwork and would love to know more about it.",
-  "Hi, I collect art and was intrigued by this artwork. Can you provide additional information?",
-  "Hello, I'm a collector and would like to inquire about this artwork. Could you please share more details?",
-  "Hi, I'm very interested in this artwork and would appreciate more information about it.",
-  "Hi there, I'm interested in this artwork and would like to know more about it. Can you provide further information?",
-  "Hello, I'm a collector and would love to learn more about this artwork. Could you please share additional details?",
-  "Hi, as someone who collects art, I was intrigued by this piece. Can you provide more information about it?",
-  "Hi, I'm a collector and would like to know more about this artwork. Can you please provide additional information?",
-]
-
-const getAutomatedMessages = () => {
-  return AUTOMATED_MESSAGES[
-    Math.floor(Math.random() * AUTOMATED_MESSAGES.length)
-  ]
-}
+export const DEFAULT_MESSAGE =
+  "Hi, I'm interested in purchasing this work. Could you please provide more information about the piece?"
 
 export interface InquiryState {
   message: string
@@ -125,7 +79,7 @@ const InquiryContext = createContext<{
   context: React.createRef<Context>(),
   current: "",
   engine: new WorkflowEngine({ workflow: [] }),
-  inquiry: { message: getAutomatedMessages() },
+  inquiry: { message: DEFAULT_MESSAGE },
   next: () => {},
   dispatchCreateAlert: () => {},
   onClose: () => {},
@@ -169,7 +123,7 @@ export const InquiryProvider: React.FC<InquiryProviderProps> = ({
   }, [])
 
   const [inquiry, setInquiry] = useState<InquiryState>({
-    message: getAutomatedMessages(),
+    message: DEFAULT_MESSAGE,
   })
 
   const handleClose = () => {

--- a/src/Components/Inquiry/Hooks/useInquiryContext.tsx
+++ b/src/Components/Inquiry/Hooks/useInquiryContext.tsx
@@ -46,7 +46,7 @@ export const DEFAULT_CONTEXT: Context = {
 }
 
 export const DEFAULT_MESSAGE =
-  "Hi, I'm interested in purchasing this work. Could you please provide more information about the piece?"
+  "I'm interested in this piece and would like to learn more about it. Could you please provide additional details?"
 
 export interface InquiryState {
   message: string

--- a/src/Components/Inquiry/Views/InquiryInquiry.tsx
+++ b/src/Components/Inquiry/Views/InquiryInquiry.tsx
@@ -20,10 +20,7 @@ import { InquiryInquiry_artwork$data } from "__generated__/InquiryInquiry_artwor
 import { InquiryInquiryQuery } from "__generated__/InquiryInquiryQuery.graphql"
 import { useArtworkInquiryRequest } from "Components/Inquiry/Hooks/useArtworkInquiryRequest"
 import { wait } from "Utils/wait"
-import {
-  useInquiryContext,
-  AUTOMATED_MESSAGES,
-} from "Components/Inquiry/Hooks/useInquiryContext"
+import { useInquiryContext } from "Components/Inquiry/Hooks/useInquiryContext"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { logger } from "Components/Inquiry/util"
 import { RouterLink } from "System/Router/RouterLink"
@@ -44,7 +41,7 @@ const InquiryInquiry: React.FC<InquiryInquiryProps> = ({ artwork }) => {
   const { submitArtworkInquiryRequest } = useArtworkInquiryRequest()
 
   const handleTextAreaChange = ({ value }: { value: string }) => {
-    if (mode === "Confirm" && !AUTOMATED_MESSAGES.includes(value)) {
+    if (mode === "Confirm" && value !== inquiry.message) {
       setMode("Pending")
     }
 
@@ -54,7 +51,7 @@ const InquiryInquiry: React.FC<InquiryInquiryProps> = ({ artwork }) => {
   const handleSubmit = async (event: React.FormEvent<HTMLElement>) => {
     event.preventDefault()
 
-    if (AUTOMATED_MESSAGES.includes(inquiry.message) && mode !== "Confirm") {
+    if (inquiry.message && mode !== "Confirm") {
       setMode("Confirm")
       return
     }

--- a/src/Components/Inquiry/__tests__/Views/InquirySpecialist.jest.tsx
+++ b/src/Components/Inquiry/__tests__/Views/InquirySpecialist.jest.tsx
@@ -1,7 +1,10 @@
 import { mount } from "enzyme"
 import { InquirySpecialist } from "Components/Inquiry/Views/InquirySpecialist"
 import { useArtworkInquiryRequest } from "Components/Inquiry/Hooks/useArtworkInquiryRequest"
-import { useInquiryContext } from "Components/Inquiry/Hooks/useInquiryContext"
+import {
+  DEFAULT_MESSAGE,
+  useInquiryContext,
+} from "Components/Inquiry/Hooks/useInquiryContext"
 import { fill } from "Components/Inquiry/__tests__/util"
 import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
 import { useSystemContext } from "System/useSystemContext"
@@ -27,15 +30,7 @@ describe("InquirySpecialist", () => {
 
       setInqirySpy = jest.spyOn(actual, "setInquiry")
 
-      return {
-        ...actual,
-        next,
-        artworkID: "example",
-        inquiry: {
-          message:
-            "Hello, I'm interested in this artwork. Could you provide more details about it?",
-        },
-      }
+      return { ...actual, next, artworkID: "example" }
     })
   })
 
@@ -121,8 +116,7 @@ describe("InquirySpecialist", () => {
         contactGallery: false,
         // TODO: Figure out why this state doesn't update within text (works in dev)
         // message: "Hello world.",
-        message:
-          "Hello, I'm interested in this artwork. Could you provide more details about it?",
+        message: DEFAULT_MESSAGE,
       })
 
       // Calls next


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [AMBER-522]

### Description

The rotating messages are being removed as part of the work to update these messages for Private Artworks. These were adding additional overhead without bringing any value. Some more conversations can be found attached to the ticket including some data to back this decision.

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AMBER-522]: https://artsyproduct.atlassian.net/browse/AMBER-522?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Before:
<img width="553" alt="Screenshot 2024-04-08 at 11 06 29" src="https://github.com/artsy/force/assets/6280410/5c583b4a-ddbd-4057-80ef-ed319ec44fd3">

After:
<img width="558" alt="Screenshot 2024-04-08 at 11 06 21" src="https://github.com/artsy/force/assets/6280410/3e5063e8-e4c3-44bd-a0a4-2784b82c9f2a">
