### PR TITLE
chore: bump font size down on editorial titles for homepage on mobile

### DIFF
--- a/src/Apps/Home/Components/HomeFeaturedMarketNews.tsx
+++ b/src/Apps/Home/Components/HomeFeaturedMarketNews.tsx
@@ -86,7 +86,7 @@ const HomeFeaturedMarketNews: React.FC<HomeFeaturedMarketNewsProps> = ({
               {firstArticle.vertical}
             </Text>
 
-            <Text variant="xl" mt={0.5}>
+            <Text variant={["lg", "xl"]} mt={0.5}>
               {firstArticle.title}
             </Text>
 


### PR DESCRIPTION
Fixes https://artsyproduct.atlassian.net/browse/DIA-620 , bumps font size down a tad for mobile (still seems big enough to me, the `["lg", "xl"]` variant on `Text` appears throughout the codebase so seems to be a reasonable pattern).