### PR TITLE
chore: disable TermsUpdateDialog

### DIFF
--- a/src/Components/TermsUpdateDialog.tsx
+++ b/src/Components/TermsUpdateDialog.tsx
@@ -1,7 +1,6 @@
 import Cookies from "cookies-js"
 import { Button, ModalDialog, Stack, Text } from "@artsy/palette"
 import { FC, useEffect, useState } from "react"
-import { useFeatureFlag } from "System/useFeatureFlag"
 import { getENV } from "Utils/getENV"
 import { useSystemContext } from "System/SystemContext"
 import { RouterLink } from "System/Router/RouterLink"
@@ -16,7 +15,7 @@ export const TermsUpdateDialog: FC<TermsUpdateDialogProps> = () => {
   const isIntegrity = getENV("USER_AGENT") === "ArtsyIntegrity"
   const isSmokeTest = getENV("USER_AGENT") === "ForceSmokeTest"
 
-  const isTermsUpdateActive = useFeatureFlag("diamond_new-terms-and-conditions")
+  const isTermsUpdateActive = false
 
   const [isDisplayable, setIsDisplayable] = useState(false)
 


### PR DESCRIPTION
It's May 1, so this PR disables the TermsUpdateDialog.

<img width="1436" alt="327158135-b4cf22b2-858b-4fb1-86d1-c5024b7a8da5" src="https://github.com/artsy/force/assets/44589599/9e85fa20-0e5a-43f7-83af-a0e859966ee0">
