### PR TITLE
chore: randomize featured viewing rooms banner order

### DIFF
--- a/src/Apps/ViewingRoom/__tests__/ViewingRoomsApp.jest.tsx
+++ b/src/Apps/ViewingRoom/__tests__/ViewingRoomsApp.jest.tsx
@@ -12,6 +12,9 @@ jest.mock("System/Router/useRouter", () => ({
     match: {},
   }),
 }))
+jest.mock("Utils/Hooks/useStableShuffle", () => ({
+  useStableShuffle: ({ items }) => ({ shuffled: items }),
+}))
 
 describe("ViewingRoomsApp", () => {
   describe("with viewing rooms", () => {

--- a/src/Utils/Hooks/useStableShuffle.ts
+++ b/src/Utils/Hooks/useStableShuffle.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react"
-import { getENV } from "../getENV"
+import { getENV } from "Utils/getENV"
 
 /**
  * Returns a shuffle function seeded using the Express requestID so that the


### PR DESCRIPTION
Fixes https://artsyproduct.atlassian.net/browse/DIA-371

Some related updates to get rid of `!` usage and relative vs absolute paths for imports (plus a Palette update that allows `image={undefined}` in the `Card` component).