### PR TITLE
feat: pull secrets from vault

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -1,4 +1,38 @@
 ---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: force
+spec:
+  refreshInterval: "5m"
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: force
+    creationPolicy: Owner
+    deletionPolicy: Merge
+    template:
+      engineVersion: v2
+      templateFrom:
+      - target: Data
+        {% raw %}
+        literal: |
+          {{ range $key, $value := . }}
+          {{$key}}: {{$value | fromJson | values | first}}
+          {{ end }}
+        {% endraw %}
+  dataFrom:
+  - find:
+      path: kubernetes/apps/force
+      name:
+        regexp: ".*"
+    rewrite:
+    - regexp:
+        source: "kubernetes/apps/force/(.*)"
+        target: "$1"
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -46,6 +80,8 @@ spec:
         envFrom:
         - configMapRef:
             name: force-environment
+        - secretRef:
+            name: force
         image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/force:production
         imagePullPolicy: Always
         ports:
@@ -135,6 +171,8 @@ spec:
         envFrom:
         - configMapRef:
             name: force-environment
+        - secretRef:
+            name: force
         image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/force:production
         imagePullPolicy: Always
         ports:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -1,4 +1,38 @@
 ---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: force
+spec:
+  refreshInterval: "5m"
+  secretStoreRef:
+    name: vault
+    kind: ClusterSecretStore
+  target:
+    name: force
+    creationPolicy: Owner
+    deletionPolicy: Merge
+    template:
+      engineVersion: v2
+      templateFrom:
+      - target: Data
+        {% raw %}
+        literal: |
+          {{ range $key, $value := . }}
+          {{$key}}: {{$value | fromJson | values | first}}
+          {{ end }}
+        {% endraw %}
+  dataFrom:
+  - find:
+      path: kubernetes/apps/force
+      name:
+        regexp: ".*"
+    rewrite:
+    - regexp:
+        source: "kubernetes/apps/force/(.*)"
+        target: "$1"
+
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -54,6 +88,8 @@ spec:
         envFrom:
         - configMapRef:
             name: force-environment
+        - secretRef:
+            name: force
         image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/force:staging
         imagePullPolicy: Always
         ports:
@@ -150,6 +186,8 @@ spec:
         envFrom:
         - configMapRef:
             name: force-environment
+        - secretRef:
+            name: force
         image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/force:staging
         imagePullPolicy: Always
         ports:


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR supports [PHIRE-813]

This PR is a re-attempt of https://github.com/artsy/force/pull/13827

### Description

Let pods [load key/value pairs from Hashicorp Vault](https://www.notion.so/artsy/Integrate-Kubernetes-with-Vault-922ee8d71ac04507a5ad38b9003ca014?pvs=4#8b5a7b5dbcb244c698535841dd1f7107). We will migrate secret configs from ConfigMap to Vault.

[PHIRE-813]: https://artsyproduct.atlassian.net/browse/PHIRE-813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ