### PR TITLE
feat: set up experiments directory for art advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -150,6 +150,7 @@
     "lodash": "^4.17.21",
     "luxon": "^3.2.1",
     "map-cursor-to-max": "^1.0.0",
+    "marked-react": "^2.0.0",
     "memoize-one": "^5.2.1",
     "mime": "2.4.0",
     "morgan": "1.10.0",

--- a/src/Apps/ArtAdvisor/01-Spike/App.tsx
+++ b/src/Apps/ArtAdvisor/01-Spike/App.tsx
@@ -1,0 +1,56 @@
+import { FC, useState } from "react"
+import { Button, Input, TextArea, Text, Spacer, Flex } from "@artsy/palette"
+import { useSystemContext } from "System/SystemContext"
+
+export const App: FC = () => {
+  const [userInput, setUserInput] = useState<string>("")
+  const [messages, setMessages] = useState<string>("")
+
+  const { user } = useSystemContext()
+
+  const onSubmit = async () => {
+    const res = await fetch("http://localhost:3000", {
+      method: "POST",
+      body: userInput,
+      headers: {
+        "Content-Type": "text/plain",
+        "X-ACCESS-TOKEN": user?.accessToken || "",
+      },
+    })
+
+    const parsedRespone = await res.text()
+
+    setMessages(
+      messages +
+        "USER: " +
+        userInput +
+        "\n" +
+        "\n" +
+        "ART ADVISOR: " +
+        parsedRespone +
+        "\n" +
+        "\n"
+    )
+  }
+
+  return (
+    <>
+      <Spacer y={4} />
+      <Text variant="lg-display">Art Advisor Chat</Text>
+      <Spacer y={4} />
+      <TextArea value={messages} />
+      <Spacer y={2} />
+      <Flex>
+        <Input
+          name="userInput"
+          placeholder="Enter your message here"
+          onChange={e => setUserInput(e.target.value)}
+        />
+        <Spacer x={2} />
+        <Button type="submit" onClick={onSubmit}>
+          Send Message
+        </Button>
+      </Flex>
+    </>
+  )
+}

--- a/src/Apps/ArtAdvisor/01-Spike/App.tsx
+++ b/src/Apps/ArtAdvisor/01-Spike/App.tsx
@@ -2,16 +2,25 @@ import { FC, useState } from "react"
 import { Button, Input, TextArea, Text, Spacer, Flex } from "@artsy/palette"
 import { useSystemContext } from "System/SystemContext"
 
+type Message = {
+  role: string
+  content: string
+}
+
 export const App: FC = () => {
   const [userInput, setUserInput] = useState<string>("")
   const [messages, setMessages] = useState<string>("")
+  const [messageList, setMessageList] = useState<Message[]>([])
 
   const { user } = useSystemContext()
 
   const onSubmit = async () => {
     const res = await fetch("http://localhost:3000", {
       method: "POST",
-      body: userInput,
+      body: JSON.stringify([
+        ...messageList,
+        { role: "user", content: userInput },
+      ]),
       headers: {
         "Content-Type": "text/plain",
         "X-ACCESS-TOKEN": user?.accessToken || "",
@@ -19,6 +28,12 @@ export const App: FC = () => {
     })
 
     const parsedRespone = await res.text()
+
+    setMessageList([
+      ...messageList,
+      { role: "user", content: userInput },
+      { role: "assistant", content: parsedRespone },
+    ])
 
     setMessages(
       messages +
@@ -51,6 +66,7 @@ export const App: FC = () => {
           Send Message
         </Button>
       </Flex>
+      <pre>{JSON.stringify(messageList, null, 2)}</pre>
     </>
   )
 }

--- a/src/Apps/ArtAdvisor/02-Markdown/App.tsx
+++ b/src/Apps/ArtAdvisor/02-Markdown/App.tsx
@@ -1,0 +1,152 @@
+import { FC, useEffect, useRef, useState } from "react"
+import { Text, Box, Input, Button, Flex } from "@artsy/palette"
+import { ChatCompletionStream } from "openai/lib/ChatCompletionStream"
+import Markdown from "marked-react"
+
+export const App: FC = () => {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const conversationRef = useRef(null)
+  const scrollMeRef = useRef<HTMLDivElement>(null)
+  const [markdownText, setMarkdownText] = useState("")
+  const [isGenerating, setIsGenerating] = useState(false)
+
+  useEffect(() => {
+    if (inputRef.current) {
+      inputRef.current.focus()
+    }
+
+    // Setup: insert some CSS rules into the document's head
+    const styleElement = insertStyles()
+
+    // Cleanup: remove the style element when the component is unmounted
+    return () => removeStyles(styleElement)
+  }, [])
+
+  async function handleSubmit(e) {
+    e.preventDefault()
+
+    if (!inputRef.current) {
+      return
+    }
+
+    const response = await fetch("http://localhost:3000", {
+      method: "POST",
+      body: inputRef.current.value,
+      headers: { "Content-Type": "text/plain" },
+    })
+
+    if (!response.body) {
+      return
+    }
+
+    const runner = ChatCompletionStream.fromReadableStream(response.body)
+    setIsGenerating(true)
+
+    runner.on("content", (delta, snapshot) => {
+      // update the conversation incrementally
+      setMarkdownText(current => current + delta)
+
+      // -vs- replace the conversation
+      // setMarkdownText(snapshot)
+
+      // keep the bottom of the conversation scrolled into view
+      let convo = (conversationRef.current as unknown) as HTMLDivElement
+      if (convo) {
+        convo.scrollTop = convo.scrollHeight - convo.clientHeight
+      }
+    })
+
+    await runner.finalChatCompletion()
+    setMarkdownText(current => current + "\n\n")
+    setIsGenerating(false)
+  }
+
+  return (
+    <Box>
+      <Text variant={"lg-display"} my={4}>
+        Chat 1
+      </Text>
+
+      <Box
+        ref={conversationRef}
+        style={{ fontSize: "1.2em" }}
+        height={"30em"}
+        border={"solid 1px"}
+        borderColor={"black60"}
+        my="2em"
+        p="1em"
+        overflow={"scroll"}
+      >
+        <Markdown>{markdownText}</Markdown>
+
+        <div ref={scrollMeRef}>
+          {/* invisible element that will be scrolled into view as `messages` gets updated */}
+        </div>
+      </Box>
+
+      <form onSubmit={handleSubmit}>
+        <Flex gap={1} mb={4}>
+          <Input
+            ref={inputRef}
+            style={{ fontSize: "1.2em" }}
+            placeholder="Chat with Artsy"
+            defaultValue="List the different printmaking techniques. For each provide the name of the technique in boldface, the definirion in italic, and a link to an example artwork for that technique on Artsy.net"
+          />
+          <Button px={6} disabled={isGenerating}>
+            Send
+          </Button>
+        </Flex>
+      </form>
+
+      <details>
+        <summary>See raw response</summary>
+
+        <textarea
+          style={{ width: "100%", height: "auto" }}
+          rows={30}
+          value={markdownText}
+          readOnly
+        />
+      </details>
+    </Box>
+  )
+}
+
+function insertStyles() {
+  // Create a new style element
+  const styleElement = document.createElement("style")
+  styleElement.type = "text/css"
+
+  // Insert the style element into the document's head
+  document.head.appendChild(styleElement)
+
+  // Add some CSS rules
+  if (styleElement.sheet) {
+    styleElement.sheet.insertRule(
+      "ul, ol { margin: 0 1em; padding: 0em; }",
+      styleElement.sheet.cssRules.length
+    )
+    styleElement.sheet.insertRule(
+      "ol li { list-style-type: number; margin-bottom: 1em; }",
+      styleElement.sheet.cssRules.length
+    )
+    styleElement.sheet.insertRule(
+      "ul li { list-style-type: disc; margin-bottom: 1em; }",
+      styleElement.sheet.cssRules.length
+    )
+    styleElement.sheet.insertRule(
+      "table { border: 1px solid gray; border-collapse: collapse; }",
+      styleElement.sheet.cssRules.length
+    )
+    styleElement.sheet.insertRule(
+      "td, th { border: 1px solid gray; padding: 0.5em; }",
+      styleElement.sheet.cssRules.length
+    )
+  }
+
+  return styleElement
+}
+
+function removeStyles(styleElement: HTMLStyleElement) {
+  document.head.removeChild(styleElement)
+}

--- a/src/Apps/ArtAdvisor/02-Markdown/App.tsx
+++ b/src/Apps/ArtAdvisor/02-Markdown/App.tsx
@@ -2,6 +2,7 @@ import { FC, useEffect, useRef, useState } from "react"
 import { Text, Box, Input, Button, Flex } from "@artsy/palette"
 import { ChatCompletionStream } from "openai/lib/ChatCompletionStream"
 import Markdown from "marked-react"
+import styled from "styled-components"
 
 export const App: FC = () => {
   const inputRef = useRef<HTMLInputElement>(null)
@@ -14,12 +15,6 @@ export const App: FC = () => {
     if (inputRef.current) {
       inputRef.current.focus()
     }
-
-    // Setup: insert some CSS rules into the document's head
-    const styleElement = insertStyles()
-
-    // Cleanup: remove the style element when the component is unmounted
-    return () => removeStyles(styleElement)
   }, [])
 
   async function handleSubmit(e) {
@@ -67,7 +62,7 @@ export const App: FC = () => {
         Chat 1
       </Text>
 
-      <Box
+      <Conversation
         ref={conversationRef}
         style={{ fontSize: "1.2em" }}
         height={"30em"}
@@ -82,7 +77,7 @@ export const App: FC = () => {
         <div ref={scrollMeRef}>
           {/* invisible element that will be scrolled into view as `messages` gets updated */}
         </div>
-      </Box>
+      </Conversation>
 
       <form onSubmit={handleSubmit}>
         <Flex gap={1} mb={4}>
@@ -112,41 +107,27 @@ export const App: FC = () => {
   )
 }
 
-function insertStyles() {
-  // Create a new style element
-  const styleElement = document.createElement("style")
-  styleElement.type = "text/css"
-
-  // Insert the style element into the document's head
-  document.head.appendChild(styleElement)
-
-  // Add some CSS rules
-  if (styleElement.sheet) {
-    styleElement.sheet.insertRule(
-      "ul, ol { margin: 0 1em; padding: 0em; }",
-      styleElement.sheet.cssRules.length
-    )
-    styleElement.sheet.insertRule(
-      "ol li { list-style-type: number; margin-bottom: 1em; }",
-      styleElement.sheet.cssRules.length
-    )
-    styleElement.sheet.insertRule(
-      "ul li { list-style-type: disc; margin-bottom: 1em; }",
-      styleElement.sheet.cssRules.length
-    )
-    styleElement.sheet.insertRule(
-      "table { border: 1px solid gray; border-collapse: collapse; }",
-      styleElement.sheet.cssRules.length
-    )
-    styleElement.sheet.insertRule(
-      "td, th { border: 1px solid gray; padding: 0.5em; }",
-      styleElement.sheet.cssRules.length
-    )
+const Conversation = styled(Box)`
+  ul,
+  ol {
+    margin: 0 1em;
+    padding: 0em;
   }
-
-  return styleElement
-}
-
-function removeStyles(styleElement: HTMLStyleElement) {
-  document.head.removeChild(styleElement)
-}
+  ol li {
+    list-style-type: number;
+    margin-bottom: 1em;
+  }
+  ul li {
+    list-style-type: disc;
+    margin-bottom: 1em;
+  }
+  table {
+    border: 1px solid gray;
+    border-collapse: collapse;
+  }
+  td,
+  th {
+    border: 1px solid gray;
+    padding: 0.5em;
+  }
+`

--- a/src/Apps/ArtAdvisor/ArtAdvisorApp.tsx
+++ b/src/Apps/ArtAdvisor/ArtAdvisorApp.tsx
@@ -1,72 +1,65 @@
-import { FC, useState } from "react"
-import { Button, Input, TextArea, Text, Spacer, Flex } from "@artsy/palette"
-import { useSystemContext } from "System/SystemContext"
-
-type Message = {
-  role: string
-  content: string
-}
+import React, { FC, PropsWithChildren } from "react"
+import { Box, Flex as _Flex, Link, Text } from "@artsy/palette"
+import styled from "styled-components"
+import { themeGet } from "@styled-system/theme-get"
 
 export const ArtAdvisorApp: FC = () => {
-  const [userInput, setUserInput] = useState<string>("")
-  const [messages, setMessages] = useState<string>("")
-  const [messageList, setMessageList] = useState<Message[]>([])
-
-  const { user } = useSystemContext()
-
-  const onSubmit = async () => {
-    const res = await fetch("http://localhost:3000", {
-      method: "POST",
-      body: JSON.stringify([
-        ...messageList,
-        { role: "user", content: userInput },
-      ]),
-      headers: {
-        "Content-Type": "text/plain",
-        "X-ACCESS-TOKEN": user?.accessToken || "",
-      },
-    })
-
-    const parsedRespone = await res.text()
-
-    setMessageList([
-      ...messageList,
-      { role: "user", content: userInput },
-      { role: "assistant", content: parsedRespone },
-    ])
-
-    setMessages(
-      messages +
-        "USER: " +
-        userInput +
-        "\n" +
-        "\n" +
-        "ART ADVISOR: " +
-        parsedRespone +
-        "\n" +
-        "\n"
-    )
-  }
-
   return (
-    <>
-      <Spacer y={4} />
-      <Text variant="lg-display">Art Advisor Chat</Text>
-      <Spacer y={4} />
-      <TextArea value={messages} />
-      <Spacer y={2} />
-      <Flex>
-        <Input
-          name="userInput"
-          placeholder="Enter your message here"
-          onChange={e => setUserInput(e.target.value)}
-        />
-        <Spacer x={2} />
-        <Button type="submit" onClick={onSubmit}>
-          Send Message
-        </Button>
-      </Flex>
-      <pre>{JSON.stringify(messageList, null, 2)}</pre>
-    </>
+    <Box marginTop="1em">
+      <Text as="h1" variant="lg-display" my={4}>
+        Art Advisory Experiments
+      </Text>
+
+      <Experiment href="/advisor/1">
+        <Name>User profile spike</Name>
+        <Description>
+          Using Force UI, Quantum backend, function calling, memory
+        </Description>
+      </Experiment>
+
+      <Experiment href="/advisor/2">
+        <Name>UI refinements</Name>
+        <Description>Markdown, auto-scrolling, etc</Description>
+      </Experiment>
+    </Box>
   )
 }
+
+interface ExperimentProps {
+  href: string
+}
+const Experiment: React.FC<PropsWithChildren<ExperimentProps>> = props => {
+  const { children, href } = props
+
+  return (
+    <Link href={href} textDecoration={"none"}>
+      <Flex
+        flexDirection={["column", "row"]}
+        pb={2}
+        pt={1}
+        borderTop="solid 1px"
+        borderColor={"black30"}
+      >
+        {children}
+      </Flex>
+    </Link>
+  )
+}
+
+const Name: React.FC<PropsWithChildren<any>> = ({ children }) => {
+  return (
+    <Text flex="1" mr={[0, 2]}>
+      {children}
+    </Text>
+  )
+}
+
+const Description: React.FC<PropsWithChildren<any>> = ({ children }) => {
+  return <Text flex="3">{children}</Text>
+}
+
+const Flex = styled(_Flex)`
+  &:hover {
+    background-color: ${themeGet("colors.black5")};
+  }
+`

--- a/src/Apps/ArtAdvisor/ArtAdvisorRoutes.tsx
+++ b/src/Apps/ArtAdvisor/ArtAdvisorRoutes.tsx
@@ -8,12 +8,26 @@ const ArtAdvisorApp = loadable(
   }
 )
 
+const ArtAdvisorApp01 = loadable(
+  () => import(/* webpackChunkName: "jobsBundle" */ "./01-Spike/App"),
+  {
+    resolveComponent: component => component.App,
+  }
+)
+
 export const artAdvisorRoutes: AppRouteConfig[] = [
   {
     path: "/advisor",
     getComponent: () => ArtAdvisorApp,
     onClientSideRender: () => {
       ArtAdvisorApp.preload()
+    },
+  },
+  {
+    path: "/advisor/1",
+    getComponent: () => ArtAdvisorApp01,
+    onClientSideRender: () => {
+      ArtAdvisorApp01.preload()
     },
   },
 ]

--- a/src/Apps/ArtAdvisor/ArtAdvisorRoutes.tsx
+++ b/src/Apps/ArtAdvisor/ArtAdvisorRoutes.tsx
@@ -14,6 +14,12 @@ const ArtAdvisorApp01 = loadable(
     resolveComponent: component => component.App,
   }
 )
+const ArtAdvisorApp02 = loadable(
+  () => import(/* webpackChunkName: "jobsBundle" */ "./02-Markdown/App"),
+  {
+    resolveComponent: component => component.App,
+  }
+)
 
 export const artAdvisorRoutes: AppRouteConfig[] = [
   {
@@ -28,6 +34,13 @@ export const artAdvisorRoutes: AppRouteConfig[] = [
     getComponent: () => ArtAdvisorApp01,
     onClientSideRender: () => {
       ArtAdvisorApp01.preload()
+    },
+  },
+  {
+    path: "/advisor/2",
+    getComponent: () => ArtAdvisorApp02,
+    onClientSideRender: () => {
+      ArtAdvisorApp02.preload()
     },
   },
 ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -16177,6 +16177,18 @@ markdown-escapes@^1.0.0:
   resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.4.tgz#c95415ef451499d7602b91095f3c8e8975f78535"
   integrity sha512-8z4efJYk43E0upd0NbVXwgSTQs6cT3T06etieCMEg7dRbzCbxUCK/GHlX8mhHRDcp+OLlHkPKsvqQTCvsRl2cg==
 
+marked-react@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/marked-react/-/marked-react-2.0.0.tgz#709ec476d3cdf8690d81f6495edd675d72eef60f"
+  integrity sha512-Mp5HqfONf/RDqFtA+6xw2EjKkSbA8/xNPwyJ8ewLy/q3v21lRsPA7h+HUndVAW/yEIoebvcyzzSDpbjzL/xjZg==
+  dependencies:
+    marked "^6.0.0"
+
+marked@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-6.0.0.tgz#80cd7f51145437cffe9f541a318b9882f75601df"
+  integrity sha512-7E3m/xIlymrFL5gWswIT4CheIE3fDeh51NV09M4x8iOc7NDYlyERcQMLAIHcSlrvwliwbPQ4OGD+MpPSYiQcqw==
+
 md5.js@^1.3.4:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/md5.js/-/md5.js-1.3.5.tgz#b5d07b8e3216e3e27cd728d72f70d1e6a342005f"


### PR DESCRIPTION
Two things:

- Sets up a folder structure similar to the one in artsy/quantum for adding numbered experiments (and moves the initial spike into experiment no. 1)

    <img width=400 src="https://github.com/artsy/force/assets/140521/168db6ca-ce7e-4818-87b0-107818a1e34d" />

- Adds experiment no. 2 which demonstrates a few UI niceties to help makes this a little more presentable and chatgpt-esque for internal testing

    <img width=400 src="https://github.com/artsy/force/assets/140521/3d8782a0-3020-4aad-946d-4aaf417f67ca" />
