### PR TITLE
fix(AMBER-625): Move About the Artist section on mobile web and adjust margins and font size

### DIFF
--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -260,13 +260,13 @@ export const ArtworkApp: React.FC<Props> = props => {
           <ArtworkImageBrowserFragmentContainer artwork={artwork} />
 
           {isPrivateArtwork ? (
-            <>
+            <Media greaterThanOrEqual="sm">
               <Spacer y={6} />
 
               <PrivateArtworkDetails artwork={artwork} />
 
               <Spacer y={6} />
-            </>
+            </Media>
           ) : (
             <Media greaterThanOrEqual="sm">
               <BelowTheFoldArtworkDetails
@@ -280,6 +280,15 @@ export const ArtworkApp: React.FC<Props> = props => {
           <ArtworkSidebarFragmentContainer artwork={artwork} me={me} />
         </Column>
       </GridColumns>
+      {isPrivateArtwork && (
+        <Media lessThan="sm">
+          <Spacer y={6} />
+
+          <PrivateArtworkDetails artwork={artwork} />
+
+          <Spacer y={6} />
+        </Media>
+      )}
       {!isPrivateArtwork && (
         <>
           <Media lessThan="sm">

--- a/src/Apps/Artwork/Components/PrivateArtwork/PrivateArtworkAboutArtist.tsx
+++ b/src/Apps/Artwork/Components/PrivateArtwork/PrivateArtworkAboutArtist.tsx
@@ -144,6 +144,7 @@ export const PrivateArtworkAboutArtist: React.FC<PrivateArtworkAboutArtistProps>
                   <Text
                     variant="xs"
                     color="white100"
+                    ml={0.5}
                     style={{ whiteSpace: "nowrap" }}
                   >
                     {followsCount} {followsCount > 1 ? "Followers" : "Follower"}

--- a/src/Apps/Artwork/Components/PrivateArtwork/PrivateArtworkAboutArtist.tsx
+++ b/src/Apps/Artwork/Components/PrivateArtwork/PrivateArtworkAboutArtist.tsx
@@ -11,7 +11,6 @@ import {
   Stack,
 } from "@artsy/palette"
 import { FollowArtistButtonQueryRenderer } from "Components/FollowButton/FollowArtistButton"
-import { FollowButtonInlineCount } from "Components/FollowButton/Button"
 import { formatFollowerCount } from "Utils/formatFollowerCount"
 import { useTracking } from "react-tracking"
 import { ActionType } from "@artsy/cohesion"
@@ -84,7 +83,13 @@ export const PrivateArtworkAboutArtist: React.FC<PrivateArtworkAboutArtistProps>
   }
 
   return (
-    <Box minHeight={275} width="100%" p={6} backgroundColor="black100">
+    <Box
+      minHeight={275}
+      width="100%"
+      px={[2, 6]}
+      py={[4, 6]}
+      backgroundColor="black100"
+    >
       <Text variant="md" color="white100">
         About the Artist
       </Text>
@@ -130,22 +135,17 @@ export const PrivateArtworkAboutArtist: React.FC<PrivateArtworkAboutArtistProps>
                     return (
                       <Stack gap={0.5} flexDirection="row" alignItems="center">
                         <Box color="white100">{label}</Box>
-
-                        {!!data.artist?.counts?.follows && (
-                          <FollowButtonInlineCount
-                            display={["block", "none"]}
-                            color="white100"
-                          >
-                            {formatFollowerCount(data.artist.counts.follows)}
-                          </FollowButtonInlineCount>
-                        )}
                       </Stack>
                     )
                   }}
                 </FollowArtistButtonQueryRenderer>
 
                 {followsCount > 0 && (
-                  <Text variant="xs" color="white100">
+                  <Text
+                    variant="xs"
+                    color="white100"
+                    style={{ whiteSpace: "nowrap" }}
+                  >
                     {followsCount} {followsCount > 1 ? "Followers" : "Follower"}
                   </Text>
                 )}
@@ -156,9 +156,9 @@ export const PrivateArtworkAboutArtist: React.FC<PrivateArtworkAboutArtistProps>
           <>
             {biographyBlurb && (
               <>
-                <Spacer y={2} />
+                <Spacer y={4} />
 
-                <HTML variant="lg" color="white100">
+                <HTML variant="md" color="white100">
                   <ReadMore
                     maxChars={190}
                     content={`${biographyBlurb}`}

--- a/src/Apps/Artwork/Components/PrivateArtwork/PrivateArtworkDetails.tsx
+++ b/src/Apps/Artwork/Components/PrivateArtwork/PrivateArtworkDetails.tsx
@@ -1,9 +1,10 @@
-import { Box, Spacer } from "@artsy/palette"
+import { Box, FullBleed, Spacer } from "@artsy/palette"
 import { PrivateArtworkDetails_artwork$key } from "__generated__/PrivateArtworkDetails_artwork.graphql"
 import { PrivateArtworkAboutArtist } from "./PrivateArtworkAboutArtist"
 import { PrivateArtworkAboutWork } from "Apps/Artwork/Components/PrivateArtwork/PrivateArtworkAboutWork"
 import { graphql, useFragment } from "react-relay"
 import { PrivateArtworkMetadata } from "Apps/Artwork/Components/PrivateArtwork/PrivateArtworkMetadata"
+import { Media } from "Utils/Responsive"
 
 interface PrivateArtworkDetailsProps {
   artwork: PrivateArtworkDetails_artwork$key
@@ -33,7 +34,14 @@ export const PrivateArtworkDetails: React.FC<PrivateArtworkDetailsProps> = ({
 
       <Spacer y={4} />
 
-      <PrivateArtworkAboutArtist artwork={data} />
+      <Media greaterThanOrEqual="sm">
+        <PrivateArtworkAboutArtist artwork={data} />
+      </Media>
+      <Media lessThan="sm">
+        <FullBleed>
+          <PrivateArtworkAboutArtist artwork={data} />
+        </FullBleed>
+      </Media>
     </Box>
   )
 }

--- a/src/Apps/Artwork/Components/PrivateArtwork/PrivateArtworkMetadata.tsx
+++ b/src/Apps/Artwork/Components/PrivateArtwork/PrivateArtworkMetadata.tsx
@@ -125,7 +125,7 @@ const MetadataDetailItem: React.FC<MetadataDetailItemProps> = ({
           width="100%"
         >
           <Text variant="md">{title}</Text>
-          {isExpanded ? <ChevronDownIcon /> : <ChevronUpIcon />}
+          {isExpanded ? <ChevronUpIcon /> : <ChevronDownIcon />}
         </Flex>
       </Clickable>
 


### PR DESCRIPTION

The type of this PR is: **FIX**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [AMBER-625]

### Description

<!-- Implementation description -->
In this PR I moved the location of the artist bio on mobile web to match the comps, and also made some small style adjustments.

<img width="448" alt="Screenshot 2024-04-22 at 3 09 18 PM" src="https://github.com/artsy/force/assets/5643895/e3a69b3d-5448-4f29-97da-5eddaed87dfe">


https://github.com/artsy/force/assets/5643895/b0d4b454-9eec-4e6c-bf25-d5d21c408d93




[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AMBER-625]: https://artsyproduct.atlassian.net/browse/AMBER-625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ