### PR TITLE
fix(artwork): only show partner bio if enabled

### DIFF
--- a/src/Apps/Artwork/Components/PrivateArtwork/PrivateArtworkAboutArtist.tsx
+++ b/src/Apps/Artwork/Components/PrivateArtwork/PrivateArtworkAboutArtist.tsx
@@ -22,6 +22,8 @@ interface PrivateArtworkAboutArtistProps {
 export const PrivateArtworkAboutArtist: React.FC<PrivateArtworkAboutArtistProps> = ({
   artwork,
 }) => {
+  const { trackEvent } = useTracking()
+
   const data = useFragment(
     graphql`
       fragment PrivateArtworkAboutArtist_artwork on Artwork {
@@ -61,16 +63,17 @@ export const PrivateArtworkAboutArtist: React.FC<PrivateArtworkAboutArtistProps>
     artwork
   )
 
+  if (!data.displayArtistBio) {
+    return null
+  }
+
   const followsCount =
     Number(formatFollowerCount(data.artist?.counts?.follows)) ?? 0
 
   const biographyBlurb =
-    data.displayArtistBio &&
-    (data.artist?.partnerBiographyBlurb?.text ??
-      data.artist?.biographyBlurb?.text ??
-      "")
-
-  const { trackEvent } = useTracking()
+    data.artist?.partnerBiographyBlurb?.text ??
+    data.artist?.biographyBlurb?.text ??
+    ""
 
   return (
     <Box

--- a/src/Apps/Artwork/Components/PrivateArtwork/__tests__/PrivateArtworkAboutArtist.jest.tsx
+++ b/src/Apps/Artwork/Components/PrivateArtwork/__tests__/PrivateArtworkAboutArtist.jest.tsx
@@ -36,4 +36,21 @@ describe("ArtworkSidebarPrivateArtwork", () => {
     expect(screen.getByText("Follow")).toBeInTheDocument()
     expect(screen.queryByText("Test Artist Biography")).toBeInTheDocument()
   })
+
+  it("does not render if displayArtistBio is false", () => {
+    renderWithRelay({
+      Artwork: () => ({
+        displayArtistBio: false,
+      }),
+      Artist: () => {
+        return {
+          name: "Test Artist Name",
+          partnerBiographyBlurb: { text: "Test Artist Biography" },
+          formattedNationalityAndBirthday: "USA, 1990",
+        }
+      },
+    })
+
+    expect(screen.queryByText("Test Artist Name")).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

This hides the private artwork partner bio unless `displayArtistBio` is true. 

cc @artsy/amber-devs 