### PR TITLE
fix: early exit from useEffect that checks for Private Artwork

### DIFF
--- a/src/Components/Footer/FooterDownloadAppBanner.tsx
+++ b/src/Components/Footer/FooterDownloadAppBanner.tsx
@@ -36,6 +36,10 @@ export const FooterDownloadAppBanner = () => {
 
   useEffect(() => {
     const checkIfPrivateArtwork = async () => {
+      const artworkSlug = match?.params?.artworkID
+      if (!artworkSlug) {
+        return
+      }
       const data = await fetchQuery<FooterDownloadAppBannerQuery>(
         relayEnvironment,
         graphql`
@@ -46,7 +50,7 @@ export const FooterDownloadAppBanner = () => {
           }
         `,
         {
-          slug: match?.params?.artworkID,
+          slug: artworkSlug,
         }
       ).toPromise()
 

--- a/src/Components/Footer/__tests__/Footer.jest.tsx
+++ b/src/Components/Footer/__tests__/Footer.jest.tsx
@@ -23,6 +23,7 @@ jest.mock("react-relay", () => ({
 
 describe("Footer", () => {
   const mockFetchQuery = fetchQuery as jest.Mock
+  const mockUseRouter = useRouter as jest.Mock
 
   const getWrapper = (breakpoint: Breakpoint) =>
     mount(
@@ -80,7 +81,7 @@ describe("Footer", () => {
     })
 
     it("hides the app download banner if we are on an ignored route", () => {
-      ;(useRouter as jest.Mock).mockImplementationOnce(() => ({
+      mockUseRouter.mockImplementationOnce(() => ({
         match: { location: { pathname: "/meet-your-new-art-advisor" } },
       }))
 
@@ -89,6 +90,10 @@ describe("Footer", () => {
     })
 
     it("hides the app download banner if the artwork is unlisted", async () => {
+      mockUseRouter.mockImplementationOnce(() => ({
+        match: { params: { artworkID: "foo" } },
+      }))
+
       mockFetchQuery.mockImplementation(() => {
         return {
           toPromise: jest


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

@joeyAghion reported in [this slack thread](https://artsy.slack.com/archives/C05F8TNKGAV/p1713558385846229) that the error rate was jumping. Turns out this relay request will 500 when not on an artwork page. 
<!-- Implementation description -->

This PR adds logic to early exit from the `useEffect` that makes the relay request, only on non-artwork pages.


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ