### PR TITLE
feat(EMI-1800): update display to only have 2 active action buttons at a time

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
@@ -312,16 +312,8 @@ export const ArtworkSidebarCommercialButtons: React.FC<ArtworkSidebarCommercialB
     setSelectedEditionSet(firstAvailableEcommerceEditionSet())
   }, [artwork.editionSets, firstAvailableEcommerceEditionSet])
 
-  const artworkEcommerceAvailable = !!(
-    artwork.isAcquireable || artwork.isOfferable
-  )
-  const shouldRenderButtons =
-    artworkEcommerceAvailable || !!artwork.isInquireable
-
   const isCreateAlertAvailable =
     artwork.isEligibleToCreateAlert && artwork.isSold
-  const isSecondaryContactGalleryButton =
-    artwork.isOfferable || isCreateAlertAvailable
 
   const AlertSwitch: FC = () => {
     if (!isCreateAlertAvailable) {
@@ -338,6 +330,19 @@ export const ArtworkSidebarCommercialButtons: React.FC<ArtworkSidebarCommercialB
   const buyNowOrPartnerOfferAvailable = !!(
     artwork.isAcquireable || activePartnerOffer
   )
+
+  const renderButtons = {}
+  if (buyNowOrPartnerOfferAvailable) {
+    renderButtons["buyNow"] = "primaryBlack"
+  }
+  if (artwork.isOfferable) {
+    renderButtons["makeOffer"] =
+      Object.keys(renderButtons).length == 0 ? "primaryBlack" : "secondaryBlack"
+  }
+  if (artwork.isInquireable && Object.keys(renderButtons).length < 2) {
+    renderButtons["contactGallery"] =
+      Object.keys(renderButtons).length == 0 ? "primaryBlack" : "secondaryBlack"
+  }
 
   const SaleMessageOrOfferDisplay: FC = () => {
     return partnerOffer ? (
@@ -380,13 +385,14 @@ export const ArtworkSidebarCommercialButtons: React.FC<ArtworkSidebarCommercialB
         </>
       )}
 
-      {shouldRenderButtons && <Spacer y={2} />}
+      {Object.keys(renderButtons).length > 0 && <Spacer y={2} />}
 
       <Flex flexDirection={["column", "column", "column", "column", "row"]}>
         <Join separator={<Spacer x={1} y={1} />}>
           <AlertSwitch />
-          {buyNowOrPartnerOfferAvailable && (
+          {renderButtons["buyNow"] && (
             <Button
+              variant={renderButtons["buyNow"]}
               width="100%"
               size="large"
               loading={isCommitingCreateOrderMutation}
@@ -400,13 +406,9 @@ export const ArtworkSidebarCommercialButtons: React.FC<ArtworkSidebarCommercialB
               {t("artworkPage.sidebar.commercialButtons.buyNow")}
             </Button>
           )}
-          {artwork.isOfferable && (
+          {renderButtons["makeOffer"] && (
             <Button
-              variant={
-                buyNowOrPartnerOfferAvailable
-                  ? "secondaryBlack"
-                  : "primaryBlack"
-              }
+              variant={renderButtons["makeOffer"]}
               width="100%"
               size="large"
               loading={isCommittingCreateOfferOrderMutation}
@@ -415,16 +417,12 @@ export const ArtworkSidebarCommercialButtons: React.FC<ArtworkSidebarCommercialB
               {t("artworkPage.sidebar.commercialButtons.makeOffer")}
             </Button>
           )}
-          {artwork.isInquireable && (
+          {renderButtons["contactGallery"] && (
             <Button
+              variant={renderButtons["contactGallery"]}
               width="100%"
               size="large"
               onClick={handleInquiry}
-              variant={
-                isSecondaryContactGalleryButton
-                  ? "secondaryBlack"
-                  : "primaryBlack"
-              }
             >
               {t("artworkPage.sidebar.commercialButtons.contactGallery")}
             </Button>

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
@@ -36,6 +36,7 @@ import { useTimer } from "Utils/Hooks/useTimer"
 import { useFeatureFlag } from "System/useFeatureFlag"
 import { extractNodes } from "Utils/extractNodes"
 import { ExpiresInTimer } from "Components/Notifications/ExpiresInTimer"
+import { ResponsiveValue } from "styled-system"
 
 interface ArtworkSidebarCommercialButtonsProps {
   artwork: ArtworkSidebarCommercialButtons_artwork$key
@@ -331,17 +332,23 @@ export const ArtworkSidebarCommercialButtons: React.FC<ArtworkSidebarCommercialB
     artwork.isAcquireable || activePartnerOffer
   )
 
-  const renderButtons = {}
+  const renderButtons: {
+    buyNow?: ResponsiveValue<"primaryBlack" | "secondaryBlack">
+    makeOffer?: ResponsiveValue<"primaryBlack" | "secondaryBlack">
+    contactGallery?: ResponsiveValue<"primaryBlack" | "secondaryBlack">
+  } = {}
   if (buyNowOrPartnerOfferAvailable) {
-    renderButtons["buyNow"] = "primaryBlack"
+    renderButtons.buyNow = "primaryBlack"
   }
   if (artwork.isOfferable) {
-    renderButtons["makeOffer"] =
+    renderButtons.makeOffer =
       Object.keys(renderButtons).length == 0 ? "primaryBlack" : "secondaryBlack"
   }
   if (artwork.isInquireable && Object.keys(renderButtons).length < 2) {
-    renderButtons["contactGallery"] =
-      Object.keys(renderButtons).length == 0 ? "primaryBlack" : "secondaryBlack"
+    renderButtons.contactGallery =
+      Object.keys(renderButtons).length > 0 || isCreateAlertAvailable
+        ? "secondaryBlack"
+        : "primaryBlack"
   }
 
   const SaleMessageOrOfferDisplay: FC = () => {
@@ -390,9 +397,9 @@ export const ArtworkSidebarCommercialButtons: React.FC<ArtworkSidebarCommercialB
       <Flex flexDirection={["column", "column", "column", "column", "row"]}>
         <Join separator={<Spacer x={1} y={1} />}>
           <AlertSwitch />
-          {renderButtons["buyNow"] && (
+          {renderButtons.buyNow && (
             <Button
-              variant={renderButtons["buyNow"]}
+              variant={renderButtons.buyNow}
               width="100%"
               size="large"
               loading={isCommitingCreateOrderMutation}
@@ -406,9 +413,9 @@ export const ArtworkSidebarCommercialButtons: React.FC<ArtworkSidebarCommercialB
               {t("artworkPage.sidebar.commercialButtons.buyNow")}
             </Button>
           )}
-          {renderButtons["makeOffer"] && (
+          {renderButtons.makeOffer && (
             <Button
-              variant={renderButtons["makeOffer"]}
+              variant={renderButtons.makeOffer}
               width="100%"
               size="large"
               loading={isCommittingCreateOfferOrderMutation}
@@ -417,9 +424,9 @@ export const ArtworkSidebarCommercialButtons: React.FC<ArtworkSidebarCommercialB
               {t("artworkPage.sidebar.commercialButtons.makeOffer")}
             </Button>
           )}
-          {renderButtons["contactGallery"] && (
+          {renderButtons.contactGallery && (
             <Button
-              variant={renderButtons["contactGallery"]}
+              variant={renderButtons.contactGallery}
               width="100%"
               size="large"
               onClick={handleInquiry}

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
@@ -328,19 +328,15 @@ export const ArtworkSidebarCommercialButtons: React.FC<ArtworkSidebarCommercialB
     )
   }
 
-  const buyNowOrPartnerOfferAvailable = !!(
-    artwork.isAcquireable || activePartnerOffer
-  )
-
   const renderButtons: {
     buyNow?: ResponsiveValue<"primaryBlack" | "secondaryBlack">
     makeOffer?: ResponsiveValue<"primaryBlack" | "secondaryBlack">
     contactGallery?: ResponsiveValue<"primaryBlack" | "secondaryBlack">
   } = {}
-  if (buyNowOrPartnerOfferAvailable) {
+  if (artwork.isAcquireable || activePartnerOffer) {
     renderButtons.buyNow = "primaryBlack"
   }
-  if (artwork.isOfferable) {
+  if (artwork.isOfferable && !(activePartnerOffer && artwork.isInquireable)) {
     renderButtons.makeOffer =
       Object.keys(renderButtons).length == 0 ? "primaryBlack" : "secondaryBlack"
   }
@@ -502,7 +498,7 @@ const OfferDisplay: React.FC<OfferDisplayProps> = ({
       <Spacer y={0.5} />
 
       <ExpiresInTimer expiresAt={endAt} available={isAvailable} />
-      <Spacer y={2} />
+      <Spacer y={1} />
     </>
   )
 }

--- a/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercialButtons.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercialButtons.jest.tsx
@@ -73,18 +73,60 @@ describe("ArtworkSidebarCommercialButtons", () => {
     mockEnvironment.mockClear()
   })
 
-  it("displays both Make an Offer and Contact Gallery CTAs when offerable from inquiry and exact price listed", () => {
-    renderWithRelay({
-      Query: () => ({ me: meMock }),
-      Artwork: () => ({
-        isOfferable: true,
-        isInquireable: true,
-        isAcquirable: false,
-      }),
+  describe("action buttons area for artwork with acitve offer", () => {
+    it("displays Purchse and Make Offer buttons and omits contact gallery for works eligeable for MO", async () => {
+      mockUseFeatureFlag.mockImplementation(() => true)
+      meMock.partnerOffersConnection.edges.push({
+        node: {
+          internalID: "partner-offer-id",
+          isAvailable: true,
+        },
+      })
+
+      renderWithRelay(
+        {
+          Query: () => ({ me: meMock }),
+          Artwork: () => ({
+            isOfferable: true,
+            isInquireable: true,
+            isAcquirable: false,
+          }),
+        },
+        null,
+        mockEnvironment
+      )
+
+      expect(screen.queryByText("Purchase")).toBeInTheDocument()
+      expect(screen.queryByText("Make an Offer")).toBeInTheDocument()
+      expect(screen.queryByText("Contact Gallery")).not.toBeInTheDocument()
     })
 
-    expect(screen.queryByText("Make an Offer")).toBeInTheDocument()
-    expect(screen.queryByText("Contact Gallery")).toBeInTheDocument()
+    it("displays Purchse and Contact Gallery buttons for work not eligeable for MO", async () => {
+      mockUseFeatureFlag.mockImplementation(() => true)
+      meMock.partnerOffersConnection.edges.push({
+        node: {
+          internalID: "partner-offer-id",
+          isAvailable: true,
+        },
+      })
+
+      renderWithRelay(
+        {
+          Query: () => ({ me: meMock }),
+          Artwork: () => ({
+            isOfferable: false,
+            isInquireable: true,
+            isAcquirable: false,
+          }),
+        },
+        null,
+        mockEnvironment
+      )
+
+      expect(screen.queryByText("Purchase")).toBeInTheDocument()
+      expect(screen.queryByText("Make an Offer")).not.toBeInTheDocument()
+      expect(screen.queryByText("Contact Gallery")).toBeInTheDocument()
+    })
   })
 
   it("displays both Make an Offer and Contact Gallery CTAs when offerable from inquiry and price range", () => {
@@ -297,7 +339,6 @@ describe("ArtworkSidebarCommercialButtons", () => {
         Query: () => ({ me: meMock }),
         Artwork: () => ({
           priceListedDisplay: "$5,000",
-          isOfferable: true,
         }),
       },
       null,

--- a/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercialButtons.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercialButtons.jest.tsx
@@ -74,7 +74,7 @@ describe("ArtworkSidebarCommercialButtons", () => {
   })
 
   describe("action buttons area for artwork with acitve offer", () => {
-    it("displays Purchse and Make Offer buttons and omits contact gallery for works eligeable for MO", async () => {
+    it("for artwork that BN only displays Purchase button only", async () => {
       mockUseFeatureFlag.mockImplementation(() => true)
       meMock.partnerOffersConnection.edges.push({
         node: {
@@ -87,9 +87,36 @@ describe("ArtworkSidebarCommercialButtons", () => {
         {
           Query: () => ({ me: meMock }),
           Artwork: () => ({
-            isOfferable: true,
-            isInquireable: true,
+            isAcquirable: true,
+            isOfferable: false,
+            isInquireable: false,
+          }),
+        },
+        null,
+        mockEnvironment
+      )
+
+      expect(screen.queryByText("Purchase")).toBeInTheDocument()
+      expect(screen.queryByText("Make an Offer")).not.toBeInTheDocument()
+      expect(screen.queryByText("Contact Gallery")).not.toBeInTheDocument()
+    })
+
+    it("for artwork that is MO only displays Purchase and Make offer buttons", async () => {
+      mockUseFeatureFlag.mockImplementation(() => true)
+      meMock.partnerOffersConnection.edges.push({
+        node: {
+          internalID: "partner-offer-id",
+          isAvailable: true,
+        },
+      })
+
+      renderWithRelay(
+        {
+          Query: () => ({ me: meMock }),
+          Artwork: () => ({
             isAcquirable: false,
+            isOfferable: true,
+            isInquireable: false,
           }),
         },
         null,
@@ -101,7 +128,7 @@ describe("ArtworkSidebarCommercialButtons", () => {
       expect(screen.queryByText("Contact Gallery")).not.toBeInTheDocument()
     })
 
-    it("displays Purchse and Contact Gallery buttons for work not eligeable for MO", async () => {
+    it("for artwork that is contact gallery only displays Purchase and Contact Gallery buttons", async () => {
       mockUseFeatureFlag.mockImplementation(() => true)
       meMock.partnerOffersConnection.edges.push({
         node: {
@@ -114,9 +141,36 @@ describe("ArtworkSidebarCommercialButtons", () => {
         {
           Query: () => ({ me: meMock }),
           Artwork: () => ({
+            isAcquirable: false,
             isOfferable: false,
             isInquireable: true,
+          }),
+        },
+        null,
+        mockEnvironment
+      )
+
+      expect(screen.queryByText("Purchase")).toBeInTheDocument()
+      expect(screen.queryByText("Make an Offer")).not.toBeInTheDocument()
+      expect(screen.queryByText("Contact Gallery")).toBeInTheDocument()
+    })
+
+    it("for MOOEA artwork displays Purchase and Contact Gallery buttons", async () => {
+      mockUseFeatureFlag.mockImplementation(() => true)
+      meMock.partnerOffersConnection.edges.push({
+        node: {
+          internalID: "partner-offer-id",
+          isAvailable: true,
+        },
+      })
+
+      renderWithRelay(
+        {
+          Query: () => ({ me: meMock }),
+          Artwork: () => ({
             isAcquirable: false,
+            isOfferable: true,
+            isInquireable: true,
           }),
         },
         null,


### PR DESCRIPTION
I tried to refactor the logic how we determine what buttons to display in which state - hopefully that is more readable now.

Here is the current look. 
<img width="1420" alt="Screen Shot 2024-04-08 at 2 51 55 PM" src="https://github.com/artsy/force/assets/437156/69a4094e-36d2-4156-989e-aa7b3389fd53">

The question I have here if we need to update partner section to display this 'contact gallery' button if purchase button bumped out the 'contact gallery' from main buttons?
