### PR TITLE
[WIP] chore: update identity verification disclaimer (DIA-552)

### DIFF
--- a/src/Apps/Auction/Components/Form/IdentityVerificationWarning.tsx
+++ b/src/Apps/Auction/Components/Form/IdentityVerificationWarning.tsx
@@ -1,9 +1,12 @@
 import { Spacer, Text } from "@artsy/palette"
 import { RouterLink } from "System/Router/RouterLink"
+import { useFeatureFlag } from "System/useFeatureFlag"
 
 export const IdentityVerificationWarning: React.FC<{
   additionalText?: string
 }> = ({ additionalText }) => {
+  const showNewDisclaimer = useFeatureFlag("diamond_new-terms-and-conditions")
+
   return (
     <>
       <Text variant="sm-display">
@@ -19,18 +22,20 @@ export const IdentityVerificationWarning: React.FC<{
 
       <Spacer y={1} />
 
-      <Text variant="sm-display">
-        To complete your registration, please confirm that you agree to the{" "}
-        <RouterLink
-          inline
-          color="black100"
-          to="/conditions-of-sale"
-          target="_blank"
-        >
-          Conditions of Sale
-        </RouterLink>
-        {additionalText}.
-      </Text>
+      {!showNewDisclaimer && (
+        <Text variant="sm-display">
+          To complete your registration, please confirm that you agree to the{" "}
+          <RouterLink
+            inline
+            color="black100"
+            to="/conditions-of-sale"
+            target="_blank"
+          >
+            Conditions of Sale
+          </RouterLink>
+          {additionalText}.
+        </Text>
+      )}
     </>
   )
 }

--- a/src/Apps/Auction/Components/Form/__tests__/IdentityVerificationWarning.jest.tsx
+++ b/src/Apps/Auction/Components/Form/__tests__/IdentityVerificationWarning.jest.tsx
@@ -1,20 +1,46 @@
-import { mount } from "enzyme"
-import { IdentityVerificationWarning } from "../IdentityVerificationWarning"
+import { render, screen } from "@testing-library/react"
+import { IdentityVerificationWarning } from "Apps/Auction/Components/Form/IdentityVerificationWarning"
+import { useFeatureFlag } from "System/useFeatureFlag"
+
+jest.mock("System/useFeatureFlag")
 
 describe("IdentityVerificationWarning", () => {
-  const getWrapper = () => {
-    return mount(<IdentityVerificationWarning />)
-  }
-
-  it("renders correct compnents", () => {
-    const wrapper = getWrapper()
-    expect(wrapper.text()).toContain(
-      "This auction requires Artsy to verify your identity before bidding."
-    )
+  it("renders correct components", () => {
+    render(<IdentityVerificationWarning />)
+    expect(
+      screen.getByText(
+        "This auction requires Artsy to verify your identity before bidding."
+      )
+    ).toBeInTheDocument()
   })
 
   it("shows /conditions-of-sale link", () => {
-    const wrapper = getWrapper()
-    expect(wrapper.html()).toContain("/conditions-of-sale")
+    render(<IdentityVerificationWarning />)
+    expect(
+      screen.getByRole("link", {
+        name: "Conditions of Sale",
+      })
+    ).toHaveAttribute("href", "/conditions-of-sale")
+  })
+
+  describe("when showNewDisclaimer is true", () => {
+    beforeAll(() => {
+      ;(useFeatureFlag as jest.Mock).mockImplementation(
+        (f: string) => f === "diamond_new-terms-and-conditions"
+      )
+    })
+
+    afterAll(() => {
+      ;(useFeatureFlag as jest.Mock).mockReset()
+    })
+
+    it("does not show /conditions-of-sale link", () => {
+      render(<IdentityVerificationWarning />)
+      expect(
+        screen.queryByRole("link", {
+          name: "Conditions of Sale",
+        })
+      ).not.toBeInTheDocument()
+    })
   })
 })


### PR DESCRIPTION
This PR removes the condition of sale blurb when identity verification is required for an auction that a user is registering for.

| Before | After |
|-------|----|
| <img width="1436" alt="Screenshot 2024-04-12 at 10 52 34 AM" src="https://github.com/artsy/force/assets/44589599/aba82d4d-4871-40f7-8b9b-d25c955fc2d8"> | <img width="1436" alt="Screenshot 2024-04-12 at 10 56 56 AM" src="https://github.com/artsy/force/assets/44589599/753c5aca-371c-4ebe-a74c-164f5c963855"> |

This PR is a WIP because I need to confirm 2 places where this is displayed (but haven't figured out where the second pace is).