### PR TITLE
fix(ONYX-969): add save artwork button to rails

### DIFF
--- a/src/Apps/Home/Components/HomeAuctionLotsForYouRail.tsx
+++ b/src/Apps/Home/Components/HomeAuctionLotsForYouRail.tsx
@@ -10,6 +10,7 @@ import {
 } from "Components/Artwork/ShelfArtwork"
 import {
   ActionType,
+  AuthContextModule,
   ClickedArtworkGroup,
   ContextModule,
   OwnerType,
@@ -27,6 +28,7 @@ const HomeAuctionLotsForYouRail: React.FC<HomeAuctionLotsForYouRailProps> = ({
   artworksForUser,
 }) => {
   const { trackEvent } = useTracking()
+  const contextModule = ContextModule.lotsForYouRail as AuthContextModule
 
   const artworks = extractNodes(artworksForUser)
 
@@ -46,6 +48,7 @@ const HomeAuctionLotsForYouRail: React.FC<HomeAuctionLotsForYouRailProps> = ({
             artwork={artwork}
             key={index}
             lazyLoad
+            contextModule={contextModule}
             onClick={() => {
               const trackingEvent: ClickedArtworkGroup = {
                 action: ActionType.clickedArtworkGroup,

--- a/src/Apps/Home/Components/HomeAuctionLotsRail.tsx
+++ b/src/Apps/Home/Components/HomeAuctionLotsRail.tsx
@@ -13,6 +13,7 @@ import {
 } from "Components/Artwork/ShelfArtwork"
 import {
   ActionType,
+  AuthContextModule,
   ClickedArtworkGroup,
   ContextModule,
   OwnerType,
@@ -26,6 +27,7 @@ const HomeAuctionLotsRail: React.FC<HomeAuctionLotsRailProps> = ({
   viewer,
 }) => {
   const { trackEvent } = useTracking()
+  const contextModule = ContextModule.topAuctionLotsRail as AuthContextModule
 
   const artworks = extractNodes(viewer.artworksConnection)
 
@@ -41,6 +43,7 @@ const HomeAuctionLotsRail: React.FC<HomeAuctionLotsRailProps> = ({
             artwork={artwork}
             key={artwork.slug}
             lazyLoad
+            contextModule={contextModule}
             onClick={() => {
               const trackingEvent: ClickedArtworkGroup = {
                 action: ActionType.clickedArtworkGroup,


### PR DESCRIPTION
The type of this PR is: Fix

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [ONYX-969](https://artsyproduct.atlassian.net/browse/ONYX-969)

### Description

Adds save artwork button on HomeAuctionLotsForYouRail and HomeAuctionLotsRail (Curators picks)
Related to this[ Cohesion PR](https://github.com/artsy/cohesion/pull/502).

Home page:

https://github.com/artsy/force/assets/17580625/a2d59e55-15c5-4753-9a78-7ec81227d306


Auctions page:

https://github.com/artsy/force/assets/17580625/77a23d24-8e9d-4879-be92-55bdf665ead7


Logged out:

https://github.com/artsy/force/assets/17580625/d86a3fb2-cc10-4bb3-af06-1152b522bf28









<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-969]: https://artsyproduct.atlassian.net/browse/ONYX-969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ