### PR TITLE
fix: remove auctions phone number (DIA-660)

### DIFF
--- a/src/Apps/Auction/Components/AuctionDetails/AuctionInfoSidebar.tsx
+++ b/src/Apps/Auction/Components/AuctionDetails/AuctionInfoSidebar.tsx
@@ -27,7 +27,6 @@ const AuctionInfoSidebar: React.FC<AuctionInfoSidebarProps> = ({ sale }) => {
         <RouterLink inline to="mailto:specialist@artsy.net">
           <Text variant="sm">specialist@artsy.net</Text>
         </RouterLink>
-        <Text variant="sm">+1-845-582-3967</Text>
       </Box>
     </Join>
   )

--- a/src/Apps/Auction/Components/AuctionDetails/__tests__/AuctionInfoSidebar.jest.tsx
+++ b/src/Apps/Auction/Components/AuctionDetails/__tests__/AuctionInfoSidebar.jest.tsx
@@ -25,6 +25,5 @@ describe("AuctionInfoSidebar", () => {
     expect(wrapper.text()).toContain("How to bid on Artsy?")
     expect(wrapper.html()).toContain("/how-auctions-work")
     expect(wrapper.html()).toContain("mailto:specialist@artsy.net")
-    expect(wrapper.text()).toContain("+1-845-582-3967")
   })
 })


### PR DESCRIPTION
Remove contact phone number from auctions pages

| BEFORE | AFTER |
|---------|--------|
| <img width="1430" alt="Screenshot 2024-05-28 at 5 45 27 AM" src="https://github.com/artsy/force/assets/44589599/9c6c790a-5f3a-4130-8124-b8902fbc40e3"> | <img width="1447" alt="Screenshot 2024-05-28 at 5 45 04 AM" src="https://github.com/artsy/force/assets/44589599/246a94d6-f8f9-42a8-bd09-71106f5ad76b"> |
