### PR TITLE
fix (Amber-583): "View More" button no longer renders on partner shows if there is no href 

### DIFF
--- a/src/Apps/Partner/Components/PartnerShows/ShowBanner.tsx
+++ b/src/Apps/Partner/Components/PartnerShows/ShowBanner.tsx
@@ -106,19 +106,20 @@ const ShowBanner: React.FC<ShowBannerProps> = ({
               </Text>
             )}
           </RouterLink>
-
-          <GridColumns mt={[2, 4]}>
-            <Column span={6}>
-              <Button
-                width="100%"
-                // @ts-ignore
-                as={RouterLink}
-                to={href}
-              >
-                View More
-              </Button>
-            </Column>
-          </GridColumns>
+          {href && (
+            <GridColumns mt={[2, 4]}>
+              <Column span={6}>
+                <Button
+                  width="100%"
+                  // @ts-ignore
+                  as={RouterLink}
+                  to={href}
+                >
+                  View More
+                </Button>
+              </Column>
+            </GridColumns>
+          )}
         </FadeBox>
       </Column>
 

--- a/src/Apps/Partner/Components/__tests__/PartnerShows/ShowBanner.jest.tsx
+++ b/src/Apps/Partner/Components/__tests__/PartnerShows/ShowBanner.jest.tsx
@@ -69,6 +69,31 @@ describe("ShowBanner", () => {
     expect(text).toContain("Description")
   })
 
+  it("does not render 'View More' button if show href is null", () => {
+    const { wrapper } = getWrapper({
+      Show: () => ({
+        name: "Ellen Altfest | Nature",
+        href: null,
+        isFairBooth: false,
+        exhibitionPeriod: "April 16 – May 30",
+        status: "running",
+        description: "Description",
+        location: {
+          city: "London",
+        },
+        coverImage: {
+          medium: {
+            src: "https://d7hftxdivxxvm.cloudfront.net?example-1.jpg",
+            srcSet: "https://d7hftxdivxxvm.cloudfront.net?example-2.jpg",
+          },
+        },
+      }),
+    })
+
+    expect(wrapper.find("Button")).toHaveLength(0)
+    expect(wrapper.text()).not.toContain("View More")
+  })
+
   it.each([
     [true, "running", "current fair booth"],
     [true, "upcoming", "upcoming fair booth"],


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [AMBER-583]

### Description

Addressing partner feedback/bug, now we check to make sure that `href` is not null before rendering the View More button.
<!-- Implementation description -->
![Screenshot 2024-05-09 at 6 05 15 PM](https://github.com/artsy/force/assets/66049063/3d8c7d59-3703-49e6-9ddc-5309c5e96c33)




[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AMBER-583]: https://artsyproduct.atlassian.net/browse/AMBER-583?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ