### PR TITLE
feat(artist): preloads the likely lcp

### DIFF
--- a/src/Apps/Artist/Components/ArtistHeader/ArtistHeaderImage.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/ArtistHeaderImage.tsx
@@ -2,7 +2,8 @@ import { BoxProps, Image, ResponsiveBox } from "@artsy/palette"
 import { FullBleedHeader } from "Components/FullBleedHeader/FullBleedHeader"
 import { FC } from "react"
 import { maxDimensionsByArea, resized } from "Utils/resized"
-import { Media } from "Utils/Responsive"
+import { BREAKPOINTS, Media } from "Utils/Responsive"
+import { Link } from "react-head"
 
 interface ArtistHeaderImageProps
   extends Omit<BoxProps, "maxHeight" | "maxWidth"> {
@@ -23,6 +24,21 @@ export const ArtistHeaderImage: FC<ArtistHeaderImageProps> = ({
 
   return (
     <>
+      <Link
+        rel="preload"
+        href={image.src}
+        as="image"
+        media={`(max-width: ${BREAKPOINTS.sm}px)`}
+      />
+
+      <Link
+        rel="preload"
+        href={desktop.src}
+        as="image"
+        imagesrcset={desktop.srcSet}
+        media={`(min-width: ${BREAKPOINTS.sm}px)`}
+      />
+
       <Media at="xs">
         <FullBleedHeader src={image.src} />
       </Media>

--- a/src/Utils/Responsive/index.tsx
+++ b/src/Utils/Responsive/index.tsx
@@ -1,11 +1,8 @@
 export * from "./DeprecatedResponsive"
 import { createMedia } from "@artsy/fresnel"
 
-// TODO: We need this to be 0-based, whereas currently in palette xs is defined
-//       as 767. We should move this up to palette, but we need to give the
-//       migration path for users of the current Responsive component some
-//       serious thought.
-const newThemeBreakpoints = {
+// FIXME: Convert to Palette breakpoints
+export const BREAKPOINTS = {
   xs: 0,
   sm: 768,
   md: 900,
@@ -14,7 +11,7 @@ const newThemeBreakpoints = {
 }
 
 const ReactionMedia = createMedia({
-  breakpoints: newThemeBreakpoints,
+  breakpoints: BREAKPOINTS,
   interactions: {
     // TODO: These should go into palette
     hover: "(pointer: coarse), (-moz-touch-enabled: 1)",


### PR DESCRIPTION
This preloads the header image for the artist pages. Should help a bit with LCP.

That said: we can cut 1mb (I'm not joking) from the page response by simply deferring the filter to the client side. It's below the fold anyway. We should try this.