### PR TITLE
fix(AMBER-678): Shows display on partner profile overview page but not in Events tab

### DIFF
--- a/src/Apps/Partner/Routes/Shows/index.tsx
+++ b/src/Apps/Partner/Routes/Shows/index.tsx
@@ -23,6 +23,9 @@ export const Shows: React.FC<PartnerShowsProps> = ({ partner }) => {
 
   const [firstFeaturedEvent] = extractNodes(featuredEvents)
 
+  let upcomingEventsList = extractNodes(upcomingEvents)
+  let currentEventsList = extractNodes(currentEvents)
+
   const filteredUpcomingEvents = extractNodes(upcomingEvents).filter(
     event => event?.internalID !== firstFeaturedEvent?.internalID
   )
@@ -31,6 +34,11 @@ export const Shows: React.FC<PartnerShowsProps> = ({ partner }) => {
     event => event?.internalID !== firstFeaturedEvent?.internalID
   )
 
+  if (firstFeaturedEvent?.isFeatured) {
+    upcomingEventsList = filteredUpcomingEvents
+    currentEventsList = filteredCurrentEvents
+  }
+
   return (
     <>
       <Join separator={<Spacer y={6} />}>
@@ -38,12 +46,12 @@ export const Shows: React.FC<PartnerShowsProps> = ({ partner }) => {
           <ShowBannerFragmentContainer my={4} show={firstFeaturedEvent!} />
         )}
 
-        {filteredCurrentEvents.length > 0 && (
+        {currentEventsList.length > 0 && (
           <>
             <Text variant="lg-display">Current Events</Text>
 
             <GridColumns gridRowGap={[2, 4]}>
-              {filteredCurrentEvents.map(show => {
+              {currentEventsList.map(show => {
                 return (
                   <Column key={show.internalID} span={[6, 6, 3, 3]}>
                     <CellShowFragmentContainer
@@ -59,12 +67,12 @@ export const Shows: React.FC<PartnerShowsProps> = ({ partner }) => {
           </>
         )}
 
-        {filteredUpcomingEvents.length > 0 && (
+        {upcomingEventsList.length > 0 && (
           <>
             <Text variant="lg-display">Upcoming Events</Text>
 
             <GridColumns gridRowGap={[2, 4]}>
-              {filteredUpcomingEvents.map(show => {
+              {upcomingEventsList.map(show => {
                 return (
                   <Column key={show.internalID} span={[6, 6, 3, 3]}>
                     <CellShowFragmentContainer

--- a/src/Apps/Partner/Routes/Shows/index.tsx
+++ b/src/Apps/Partner/Routes/Shows/index.tsx
@@ -26,15 +26,15 @@ export const Shows: React.FC<PartnerShowsProps> = ({ partner }) => {
   let upcomingEventsList = extractNodes(upcomingEvents)
   let currentEventsList = extractNodes(currentEvents)
 
-  const filteredUpcomingEvents = extractNodes(upcomingEvents).filter(
-    event => event?.internalID !== firstFeaturedEvent?.internalID
-  )
-
-  const filteredCurrentEvents = extractNodes(currentEvents).filter(
-    event => event?.internalID !== firstFeaturedEvent?.internalID
-  )
-
   if (firstFeaturedEvent?.isFeatured) {
+    const filteredUpcomingEvents = extractNodes(upcomingEvents).filter(
+      event => event?.internalID !== firstFeaturedEvent?.internalID
+    )
+
+    const filteredCurrentEvents = extractNodes(currentEvents).filter(
+      event => event?.internalID !== firstFeaturedEvent?.internalID
+    )
+
     upcomingEventsList = filteredUpcomingEvents
     currentEventsList = filteredCurrentEvents
   }


### PR DESCRIPTION
The type of this PR is: **FIX**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [AMBER-678]

### Description

Partner Shows are displaying as Current events on partner profile overview page but not in Events tab under Current Events

Partner: Galerie Max Hetzler
[Events page](https://www.artsy.net/partner/galerie-max-hetzler/shows)
[Profile overview page](https://www.artsy.net/partner/galerie-max-hetzler)

Slack thread: https://artsy.slack.com/archives/C03N12SR0RK/p1715016600143109

So basically we show a banner for the first featured show but only if `isFeatured` is true, and its false for that show. So its technically not broken but I think if the first featured show has `isFeatured` set to false we should show that show in the regular show rail, so that's what I did.

__Before:__
<img width="1141" alt="Screenshot 2024-05-21 at 1 00 49 PM" src="https://github.com/artsy/force/assets/5643895/24c7e182-741a-48b9-869b-1c61e046e737">

__After:__
<img width="964" alt="Screenshot 2024-05-21 at 1 01 13 PM" src="https://github.com/artsy/force/assets/5643895/9d5d1746-439a-4ac8-af92-d4fe91f1be7d">



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AMBER-678]: https://artsyproduct.atlassian.net/browse/AMBER-678?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ