### PR TITLE
fix(AMBER-342): show submitted order modal for private artworks

### DIFF
--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -322,11 +322,10 @@ export const ArtworkApp: React.FC<Props> = props => {
           <Spacer y={6} />
 
           <RecentlyViewed />
-
-          {!!submittedOrderId && (
-            <SubmittedOrderModalQueryRenderer orderId={submittedOrderId} />
-          )}
         </>
+      )}
+      {!!submittedOrderId && (
+        <SubmittedOrderModalQueryRenderer orderId={submittedOrderId} />
       )}
     </>
   )


### PR DESCRIPTION
The type of this PR is: **TYPE**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [AMBER-640]

### Description

As per [this discussion](https://artsy.slack.com/archives/C05F8TNKGAV/p1713885480541039), the submitted order modal is not rendering for private works. We should show this for all works.

_Modal rendering over PA page:_ 
<img width="1234" alt="Screenshot 2024-04-23 at 12 55 14 PM" src="https://github.com/artsy/force/assets/5643895/b98c4170-c030-49a7-a414-4f6e3c91ef0b">




[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AMBER-640]: https://artsyproduct.atlassian.net/browse/AMBER-640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ