### PR TITLE
feat: Carry over auto-completed location when submitting a MyC artwork

### DIFF
--- a/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails.tsx
@@ -74,7 +74,6 @@ export const ArtworkDetails: React.FC<ArtworkDetailsProps> = ({
   }
 
   const initialValue = getArtworkDetailsFormInitialValues(data)
-  console.log({ initialValue })
   const initialErrors = validate(initialValue, artworkDetailsValidationSchema)
 
   const artworkId = myCollectionArtwork?.internalID

--- a/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails.tsx
@@ -74,6 +74,7 @@ export const ArtworkDetails: React.FC<ArtworkDetailsProps> = ({
   }
 
   const initialValue = getArtworkDetailsFormInitialValues(data)
+  console.log({ initialValue })
   const initialErrors = validate(initialValue, artworkDetailsValidationSchema)
 
   const artworkId = myCollectionArtwork?.internalID
@@ -338,7 +339,7 @@ export const ArtworkDetailsFragmentContainer = createFragmentContainer(
           internalID
           name
         }
-        location {
+        collectorLocation {
           city
           country
           state

--- a/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtworkDetailsForm.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtworkDetailsForm.tsx
@@ -107,9 +107,7 @@ export const getArtworkDetailsFormInitialValues = (
         depth: props.values.depth ?? "",
         units: props.values.metric ?? "in",
         provenance: props.values.provenance ?? "",
-        location: {
-          city: "",
-        },
+        location: props.values.collectorLocation ?? { city: "" },
         postalCode: undefined,
       } as ArtworkDetailsFormModel
     default:

--- a/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtworkDetails.jest.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtworkDetails.jest.tsx
@@ -1,16 +1,16 @@
-import { MockBoot } from "DevTools/MockBoot"
-import { Breakpoint } from "Utils/Responsive"
-import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
-import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
-import { graphql } from "react-relay"
 import { fireEvent, screen } from "@testing-library/react"
-import { ArtworkDetailsFragmentContainer } from "Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails"
-import { ArtworkDetails_submission$data } from "__generated__/ArtworkDetails_submission.graphql"
-import { createOrUpdateConsignSubmission } from "Apps/Consign/Routes/SubmissionFlow/Utils/createOrUpdateConsignSubmission"
 import {
   submissionFlowSteps,
   submissionFlowStepsMobile,
 } from "Apps/Consign/Hooks/useSubmissionFlowSteps"
+import { ArtworkDetailsFragmentContainer } from "Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/ArtworkDetails"
+import { createOrUpdateConsignSubmission } from "Apps/Consign/Routes/SubmissionFlow/Utils/createOrUpdateConsignSubmission"
+import { MockBoot } from "DevTools/MockBoot"
+import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
+import { Breakpoint } from "Utils/Responsive"
+import { ArtworkDetails_submission$data } from "__generated__/ArtworkDetails_submission.graphql"
+import { graphql } from "react-relay"
 
 const validForm = {
   externalId: "b2449fe2-e828-4a32-ace7-ff0753cd01ef",
@@ -180,7 +180,9 @@ describe("ArtworkDetails", () => {
 
       expect(
         screen.getByPlaceholderText("Enter city where artwork is located")
-      ).toHaveValue("")
+      ).toHaveValue(
+        '<mock-value-for-field-"city">, <mock-value-for-field-"state">, <mock-value-for-field-"country">'
+      )
     })
   })
 

--- a/src/__generated__/ArtworkDetails_SubmissionFlowPrepopulatedTest_Query.graphql.ts
+++ b/src/__generated__/ArtworkDetails_SubmissionFlowPrepopulatedTest_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f211578c255070b24592814b2035153a>>
+ * @generated SignedSource<<ae65b7d375caaac083ca0f32bd157e56>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -130,9 +130,9 @@ return {
           {
             "alias": null,
             "args": null,
-            "concreteType": "Location",
+            "concreteType": "MyLocation",
             "kind": "LinkedField",
-            "name": "location",
+            "name": "collectorLocation",
             "plural": false,
             "selections": [
               {
@@ -269,7 +269,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b363bc632eb389e171ae30e06299571d",
+    "cacheID": "8785c1ed93a7ae24a2d7e6a7c55e829a",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -296,6 +296,17 @@ return {
         },
         "myCollectionArtwork.attributionClass.id": (v5/*: any*/),
         "myCollectionArtwork.attributionClass.name": (v6/*: any*/),
+        "myCollectionArtwork.collectorLocation": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "MyLocation"
+        },
+        "myCollectionArtwork.collectorLocation.city": (v6/*: any*/),
+        "myCollectionArtwork.collectorLocation.country": (v6/*: any*/),
+        "myCollectionArtwork.collectorLocation.id": (v5/*: any*/),
+        "myCollectionArtwork.collectorLocation.postalCode": (v6/*: any*/),
+        "myCollectionArtwork.collectorLocation.state": (v6/*: any*/),
         "myCollectionArtwork.date": (v6/*: any*/),
         "myCollectionArtwork.depth": (v6/*: any*/),
         "myCollectionArtwork.editionNumber": (v6/*: any*/),
@@ -303,17 +314,6 @@ return {
         "myCollectionArtwork.height": (v6/*: any*/),
         "myCollectionArtwork.id": (v5/*: any*/),
         "myCollectionArtwork.internalID": (v5/*: any*/),
-        "myCollectionArtwork.location": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Location"
-        },
-        "myCollectionArtwork.location.city": (v6/*: any*/),
-        "myCollectionArtwork.location.country": (v6/*: any*/),
-        "myCollectionArtwork.location.id": (v5/*: any*/),
-        "myCollectionArtwork.location.postalCode": (v6/*: any*/),
-        "myCollectionArtwork.location.state": (v6/*: any*/),
         "myCollectionArtwork.medium": (v6/*: any*/),
         "myCollectionArtwork.mediumType": {
           "enumValues": null,
@@ -330,7 +330,7 @@ return {
     },
     "name": "ArtworkDetails_SubmissionFlowPrepopulatedTest_Query",
     "operationKind": "query",
-    "text": "query ArtworkDetails_SubmissionFlowPrepopulatedTest_Query(\n  $artworkId: String!\n) {\n  myCollectionArtwork: artwork(id: $artworkId) {\n    ...ArtworkDetails_myCollectionArtwork\n    id\n  }\n}\n\nfragment ArtworkDetails_myCollectionArtwork on Artwork {\n  internalID\n  artist {\n    internalID\n    name\n    id\n  }\n  location {\n    city\n    country\n    state\n    postalCode\n    id\n  }\n  date\n  title\n  medium\n  mediumType {\n    name\n  }\n  attributionClass {\n    name\n    id\n  }\n  editionNumber\n  editionSize\n  height\n  width\n  depth\n  metric\n  provenance\n}\n"
+    "text": "query ArtworkDetails_SubmissionFlowPrepopulatedTest_Query(\n  $artworkId: String!\n) {\n  myCollectionArtwork: artwork(id: $artworkId) {\n    ...ArtworkDetails_myCollectionArtwork\n    id\n  }\n}\n\nfragment ArtworkDetails_myCollectionArtwork on Artwork {\n  internalID\n  artist {\n    internalID\n    name\n    id\n  }\n  collectorLocation {\n    city\n    country\n    state\n    postalCode\n    id\n  }\n  date\n  title\n  medium\n  mediumType {\n    name\n  }\n  attributionClass {\n    name\n    id\n  }\n  editionNumber\n  editionSize\n  height\n  width\n  depth\n  metric\n  provenance\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtworkDetails_myCollectionArtwork.graphql.ts
+++ b/src/__generated__/ArtworkDetails_myCollectionArtwork.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2fe4a1d84a9a58832208c95866ed9a1f>>
+ * @generated SignedSource<<3dd8ac53ea797d93b73d6272fbb851f1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,18 +18,18 @@ export type ArtworkDetails_myCollectionArtwork$data = {
   readonly attributionClass: {
     readonly name: string | null | undefined;
   } | null | undefined;
+  readonly collectorLocation: {
+    readonly city: string | null | undefined;
+    readonly country: string | null | undefined;
+    readonly postalCode: string | null | undefined;
+    readonly state: string | null | undefined;
+  } | null | undefined;
   readonly date: string | null | undefined;
   readonly depth: string | null | undefined;
   readonly editionNumber: string | null | undefined;
   readonly editionSize: string | null | undefined;
   readonly height: string | null | undefined;
   readonly internalID: string;
-  readonly location: {
-    readonly city: string | null | undefined;
-    readonly country: string | null | undefined;
-    readonly postalCode: string | null | undefined;
-    readonly state: string | null | undefined;
-  } | null | undefined;
   readonly medium: string | null | undefined;
   readonly mediumType: {
     readonly name: string | null | undefined;
@@ -86,9 +86,9 @@ return {
     {
       "alias": null,
       "args": null,
-      "concreteType": "Location",
+      "concreteType": "MyLocation",
       "kind": "LinkedField",
-      "name": "location",
+      "name": "collectorLocation",
       "plural": false,
       "selections": [
         {
@@ -218,6 +218,6 @@ return {
 };
 })();
 
-(node as any).hash = "af886e120dbdc155b8f9e65bd9a14578";
+(node as any).hash = "f9f3a55f53a9fa72d6847dcf28e6c2a0";
 
 export default node;

--- a/src/__generated__/consignRoutes_artworkDetailsWithArtworkIdQuery.graphql.ts
+++ b/src/__generated__/consignRoutes_artworkDetailsWithArtworkIdQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4e708fdc0788be60d78f260abaebf009>>
+ * @generated SignedSource<<abc47e12660d154877ecd765a623c4c4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -461,9 +461,9 @@ return {
           {
             "alias": null,
             "args": null,
-            "concreteType": "Location",
+            "concreteType": "MyLocation",
             "kind": "LinkedField",
-            "name": "location",
+            "name": "collectorLocation",
             "plural": false,
             "selections": [
               {
@@ -552,12 +552,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1b89d09455b568b91e53fc8eca572de4",
+    "cacheID": "1c0eafa2e0538ad679cdf427cb928a04",
     "id": null,
     "metadata": {},
     "name": "consignRoutes_artworkDetailsWithArtworkIdQuery",
     "operationKind": "query",
-    "text": "query consignRoutes_artworkDetailsWithArtworkIdQuery(\n  $id: ID\n  $externalId: ID\n  $sessionID: String\n  $artworkId: String!\n) {\n  submission(id: $id, externalId: $externalId, sessionID: $sessionID) {\n    ...ArtworkDetails_submission\n    externalId\n    artist {\n      internalID\n      name\n      id\n    }\n    category\n    locationCity\n    locationCountry\n    locationState\n    locationPostalCode\n    locationCountryCode\n    year\n    title\n    medium\n    attributionClass\n    editionNumber\n    editionSize\n    height\n    width\n    depth\n    dimensionsMetric\n    provenance\n    userId\n    userEmail\n    assets {\n      id\n      imageUrls\n      geminiToken\n      size\n      filename\n    }\n    id\n  }\n  myCollectionArtwork: artwork(id: $artworkId) {\n    ...ArtworkDetails_myCollectionArtwork\n    id\n  }\n}\n\nfragment ArtworkDetails_myCollectionArtwork on Artwork {\n  internalID\n  artist {\n    internalID\n    name\n    id\n  }\n  location {\n    city\n    country\n    state\n    postalCode\n    id\n  }\n  date\n  title\n  medium\n  mediumType {\n    name\n  }\n  attributionClass {\n    name\n    id\n  }\n  editionNumber\n  editionSize\n  height\n  width\n  depth\n  metric\n  provenance\n}\n\nfragment ArtworkDetails_submission on ConsignmentSubmission {\n  externalId\n  artist {\n    internalID\n    name\n    id\n  }\n  category\n  locationCity\n  locationCountry\n  locationState\n  locationPostalCode\n  locationCountryCode\n  year\n  title\n  medium\n  attributionClass\n  editionNumber\n  editionSize\n  height\n  width\n  depth\n  dimensionsMetric\n  provenance\n  userId\n  userEmail\n}\n"
+    "text": "query consignRoutes_artworkDetailsWithArtworkIdQuery(\n  $id: ID\n  $externalId: ID\n  $sessionID: String\n  $artworkId: String!\n) {\n  submission(id: $id, externalId: $externalId, sessionID: $sessionID) {\n    ...ArtworkDetails_submission\n    externalId\n    artist {\n      internalID\n      name\n      id\n    }\n    category\n    locationCity\n    locationCountry\n    locationState\n    locationPostalCode\n    locationCountryCode\n    year\n    title\n    medium\n    attributionClass\n    editionNumber\n    editionSize\n    height\n    width\n    depth\n    dimensionsMetric\n    provenance\n    userId\n    userEmail\n    assets {\n      id\n      imageUrls\n      geminiToken\n      size\n      filename\n    }\n    id\n  }\n  myCollectionArtwork: artwork(id: $artworkId) {\n    ...ArtworkDetails_myCollectionArtwork\n    id\n  }\n}\n\nfragment ArtworkDetails_myCollectionArtwork on Artwork {\n  internalID\n  artist {\n    internalID\n    name\n    id\n  }\n  collectorLocation {\n    city\n    country\n    state\n    postalCode\n    id\n  }\n  date\n  title\n  medium\n  mediumType {\n    name\n  }\n  attributionClass {\n    name\n    id\n  }\n  editionNumber\n  editionSize\n  height\n  width\n  depth\n  metric\n  provenance\n}\n\nfragment ArtworkDetails_submission on ConsignmentSubmission {\n  externalId\n  artist {\n    internalID\n    name\n    id\n  }\n  category\n  locationCity\n  locationCountry\n  locationState\n  locationPostalCode\n  locationCountryCode\n  year\n  title\n  medium\n  attributionClass\n  editionNumber\n  editionSize\n  height\n  width\n  depth\n  dimensionsMetric\n  provenance\n  userId\n  userEmail\n}\n"
   }
 };
 })();

--- a/src/__generated__/consignRoutes_myCollectionArtworkQuery.graphql.ts
+++ b/src/__generated__/consignRoutes_myCollectionArtworkQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9044dd45e047e25233b4459421d01ec3>>
+ * @generated SignedSource<<c07ce6897410417bcfa1edfb509c445f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -118,9 +118,9 @@ return {
           {
             "alias": null,
             "args": null,
-            "concreteType": "Location",
+            "concreteType": "MyLocation",
             "kind": "LinkedField",
-            "name": "location",
+            "name": "collectorLocation",
             "plural": false,
             "selections": [
               {
@@ -257,12 +257,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "40b89a4fa081075a42a2652927224145",
+    "cacheID": "37bc72ebe461f9a444332482bd10b1f4",
     "id": null,
     "metadata": {},
     "name": "consignRoutes_myCollectionArtworkQuery",
     "operationKind": "query",
-    "text": "query consignRoutes_myCollectionArtworkQuery(\n  $artworkId: String!\n) {\n  myCollectionArtwork: artwork(id: $artworkId) {\n    ...ArtworkDetails_myCollectionArtwork\n    id\n  }\n}\n\nfragment ArtworkDetails_myCollectionArtwork on Artwork {\n  internalID\n  artist {\n    internalID\n    name\n    id\n  }\n  location {\n    city\n    country\n    state\n    postalCode\n    id\n  }\n  date\n  title\n  medium\n  mediumType {\n    name\n  }\n  attributionClass {\n    name\n    id\n  }\n  editionNumber\n  editionSize\n  height\n  width\n  depth\n  metric\n  provenance\n}\n"
+    "text": "query consignRoutes_myCollectionArtworkQuery(\n  $artworkId: String!\n) {\n  myCollectionArtwork: artwork(id: $artworkId) {\n    ...ArtworkDetails_myCollectionArtwork\n    id\n  }\n}\n\nfragment ArtworkDetails_myCollectionArtwork on Artwork {\n  internalID\n  artist {\n    internalID\n    name\n    id\n  }\n  collectorLocation {\n    city\n    country\n    state\n    postalCode\n    id\n  }\n  date\n  title\n  medium\n  mediumType {\n    name\n  }\n  attributionClass {\n    name\n    id\n  }\n  editionNumber\n  editionSize\n  height\n  width\n  depth\n  metric\n  provenance\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Addresses [ONYX-1059]

## Description

With this update, we correctly carry over the (new) auto-completed collector location when submitting a MyC artwork.

| | |
| --- | --- |
|<img width="1425" alt="Screenshot 2024-06-13 at 09 22 36" src="https://github.com/artsy/force/assets/4691889/60a6641d-5f88-45c7-873d-c4356ba0ce75"> |<img width="1426" alt="Screenshot 2024-06-13 at 09 22 19" src="https://github.com/artsy/force/assets/4691889/d83cb703-e672-4eab-b11d-829aa3890740"> |




[ONYX-1059]: https://artsyproduct.atlassian.net/browse/ONYX-1059?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ