### PR TITLE
feat(onyx-866): tooltip in My Collection

### DIFF
--- a/src/Apps/Settings/Routes/MyCollection/Components/MyCollectionArtworkGrid.tsx
+++ b/src/Apps/Settings/Routes/MyCollection/Components/MyCollectionArtworkGrid.tsx
@@ -1,22 +1,77 @@
+import { useDismissibleContext } from "@artsy/dismissible"
 import ArtworkGrid from "Components/ArtworkGrid/ArtworkGrid"
+import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
+import { Text } from "@artsy/palette"
+import { PROGRESSIVE_ONBOARDING } from "Components/ProgressiveOnboarding/progressiveOnboardingKeys"
+import { _FragmentRefs } from "relay-runtime"
 
-export const MyCollectionArtworkGrid = createFragmentContainer(ArtworkGrid, {
-  artworks: graphql`
-    fragment MyCollectionArtworkGrid_artworks on MyCollectionConnection {
-      edges {
-        node {
-          id
-          slug
-          href
-          internalID
-          image(includeAll: true) {
-            aspectRatio
+const POPOVER_KEY = PROGRESSIVE_ONBOARDING.startSelling
+
+interface MyCollectionArtworkGridProps {
+  artworks: _FragmentRefs<"MyCollectionArtworkGrid_artworks">
+  onLoadMore: () => void
+}
+
+const MyCollectionArtworksGrid: FC<MyCollectionArtworkGridProps> = ({
+  artworks,
+  onLoadMore,
+}) => {
+  const { dismiss, isDismissed } = useDismissibleContext()
+
+  const displayPopover = !isDismissed(POPOVER_KEY).status
+
+  return (
+    <ArtworkGrid
+      artworks={artworks}
+      columnCount={[2, 3, 4, 4]}
+      showHoverDetails={false}
+      showArtworksWithoutImages
+      hideSaleInfo
+      to={artwork =>
+        `/collector-profile/my-collection/artwork/${artwork.internalID}`
+      }
+      showHighDemandIcon
+      showSaveButton={false}
+      onLoadMore={onLoadMore}
+      popoverContent={
+        displayPopover && (
+          <Text variant="xs">
+            <strong>Interested in Selling This Work?</strong>
+            <br />
+            Let our experts find the best sales option for you.
+          </Text>
+        )
+      }
+      onPopoverDismiss={() => dismiss(POPOVER_KEY)}
+    />
+  )
+}
+
+export const MyCollectionArtworkGrid = createFragmentContainer(
+  MyCollectionArtworksGrid,
+  {
+    artworks: graphql`
+      fragment MyCollectionArtworkGrid_artworks on MyCollectionConnection {
+        edges {
+          node {
+            id
+            slug
+            href
+            internalID
+            image(includeAll: true) {
+              aspectRatio
+            }
+            artist {
+              targetSupply {
+                priority
+              }
+            }
+            ...GridItem_artwork @arguments(includeAllImages: true)
+            ...FlatGridItem_artwork @arguments(includeAllImages: true)
           }
-          ...GridItem_artwork @arguments(includeAllImages: true)
-          ...FlatGridItem_artwork @arguments(includeAllImages: true)
         }
       }
-    }
-  `,
-})
+    `,
+  }
+)

--- a/src/Apps/Settings/Routes/MyCollection/MyCollectionRoute.tsx
+++ b/src/Apps/Settings/Routes/MyCollection/MyCollectionRoute.tsx
@@ -101,15 +101,6 @@ const MyCollectionRoute: FC<MyCollectionRouteProps> = ({ me, relay }) => {
 
           <MyCollectionArtworkGrid
             artworks={myCollectionConnection}
-            columnCount={[2, 3, 4, 4]}
-            showHoverDetails={false}
-            showArtworksWithoutImages
-            hideSaleInfo
-            to={artwork =>
-              `/collector-profile/my-collection/artwork/${artwork.internalID}`
-            }
-            showHighDemandIcon
-            showSaveButton={false}
             onLoadMore={handleLoadMore}
           />
 

--- a/src/Components/Artwork/GridItem.tsx
+++ b/src/Components/Artwork/GridItem.tsx
@@ -1,5 +1,5 @@
 import { AuthContextModule, ContextModule } from "@artsy/cohesion"
-import { Box, Flex, ResponsiveBox } from "@artsy/palette"
+import { Box, Flex, Popover, ResponsiveBox } from "@artsy/palette"
 import { ManageArtworkForSavesProvider } from "Components/Artwork/ManageArtworkForSaves"
 import { MagnifyImage } from "Components/MagnifyImage"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -15,6 +15,7 @@ import Metadata from "./Metadata"
 import { useHoverMetadata } from "./useHoverMetadata"
 import NoArtIcon from "@artsy/icons/NoArtIcon"
 import { ExclusiveAccessBadge } from "Components/Artwork/ExclusiveAccessBadge"
+import { Z } from "Apps/Components/constants"
 
 export const DEFAULT_GRID_ITEM_ASPECT_RATIO = 4 / 3
 
@@ -30,7 +31,9 @@ interface ArtworkGridItemProps extends React.HTMLAttributes<HTMLDivElement> {
   showSaveButton?: boolean
   to?: string | null
   savedListId?: string
+  popoverContent?: React.ReactNode | null
   renderSaveButton?: (artworkId: string) => React.ReactNode
+  onPopoverDismiss?: () => void
 }
 
 export const ArtworkGridItem: React.FC<ArtworkGridItemProps> = ({
@@ -46,6 +49,8 @@ export const ArtworkGridItem: React.FC<ArtworkGridItemProps> = ({
   to,
   savedListId,
   renderSaveButton,
+  popoverContent,
+  onPopoverDismiss,
   ...rest
 }) => {
   const localImage = useLocalImage(artwork.image)
@@ -77,7 +82,7 @@ export const ArtworkGridItem: React.FC<ArtworkGridItemProps> = ({
     (artwork?.image?.url && artwork.image?.placeholder) ||
     undefined
 
-  return (
+  const item = (
     <ManageArtworkForSavesProvider savedListId={savedListId}>
       <div
         data-id={artwork.internalID}
@@ -125,6 +130,28 @@ export const ArtworkGridItem: React.FC<ArtworkGridItemProps> = ({
         />
       </div>
     </ManageArtworkForSavesProvider>
+  )
+
+  if (!popoverContent) return item
+
+  return (
+    <Popover
+      popover={popoverContent}
+      width={250}
+      variant="defaultDark"
+      pointer
+      visible
+      ignoreClickOutside
+      zIndex={Z.popover}
+      manageFocus={false}
+      placement="top"
+      key={artwork.internalID}
+      onDismiss={onPopoverDismiss}
+    >
+      {({ anchorRef }) => {
+        return <Box ref={anchorRef as any}>{item}</Box>
+      }}
+    </Popover>
   )
 }
 

--- a/src/Components/ArtworkGrid/ArtworkGrid.tsx
+++ b/src/Components/ArtworkGrid/ArtworkGrid.tsx
@@ -55,6 +55,8 @@ interface ArtworkGridProps extends React.HTMLProps<HTMLDivElement> {
   to?: (artwork: Artwork) => string | null
   savedListId?: string
   renderSaveButton?: (artworkId: string) => React.ReactNode
+  popoverContent?: ReactNode | null
+  onPopoverDismiss?: () => void
 }
 
 export interface ArtworkGridContainerState {
@@ -151,6 +153,11 @@ export class ArtworkGridContainer extends React.Component<
     }
     const sections = []
 
+    // applicable only for My Collection grid: we want to show the popover only for the first P1 artwork
+    const firstP1Artwork = extractNodes(this.props.artworks).find(
+      artwork => (artwork as any)?.artist?.targetSupply?.priority === "TRUE"
+    )
+
     for (let column = 0; column < columnCount; column++) {
       const artworkComponents = []
       for (let row = 0; row < sectionedArtworks[column].length; row++) {
@@ -187,6 +194,12 @@ export class ArtworkGridContainer extends React.Component<
             to={to?.(artwork)}
             savedListId={this.props.savedListId}
             renderSaveButton={this.props.renderSaveButton}
+            popoverContent={
+              firstP1Artwork?.id == artwork.id
+                ? this.props.popoverContent
+                : null
+            }
+            onPopoverDismiss={this.props.onPopoverDismiss}
           />
         )
         // Setting a marginBottom on the artwork component didn’t work, so using a spacer view instead.

--- a/src/Components/ProgressiveOnboarding/progressiveOnboardingKeys.tsx
+++ b/src/Components/ProgressiveOnboarding/progressiveOnboardingKeys.tsx
@@ -18,6 +18,9 @@ export const PROGRESSIVE_ONBOARDING = {
   alertCreate: "alert-create",
   alertFind: "alert-find",
   alertHighlight: "alert-highlight",
+
+  // My Collection
+  startSelling: "start-selling",
 }
 
 export const PROGRESSIVE_ONBOARDING_FOLLOW_ARTIST_CHAIN = [

--- a/src/__generated__/MyCollectionArtworkGrid_artworks.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkGrid_artworks.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1d70a3ee096bec95d3aabfdf25d06bad>>
+ * @generated SignedSource<<9bf3ba92130dd5a359aed2e24abac7f1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,10 +9,16 @@
 // @ts-nocheck
 
 import { Fragment, ReaderFragment } from 'relay-runtime';
+export type ArtistTargetSupplyPriority = "FALSE" | "TRUE" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type MyCollectionArtworkGrid_artworks$data = {
   readonly edges: ReadonlyArray<{
     readonly node: {
+      readonly artist: {
+        readonly targetSupply: {
+          readonly priority: ArtistTargetSupplyPriority | null | undefined;
+        };
+      } | null | undefined;
       readonly href: string | null | undefined;
       readonly id: string;
       readonly image: {
@@ -113,6 +119,35 @@ return {
               "storageKey": "image(includeAll:true)"
             },
             {
+              "alias": null,
+              "args": null,
+              "concreteType": "Artist",
+              "kind": "LinkedField",
+              "name": "artist",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": "ArtistTargetSupply",
+                  "kind": "LinkedField",
+                  "name": "targetSupply",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "alias": null,
+                      "args": null,
+                      "kind": "ScalarField",
+                      "name": "priority",
+                      "storageKey": null
+                    }
+                  ],
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            },
+            {
               "args": (v0/*: any*/),
               "kind": "FragmentSpread",
               "name": "GridItem_artwork"
@@ -134,6 +169,6 @@ return {
 };
 })();
 
-(node as any).hash = "90c729196de9afdcbd1c13676338c718";
+(node as any).hash = "120892fd7d51ef6f946438ec99072ca8";
 
 export default node;

--- a/src/__generated__/MyCollectionRouteQuery.graphql.ts
+++ b/src/__generated__/MyCollectionRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<47af69c6221c5934196855b3b9248979>>
+ * @generated SignedSource<<51c3b2dc19edbc4cd067dbdf30918597>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -321,6 +321,43 @@ return {
                       {
                         "alias": null,
                         "args": null,
+                        "concreteType": "Artist",
+                        "kind": "LinkedField",
+                        "name": "artist",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ArtistTargetSupply",
+                            "kind": "LinkedField",
+                            "name": "targetSupply",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "priority",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isP1",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          (v2/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
                         "kind": "ScalarField",
                         "name": "title",
                         "storageKey": null
@@ -358,36 +395,6 @@ return {
                         "args": null,
                         "kind": "ScalarField",
                         "name": "culturalMaker",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Artist",
-                        "kind": "LinkedField",
-                        "name": "artist",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "ArtistTargetSupply",
-                            "kind": "LinkedField",
-                            "name": "targetSupply",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "isP1",
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          },
-                          (v2/*: any*/)
-                        ],
                         "storageKey": null
                       },
                       {
@@ -755,12 +762,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ed243d2136f8b1231c4701a363c4989a",
+    "cacheID": "92f8515e1663360def427d8436b28b94",
     "id": null,
     "metadata": {},
     "name": "MyCollectionRouteQuery",
     "operationKind": "query",
-    "text": "query MyCollectionRouteQuery(\n  $count: Int!\n  $cursor: String\n) {\n  me {\n    ...MyCollectionRoute_me_1G22uz\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment DeprecatedSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_yvCPB on Artwork {\n  ...Metadata_artwork\n  ...DeprecatedSaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: true) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n  isSaved\n}\n\nfragment GridItem_artwork_yvCPB on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: true) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...ExclusiveAccessBadge_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment MyCollectionArtworkGrid_artworks on MyCollectionConnection {\n  edges {\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: true) {\n        aspectRatio\n      }\n      ...GridItem_artwork_yvCPB\n      ...FlatGridItem_artwork_yvCPB\n    }\n  }\n}\n\nfragment MyCollectionRoute_me_1G22uz on Me {\n  myCollectionConnection(first: $count, after: $cursor, sort: CREATED_AT_DESC) {\n    ...MyCollectionArtworkGrid_artworks\n    totalCount\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isSavedToList\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n"
+    "text": "query MyCollectionRouteQuery(\n  $count: Int!\n  $cursor: String\n) {\n  me {\n    ...MyCollectionRoute_me_1G22uz\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment DeprecatedSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_yvCPB on Artwork {\n  ...Metadata_artwork\n  ...DeprecatedSaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: true) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n  isSaved\n}\n\nfragment GridItem_artwork_yvCPB on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: true) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...ExclusiveAccessBadge_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment MyCollectionArtworkGrid_artworks on MyCollectionConnection {\n  edges {\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: true) {\n        aspectRatio\n      }\n      artist {\n        targetSupply {\n          priority\n        }\n        id\n      }\n      ...GridItem_artwork_yvCPB\n      ...FlatGridItem_artwork_yvCPB\n    }\n  }\n}\n\nfragment MyCollectionRoute_me_1G22uz on Me {\n  myCollectionConnection(first: $count, after: $cursor, sort: CREATED_AT_DESC) {\n    ...MyCollectionArtworkGrid_artworks\n    totalCount\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isSavedToList\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n"
   }
 };
 })();

--- a/src/__generated__/collectorProfileRoutes_MyCollectionRouteQuery.graphql.ts
+++ b/src/__generated__/collectorProfileRoutes_MyCollectionRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6e0e1c53047099fc83a85cdfdcc25231>>
+ * @generated SignedSource<<3bbbdc7eadb2a5b03cdc960b260b1de0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -290,6 +290,43 @@ return {
                       {
                         "alias": null,
                         "args": null,
+                        "concreteType": "Artist",
+                        "kind": "LinkedField",
+                        "name": "artist",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ArtistTargetSupply",
+                            "kind": "LinkedField",
+                            "name": "targetSupply",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "priority",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isP1",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          (v1/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
                         "kind": "ScalarField",
                         "name": "title",
                         "storageKey": null
@@ -327,36 +364,6 @@ return {
                         "args": null,
                         "kind": "ScalarField",
                         "name": "culturalMaker",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Artist",
-                        "kind": "LinkedField",
-                        "name": "artist",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "ArtistTargetSupply",
-                            "kind": "LinkedField",
-                            "name": "targetSupply",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "isP1",
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          },
-                          (v1/*: any*/)
-                        ],
                         "storageKey": null
                       },
                       {
@@ -724,12 +731,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c180d6841a2422121ad542313c788ad2",
+    "cacheID": "f62ba5c70a12c06437195f2a823bdf0b",
     "id": null,
     "metadata": {},
     "name": "collectorProfileRoutes_MyCollectionRouteQuery",
     "operationKind": "query",
-    "text": "query collectorProfileRoutes_MyCollectionRouteQuery {\n  me {\n    ...MyCollectionRoute_me\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment DeprecatedSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_yvCPB on Artwork {\n  ...Metadata_artwork\n  ...DeprecatedSaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: true) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n  isSaved\n}\n\nfragment GridItem_artwork_yvCPB on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: true) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...ExclusiveAccessBadge_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment MyCollectionArtworkGrid_artworks on MyCollectionConnection {\n  edges {\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: true) {\n        aspectRatio\n      }\n      ...GridItem_artwork_yvCPB\n      ...FlatGridItem_artwork_yvCPB\n    }\n  }\n}\n\nfragment MyCollectionRoute_me on Me {\n  myCollectionConnection(first: 25, sort: CREATED_AT_DESC) {\n    ...MyCollectionArtworkGrid_artworks\n    totalCount\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isSavedToList\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n"
+    "text": "query collectorProfileRoutes_MyCollectionRouteQuery {\n  me {\n    ...MyCollectionRoute_me\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment DeprecatedSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_yvCPB on Artwork {\n  ...Metadata_artwork\n  ...DeprecatedSaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: true) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n  isSaved\n}\n\nfragment GridItem_artwork_yvCPB on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: true) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...ExclusiveAccessBadge_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment MyCollectionArtworkGrid_artworks on MyCollectionConnection {\n  edges {\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: true) {\n        aspectRatio\n      }\n      artist {\n        targetSupply {\n          priority\n        }\n        id\n      }\n      ...GridItem_artwork_yvCPB\n      ...FlatGridItem_artwork_yvCPB\n    }\n  }\n}\n\nfragment MyCollectionRoute_me on Me {\n  myCollectionConnection(first: 25, sort: CREATED_AT_DESC) {\n    ...MyCollectionArtworkGrid_artworks\n    totalCount\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isSavedToList\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [ONYX-866]

### Description

Add "Interested in Selling" tooltip which points to the first P1 artwork within my collection artworks grid:

<img width="1511" alt="image" src="https://github.com/artsy/force/assets/3934579/c78150fb-1d6b-43bd-a52f-c6410b91bb30">

I **really** don't like that for this task I have to make changes in `ArtworkGrid` and `GridItem` components - but I don't know how to avoid doing so without fully rewriting `MyCollectionArtworkGrid`. `ArtworkGrid` has logic to properly handle artworks layout, pagination logic, etc - this all needs to be copied to `MyCollectionArtworkGrid` if we want to not pollute generic `ArtworkGrid` component with MyCollection-related things.