### PR TITLE
fix(alerts): makes ui usable on all screens

### DIFF
--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditForm.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditForm.tsx
@@ -29,7 +29,7 @@ import { ModalHeader } from "Components/Alert/Components/Modal/ModalHeader"
 import { Modal } from "Components/Alert/Components/Modal/Modal"
 import { NotificationPreferencesQueryRenderer } from "Components/Alert/Components/NotificationPreferences"
 import { SugggestedFiltersQueryRenderer } from "Components/Alert/Components/Form/SuggestedFilters"
-import { Sticky } from "Components/Sticky"
+import { useJump } from "Utils/Hooks/useJump"
 
 interface SavedSearchAlertEditFormQueryRendererProps {
   editAlertEntity: EditAlertEntity
@@ -66,24 +66,27 @@ const SavedSearchAlertEditSteps: React.FC<SavedSearchAlertEditStepsProps> = ({
     <>
       <Media greaterThanOrEqual="md">
         {current === "ALERT_DETAILS" && (
-          <Sticky bottomBoundary="#content-end">
-            <Box p={4}>
-              <Flex justifyContent="space-between">
-                <ModalHeader />
-              </Flex>
-              <Spacer y={4} />
-              <SavedSearchAlertEditForm
-                viewer={viewer}
-                onDeleteClick={onDeleteClick}
-                onCompleted={onCompleted}
-              />
-            </Box>
-          </Sticky>
+          <Box p={4}>
+            <Flex justifyContent="space-between">
+              <ModalHeader />
+            </Flex>
+
+            <Spacer y={4} />
+
+            <SavedSearchAlertEditForm
+              viewer={viewer}
+              onDeleteClick={onDeleteClick}
+              onCompleted={onCompleted}
+            />
+          </Box>
         )}
+
         {current === "ALERT_FILTERS" && (
           <Box flex={1} px={2} pt={4}>
             <ModalHeader />
+
             <Filters />
+
             <FiltersFooter />
           </Box>
         )}
@@ -99,6 +102,7 @@ const SavedSearchAlertEditSteps: React.FC<SavedSearchAlertEditStepsProps> = ({
                 onCompleted={onCompleted}
               />
             )}
+
             {current === "ALERT_FILTERS" && <Filters />}
           </Flex>
         </Modal>
@@ -112,6 +116,7 @@ const SavedSearchAlertEditForm: React.FC<SavedSearchAlertEditFormProps> = ({
   onCompleted,
 }) => {
   const { state, goToFilters, dispatch, onComplete } = useAlertContext()
+  const { jumpTo } = useJump()
 
   const isMounted = useDidMount()
 
@@ -135,6 +140,7 @@ const SavedSearchAlertEditForm: React.FC<SavedSearchAlertEditFormProps> = ({
 
         const transitionToFilters = () => {
           goToFilters()
+          jumpTo("Alerts")
         }
 
         return (

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditFormPlaceholder.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertEditFormPlaceholder.tsx
@@ -5,9 +5,7 @@ import {
   SkeletonText,
   SkeletonBox,
   Skeleton,
-  Box,
 } from "@artsy/palette"
-import { ALERTS_APP_DESKTOP_HEIGHT } from "Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp"
 import { AlertProvider } from "Components/Alert/AlertProvider"
 import { CriteriaPillsPlaceholder } from "Components/Alert/Components/CriteriaPills"
 import { Modal } from "Components/Alert/Components/Modal/Modal"
@@ -17,11 +15,7 @@ export const SavedSearchAlertEditFormPlaceholder: React.FC<{
   onCloseClick?: () => void
 }> = ({ onCloseClick }) => {
   return (
-    <Box
-      maxHeight={ALERTS_APP_DESKTOP_HEIGHT}
-      overflow="hidden"
-      flexDirection="column"
-    >
+    <>
       <Media greaterThanOrEqual="md">
         <Skeleton flex={1} p={4}>
           <SavedSearchAlertEditFormPlaceholderContext />
@@ -38,7 +32,7 @@ export const SavedSearchAlertEditFormPlaceholder: React.FC<{
           </Skeleton>
         </AlertProvider>
       </Media>
-    </Box>
+    </>
   )
 }
 

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertHeader.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertHeader.tsx
@@ -20,12 +20,9 @@ export const SavedSearchAlertHeader: FC<SavedSearchAlertHeaderProps> = ({
       flexDirection={["column", "row"]}
       alignItems={["stretch", "center"]}
       justifyContent="space-between"
-      mb={4}
-      mx={[2, 0]}
+      gap={[1, 2]}
     >
-      <Text variant={["md", "lg"]} mb={[4, 0]} mr={[0, 2]}>
-        Your Alerts
-      </Text>
+      <Text variant={["md", "lg"]}>Your Alerts</Text>
 
       <Select
         title="Sort"

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertListItem.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertListItem.tsx
@@ -2,6 +2,7 @@ import { Box, Clickable, Flex, Spacer, Sup, Text } from "@artsy/palette"
 import { createFragmentContainer, graphql } from "react-relay"
 import { SavedSearchAlertListItem_item$data } from "__generated__/SavedSearchAlertListItem_item.graphql"
 import { EditAlertEntity } from "Apps/Settings/Routes/SavedSearchAlerts/types"
+import { useJump } from "Utils/Hooks/useJump"
 
 export type SavedSearchAlertListItemVariant = "active" | "inactive"
 
@@ -19,6 +20,8 @@ export const SavedSearchAlertListItem: React.FC<SavedSearchAlertListItemProps> =
   onViewArtworksClick,
 }) => {
   const matchingArtworksCount = item.artworksConnection?.counts?.total
+
+  const { jumpTo } = useJump()
 
   return (
     <Box
@@ -79,11 +82,14 @@ export const SavedSearchAlertListItem: React.FC<SavedSearchAlertListItemProps> =
             <Clickable
               textDecoration="underline"
               onClick={() => {
-                onEditAlertClick({
-                  id: item.internalID,
-                  name: item.settings?.name ?? undefined,
-                  artistIds: item.artistIDs as string[],
-                })
+                {
+                  onEditAlertClick({
+                    id: item.internalID,
+                    name: item.settings?.name ?? undefined,
+                    artistIds: item.artistIDs as string[],
+                  })
+                  jumpTo("Alerts")
+                }
               }}
             >
               Edit
@@ -98,13 +104,14 @@ export const SavedSearchAlertListItem: React.FC<SavedSearchAlertListItemProps> =
             ]}
           >
             <Clickable
-              onClick={() =>
+              onClick={() => {
                 onViewArtworksClick({
                   id: item.internalID,
                   name: item.settings?.name ?? undefined,
                   artistIds: item.artistIDs as string[],
                 })
-              }
+                jumpTo("Alerts")
+              }}
               textDecoration="underline"
             >
               View Artworks

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertsArtworks.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertsArtworks.tsx
@@ -31,7 +31,7 @@ import {
   CriteriaPillsPlaceholder,
 } from "Components/Alert/Components/CriteriaPills"
 import { ModalHeader } from "Components/Alert/Components/Modal/ModalHeader"
-import { ALERTS_APP_DESKTOP_HEIGHT } from "Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp"
+import { useJump } from "Utils/Hooks/useJump"
 
 interface AlertArtworksProps {
   alert: NonNullable<SavedSearchAlertsArtworksQuery["response"]["me"]>["alert"]
@@ -44,6 +44,8 @@ export const AlertArtworks: React.FC<AlertArtworksProps> = ({
   onCloseClick,
   onEditAlertClick,
 }) => {
+  const { jumpTo } = useJump()
+
   if (!alert || !alert.artworksConnection)
     return <SavedSearchAlertsArtworksPlaseholder onCloseClick={onCloseClick} />
 
@@ -98,6 +100,7 @@ export const AlertArtworks: React.FC<AlertArtworksProps> = ({
                       variant="secondaryBlack"
                       onClick={() => {
                         onEditAlertClick()
+                        jumpTo("Alerts")
                       }}
                     >
                       Edit Alert
@@ -114,6 +117,7 @@ export const AlertArtworks: React.FC<AlertArtworksProps> = ({
                   variant="secondaryBlack"
                   onClick={() => {
                     onEditAlertClick()
+                    jumpTo("Alerts")
                   }}
                 >
                   Edit Alert
@@ -284,24 +288,22 @@ export const SavedSearchAlertsArtworksQueryRenderer: React.FC<SavedSearchAlertsA
 
 const SavedSearchAlertsArtworksPlaseholderContext: React.FC = () => {
   return (
-    <>
-      <Join separator={<Spacer y={2} />}>
-        <CriteriaPillsPlaceholder />
-        <SkeletonBox display={["none", "block"]}>
-          <Separator />
-        </SkeletonBox>
-        <Flex flexDirection="column">
-          <SkeletonText variant="sm-display">
-            20 works currently on Artsy match your criteria.
-          </SkeletonText>
-          <SkeletonText variant="sm-display">
-            See our top picks for you:
-          </SkeletonText>
-          <Spacer y={[4, 2]} />
-        </Flex>
-        <ArtworkGridPlaceholder columnCount={2} amount={2} />
-      </Join>
-    </>
+    <Join separator={<Spacer y={2} />}>
+      <CriteriaPillsPlaceholder />
+      <SkeletonBox display={["none", "block"]}>
+        <Separator />
+      </SkeletonBox>
+      <Flex flexDirection="column">
+        <SkeletonText variant="sm-display">
+          20 works currently on Artsy match your criteria.
+        </SkeletonText>
+        <SkeletonText variant="sm-display">
+          See our top picks for you:
+        </SkeletonText>
+        <Spacer y={[4, 2]} />
+      </Flex>
+      <ArtworkGridPlaceholder columnCount={2} />
+    </Join>
   )
 }
 
@@ -311,14 +313,8 @@ const SavedSearchAlertsArtworksPlaseholder: React.FC<{
   return (
     <>
       <Media greaterThanOrEqual="md">
-        <Skeleton
-          p={4}
-          // Setting a max height to force scrolling to top when the content changes.
-          maxHeight={ALERTS_APP_DESKTOP_HEIGHT}
-          overflow="hidden"
-          flexDirection="column"
-        >
-          <Text variant="lg" pb={2}>
+        <Skeleton p={4}>
+          <Text variant="lg" mb={2}>
             View Artworks
           </Text>
           <SavedSearchAlertsArtworksPlaseholderContext />


### PR DESCRIPTION
Closes [DIA-611](https://artsyproduct.atlassian.net/browse/DIA-611)

Cherry-picking this as it's not directly related to the work I'm doing.

As part of https://github.com/artsy/force/pull/13820 the situation with the alerts UI got worse due to there being even more vertical space occupied. This just removes all fixed pane and just has things sit on the page naturally. Clicking items scrolls to the top. It isn't ideal (this sidebar layout should only be used with fullscreen UIs, IMO), but it's actually usable.

https://github.com/artsy/force/assets/112297/5d64727b-0d9b-460f-88e7-bd7cf8065d83



[DIA-611]: https://artsyproduct.atlassian.net/browse/DIA-611?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ