### PR TITLE
feat(dia-570): user can remove artist

### DIFF
--- a/src/Apps/CollectorProfile/Components/CollectorProfileArtists/CollectorProfileArtistsDeleteDialog.tsx
+++ b/src/Apps/CollectorProfile/Components/CollectorProfileArtists/CollectorProfileArtistsDeleteDialog.tsx
@@ -1,0 +1,87 @@
+import { Button, ModalDialog, Stack, Text, useToasts } from "@artsy/palette"
+import { FC, useState } from "react"
+import { graphql } from "react-relay"
+import { useMutation } from "Utils/Hooks/useMutation"
+import { CollectorProfileArtistsDeleteDialogMutation } from "__generated__/CollectorProfileArtistsDeleteDialogMutation.graphql"
+
+interface CollectorProfileArtistsDeleteDialogProps {
+  id: string
+  name?: string | null
+  onClose: () => void
+}
+
+export const CollectorProfileArtistsDeleteDialog: FC<CollectorProfileArtistsDeleteDialogProps> = ({
+  id,
+  name,
+  onClose,
+}) => {
+  const { submitMutation } = useMutation<
+    CollectorProfileArtistsDeleteDialogMutation
+  >({
+    mutation: MUTATION,
+  })
+
+  const { sendToast } = useToasts()
+
+  const [mode, setMode] = useState<"Idle" | "Deleting">("Idle")
+
+  const handleRemove = async () => {
+    setMode("Deleting")
+
+    try {
+      await submitMutation({ variables: { input: { id } } })
+
+      onClose()
+
+      // FIXME: We do not have a good way to fetch an updated page
+      window.location.reload()
+    } catch (err) {
+      console.error(err)
+
+      sendToast({
+        variant: "error",
+        message: err.message,
+      })
+    }
+
+    setMode("Idle")
+  }
+
+  return (
+    <ModalDialog
+      title="Remove artist"
+      onClose={onClose}
+      footer={
+        <Stack gap={1}>
+          <Button
+            variant="primaryBlack"
+            onClick={handleRemove}
+            loading={mode === "Deleting"}
+          >
+            Remove artist
+          </Button>
+
+          <Button variant="secondaryBlack" onClick={onClose}>
+            Keep artist
+          </Button>
+        </Stack>
+      }
+    >
+      <Text variant="sm">
+        {name || "This artist"} will be removed from My Collection.
+      </Text>
+    </ModalDialog>
+  )
+}
+
+const MUTATION = graphql`
+  mutation CollectorProfileArtistsDeleteDialogMutation(
+    $input: DeleteUserInterestMutationInput!
+  ) {
+    deleteUserInterest(input: $input) {
+      me {
+        id
+      }
+    }
+  }
+`

--- a/src/Apps/CollectorProfile/Components/CollectorProfileArtists/CollectorProfileArtistsList.tsx
+++ b/src/Apps/CollectorProfile/Components/CollectorProfileArtists/CollectorProfileArtistsList.tsx
@@ -1,4 +1,11 @@
-import { PaginationSkeleton, Stack, Text, useDidMount } from "@artsy/palette"
+import {
+  Column,
+  GridColumns,
+  PaginationSkeleton,
+  Stack,
+  Text,
+  useDidMount,
+} from "@artsy/palette"
 import { FC, Suspense, useState } from "react"
 import { graphql, useLazyLoadQuery } from "react-relay"
 import { CollectorProfileArtistsListArtistsQuery } from "__generated__/CollectorProfileArtistsListArtistsQuery.graphql"
@@ -20,31 +27,43 @@ export const CollectorProfileArtistsList: FC<CollectorProfileArtistsListProps> =
 
   return (
     <Stack gap={2}>
-      <Stack
-        gap={2}
-        flexDirection="row"
-        alignItems="center"
+      <GridColumns
         color="black60"
         borderBottom="1px solid"
         borderColor="black10"
         pb={2}
+        gridColumnGap={0.5}
       >
-        <Text size="sm-display" overflowEllipsis flex={1}>
-          Artist
-        </Text>
+        <Column span={3}>
+          <Text size="sm-display" overflowEllipsis>
+            Artist
+          </Text>
+        </Column>
 
-        <Text size="sm-display" overflowEllipsis flex={1}>
-          Artworks uploaded
-        </Text>
+        <Column span={2}>
+          <Text size="sm-display" overflowEllipsis>
+            Artworks uploaded
+          </Text>
+        </Column>
 
-        <Text size="sm-display" overflowEllipsis flex={1}>
-          Share with the galleries during inquiries
-        </Text>
+        <Column span={4}>
+          <Text size="sm-display" overflowEllipsis>
+            Share with the galleries during inquiries
+          </Text>
+        </Column>
 
-        <Text size="sm-display" overflowEllipsis flex={1} textAlign="right">
-          Follow artist
-        </Text>
-      </Stack>
+        <Column span={2}>
+          <Text size="sm-display" overflowEllipsis>
+            Follow artist
+          </Text>
+        </Column>
+
+        <Column span={1} display="flex" justifyContent="flex-end">
+          <Text size="sm-display" overflowEllipsis textAlign="right">
+            More
+          </Text>
+        </Column>
+      </GridColumns>
 
       {isMounted ? (
         <Suspense fallback={<CollectorProfileArtistsListPlaceholder />}>

--- a/src/__generated__/CollectorProfileArtistsDeleteDialogMutation.graphql.ts
+++ b/src/__generated__/CollectorProfileArtistsDeleteDialogMutation.graphql.ts
@@ -1,0 +1,108 @@
+/**
+ * @generated SignedSource<<63b868b6c80e8a4d2100959331f7ad35>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type DeleteUserInterestMutationInput = {
+  anonymousSessionId?: string | null | undefined;
+  clientMutationId?: string | null | undefined;
+  id: string;
+  sessionID?: string | null | undefined;
+};
+export type CollectorProfileArtistsDeleteDialogMutation$variables = {
+  input: DeleteUserInterestMutationInput;
+};
+export type CollectorProfileArtistsDeleteDialogMutation$data = {
+  readonly deleteUserInterest: {
+    readonly me: {
+      readonly id: string;
+    };
+  } | null | undefined;
+};
+export type CollectorProfileArtistsDeleteDialogMutation = {
+  response: CollectorProfileArtistsDeleteDialogMutation$data;
+  variables: CollectorProfileArtistsDeleteDialogMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "DeleteUserInterestMutationPayload",
+    "kind": "LinkedField",
+    "name": "deleteUserInterest",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "CollectorProfileArtistsDeleteDialogMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "CollectorProfileArtistsDeleteDialogMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "018f862abd2a74397ffb232922b6b2cd",
+    "id": null,
+    "metadata": {},
+    "name": "CollectorProfileArtistsDeleteDialogMutation",
+    "operationKind": "mutation",
+    "text": "mutation CollectorProfileArtistsDeleteDialogMutation(\n  $input: DeleteUserInterestMutationInput!\n) {\n  deleteUserInterest(input: $input) {\n    me {\n      id\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "a6c41f0b4e3c4feb6c1ad6e148ba1328";
+
+export default node;


### PR DESCRIPTION
Closes [DIA-570](https://artsyproduct.atlassian.net/browse/DIA-570)

This feature raised this issue: https://artsyproduct.atlassian.net/browse/DIA-590 — sort of annoying to remove a thing from a paginated list and then update the list once it's removed.

I feel like the natural way to do this would be to 'fade' out the item and _not_ refetch anything, but then navigating to the next page is going to be broken as it'll skip one item because of how it's paginated.

I feel like the only way to do this given our current API would be to force navigation to the first page while refetching the list.

For now it's just refreshing the page.


https://github.com/artsy/force/assets/112297/2750fba0-d36f-4c4c-8a9f-1e32d92c527e



[DIA-570]: https://artsyproduct.atlassian.net/browse/DIA-570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ