### PR TITLE
feat: change SWA tooltip copy and do not show tooltip for submitted artworks

### DIFF
--- a/src/Apps/Settings/Routes/MyCollection/Components/MyCollectionArtworkGrid.tsx
+++ b/src/Apps/Settings/Routes/MyCollection/Components/MyCollectionArtworkGrid.tsx
@@ -40,7 +40,8 @@ const MyCollectionArtworksGrid: FC<MyCollectionArtworkGridProps> = ({
           <Text variant="xs">
             <strong>Interested in Selling This Work?</strong>
             <br />
-            Let our experts find the best sales option for you.
+            Submit for sale and let our experts find the best selling option for
+            you.
           </Text>
         )
       }
@@ -67,6 +68,9 @@ export const MyCollectionArtworkGrid = createFragmentContainer(
               targetSupply {
                 priority
               }
+            }
+            consignmentSubmission {
+              state
             }
             ...GridItem_artwork @arguments(includeAllImages: true)
             ...FlatGridItem_artwork @arguments(includeAllImages: true)

--- a/src/Components/ArtworkGrid/ArtworkGrid.tsx
+++ b/src/Components/ArtworkGrid/ArtworkGrid.tsx
@@ -155,7 +155,9 @@ export class ArtworkGridContainer extends React.Component<
 
     // applicable only for My Collection grid: we want to show the popover only for the first P1 artwork
     const firstP1Artwork = extractNodes(this.props.artworks).find(
-      artwork => (artwork as any)?.artist?.targetSupply?.priority === "TRUE"
+      artwork =>
+        (artwork as any)?.artist?.targetSupply?.priority === "TRUE" &&
+        !(artwork as any).consignmentSubmission
     )
 
     for (let column = 0; column < columnCount; column++) {

--- a/src/__generated__/MyCollectionArtworkGrid_artworks.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkGrid_artworks.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9bf3ba92130dd5a359aed2e24abac7f1>>
+ * @generated SignedSource<<b4746f75f14aa5ff5704af0bb9628508>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,6 +10,7 @@
 
 import { Fragment, ReaderFragment } from 'relay-runtime';
 export type ArtistTargetSupplyPriority = "FALSE" | "TRUE" | "%future added value";
+export type ArtworkConsignmentSubmissionState = "APPROVED" | "CLOSED" | "DRAFT" | "HOLD" | "PUBLISHED" | "REJECTED" | "SUBMITTED" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type MyCollectionArtworkGrid_artworks$data = {
   readonly edges: ReadonlyArray<{
@@ -18,6 +19,9 @@ export type MyCollectionArtworkGrid_artworks$data = {
         readonly targetSupply: {
           readonly priority: ArtistTargetSupplyPriority | null | undefined;
         };
+      } | null | undefined;
+      readonly consignmentSubmission: {
+        readonly state: ArtworkConsignmentSubmissionState;
       } | null | undefined;
       readonly href: string | null | undefined;
       readonly id: string;
@@ -148,6 +152,24 @@ return {
               "storageKey": null
             },
             {
+              "alias": null,
+              "args": null,
+              "concreteType": "ArtworkConsignmentSubmission",
+              "kind": "LinkedField",
+              "name": "consignmentSubmission",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "state",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            },
+            {
               "args": (v0/*: any*/),
               "kind": "FragmentSpread",
               "name": "GridItem_artwork"
@@ -169,6 +191,6 @@ return {
 };
 })();
 
-(node as any).hash = "120892fd7d51ef6f946438ec99072ca8";
+(node as any).hash = "7af70d288b96fac16ee9cd2e65df57d8";
 
 export default node;

--- a/src/__generated__/MyCollectionRouteQuery.graphql.ts
+++ b/src/__generated__/MyCollectionRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<51c3b2dc19edbc4cd067dbdf30918597>>
+ * @generated SignedSource<<c99e5389898f92499bc5734d2a809d96>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -352,6 +352,24 @@ return {
                             "storageKey": null
                           },
                           (v2/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ArtworkConsignmentSubmission",
+                        "kind": "LinkedField",
+                        "name": "consignmentSubmission",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "state",
+                            "storageKey": null
+                          }
                         ],
                         "storageKey": null
                       },
@@ -762,12 +780,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "92f8515e1663360def427d8436b28b94",
+    "cacheID": "f166b4bea75e7e622cb83a1561c0779b",
     "id": null,
     "metadata": {},
     "name": "MyCollectionRouteQuery",
     "operationKind": "query",
-    "text": "query MyCollectionRouteQuery(\n  $count: Int!\n  $cursor: String\n) {\n  me {\n    ...MyCollectionRoute_me_1G22uz\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment DeprecatedSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_yvCPB on Artwork {\n  ...Metadata_artwork\n  ...DeprecatedSaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: true) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n  isSaved\n}\n\nfragment GridItem_artwork_yvCPB on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: true) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...ExclusiveAccessBadge_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment MyCollectionArtworkGrid_artworks on MyCollectionConnection {\n  edges {\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: true) {\n        aspectRatio\n      }\n      artist {\n        targetSupply {\n          priority\n        }\n        id\n      }\n      ...GridItem_artwork_yvCPB\n      ...FlatGridItem_artwork_yvCPB\n    }\n  }\n}\n\nfragment MyCollectionRoute_me_1G22uz on Me {\n  myCollectionConnection(first: $count, after: $cursor, sort: CREATED_AT_DESC) {\n    ...MyCollectionArtworkGrid_artworks\n    totalCount\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isSavedToList\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n"
+    "text": "query MyCollectionRouteQuery(\n  $count: Int!\n  $cursor: String\n) {\n  me {\n    ...MyCollectionRoute_me_1G22uz\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment DeprecatedSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_yvCPB on Artwork {\n  ...Metadata_artwork\n  ...DeprecatedSaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: true) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n  isSaved\n}\n\nfragment GridItem_artwork_yvCPB on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: true) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...ExclusiveAccessBadge_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment MyCollectionArtworkGrid_artworks on MyCollectionConnection {\n  edges {\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: true) {\n        aspectRatio\n      }\n      artist {\n        targetSupply {\n          priority\n        }\n        id\n      }\n      consignmentSubmission {\n        state\n      }\n      ...GridItem_artwork_yvCPB\n      ...FlatGridItem_artwork_yvCPB\n    }\n  }\n}\n\nfragment MyCollectionRoute_me_1G22uz on Me {\n  myCollectionConnection(first: $count, after: $cursor, sort: CREATED_AT_DESC) {\n    ...MyCollectionArtworkGrid_artworks\n    totalCount\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isSavedToList\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n"
   }
 };
 })();

--- a/src/__generated__/collectorProfileRoutes_MyCollectionRouteQuery.graphql.ts
+++ b/src/__generated__/collectorProfileRoutes_MyCollectionRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3bbbdc7eadb2a5b03cdc960b260b1de0>>
+ * @generated SignedSource<<a9fcf881528487f2a3dee2a49edd2a16>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -321,6 +321,24 @@ return {
                             "storageKey": null
                           },
                           (v1/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "ArtworkConsignmentSubmission",
+                        "kind": "LinkedField",
+                        "name": "consignmentSubmission",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "state",
+                            "storageKey": null
+                          }
                         ],
                         "storageKey": null
                       },
@@ -731,12 +749,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f62ba5c70a12c06437195f2a823bdf0b",
+    "cacheID": "27e6625457ba7db5a88339072bca5e33",
     "id": null,
     "metadata": {},
     "name": "collectorProfileRoutes_MyCollectionRouteQuery",
     "operationKind": "query",
-    "text": "query collectorProfileRoutes_MyCollectionRouteQuery {\n  me {\n    ...MyCollectionRoute_me\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment DeprecatedSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_yvCPB on Artwork {\n  ...Metadata_artwork\n  ...DeprecatedSaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: true) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n  isSaved\n}\n\nfragment GridItem_artwork_yvCPB on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: true) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...ExclusiveAccessBadge_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment MyCollectionArtworkGrid_artworks on MyCollectionConnection {\n  edges {\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: true) {\n        aspectRatio\n      }\n      artist {\n        targetSupply {\n          priority\n        }\n        id\n      }\n      ...GridItem_artwork_yvCPB\n      ...FlatGridItem_artwork_yvCPB\n    }\n  }\n}\n\nfragment MyCollectionRoute_me on Me {\n  myCollectionConnection(first: 25, sort: CREATED_AT_DESC) {\n    ...MyCollectionArtworkGrid_artworks\n    totalCount\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isSavedToList\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n"
+    "text": "query collectorProfileRoutes_MyCollectionRouteQuery {\n  me {\n    ...MyCollectionRoute_me\n    id\n  }\n}\n\nfragment Badge_artwork on Artwork {\n  is_biddable: isBiddable\n  href\n  sale {\n    is_preview: isPreview\n    display_timely_at: displayTimelyAt\n    id\n  }\n}\n\nfragment DeprecatedSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_yvCPB on Artwork {\n  ...Metadata_artwork\n  ...DeprecatedSaveButton_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: true) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n  isSaved\n}\n\nfragment GridItem_artwork_yvCPB on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: true) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...ExclusiveAccessBadge_artwork\n  ...Badge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n}\n\nfragment MyCollectionArtworkGrid_artworks on MyCollectionConnection {\n  edges {\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: true) {\n        aspectRatio\n      }\n      artist {\n        targetSupply {\n          priority\n        }\n        id\n      }\n      consignmentSubmission {\n        state\n      }\n      ...GridItem_artwork_yvCPB\n      ...FlatGridItem_artwork_yvCPB\n    }\n  }\n}\n\nfragment MyCollectionRoute_me on Me {\n  myCollectionConnection(first: 25, sort: CREATED_AT_DESC) {\n    ...MyCollectionArtworkGrid_artworks\n    totalCount\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isSavedToList\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n}\n"
   }
 };
 })();


### PR DESCRIPTION
### Description

- Change tooltip copy
- If artwork was already submitted - do not display tooltip on top of it (thanks @dariakoko for noticing this bug)

| Before | After |
|---|---|
| <img width="1510" alt="Screenshot 2024-05-15 at 09 06 48" src="https://github.com/artsy/force/assets/3934579/5dfe0d00-5c63-4753-ad23-dd3ba5aa80c8"> | <img width="1511" alt="Screenshot 2024-05-15 at 09 06 57" src="https://github.com/artsy/force/assets/3934579/e8b2295a-6e00-485a-9d45-825aa5df4a11"> |