### PR TITLE
fix: add border radius to limited-time offer

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
@@ -514,7 +514,13 @@ const OfferDisplay: React.FC<OfferDisplayProps> = ({
     <>
       <Spacer y={2} />
       <Flex>
-        <Text variant="xs" color="blue100" backgroundColor="blue10" px={0.5}>
+        <Text
+          variant="xs"
+          color="blue100"
+          backgroundColor="blue10"
+          px={0.5}
+          borderRadius={3}
+        >
           Limited-Time Offer
         </Text>
       </Flex>

--- a/src/Components/Notifications/NotificationItem.tsx
+++ b/src/Components/Notifications/NotificationItem.tsx
@@ -136,6 +136,7 @@ const NotificationItem: FC<NotificationItemProps> = ({ item }) => {
             backgroundColor="blue10"
             px={0.5}
             alignSelf="flex-start"
+            borderRadius={3}
           >
             {getNotificationPrelude(item)}
           </Text>

--- a/src/Components/Notifications/PartnerOfferCreatedNotification.tsx
+++ b/src/Components/Notifications/PartnerOfferCreatedNotification.tsx
@@ -47,7 +47,13 @@ export const PartnerOfferCreatedNotification: FC<PartnerOfferCreatedNotification
   return (
     <Box>
       <Flex width="100%" justifyContent="space-between">
-        <Text variant="xs" color="blue100" backgroundColor="blue10" px={0.5}>
+        <Text
+          variant="xs"
+          color="blue100"
+          backgroundColor="blue10"
+          px={0.5}
+          borderRadius={3}
+        >
           Limited-Time Offer
         </Text>
         <RouterLink to={BASE_SAVES_PATH} data-testid="manage-saves-link">


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Add border radius to limited-time offer to match [designs](https://www.figma.com/file/RHkhhJJwixhFPltqhH9ZkW/v1.5-Saves-Partner-Offers?node-id=4381%3A13945&mode=dev)
<img width="606" alt="Screenshot 2024-04-17 at 12 16 58" src="https://github.com/artsy/force/assets/7518671/677de3f2-234d-4933-94f6-0ddd82cc17ad">
<img width="606" alt="Screenshot 2024-04-17 at 12 17 06" src="https://github.com/artsy/force/assets/7518671/2ca6abde-6657-421c-bf69-33f079f5926c">

