### PR TITLE
fix: Start Selling sticky hidden on mWeb

### DIFF
--- a/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/SWAStickyFooter.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/SWAStickyFooter.tsx
@@ -1,5 +1,6 @@
 import { ContextModule, Intent } from "@artsy/cohesion"
-import { Flex, Button, Text, useTheme } from "@artsy/palette"
+import { Button, Text, useTheme, Box } from "@artsy/palette"
+import { Z } from "Apps/Components/constants"
 import { useMarketingLandingTracking } from "Apps/Consign/Routes/MarketingLanding/Utils/marketingLandingTracking"
 import { useAuthDialog } from "Components/AuthDialog"
 import { RouterLink } from "System/Router/RouterLink"
@@ -17,7 +18,7 @@ export const SWAStickyFooter = () => {
   const getInTouchRoute = "/sell/inquiry"
 
   return (
-    <Flex
+    <Box
       flexDirection="column"
       width="100%"
       p={2}
@@ -25,7 +26,12 @@ export const SWAStickyFooter = () => {
         transition: "box-shadow 250ms",
         boxShadow: theme.effects.dropShadow,
       }}
-      zIndex={1}
+      zIndex={Z.globalNav}
+      position="fixed"
+      right={0}
+      bottom={0}
+      left={0}
+      bg="white100"
     >
       <Button
         // @ts-ignore
@@ -70,6 +76,6 @@ export const SWAStickyFooter = () => {
           Speak to an advisor
         </RouterLink>
       </Text>
-    </Flex>
+    </Box>
   )
 }

--- a/src/Apps/Consign/Routes/MarketingLanding/MarketingLandingApp.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/MarketingLandingApp.tsx
@@ -17,15 +17,8 @@ import { Media } from "Utils/Responsive"
 import { SWAStickyFooter } from "Apps/Consign/Routes/MarketingLanding/Components/LandingPage/SWAStickyFooter"
 import { SWAFooter } from "Apps/Consign/Routes/MarketingLanding/Components/LandingPage/SWAFooter"
 import { Footer } from "Components/Footer/Footer"
-import { useNavBarHeight } from "Components/NavBar/useNavBarHeight"
 
 export const MarketingLandingApp = () => {
-  const {
-    height: [mobileNavBarHeight],
-  } = useNavBarHeight()
-
-  const mobileHeight = `calc(100vh - ${mobileNavBarHeight}px)`
-
   const {
     match: {
       location: { query },
@@ -52,7 +45,7 @@ export const MarketingLandingApp = () => {
       <SellMeta />
 
       <Media lessThan="sm">
-        <Flex flexDirection="column" maxHeight={mobileHeight} overflow="hidden">
+        <Flex flexDirection="column">
           <Box
             flex={1}
             overflow="auto"


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

[Slack thread](https://artsy.slack.com/archives/C05EQL4R5N0/p1717421505002459)

Should fix broken sticky with CTA on /sell page on mWeb.
I cannot reproduce the issue on my laptop - still looking for how to do it (going to create review app soon in any case). In the meantime I borrowed the code from the "cookie content" sticky. I think it should work.