### PR TITLE
fix: use UTC for sale agreement timezone

### DIFF
--- a/src/Apps/SaleAgreements/Components/SaleAgreementsFilter.tsx
+++ b/src/Apps/SaleAgreements/Components/SaleAgreementsFilter.tsx
@@ -78,8 +78,8 @@ const saleAgreementsFilterFragment = graphql`
         node {
           internalID
           content
-          displayStartAt(format: "MMM Do, YYYY")
-          displayEndAt(format: "MMM Do, YYYY")
+          displayStartAt(format: "MMM Do, YYYY", timezone: "UTC")
+          displayEndAt(format: "MMM Do, YYYY", timezone: "UTC")
           published
           status
           sale @required(action: NONE) {

--- a/src/Apps/SaleAgreements/Routes/SaleAgreementRoute.tsx
+++ b/src/Apps/SaleAgreements/Routes/SaleAgreementRoute.tsx
@@ -59,8 +59,8 @@ const saleAgreementFragment = graphql`
   fragment SaleAgreementRoute_saleAgreement on SaleAgreement {
     internalID
     content(format: HTML) @required(action: NONE)
-    displayStartAt(format: "MMM Do, YYYY")
-    displayEndAt(format: "MMM Do, YYYY")
+    displayStartAt(format: "MMM Do, YYYY", timezone: "UTC")
+    displayEndAt(format: "MMM Do, YYYY", timezone: "UTC")
     sale @required(action: NONE) {
       internalID
       name

--- a/src/__generated__/SaleAgreementRoute_Test_Query.graphql.ts
+++ b/src/__generated__/SaleAgreementRoute_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4ef06f08849f5e4bbf8917904c8ebcf7>>
+ * @generated SignedSource<<504b6e9070b23ab04e118f0810e8e6e3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -41,6 +41,11 @@ v2 = [
     "kind": "Literal",
     "name": "format",
     "value": "MMM Do, YYYY"
+  },
+  {
+    "kind": "Literal",
+    "name": "timezone",
+    "value": "UTC"
   }
 ],
 v3 = {
@@ -110,14 +115,14 @@ return {
             "args": (v2/*: any*/),
             "kind": "ScalarField",
             "name": "displayStartAt",
-            "storageKey": "displayStartAt(format:\"MMM Do, YYYY\")"
+            "storageKey": "displayStartAt(format:\"MMM Do, YYYY\",timezone:\"UTC\")"
           },
           {
             "alias": null,
             "args": (v2/*: any*/),
             "kind": "ScalarField",
             "name": "displayEndAt",
-            "storageKey": "displayEndAt(format:\"MMM Do, YYYY\")"
+            "storageKey": "displayEndAt(format:\"MMM Do, YYYY\",timezone:\"UTC\")"
           },
           {
             "alias": null,
@@ -146,12 +151,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "51bc53cd0d3df1b6552fdbbd9b3965a3",
+    "cacheID": "fc119b3e6e67e3ca5d7ff1574fc123d3",
     "id": null,
     "metadata": {},
     "name": "SaleAgreementRoute_Test_Query",
     "operationKind": "query",
-    "text": "query SaleAgreementRoute_Test_Query {\n  saleAgreement(id: \"abc123\") {\n    ...SaleAgreementRoute_saleAgreement\n    id\n  }\n}\n\nfragment SaleAgreementRoute_saleAgreement on SaleAgreement {\n  internalID\n  content(format: HTML)\n  displayStartAt(format: \"MMM Do, YYYY\")\n  displayEndAt(format: \"MMM Do, YYYY\")\n  sale {\n    internalID\n    name\n    id\n  }\n}\n"
+    "text": "query SaleAgreementRoute_Test_Query {\n  saleAgreement(id: \"abc123\") {\n    ...SaleAgreementRoute_saleAgreement\n    id\n  }\n}\n\nfragment SaleAgreementRoute_saleAgreement on SaleAgreement {\n  internalID\n  content(format: HTML)\n  displayStartAt(format: \"MMM Do, YYYY\", timezone: \"UTC\")\n  displayEndAt(format: \"MMM Do, YYYY\", timezone: \"UTC\")\n  sale {\n    internalID\n    name\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SaleAgreementRoute_saleAgreement.graphql.ts
+++ b/src/__generated__/SaleAgreementRoute_saleAgreement.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ddb43237da4c4e27bac6cccce88498c8>>
+ * @generated SignedSource<<589dbbb54fe5e7987a6e44d0475c7601>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -39,6 +39,11 @@ v1 = [
     "kind": "Literal",
     "name": "format",
     "value": "MMM Do, YYYY"
+  },
+  {
+    "kind": "Literal",
+    "name": "timezone",
+    "value": "UTC"
   }
 ];
 return {
@@ -71,14 +76,14 @@ return {
       "args": (v1/*: any*/),
       "kind": "ScalarField",
       "name": "displayStartAt",
-      "storageKey": "displayStartAt(format:\"MMM Do, YYYY\")"
+      "storageKey": "displayStartAt(format:\"MMM Do, YYYY\",timezone:\"UTC\")"
     },
     {
       "alias": null,
       "args": (v1/*: any*/),
       "kind": "ScalarField",
       "name": "displayEndAt",
-      "storageKey": "displayEndAt(format:\"MMM Do, YYYY\")"
+      "storageKey": "displayEndAt(format:\"MMM Do, YYYY\",timezone:\"UTC\")"
     },
     {
       "kind": "RequiredField",
@@ -110,6 +115,6 @@ return {
 };
 })();
 
-(node as any).hash = "e1025c8dd087c02392317ca7d46fd144";
+(node as any).hash = "f4722283152ee23c76142fd1b8f403ec";
 
 export default node;

--- a/src/__generated__/SaleAgreementsApp_Test_Query.graphql.ts
+++ b/src/__generated__/SaleAgreementsApp_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f5757a0dbb2f4e02e9d5a9bb091e6a04>>
+ * @generated SignedSource<<66254cbddf37f80486ad8a83b7804cb3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -34,6 +34,11 @@ v1 = [
     "kind": "Literal",
     "name": "format",
     "value": "MMM Do, YYYY"
+  },
+  {
+    "kind": "Literal",
+    "name": "timezone",
+    "value": "UTC"
   }
 ],
 v2 = {
@@ -151,14 +156,14 @@ return {
                         "args": (v1/*: any*/),
                         "kind": "ScalarField",
                         "name": "displayStartAt",
-                        "storageKey": "displayStartAt(format:\"MMM Do, YYYY\")"
+                        "storageKey": "displayStartAt(format:\"MMM Do, YYYY\",timezone:\"UTC\")"
                       },
                       {
                         "alias": null,
                         "args": (v1/*: any*/),
                         "kind": "ScalarField",
                         "name": "displayEndAt",
-                        "storageKey": "displayEndAt(format:\"MMM Do, YYYY\")"
+                        "storageKey": "displayEndAt(format:\"MMM Do, YYYY\",timezone:\"UTC\")"
                       },
                       {
                         "alias": null,
@@ -231,7 +236,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "33b65f7d43a7b8197933adb354e47592",
+    "cacheID": "c52af6336c60b625d9610446fef7a3ff",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -291,7 +296,7 @@ return {
     },
     "name": "SaleAgreementsApp_Test_Query",
     "operationKind": "query",
-    "text": "query SaleAgreementsApp_Test_Query {\n  viewer {\n    ...SaleAgreementsApp_viewer\n  }\n}\n\nfragment SaleAgreementsApp_viewer on Viewer {\n  ...SaleAgreementsFilter_viewer\n}\n\nfragment SaleAgreementsFilter_viewer on Viewer {\n  saleAgreementsConnection(first: 100) {\n    edges {\n      node {\n        internalID\n        content\n        displayStartAt(format: \"MMM Do, YYYY\")\n        displayEndAt(format: \"MMM Do, YYYY\")\n        published\n        status\n        sale {\n          internalID\n          name\n          isArtsyLicensed\n          isBenefit\n          isAuction\n          id\n        }\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query SaleAgreementsApp_Test_Query {\n  viewer {\n    ...SaleAgreementsApp_viewer\n  }\n}\n\nfragment SaleAgreementsApp_viewer on Viewer {\n  ...SaleAgreementsFilter_viewer\n}\n\nfragment SaleAgreementsFilter_viewer on Viewer {\n  saleAgreementsConnection(first: 100) {\n    edges {\n      node {\n        internalID\n        content\n        displayStartAt(format: \"MMM Do, YYYY\", timezone: \"UTC\")\n        displayEndAt(format: \"MMM Do, YYYY\", timezone: \"UTC\")\n        published\n        status\n        sale {\n          internalID\n          name\n          isArtsyLicensed\n          isBenefit\n          isAuction\n          id\n        }\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SaleAgreementsFilter_viewer.graphql.ts
+++ b/src/__generated__/SaleAgreementsFilter_viewer.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6aeb7dc1190bb775ff1d244ae499c8ad>>
+ * @generated SignedSource<<972437d8b712917f301d8b14f647c454>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -51,6 +51,11 @@ v1 = [
     "kind": "Literal",
     "name": "format",
     "value": "MMM Do, YYYY"
+  },
+  {
+    "kind": "Literal",
+    "name": "timezone",
+    "value": "UTC"
   }
 ];
 return {
@@ -102,14 +107,14 @@ return {
                   "args": (v1/*: any*/),
                   "kind": "ScalarField",
                   "name": "displayStartAt",
-                  "storageKey": "displayStartAt(format:\"MMM Do, YYYY\")"
+                  "storageKey": "displayStartAt(format:\"MMM Do, YYYY\",timezone:\"UTC\")"
                 },
                 {
                   "alias": null,
                   "args": (v1/*: any*/),
                   "kind": "ScalarField",
                   "name": "displayEndAt",
-                  "storageKey": "displayEndAt(format:\"MMM Do, YYYY\")"
+                  "storageKey": "displayEndAt(format:\"MMM Do, YYYY\",timezone:\"UTC\")"
                 },
                 {
                   "alias": null,
@@ -185,6 +190,6 @@ return {
 };
 })();
 
-(node as any).hash = "c70c144c34813df06d9d89c2b8b5f44f";
+(node as any).hash = "32ce3c6b3a5804f02c949a6e77ee7c92";
 
 export default node;

--- a/src/__generated__/saleAgreementsRoutes_SaleAgreementQuery.graphql.ts
+++ b/src/__generated__/saleAgreementsRoutes_SaleAgreementQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6aa71bc34956acb8ee5a4735602ce529>>
+ * @generated SignedSource<<24e358ed91ee99fce0ff0ba54ed9c1cc>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -50,6 +50,11 @@ v3 = [
     "kind": "Literal",
     "name": "format",
     "value": "MMM Do, YYYY"
+  },
+  {
+    "kind": "Literal",
+    "name": "timezone",
+    "value": "UTC"
   }
 ],
 v4 = {
@@ -119,14 +124,14 @@ return {
             "args": (v3/*: any*/),
             "kind": "ScalarField",
             "name": "displayStartAt",
-            "storageKey": "displayStartAt(format:\"MMM Do, YYYY\")"
+            "storageKey": "displayStartAt(format:\"MMM Do, YYYY\",timezone:\"UTC\")"
           },
           {
             "alias": null,
             "args": (v3/*: any*/),
             "kind": "ScalarField",
             "name": "displayEndAt",
-            "storageKey": "displayEndAt(format:\"MMM Do, YYYY\")"
+            "storageKey": "displayEndAt(format:\"MMM Do, YYYY\",timezone:\"UTC\")"
           },
           {
             "alias": null,
@@ -155,12 +160,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "3763e64883773f1e4c1f93ec13e4533a",
+    "cacheID": "a2ee8a32c62410950fa3fab096c1f49e",
     "id": null,
     "metadata": {},
     "name": "saleAgreementsRoutes_SaleAgreementQuery",
     "operationKind": "query",
-    "text": "query saleAgreementsRoutes_SaleAgreementQuery(\n  $id: ID!\n) {\n  saleAgreement(id: $id) {\n    ...SaleAgreementRoute_saleAgreement\n    id\n  }\n}\n\nfragment SaleAgreementRoute_saleAgreement on SaleAgreement {\n  internalID\n  content(format: HTML)\n  displayStartAt(format: \"MMM Do, YYYY\")\n  displayEndAt(format: \"MMM Do, YYYY\")\n  sale {\n    internalID\n    name\n    id\n  }\n}\n"
+    "text": "query saleAgreementsRoutes_SaleAgreementQuery(\n  $id: ID!\n) {\n  saleAgreement(id: $id) {\n    ...SaleAgreementRoute_saleAgreement\n    id\n  }\n}\n\nfragment SaleAgreementRoute_saleAgreement on SaleAgreement {\n  internalID\n  content(format: HTML)\n  displayStartAt(format: \"MMM Do, YYYY\", timezone: \"UTC\")\n  displayEndAt(format: \"MMM Do, YYYY\", timezone: \"UTC\")\n  sale {\n    internalID\n    name\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/saleAgreementsRoutes_SaleAgreementsAppQuery.graphql.ts
+++ b/src/__generated__/saleAgreementsRoutes_SaleAgreementsAppQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0c66b52b38602716e3f36337a276b4ae>>
+ * @generated SignedSource<<7d305a1f5c394a16ec5cd97871b3c3c6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -34,6 +34,11 @@ v1 = [
     "kind": "Literal",
     "name": "format",
     "value": "MMM Do, YYYY"
+  },
+  {
+    "kind": "Literal",
+    "name": "timezone",
+    "value": "UTC"
   }
 ],
 v2 = {
@@ -127,14 +132,14 @@ return {
                         "args": (v1/*: any*/),
                         "kind": "ScalarField",
                         "name": "displayStartAt",
-                        "storageKey": "displayStartAt(format:\"MMM Do, YYYY\")"
+                        "storageKey": "displayStartAt(format:\"MMM Do, YYYY\",timezone:\"UTC\")"
                       },
                       {
                         "alias": null,
                         "args": (v1/*: any*/),
                         "kind": "ScalarField",
                         "name": "displayEndAt",
-                        "storageKey": "displayEndAt(format:\"MMM Do, YYYY\")"
+                        "storageKey": "displayEndAt(format:\"MMM Do, YYYY\",timezone:\"UTC\")"
                       },
                       {
                         "alias": null,
@@ -207,12 +212,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1dc48b5fbbbe8a0713a88bec2e1fea7c",
+    "cacheID": "42b1144b3daa6e3b35aaeed40157c8b6",
     "id": null,
     "metadata": {},
     "name": "saleAgreementsRoutes_SaleAgreementsAppQuery",
     "operationKind": "query",
-    "text": "query saleAgreementsRoutes_SaleAgreementsAppQuery {\n  viewer {\n    ...SaleAgreementsApp_viewer\n  }\n}\n\nfragment SaleAgreementsApp_viewer on Viewer {\n  ...SaleAgreementsFilter_viewer\n}\n\nfragment SaleAgreementsFilter_viewer on Viewer {\n  saleAgreementsConnection(first: 100) {\n    edges {\n      node {\n        internalID\n        content\n        displayStartAt(format: \"MMM Do, YYYY\")\n        displayEndAt(format: \"MMM Do, YYYY\")\n        published\n        status\n        sale {\n          internalID\n          name\n          isArtsyLicensed\n          isBenefit\n          isAuction\n          id\n        }\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query saleAgreementsRoutes_SaleAgreementsAppQuery {\n  viewer {\n    ...SaleAgreementsApp_viewer\n  }\n}\n\nfragment SaleAgreementsApp_viewer on Viewer {\n  ...SaleAgreementsFilter_viewer\n}\n\nfragment SaleAgreementsFilter_viewer on Viewer {\n  saleAgreementsConnection(first: 100) {\n    edges {\n      node {\n        internalID\n        content\n        displayStartAt(format: \"MMM Do, YYYY\", timezone: \"UTC\")\n        displayEndAt(format: \"MMM Do, YYYY\", timezone: \"UTC\")\n        published\n        status\n        sale {\n          internalID\n          name\n          isArtsyLicensed\n          isBenefit\n          isAuction\n          id\n        }\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: fix

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

### Description

<!-- Implementation description -->

This PR patches #13713 to enforce the use of the `UTC` timezone when requesting a sale agreement's `displayStartAt` and `displayEndAt` fields. 

### Problem
Currently, there is a mismatch between the dates shown on the `artsy.net/supplemental-cos` and `artsy.net/supplemental-cos/:id`pages. This appears to be a bug resulting from `metaphysics` [using the browser's timezone](https://github.com/artsy/metaphysics/blob/main/src/schema/v2/fields/date.ts#L38) unless one is explicitly passed in as an argument. This standardized the returned format of the dates resulting in the correct date string (e.g. `2024-04-18T00:00:00Z` instead of `2024-04-17T20:00:00-04:00`).

![Screenshot 2024-04-23 at 7 43 15 PM](https://github.com/artsy/force/assets/38149304/0cd6cf6b-5e4a-4408-bbf5-5d71087abad7)
![Screenshot 2024-04-23 at 7 43 41 PM](https://github.com/artsy/force/assets/38149304/10706560-759e-4a97-9f04-18deb180dca7)