### PR TITLE
feat(admin): Add admin/navigate-to-route route

### DIFF
--- a/src/Apps/Admin/NavigateToRoute.tsx
+++ b/src/Apps/Admin/NavigateToRoute.tsx
@@ -1,0 +1,70 @@
+import {
+  Button,
+  Column,
+  Flex,
+  GridColumns,
+  Input,
+  Spacer,
+  Text,
+} from "@artsy/palette"
+import { MetaTags } from "Components/MetaTags"
+import { useRouter } from "System/Router/useRouter"
+import { useEffect, useRef } from "react"
+
+export const NavigateToRoute: React.FC = () => {
+  const ref = useRef<HTMLInputElement>(null)
+  const { router } = useRouter()
+
+  const navigateToRoute = () => {
+    const route = ref.current?.value
+
+    if (!route) {
+      return
+    }
+
+    router.push(route)
+  }
+
+  const handleClick = (event: React.MouseEvent) => {
+    navigateToRoute()
+  }
+
+  const handleEnterKeyPress = (event: KeyboardEvent) => {
+    if (event.key === "Enter") {
+      navigateToRoute()
+    }
+  }
+
+  useEffect(() => {
+    window.addEventListener("keypress", handleEnterKeyPress)
+
+    return () => {
+      window.removeEventListener("keypress", handleEnterKeyPress)
+    }
+  })
+
+  return (
+    <>
+      <MetaTags title="Admin | Navigate" />
+
+      <Text variant="lg" pt={2}>
+        Navigate
+      </Text>
+
+      <Spacer y={2} />
+
+      <GridColumns>
+        <Column span={8}>
+          <Flex>
+            <Input
+              ref={ref}
+              placeholder="Enter route (e.g., /artist/andy-warhol)"
+              mr={2}
+            />
+            <Button onClick={handleClick}>Navigate to route</Button>
+          </Flex>
+        </Column>
+      </GridColumns>
+    </>
+  )
+}

--- a/src/Apps/Admin/adminRoutes.tsx
+++ b/src/Apps/Admin/adminRoutes.tsx
@@ -8,6 +8,11 @@ const AdminClearCacheApp = loadable(
   { resolveComponent: component => component.AdminClearCacheApp }
 )
 
+const NavigateToRoute = loadable(
+  () => import(/* webpackChunkName: "adminBundle" */ "./NavigateToRoute"),
+  { resolveComponent: component => component.NavigateToRoute }
+)
+
 export const adminRoutes: AppRouteConfig[] = [
   {
     path: "/admin",
@@ -22,6 +27,11 @@ export const adminRoutes: AppRouteConfig[] = [
             throw new HttpError(403)
           }
         },
+      },
+      {
+        path: "navigate-to-route",
+        Component: NavigateToRoute,
+        layout: "NavOnly",
       },
     ],
   },


### PR DESCRIPTION
The type of this PR is: **Feat**

### Description

Inspired by a slack thread around needing to see request info for routes that we can only access via a direct link (and thus are SSR'd, and hard to get relay logging info), this adds a new admin app / route `/admin/navigate-to-route` which allows us to quickly jump anywhere on the site:

<img width="1141" alt="Screenshot 2024-04-26 at 10 43 37 AM" src="https://github.com/artsy/force/assets/236943/bfecd154-391e-497c-b27d-ff8e83ae7deb">

