### PR TITLE
feat: New submission flow artist step

### DIFF
--- a/src/Apps/Artwork/Components/__tests__/ArtworkPageBanner.jest.tsx
+++ b/src/Apps/Artwork/Components/__tests__/ArtworkPageBanner.jest.tsx
@@ -1,14 +1,13 @@
-import React from "react"
-import { waitFor } from "@testing-library/react"
 import { screen } from "@testing-library/dom"
+import { waitFor } from "@testing-library/react"
 import { ArtworkPageBanner } from "Apps/Artwork/Components/ArtworkPageBanner"
-import { graphql } from "react-relay"
+import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
-import { ArtworkPageBanner_Test_Query$rawResponse } from "__generated__/ArtworkPageBanner_Test_Query.graphql"
 import { useRouter } from "System/Router/useRouter"
 import { useFeatureFlag } from "System/useFeatureFlag"
 import { DeepPartial } from "Utils/typeSupport"
-import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
+import { ArtworkPageBanner_Test_Query$rawResponse } from "__generated__/ArtworkPageBanner_Test_Query.graphql"
+import { graphql } from "react-relay"
 
 const mockUseRouter = useRouter as jest.Mock
 const mockUseFeatureFlag = useFeatureFlag as jest.Mock

--- a/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtistAutocomplete.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtistAutocomplete.tsx
@@ -1,3 +1,4 @@
+import ChevronRightIcon from "@artsy/icons/ChevronRightIcon"
 import {
   AutocompleteInput,
   AutocompleteInputOptionType,
@@ -6,16 +7,16 @@ import {
   Image,
   Text,
 } from "@artsy/palette"
-import { useFormikContext } from "formik"
-import { debounce } from "lodash"
-import { useEffect, useMemo, useState } from "react"
-import { Environment, fetchQuery, graphql } from "react-relay"
 import { useSystemContext } from "System/useSystemContext"
 import { extractNodes } from "Utils/extractNodes"
 import {
   ArtistAutocomplete_SearchConnection_Query,
   ArtistAutocomplete_SearchConnection_Query$data,
 } from "__generated__/ArtistAutocomplete_SearchConnection_Query.graphql"
+import { useFormikContext } from "formik"
+import { debounce } from "lodash"
+import { useEffect, useMemo, useState } from "react"
+import { Environment, fetchQuery, graphql } from "react-relay"
 import { ArtworkDetailsFormModel } from "./ArtworkDetailsForm"
 
 const DEBOUNCE_DELAY = 300
@@ -43,6 +44,7 @@ export const ArtistAutoComplete: React.FC<{
   onChange?: (value: string) => void
   onSelect: (artist: AutocompleteArtist | null) => void
   placeholder?: string
+  showChevronIcon?: boolean
   required?: boolean
   title?: string
 }> = ({
@@ -51,6 +53,7 @@ export const ArtistAutoComplete: React.FC<{
   onChange,
   onSelect,
   placeholder = "Enter full name",
+  showChevronIcon = true,
   required,
   title,
 }) => {
@@ -156,25 +159,29 @@ export const ArtistAutoComplete: React.FC<{
     const image = option.option?.image
 
     return (
-      <Flex alignItems="center" p={1} width="100%">
-        {option.option?.image ? (
-          <Image
-            src={image?.cropped?.src}
-            srcSet={image?.cropped?.srcSet}
-            width={image?.cropped?.width}
-            height={image?.cropped?.height}
-          />
-        ) : (
-          <Box width={44} height={44} backgroundColor="black10" />
-        )}
-        <Flex flexDirection={"column"}>
-          <Text ml={1} variant="sm-display">
-            {option.text}
-          </Text>
-          <Text ml={1} lineHeight={1.5} variant="sm-display" color="black60">
-            {option.option?.formattedNationalityAndBirthday}
-          </Text>
+      <Flex justifyContent="space-between">
+        <Flex alignItems="center" p={1} width="100%">
+          {option.option?.image ? (
+            <Image
+              src={image?.cropped?.src}
+              srcSet={image?.cropped?.srcSet}
+              width={image?.cropped?.width}
+              height={image?.cropped?.height}
+            />
+          ) : (
+            <Box width={44} height={44} backgroundColor="black10" />
+          )}
+          <Flex flexDirection={"column"}>
+            <Text ml={1} variant="sm-display">
+              {option.text}
+            </Text>
+            <Text ml={1} lineHeight={1.5} variant="sm-display" color="black60">
+              {option.option?.formattedNationalityAndBirthday}
+            </Text>
+          </Flex>
         </Flex>
+
+        {!!showChevronIcon && <ChevronRightIcon m="auto" mr={1} />}
       </Flex>
     )
   }

--- a/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtistAutocomplete.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtistAutocomplete.tsx
@@ -171,11 +171,9 @@ export const ArtistAutoComplete: React.FC<{
           ) : (
             <Box width={44} height={44} backgroundColor="black10" />
           )}
-          <Flex flexDirection={"column"}>
-            <Text ml={1} variant="sm-display">
-              {option.text}
-            </Text>
-            <Text ml={1} lineHeight={1.5} variant="sm-display" color="black60">
+          <Flex ml={1} flexDirection="column">
+            <Text variant="sm-display">{option.text}</Text>
+            <Text lineHeight={1.5} variant="sm-display" color="black60">
               {option.option?.formattedNationalityAndBirthday}
             </Text>
           </Flex>

--- a/src/Apps/Sell/Components/BottomFormNavigation.tsx
+++ b/src/Apps/Sell/Components/BottomFormNavigation.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, Link } from "@artsy/palette"
+import { Box, Button, Flex, Link } from "@artsy/palette"
 import { useSellFlowContext } from "Apps/Sell/SellFlowContext"
 import { useRouter } from "System/Router/useRouter"
 import { useFormikContext } from "formik"
@@ -8,7 +8,7 @@ export const BottomFormNavigation = () => {
   const { router } = useRouter()
   const {
     actions,
-    state: { isLastStep, submissionID },
+    state: { isFirstStep, isLastStep, submissionID },
   } = useSellFlowContext()
 
   const onContinue = async () => {
@@ -32,7 +32,11 @@ export const BottomFormNavigation = () => {
         justifyContent="space-between"
         alignItems="center"
       >
-        <Link onClick={actions.goToPreviousStep}>Back</Link>
+        {isFirstStep ? (
+          <Box />
+        ) : (
+          <Link onClick={actions.goToPreviousStep}>Back</Link>
+        )}
 
         {isLastStep ? (
           <Button

--- a/src/Apps/Sell/Routes/ArtistRoute.tsx
+++ b/src/Apps/Sell/Routes/ArtistRoute.tsx
@@ -7,12 +7,12 @@ import { DevDebug } from "Apps/Sell/Components/DevDebug"
 import { SubmissionLayout } from "Apps/Sell/Components/SubmissionLayout"
 import { useSellFlowContext } from "Apps/Sell/SellFlowContext"
 import { RouterLink } from "System/Router/RouterLink"
+import { useRouter } from "System/Router/useRouter"
 import {
   ArtistRoute_submission$data,
   ArtistRoute_submission$key,
 } from "__generated__/ArtistRoute_submission.graphql"
 import { Formik, FormikProps } from "formik"
-import { useRouter } from "found"
 import * as React from "react"
 import { graphql, useFragment } from "react-relay"
 import * as Yup from "yup"
@@ -60,7 +60,7 @@ export const ArtistRoute: React.FC<{
 
   const isNewSubmission = !submission?.internalID
 
-  const onSubmit = async (values: FormValues) => {}
+  const onSubmit = async () => {}
 
   const createSubmission = async (artist: AutocompleteArtist) => {
     if (!artist?.internalID) return

--- a/src/Apps/Sell/Routes/ArtistRoute.tsx
+++ b/src/Apps/Sell/Routes/ArtistRoute.tsx
@@ -1,0 +1,178 @@
+import { Spacer, Text } from "@artsy/palette"
+import {
+  ArtistAutoComplete,
+  AutocompleteArtist,
+} from "Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtistAutocomplete"
+import { DevDebug } from "Apps/Sell/Components/DevDebug"
+import { SubmissionLayout } from "Apps/Sell/Components/SubmissionLayout"
+import { useSellFlowContext } from "Apps/Sell/SellFlowContext"
+import { RouterLink } from "System/Router/RouterLink"
+import {
+  ArtistRoute_submission$data,
+  ArtistRoute_submission$key,
+} from "__generated__/ArtistRoute_submission.graphql"
+import { Formik, FormikProps } from "formik"
+import { useRouter } from "found"
+import * as React from "react"
+import { graphql, useFragment } from "react-relay"
+import * as Yup from "yup"
+
+const FRAGMENT = graphql`
+  fragment ArtistRoute_submission on ConsignmentSubmission {
+    internalID
+    artist {
+      internalID
+      targetSupply {
+        isTargetSupply
+      }
+      name
+    }
+  }
+`
+
+const Schema = Yup.object().shape({
+  artistName: Yup.string().required(),
+  artistId: Yup.string().required(),
+  isTargetSupply: Yup.boolean().isTrue(),
+})
+
+interface FormValues {
+  artistId: string
+  artistName: string
+  isTargetSupply: boolean
+}
+
+interface ArtistRouteProps {
+  submission: ArtistRoute_submission$key
+}
+
+export const ArtistRouteFragmentContainer: React.FC<ArtistRouteProps> = props => {
+  const submission = useFragment(FRAGMENT, props.submission)
+
+  return <ArtistRoute submission={submission} />
+}
+
+export const ArtistRoute: React.FC<{
+  submission?: ArtistRoute_submission$data
+}> = ({ submission }) => {
+  const { router } = useRouter()
+  const { actions } = useSellFlowContext()
+
+  const isNewSubmission = !submission?.internalID
+
+  const onSubmit = async (values: FormValues) => {}
+
+  const createSubmission = async (artist: AutocompleteArtist) => {
+    if (!artist?.internalID) return
+
+    const isTargetSupply = artist?.targetSupply?.isTargetSupply
+
+    if (!isTargetSupply) {
+      router.push(`/sell2/artist-not-eligible/${artist.internalID}`)
+      return
+    }
+
+    const response = await actions.createSubmission({
+      artistID: artist.internalID,
+    })
+    const submissionID =
+      response?.createConsignmentSubmission?.consignmentSubmission?.externalId
+
+    router.replace(`/sell2/submissions/${submissionID}/artist`)
+    router.push(`/sell2/submissions/${submissionID}/title`)
+  }
+
+  const updateSubmission = async (artist: AutocompleteArtist) => {
+    if (!artist?.internalID) return
+
+    const isTargetSupply = artist?.targetSupply?.isTargetSupply
+    if (!isTargetSupply) {
+      return
+    }
+
+    await actions.updateSubmission({ artistID: artist.internalID })
+    actions.goToNextStep()
+  }
+
+  const onSelect = async (
+    artist: AutocompleteArtist,
+    formik: FormikProps<FormValues>
+  ) => {
+    if (!artist?.internalID) return
+
+    const isTargetSupply = artist?.targetSupply?.isTargetSupply
+    formik.setFieldValue("isTargetSupply", isTargetSupply)
+
+    if (isNewSubmission) {
+      createSubmission(artist)
+    } else {
+      updateSubmission(artist)
+    }
+  }
+
+  const initialValues: FormValues = {
+    artistName: submission?.artist?.name || "",
+    artistId: submission?.artist?.internalID || "",
+    isTargetSupply: submission?.artist?.targetSupply?.isTargetSupply || false,
+  }
+
+  return (
+    <Formik<FormValues>
+      initialValues={initialValues}
+      onSubmit={onSubmit}
+      validateOnMount
+      validationSchema={Schema}
+    >
+      {formik => (
+        <SubmissionLayout hideNavigation={isNewSubmission}>
+          <Text mb={2} variant="xl">
+            Add artist name
+          </Text>
+
+          <ArtistAutoComplete
+            onSelect={artist => {
+              onSelect(artist, formik)
+            }}
+            onError={() => console.error("something happened")}
+            showChevronIcon
+            title="Artist"
+          />
+
+          <Text mt={2} variant="sm" color="black60">
+            Currently, artists can not sell their own work on Artsy.{" "}
+            <RouterLink to="https://support.artsy.net/s/article/Im-an-artist-Can-I-submit-my-own-work-to-sell">
+              Learn more.
+            </RouterLink>
+          </Text>
+
+          {!isNewSubmission &&
+            formik.values.artistId &&
+            !formik.values.isTargetSupply && (
+              <>
+                <Spacer y={2} />
+                <Text variant="lg">
+                  This artist isn't currently eligible to sell on our platform
+                </Text>
+                <Text mt={2} variant="sm">
+                  Try again with another artist or add your artwork to My
+                  Collection, your personal space to manage your collection,
+                  track demand for your artwork and see updates about the
+                  artist. If you'd like to know more, you can&nbsp;
+                  <RouterLink to="#">contact an advisor&nbsp;</RouterLink>
+                  or read about&nbsp;
+                  <RouterLink to="#">
+                    what our specialists are looking for
+                  </RouterLink>
+                  . After adding to My Collection, an Artsy Advisor will be in
+                  touch if there is an opportunity to sell your work in the
+                  future.
+                </Text>
+              </>
+            )}
+
+          <DevDebug />
+        </SubmissionLayout>
+      )}
+    </Formik>
+  )
+}

--- a/src/Apps/Sell/Routes/NewRoute.tsx
+++ b/src/Apps/Sell/Routes/NewRoute.tsx
@@ -1,122 +1,15 @@
-import { FullBleed, Spacer, Text } from "@artsy/palette"
+import { FullBleed } from "@artsy/palette"
 import { AppContainer } from "Apps/Components/AppContainer"
-import {
-  ArtistAutoComplete,
-  AutocompleteArtist,
-} from "Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtistAutocomplete"
-import { DevDebug } from "Apps/Sell/Components/DevDebug"
-import { SubmissionLayout } from "Apps/Sell/Components/SubmissionLayout"
-import { useCreateSubmission } from "Apps/Sell/Mutations/useCreateSubmission"
+import { ArtistRoute } from "Apps/Sell/Routes/ArtistRoute"
 import { SellFlowContextProvider } from "Apps/Sell/SellFlowContext"
-import { RouterLink } from "System/Router/RouterLink"
-import { Formik, FormikProps } from "formik"
-import { useRouter } from "found"
 import * as React from "react"
-import * as Yup from "yup"
-
-const Schema = Yup.object().shape({
-  artistId: Yup.string().required(),
-  isTargetSupply: Yup.boolean().isTrue(),
-})
-
-interface FormValues {
-  artistId: string
-  isTargetSupply: boolean
-}
 
 export const NewRoute: React.FC = () => {
-  const { router } = useRouter()
-  const {
-    submitMutation: submitCreateSubmissionMutation,
-  } = useCreateSubmission()
-
-  const onSubmit = async (values: FormValues) => {}
-
-  const onSelect = async (
-    artist: AutocompleteArtist,
-    formik: FormikProps<FormValues>
-  ) => {
-    const isTargetSupply = artist?.targetSupply?.isTargetSupply
-    formik.setFieldValue("isTargetSupply", isTargetSupply)
-
-    if (artist?.internalID && isTargetSupply) {
-      const response = await submitCreateSubmissionMutation({
-        variables: {
-          input: { artistID: artist.internalID },
-        },
-      })
-
-      const submissionID =
-        response.createConsignmentSubmission?.consignmentSubmission?.externalId
-
-      router.push(`/sell2/submissions/${submissionID}/title`)
-    }
-  }
-
-  const initialValues: FormValues = {
-    artistId: "",
-    isTargetSupply: false,
-  }
-
   return (
     <FullBleed>
       <AppContainer>
         <SellFlowContextProvider>
-          <Formik<FormValues>
-            initialValues={initialValues}
-            onSubmit={onSubmit}
-            validateOnMount
-            validationSchema={Schema}
-          >
-            {formik => (
-              <SubmissionLayout hideNavigation>
-                <Text mb={2} variant="xl">
-                  Add artist name
-                </Text>
-
-                <ArtistAutoComplete
-                  onSelect={artist => {
-                    onSelect(artist, formik)
-                  }}
-                  onError={() => console.error("something happened")}
-                  title="Artist"
-                />
-
-                <Text mt={2} variant="sm" color="black60">
-                  Currently, artists can not sell their own work on Artsy.{" "}
-                  <RouterLink to="https://support.artsy.net/s/article/Im-an-artist-Can-I-submit-my-own-work-to-sell">
-                    Learn more.
-                  </RouterLink>
-                </Text>
-
-                {formik.values.artistId && !formik.values.isTargetSupply && (
-                  <>
-                    <Spacer y={2} />
-                    <Text variant="lg">
-                      This artist isn't currently eligible to sell on our
-                      platform
-                    </Text>
-                    <Text mt={2} variant="sm">
-                      Try again with another artist or add your artwork to My
-                      Collection, your personal space to manage your collection,
-                      track demand for your artwork and see updates about the
-                      artist. If you'd like to know more, you can&nbsp;
-                      <RouterLink to="#">contact an advisor&nbsp;</RouterLink>
-                      or read about&nbsp;
-                      <RouterLink to="#">
-                        what our specialists are looking for
-                      </RouterLink>
-                      . After adding to My Collection, an Artsy Advisor will be
-                      in touch if there is an opportunity to sell your work in
-                      the future.
-                    </Text>
-                  </>
-                )}
-
-                <DevDebug />
-              </SubmissionLayout>
-            )}
-          </Formik>
+          <ArtistRoute />
         </SellFlowContextProvider>
       </AppContainer>
     </FullBleed>

--- a/src/Apps/Sell/Routes/__tests__/ArtistRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/ArtistRoute.jest.tsx
@@ -1,24 +1,55 @@
-import { screen } from "@testing-library/dom"
-import { waitFor } from "@testing-library/react"
-import { ArtistRouteFragmentContainer } from "Apps/Sell/Routes/ArtistRoute"
+import { screen } from "@testing-library/react"
+import { fireEvent, waitFor } from "@testing-library/react"
+import { ArtistRoute } from "Apps/Sell/Routes/ArtistRoute"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
-import { trackEvent } from "Server/analytics/helpers"
 import { useRouter } from "System/Router/useRouter"
+import { DeepPartial } from "Utils/typeSupport"
+import { ArtistRoute_Test_Query$rawResponse } from "__generated__/ArtistRoute_Test_Query.graphql"
 import { graphql } from "react-relay"
-import { useTracking } from "react-tracking"
 
+const mockUseRouter = useRouter as jest.Mock
+const mockPush = jest.fn()
+const mockReplace = jest.fn()
+
+jest.mock("System/Router/useRouter", () => ({
+  useRouter: jest.fn(() => ({ match: { location: { query: {} } } })),
+}))
 jest.unmock("react-relay")
 
-jest.mock("System/Router/useRouter")
-jest.mock("System/useSystemContext")
+jest.mock("react-relay", () => ({
+  ...jest.requireActual("react-relay"),
+  fetchQuery: jest.fn(),
+}))
+
+const submissionMock: DeepPartial<
+  ArtistRoute_Test_Query$rawResponse["submission"]
+> = {
+  internalID: "example",
+  artist: {
+    internalID: "example-id",
+    targetSupply: {
+      isTargetSupply: true,
+    },
+    name: "Example Artist",
+  },
+}
+
+beforeEach(() => {
+  mockUseRouter.mockImplementation(() => ({
+    router: {
+      push: mockPush,
+      replace: mockReplace,
+    },
+  }))
+})
 
 const { renderWithRelay } = setupTestWrapperTL({
   Component: (props: any) => {
-    return <ArtistRouteFragmentContainer submission={props.submission} />
+    return <ArtistRoute submission={props.submission} />
   },
   query: graphql`
     query ArtistRoute_Test_Query @raw_response_type {
-      submission(id: "example") {
+      submission(id: "submission-id") {
         ...ArtistRoute_submission
       }
     }
@@ -26,42 +57,43 @@ const { renderWithRelay } = setupTestWrapperTL({
 })
 
 describe("ArtistRoute", () => {
-  beforeEach(() => {
-    ;(useTracking as jest.Mock).mockImplementation(() => {
-      return {
-        trackEvent,
-      }
-    })
-    ;(useRouter as jest.Mock).mockImplementation(() => {
-      return {
-        match: {
-          params: {
-            id: "12345",
-          },
-        },
-        router: {
-          push: jest.fn(),
-        },
-      }
-    })
-  })
-
-  it("renders the submission with artist", async () => {
+  it("renders the artist step", async () => {
     renderWithRelay({
-      Submission: () => ({
-        internalID: "example",
-        artist: {
-          internalID: "example-id",
-          targetSupply: {
-            isTargetSupply: true,
-          },
-          name: "Example Artist",
-        },
-      }),
+      submission: () => submissionMock,
     })
 
     await waitFor(() => {
       expect(screen.getByText("Add artist name")).toBeInTheDocument()
+    })
+  })
+
+  describe("artist input", () => {
+    it("is required", async () => {
+      renderWithRelay({
+        submission: () => submissionMock,
+      })
+
+      await waitFor(async () => {
+        const artistInput = screen.getByPlaceholderText("Enter full name")
+
+        fireEvent.change(artistInput, { target: { value: "Banksy" } })
+
+        expect(artistInput).toBeInTheDocument()
+
+        expect(artistInput).toHaveValue("Banksy")
+      })
+    })
+  })
+
+  describe("Learn more link", () => {
+    it("navigates to the artist not eligible page if the artist is not eligible", async () => {
+      renderWithRelay({
+        submission: () => submissionMock,
+      })
+
+      expect(screen.getByText("Learn more.").attributes["href"].value).toBe(
+        "https://support.artsy.net/s/article/Im-an-artist-Can-I-submit-my-own-work-to-sell"
+      )
     })
   })
 })

--- a/src/Apps/Sell/Routes/__tests__/ArtistRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/ArtistRoute.jest.tsx
@@ -1,0 +1,67 @@
+import { screen } from "@testing-library/dom"
+import { waitFor } from "@testing-library/react"
+import { ArtistRouteFragmentContainer } from "Apps/Sell/Routes/ArtistRoute"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
+import { trackEvent } from "Server/analytics/helpers"
+import { useRouter } from "System/Router/useRouter"
+import { graphql } from "react-relay"
+import { useTracking } from "react-tracking"
+
+jest.unmock("react-relay")
+
+jest.mock("System/Router/useRouter")
+jest.mock("System/useSystemContext")
+
+const { renderWithRelay } = setupTestWrapperTL({
+  Component: (props: any) => {
+    return <ArtistRouteFragmentContainer submission={props.submission} />
+  },
+  query: graphql`
+    query ArtistRoute_Test_Query @raw_response_type {
+      submission(id: "example") {
+        ...ArtistRoute_submission
+      }
+    }
+  `,
+})
+
+describe("ArtistRoute", () => {
+  beforeEach(() => {
+    ;(useTracking as jest.Mock).mockImplementation(() => {
+      return {
+        trackEvent,
+      }
+    })
+    ;(useRouter as jest.Mock).mockImplementation(() => {
+      return {
+        match: {
+          params: {
+            id: "12345",
+          },
+        },
+        router: {
+          push: jest.fn(),
+        },
+      }
+    })
+  })
+
+  it("renders the submission with artist", async () => {
+    renderWithRelay({
+      Submission: () => ({
+        internalID: "example",
+        artist: {
+          internalID: "example-id",
+          targetSupply: {
+            isTargetSupply: true,
+          },
+          name: "Example Artist",
+        },
+      }),
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("Add artist name")).toBeInTheDocument()
+    })
+  })
+})

--- a/src/Apps/Sell/Routes/__tests__/NewRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/NewRoute.jest.tsx
@@ -1,0 +1,38 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { NewRoute } from "Apps/Sell/Routes/NewRoute"
+import { useRouter } from "System/Router/useRouter"
+
+const mockUseRouter = useRouter as jest.Mock
+const mockPush = jest.fn()
+const mockReplace = jest.fn()
+
+jest.mock("System/Router/useRouter", () => ({
+  useRouter: jest.fn(() => ({ match: { location: { query: {} } } })),
+}))
+jest.unmock("react-relay")
+
+beforeEach(() => {
+  mockUseRouter.mockImplementation(() => ({
+    router: {
+      push: mockPush,
+      replace: mockReplace,
+    },
+    match: { location: { pathname: "/submissions/new" } },
+  }))
+})
+
+describe("NewRoute", () => {
+  it("renders the artist step with context", async () => {
+    render(<NewRoute />)
+
+    await waitFor(() => {
+      expect(screen.getByText("Add artist name")).toBeInTheDocument()
+
+      const artistInput = screen.getByPlaceholderText("Enter full name")
+
+      fireEvent.change(artistInput, { target: { value: "Banksy" } })
+
+      expect(artistInput).toBeInTheDocument()
+    })
+  })
+})

--- a/src/Apps/Sell/sellRoutes.tsx
+++ b/src/Apps/Sell/sellRoutes.tsx
@@ -23,6 +23,13 @@ const NewRoute = loadable(
   }
 )
 
+const ArtistRoute = loadable(
+  () => import(/* webpackChunkName: "sellBundle" */ "./Routes/ArtistRoute"),
+  {
+    resolveComponent: component => component.ArtistRouteFragmentContainer,
+  }
+)
+
 const TitleRoute = loadable(
   () => import(/* webpackChunkName: "sellBundle" */ "./Routes/TitleRoute"),
   {
@@ -85,7 +92,7 @@ export const sellRoutes: AppRouteConfig[] = [
       {
         path: "intro",
         layout: "ContainerOnly",
-        Component : IntroRoute,
+        Component: IntroRoute,
         onClientSideRender: () => {
           IntroRoute.preload()
         },
@@ -141,6 +148,24 @@ export const sellRoutes: AppRouteConfig[] = [
           return { id }
         },
         children: [
+          {
+            path: "artist",
+            layout: "ContainerOnly",
+            Component: ArtistRoute,
+            onClientSideRender: () => {
+              ArtistRoute.preload()
+            },
+            query: graphql`
+              query sellRoutes_ArtistRouteQuery($id: ID!) {
+                submission(id: $id) @principalField {
+                  ...ArtistRoute_submission
+                }
+              }
+            `,
+            prepareVariables: ({ id }) => {
+              return { id }
+            },
+          },
           {
             path: "title",
             layout: "ContainerOnly",

--- a/src/__generated__/ArtistRoute_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistRoute_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ea665ef4b9e6c21a89b77535eaa408bc>>
+ * @generated SignedSource<<6cb9245d5474663f1217a8dd9a546cbe>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -41,7 +41,7 @@ var v0 = [
   {
     "kind": "Literal",
     "name": "id",
-    "value": "example"
+    "value": "submission-id"
   }
 ],
 v1 = {
@@ -79,7 +79,7 @@ return {
             "name": "ArtistRoute_submission"
           }
         ],
-        "storageKey": "submission(id:\"example\")"
+        "storageKey": "submission(id:\"submission-id\")"
       }
     ],
     "type": "Query",
@@ -140,21 +140,21 @@ return {
           },
           (v2/*: any*/)
         ],
-        "storageKey": "submission(id:\"example\")"
+        "storageKey": "submission(id:\"submission-id\")"
       }
     ]
   },
   "params": {
-    "cacheID": "015429ae5b5dc1e2325217076eb15209",
+    "cacheID": "02f33048eaad2ecc9b66d4105804f148",
     "id": null,
     "metadata": {},
     "name": "ArtistRoute_Test_Query",
     "operationKind": "query",
-    "text": "query ArtistRoute_Test_Query {\n  submission(id: \"example\") {\n    ...ArtistRoute_submission\n    id\n  }\n}\n\nfragment ArtistRoute_submission on ConsignmentSubmission {\n  internalID\n  artist {\n    internalID\n    targetSupply {\n      isTargetSupply\n    }\n    name\n    id\n  }\n}\n"
+    "text": "query ArtistRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...ArtistRoute_submission\n    id\n  }\n}\n\nfragment ArtistRoute_submission on ConsignmentSubmission {\n  internalID\n  artist {\n    internalID\n    targetSupply {\n      isTargetSupply\n    }\n    name\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "e29ccfe5ac54835327285ebe91fb9213";
+(node as any).hash = "4dfa674c44131bf1825354211b1d8642";
 
 export default node;

--- a/src/__generated__/ArtistRoute_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistRoute_Test_Query.graphql.ts
@@ -1,0 +1,160 @@
+/**
+ * @generated SignedSource<<ea665ef4b9e6c21a89b77535eaa408bc>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ArtistRoute_Test_Query$variables = Record<PropertyKey, never>;
+export type ArtistRoute_Test_Query$data = {
+  readonly submission: {
+    readonly " $fragmentSpreads": FragmentRefs<"ArtistRoute_submission">;
+  } | null | undefined;
+};
+export type ArtistRoute_Test_Query$rawResponse = {
+  readonly submission: {
+    readonly artist: {
+      readonly id: string;
+      readonly internalID: string;
+      readonly name: string | null | undefined;
+      readonly targetSupply: {
+        readonly isTargetSupply: boolean | null | undefined;
+      };
+    } | null | undefined;
+    readonly id: string;
+    readonly internalID: string | null | undefined;
+  } | null | undefined;
+};
+export type ArtistRoute_Test_Query = {
+  rawResponse: ArtistRoute_Test_Query$rawResponse;
+  response: ArtistRoute_Test_Query$data;
+  variables: ArtistRoute_Test_Query$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "example"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ArtistRoute_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "ConsignmentSubmission",
+        "kind": "LinkedField",
+        "name": "submission",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ArtistRoute_submission"
+          }
+        ],
+        "storageKey": "submission(id:\"example\")"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "ArtistRoute_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "ConsignmentSubmission",
+        "kind": "LinkedField",
+        "name": "submission",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Artist",
+            "kind": "LinkedField",
+            "name": "artist",
+            "plural": false,
+            "selections": [
+              (v1/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ArtistTargetSupply",
+                "kind": "LinkedField",
+                "name": "targetSupply",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "isTargetSupply",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              },
+              (v2/*: any*/)
+            ],
+            "storageKey": null
+          },
+          (v2/*: any*/)
+        ],
+        "storageKey": "submission(id:\"example\")"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "015429ae5b5dc1e2325217076eb15209",
+    "id": null,
+    "metadata": {},
+    "name": "ArtistRoute_Test_Query",
+    "operationKind": "query",
+    "text": "query ArtistRoute_Test_Query {\n  submission(id: \"example\") {\n    ...ArtistRoute_submission\n    id\n  }\n}\n\nfragment ArtistRoute_submission on ConsignmentSubmission {\n  internalID\n  artist {\n    internalID\n    targetSupply {\n      isTargetSupply\n    }\n    name\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "e29ccfe5ac54835327285ebe91fb9213";
+
+export default node;

--- a/src/__generated__/ArtistRoute_submission.graphql.ts
+++ b/src/__generated__/ArtistRoute_submission.graphql.ts
@@ -1,0 +1,89 @@
+/**
+ * @generated SignedSource<<18acda3c0329298bafcb34749999620c>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { Fragment, ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ArtistRoute_submission$data = {
+  readonly artist: {
+    readonly internalID: string;
+    readonly name: string | null | undefined;
+    readonly targetSupply: {
+      readonly isTargetSupply: boolean | null | undefined;
+    };
+  } | null | undefined;
+  readonly internalID: string | null | undefined;
+  readonly " $fragmentType": "ArtistRoute_submission";
+};
+export type ArtistRoute_submission$key = {
+  readonly " $data"?: ArtistRoute_submission$data;
+  readonly " $fragmentSpreads": FragmentRefs<"ArtistRoute_submission">;
+};
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+};
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ArtistRoute_submission",
+  "selections": [
+    (v0/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Artist",
+      "kind": "LinkedField",
+      "name": "artist",
+      "plural": false,
+      "selections": [
+        (v0/*: any*/),
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ArtistTargetSupply",
+          "kind": "LinkedField",
+          "name": "targetSupply",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "isTargetSupply",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "ConsignmentSubmission",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "86fb9dcc510e71adcc0b29ed0f2ffbb2";
+
+export default node;

--- a/src/__generated__/sellRoutes_ArtistRouteQuery.graphql.ts
+++ b/src/__generated__/sellRoutes_ArtistRouteQuery.graphql.ts
@@ -1,0 +1,154 @@
+/**
+ * @generated SignedSource<<6e94064e0a43668b0766b4efd4cecfef>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type sellRoutes_ArtistRouteQuery$variables = {
+  id: string;
+};
+export type sellRoutes_ArtistRouteQuery$data = {
+  readonly submission: {
+    readonly " $fragmentSpreads": FragmentRefs<"ArtistRoute_submission">;
+  } | null | undefined;
+};
+export type sellRoutes_ArtistRouteQuery = {
+  response: sellRoutes_ArtistRouteQuery$data;
+  variables: sellRoutes_ArtistRouteQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "sellRoutes_ArtistRouteQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "ConsignmentSubmission",
+        "kind": "LinkedField",
+        "name": "submission",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ArtistRoute_submission"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "sellRoutes_ArtistRouteQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "ConsignmentSubmission",
+        "kind": "LinkedField",
+        "name": "submission",
+        "plural": false,
+        "selections": [
+          (v2/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Artist",
+            "kind": "LinkedField",
+            "name": "artist",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ArtistTargetSupply",
+                "kind": "LinkedField",
+                "name": "targetSupply",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "isTargetSupply",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              },
+              (v3/*: any*/)
+            ],
+            "storageKey": null
+          },
+          (v3/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "f9cc0979cfbbc7699bec4a1670ad2fb7",
+    "id": null,
+    "metadata": {},
+    "name": "sellRoutes_ArtistRouteQuery",
+    "operationKind": "query",
+    "text": "query sellRoutes_ArtistRouteQuery(\n  $id: ID!\n) {\n  submission(id: $id) @principalField {\n    ...ArtistRoute_submission\n    id\n  }\n}\n\nfragment ArtistRoute_submission on ConsignmentSubmission {\n  internalID\n  artist {\n    internalID\n    targetSupply {\n      isTargetSupply\n    }\n    name\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "45d0577595aaac4b3851de2c920f2805";
+
+export default node;


### PR DESCRIPTION
Addresses [ONYX-1014]

## Description

This implements the "Artist step for the new submission flow. 

### New Route

- `/sell2/submissions/new`
- renders the artist step without initializing the form


<img width="1424" alt="Screenshot 2024-06-11 at 14 44 34" src="https://github.com/artsy/force/assets/4691889/dbeafefd-1453-4813-b14a-4912f2dbca37">

## Edit Route

- `/sell2/submissions/:id/artist`
- renders the artist step and initializes the form

<img width="1423" alt="Screenshot 2024-06-11 at 14 43 38" src="https://github.com/artsy/force/assets/4691889/daf09b00-12a0-430c-8194-fe3c72e495e8">

[ONYX-1014]: https://artsyproduct.atlassian.net/browse/ONYX-1014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ