### PR TITLE
fix: fixes alerts redirects

### DIFF
--- a/src/Server/middleware/hardcodedRedirects.ts
+++ b/src/Server/middleware/hardcodedRedirects.ts
@@ -71,6 +71,8 @@ const PERMANENT_REDIRECTS = {
   "/user/payments": "/settings/payments",
   "/user/alerts": "/favorites/alerts",
   "/settings/alerts": "/favorites/alerts",
+  "/settings/alerts/:alertID/edit": "/favorites/alerts/:alertID/edit",
+  "/settings/alerts/:alertID/artworks": "/favorites/alerts/:alertID/artworks",
   "/alerts/:alertID/edit": "/favorites/alerts/:alertID/edit",
   "/alerts/:alertID/artworks": "/favorites/alerts/:alertID/artworks",
   "/my-collection": "/collector-profile/my-collection",


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Redirects from pages like `https://www.artsy.net/settings/alerts/c99019b3-029c-433f-8a55-7117bd397598/edit` (come from email) are broken.

[Slack thread](https://artsy.slack.com/archives/C05EQL4R5N0/p1716387774309809)