### PR TITLE
chore: update auction artwork disclaimer (DIA-552)

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarLinks.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarLinks.tsx
@@ -5,6 +5,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import { RouterLink } from "System/Router/RouterLink"
 import { ArtworkSidebarLinks_artwork$data } from "__generated__/ArtworkSidebarLinks_artwork.graphql"
+import { useFeatureFlag } from "System/useFeatureFlag"
 
 interface ArtworkSidebarLinksProps {
   artwork: ArtworkSidebarLinks_artwork$data
@@ -16,6 +17,8 @@ const ArtworkSidebarLinks: React.FC<ArtworkSidebarLinksProps> = ({
   const { t } = useTranslation()
   const tracking = useTracking()
   const { sale, isInAuction } = artwork
+
+  const showNewDisclaimer = useFeatureFlag("diamond_new-terms-and-conditions")
 
   const isInOpenAuction = isInAuction && sale && !sale.isClosed
 
@@ -44,10 +47,12 @@ const ArtworkSidebarLinks: React.FC<ArtworkSidebarLinksProps> = ({
             {t("artworkPage.sidebar.conditionsOfSale")}{" "}
             <RouterLink
               inline
-              to="/conditions-of-sale"
+              to={showNewDisclaimer ? "/terms" : "/conditions-of-sale"}
               onClick={trackClickedConditionsOfSale}
             >
-              {t("artworkPage.sidebar.conditionsOfSaleLink")}
+              {showNewDisclaimer
+                ? t("artworkPage.sidebar.generalTermsAndConditionsOfSaleLink")
+                : t("artworkPage.sidebar.conditionsOfSaleLink")}
             </RouterLink>
           </Text>
           <Spacer y={1} />

--- a/src/System/i18n/locales/en-US/translation.json
+++ b/src/System/i18n/locales/en-US/translation.json
@@ -90,6 +90,7 @@
       "sellWithArtsyLink": "Sell with Artsy",
       "conditionsOfSale": "By placing your bid you agree to Artsy's",
       "conditionsOfSaleLink": "Conditions of Sale",
+      "generalTermsAndConditionsOfSaleLink": "General Terms and Conditions of Sale",
       "auction": {
         "biddingClosed": "Bidding closed",
         "estimatedValue": "Estimated value: {{value}}"


### PR DESCRIPTION
This PR updates the disclaimer that appears at the bottom of an artwork page if that artwork is in an active auction.

| Before | After |
|--------|------|
| <img width="1436" alt="Screenshot 2024-04-12 at 10 02 18 AM" src="https://github.com/artsy/force/assets/44589599/a40bc108-5835-46d9-8790-4bb77c1294a0"> | <img width="1436" alt="Screenshot 2024-04-12 at 10 12 20 AM" src="https://github.com/artsy/force/assets/44589599/bce85084-1579-42a3-9b2b-4613e451e8ab"> |

