### PR TITLE
fix: Suppress duplicate edition set info on private artwork pages AMBER-629

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
@@ -381,11 +381,13 @@ export const ArtworkSidebarCommercialButtons: React.FC<ArtworkSidebarCommercialB
     )
   }
 
+  const hasEditions = (artwork?.editionSets?.length ?? 0) > 1
+
   return (
     <>
       {inquiryComponent}
 
-      {(artwork?.editionSets?.length ?? 0) < 2 ? (
+      {!hasEditions ? (
         <SaleMessageOrOfferDisplay />
       ) : (
         <>

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
@@ -381,6 +381,27 @@ export const ArtworkSidebarCommercialButtons: React.FC<ArtworkSidebarCommercialB
     )
   }
 
+  const EditionSetPriceDisplay: FC = () => {
+    return (
+      <>
+        <Separator />
+        <ArtworkSidebarEditionSetFragmentContainer
+          artwork={artwork}
+          selectedEditionSet={selectedEditionSet as EditionSet}
+          onSelectEditionSet={setSelectedEditionSet}
+        />
+
+        {!!selectedEditionSet && (
+          <>
+            <Separator />
+            <Spacer y={4} />
+            <SaleMessage saleMessage={selectedEditionSet.saleMessage} />
+          </>
+        )}
+      </>
+    )
+  }
+
   const hasEditions = (artwork?.editionSets?.length ?? 0) > 1
 
   return (
@@ -390,22 +411,7 @@ export const ArtworkSidebarCommercialButtons: React.FC<ArtworkSidebarCommercialB
       {!hasEditions ? (
         <SaleMessageOrOfferDisplay />
       ) : (
-        <>
-          <Separator />
-          <ArtworkSidebarEditionSetFragmentContainer
-            artwork={artwork}
-            selectedEditionSet={selectedEditionSet as EditionSet}
-            onSelectEditionSet={setSelectedEditionSet}
-          />
-
-          {!!selectedEditionSet && (
-            <>
-              <Separator />
-              <Spacer y={4} />
-              <SaleMessage saleMessage={selectedEditionSet.saleMessage} />
-            </>
-          )}
-        </>
+        <EditionSetPriceDisplay />
       )}
 
       {showButtonActions && (

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
@@ -408,11 +408,7 @@ export const ArtworkSidebarCommercialButtons: React.FC<ArtworkSidebarCommercialB
     <>
       {inquiryComponent}
 
-      {!hasEditions ? (
-        <SaleMessageOrOfferDisplay />
-      ) : (
-        <EditionSetPriceDisplay />
-      )}
+      {hasEditions ? <EditionSetPriceDisplay /> : <SaleMessageOrOfferDisplay />}
 
       {showButtonActions && (
         <>

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
@@ -358,10 +358,6 @@ export const ArtworkSidebarCommercialButtons: React.FC<ArtworkSidebarCommercialB
   }
 
   const SaleMessageOrOfferDisplay: FC = () => {
-    if (!showPrice) {
-      return null
-    }
-
     return (
       <>
         {partnerOffer ? (
@@ -408,7 +404,12 @@ export const ArtworkSidebarCommercialButtons: React.FC<ArtworkSidebarCommercialB
     <>
       {inquiryComponent}
 
-      {hasEditions ? <EditionSetPriceDisplay /> : <SaleMessageOrOfferDisplay />}
+      {showPrice &&
+        (hasEditions ? (
+          <EditionSetPriceDisplay />
+        ) : (
+          <SaleMessageOrOfferDisplay />
+        ))}
 
       {showButtonActions && (
         <>


### PR DESCRIPTION
This PR ensures that we do not double render edition set information for private artworks.

<details><summary>screenshots below!</summary>

![Screenshot 2024-04-22 at 11 22 18 AM](https://github.com/artsy/force/assets/79799/ea7d6e5d-6b1f-47b5-8a2c-f70b1365cf66)
![Screenshot 2024-04-22 at 11 22 12 AM](https://github.com/artsy/force/assets/79799/0f5f44aa-8b17-4ddd-b1a8-145a5b1d1491)
![Screenshot 2024-04-22 at 11 22 25 AM](https://github.com/artsy/force/assets/79799/a41a88f8-6277-4c39-9a1f-ba16c3b66c03)
![Screenshot 2024-04-22 at 11 22 30 AM](https://github.com/artsy/force/assets/79799/d49e1a39-e32e-4e19-b2b4-b57f5f40498f)

</details> 

My approach was to start by extracting a boolean for whether the work is editioned and also extracting the edition set info into it's own component. These moves seemed helpful so that we could operate at the same level of abstraction - one component for editioned works, another for non-editioned works. Boolean flag to render one or the other.

Then the actual fix was to wrap that with a check for the flag to show price info. When false bail on the rendering whether editioned or not.

https://artsyproduct.atlassian.net/browse/AMBER-629

/cc @artsy/amber-devs