### PR TITLE
fix(collections): Make even safer

### DIFF
--- a/src/Apps/Collect/Routes/Collection/Components/Header/index.tsx
+++ b/src/Apps/Collect/Routes/Collection/Components/Header/index.tsx
@@ -28,7 +28,7 @@ export const CollectionHeader: React.FC<CollectionHeaderProps> = ({
   artworks,
   collection,
 }) => {
-  const merchandisableArtists = artworks.merchandisableArtists ?? []
+  const merchandisableArtists = artworks?.merchandisableArtists ?? []
   const hasMultipleArtists = merchandisableArtists.length > 1
 
   const featuredArtists = getFeaturedArtists(


### PR DESCRIPTION
The type of this PR is: **Fix**

Addresses https://artsy.slack.com/archives/C03N12SR0RK/p1713983397739069?thread_ts=1713543478.775019&cid=C03N12SR0RK. 

### Description 

Seems like somewhere there's a network race condition where artworks could come back null. Not sure why, but this makes things even safer for the time being. 