### PR TITLE
fix: remove minHeight so that Partner Offers are fixed

### DIFF
--- a/src/Components/Artwork/Details.tsx
+++ b/src/Components/Artwork/Details.tsx
@@ -256,7 +256,7 @@ export const Details: React.FC<DetailsProps> = ({
   }
 
   return (
-    <Box minHeight={105}>
+    <Box>
       {isAuctionArtwork && (
         <Flex flexDirection="row">
           <Join separator={<Spacer x={1} />}>


### PR DESCRIPTION
The type of this PR is: **FIX**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR partially solves [AMBER-550]

### Description

The previous PR for 550: https://github.com/artsy/force/pull/13685 introduced a visual bug for Partner Offers. This PR solves that bug by removing the `minHeight` which will cause a currently unseen issue with partner artworks.

Reverting the offending PR would be the best choice, but the revert is not very clean due to the number of files changed so this is the next best option. We can fix forward on the private artworks rail issue.

Before (Rail looking good, but Partner Offers not looking good):
![Screenshot 2024-04-11 at 11 05 49](https://github.com/artsy/force/assets/6280410/a54804f8-eeff-419a-ac18-549f01e74000)
![Screenshot 2024-04-11 at 11 05 54](https://github.com/artsy/force/assets/6280410/e4778159-e175-43c0-986d-50d174f87464)


After (Rail not looking good, but Partner Offers fixed):
![Screenshot 2024-04-11 at 10 57 37](https://github.com/artsy/force/assets/6280410/d648d8de-7d34-48d8-8014-2b5571d49595)

![Screenshot 2024-04-11 at 11 05 29](https://github.com/artsy/force/assets/6280410/cb206349-40b9-4b97-aa8e-3975c0b9404b)


<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AMBER-550]: https://artsyproduct.atlassian.net/browse/AMBER-550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ