### PR TITLE
chore: suppress cursor pointer when a ref show rendered via CellShow

### DIFF
--- a/src/Components/Cells/CellShow.tsx
+++ b/src/Components/Cells/CellShow.tsx
@@ -40,6 +40,7 @@ const CellShow: FC<CellShowProps> = ({
       to={show.href}
       display="block"
       textDecoration="none"
+      style={{ cursor: show.href ? "pointer" : "default" }}
       width={width}
       {...rest}
     >


### PR DESCRIPTION
Fixes https://artsyproduct.atlassian.net/browse/DIA-617

We have reference shows (not _really_, but shows with only unpublished artworks count as reference shows), that can be rendered using this component, and those are not linkable (`href: null`).

When passing `href=null` to our link component, it renders a cursor indicating this is clickable (even though it isn't).

I thought about making that change in `RouterLink` (suppressing that cursor pointer if `!href`), but that felt a touch global, so just made this update in this component.

Another option might be to skip rendering a wrapping link entirely (either here _or_ in `RouterLink`) if `href == null`, but also a bit of a global change that I'm not insanely confident on.