### PR TITLE
fix: Edit profile settings location input arbitrary string support

### DIFF
--- a/src/Apps/Settings/Routes/EditProfile/Components/SettingsEditProfileFields.tsx
+++ b/src/Apps/Settings/Routes/EditProfile/Components/SettingsEditProfileFields.tsx
@@ -90,11 +90,16 @@ const SettingsEditProfileFields: React.FC<SettingsEditProfileFieldsProps> = ({
 
   const onSubmit = async (values: EditProfileFormModel) => {
     try {
-      const newLocation = { ...values.location }
-      delete newLocation.display
+      const location = {
+        city: values.location?.city || null,
+        state: values.location?.state || null,
+        country: values.location?.country || null,
+        countryCode: values.location?.countryCode || null,
+      }
+
       const payload = {
         name: values.name,
-        location: newLocation,
+        location,
         profession: values.profession,
         otherRelevantPositions: values.otherRelevantPositions,
         bio: values.bio,
@@ -152,8 +157,8 @@ const SettingsEditProfileFields: React.FC<SettingsEditProfileFieldsProps> = ({
                 onSelect={(place?: Place) => {
                   setFieldValue("location", normalizePlace(place, false))
                 }}
-                onChange={() => {
-                  setFieldValue("location", {})
+                onChange={place => {
+                  setFieldValue("location", normalizePlace(place, false))
                 }}
               />
 

--- a/src/Apps/Settings/Routes/EditProfile/Components/__tests__/SettingsEditProfileFields.jest.tsx
+++ b/src/Apps/Settings/Routes/EditProfile/Components/__tests__/SettingsEditProfileFields.jest.tsx
@@ -112,7 +112,12 @@ describe("SettingsEditProfileFields", () => {
     await waitFor(() => {
       expect(mockSubmitUpdateMyUserProfile).toHaveBeenCalledWith({
         name: "Collector Name",
-        location: {},
+        location: {
+          city: "A",
+          country: null,
+          countryCode: null,
+          state: null,
+        },
         profession: "Artist and Collector",
         otherRelevantPositions: "Positions",
         bio: "I collect",


### PR DESCRIPTION
Addresses [ONYX-985]

## Description

This fixes the profile settings location input. 

When entering an arbitrary string in the location input, users can save the profile, but the location does not get updated. This corrects the input by updating the location correctly for arbitrary strings.

The app already accepts arbitrary strings as location and works as expected.

![Screenshot 2024-05-23 at 11 18 08](https://github.com/artsy/force/assets/4691889/61be5d05-eccf-4e8c-83c7-e913f8268895)

[ONYX-985]: https://artsyproduct.atlassian.net/browse/ONYX-985?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ