### PR TITLE
chore(private-artworks): Update tracking calls a bit

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarArtsyGuarantee.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarArtsyGuarantee.tsx
@@ -7,7 +7,7 @@ import LockIcon from "@artsy/icons/LockIcon"
 import MoneyBackIcon from "@artsy/icons/MoneyBackIcon"
 import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
-import { ActionType } from "@artsy/cohesion"
+import { ActionType, ClickedOnLearnMore } from "@artsy/cohesion"
 
 interface ArtworkSidebarArtsyGuaranteeProps {
   artwork: ArtworkSidebarArtsyGuarantee_artwork$key
@@ -26,13 +26,6 @@ export const ArtworkSidebarArtsyGuarantee: React.FC<ArtworkSidebarArtsyGuarantee
   )
   const { t } = useTranslation()
   const { trackEvent } = useTracking()
-  const payload = {
-    action: ActionType.clickedOnLearnMore,
-    context_module: "Sidebar",
-    subject: "Learn more",
-    type: "Link",
-    flow: "Artsy Guarantee",
-  }
 
   if (data.isUnlisted) {
     return (
@@ -45,6 +38,14 @@ export const ArtworkSidebarArtsyGuarantee: React.FC<ArtworkSidebarArtsyGuarantee
             target="_blank"
             rel="noopener noreferrer"
             onClick={() => {
+              const payload: ClickedOnLearnMore = {
+                action: ActionType.clickedOnLearnMore,
+                context_module: "Sidebar",
+                subject: "Learn more",
+                type: "Link",
+                flow: "Artsy Guarantee",
+              }
+
               trackEvent(payload)
             }}
           >

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarPrivateArtwork.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarPrivateArtwork.tsx
@@ -17,13 +17,6 @@ export const ArtworkSidebarPrivateArtwork: React.FC<ArtworkSidebarPrivateArtwork
     "amber_artwork_visibility_unlisted"
   )
   const { trackEvent } = useTracking()
-  const payload = {
-    action: "Click",
-    context_module: "Sidebar",
-    subject: "Gallery Name",
-    type: "Link",
-    flow: "Exclusive Access",
-  }
 
   const data = useFragment(
     graphql`
@@ -59,6 +52,14 @@ export const ArtworkSidebarPrivateArtwork: React.FC<ArtworkSidebarPrivateArtwork
         <RouterLink
           to={`/partner/${data.partner?.slug}`}
           onClick={() => {
+            const payload = {
+              action: "Click",
+              context_module: "Sidebar",
+              subject: "Gallery Name",
+              type: "Link",
+              flow: "Exclusive Access",
+            }
+
             trackEvent(payload)
           }}
         >

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarShippingInformation.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarShippingInformation.tsx
@@ -4,7 +4,7 @@ import { ArtworkSidebarShippingInformation_artwork$data } from "__generated__/Ar
 import { useTranslation } from "react-i18next"
 import { RouterLink } from "System/Router/RouterLink"
 import { useTracking } from "react-tracking"
-import { ActionType } from "@artsy/cohesion"
+import { ActionType, ClickedOnLearnMore } from "@artsy/cohesion"
 
 export interface ShippingInformationProps {
   artwork: ArtworkSidebarShippingInformation_artwork$data
@@ -15,13 +15,6 @@ const ArtworkSidebarShippingInformation: React.FC<ShippingInformationProps> = ({
 }) => {
   const { t } = useTranslation()
   const { trackEvent } = useTracking()
-  const payload = {
-    action: ActionType.clickedOnLearnMore,
-    context_module: "Sidebar",
-    subject: "Learn more",
-    type: "Link",
-    flow: "Shipping",
-  }
 
   if (isUnlisted) {
     return (
@@ -40,6 +33,14 @@ const ArtworkSidebarShippingInformation: React.FC<ShippingInformationProps> = ({
             target="_blank"
             rel="noopener noreferrer"
             onClick={() => {
+              const payload: ClickedOnLearnMore = {
+                action: ActionType.clickedOnLearnMore,
+                context_module: "Sidebar",
+                subject: "Learn more",
+                type: "Link",
+                flow: "Shipping",
+              }
+
               trackEvent(payload)
             }}
           >

--- a/src/Apps/Artwork/Components/PrivateArtwork/PrivateArtworkAboutArtist.tsx
+++ b/src/Apps/Artwork/Components/PrivateArtwork/PrivateArtworkAboutArtist.tsx
@@ -14,7 +14,7 @@ import { FollowArtistButtonQueryRenderer } from "Components/FollowButton/FollowA
 import { FollowButtonInlineCount } from "Components/FollowButton/Button"
 import { formatFollowerCount } from "Utils/formatFollowerCount"
 import { useTracking } from "react-tracking"
-import { ActionType } from "@artsy/cohesion"
+import { ActionType, ClickedOnReadMore } from "@artsy/cohesion"
 
 interface PrivateArtworkAboutArtistProps {
   artwork: PrivateArtworkAboutArtist_artwork$key
@@ -76,12 +76,6 @@ export const PrivateArtworkAboutArtist: React.FC<PrivateArtworkAboutArtistProps>
     ""
 
   const { trackEvent } = useTracking()
-  const payload = {
-    action: ActionType.clickedOnReadMore,
-    context_module: "About the artist",
-    subject: "Read more",
-    type: "Link",
-  }
 
   return (
     <Box minHeight={275} width="100%" p={6} backgroundColor="black100">
@@ -164,6 +158,13 @@ export const PrivateArtworkAboutArtist: React.FC<PrivateArtworkAboutArtistProps>
                     content={`${biographyBlurb}`}
                     inlineReadMoreLink={false}
                     onReadMoreClicked={() => {
+                      const payload: ClickedOnReadMore = {
+                        action: ActionType.clickedOnReadMore,
+                        context_module: "About the artist",
+                        subject: "Read more",
+                        type: "Link",
+                      }
+
                       trackEvent(payload)
                     }}
                   />

--- a/src/Apps/Artwork/Components/PrivateArtwork/PrivateArtworkAboutWork.tsx
+++ b/src/Apps/Artwork/Components/PrivateArtwork/PrivateArtworkAboutWork.tsx
@@ -2,7 +2,7 @@ import { Box, HTML, ReadMore, Spacer, Text } from "@artsy/palette"
 import { graphql, useFragment } from "react-relay"
 import { PrivateArtworkAboutWork_artwork$key } from "__generated__/PrivateArtworkAboutWork_artwork.graphql"
 import { useTracking } from "react-tracking"
-import { ActionType } from "@artsy/cohesion"
+import { ActionType, ClickedOnReadMore } from "@artsy/cohesion"
 
 interface PrivateArtworkAboutWorkProps {
   artwork: PrivateArtworkAboutWork_artwork$key
@@ -20,12 +20,6 @@ export const PrivateArtworkAboutWork: React.FC<PrivateArtworkAboutWorkProps> = (
     artwork
   )
   const { trackEvent } = useTracking()
-  const payload = {
-    action: ActionType.clickedOnReadMore,
-    context_module: "About the work",
-    subject: "Read more",
-    type: "Link",
-  }
 
   if (!data.additionalInformationHTML) {
     return null
@@ -47,6 +41,13 @@ export const PrivateArtworkAboutWork: React.FC<PrivateArtworkAboutWorkProps> = (
               content={`${data.additionalInformationHTML}`}
               maxChars={200}
               onReadMoreClicked={() => {
+                const payload: ClickedOnReadMore = {
+                  action: ActionType.clickedOnReadMore,
+                  context_module: "About the work",
+                  subject: "Read more",
+                  type: "Link",
+                }
+
                 trackEvent(payload)
               }}
             />

--- a/src/Apps/Artwork/Components/PrivateArtwork/PrivateArtworkMetadata.tsx
+++ b/src/Apps/Artwork/Components/PrivateArtwork/PrivateArtworkMetadata.tsx
@@ -101,18 +101,19 @@ const MetadataDetailItem: React.FC<MetadataDetailItemProps> = ({
 }) => {
   const [isExpanded, setIsExpanded] = useState(expanded)
   const { trackEvent } = useTracking()
-  const payload = {
-    action: "Click",
-    context_module: "About the work",
-    context_owner_type: "artwork",
-    expand: !isExpanded,
-    subject: title,
-  }
 
   return (
     <Box>
       <Clickable
         onClick={() => {
+          const payload = {
+            action: "Click",
+            context_module: "About the work",
+            context_owner_type: "artwork",
+            expand: !isExpanded,
+            subject: title,
+          }
+
           trackEvent(payload)
           setIsExpanded(!isExpanded)
         }}


### PR DESCRIPTION
The type of this PR is: **Chore**

### Description

This is some minor convention-ish updates to https://github.com/artsy/force/pull/13773. Main changes are:
- make the tracking analytics payload more local in scope, vs "global" to the component. Move `payload` to where it is being called, since it doesn't need to be anywhere else (for sharing purposes)
- Add specific interface types where it makes sense, and is obvious
