### PR TITLE
feat(EMI-1799): partner offer note redesign in notification panel

### DIFF
--- a/src/Components/Notifications/NotificationItem.tsx
+++ b/src/Components/Notifications/NotificationItem.tsx
@@ -132,7 +132,13 @@ const NotificationItem: FC<NotificationItemProps> = ({ item }) => {
             </Flex>
           )}
 
-          <Text variant="xs" color="blue100">
+          <Text
+            variant="xs"
+            color="blue100"
+            backgroundColor="blue10"
+            px={0.5}
+            alignSelf="flex-start"
+          >
             {getNotificationPrelude(item)}
           </Text>
 
@@ -291,7 +297,7 @@ const getNotificationUrl = (notification: NotificationItem_item$data) => {
 const getNotificationPrelude = (item: NotificationItem_item$data) => {
   switch (item.notificationType) {
     case "PARTNER_OFFER_CREATED":
-      return "Limited Time Offer"
+      return "Limited-Time Offer"
     default:
       return null
   }

--- a/src/Components/Notifications/PartnerOfferArtwork.tsx
+++ b/src/Components/Notifications/PartnerOfferArtwork.tsx
@@ -42,6 +42,7 @@ export const PartnerOfferArtwork: FC<PartnerOfferArtworkProps> = ({
   const partnerOfferVisibilityEnabled = useFeatureFlag(
     "emerald_partner-offers-to-artwork-page"
   )
+  const partnerIcon = artwork.partner?.profile?.icon?.resized
   const artworkListingHref =
     artwork.href + "?partner_offer_id=" + partnerOfferID
 
@@ -132,24 +133,8 @@ export const PartnerOfferArtwork: FC<PartnerOfferArtworkProps> = ({
           </Flex>
         )}
       </Box>
-      {note && (
-        <Box
-          backgroundColor={"black10"}
-          mb={2}
-          padding={1}
-          width="100%"
-          maxWidth={CARD_MAX_WIDTH}
-        >
-          <Text variant="xs" color="black100">
-            Note from the gallery:
-          </Text>
-          <Text variant="xs" color="black60">
-            {note}
-          </Text>
-        </Box>
-      )}
       <Box
-        mb={4}
+        mb={2}
         display="flex"
         justifyContent="space-between"
         width="100%"
@@ -178,6 +163,34 @@ export const PartnerOfferArtwork: FC<PartnerOfferArtworkProps> = ({
           </Button>
         )}
       </Box>
+      {note && (
+        <Box
+          backgroundColor={"black5"}
+          padding={2}
+          width="100%"
+          maxWidth={CARD_MAX_WIDTH}
+          display={"flex"}
+          gap={1}
+        >
+          {partnerIcon && (
+            <Box>
+              <Image
+                borderRadius={"50%"}
+                src={partnerIcon.src}
+                srcSet={partnerIcon.srcSet}
+              />
+            </Box>
+          )}
+          <Box flex={1}>
+            <Text variant="sm" color="black100" fontWeight={"bold"}>
+              Note from the gallery
+            </Text>
+            <Text variant="sm" color="black100">
+              "{note}"
+            </Text>
+          </Box>
+        </Box>
+      )}
     </ManageArtworkForSavesProvider>
   )
 }
@@ -192,6 +205,16 @@ const partnerOfferArtworkFragment = graphql`
       src: url(version: ["larger", "large"])
       width
       height
+    }
+    partner(shallow: true) {
+      profile {
+        icon {
+          resized(width: 30, height: 30, version: "square") {
+            src
+            srcSet
+          }
+        }
+      }
     }
     ...Metadata_artwork
   }

--- a/src/Components/Notifications/PartnerOfferCreatedNotification.tsx
+++ b/src/Components/Notifications/PartnerOfferCreatedNotification.tsx
@@ -47,8 +47,8 @@ export const PartnerOfferCreatedNotification: FC<PartnerOfferCreatedNotification
   return (
     <Box>
       <Flex width="100%" justifyContent="space-between">
-        <Text variant="xs" color="blue100">
-          Limited Time Offer
+        <Text variant="xs" color="blue100" backgroundColor="blue10" px={0.5}>
+          Limited-Time Offer
         </Text>
         <RouterLink to={BASE_SAVES_PATH} data-testid="manage-saves-link">
           <Text variant="xs">Manage Saves</Text>

--- a/src/Components/Notifications/__tests__/PartnerOfferCreatedNotification.jest.tsx
+++ b/src/Components/Notifications/__tests__/PartnerOfferCreatedNotification.jest.tsx
@@ -86,8 +86,8 @@ describe("PartnerOfferCreatedNotification", () => {
           notification("2099-01-01T00:00:00+00:00", true, "Please buy this!"),
       })
 
-      expect(screen.getByText("Note from the gallery:")).toBeInTheDocument()
-      expect(screen.getByText("Please buy this!")).toBeInTheDocument()
+      expect(screen.getByText("Note from the gallery")).toBeInTheDocument()
+      expect(screen.getByText('"Please buy this!"')).toBeInTheDocument()
     })
   })
 

--- a/src/__generated__/NotificationQuery.graphql.ts
+++ b/src/__generated__/NotificationQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bceed90985f135981eea69aa951cef29>>
+ * @generated SignedSource<<d74426bcdc6dfa6f1c5033bc5aab3a7d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -258,33 +258,19 @@ v23 = {
 },
 v24 = {
   "alias": null,
-  "args": (v20/*: any*/),
-  "concreteType": "Partner",
-  "kind": "LinkedField",
-  "name": "partner",
-  "plural": false,
-  "selections": [
-    (v21/*: any*/),
-    (v8/*: any*/),
-    (v2/*: any*/)
-  ],
-  "storageKey": "partner(shallow:true)"
-},
-v25 = {
-  "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v26 = {
+v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "startAt",
   "storageKey": null
 },
-v27 = {
+v26 = {
   "alias": null,
   "args": null,
   "concreteType": "Sale",
@@ -292,7 +278,7 @@ v27 = {
   "name": "sale",
   "plural": false,
   "selections": [
-    (v25/*: any*/),
+    (v24/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -307,7 +293,7 @@ v27 = {
       "name": "extendedBiddingIntervalMinutes",
       "storageKey": null
     },
-    (v26/*: any*/),
+    (v25/*: any*/),
     {
       "alias": "is_auction",
       "args": null,
@@ -326,7 +312,7 @@ v27 = {
   ],
   "storageKey": null
 },
-v28 = [
+v27 = [
   {
     "alias": null,
     "args": null,
@@ -335,7 +321,7 @@ v28 = [
     "storageKey": null
   }
 ],
-v29 = {
+v28 = {
   "alias": "sale_artwork",
   "args": null,
   "concreteType": "SaleArtwork",
@@ -357,7 +343,7 @@ v29 = {
       "name": "lotLabel",
       "storageKey": null
     },
-    (v25/*: any*/),
+    (v24/*: any*/),
     {
       "alias": null,
       "args": null,
@@ -397,7 +383,7 @@ v29 = {
       "kind": "LinkedField",
       "name": "highestBid",
       "plural": false,
-      "selections": (v28/*: any*/),
+      "selections": (v27/*: any*/),
       "storageKey": null
     },
     {
@@ -407,26 +393,31 @@ v29 = {
       "kind": "LinkedField",
       "name": "openingBid",
       "plural": false,
-      "selections": (v28/*: any*/),
+      "selections": (v27/*: any*/),
       "storageKey": null
     },
     (v2/*: any*/)
   ],
   "storageKey": null
 },
-v30 = {
+v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v31 = {
+v30 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isSaved",
   "storageKey": null
+},
+v31 = {
+  "kind": "Literal",
+  "name": "version",
+  "value": "square"
 },
 v32 = {
   "alias": "preview",
@@ -439,11 +430,7 @@ v32 = {
     {
       "alias": null,
       "args": [
-        {
-          "kind": "Literal",
-          "name": "version",
-          "value": "square"
-        }
+        (v31/*: any*/)
       ],
       "kind": "ScalarField",
       "name": "url",
@@ -520,7 +507,11 @@ v39 = {
     (v2/*: any*/)
   ],
   "storageKey": null
-};
+},
+v40 = [
+  (v37/*: any*/),
+  (v38/*: any*/)
+];
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -651,12 +642,25 @@ return {
                           (v19/*: any*/),
                           (v22/*: any*/),
                           (v23/*: any*/),
-                          (v24/*: any*/),
-                          (v27/*: any*/),
-                          (v29/*: any*/),
+                          {
+                            "alias": null,
+                            "args": (v20/*: any*/),
+                            "concreteType": "Partner",
+                            "kind": "LinkedField",
+                            "name": "partner",
+                            "plural": false,
+                            "selections": [
+                              (v21/*: any*/),
+                              (v8/*: any*/),
+                              (v2/*: any*/)
+                            ],
+                            "storageKey": "partner(shallow:true)"
+                          },
+                          (v26/*: any*/),
+                          (v28/*: any*/),
                           (v2/*: any*/),
+                          (v29/*: any*/),
                           (v30/*: any*/),
-                          (v31/*: any*/),
                           (v32/*: any*/),
                           (v33/*: any*/),
                           (v35/*: any*/),
@@ -720,7 +724,7 @@ return {
                             "plural": true,
                             "selections": [
                               (v21/*: any*/),
-                              (v30/*: any*/),
+                              (v29/*: any*/),
                               (v2/*: any*/)
                             ],
                             "storageKey": null
@@ -771,7 +775,7 @@ return {
                             "storageKey": null
                           },
                           (v21/*: any*/),
-                          (v30/*: any*/),
+                          (v29/*: any*/),
                           (v2/*: any*/)
                         ],
                         "storageKey": null
@@ -885,7 +889,7 @@ return {
                                 "plural": false,
                                 "selections": [
                                   (v21/*: any*/),
-                                  (v30/*: any*/),
+                                  (v29/*: any*/),
                                   (v3/*: any*/),
                                   (v8/*: any*/),
                                   (v2/*: any*/)
@@ -914,7 +918,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v3/*: any*/),
-                          (v25/*: any*/),
+                          (v24/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -936,7 +940,7 @@ return {
                             "kind": "LinkedField",
                             "name": "priceWithDiscount",
                             "plural": false,
-                            "selections": (v28/*: any*/),
+                            "selections": (v27/*: any*/),
                             "storageKey": null
                           },
                           (v2/*: any*/)
@@ -1016,8 +1020,8 @@ return {
                                     "name": "exhibitionPeriod",
                                     "storageKey": null
                                   },
-                                  (v26/*: any*/),
                                   (v25/*: any*/),
+                                  (v24/*: any*/),
                                   (v21/*: any*/),
                                   {
                                     "alias": null,
@@ -1054,16 +1058,13 @@ return {
                                         "kind": "LinkedField",
                                         "name": "cropped",
                                         "plural": false,
-                                        "selections": [
-                                          (v37/*: any*/),
-                                          (v38/*: any*/)
-                                        ],
+                                        "selections": (v40/*: any*/),
                                         "storageKey": "cropped(height:450,version:[\"larger\",\"large\"],width:600)"
                                       }
                                     ],
                                     "storageKey": null
                                   },
-                                  (v30/*: any*/),
+                                  (v29/*: any*/),
                                   (v2/*: any*/)
                                 ],
                                 "storageKey": null
@@ -1231,6 +1232,65 @@ return {
                             "storageKey": null
                           },
                           (v12/*: any*/),
+                          {
+                            "alias": null,
+                            "args": (v20/*: any*/),
+                            "concreteType": "Partner",
+                            "kind": "LinkedField",
+                            "name": "partner",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Profile",
+                                "kind": "LinkedField",
+                                "name": "profile",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Image",
+                                    "kind": "LinkedField",
+                                    "name": "icon",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": [
+                                          {
+                                            "kind": "Literal",
+                                            "name": "height",
+                                            "value": 30
+                                          },
+                                          (v31/*: any*/),
+                                          {
+                                            "kind": "Literal",
+                                            "name": "width",
+                                            "value": 30
+                                          }
+                                        ],
+                                        "concreteType": "ResizedImageUrl",
+                                        "kind": "LinkedField",
+                                        "name": "resized",
+                                        "plural": false,
+                                        "selections": (v40/*: any*/),
+                                        "storageKey": "resized(height:30,version:\"square\",width:30)"
+                                      }
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  (v2/*: any*/)
+                                ],
+                                "storageKey": null
+                              },
+                              (v2/*: any*/),
+                              (v21/*: any*/),
+                              (v8/*: any*/)
+                            ],
+                            "storageKey": "partner(shallow:true)"
+                          },
                           (v3/*: any*/),
                           (v14/*: any*/),
                           (v15/*: any*/),
@@ -1240,12 +1300,11 @@ return {
                           (v19/*: any*/),
                           (v22/*: any*/),
                           (v23/*: any*/),
-                          (v24/*: any*/),
-                          (v27/*: any*/),
-                          (v29/*: any*/),
+                          (v26/*: any*/),
+                          (v28/*: any*/),
                           (v2/*: any*/),
+                          (v29/*: any*/),
                           (v30/*: any*/),
-                          (v31/*: any*/),
                           (v32/*: any*/),
                           (v33/*: any*/),
                           (v35/*: any*/),
@@ -1269,12 +1328,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a4f977800b3e3b06120b63d8a7d6e51c",
+    "cacheID": "27aa8ba6aa3caad0800c4dab57c7dbde",
     "id": null,
     "metadata": {},
     "name": "NotificationQuery",
     "operationKind": "query",
-    "text": "query NotificationQuery(\n  $internalID: String!\n) {\n  me {\n    notification(id: $internalID) {\n      id\n      internalID\n      notificationType\n      targetHref\n      ...AlertNotification_notification\n      ...ArtworkPublishedNotification_notification\n      ...ArticleFeaturedArtistNotification_notification\n      ...PartnerOfferCreatedNotification_notification\n      ...PartnerShowOpenedNotification_notification\n      ...ViewingRoomPublishedNotification_notification\n    }\n    id\n  }\n}\n\nfragment AlertNotification_notification on Notification {\n  artworksConnection(first: 10) {\n    ...NotificationArtworkList_artworksConnection\n    totalCount\n  }\n  headline\n  item {\n    __typename\n    ... on AlertNotificationItem {\n      alert {\n        internalID\n        artists {\n          name\n          slug\n          id\n        }\n        labels {\n          displayValue\n        }\n        id\n      }\n    }\n  }\n  notificationType\n  ...NotificationTypeLabel_notification\n}\n\nfragment ArticleFeaturedArtistNotification_notification on Notification {\n  headline\n  item {\n    __typename\n    ... on ArticleFeaturedArtistNotificationItem {\n      article {\n        href\n        thumbnailTitle\n        byline\n        publishedAt(format: \"MMM D, YYYY\")\n        thumbnailImage {\n          cropped(width: 910, height: 607) {\n            src\n            srcSet\n            width\n            height\n          }\n        }\n        id\n      }\n      artistsConnection(first: 10) {\n        edges {\n          node {\n            name\n            slug\n            internalID\n            href\n            id\n          }\n        }\n      }\n    }\n  }\n  notificationType\n  ...NotificationTypeLabel_notification\n}\n\nfragment ArtworkPublishedNotification_notification on Notification {\n  artworksConnection(first: 10) {\n    ...NotificationArtworkList_artworksConnection\n    totalCount\n  }\n  headline\n  item {\n    __typename\n    ... on ArtworkPublishedNotificationItem {\n      artists {\n        internalID\n        isFollowed\n        name\n        slug\n        id\n      }\n    }\n  }\n  notificationType\n  ...NotificationTypeLabel_notification\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  isUnlisted\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NotificationArtworkList_artworksConnection on ArtworkConnection {\n  edges {\n    node {\n      ...NotificationArtwork_artwork\n      internalID\n      id\n    }\n  }\n}\n\nfragment NotificationArtwork_artwork on Artwork {\n  artistNames\n  href\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n  }\n  title\n  ...Metadata_artwork\n}\n\nfragment NotificationPartnerShow_show on Show {\n  location {\n    city\n    id\n  }\n  exhibitionPeriod\n  startAt\n  endAt\n  name\n  description\n  href\n  coverImage {\n    cropped(width: 600, height: 450, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n    }\n  }\n  slug\n}\n\nfragment NotificationTypeLabel_notification on Notification {\n  notificationType\n  publishedAt(format: \"RELATIVE\")\n}\n\nfragment NotificationViewingRoom_viewingRoom on ViewingRoom {\n  title\n  href\n  introStatement\n  image {\n    imageURLs {\n      normalized\n    }\n    width\n    height\n  }\n}\n\nfragment NotificationViewingRoomsList_viewingRoomsConnection on ViewingRoomsConnection {\n  edges {\n    node {\n      ...NotificationViewingRoom_viewingRoom\n      internalID\n    }\n  }\n}\n\nfragment PartnerOfferArtwork_artwork on Artwork {\n  href\n  title\n  artistNames\n  price\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n  }\n  ...Metadata_artwork\n}\n\nfragment PartnerOfferCreatedNotification_notification on Notification {\n  headline\n  targetHref\n  item {\n    __typename\n    ... on PartnerOfferCreatedNotificationItem {\n      partnerOffer {\n        internalID\n        endAt\n        isAvailable\n        note\n        priceWithDiscount {\n          display\n        }\n        id\n      }\n    }\n  }\n  offerArtworksConnection: artworksConnection(first: 1) {\n    edges {\n      node {\n        ...PartnerOfferArtwork_artwork\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerShowOpenedNotification_notification on Notification {\n  headline\n  item {\n    __typename\n    ... on ShowOpenedNotificationItem {\n      partner {\n        href\n        name\n        profile {\n          internalID\n          id\n        }\n        id\n      }\n      showsConnection {\n        edges {\n          node {\n            internalID\n            ...NotificationPartnerShow_show\n            id\n          }\n        }\n      }\n    }\n  }\n  ...NotificationTypeLabel_notification\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isSavedToList\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n\nfragment ViewingRoomPublishedNotification_notification on Notification {\n  headline\n  item {\n    __typename\n    ... on ViewingRoomPublishedNotificationItem {\n      partner {\n        name\n        href\n        profile {\n          internalID\n          id\n        }\n        id\n      }\n      viewingRoomsConnection(first: 10) {\n        ...NotificationViewingRoomsList_viewingRoomsConnection\n      }\n    }\n  }\n  notificationType\n  ...NotificationTypeLabel_notification\n}\n"
+    "text": "query NotificationQuery(\n  $internalID: String!\n) {\n  me {\n    notification(id: $internalID) {\n      id\n      internalID\n      notificationType\n      targetHref\n      ...AlertNotification_notification\n      ...ArtworkPublishedNotification_notification\n      ...ArticleFeaturedArtistNotification_notification\n      ...PartnerOfferCreatedNotification_notification\n      ...PartnerShowOpenedNotification_notification\n      ...ViewingRoomPublishedNotification_notification\n    }\n    id\n  }\n}\n\nfragment AlertNotification_notification on Notification {\n  artworksConnection(first: 10) {\n    ...NotificationArtworkList_artworksConnection\n    totalCount\n  }\n  headline\n  item {\n    __typename\n    ... on AlertNotificationItem {\n      alert {\n        internalID\n        artists {\n          name\n          slug\n          id\n        }\n        labels {\n          displayValue\n        }\n        id\n      }\n    }\n  }\n  notificationType\n  ...NotificationTypeLabel_notification\n}\n\nfragment ArticleFeaturedArtistNotification_notification on Notification {\n  headline\n  item {\n    __typename\n    ... on ArticleFeaturedArtistNotificationItem {\n      article {\n        href\n        thumbnailTitle\n        byline\n        publishedAt(format: \"MMM D, YYYY\")\n        thumbnailImage {\n          cropped(width: 910, height: 607) {\n            src\n            srcSet\n            width\n            height\n          }\n        }\n        id\n      }\n      artistsConnection(first: 10) {\n        edges {\n          node {\n            name\n            slug\n            internalID\n            href\n            id\n          }\n        }\n      }\n    }\n  }\n  notificationType\n  ...NotificationTypeLabel_notification\n}\n\nfragment ArtworkPublishedNotification_notification on Notification {\n  artworksConnection(first: 10) {\n    ...NotificationArtworkList_artworksConnection\n    totalCount\n  }\n  headline\n  item {\n    __typename\n    ... on ArtworkPublishedNotificationItem {\n      artists {\n        internalID\n        isFollowed\n        name\n        slug\n        id\n      }\n    }\n  }\n  notificationType\n  ...NotificationTypeLabel_notification\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  isUnlisted\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment NotificationArtworkList_artworksConnection on ArtworkConnection {\n  edges {\n    node {\n      ...NotificationArtwork_artwork\n      internalID\n      id\n    }\n  }\n}\n\nfragment NotificationArtwork_artwork on Artwork {\n  artistNames\n  href\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n  }\n  title\n  ...Metadata_artwork\n}\n\nfragment NotificationPartnerShow_show on Show {\n  location {\n    city\n    id\n  }\n  exhibitionPeriod\n  startAt\n  endAt\n  name\n  description\n  href\n  coverImage {\n    cropped(width: 600, height: 450, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n    }\n  }\n  slug\n}\n\nfragment NotificationTypeLabel_notification on Notification {\n  notificationType\n  publishedAt(format: \"RELATIVE\")\n}\n\nfragment NotificationViewingRoom_viewingRoom on ViewingRoom {\n  title\n  href\n  introStatement\n  image {\n    imageURLs {\n      normalized\n    }\n    width\n    height\n  }\n}\n\nfragment NotificationViewingRoomsList_viewingRoomsConnection on ViewingRoomsConnection {\n  edges {\n    node {\n      ...NotificationViewingRoom_viewingRoom\n      internalID\n    }\n  }\n}\n\nfragment PartnerOfferArtwork_artwork on Artwork {\n  href\n  title\n  artistNames\n  price\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n  }\n  partner(shallow: true) {\n    profile {\n      icon {\n        resized(width: 30, height: 30, version: \"square\") {\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    id\n  }\n  ...Metadata_artwork\n}\n\nfragment PartnerOfferCreatedNotification_notification on Notification {\n  headline\n  targetHref\n  item {\n    __typename\n    ... on PartnerOfferCreatedNotificationItem {\n      partnerOffer {\n        internalID\n        endAt\n        isAvailable\n        note\n        priceWithDiscount {\n          display\n        }\n        id\n      }\n    }\n  }\n  offerArtworksConnection: artworksConnection(first: 1) {\n    edges {\n      node {\n        ...PartnerOfferArtwork_artwork\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerShowOpenedNotification_notification on Notification {\n  headline\n  item {\n    __typename\n    ... on ShowOpenedNotificationItem {\n      partner {\n        href\n        name\n        profile {\n          internalID\n          id\n        }\n        id\n      }\n      showsConnection {\n        edges {\n          node {\n            internalID\n            ...NotificationPartnerShow_show\n            id\n          }\n        }\n      }\n    }\n  }\n  ...NotificationTypeLabel_notification\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isSavedToList\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n\nfragment ViewingRoomPublishedNotification_notification on Notification {\n  headline\n  item {\n    __typename\n    ... on ViewingRoomPublishedNotificationItem {\n      partner {\n        name\n        href\n        profile {\n          internalID\n          id\n        }\n        id\n      }\n      viewingRoomsConnection(first: 10) {\n        ...NotificationViewingRoomsList_viewingRoomsConnection\n      }\n    }\n  }\n  notificationType\n  ...NotificationTypeLabel_notification\n}\n"
   }
 };
 })();

--- a/src/__generated__/PartnerOfferArtwork_artwork.graphql.ts
+++ b/src/__generated__/PartnerOfferArtwork_artwork.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<aca2c9f324af8bf2fdf2173d6e37a063>>
+ * @generated SignedSource<<eb8e943c3ee52604f90eb31d16a8d97a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -17,6 +17,16 @@ export type PartnerOfferArtwork_artwork$data = {
     readonly height: number | null | undefined;
     readonly src: string | null | undefined;
     readonly width: number | null | undefined;
+  } | null | undefined;
+  readonly partner: {
+    readonly profile: {
+      readonly icon: {
+        readonly resized: {
+          readonly src: string;
+          readonly srcSet: string;
+        } | null | undefined;
+      } | null | undefined;
+    } | null | undefined;
   } | null | undefined;
   readonly price: string | null | undefined;
   readonly title: string | null | undefined;
@@ -104,6 +114,86 @@ const node: ReaderFragment = {
       "storageKey": null
     },
     {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "shallow",
+          "value": true
+        }
+      ],
+      "concreteType": "Partner",
+      "kind": "LinkedField",
+      "name": "partner",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Profile",
+          "kind": "LinkedField",
+          "name": "profile",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Image",
+              "kind": "LinkedField",
+              "name": "icon",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": [
+                    {
+                      "kind": "Literal",
+                      "name": "height",
+                      "value": 30
+                    },
+                    {
+                      "kind": "Literal",
+                      "name": "version",
+                      "value": "square"
+                    },
+                    {
+                      "kind": "Literal",
+                      "name": "width",
+                      "value": 30
+                    }
+                  ],
+                  "concreteType": "ResizedImageUrl",
+                  "kind": "LinkedField",
+                  "name": "resized",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "src",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "srcSet",
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": "resized(height:30,version:\"square\",width:30)"
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "partner(shallow:true)"
+    },
+    {
       "args": null,
       "kind": "FragmentSpread",
       "name": "Metadata_artwork"
@@ -113,6 +203,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "ea4b3a0baac7e94cda2ba11dcade250e";
+(node as any).hash = "9bc5ac4bc8dacfb93c8f5c020e305b33";
 
 export default node;

--- a/src/__generated__/PartnerOfferCreatedNotification_test_Query.graphql.ts
+++ b/src/__generated__/PartnerOfferCreatedNotification_test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0f99c0da4b2ec2afbad5fed1c39a798b>>
+ * @generated SignedSource<<6483a238a527c8390bc0dc9ad7f64a36>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -78,53 +78,58 @@ v6 = [
   }
 ],
 v7 = {
+  "kind": "Literal",
+  "name": "version",
+  "value": "square"
+},
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v8 = [
-  (v7/*: any*/),
+v9 = [
+  (v8/*: any*/),
   (v4/*: any*/)
 ],
-v9 = {
+v10 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v10 = {
+v11 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v11 = {
+v12 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v12 = {
+v13 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Boolean"
 },
-v13 = {
+v14 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Image"
 },
-v14 = {
+v15 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v15 = {
+v16 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
@@ -373,6 +378,80 @@ return {
                                 ],
                                 "storageKey": null
                               },
+                              {
+                                "alias": null,
+                                "args": (v6/*: any*/),
+                                "concreteType": "Partner",
+                                "kind": "LinkedField",
+                                "name": "partner",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Profile",
+                                    "kind": "LinkedField",
+                                    "name": "profile",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "concreteType": "Image",
+                                        "kind": "LinkedField",
+                                        "name": "icon",
+                                        "plural": false,
+                                        "selections": [
+                                          {
+                                            "alias": null,
+                                            "args": [
+                                              {
+                                                "kind": "Literal",
+                                                "name": "height",
+                                                "value": 30
+                                              },
+                                              (v7/*: any*/),
+                                              {
+                                                "kind": "Literal",
+                                                "name": "width",
+                                                "value": 30
+                                              }
+                                            ],
+                                            "concreteType": "ResizedImageUrl",
+                                            "kind": "LinkedField",
+                                            "name": "resized",
+                                            "plural": false,
+                                            "selections": [
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "kind": "ScalarField",
+                                                "name": "src",
+                                                "storageKey": null
+                                              },
+                                              {
+                                                "alias": null,
+                                                "args": null,
+                                                "kind": "ScalarField",
+                                                "name": "srcSet",
+                                                "storageKey": null
+                                              }
+                                            ],
+                                            "storageKey": "resized(height:30,version:\"square\",width:30)"
+                                          }
+                                        ],
+                                        "storageKey": null
+                                      },
+                                      (v4/*: any*/)
+                                    ],
+                                    "storageKey": null
+                                  },
+                                  (v4/*: any*/),
+                                  (v8/*: any*/),
+                                  (v5/*: any*/)
+                                ],
+                                "storageKey": "partner(shallow:true)"
+                              },
                               (v1/*: any*/),
                               {
                                 "alias": null,
@@ -460,7 +539,7 @@ return {
                                 "selections": [
                                   (v4/*: any*/),
                                   (v5/*: any*/),
-                                  (v7/*: any*/)
+                                  (v8/*: any*/)
                                 ],
                                 "storageKey": "artists(shallow:true)"
                               },
@@ -470,20 +549,6 @@ return {
                                 "kind": "ScalarField",
                                 "name": "collectingInstitution",
                                 "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": (v6/*: any*/),
-                                "concreteType": "Partner",
-                                "kind": "LinkedField",
-                                "name": "partner",
-                                "plural": false,
-                                "selections": [
-                                  (v7/*: any*/),
-                                  (v5/*: any*/),
-                                  (v4/*: any*/)
-                                ],
-                                "storageKey": "partner(shallow:true)"
                               },
                               {
                                 "alias": null,
@@ -638,11 +703,7 @@ return {
                                   {
                                     "alias": null,
                                     "args": [
-                                      {
-                                        "kind": "Literal",
-                                        "name": "version",
-                                        "value": "square"
-                                      }
+                                      (v7/*: any*/)
                                     ],
                                     "kind": "ScalarField",
                                     "name": "url",
@@ -665,7 +726,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "attributionClass",
                                 "plural": false,
-                                "selections": (v8/*: any*/),
+                                "selections": (v9/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -683,7 +744,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "filterGene",
                                     "plural": false,
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v9/*: any*/),
                                     "storageKey": null
                                   }
                                 ],
@@ -711,7 +772,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4097b1308df182d5d34f20ec6e192f19",
+    "cacheID": "c590fa011974d745c506fa8177707201",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -733,33 +794,33 @@ return {
           "plural": false,
           "type": "Notification"
         },
-        "notificationsConnection.edges.node.headline": (v9/*: any*/),
-        "notificationsConnection.edges.node.id": (v10/*: any*/),
+        "notificationsConnection.edges.node.headline": (v10/*: any*/),
+        "notificationsConnection.edges.node.id": (v11/*: any*/),
         "notificationsConnection.edges.node.item": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "NotificationItem"
         },
-        "notificationsConnection.edges.node.item.__typename": (v9/*: any*/),
+        "notificationsConnection.edges.node.item.__typename": (v10/*: any*/),
         "notificationsConnection.edges.node.item.partnerOffer": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "PartnerOffer"
         },
-        "notificationsConnection.edges.node.item.partnerOffer.endAt": (v11/*: any*/),
-        "notificationsConnection.edges.node.item.partnerOffer.id": (v10/*: any*/),
-        "notificationsConnection.edges.node.item.partnerOffer.internalID": (v10/*: any*/),
-        "notificationsConnection.edges.node.item.partnerOffer.isAvailable": (v12/*: any*/),
-        "notificationsConnection.edges.node.item.partnerOffer.note": (v11/*: any*/),
+        "notificationsConnection.edges.node.item.partnerOffer.endAt": (v12/*: any*/),
+        "notificationsConnection.edges.node.item.partnerOffer.id": (v11/*: any*/),
+        "notificationsConnection.edges.node.item.partnerOffer.internalID": (v11/*: any*/),
+        "notificationsConnection.edges.node.item.partnerOffer.isAvailable": (v13/*: any*/),
+        "notificationsConnection.edges.node.item.partnerOffer.note": (v12/*: any*/),
         "notificationsConnection.edges.node.item.partnerOffer.priceWithDiscount": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Money"
         },
-        "notificationsConnection.edges.node.item.partnerOffer.priceWithDiscount.display": (v11/*: any*/),
+        "notificationsConnection.edges.node.item.partnerOffer.priceWithDiscount.display": (v12/*: any*/),
         "notificationsConnection.edges.node.offerArtworksConnection": {
           "enumValues": null,
           "nullable": true,
@@ -784,45 +845,45 @@ return {
           "plural": false,
           "type": "Artist"
         },
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.artist.id": (v10/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.artist.id": (v11/*: any*/),
         "notificationsConnection.edges.node.offerArtworksConnection.edges.node.artist.targetSupply": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "ArtistTargetSupply"
         },
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.artist.targetSupply.isP1": (v12/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.artistNames": (v11/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.artist.targetSupply.isP1": (v13/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.artistNames": (v12/*: any*/),
         "notificationsConnection.edges.node.offerArtworksConnection.edges.node.artists": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Artist"
         },
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.artists.href": (v11/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.artists.id": (v10/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.artists.name": (v11/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.artists.href": (v12/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.artists.id": (v11/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.artists.name": (v12/*: any*/),
         "notificationsConnection.edges.node.offerArtworksConnection.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.attributionClass.id": (v10/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.attributionClass.name": (v11/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.collecting_institution": (v11/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.cultural_maker": (v11/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.date": (v11/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.href": (v11/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.id": (v10/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.image": (v13/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.image.height": (v14/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.image.src": (v11/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.image.width": (v14/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.internalID": (v10/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.isSaved": (v12/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.isSavedToList": (v15/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.isUnlisted": (v15/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.attributionClass.id": (v11/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.attributionClass.name": (v12/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.collecting_institution": (v12/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.cultural_maker": (v12/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.date": (v12/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.href": (v12/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.id": (v11/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.image": (v14/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.image.height": (v15/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.image.src": (v12/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.image.width": (v15/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.internalID": (v11/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.isSaved": (v13/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.isSavedToList": (v16/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.isUnlisted": (v16/*: any*/),
         "notificationsConnection.edges.node.offerArtworksConnection.edges.node.marketPriceInsights": {
           "enumValues": null,
           "nullable": true,
@@ -847,33 +908,49 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.mediumType.filterGene.id": (v10/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.mediumType.filterGene.name": (v11/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.mediumType.filterGene.id": (v11/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.mediumType.filterGene.name": (v12/*: any*/),
         "notificationsConnection.edges.node.offerArtworksConnection.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.partner.href": (v11/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.partner.id": (v10/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.partner.name": (v11/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.preview": (v13/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.preview.url": (v11/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.price": (v11/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.partner.href": (v12/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.partner.id": (v11/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.partner.name": (v12/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.partner.profile": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Profile"
+        },
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.partner.profile.icon": (v14/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.partner.profile.icon.resized": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ResizedImageUrl"
+        },
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.partner.profile.icon.resized.src": (v10/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.partner.profile.icon.resized.srcSet": (v10/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.partner.profile.id": (v11/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.preview": (v14/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.preview.url": (v12/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.price": (v12/*: any*/),
         "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v14/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale.endAt": (v11/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v14/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale.id": (v10/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale.is_auction": (v12/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale.is_closed": (v12/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale.startAt": (v11/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v15/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale.endAt": (v12/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v15/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale.id": (v11/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale.is_auction": (v13/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale.is_closed": (v13/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale.startAt": (v12/*: any*/),
         "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale_artwork": {
           "enumValues": null,
           "nullable": true,
@@ -892,35 +969,35 @@ return {
           "plural": false,
           "type": "FormattedNumber"
         },
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale_artwork.endAt": (v11/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v11/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v11/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale_artwork.endAt": (v12/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v12/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v12/*: any*/),
         "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale_artwork.highest_bid.display": (v11/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale_artwork.id": (v10/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale_artwork.lotID": (v11/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale_artwork.lotLabel": (v11/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale_artwork.highest_bid.display": (v12/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale_artwork.id": (v11/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale_artwork.lotID": (v12/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale_artwork.lotLabel": (v12/*: any*/),
         "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale_artwork.opening_bid.display": (v11/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale_message": (v11/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.slug": (v10/*: any*/),
-        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.title": (v11/*: any*/),
-        "notificationsConnection.edges.node.targetHref": (v9/*: any*/)
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale_artwork.opening_bid.display": (v12/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.sale_message": (v12/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.slug": (v11/*: any*/),
+        "notificationsConnection.edges.node.offerArtworksConnection.edges.node.title": (v12/*: any*/),
+        "notificationsConnection.edges.node.targetHref": (v10/*: any*/)
       }
     },
     "name": "PartnerOfferCreatedNotification_test_Query",
     "operationKind": "query",
-    "text": "query PartnerOfferCreatedNotification_test_Query {\n  notificationsConnection(first: 1) {\n    edges {\n      node {\n        ...PartnerOfferCreatedNotification_notification\n        id\n      }\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  isUnlisted\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment PartnerOfferArtwork_artwork on Artwork {\n  href\n  title\n  artistNames\n  price\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n  }\n  ...Metadata_artwork\n}\n\nfragment PartnerOfferCreatedNotification_notification on Notification {\n  headline\n  targetHref\n  item {\n    __typename\n    ... on PartnerOfferCreatedNotificationItem {\n      partnerOffer {\n        internalID\n        endAt\n        isAvailable\n        note\n        priceWithDiscount {\n          display\n        }\n        id\n      }\n    }\n  }\n  offerArtworksConnection: artworksConnection(first: 1) {\n    edges {\n      node {\n        ...PartnerOfferArtwork_artwork\n        id\n      }\n    }\n  }\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isSavedToList\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n"
+    "text": "query PartnerOfferCreatedNotification_test_Query {\n  notificationsConnection(first: 1) {\n    edges {\n      node {\n        ...PartnerOfferCreatedNotification_notification\n        id\n      }\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  isUnlisted\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment PartnerOfferArtwork_artwork on Artwork {\n  href\n  title\n  artistNames\n  price\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n  }\n  partner(shallow: true) {\n    profile {\n      icon {\n        resized(width: 30, height: 30, version: \"square\") {\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    id\n  }\n  ...Metadata_artwork\n}\n\nfragment PartnerOfferCreatedNotification_notification on Notification {\n  headline\n  targetHref\n  item {\n    __typename\n    ... on PartnerOfferCreatedNotificationItem {\n      partnerOffer {\n        internalID\n        endAt\n        isAvailable\n        note\n        priceWithDiscount {\n          display\n        }\n        id\n      }\n    }\n  }\n  offerArtworksConnection: artworksConnection(first: 1) {\n    edges {\n      node {\n        ...PartnerOfferArtwork_artwork\n        id\n      }\n    }\n  }\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isSavedToList\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [EMI-1799]

### Description

Show the note for partner offers on Activity Panel. Adjust `Limited-Time Offer` label to match [designs](https://www.figma.com/file/RHkhhJJwixhFPltqhH9ZkW/v1.5-Saves-Partner-Offers?node-id=4381%3A13607&mode=dev).

<img width="1792" alt="Screenshot 2024-04-11 at 13 00 21" src="https://github.com/artsy/force/assets/7518671/c985cb55-05bf-4cc6-879e-b7f656262143">
<img width="496" alt="Screenshot 2024-04-11 at 13 01 13" src="https://github.com/artsy/force/assets/7518671/33202d6d-6018-475b-a2ca-540af359cd3d">
 


[EMI-1799]: https://artsyproduct.atlassian.net/browse/EMI-1799?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ