### PR TITLE
fix(artwork): fixes re-rendering alert button

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
@@ -16,7 +16,7 @@ import {
   useTheme,
 } from "@artsy/palette"
 import * as DeprecatedSchema from "@artsy/cohesion/dist/DeprecatedSchema"
-import { FC, useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import { useInquiry } from "Components/Inquiry/useInquiry"
 import { ErrorWithMetadata } from "Utils/errors"
 import { logger } from "@sentry/utils"
@@ -351,18 +351,6 @@ export const ArtworkSidebarCommercialButtons: React.FC<ArtworkSidebarCommercialB
   const isCreateAlertAvailable =
     artwork.isEligibleToCreateAlert && artwork.isSold
 
-  const AlertSwitch: FC = () => {
-    if (!isCreateAlertAvailable) {
-      return null
-    }
-
-    return (
-      <ProgressiveOnboardingAlertCreateSimple>
-        <CreateAlertButton width="100%" size="large" />
-      </ProgressiveOnboardingAlertCreateSimple>
-    )
-  }
-
   const renderButtons: {
     buyNow?: ResponsiveValue<"primaryBlack" | "secondaryBlack">
     makeOffer?: ResponsiveValue<"primaryBlack" | "secondaryBlack">
@@ -430,7 +418,12 @@ export const ArtworkSidebarCommercialButtons: React.FC<ArtworkSidebarCommercialB
 
           <Flex flexDirection={["column", "column", "column", "column", "row"]}>
             <Join separator={<Spacer x={1} y={1} />}>
-              <AlertSwitch />
+              {isCreateAlertAvailable && (
+                <ProgressiveOnboardingAlertCreateSimple>
+                  <CreateAlertButton width="100%" size="large" />
+                </ProgressiveOnboardingAlertCreateSimple>
+              )}
+
               {renderButtons.buyNow && (
                 <Button
                   variant={renderButtons.buyNow}


### PR DESCRIPTION
Noticed this flashing alert button on the artwork page:


https://github.com/artsy/force/assets/112297/4d4f32bd-5da1-4059-a270-216ba6f7934a

------

This was primarily due to the alert button component being declared _inside_ of another component's body. Just _never do this_. I wish there was a linting rule for this sort of thing because it's happened a number of times.

Initially I thought it was due to the timer hook being used to just determine if a date was in the past, which is related, but in fact _any_ timer/polling on the page would cause this thing to re-render. I fixed that anyway because it was unnecessary.