### PR TITLE
feat: update Institutions page title

### DIFF
--- a/cypress/e2e/institutions.cy.ts
+++ b/cypress/e2e/institutions.cy.ts
@@ -3,7 +3,7 @@ import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
 describe("Institutions", () => {
   it("/institutions", () => {
     visitWithStatusRetries("institutions")
-    cy.get("h1").should("contain", "Browse Institutions")
+    cy.get("h1").should("contain", "Browse Museums and Institutions")
     cy.title().should("eq", "Institutions | Artsy")
   })
 

--- a/src/Apps/Partners/Routes/InstitutionsRoute.tsx
+++ b/src/Apps/Partners/Routes/InstitutionsRoute.tsx
@@ -43,7 +43,7 @@ const InstitutionsRoute: React.FC<InstitutionsRouteProps> = ({ viewer }) => {
 
         <Flex justifyContent="space-between" alignItems="center">
           <Text variant="xl" as="h1">
-            Browse Institutions
+            Browse Museums and Institutions
           </Text>
 
           <Text


### PR DESCRIPTION
The type of this PR is: tiny **Feat**

See discussion: [Slack thread](https://artsy.slack.com/archives/C03N12SR0RK/p1715174220151949)

"Browse Institutions" → "Browse Museums and Institutions" to better parallel the global nav as well as the content of the page.