### PR TITLE
feat(EMI-1841): hide partner offer details if not available anymore

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
@@ -360,7 +360,7 @@ export const ArtworkSidebarCommercialButtons: React.FC<ArtworkSidebarCommercialB
   const SaleMessageOrOfferDisplay: FC = () => {
     return (
       <>
-        {partnerOffer ? (
+        {partnerOffer?.isAvailable ? (
           <OfferDisplay
             originalPrice={artwork.priceListedDisplay}
             offerPrice={partnerOffer.priceWithDiscount?.display}

--- a/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercialButtons.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarCommercialButtons.jest.tsx
@@ -429,6 +429,37 @@ describe("ArtworkSidebarCommercialButtons", () => {
     expect(screen.queryByText("(List price: $5,000)")).toBeInTheDocument()
   })
 
+  it("does not displays offer details when viewed by user without an active partner offer on the artwork", async () => {
+    mockUseFeatureFlag.mockImplementation(() => true)
+    meMock.partnerOffersConnection.edges.push({
+      node: {
+        internalID: "partner-offer-id",
+        isAvailable: false,
+        priceWithDiscount: {
+          display: "$3,350.00",
+        },
+      },
+    })
+
+    renderWithRelay(
+      {
+        Query: () => ({ me: meMock }),
+        Artwork: () => ({
+          priceListedDisplay: "$5,000",
+          saleMessage: "Sold",
+          isSold: true,
+        }),
+      },
+      null,
+      mockEnvironment
+    )
+
+    expect(screen.queryByText("Limited-Time Offer")).not.toBeInTheDocument()
+    expect(screen.queryByText("$3,350.00")).not.toBeInTheDocument()
+    expect(screen.queryByText("(List price: $5,000)")).not.toBeInTheDocument()
+    expect(screen.queryByText("Sold")).toBeInTheDocument()
+  })
+
   it("displays partner offer note if present", () => {
     mockUseFeatureFlag.mockImplementation(() => true)
     const futureDate = new Date()


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-1841]

### Description

If a Partner Offer is not available anymore, it's details should be hidden in the artwork page.

https://github.com/artsy/force/assets/554507/422d392d-2ca5-47c6-b55c-488084999ce8



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EMI-1841]: https://artsyproduct.atlassian.net/browse/EMI-1841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ