### PR TITLE
fix: Partner and viewing room notification layout adjustments

### DIFF
--- a/src/Components/Notifications/NotificationPartnerShow.tsx
+++ b/src/Components/Notifications/NotificationPartnerShow.tsx
@@ -6,7 +6,6 @@ import { Box, Button, Image, ResponsiveBox, Spacer, Text } from "@artsy/palette"
 import { NotificationPartnerShow_show$key } from "__generated__/NotificationPartnerShow_show.graphql"
 import { compact, truncate } from "lodash"
 import { CellShowStatus } from "Components/Cells/CellShow"
-import { MAX_WIDTH } from "Components/ArtworkFilter/Utils/rangeToTuple"
 import { NOTIFICATION_MAX_WIDTH } from "Components/Notifications/Notification"
 
 export interface NotificationShowProps
@@ -27,14 +26,13 @@ export const NotificationPartnerShow: React.FC<NotificationShowProps> = ({
   const image = show?.coverImage?.cropped
 
   return (
-    <Box mb={4}>
+    <Box mb={4} width="100%" maxWidth={NOTIFICATION_MAX_WIDTH}>
       <RouterLink
         to={show?.href}
         onClick={onClick}
         display="flex"
         flexDirection="column"
         textDecoration="none"
-        maxWidth={NOTIFICATION_MAX_WIDTH}
         overflow="hidden"
         width="100%"
         {...rest}
@@ -80,7 +78,7 @@ export const NotificationPartnerShow: React.FC<NotificationShowProps> = ({
         )}
       </RouterLink>
 
-      <Box mb={4} width="100%" maxWidth={MAX_WIDTH}>
+      <Box mb={4} width="100%">
         <Button
           // @ts-ignore
           as={RouterLink}

--- a/src/Components/Notifications/NotificationViewingRoom.tsx
+++ b/src/Components/Notifications/NotificationViewingRoom.tsx
@@ -43,7 +43,7 @@ export const NotificationViewingRoom: React.FC<NotificationViewingRoomProps> = (
         flexDirection="column"
         textDecoration="none"
         aria-label={viewingRoom?.title}
-        maxWidth={MAX_WIDTH}
+        maxWidth={NOTIFICATION_MAX_WIDTH}
         overflow="hidden"
         width="100%"
         {...rest}
@@ -77,7 +77,7 @@ export const NotificationViewingRoom: React.FC<NotificationViewingRoomProps> = (
         </Text>
       </RouterLink>
 
-      <Box mb={4} width="100%" maxWidth={MAX_WIDTH}>
+      <Box mb={4} width="100%">
         <Button
           // @ts-ignore
           as={RouterLink}

--- a/src/Components/Notifications/NotificationViewingRoom.tsx
+++ b/src/Components/Notifications/NotificationViewingRoom.tsx
@@ -6,7 +6,6 @@ import { AuthContextModule } from "@artsy/cohesion"
 import { Box, Button, Image, Spacer, Text } from "@artsy/palette"
 import { resized } from "Utils/resized"
 import { NOTIFICATION_MAX_WIDTH } from "Components/Notifications/Notification"
-import { MAX_WIDTH } from "Components/ArtworkFilter/Utils/rangeToTuple"
 
 export interface NotificationViewingRoomProps
   extends Omit<RouterLinkProps, "to" | "width"> {

--- a/src/Components/Notifications/ViewingRoomPublishedNotification.tsx
+++ b/src/Components/Notifications/ViewingRoomPublishedNotification.tsx
@@ -31,7 +31,7 @@ export const ViewingRoomPublishedNotification: FC<ViewingRoomPublishedNotificati
   }
 
   return (
-    <Box m={4}>
+    <Box>
       <Flex width="100%" justifyContent="space-between">
         <Flex flex={1}>
           <Text variant="lg-display">{headline}</Text>


### PR DESCRIPTION
The type of this PR is: **Fix**

Partner and viewing room notification layout adjustments

| Before | After |
| --- | --- |
|<img width="2056" alt="Screenshot 2024-04-12 at 15 05 58" src="https://github.com/artsy/force/assets/4691889/bae05960-751e-4839-ad12-29b4a88825f7"> | <img width="2056" alt="Screenshot 2024-04-12 at 15 06 12" src="https://github.com/artsy/force/assets/4691889/cd567bce-8973-44ec-a412-c6f2a8d19ef0">|
| --- | --- |
|<img width="2056" alt="Screenshot 2024-04-12 at 15 06 20" src="https://github.com/artsy/force/assets/4691889/22229b06-59b4-4009-bf67-5054b238341a"> | <img width="2056" alt="Screenshot 2024-04-12 at 15 06 53" src="https://github.com/artsy/force/assets/4691889/b263d53b-6bd5-435d-8270-299cf5e9c2ec">|









### Description

<!-- Implementation description -->
