### PR TITLE
chore(EMI-1864): replace localization with blant conversion to comma separated numbers to match display

### DIFF
--- a/src/Apps/Order/Components/OfferInput.tsx
+++ b/src/Apps/Order/Components/OfferInput.tsx
@@ -22,7 +22,7 @@ export const OfferInput: FC<OfferInputProps> = ({
 }) => {
   const formatValueForDisplay = (val: number | undefined) => {
     if (val !== undefined && val > 0) {
-      return val.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")
+      return val.toLocaleString("en-US")
     }
     return ""
   }

--- a/src/Apps/Order/Components/OfferInput.tsx
+++ b/src/Apps/Order/Components/OfferInput.tsx
@@ -22,7 +22,7 @@ export const OfferInput: FC<OfferInputProps> = ({
 }) => {
   const formatValueForDisplay = (val: number | undefined) => {
     if (val !== undefined && val > 0) {
-      return val.toLocaleString()
+      return val.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",")
     }
     return ""
   }


### PR DESCRIPTION
I tried just removing this separator as the other option the ticket suggests but those big numbers where cents are not allowed felt strange to me. Also it's kinda nice when it's matching the display above.

Regex for the win!