### PR TITLE
fix(EMI-1791): Fix unsaving artwork in multiple lists bug

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActionsSaveButton.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActionsSaveButton.tsx
@@ -27,7 +27,7 @@ export const ArtworkActionsSaveButton: FC<ArtworkActionsSaveButtonProps> = ({
       internalID: artwork.internalID,
       id: artwork.id,
       slug: artwork.slug,
-      title: artwork.title!,
+      title: artwork.title ?? "",
       year: artwork.date,
       artistNames: artwork.artistNames,
       imageURL: artwork.preview?.url ?? null,

--- a/src/Apps/CollectorProfile/Routes/Saves/Components/SelectArtworkListsModal/__tests__/SelectArtworkListsModal.jest.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves/Components/SelectArtworkListsModal/__tests__/SelectArtworkListsModal.jest.tsx
@@ -15,6 +15,7 @@ import { useMutation } from "Utils/Hooks/useMutation"
 import { AnalyticsCombinedContextProvider } from "System/Analytics/AnalyticsContext"
 import { FC } from "react"
 import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
+import { MockBoot } from "DevTools/MockBoot"
 
 jest.unmock("react-relay")
 jest.mock("Utils/Hooks/useMutation")
@@ -34,19 +35,17 @@ const { renderWithRelay } = setupTestWrapperTL<
   SelectArtworkListsModal_Test_Query
 >({
   Component: props => {
-    if (!props.me) {
-      return null
-    }
-
     return (
-      <AnalyticsCombinedContextProvider
-        contextPageOwnerId="page-owner-id"
-        path="/artist/page-owner-slug"
-      >
-        <ManageArtworkForSavesProvider artwork={artwork}>
-          <TestComponent {...props} />
-        </ManageArtworkForSavesProvider>
-      </AnalyticsCombinedContextProvider>
+      <MockBoot>
+        <AnalyticsCombinedContextProvider
+          contextPageOwnerId="page-owner-id"
+          path="/artist/page-owner-slug"
+        >
+          <ManageArtworkForSavesProvider artwork={artwork}>
+            <TestComponent {...props} />
+          </ManageArtworkForSavesProvider>
+        </AnalyticsCombinedContextProvider>
+      </MockBoot>
     )
   },
   query: graphql`
@@ -58,21 +57,15 @@ const { renderWithRelay } = setupTestWrapperTL<
   `,
 })
 
-// FIXME:
-describe.skip("SelectArtworkListsModal", () => {
+describe("SelectArtworkListsModal", () => {
   const mockUseMutation = useMutation as jest.Mock
   const mockUseTracking = useTracking as jest.Mock
   const trackEvent = jest.fn()
   const submitMutation = jest.fn()
 
   beforeEach(() => {
-    mockUseMutation.mockImplementation(() => {
-      return { submitMutation }
-    })
-
-    mockUseTracking.mockImplementation(() => ({
-      trackEvent,
-    }))
+    mockUseMutation.mockImplementation(() => ({ submitMutation }))
+    mockUseTracking.mockImplementation(() => ({ trackEvent }))
   })
 
   it("should render artwork data", async () => {

--- a/src/Apps/CollectorProfile/Routes/Saves/Components/SelectArtworkListsModal/useSelectArtworkLists.ts
+++ b/src/Apps/CollectorProfile/Routes/Saves/Components/SelectArtworkListsModal/useSelectArtworkLists.ts
@@ -71,8 +71,11 @@ export const useSelectArtworkLists = (artworkID: string) => {
         artwork.setValue(false, "isSaved")
       }
 
-      // Update `isSavedToList` field to reflect if artwork was saved to any list
-      const hasBeenSavedToList = addedCounts.custom - removedCounts.custom > 0
+      // Update `isSavedToList` field to reflect if artwork was saved to any list or it was already saved
+      const hasBeenSavedToList =
+        addedCounts.custom - removedCounts.custom > 0 ||
+        (removedCounts.custom === 0 && artwork.getValue("isSavedToList"))
+
       artwork.setValue(hasBeenSavedToList, "isSavedToList")
     },
   })

--- a/src/Components/Artwork/SaveButton/SaveArtworkToListsButton.tsx
+++ b/src/Components/Artwork/SaveButton/SaveArtworkToListsButton.tsx
@@ -31,7 +31,7 @@ const SaveArtworkToListsButton: FC<SaveArtworkToListsButtonProps> = ({
       internalID: artwork.internalID,
       id: artwork.id,
       slug: artwork.slug,
-      title: artwork.title!,
+      title: artwork.title ?? "",
       year: artwork.date,
       artistNames: artwork.artistNames,
       imageURL: artwork.preview?.url ?? null,

--- a/src/Components/Artwork/SaveButton/useSaveArtwork.ts
+++ b/src/Components/Artwork/SaveButton/useSaveArtwork.ts
@@ -35,8 +35,8 @@ export const useSaveArtwork = ({
           {
             saveArtwork: {
               artwork: {
-                id: artwork.id!,
-                slug: artwork.slug!,
+                id: artwork.id ?? "",
+                slug: artwork.slug ?? "",
                 isSaved: !isSaved,
               },
               /**

--- a/src/Components/Artwork/SaveButton/useSaveArtworkToLists.ts
+++ b/src/Components/Artwork/SaveButton/useSaveArtworkToLists.ts
@@ -83,8 +83,8 @@ export const useSaveArtworkToLists = (options: SaveArtworkToListsOptions) => {
       {
         saveArtwork: {
           artwork: {
-            id: artwork.id!,
-            slug: artwork.slug!,
+            id: artwork.id,
+            slug: artwork.slug,
             isSaved: !artwork.isSavedToDefaultList,
           },
           /**


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-1791]

### Description
This PR fixes a case in saving artworks when a collector does the following:
1. Saves an artwork to a custom list
2. Saves the same artwork to default using the Select List modal
3. Clicking the saves button on the Artwork Page

The previous steps results in un-saving the artwork from the default saves list without showing the modal

This PR also re-enables some tests and removes non-null assersions

### Videos

| Before | After |
|---|---|
| <video src="https://github.com/artsy/force/assets/20655703/eac090d2-e101-4d18-9ae5-fefdf917be3c" /> | <video src="https://github.com/artsy/force/assets/20655703/756c78a7-eeb1-4e10-b483-0e063d55702e" /> |

<!-- Implementation description -->


cc @artsy/emerald-devs 

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EMI-1791]: https://artsyproduct.atlassian.net/browse/EMI-1791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ