### PR TITLE
feat: add 05-near-object-rail experiment

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,5 +28,5 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "typescript.preferences.importModuleSpecifier": "non-relative",
-  "cSpell.words": ["openai"]
+  "cSpell.words": ["openai", "weaviate"]
 }

--- a/package.json
+++ b/package.json
@@ -203,6 +203,7 @@
     "use-deep-compare-effect": "^1.2.0",
     "uuid": "3.3.2",
     "waypoints": "4.0.0",
+    "weaviate-ts-client": "^2.2.0",
     "yargs": "11.0.0",
     "yup": "0.32.6"
   },

--- a/src/Apps/ArtAdvisor/05-Near-Object-Rail/App.tsx
+++ b/src/Apps/ArtAdvisor/05-Near-Object-Rail/App.tsx
@@ -1,0 +1,144 @@
+import { FC, useEffect, useState } from "react"
+import {
+  Spinner,
+  Spacer,
+  Box,
+  Select,
+  Text,
+  useToasts,
+  GridColumns,
+  Column,
+} from "@artsy/palette"
+import { Rail } from "Components/Rail/Rail"
+import { Artwork } from "Apps/ArtAdvisor/05-Near-Object-Rail/components/Artwork"
+import _ from "lodash"
+
+export type ArtworkType = {
+  _additional: {
+    id: string
+  }
+  title: string
+  imageUrl: string | null
+}
+
+type UserType = {
+  _additional: {
+    id: string
+  }
+  name: string
+}
+
+type UsersListType = {
+  value: string
+  text: string
+}
+
+export const App: FC = () => {
+  const [artworks, setArtworks] = useState<ArtworkType[]>([])
+  const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [usersList, setUsersList] = useState<UsersListType[]>([])
+  const [userId, setUserId] = useState<string>("")
+
+  const { sendToast } = useToasts()
+
+  const getNearObject = async (id: string) => {
+    if (!id) return
+
+    setIsLoading(true)
+
+    try {
+      const response = await fetch(`/api/advisor/5/near_object/${id}`)
+      const data = await response.json()
+      setArtworks(data)
+    } catch (error) {
+      console.error(error)
+      sendToast({
+        variant: "error",
+        message: `An error occurred: ${error}`,
+      })
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    const getUsers = async () => {
+      setIsLoading(true)
+      try {
+        const response = await fetch("/api/advisor/5/users")
+
+        const users = await response.json()
+
+        let usersList: UsersListType[] = users.map((user: UserType) => {
+          return {
+            value: user._additional.id,
+            text: user.name,
+          }
+        })
+        setUsersList([{ text: "", value: "" }, ...usersList])
+      } catch (error) {
+        console.error(error)
+        sendToast({
+          variant: "error",
+          message: `An error occurred: ${error}`,
+        })
+      } finally {
+        setIsLoading(false)
+      }
+    }
+    getUsers()
+  }, [sendToast])
+
+  return (
+    <Box minHeight={600}>
+      <Spacer y={2} />
+      <Select
+        title={"Pick A User"}
+        width={"25%"}
+        options={usersList}
+        disabled={isLoading}
+        onSelect={value => {
+          console.log("Selected user: ", value)
+          setUserId(value)
+          getNearObject(value)
+          setArtworks([])
+        }}
+      />
+      <Spacer y={2} />
+      <GridColumns>
+        <Column span={12} minHeight={850}>
+          {isLoading ? (
+            <Spinner />
+          ) : (
+            <>
+              {userId ? (
+                <Rail
+                  title={"Near Object"}
+                  getItems={() => {
+                    return artworks.map((artwork: ArtworkType) => {
+                      return (
+                        <>
+                          <Artwork
+                            artwork={artwork}
+                            userId={userId}
+                            getNearObject={getNearObject}
+                          />
+                        </>
+                      )
+                    })
+                  }}
+                />
+              ) : (
+                <Box display={"flex"} justifyContent={"center"}>
+                  <Text py={6} variant={"lg"}>
+                    Select a user to get started
+                  </Text>
+                </Box>
+              )}
+            </>
+          )}
+        </Column>
+      </GridColumns>
+    </Box>
+  )
+}

--- a/src/Apps/ArtAdvisor/05-Near-Object-Rail/components/Artwork.tsx
+++ b/src/Apps/ArtAdvisor/05-Near-Object-Rail/components/Artwork.tsx
@@ -1,0 +1,84 @@
+import CloseIcon from "@artsy/icons/CloseIcon"
+import HeartStrokeIcon from "@artsy/icons/HeartStrokeIcon"
+import {
+  Column,
+  Text,
+  Image,
+  Clickable,
+  Flex,
+  Spacer,
+  useToasts,
+} from "@artsy/palette"
+import { FC } from "react"
+import { ArtworkType } from "Apps/ArtAdvisor/05-Near-Object-Rail/App"
+
+type ActionType = "like" | "dislike"
+
+type ArtworkProps = {
+  artwork: ArtworkType
+  userId: string
+  getNearObject: any
+}
+
+export const Artwork: FC<ArtworkProps> = ({
+  artwork,
+  userId,
+  getNearObject,
+}) => {
+  const { sendToast } = useToasts()
+
+  const handleClick = async (action: ActionType) => {
+    try {
+      const response = await fetch(`/api/advisor/5/${action}_artwork`, {
+        method: "POST",
+        body: JSON.stringify({
+          artworkId: artwork._additional.id,
+          userId,
+        }),
+        headers: {
+          "Content-Type": "application/json",
+        },
+      })
+
+      if (!response.ok) {
+        throw new Error("An error occurred")
+      }
+
+      getNearObject(userId)
+
+      sendToast({
+        message: `${artwork.title} ${action}d`,
+      })
+    } catch (error) {
+      sendToast({
+        variant: "error",
+        message: `Something went wrong ${action}ing artwork: ${artwork.title}`,
+      })
+      console.error(error)
+    }
+  }
+
+  if (!artwork.imageUrl) {
+    return null
+  }
+
+  return (
+    <Column span={[6, 4]}>
+      <Flex flexDirection={"column"} alignItems={"center"}>
+        <Image src={artwork.imageUrl} height={500} />
+        <Spacer y={1} />
+        <Flex>
+          <Clickable onClick={() => handleClick("like")}>
+            <HeartStrokeIcon />
+          </Clickable>
+          <Spacer x={6} />
+          <Clickable onClick={() => handleClick("dislike")}>
+            <CloseIcon />
+          </Clickable>
+        </Flex>
+        <Spacer y={1} />
+        <Text variant="sm">{artwork.title}</Text>
+      </Flex>
+    </Column>
+  )
+}

--- a/src/Apps/ArtAdvisor/05-Near-Object-Rail/helpers/weaviate.tsx
+++ b/src/Apps/ArtAdvisor/05-Near-Object-Rail/helpers/weaviate.tsx
@@ -1,0 +1,130 @@
+import weaviate, { WeaviateClient } from "weaviate-ts-client"
+
+export async function createReference(args: {
+  fromClassName: "DiscoveryUsers"
+  fromWeaviateId: string
+  toClassName: "DiscoveryArtworks"
+  toWeaviateId: string
+  referenceProperty: "likedArtworks" | "dislikedArtworks"
+}) {
+  const {
+    fromClassName,
+    fromWeaviateId,
+    toClassName,
+    referenceProperty,
+    toWeaviateId,
+  } = args
+
+  try {
+    const client = await getClient()
+
+    await client.data
+      .referenceCreator()
+      .withClassName(fromClassName)
+      .withId(fromWeaviateId)
+      .withReferenceProperty(referenceProperty)
+      .withReference(
+        client.data
+          .referencePayloadBuilder()
+          .withClassName(toClassName)
+          .withId(toWeaviateId)
+          .payload()
+      )
+      .do()
+  } catch (e) {
+    console.error("[Force] Error creating reference", e)
+  }
+}
+
+export async function getObjectWithId(args: {
+  objectId: string
+  query: string
+  className: "DiscoveryUsers"
+}) {
+  const { objectId, query, className } = args
+
+  try {
+    const client = await getClient()
+
+    return await client.graphql
+      .get()
+      .withClassName(className)
+      .withFields(query)
+      .withWhere({
+        operator: "Equal",
+        path: ["id"],
+        valueText: objectId,
+      })
+      .do()
+  } catch (e) {
+    console.error("[Force] Error getting weaviate object with id", e)
+  }
+}
+
+export async function getNearObjects(args: {
+  objectId: string
+  objectClassName: "DiscoveryUsers"
+  targetClassName: "DiscoveryArtworks"
+  query: string
+  limit: number
+}) {
+  const { objectId, objectClassName, targetClassName, query, limit } = args
+
+  try {
+    const client = await getClient()
+
+    return await client.graphql
+      .get()
+      .withClassName(targetClassName)
+      .withFields(query)
+      .withNearObject({
+        beacon: generateBeacon(objectId, objectClassName),
+      })
+      .withLimit(limit)
+      .do()
+  } catch (e) {
+    console.error("[Force] Error getting weaviate nearObjects ", e)
+  }
+}
+
+export async function getObjects(args: {
+  className: "DiscoveryArtworks" | "DiscoveryUsers"
+  query: string
+  limit: number
+}) {
+  const { limit, className, query } = args
+
+  try {
+    const client = await getClient()
+
+    return await client.graphql
+      .get()
+      .withClassName(className)
+      .withFields(query)
+      .withLimit(limit)
+      .do()
+  } catch (e) {
+    console.error("[Force] Error getting weaviate objects", e)
+  }
+}
+
+function generateBeacon(userId: string, className: string) {
+  return `weaviate://weaviate.stg.artsy.systems/${className}/${userId}`
+}
+
+function getClient(): Promise<WeaviateClient> {
+  let client
+
+  try {
+    if (!process.env.WEAVIATE_URL) {
+      throw new Error("WEAVIATE_URL environment variable is not set")
+    }
+
+    client = weaviate.client({
+      host: process.env.WEAVIATE_URL,
+    })
+  } catch (e) {
+    console.error("[Force] Error creating weaviate client: ", e)
+  }
+  return client
+}

--- a/src/Apps/ArtAdvisor/05-Near-Object-Rail/server.ts
+++ b/src/Apps/ArtAdvisor/05-Near-Object-Rail/server.ts
@@ -1,0 +1,129 @@
+import {
+  createReference,
+  getNearObjects,
+  getObjects,
+  getObjectWithId,
+} from "Apps/ArtAdvisor/05-Near-Object-Rail/helpers/weaviate"
+import chalk from "chalk"
+import express, { Request, Response } from "express"
+import { filter } from "lodash"
+
+const likeArtwork = async (req: Request, res: Response) => {
+  const { artworkId, userId } = req.body
+
+  try {
+    await createReference({
+      referenceProperty: "likedArtworks",
+      fromClassName: "DiscoveryUsers",
+      fromWeaviateId: userId,
+      toClassName: "DiscoveryArtworks",
+      toWeaviateId: artworkId,
+    })
+
+    res.end()
+  } catch (e) {
+    console.error(chalk.red("ERROR: "), e)
+    res.status(500).send("An error occurred")
+  }
+}
+
+const dislikeArtwork = async (req: Request, res: Response) => {
+  const { artworkId, userId } = req.body
+
+  try {
+    await createReference({
+      referenceProperty: "dislikedArtworks",
+      fromClassName: "DiscoveryUsers",
+      fromWeaviateId: userId,
+      toClassName: "DiscoveryArtworks",
+      toWeaviateId: artworkId,
+    })
+
+    res.end()
+  } catch (e) {
+    console.error(chalk.red("ERROR: "), e)
+    res.status(500).send("An error occurred")
+  }
+}
+
+const nearObject = async (req: Request, res: Response) => {
+  console.log("nearObject")
+
+  try {
+    const userId = req.params.id
+
+    const userQuery =
+      "name likedArtworks { ... on DiscoveryArtworks { title _additional { id }}} dislikedArtworks { ... on DiscoveryArtworks { title _additional { id }}} _additional { id }"
+
+    const weaviateUser = await getObjectWithId({
+      objectId: userId,
+      query: userQuery,
+      className: "DiscoveryUsers",
+    })
+
+    const userLikes =
+      weaviateUser?.data?.Get?.DiscoveryUsers[0].likedArtworks || []
+    const userDislikes =
+      weaviateUser?.data?.Get?.DiscoveryUsers[0].dislikedArtworks || []
+
+    const artworksQuery = "title imageUrl _additional { id }"
+
+    let artworks
+
+    if (userLikes.length > 0) {
+      artworks = await getNearObjects({
+        objectId: userId,
+        objectClassName: "DiscoveryUsers",
+        targetClassName: "DiscoveryArtworks",
+        query: artworksQuery,
+        limit: 50,
+      })
+    } else {
+      artworks = await getObjects({
+        className: "DiscoveryArtworks",
+        query: artworksQuery,
+        limit: 50,
+      })
+    }
+
+    const filterIdList = [...userLikes, ...userDislikes].map(
+      artwork => artwork._additional.id
+    )
+
+    const filteredArtworks = filter(
+      artworks.data.Get.DiscoveryArtworks,
+      artwork => {
+        return !filterIdList.includes(artwork._additional.id)
+      }
+    )
+
+    res.send(JSON.stringify(filteredArtworks) || [])
+  } catch (error) {
+    console.error(JSON.stringify(error, null, 2))
+    res.status(500).send("An error occurred")
+  }
+}
+
+const users = async (req: Request, res: Response) => {
+  try {
+    const weaviateUsers = await getObjects({
+      className: "DiscoveryUsers",
+      query: "name _additional { id }",
+      limit: 25,
+    })
+
+    res.send(weaviateUsers?.data.Get.DiscoveryUsers || [])
+  } catch (error) {
+    console.error(JSON.stringify(error, null, 2))
+    res.status(500).send("An error occurred")
+  }
+}
+
+/*
+ * Define the express server routes
+ */
+export const router = express.Router()
+router.get("/users", users)
+router.get("/near_object/:id", nearObject)
+router.post("/like_artwork", likeArtwork)
+router.post("/dislike_artwork", dislikeArtwork)

--- a/src/Apps/ArtAdvisor/ArtAdvisorApp.tsx
+++ b/src/Apps/ArtAdvisor/ArtAdvisorApp.tsx
@@ -41,6 +41,15 @@ export const ArtAdvisorApp: FC = () => {
           collector profile as your bio, follow an artist and/or create alerts
         </Description>
       </Experiment>
+
+      <Experiment href="/advisor/5">
+        <Name>Near Object Search Rail</Name>
+        <Description>
+          A artwork rail that demonstrates near object search functionality. It
+          provides real time personalization based on user actions (liking or
+          disliking an artwork)
+        </Description>
+      </Experiment>
     </Box>
   )
 }

--- a/src/Apps/ArtAdvisor/ArtAdvisorRoutes.tsx
+++ b/src/Apps/ArtAdvisor/ArtAdvisorRoutes.tsx
@@ -40,6 +40,14 @@ const ArtAdvisorApp04 = loadable(
   }
 )
 
+const ArtAdvisorApp05 = loadable(
+  () =>
+    import(/* webpackChunkName: "advisorBundle" */ "./05-Near-Object-Rail/App"),
+  {
+    resolveComponent: component => component.App,
+  }
+)
+
 export const artAdvisorRoutes: AppRouteConfig[] = [
   {
     path: "/advisor",
@@ -74,6 +82,13 @@ export const artAdvisorRoutes: AppRouteConfig[] = [
     getComponent: () => ArtAdvisorApp04,
     onClientSideRender: () => {
       ArtAdvisorApp04.preload()
+    },
+  },
+  {
+    path: "/advisor/5",
+    getComponent: () => ArtAdvisorApp05,
+    onClientSideRender: () => {
+      ArtAdvisorApp05.preload()
     },
   },
 ]

--- a/src/Apps/ArtAdvisor/ArtAdvisorServerRoutes.ts
+++ b/src/Apps/ArtAdvisor/ArtAdvisorServerRoutes.ts
@@ -3,6 +3,7 @@ import { router as router1 } from "./01-Spike/server"
 import { router as router2 } from "./02-Markdown/server"
 import { router as router3 } from "./03-Instruction-Experiments/server"
 import { router as router4 } from "./04-Bio-Follows-Alerts/server"
+import { router as router5 } from "./05-Near-Object-Rail/server"
 
 /*
  * Define API routes that can be collocated with each app experiment
@@ -14,3 +15,4 @@ artAdvisorServerRoutes.use("/api/advisor/1", router1)
 artAdvisorServerRoutes.use("/api/advisor/2", router2)
 artAdvisorServerRoutes.use("/api/advisor/3", router3)
 artAdvisorServerRoutes.use("/api/advisor/4", router4)
+artAdvisorServerRoutes.use("/api/advisor/5", router5)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2266,6 +2266,11 @@
     tslib "~2.2.0"
     value-or-promise "1.0.6"
 
+"@graphql-typed-document-node/core@^3.1.1":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@graphql-typed-document-node/core/-/core-3.2.0.tgz#5f3d96ec6b2354ad6d8a28bf216a1d97b5426861"
+  integrity sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==
+
 "@iarna/toml@^2.2.5":
   version "2.2.5"
   resolved "https://registry.yarnpkg.com/@iarna/toml/-/toml-2.2.5.tgz#b32366c89b43c6f8cefbdefac778b9c828e3ba8c"
@@ -12240,6 +12245,16 @@ graphql-config@^3.0.2:
     cosmiconfig-toml-loader "1.0.0"
     minimatch "3.0.4"
     string-env-interpolation "1.0.1"
+
+graphql-request@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-5.2.0.tgz#a05fb54a517d91bb2d7aefa17ade4523dc5ebdca"
+  integrity sha512-pLhKIvnMyBERL0dtFI3medKqWOz/RhHdcgbZ+hMMIb32mEPa5MJSzS4AuXxfI4sRAu6JVVk5tvXuGfCWl9JYWQ==
+  dependencies:
+    "@graphql-typed-document-node/core" "^3.1.1"
+    cross-fetch "^3.1.5"
+    extract-files "^9.0.0"
+    form-data "^3.0.0"
 
 graphql-tag@2.10.3:
   version "2.10.3"
@@ -22660,6 +22675,11 @@ uuid@^8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
+uuid@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
+
 v8-compile-cache@^2.0.3:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz#54bc3cdd43317bca91e35dcaf305b1a7237de745"
@@ -22880,6 +22900,14 @@ wcwidth@^1.0.1:
   integrity sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=
   dependencies:
     defaults "^1.0.3"
+
+weaviate-ts-client@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/weaviate-ts-client/-/weaviate-ts-client-2.2.0.tgz#59dc88b6aa33dd1883e1fc23c78da70435678cd5"
+  integrity sha512-sOvX1Gt8+u9wIVmiYii26N4KSpZ8jM5fM4DMmtRL6yPNO9u8elsvg5g7eJOwmrICsn1Zt2efxhxuSChI0M8FzQ==
+  dependencies:
+    graphql-request "^5.2.0"
+    uuid "^9.0.1"
 
 web-namespaces@^1.0.0:
   version "1.1.4"


### PR DESCRIPTION
This PR adds and experiment to evaluate using a `nearObject` [search](https://weaviate.io/developers/weaviate/api/graphql/search-operators#nearobject) to populate and update an artwork rail based on user interactions. Specifically, "liking" or "disliking" an artwork. 

https://github.com/artsy/force/assets/38149304/9efb31ee-95e4-4fc7-ac59-15f7c7cbbe38

### Considerations

- This experiment has generated a few open questions that we would need to address before introducing this approach into a product. I believe they are best demonstrated through the code, so I have highlighted them in PR comments. 
- There are some UI rough edges that we would want to address, but my focus on this experiment was fleshing out the `nearObject` based rail concept. 



