### PR TITLE
chore: Adds visibility level to artwork pageview track events

### DIFF
--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -134,7 +134,13 @@ export const ArtworkApp: React.FC<Props> = props => {
     artwork?.partner
 
   const trackPageview = useCallback(() => {
-    const { listPrice, availability, isOfferable, isAcquireable } = artwork
+    const {
+      listPrice,
+      availability,
+      isOfferable,
+      isAcquireable,
+      visibilityLevel,
+    } = artwork
     const path = window.location.pathname
 
     if (typeof window.analytics !== "undefined") {
@@ -144,6 +150,7 @@ export const ArtworkApp: React.FC<Props> = props => {
         offerable: isOfferable,
         path,
         price_listed: !!listPrice,
+        visibility_level: visibilityLevel,
         url: getENV("APP_URL") + path,
       }
 


### PR DESCRIPTION
The type of this PR is:  CHORE

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PROJECT-XX]

### Description

Adds an artworks visibility level to Artwork Pageview tracking:
<img width="413" alt="Screenshot 2024-04-26 at 5 07 15 PM" src="https://github.com/artsy/force/assets/12748344/e8eac6e3-c3c0-490f-ad14-b455e591eb61">


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ