### PR TITLE
Chore(EMI-1671): remove name from pickup form

### DIFF
--- a/src/Apps/Order/Routes/Shipping2/Components/FulfillmentDetailsForm.tsx
+++ b/src/Apps/Order/Routes/Shipping2/Components/FulfillmentDetailsForm.tsx
@@ -567,18 +567,6 @@ const FulfillmentDetailsFormLayout = (
           <>
             <Input
               tabIndex={tabbableIf("pickup")}
-              name="attributes.name"
-              placeholder="Full name"
-              title={"Full name"}
-              autoCorrect="off"
-              value={values.attributes.name}
-              onChange={handleChange}
-              onBlur={handleBlur}
-              error={touched.attributes?.name && errors.attributes?.name}
-              data-testid="AddressForm_name"
-            />
-            <Input
-              tabIndex={tabbableIf("pickup")}
               name="attributes.phoneNumber"
               title="Phone number"
               type="tel"
@@ -634,10 +622,13 @@ const VALIDATION_SCHEMA = Yup.object().shape({
       phoneNumber: Yup.string()
         .required("Phone number is required")
         .matches(/^[+\-\d]+$/, "Phone number is required"),
-      name: Yup.string().required("Full name is required"),
     })
     .when("fulfillmentType", {
       is: FulfillmentType.SHIP,
-      then: schema => schema.shape(ADDRESS_VALIDATION_SHAPE),
+      then: schema =>
+        schema.shape({
+          ...ADDRESS_VALIDATION_SHAPE,
+          name: Yup.string().required("Full name is required"),
+        }),
     }),
 })

--- a/src/Apps/Order/Routes/Shipping2/Components/__tests__/FulfillmentDetailsForm.jest.tsx
+++ b/src/Apps/Order/Routes/Shipping2/Components/__tests__/FulfillmentDetailsForm.jest.tsx
@@ -150,19 +150,17 @@ describe("FulfillmentDetailsForm", () => {
       ).toBeVisible()
     })
 
-    it("has name and phone number fields", async () => {
+    it("has phone number field", async () => {
       renderTree(testProps)
 
       await userEvent.click(
         screen.getByRole("radio", { name: /Arrange for pickup/ })
       )
 
-      const fullNameField = await screen.findByPlaceholderText("Full name")
       const phoneNumberField = await screen.findByPlaceholderText(
         "Add phone number including country code"
       )
 
-      expect(fullNameField).toBeVisible()
       expect(phoneNumberField).toBeVisible()
       expect(
         screen.getByText("Required for pickup logistics")
@@ -187,11 +185,9 @@ describe("FulfillmentDetailsForm", () => {
       await flushPromiseQueue()
 
       await waitFor(() => {
-        ;["Full name is required", "Phone number is required"].forEach(
-          error => {
-            expect(screen.getByText(error)).toBeInTheDocument()
-          }
-        )
+        ;["Phone number is required"].forEach(error => {
+          expect(screen.getByText(error)).toBeInTheDocument()
+        })
       })
 
       expect(mockOnSubmit).not.toHaveBeenCalled()
@@ -202,12 +198,10 @@ describe("FulfillmentDetailsForm", () => {
       await userEvent.click(
         screen.getByRole("radio", { name: /Arrange for pickup/ })
       )
-      const fullNameField = await screen.findByPlaceholderText("Full name")
       const phoneNumberField = await screen.findByPlaceholderText(
         "Add phone number including country code"
       )
 
-      await userEvent.type(fullNameField, "John Doe")
       await userEvent.type(phoneNumberField, "1234567890")
 
       // we have to submit the form manually because its submit button is on the shipping route main screen
@@ -217,7 +211,7 @@ describe("FulfillmentDetailsForm", () => {
           {
             fulfillmentType: "PICKUP",
             attributes: {
-              name: "John Doe",
+              name: "",
               phoneNumber: "1234567890",
               city: "",
               region: "",
@@ -241,7 +235,6 @@ describe("FulfillmentDetailsForm", () => {
 
       // we have to submit the form manually because its submit button is on the shipping route main screen
       await submitForm()
-      await screen.findByText("Full name is required")
       await screen.findByText("Phone number is required")
       expect(mockOnSubmit).not.toHaveBeenCalled()
     })

--- a/src/Apps/Order/Routes/Shipping2/Components/__tests__/FulfillmentDetailsForm.jest.tsx
+++ b/src/Apps/Order/Routes/Shipping2/Components/__tests__/FulfillmentDetailsForm.jest.tsx
@@ -185,9 +185,7 @@ describe("FulfillmentDetailsForm", () => {
       await flushPromiseQueue()
 
       await waitFor(() => {
-        ;["Phone number is required"].forEach(error => {
-          expect(screen.getByText(error)).toBeInTheDocument()
-        })
+        expect(screen.getByText("Phone number is required")).toBeInTheDocument()
       })
 
       expect(mockOnSubmit).not.toHaveBeenCalled()

--- a/src/Apps/Order/Routes/Shipping2/__tests__/Shipping2.jest.tsx
+++ b/src/Apps/Order/Routes/Shipping2/__tests__/Shipping2.jest.tsx
@@ -271,6 +271,7 @@ describe.skip("Shipping", () => {
   const mockPush = jest.fn()
 
   beforeEach(() => {
+    HTMLElement.prototype.scrollIntoView = jest.fn()
     mockTrackEvent = jest.fn()
     ;(useTracking as jest.Mock).mockImplementation(() => ({
       trackEvent: mockTrackEvent,
@@ -2312,10 +2313,6 @@ describe.skip("Shipping", () => {
           "Add phone number including country code"
         )[0],
         "2813308004"
-      )
-      await userEvent.paste(
-        screen.getByPlaceholderText("Full name"),
-        "Joelle Van Dyne"
       )
 
       await flushPromiseQueue()


### PR DESCRIPTION
The type of this PR is: **Chore**

This PR solves [EMI-1671]

### Description
This PR removes the name field from the pickup form in the refactored shipping route. It also fixes a (skipped) test that depends on filling in [jsdom's missing srcroll-into-view helper](https://stackoverflow.com/questions/53271193/typeerror-scrollintoview-is-not-a-function) on an HTML element.

<!-- Implementation description -->


[EMI-1671]: https://artsyproduct.atlassian.net/browse/EMI-1671?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ