### PR TITLE
fix: Correctly initializing SWA form contact info on back press

### DIFF
--- a/src/Apps/Consign/Routes/SubmissionFlow/ContactInformation/ContactInformation.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ContactInformation/ContactInformation.tsx
@@ -24,26 +24,9 @@ import {
   ContactInformationFormModel,
 } from "./Components/ContactInformationForm"
 import { TopContextBar } from "Components/TopContextBar"
+import { getContactInformationFormInitialValues } from "Apps/Consign/Routes/SubmissionFlow/Utils/formHelpers"
 
 const logger = createLogger("SubmissionFlow/ContactInformation.tsx")
-
-const getContactInformationFormInitialValues = (
-  me: ContactInformation_me$data
-): ContactInformationFormModel => {
-  const userRegionCode = me?.phoneNumber?.regionCode ?? ""
-  const countryCode = COUNTRY_CODES[userRegionCode.toLocaleUpperCase()]
-  let phoneNumber = me?.phone ?? ""
-
-  if (countryCode) {
-    phoneNumber = phoneNumber.replace(`+${countryCode}`, "")
-  }
-  return {
-    name: me?.name || "",
-    email: me?.email || "",
-    phoneNumber,
-    phoneNumberCountryCode: me?.phoneNumber?.regionCode || "us",
-  }
-}
 
 export interface ContactInformationProps {
   me: ContactInformation_me$data
@@ -58,7 +41,7 @@ export const ContactInformation: React.FC<ContactInformationProps> = ({
   const { router, match } = useRouter()
   const { sendToast } = useToasts()
   const { relayEnvironment, isLoggedIn } = useSystemContext()
-  const initialValue = getContactInformationFormInitialValues(me)
+  const initialValue = getContactInformationFormInitialValues(me, submission)
   const initialErrors = validate(
     initialValue,
     contactInformationValidationSchema
@@ -268,6 +251,9 @@ export const ContactInformationFragmentContainer = createFragmentContainer(
     submission: graphql`
       fragment ContactInformation_submission on ConsignmentSubmission {
         externalId
+        userName
+        userEmail
+        userPhone
       }
     `,
     me: graphql`

--- a/src/Apps/Consign/Routes/SubmissionFlow/ContactInformation/__tests__/ContactInformation.jest.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ContactInformation/__tests__/ContactInformation.jest.tsx
@@ -33,6 +33,16 @@ const mockEmptyMe = {
 
 const mockSubmission = {
   externalId: "b2449fe2-e828-4a32-ace7-ff0753cd01ef",
+  userName: "Serge",
+  userEmail: "serge@test.test",
+  userPhone: "+1 415-555-0132",
+}
+
+const mockEmptySubmission = {
+  externalId: "b2449fe2-e828-4a32-ace7-ff0753cd01ef",
+  userName: null,
+  userEmail: null,
+  userPhone: null,
 }
 
 const mockRouterPush = jest.fn()
@@ -96,7 +106,7 @@ const getWrapper = (user?: User) =>
       }
     `,
     variables: {
-      externalId: mockSubmission.externalId,
+      externalId: mockEmptySubmission.externalId,
     },
   })
 
@@ -117,10 +127,21 @@ describe("Save and Continue button", () => {
       }))
     })
 
+    describe("when submission has values", () => {
+      it("is enabled if all fields are received valid", async () => {
+        getWrapper().renderWithRelay({
+          Me: () => mockMe,
+          ConsignmentSubmission: () => mockSubmission,
+        })
+
+        expect(getSubmitButton()).toBeEnabled()
+      })
+    })
+
     it("is enabled if all fields are received valid", async () => {
       getWrapper().renderWithRelay({
         Me: () => mockMe,
-        ConsignmentSubmission: () => mockSubmission,
+        ConsignmentSubmission: () => mockEmptySubmission,
       })
 
       expect(getSubmitButton()).toBeEnabled()
@@ -129,7 +150,7 @@ describe("Save and Continue button", () => {
     it("is enabled if all fields are typed valid", async () => {
       getWrapper().renderWithRelay({
         Me: () => mockEmptyMe,
-        ConsignmentSubmission: () => mockSubmission,
+        ConsignmentSubmission: () => mockEmptySubmission,
       })
 
       await waitFor(() => {
@@ -166,7 +187,7 @@ describe("Save and Continue button", () => {
     it("is disabled when number is not valid", async () => {
       getWrapper().renderWithRelay({
         Me: () => mockMe,
-        ConsignmentSubmission: () => mockSubmission,
+        ConsignmentSubmission: () => mockEmptySubmission,
       })
 
       simulateTyping("name", "Banksy")
@@ -190,7 +211,7 @@ describe("Save and Continue button", () => {
     it("is disabled when number is not valid", async () => {
       getWrapper().renderWithRelay({
         Me: () => mockMe,
-        ConsignmentSubmission: () => mockSubmission,
+        ConsignmentSubmission: () => mockEmptySubmission,
       })
 
       simulateTyping("name", "Banksy")
@@ -205,7 +226,7 @@ describe("Save and Continue button", () => {
     it("is disabled when a valid number is removed by user", async () => {
       getWrapper().renderWithRelay({
         Me: () => mockMe,
-        ConsignmentSubmission: () => mockSubmission,
+        ConsignmentSubmission: () => mockEmptySubmission,
       })
 
       simulateTyping("name", "Banksy")
@@ -240,7 +261,7 @@ describe("Contact Information step", () => {
     it("renders correctly", async () => {
       getWrapper().renderWithRelay({
         Me: () => mockMe,
-        ConsignmentSubmission: () => mockSubmission,
+        ConsignmentSubmission: () => mockEmptySubmission,
       })
 
       expect(
@@ -256,7 +277,7 @@ describe("Contact Information step", () => {
         screen.getAllByRole("link").find(c => c.textContent?.includes("Back"))
       ).toHaveAttribute(
         "href",
-        `/sell/submission/${mockSubmission.externalId}/upload-photos`
+        `/sell/submission/${mockEmptySubmission.externalId}/upload-photos`
       )
 
       expect(getSubmitButton()).toBeInTheDocument()
@@ -267,7 +288,7 @@ describe("Contact Information step", () => {
     it("fields are not pre-populating from user profile", async () => {
       getWrapper().renderWithRelay({
         Me: () => mockEmptyMe,
-        ConsignmentSubmission: () => mockSubmission,
+        ConsignmentSubmission: () => mockEmptySubmission,
       })
 
       expect(getInput("name")).not.toHaveValue()
@@ -278,7 +299,7 @@ describe("Contact Information step", () => {
     it("submitting a valid form", async () => {
       getWrapper().renderWithRelay({
         Me: () => mockMe,
-        ConsignmentSubmission: () => mockSubmission,
+        ConsignmentSubmission: () => mockEmptySubmission,
       })
 
       simulateTyping("name", "Banksy")
@@ -286,7 +307,7 @@ describe("Contact Information step", () => {
       simulateTyping("phoneNumber", "415-555-0132")
 
       mockCreateOrUpdateConsignSubmission.mockResolvedValueOnce(
-        mockSubmission.externalId
+        mockEmptySubmission.externalId
       )
 
       fireEvent.click(getSubmitButton())
@@ -297,7 +318,7 @@ describe("Contact Information step", () => {
         })
         expect(mockCreateOrUpdateConsignSubmission).toHaveBeenCalled()
         expect(mockCreateOrUpdateConsignSubmission.mock.calls[0][1]).toEqual({
-          externalId: mockSubmission.externalId,
+          externalId: mockEmptySubmission.externalId,
           userName: "Banksy",
           userEmail: "banksy@test.test",
           userPhone: "+1 415-555-0132",
@@ -306,7 +327,7 @@ describe("Contact Information step", () => {
         })
         expect(mockRouterReplace).toHaveBeenCalledWith("/sell")
         expect(mockRouterPush).toHaveBeenCalledWith(
-          `/sell/submission/${mockSubmission.externalId}/thank-you`
+          `/sell/submission/${mockEmptySubmission.externalId}/thank-you`
         )
       })
     })
@@ -316,7 +337,7 @@ describe("Contact Information step", () => {
     it("fields are pre-populating from user profile", async () => {
       getWrapper().renderWithRelay({
         Me: () => mockMe,
-        ConsignmentSubmission: () => mockSubmission,
+        ConsignmentSubmission: () => mockEmptySubmission,
       })
 
       expect(getInput("name")).toHaveValue(mockMe.name)
@@ -327,11 +348,11 @@ describe("Contact Information step", () => {
     it("submiting a valid form", async () => {
       getWrapper().renderWithRelay({
         Me: () => mockMe,
-        ConsignmentSubmission: () => mockSubmission,
+        ConsignmentSubmission: () => mockEmptySubmission,
       })
 
       mockCreateOrUpdateConsignSubmission.mockResolvedValueOnce(
-        mockSubmission.externalId
+        mockEmptySubmission.externalId
       )
 
       fireEvent.click(getSubmitButton())
@@ -342,7 +363,7 @@ describe("Contact Information step", () => {
         })
         expect(mockCreateOrUpdateConsignSubmission).toHaveBeenCalled()
         expect(mockCreateOrUpdateConsignSubmission.mock.calls[0][1]).toEqual({
-          externalId: mockSubmission.externalId,
+          externalId: mockEmptySubmission.externalId,
           userName: "Serge",
           userEmail: "serge@test.test",
           userPhone: "+1 415-555-0132",
@@ -351,7 +372,7 @@ describe("Contact Information step", () => {
         })
         expect(mockRouterReplace).toHaveBeenCalledWith("/sell")
         expect(mockRouterPush).toHaveBeenCalledWith(
-          `/sell/submission/${mockSubmission.externalId}/thank-you`
+          `/sell/submission/${mockEmptySubmission.externalId}/thank-you`
         )
       })
     })
@@ -380,10 +401,12 @@ describe("Contact Information step", () => {
 
       getWrapper().renderWithRelay({
         Me: () => mockMe,
-        ConsignmentSubmission: () => null,
+        ConsignmentSubmission: () => mockEmptySubmission,
       })
 
       await flushPromiseQueue()
+
+      expect(getSubmitButton()).toBeEnabled()
 
       fireEvent.click(getSubmitButton())
 
@@ -401,7 +424,7 @@ describe("Contact Information step", () => {
   it("values are trimmed before any actions", async () => {
     getWrapper().renderWithRelay({
       Me: () => mockEmptyMe,
-      ConsignmentSubmission: () => mockSubmission,
+      ConsignmentSubmission: () => mockEmptySubmission,
     })
 
     simulateTyping("name", " Banksy  ")
@@ -417,7 +440,7 @@ describe("Contact Information step", () => {
     await waitFor(() => {
       expect(mockCreateOrUpdateConsignSubmission).toHaveBeenCalled()
       expect(mockCreateOrUpdateConsignSubmission.mock.calls[0][1]).toEqual({
-        externalId: mockSubmission.externalId,
+        externalId: mockEmptySubmission.externalId,
         userName: "Banksy",
         userEmail: "banksy@test.test",
         userPhone: "+1 415-555-0132",
@@ -431,7 +454,7 @@ describe("Contact Information step", () => {
     mockCreateOrUpdateConsignSubmission.mockRejectedValueOnce("rejected")
     getWrapper().renderWithRelay({
       Me: () => mockMe,
-      ConsignmentSubmission: () => mockSubmission,
+      ConsignmentSubmission: () => mockEmptySubmission,
     })
 
     fireEvent.click(getSubmitButton())
@@ -444,7 +467,7 @@ describe("Contact Information step", () => {
   it("tracks consignment submitted event with user email when logged in", async () => {
     getWrapper().renderWithRelay({
       Me: () => mockMe,
-      ConsignmentSubmission: () => mockSubmission,
+      ConsignmentSubmission: () => mockEmptySubmission,
     })
 
     fireEvent.click(getSubmitButton())
@@ -453,7 +476,7 @@ describe("Contact Information step", () => {
       expect(mockTrackEvent).toHaveBeenCalled()
       expect(mockTrackEvent).toHaveBeenCalledWith({
         action: ActionType.consignmentSubmitted,
-        submission_id: mockSubmission.externalId,
+        submission_id: mockEmptySubmission.externalId,
         user_id: "123",
         user_email: "serge@test.test",
       })
@@ -463,7 +486,7 @@ describe("Contact Information step", () => {
   it("tracks consignment submitted event with submission email when not logged in", async () => {
     getWrapper().renderWithRelay({
       Me: () => mockEmptyMe,
-      ConsignmentSubmission: () => mockSubmission,
+      ConsignmentSubmission: () => mockEmptySubmission,
     })
 
     simulateTyping("name", "Banksy")
@@ -482,7 +505,7 @@ describe("Contact Information step", () => {
       expect(mockTrackEvent).toHaveBeenCalled()
       expect(mockTrackEvent).toHaveBeenCalledWith({
         action: ActionType.consignmentSubmitted,
-        submission_id: mockSubmission.externalId,
+        submission_id: mockEmptySubmission.externalId,
         user_id: null,
         user_email: "banksy@test.test",
       })

--- a/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/UploadPhotos.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/UploadPhotos.tsx
@@ -42,24 +42,17 @@ import {
   UploadPhotosForm,
   UploadPhotosFormModel,
 } from "./Components/UploadPhotosForm"
+import {
+  SubmissionAsset,
+  getPhotoUrlFromAsset,
+  shouldRefetchPhotoUrls,
+} from "Apps/Consign/Routes/SubmissionFlow/Utils/formHelpers"
 
 const logger = createLogger("SubmissionFlow/UploadPhotos.tsx")
 
 export interface UploadPhotosProps {
   submission?: UploadPhotos_submission$data
   myCollectionArtwork?: UploadPhotos_myCollectionArtwork$data
-}
-
-type SubmissionAsset = NonNullable<UploadPhotos_submission$data["assets"]>[0]
-
-const shouldRefetchPhotoUrls = (photos: Photo[]) => {
-  return photos.some(photo => !!photo.assetId && !photo.url && !photo.file)
-}
-
-const getPhotoUrlFromAsset = (asset: SubmissionAsset) => {
-  return (
-    (asset?.imageUrls as any)?.thumbnail || (asset?.imageUrls as any)?.square
-  )
 }
 
 export const getUploadPhotosFormInitialValues = (

--- a/src/Apps/Consign/Routes/SubmissionFlow/Utils/formHelpers.ts
+++ b/src/Apps/Consign/Routes/SubmissionFlow/Utils/formHelpers.ts
@@ -21,7 +21,7 @@ export const getContactInformationFormInitialValues = (
   const userRegionCode = me?.phoneNumber?.regionCode ?? ""
 
   const countryCode =
-    submission?.userPhone?.split(" ")?.[0].replace("+", "") ||
+    submission?.userPhone?.split(" ")?.[0]?.replace("+", "") ||
     COUNTRY_CODES[userRegionCode.toLocaleUpperCase()]
 
   const phoneNumberCountryCode =

--- a/src/Apps/Consign/Routes/SubmissionFlow/Utils/formHelpers.ts
+++ b/src/Apps/Consign/Routes/SubmissionFlow/Utils/formHelpers.ts
@@ -1,0 +1,52 @@
+import { ContactInformationFormModel } from "Apps/Consign/Routes/SubmissionFlow/ContactInformation/Components/ContactInformationForm"
+import { Photo } from "Components/PhotoUpload/Utils/fileUtils"
+import { COUNTRY_CODES } from "Utils/countries"
+import { ContactInformation_me$data } from "__generated__/ContactInformation_me.graphql"
+import { ContactInformation_submission$data } from "__generated__/ContactInformation_submission.graphql"
+import { UploadPhotos_submission$data } from "__generated__/UploadPhotos_submission.graphql"
+import { findKey } from "lodash"
+
+export type SubmissionAsset = NonNullable<
+  UploadPhotos_submission$data["assets"]
+>[0]
+
+const DEFAULT_COUNTRY_CODE = "us"
+
+export const getContactInformationFormInitialValues = (
+  me: ContactInformation_me$data,
+  submission: ContactInformation_submission$data | null
+): ContactInformationFormModel => {
+  let phoneNumber = submission?.userPhone ?? me?.phone ?? ""
+
+  const userRegionCode = me?.phoneNumber?.regionCode ?? ""
+
+  const countryCode =
+    submission?.userPhone?.split(" ")?.[0].replace("+", "") ||
+    COUNTRY_CODES[userRegionCode.toLocaleUpperCase()]
+
+  const phoneNumberCountryCode =
+    findKey(COUNTRY_CODES, v => v === countryCode)?.toLowerCase() ||
+    me?.phoneNumber?.regionCode ||
+    DEFAULT_COUNTRY_CODE
+
+  if (countryCode) {
+    phoneNumber = phoneNumber.replace(`+${countryCode}`, "")
+  }
+
+  return {
+    name: submission?.userName || me?.name || "",
+    email: submission?.userEmail || me?.email || "",
+    phoneNumber,
+    phoneNumberCountryCode,
+  }
+}
+
+export const shouldRefetchPhotoUrls = (photos: Photo[]) => {
+  return photos.some(photo => !!photo.assetId && !photo.url && !photo.file)
+}
+
+export const getPhotoUrlFromAsset = (asset: SubmissionAsset) => {
+  return (
+    (asset?.imageUrls as any)?.thumbnail || (asset?.imageUrls as any)?.square
+  )
+}

--- a/src/__generated__/ContactInformation_SubmissionFlowTest_Query.graphql.ts
+++ b/src/__generated__/ContactInformation_SubmissionFlowTest_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<888c5341e4a9f0ca1d613b68619fb4d7>>
+ * @generated SignedSource<<5d5a1b7122bd9c1e15293de46f76f2f6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -182,6 +182,27 @@ return {
             "name": "externalId",
             "storageKey": null
           },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "userName",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "userEmail",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "userPhone",
+            "storageKey": null
+          },
           (v2/*: any*/)
         ],
         "storageKey": null
@@ -189,7 +210,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4cabf7f3fe975f7b2860fdf99bf9937b",
+    "cacheID": "03cc992235f250514f60e69a19779993",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -218,12 +239,15 @@ return {
           "type": "ConsignmentSubmission"
         },
         "submission.externalId": (v4/*: any*/),
-        "submission.id": (v4/*: any*/)
+        "submission.id": (v4/*: any*/),
+        "submission.userEmail": (v3/*: any*/),
+        "submission.userName": (v3/*: any*/),
+        "submission.userPhone": (v3/*: any*/)
       }
     },
     "name": "ContactInformation_SubmissionFlowTest_Query",
     "operationKind": "query",
-    "text": "query ContactInformation_SubmissionFlowTest_Query(\n  $externalId: ID\n) {\n  me {\n    ...ContactInformation_me\n    id\n  }\n  submission(externalId: $externalId) {\n    ...ContactInformation_submission\n    id\n  }\n}\n\nfragment ContactInformationForm_me on Me {\n  internalID\n  name\n  email\n  phone\n  phoneNumber {\n    regionCode\n  }\n}\n\nfragment ContactInformation_me on Me {\n  internalID\n  name\n  email\n  phone\n  phoneNumber {\n    regionCode\n  }\n  ...ContactInformationForm_me\n}\n\nfragment ContactInformation_submission on ConsignmentSubmission {\n  externalId\n}\n"
+    "text": "query ContactInformation_SubmissionFlowTest_Query(\n  $externalId: ID\n) {\n  me {\n    ...ContactInformation_me\n    id\n  }\n  submission(externalId: $externalId) {\n    ...ContactInformation_submission\n    id\n  }\n}\n\nfragment ContactInformationForm_me on Me {\n  internalID\n  name\n  email\n  phone\n  phoneNumber {\n    regionCode\n  }\n}\n\nfragment ContactInformation_me on Me {\n  internalID\n  name\n  email\n  phone\n  phoneNumber {\n    regionCode\n  }\n  ...ContactInformationForm_me\n}\n\nfragment ContactInformation_submission on ConsignmentSubmission {\n  externalId\n  userName\n  userEmail\n  userPhone\n}\n"
   }
 };
 })();

--- a/src/__generated__/ContactInformation_submission.graphql.ts
+++ b/src/__generated__/ContactInformation_submission.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<749a31ffa7dc4ed59cabbabcb6e90045>>
+ * @generated SignedSource<<9f3faff2d3a541f80722ebb2dc39ae72>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,9 @@ import { Fragment, ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type ContactInformation_submission$data = {
   readonly externalId: string;
+  readonly userEmail: string | null | undefined;
+  readonly userName: string | null | undefined;
+  readonly userPhone: string | null | undefined;
   readonly " $fragmentType": "ContactInformation_submission";
 };
 export type ContactInformation_submission$key = {
@@ -31,12 +34,33 @@ const node: ReaderFragment = {
       "kind": "ScalarField",
       "name": "externalId",
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "userName",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "userEmail",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "userPhone",
+      "storageKey": null
     }
   ],
   "type": "ConsignmentSubmission",
   "abstractKey": null
 };
 
-(node as any).hash = "403f4a265149c820349eb773cd1f812d";
+(node as any).hash = "1a7d8a788118c645057a534e897770f6";
 
 export default node;

--- a/src/__generated__/consignFromCollectorProfileMyCollectionRoutes_contactInformationArtworkOwnerQuery.graphql.ts
+++ b/src/__generated__/consignFromCollectorProfileMyCollectionRoutes_contactInformationArtworkOwnerQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<635cf5ef699f0293dce71bf9975f36c9>>
+ * @generated SignedSource<<115b8dce754c9f08d1cafb4ea84f9d68>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -397,6 +397,21 @@ return {
           {
             "alias": null,
             "args": null,
+            "kind": "ScalarField",
+            "name": "userName",
+            "storageKey": null
+          },
+          (v25/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "userPhone",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "concreteType": "Artist",
             "kind": "LinkedField",
             "name": "artist",
@@ -426,7 +441,6 @@ return {
           (v22/*: any*/),
           (v23/*: any*/),
           (v24/*: any*/),
-          (v25/*: any*/),
           (v27/*: any*/),
           (v26/*: any*/)
         ],
@@ -481,12 +495,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "6d486a4b8348c5d5ae3dae721d5394ef",
+    "cacheID": "8fff79aa99ac96464f866165689b7907",
     "id": null,
     "metadata": {},
     "name": "consignFromCollectorProfileMyCollectionRoutes_contactInformationArtworkOwnerQuery",
     "operationKind": "query",
-    "text": "query consignFromCollectorProfileMyCollectionRoutes_contactInformationArtworkOwnerQuery(\n  $id: ID\n  $externalId: ID\n  $sessionID: String\n) {\n  submission(id: $id, externalId: $externalId, sessionID: $sessionID) {\n    ...ContactInformation_submission\n    externalId\n    artist {\n      internalID\n      name\n      id\n    }\n    category\n    locationCity\n    locationCountry\n    locationState\n    locationPostalCode\n    locationCountryCode\n    year\n    title\n    medium\n    attributionClass\n    editionNumber\n    editionSize\n    height\n    width\n    depth\n    dimensionsMetric\n    provenance\n    userId\n    userEmail\n    assets {\n      id\n      imageUrls\n      geminiToken\n      size\n      filename\n    }\n    id\n  }\n  me {\n    ...ContactInformation_me\n    id\n  }\n}\n\nfragment ContactInformationForm_me on Me {\n  internalID\n  name\n  email\n  phone\n  phoneNumber {\n    regionCode\n  }\n}\n\nfragment ContactInformation_me on Me {\n  internalID\n  name\n  email\n  phone\n  phoneNumber {\n    regionCode\n  }\n  ...ContactInformationForm_me\n}\n\nfragment ContactInformation_submission on ConsignmentSubmission {\n  externalId\n}\n"
+    "text": "query consignFromCollectorProfileMyCollectionRoutes_contactInformationArtworkOwnerQuery(\n  $id: ID\n  $externalId: ID\n  $sessionID: String\n) {\n  submission(id: $id, externalId: $externalId, sessionID: $sessionID) {\n    ...ContactInformation_submission\n    externalId\n    artist {\n      internalID\n      name\n      id\n    }\n    category\n    locationCity\n    locationCountry\n    locationState\n    locationPostalCode\n    locationCountryCode\n    year\n    title\n    medium\n    attributionClass\n    editionNumber\n    editionSize\n    height\n    width\n    depth\n    dimensionsMetric\n    provenance\n    userId\n    userEmail\n    assets {\n      id\n      imageUrls\n      geminiToken\n      size\n      filename\n    }\n    id\n  }\n  me {\n    ...ContactInformation_me\n    id\n  }\n}\n\nfragment ContactInformationForm_me on Me {\n  internalID\n  name\n  email\n  phone\n  phoneNumber {\n    regionCode\n  }\n}\n\nfragment ContactInformation_me on Me {\n  internalID\n  name\n  email\n  phone\n  phoneNumber {\n    regionCode\n  }\n  ...ContactInformationForm_me\n}\n\nfragment ContactInformation_submission on ConsignmentSubmission {\n  externalId\n  userName\n  userEmail\n  userPhone\n}\n"
   }
 };
 })();

--- a/src/__generated__/consignFromMyCollectionRoutes_contactInformationArtworkOwnerQuery.graphql.ts
+++ b/src/__generated__/consignFromMyCollectionRoutes_contactInformationArtworkOwnerQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3d33e1bba4489c1fc1de8d5ede21c399>>
+ * @generated SignedSource<<e617e20af254303c37b1c8eef437c81b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -397,6 +397,21 @@ return {
           {
             "alias": null,
             "args": null,
+            "kind": "ScalarField",
+            "name": "userName",
+            "storageKey": null
+          },
+          (v25/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "userPhone",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "concreteType": "Artist",
             "kind": "LinkedField",
             "name": "artist",
@@ -426,7 +441,6 @@ return {
           (v22/*: any*/),
           (v23/*: any*/),
           (v24/*: any*/),
-          (v25/*: any*/),
           (v27/*: any*/),
           (v26/*: any*/)
         ],
@@ -481,12 +495,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "2f79f2ffd75d540585a77df21211c14a",
+    "cacheID": "14d23ceae960ea213fc88f42f757bf11",
     "id": null,
     "metadata": {},
     "name": "consignFromMyCollectionRoutes_contactInformationArtworkOwnerQuery",
     "operationKind": "query",
-    "text": "query consignFromMyCollectionRoutes_contactInformationArtworkOwnerQuery(\n  $id: ID\n  $externalId: ID\n  $sessionID: String\n) {\n  submission(id: $id, externalId: $externalId, sessionID: $sessionID) {\n    ...ContactInformation_submission\n    externalId\n    artist {\n      internalID\n      name\n      id\n    }\n    category\n    locationCity\n    locationCountry\n    locationState\n    locationPostalCode\n    locationCountryCode\n    year\n    title\n    medium\n    attributionClass\n    editionNumber\n    editionSize\n    height\n    width\n    depth\n    dimensionsMetric\n    provenance\n    userId\n    userEmail\n    assets {\n      id\n      imageUrls\n      geminiToken\n      size\n      filename\n    }\n    id\n  }\n  me {\n    ...ContactInformation_me\n    id\n  }\n}\n\nfragment ContactInformationForm_me on Me {\n  internalID\n  name\n  email\n  phone\n  phoneNumber {\n    regionCode\n  }\n}\n\nfragment ContactInformation_me on Me {\n  internalID\n  name\n  email\n  phone\n  phoneNumber {\n    regionCode\n  }\n  ...ContactInformationForm_me\n}\n\nfragment ContactInformation_submission on ConsignmentSubmission {\n  externalId\n}\n"
+    "text": "query consignFromMyCollectionRoutes_contactInformationArtworkOwnerQuery(\n  $id: ID\n  $externalId: ID\n  $sessionID: String\n) {\n  submission(id: $id, externalId: $externalId, sessionID: $sessionID) {\n    ...ContactInformation_submission\n    externalId\n    artist {\n      internalID\n      name\n      id\n    }\n    category\n    locationCity\n    locationCountry\n    locationState\n    locationPostalCode\n    locationCountryCode\n    year\n    title\n    medium\n    attributionClass\n    editionNumber\n    editionSize\n    height\n    width\n    depth\n    dimensionsMetric\n    provenance\n    userId\n    userEmail\n    assets {\n      id\n      imageUrls\n      geminiToken\n      size\n      filename\n    }\n    id\n  }\n  me {\n    ...ContactInformation_me\n    id\n  }\n}\n\nfragment ContactInformationForm_me on Me {\n  internalID\n  name\n  email\n  phone\n  phoneNumber {\n    regionCode\n  }\n}\n\nfragment ContactInformation_me on Me {\n  internalID\n  name\n  email\n  phone\n  phoneNumber {\n    regionCode\n  }\n  ...ContactInformationForm_me\n}\n\nfragment ContactInformation_submission on ConsignmentSubmission {\n  externalId\n  userName\n  userEmail\n  userPhone\n}\n"
   }
 };
 })();

--- a/src/__generated__/consignRoutes_contactInformationQuery.graphql.ts
+++ b/src/__generated__/consignRoutes_contactInformationQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7783dac2df8cf1f4f137baf984d76ccc>>
+ * @generated SignedSource<<475ba5143fedd96c027567de7bcf9020>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -397,6 +397,21 @@ return {
           {
             "alias": null,
             "args": null,
+            "kind": "ScalarField",
+            "name": "userName",
+            "storageKey": null
+          },
+          (v25/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "userPhone",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "concreteType": "Artist",
             "kind": "LinkedField",
             "name": "artist",
@@ -426,7 +441,6 @@ return {
           (v22/*: any*/),
           (v23/*: any*/),
           (v24/*: any*/),
-          (v25/*: any*/),
           (v27/*: any*/),
           (v26/*: any*/)
         ],
@@ -481,12 +495,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "63325a7fbdf744c75153f407b37ef8ae",
+    "cacheID": "5129d976f7dd4e4cd130e073b9026658",
     "id": null,
     "metadata": {},
     "name": "consignRoutes_contactInformationQuery",
     "operationKind": "query",
-    "text": "query consignRoutes_contactInformationQuery(\n  $id: ID\n  $externalId: ID\n  $sessionID: String\n) {\n  submission(id: $id, externalId: $externalId, sessionID: $sessionID) {\n    ...ContactInformation_submission\n    externalId\n    artist {\n      internalID\n      name\n      id\n    }\n    category\n    locationCity\n    locationCountry\n    locationState\n    locationPostalCode\n    locationCountryCode\n    year\n    title\n    medium\n    attributionClass\n    editionNumber\n    editionSize\n    height\n    width\n    depth\n    dimensionsMetric\n    provenance\n    userId\n    userEmail\n    assets {\n      id\n      imageUrls\n      geminiToken\n      size\n      filename\n    }\n    id\n  }\n  me {\n    ...ContactInformation_me\n    id\n  }\n}\n\nfragment ContactInformationForm_me on Me {\n  internalID\n  name\n  email\n  phone\n  phoneNumber {\n    regionCode\n  }\n}\n\nfragment ContactInformation_me on Me {\n  internalID\n  name\n  email\n  phone\n  phoneNumber {\n    regionCode\n  }\n  ...ContactInformationForm_me\n}\n\nfragment ContactInformation_submission on ConsignmentSubmission {\n  externalId\n}\n"
+    "text": "query consignRoutes_contactInformationQuery(\n  $id: ID\n  $externalId: ID\n  $sessionID: String\n) {\n  submission(id: $id, externalId: $externalId, sessionID: $sessionID) {\n    ...ContactInformation_submission\n    externalId\n    artist {\n      internalID\n      name\n      id\n    }\n    category\n    locationCity\n    locationCountry\n    locationState\n    locationPostalCode\n    locationCountryCode\n    year\n    title\n    medium\n    attributionClass\n    editionNumber\n    editionSize\n    height\n    width\n    depth\n    dimensionsMetric\n    provenance\n    userId\n    userEmail\n    assets {\n      id\n      imageUrls\n      geminiToken\n      size\n      filename\n    }\n    id\n  }\n  me {\n    ...ContactInformation_me\n    id\n  }\n}\n\nfragment ContactInformationForm_me on Me {\n  internalID\n  name\n  email\n  phone\n  phoneNumber {\n    regionCode\n  }\n}\n\nfragment ContactInformation_me on Me {\n  internalID\n  name\n  email\n  phone\n  phoneNumber {\n    regionCode\n  }\n  ...ContactInformationForm_me\n}\n\nfragment ContactInformation_submission on ConsignmentSubmission {\n  externalId\n  userName\n  userEmail\n  userPhone\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Addresses [ONYX-821]

## Description

Correctly initializing the SWA form contact info on back press. This was not happening before at this step. It is likely that it was never set up because this is the first step of the form without loading an already existing submission.

<img width="1369" alt="Screenshot 2024-04-11 at 13 50 30" src="https://github.com/artsy/force/assets/4691889/bcaa15ed-80d7-481f-b4fe-11e522e2c1c0">


[ONYX-821]: https://artsyproduct.atlassian.net/browse/ONYX-821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ