### PR TITLE
fix: EMI-1806 partner offer timer re-mounts over and over

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
@@ -357,47 +357,6 @@ export const ArtworkSidebarCommercialButtons: React.FC<ArtworkSidebarCommercialB
         : "primaryBlack"
   }
 
-  const SaleMessageOrOfferDisplay: FC = () => {
-    return (
-      <>
-        {partnerOffer?.isAvailable ? (
-          <OfferDisplay
-            originalPrice={artwork.priceListedDisplay}
-            offerPrice={partnerOffer.priceWithDiscount?.display}
-            endAt={partnerOffer.endAt}
-            isAvailable={partnerOffer.isAvailable}
-          />
-        ) : (
-          <>
-            <SaleMessage saleMessage={artwork.saleMessage} />
-            {!!isCreateAlertAvailable && <Spacer y={1} />}
-          </>
-        )}
-      </>
-    )
-  }
-
-  const EditionSetPriceDisplay: FC = () => {
-    return (
-      <>
-        <Separator />
-        <ArtworkSidebarEditionSetFragmentContainer
-          artwork={artwork}
-          selectedEditionSet={selectedEditionSet as EditionSet}
-          onSelectEditionSet={setSelectedEditionSet}
-        />
-
-        {!!selectedEditionSet && (
-          <>
-            <Separator />
-            <Spacer y={4} />
-            <SaleMessage saleMessage={selectedEditionSet.saleMessage} />
-          </>
-        )}
-      </>
-    )
-  }
-
   const hasEditions = (artwork?.editionSets?.length ?? 0) > 1
 
   return (
@@ -406,9 +365,38 @@ export const ArtworkSidebarCommercialButtons: React.FC<ArtworkSidebarCommercialB
 
       {showPrice &&
         (hasEditions ? (
-          <EditionSetPriceDisplay />
+          <>
+            <Separator />
+            <ArtworkSidebarEditionSetFragmentContainer
+              artwork={artwork}
+              selectedEditionSet={selectedEditionSet as EditionSet}
+              onSelectEditionSet={setSelectedEditionSet}
+            />
+
+            {!!selectedEditionSet && (
+              <>
+                <Separator />
+                <Spacer y={4} />
+                <SaleMessage saleMessage={selectedEditionSet.saleMessage} />
+              </>
+            )}
+          </>
         ) : (
-          <SaleMessageOrOfferDisplay />
+          <>
+            {partnerOffer?.isAvailable ? (
+              <OfferDisplay
+                originalPrice={artwork.priceListedDisplay}
+                offerPrice={partnerOffer.priceWithDiscount?.display}
+                endAt={partnerOffer.endAt}
+                isAvailable={partnerOffer.isAvailable}
+              />
+            ) : (
+              <>
+                <SaleMessage saleMessage={artwork.saleMessage} />
+                {!!isCreateAlertAvailable && <Spacer y={1} />}
+              </>
+            )}
+          </>
         ))}
 
       {showButtonActions && (


### PR DESCRIPTION
The type of this PR is: **fix**
Fixes [EMI-1806]- or improves it at least.


### Description

_See linked ticket for bug_

This PR improves some visual bugs with the partner offer countdown timer by removing a component that is defined in the body of another component. As a result of doing this the `useTimer()` hook was repeatedly re-rendering, causing the internal hook to sync with our official server time to continually cancel itself out.

However, I think there may be something more to improve here. I wasn't able to eliminate 100% of the visual tics and there is still some flickering in the first instant the component loads. This might deserve more investigation.

<!-- Implementation description -->


[EMI-1806]: https://artsyproduct.atlassian.net/browse/EMI-1806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ