### PR TITLE
chore: disable social login

### DIFF
--- a/src/Components/AuthDialog/Components/AuthDialogSocial.tsx
+++ b/src/Components/AuthDialog/Components/AuthDialogSocial.tsx
@@ -1,4 +1,4 @@
-import { Button, Join, Spacer } from "@artsy/palette"
+import { Button, Join, Message, Spacer, Text } from "@artsy/palette"
 import { useAuthDialogContext } from "Components/AuthDialog/AuthDialogContext"
 import { useAfterAuthenticationRedirectUrl } from "Components/AuthDialog/Hooks/useAfterAuthenticationRedirectUrl"
 import { setSocialAuthTracking } from "Components/AuthDialog/Hooks/useSocialAuthTracking"
@@ -47,6 +47,11 @@ export const AuthDialogSocial: FC = () => {
 
   return (
     <Join separator={<Spacer y={1} />}>
+      {/* TODO: remove the message and reenable the social login buttons before
+                merging the review app into main */}
+      <Message variant="info">
+        <Text>Social login not supported in this review app</Text>
+      </Message>
       <Button
         variant="secondaryBlack"
         width="100%"
@@ -56,6 +61,7 @@ export const AuthDialogSocial: FC = () => {
         href={`${applePath}?${query}`}
         onClick={handleClick("apple")}
         rel="nofollow"
+        disabled
       >
         Continue with Apple
       </Button>
@@ -69,6 +75,7 @@ export const AuthDialogSocial: FC = () => {
         href={`${googlePath}?${query}`}
         onClick={handleClick("google")}
         rel="nofollow"
+        disabled
       >
         Continue with Google
       </Button>
@@ -82,6 +89,7 @@ export const AuthDialogSocial: FC = () => {
         href={`${facebookPath}?${query}`}
         onClick={handleClick("facebook")}
         rel="nofollow"
+        disabled
       >
         Continue with Facebook
       </Button>


### PR DESCRIPTION
The type of this PR is: Chore

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

<!-- Implementation description -->

This PR adds a note that social login [does not work ](https://artsy.slack.com/archives/C06SSV1K10D/p1714662670281049?thread_ts=1714662167.086639&cid=C06SSV1K10D)in this review app and disables the buttons. I figured it is better to be explicit and keep them in the UI but add a note, rather than just removing them. If we decide we want to support social login, we can dig into the root issue. 


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ