### PR TITLE
fix(DIA-664): Cleans up theme selection

### DIFF
--- a/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsThemeSelect.tsx
+++ b/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsThemeSelect.tsx
@@ -1,4 +1,4 @@
-import { Button, Text } from "@artsy/palette"
+import { Radio, RadioGroup, Spacer, Text } from "@artsy/palette"
 import { useAppPreferences } from "Apps/AppPreferences/useAppPreferences"
 import { FC } from "react"
 
@@ -13,15 +13,18 @@ export const SettingsEditSettingsThemeSelect: FC<SettingsEditSettingsThemeSelect
         Theme
       </Text>
 
-      <Button
-        onClick={() => {
-          updatePreferences({
-            theme: preferences.theme === "light" ? "dark" : "light",
-          })
+      <RadioGroup
+        onSelect={(theme: "light" | "dark") => {
+          updatePreferences({ theme })
         }}
+        defaultValue={preferences.theme}
       >
-        Dark mode: {preferences.theme === "light" ? "Off" : "On"}
-      </Button>
+        <Radio value="light">Default</Radio>
+
+        <Spacer y={1} />
+
+        <Radio value="dark">Dark</Radio>
+      </RadioGroup>
     </>
   )
 }

--- a/src/Components/Footer/Footer.tsx
+++ b/src/Components/Footer/Footer.tsx
@@ -30,6 +30,9 @@ import { useSystemContext } from "System/useSystemContext"
 import ArtsyMarkIcon from "@artsy/icons/ArtsyMarkIcon"
 import { useFeatureFlag } from "System/useFeatureFlag"
 import { useDarkModeToggle } from "Utils/Hooks/useDarkModeToggle"
+import { themeGet } from "@styled-system/theme-get"
+import CheckmarkStrokeIcon from "@artsy/icons/CheckmarkStrokeIcon"
+import EmptyCheckCircleIcon from "@artsy/icons/EmptyCheckCircleIcon"
 
 interface FooterProps extends BoxProps {}
 
@@ -175,7 +178,7 @@ export const Footer: React.FC<FooterProps> = props => {
 
           {isDarkModeEnabled && (
             <Column span={12} display={["flex", "none"]}>
-              <DarkModeToggle />
+              <ThemeSelect />
             </Column>
           )}
         </GridColumns>
@@ -208,7 +211,7 @@ export const Footer: React.FC<FooterProps> = props => {
                   <>
                     <Spacer x={1} />
 
-                    <DarkModeToggle />
+                    <ThemeSelect />
                   </>
                 )}
               </Flex>
@@ -297,25 +300,82 @@ export const Footer: React.FC<FooterProps> = props => {
   )
 }
 
-const DarkModeToggle: React.FC = () => {
-  const { toggleDarkMode, isDarkModeActive } = useDarkModeToggle({
+const ThemeSelect: React.FC = () => {
+  const { preferences, updatePreferences } = useDarkModeToggle({
     attachKeyListeners: false,
   })
 
   return (
     <>
-      <Clickable onClick={toggleDarkMode}>
-        <Text
-          variant="xs"
-          color="black60"
-          style={{ textDecoration: "underline" }}
-        >
-          Dark Mode | {isDarkModeActive ? "On" : "Off"}
-        </Text>
-      </Clickable>
+      <Dropdown
+        openDropdownByClick
+        // eslint-disable-next-line react/no-unstable-nested-components
+        dropdown={({ onHide }) => {
+          return (
+            <>
+              <ThemeSelectOption
+                as={Clickable}
+                onClick={() => {
+                  updatePreferences({ theme: "light" })
+                  onHide()
+                }}
+              >
+                {preferences.theme === "light" ? (
+                  <CheckmarkStrokeIcon />
+                ) : (
+                  <EmptyCheckCircleIcon />
+                )}
+                Default
+              </ThemeSelectOption>
+
+              <ThemeSelectOption
+                as={Clickable}
+                onClick={() => {
+                  updatePreferences({ theme: "dark" })
+                  onHide()
+                }}
+              >
+                {preferences.theme === "dark" ? (
+                  <CheckmarkStrokeIcon />
+                ) : (
+                  <EmptyCheckCircleIcon />
+                )}
+                Dark
+              </ThemeSelectOption>
+            </>
+          )
+        }}
+      >
+        {({ anchorRef, anchorProps }) => {
+          return (
+            <Clickable ref={anchorRef as any} {...anchorProps}>
+              <Text variant="xs" color="black60">
+                Theme
+              </Text>
+            </Clickable>
+          )
+        }}
+      </Dropdown>
     </>
   )
 }
+
+const ThemeSelectOption = styled(Text).attrs({
+  variant: "xs",
+  pl: 1,
+  pr: 1,
+  py: 0.5,
+  gap: 0.5,
+})`
+  display: flex;
+  position: relative;
+  align-items: center;
+  width: 100%;
+
+  &:hover {
+    background-color: ${themeGet("colors.black5")};
+  }
+`
 
 const PolicyLinks = () => {
   const { CCPARequestComponent, showCCPARequest } = useCCPARequest()

--- a/src/Utils/Hooks/useDarkModeToggle.ts
+++ b/src/Utils/Hooks/useDarkModeToggle.ts
@@ -40,5 +40,7 @@ export const useDarkModeToggle = ({
   return {
     toggleDarkMode,
     isDarkModeActive,
+    updatePreferences,
+    preferences,
   }
 }

--- a/src/__generated__/PreferencesAppTestQuery.graphql.ts
+++ b/src/__generated__/PreferencesAppTestQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5369f2340b50ca4b61cf2b15661f3268>>
+ * @generated SignedSource<<724a54a6495567db1d2612f95c3bacc0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -21,15 +21,7 @@ export type PreferencesAppTestQuery = {
   variables: PreferencesAppTestQuery$variables;
 };
 
-const node: ConcreteRequest = (function(){
-var v0 = [
-  {
-    "kind": "Literal",
-    "name": "authenticationToken",
-    "value": "123"
-  }
-];
-return {
+const node: ConcreteRequest = {
   "fragment": {
     "argumentDefinitions": [],
     "kind": "Fragment",
@@ -45,7 +37,7 @@ return {
         "plural": false,
         "selections": [
           {
-            "args": (v0/*: any*/),
+            "args": null,
             "kind": "FragmentSpread",
             "name": "PreferencesApp_viewer"
           }
@@ -72,7 +64,7 @@ return {
         "selections": [
           {
             "alias": null,
-            "args": (v0/*: any*/),
+            "args": null,
             "concreteType": "NotificationPreference",
             "kind": "LinkedField",
             "name": "notificationPreferences",
@@ -93,7 +85,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "notificationPreferences(authenticationToken:\"123\")"
+            "storageKey": null
           }
         ],
         "storageKey": null
@@ -101,16 +93,45 @@ return {
     ]
   },
   "params": {
-    "cacheID": "9e502959c4441f0cdce67b766bbc6f2a",
+    "cacheID": "1a18f0845044c123c015049ea2a69573",
     "id": null,
-    "metadata": {},
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "viewer": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Viewer"
+        },
+        "viewer.notificationPreferences": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": true,
+          "type": "NotificationPreference"
+        },
+        "viewer.notificationPreferences.name": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "String"
+        },
+        "viewer.notificationPreferences.status": {
+          "enumValues": [
+            "SUBSCRIBED",
+            "UNSUBSCRIBED"
+          ],
+          "nullable": false,
+          "plural": false,
+          "type": "SubGroupStatus"
+        }
+      }
+    },
     "name": "PreferencesAppTestQuery",
     "operationKind": "query",
-    "text": "query PreferencesAppTestQuery {\n  viewer {\n    ...PreferencesApp_viewer_1hTG6C\n  }\n}\n\nfragment PreferencesApp_viewer_1hTG6C on Viewer {\n  notificationPreferences(authenticationToken: \"123\") {\n    name\n    status\n  }\n}\n"
+    "text": "query PreferencesAppTestQuery {\n  viewer {\n    ...PreferencesApp_viewer\n  }\n}\n\nfragment PreferencesApp_viewer on Viewer {\n  notificationPreferences {\n    name\n    status\n  }\n}\n"
   }
 };
-})();
 
-(node as any).hash = "2b3d5ff860b9ce102cde04d52e242790";
+(node as any).hash = "643af9897cedd91a59e33cc6ce08fe50";
 
 export default node;


### PR DESCRIPTION
Closes [DIA-664](https://artsyproduct.atlassian.net/browse/DIA-664)

With this we can enable the feature flag. I'll leave the flag in place for a week then PR it's removal.

This PR fixes a small bug where we would block updates to preferences until the previous one completed. Instead now we maintain a queue of operations and apply them in order, while optimistically updating them in local state. (Read: It's fun to flip the theme back and forth rapidly).

And some minor rework of the theme selector design.

In the footer:
![](https://capture.static.damonzucconi.com/Screen-Shot-2024-06-07-07-54-58.77-LizPvAjUoF1ZXYtkuD2sgYNtLp6xoQZIedEUfe1f664ase6zhE185RF659Itz9La160ro5gwDEfN8HO58VR0ldk7ZusXreo3v2fx.png)

In account settings:
![](https://capture.static.damonzucconi.com/Screen-Shot-2024-06-07-07-55-33.63-2LsC9AKteLWYigxgqYXvrX1sC8V6JHqD89AOs7rFWy3NnBpfeizc9qNQn2OqMxqaOBnq0btzuVYUtwfzQCqxEzYGXxdH7bLKmv5Y.png)


[DIA-664]: https://artsyproduct.atlassian.net/browse/DIA-664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ