### PR TITLE
feat(ONYX-804): add Lots for You tab on Auction page

### DIFF
--- a/src/Apps/Auctions/Components/CuritorialRailsTabBar.tsx
+++ b/src/Apps/Auctions/Components/CuritorialRailsTabBar.tsx
@@ -1,4 +1,4 @@
-import { Join, Spacer, Tab, Tabs } from "@artsy/palette"
+import { Join, Spacer, Tab, Tabs, Text } from "@artsy/palette"
 import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { CuritorialRailsTabBar_viewer$data } from "__generated__/CuritorialRailsTabBar_viewer.graphql"
@@ -7,6 +7,8 @@ import { MyBidsFragmentContainer } from "./MyBids/MyBids"
 import { StandoutLotsRailFragmentContainer } from "./StandoutLotsRail"
 import { TrendingLotsRailFragmentContainer } from "./TrendingLotsRail"
 import { WorksByArtistsYouFollowRailFragmentContainer } from "./WorksByArtistsYouFollowRail"
+import { HomeAuctionLotsForYouRailQueryRenderer } from "Apps/Home/Components/HomeAuctionLotsForYouRail"
+import { useSystemContext } from "System/SystemContext"
 
 interface CuritorialRailsTabBarProps {
   viewer: CuritorialRailsTabBar_viewer$data
@@ -16,15 +18,25 @@ export const CuritorialRailsTabBar: React.FC<CuritorialRailsTabBarProps> = ({
   viewer,
 }) => {
   const showWorksForYouTab = !!viewer.followedArtistsInAuction?.counts?.total
+  const { user } = useSystemContext()
 
   return (
     <Tabs mb={4}>
       {showWorksForYouTab && (
-        <Tab name="Lots for You">
+        <Tab name="Works for You">
           <Join separator={<Spacer y={2} />}>
             {viewer.me && <MyBidsFragmentContainer me={viewer.me} />}
             <WorksByArtistsYouFollowRailFragmentContainer viewer={viewer} />
           </Join>
+        </Tab>
+      )}
+      {!user ? null : (
+        <Tab name="Lots for You">
+          <Text variant="lg-display">Lots for You</Text>
+          <Text variant="lg-display" color="black60">
+            Works recommended for you
+          </Text>
+          <HomeAuctionLotsForYouRailQueryRenderer />
         </Tab>
       )}
       <Tab name="Curators’ Picks">

--- a/src/Apps/Auctions/Components/__tests__/CuritorialRailsTabBar.jest.tsx
+++ b/src/Apps/Auctions/Components/__tests__/CuritorialRailsTabBar.jest.tsx
@@ -26,7 +26,7 @@ describe("CuritorialRailsTabBar", () => {
     expect(screen.queryByText("Trending Lots")).toBeInTheDocument()
   })
 
-  it('hides "Lots for You" tab if no sale artworks', () => {
+  it('hides "Works for You" tab if no sale artworks', () => {
     renderWithRelay({
       SaleArtworksConnection: () => ({
         counts: {
@@ -35,10 +35,10 @@ describe("CuritorialRailsTabBar", () => {
       }),
     })
 
-    expect(screen.queryByText("Lots for You")).not.toBeInTheDocument()
+    expect(screen.queryByText("Works for You")).not.toBeInTheDocument()
   })
 
-  it('shows "Lots for You" tab if sale artworks', () => {
+  it('shows "Works for You" tab if sale artworks', () => {
     renderWithRelay({
       SaleArtworksConnection: () => ({
         counts: {
@@ -48,6 +48,6 @@ describe("CuritorialRailsTabBar", () => {
       }),
     })
 
-    expect(screen.queryByText("Lots for You")).toBeInTheDocument()
+    expect(screen.queryByText("Works for You")).toBeInTheDocument()
   })
 })


### PR DESCRIPTION
The type of this PR is: Feat

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [ONYX-804](https://artsyproduct.atlassian.net/browse/ONYX-804)

### Description

Add "Lots for You" tab to Auctions page:


https://github.com/artsy/force/assets/17580625/a3e180c9-5d2a-42d5-8087-6ceb20d94a84




<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-804]: https://artsyproduct.atlassian.net/browse/ONYX-804?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ