### PR TITLE
feat: New submission flow details step

### DIFF
--- a/src/Apps/Sell/Routes/DetailsRoute.tsx
+++ b/src/Apps/Sell/Routes/DetailsRoute.tsx
@@ -82,7 +82,7 @@ export const DetailsRoute: React.FC<DetailsRouteProps> = props => {
 
           <Join separator={<Spacer y={4} />}>
             <GridColumns>
-              <Column span={4}>
+              <Column span={[6, 4]}>
                 <Input
                   onChange={handleChange}
                   name="year"

--- a/src/Apps/Sell/Routes/DetailsRoute.tsx
+++ b/src/Apps/Sell/Routes/DetailsRoute.tsx
@@ -1,14 +1,23 @@
-import * as React from "react"
-import * as Yup from "yup"
-import { DetailsRoute_submission$key } from "__generated__/DetailsRoute_submission.graphql"
-import { Input, Join, Select, Spacer, Text } from "@artsy/palette"
+import {
+  Column,
+  GridColumns,
+  Input,
+  Join,
+  Select,
+  Spacer,
+  Text,
+} from "@artsy/palette"
 import { acceptableCategoriesForSubmission } from "Apps/Consign/Routes/SubmissionFlow/Utils/acceptableCategoriesForSubmission"
-import { graphql, useFragment } from "react-relay"
-import { Formik } from "formik"
-import { ConsignmentSubmissionCategoryAggregation } from "__generated__/UpdateConsignSubmissionMutation.graphql"
 import { DevDebug } from "Apps/Sell/Components/DevDebug"
-import { useSellFlowContext } from "Apps/Sell/SellFlowContext"
 import { SubmissionLayout } from "Apps/Sell/Components/SubmissionLayout"
+import { useSellFlowContext } from "Apps/Sell/SellFlowContext"
+import { DetailsRoute_submission$key } from "__generated__/DetailsRoute_submission.graphql"
+import { ConsignmentSubmissionCategoryAggregation } from "__generated__/UpdateConsignSubmissionMutation.graphql"
+import { Formik } from "formik"
+import * as React from "react"
+import { useEffect } from "react"
+import { graphql, useFragment } from "react-relay"
+import * as Yup from "yup"
 
 const FRAGMENT = graphql`
   fragment DetailsRoute_submission on ConsignmentSubmission {
@@ -52,6 +61,12 @@ export const DetailsRoute: React.FC<DetailsRouteProps> = props => {
     medium: submission.medium ?? "",
   }
 
+  const yearInputRef = React.useRef<HTMLInputElement | null>(null)
+
+  useEffect(() => {
+    yearInputRef.current?.focus()
+  }, [])
+
   return (
     <Formik<FormValues>
       initialValues={initialValues}
@@ -64,27 +79,38 @@ export const DetailsRoute: React.FC<DetailsRouteProps> = props => {
           <Text mb={2} variant="xl">
             Artwork details
           </Text>
-          <Join separator={<Spacer y={2} />}>
-            <Input
-              onChange={handleChange}
-              name="year"
-              title="Year"
-              defaultValue={values.year || ""}
-            ></Input>
+
+          <Join separator={<Spacer y={4} />}>
+            <GridColumns>
+              <Column span={4}>
+                <Input
+                  onChange={handleChange}
+                  name="year"
+                  title="Year"
+                  defaultValue={values.year || ""}
+                  ref={yearInputRef}
+                  data-testid="year-input"
+                />
+              </Column>
+            </GridColumns>
+
             <Select
               title="Medium"
               name="category"
               options={acceptableCategoriesForSubmission()}
-              defaultValue={values.category?.toUpperCase() ?? undefined}
+              selected={values.category}
               onChange={handleChange}
               required
+              data-testid="category-input"
             />
+
             <Input
               onChange={handleChange}
               name="medium"
               title="Materials"
               defaultValue={values.medium || ""}
-            ></Input>
+              data-testid="medium-input"
+            />
           </Join>
           <DevDebug />
         </SubmissionLayout>

--- a/src/Apps/Sell/Routes/__tests__/ArtistRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/ArtistRoute.jest.tsx
@@ -1,9 +1,8 @@
-import { screen } from "@testing-library/react"
-import { fireEvent, waitFor } from "@testing-library/react"
+import { fireEvent, screen } from "@testing-library/react"
 import { ArtistRoute } from "Apps/Sell/Routes/ArtistRoute"
+import { SubmissionRoute } from "Apps/Sell/Routes/SubmissionRoute"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { useRouter } from "System/Router/useRouter"
-import { DeepPartial } from "Utils/typeSupport"
 import { ArtistRoute_Test_Query$rawResponse } from "__generated__/ArtistRoute_Test_Query.graphql"
 import { graphql } from "react-relay"
 
@@ -12,7 +11,7 @@ const mockPush = jest.fn()
 const mockReplace = jest.fn()
 
 jest.mock("System/Router/useRouter", () => ({
-  useRouter: jest.fn(() => ({ match: { location: { query: {} } } })),
+  useRouter: jest.fn(),
 }))
 jest.unmock("react-relay")
 
@@ -21,11 +20,12 @@ jest.mock("react-relay", () => ({
   fetchQuery: jest.fn(),
 }))
 
-const submissionMock: DeepPartial<
-  ArtistRoute_Test_Query$rawResponse["submission"]
-> = {
-  internalID: "example",
+const submissionMock: ArtistRoute_Test_Query$rawResponse["submission"] = {
+  id: "submission-id",
+  internalID: "submission-id",
+  externalId: "submission-id",
   artist: {
+    id: "example-id",
     internalID: "example-id",
     targetSupply: {
       isTargetSupply: true,
@@ -40,16 +40,22 @@ beforeEach(() => {
       push: mockPush,
       replace: mockReplace,
     },
+    match: { location: { pathname: "submissions/submission-id/details" } },
   }))
 })
 
 const { renderWithRelay } = setupTestWrapperTL({
   Component: (props: any) => {
-    return <ArtistRoute submission={props.submission} />
+    return (
+      <SubmissionRoute submission={props.submission}>
+        <ArtistRoute submission={props.submission} />
+      </SubmissionRoute>
+    )
   },
   query: graphql`
     query ArtistRoute_Test_Query @raw_response_type {
       submission(id: "submission-id") {
+        ...SubmissionRoute_submission
         ...ArtistRoute_submission
       }
     }
@@ -57,43 +63,55 @@ const { renderWithRelay } = setupTestWrapperTL({
 })
 
 describe("ArtistRoute", () => {
-  it("renders the artist step", async () => {
+  it("renders the artist step", () => {
     renderWithRelay({
-      submission: () => submissionMock,
+      Submission: () => submissionMock,
     })
 
-    await waitFor(() => {
-      expect(screen.getByText("Add artist name")).toBeInTheDocument()
-    })
+    expect(screen.getByText("Add artist name")).toBeInTheDocument()
   })
 
   describe("artist input", () => {
-    it("is required", async () => {
+    it("is required", () => {
       renderWithRelay({
-        submission: () => submissionMock,
+        Submission: () => submissionMock,
       })
 
-      await waitFor(async () => {
-        const artistInput = screen.getByPlaceholderText("Enter full name")
+      const artistInput = screen.getByPlaceholderText("Enter full name")
 
-        fireEvent.change(artistInput, { target: { value: "Banksy" } })
+      fireEvent.change(artistInput, { target: { value: "Banksy" } })
 
-        expect(artistInput).toBeInTheDocument()
+      expect(artistInput).toBeInTheDocument()
 
-        expect(artistInput).toHaveValue("Banksy")
-      })
+      expect(artistInput).toHaveValue("Banksy")
     })
   })
 
   describe("Learn more link", () => {
     it("navigates to the artist not eligible page if the artist is not eligible", async () => {
       renderWithRelay({
-        submission: () => submissionMock,
+        Submission: () => submissionMock,
       })
 
       expect(screen.getByText("Learn more.").attributes["href"].value).toBe(
         "https://support.artsy.net/s/article/Im-an-artist-Can-I-submit-my-own-work-to-sell"
       )
     })
+  })
+
+  it("Continue button isn't visible", () => {
+    renderWithRelay({
+      Submission: () => submissionMock,
+    })
+
+    expect(screen.queryByText("Continue")).not.toBeInTheDocument()
+  })
+
+  it("Back button isn't visible", () => {
+    renderWithRelay({
+      Submission: () => submissionMock,
+    })
+
+    expect(screen.queryByText("Back")).not.toBeInTheDocument()
   })
 })

--- a/src/Apps/Sell/Routes/__tests__/ArtistRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/ArtistRoute.jest.tsx
@@ -3,7 +3,6 @@ import { ArtistRoute } from "Apps/Sell/Routes/ArtistRoute"
 import { SubmissionRoute } from "Apps/Sell/Routes/SubmissionRoute"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { useRouter } from "System/Router/useRouter"
-import { ArtistRoute_Test_Query$rawResponse } from "__generated__/ArtistRoute_Test_Query.graphql"
 import { graphql } from "react-relay"
 
 const mockUseRouter = useRouter as jest.Mock
@@ -19,20 +18,6 @@ jest.mock("react-relay", () => ({
   ...jest.requireActual("react-relay"),
   fetchQuery: jest.fn(),
 }))
-
-const submissionMock: ArtistRoute_Test_Query$rawResponse["submission"] = {
-  id: "submission-id",
-  internalID: "submission-id",
-  externalId: "submission-id",
-  artist: {
-    id: "example-id",
-    internalID: "example-id",
-    targetSupply: {
-      isTargetSupply: true,
-    },
-    name: "Example Artist",
-  },
-}
 
 beforeEach(() => {
   mockUseRouter.mockImplementation(() => ({
@@ -64,18 +49,14 @@ const { renderWithRelay } = setupTestWrapperTL({
 
 describe("ArtistRoute", () => {
   it("renders the artist step", () => {
-    renderWithRelay({
-      Submission: () => submissionMock,
-    })
+    renderWithRelay({})
 
     expect(screen.getByText("Add artist name")).toBeInTheDocument()
   })
 
   describe("artist input", () => {
     it("is required", () => {
-      renderWithRelay({
-        Submission: () => submissionMock,
-      })
+      renderWithRelay({})
 
       const artistInput = screen.getByPlaceholderText("Enter full name")
 
@@ -89,9 +70,7 @@ describe("ArtistRoute", () => {
 
   describe("Learn more link", () => {
     it("navigates to the artist not eligible page if the artist is not eligible", async () => {
-      renderWithRelay({
-        Submission: () => submissionMock,
-      })
+      renderWithRelay({})
 
       expect(screen.getByText("Learn more.").attributes["href"].value).toBe(
         "https://support.artsy.net/s/article/Im-an-artist-Can-I-submit-my-own-work-to-sell"
@@ -100,17 +79,13 @@ describe("ArtistRoute", () => {
   })
 
   it("Continue button isn't visible", () => {
-    renderWithRelay({
-      Submission: () => submissionMock,
-    })
+    renderWithRelay({})
 
     expect(screen.queryByText("Continue")).not.toBeInTheDocument()
   })
 
   it("Back button isn't visible", () => {
-    renderWithRelay({
-      Submission: () => submissionMock,
-    })
+    renderWithRelay({})
 
     expect(screen.queryByText("Back")).not.toBeInTheDocument()
   })

--- a/src/Apps/Sell/Routes/__tests__/DetailsRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/DetailsRoute.jest.tsx
@@ -1,0 +1,132 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react"
+import { DetailsRoute } from "Apps/Sell/Routes/DetailsRoute"
+import { SubmissionRoute } from "Apps/Sell/Routes/SubmissionRoute"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
+import { useRouter } from "System/Router/useRouter"
+import { DetailsRoute_Test_Query$rawResponse } from "__generated__/DetailsRoute_Test_Query.graphql"
+import { graphql } from "react-relay"
+
+const mockUseRouter = useRouter as jest.Mock
+const mockPush = jest.fn()
+const mockReplace = jest.fn()
+
+jest.mock("System/Router/useRouter", () => ({
+  useRouter: jest.fn(),
+}))
+jest.unmock("react-relay")
+
+jest.mock("react-relay", () => ({
+  ...jest.requireActual("react-relay"),
+  fetchQuery: jest.fn(),
+}))
+
+const submissionMock: DetailsRoute_Test_Query$rawResponse["submission"] = {
+  id: "submission-id",
+  internalID: "submission-id",
+  externalId: "submission-id",
+  year: "2021",
+  category: "Painting",
+  medium: "Oil on canvas",
+}
+
+beforeEach(() => {
+  mockUseRouter.mockImplementation(() => ({
+    router: {
+      push: mockPush,
+      replace: mockReplace,
+    },
+    match: { location: { pathname: "submissions/submission-id/details" } },
+  }))
+})
+
+const { renderWithRelay } = setupTestWrapperTL({
+  Component: (props: any) => {
+    return (
+      <SubmissionRoute submission={props.submission}>
+        <DetailsRoute submission={props.submission} />
+      </SubmissionRoute>
+    )
+  },
+  query: graphql`
+    query DetailsRoute_Test_Query @raw_response_type {
+      submission(id: "submission-id") {
+        ...SubmissionRoute_submission
+        ...DetailsRoute_submission
+      }
+    }
+  `,
+})
+
+describe("DetailsRoute", () => {
+  it("renders the Details step", () => {
+    renderWithRelay({
+      Submission: () => submissionMock,
+    })
+
+    expect(screen.getByText("Artwork details")).toBeInTheDocument()
+    expect(screen.getByText("Back")).toBeInTheDocument()
+    expect(screen.getByText("Continue")).toBeInTheDocument()
+    expect(screen.getByText("Save & Exit")).toBeInTheDocument()
+  })
+
+  it("initializes the form with the submission data", async () => {
+    renderWithRelay({
+      Submission: () => submissionMock,
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("year-input")).toHaveValue(
+        '<mock-value-for-field-"year">'
+      )
+      expect(screen.getByTestId("medium-input")).toHaveValue(
+        '<mock-value-for-field-"medium">'
+      )
+    })
+  })
+
+  it("saves the submission & navigates to the next step when Continue button is clicked", async () => {
+    renderWithRelay({
+      Submission: () => submissionMock,
+    })
+
+    screen.getByText("Continue").click()
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith(
+        '/sell2/submissions/<mock-value-for-field-"externalId">/purchase-history'
+      )
+
+      // TODO: Test that the submission was saved
+    })
+  })
+
+  it("saves the submission & navigates to the previous step when the back button is clicked", async () => {
+    renderWithRelay({
+      Submission: () => submissionMock,
+    })
+
+    screen.getByText("Back").click()
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith(
+        '/sell2/submissions/<mock-value-for-field-"externalId">/photos'
+      )
+
+      // TODO: Test that the submission was saved
+    })
+  })
+
+  describe("when form is not valid", () => {
+    it("disables the continue button", async () => {
+      renderWithRelay({
+        Submission: () => ({ ...submissionMock, category: "default" }),
+      })
+
+      const mediumInput = screen.getByTestId("medium-input")
+
+      fireEvent.change(mediumInput, { target: { value: "" } })
+
+      expect(screen.getByText("Continue")).toBeDisabled()
+    })
+  })
+})

--- a/src/__generated__/ArtistRoute_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistRoute_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6cb9245d5474663f1217a8dd9a546cbe>>
+ * @generated SignedSource<<035b91874930fc71e90d2c802e321f1f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,7 +13,7 @@ import { FragmentRefs } from "relay-runtime";
 export type ArtistRoute_Test_Query$variables = Record<PropertyKey, never>;
 export type ArtistRoute_Test_Query$data = {
   readonly submission: {
-    readonly " $fragmentSpreads": FragmentRefs<"ArtistRoute_submission">;
+    readonly " $fragmentSpreads": FragmentRefs<"ArtistRoute_submission" | "SubmissionRoute_submission">;
   } | null | undefined;
 };
 export type ArtistRoute_Test_Query$rawResponse = {
@@ -26,6 +26,7 @@ export type ArtistRoute_Test_Query$rawResponse = {
         readonly isTargetSupply: boolean | null | undefined;
       };
     } | null | undefined;
+    readonly externalId: string;
     readonly id: string;
     readonly internalID: string | null | undefined;
   } | null | undefined;
@@ -76,6 +77,11 @@ return {
           {
             "args": null,
             "kind": "FragmentSpread",
+            "name": "SubmissionRoute_submission"
+          },
+          {
+            "args": null,
+            "kind": "FragmentSpread",
             "name": "ArtistRoute_submission"
           }
         ],
@@ -100,6 +106,13 @@ return {
         "plural": false,
         "selections": [
           (v1/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "externalId",
+            "storageKey": null
+          },
           {
             "alias": null,
             "args": null,
@@ -145,16 +158,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "02f33048eaad2ecc9b66d4105804f148",
+    "cacheID": "9a4de83cc9a2be0661f8728708474f98",
     "id": null,
     "metadata": {},
     "name": "ArtistRoute_Test_Query",
     "operationKind": "query",
-    "text": "query ArtistRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...ArtistRoute_submission\n    id\n  }\n}\n\nfragment ArtistRoute_submission on ConsignmentSubmission {\n  internalID\n  artist {\n    internalID\n    targetSupply {\n      isTargetSupply\n    }\n    name\n    id\n  }\n}\n"
+    "text": "query ArtistRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...SubmissionRoute_submission\n    ...ArtistRoute_submission\n    id\n  }\n}\n\nfragment ArtistRoute_submission on ConsignmentSubmission {\n  internalID\n  artist {\n    internalID\n    targetSupply {\n      isTargetSupply\n    }\n    name\n    id\n  }\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n}\n"
   }
 };
 })();
 
-(node as any).hash = "4dfa674c44131bf1825354211b1d8642";
+(node as any).hash = "88fd30c654857c69dcd09df8073ec7d7";
 
 export default node;

--- a/src/__generated__/DetailsRoute_Test_Query.graphql.ts
+++ b/src/__generated__/DetailsRoute_Test_Query.graphql.ts
@@ -1,0 +1,149 @@
+/**
+ * @generated SignedSource<<ebac4965c08048f6ea3d683193b5d3e0>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type DetailsRoute_Test_Query$variables = Record<PropertyKey, never>;
+export type DetailsRoute_Test_Query$data = {
+  readonly submission: {
+    readonly " $fragmentSpreads": FragmentRefs<"DetailsRoute_submission" | "SubmissionRoute_submission">;
+  } | null | undefined;
+};
+export type DetailsRoute_Test_Query$rawResponse = {
+  readonly submission: {
+    readonly category: string | null | undefined;
+    readonly externalId: string;
+    readonly id: string;
+    readonly internalID: string | null | undefined;
+    readonly medium: string | null | undefined;
+    readonly year: string | null | undefined;
+  } | null | undefined;
+};
+export type DetailsRoute_Test_Query = {
+  rawResponse: DetailsRoute_Test_Query$rawResponse;
+  response: DetailsRoute_Test_Query$data;
+  variables: DetailsRoute_Test_Query$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "submission-id"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "DetailsRoute_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "ConsignmentSubmission",
+        "kind": "LinkedField",
+        "name": "submission",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "SubmissionRoute_submission"
+          },
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "DetailsRoute_submission"
+          }
+        ],
+        "storageKey": "submission(id:\"submission-id\")"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "DetailsRoute_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "ConsignmentSubmission",
+        "kind": "LinkedField",
+        "name": "submission",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "internalID",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "externalId",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "year",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "category",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "medium",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": "submission(id:\"submission-id\")"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "fc488fa7f814f16e03fa6cdabee52b63",
+    "id": null,
+    "metadata": {},
+    "name": "DetailsRoute_Test_Query",
+    "operationKind": "query",
+    "text": "query DetailsRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...SubmissionRoute_submission\n    ...DetailsRoute_submission\n    id\n  }\n}\n\nfragment DetailsRoute_submission on ConsignmentSubmission {\n  year\n  category\n  medium\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "fae619a74d924cc0087b1b0c2fd2dbcf";
+
+export default node;


### PR DESCRIPTION
Addresses [ONYX-1017]

## Description

This implements the **Details step** for the new submission flow.

| desktop | mWeb |
| --- | --- |
|<img width="1395" alt="Screenshot 2024-06-13 at 11 19 11" src="https://github.com/artsy/force/assets/4691889/553f4d6c-f588-4382-927a-5a56f37592f7"> | <img width="395" alt="Screenshot 2024-06-13 at 11 19 35" src="https://github.com/artsy/force/assets/4691889/de2f4f08-6a8f-47e1-8dd1-69cd6463ea4d">|



[ONYX-1017]: https://artsyproduct.atlassian.net/browse/ONYX-1017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ