### PR TITLE
feat: add 06 neartext experiment

### DIFF
--- a/.env.oss
+++ b/.env.oss
@@ -24,3 +24,4 @@ GEMINI_CLOUDFRONT_URL=https://d7hftxdivxxvm.cloudfront.net
 GENOME_URL=https://helix.artsy.net
 SECURE_IMAGES_URL=https://d1ycxz9plii3tb.cloudfront.net
 OPENAI_API_KEY=REPLACE # pragma: allowlist secret
+WEAVIATE_URL=REPLACE # pragma: allowlist secret

--- a/.env.oss
+++ b/.env.oss
@@ -3,7 +3,6 @@
 # projects, and are not a problem. OSS contributors: Please don't abuse the keys,
 # as then we'll have to change it, making it harder for others to learn from.
 # As such, these keys do not come under the Artsy security bounty either.
-
 # ------------------------
 # OSS Environment
 # ------------------------
@@ -24,4 +23,4 @@ GEMINI_CLOUDFRONT_URL=https://d7hftxdivxxvm.cloudfront.net
 GENOME_URL=https://helix.artsy.net
 SECURE_IMAGES_URL=https://d1ycxz9plii3tb.cloudfront.net
 OPENAI_API_KEY=REPLACE # pragma: allowlist secret
-WEAVIATE_URL=REPLACE # pragma: allowlist secret
+WEAVIATE_URL=https://REPLACE # pragma: allowlist secret

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -124,7 +124,7 @@
         "filename": ".env.oss",
         "hashed_secret": "fafec1e5ff94390c631054d24bd289e8951e151e",
         "is_verified": false,
-        "line_number": 22
+        "line_number": 21
       }
     ],
     "src/Apps/MyCollection/Routes/EditArtwork/__tests__/MyCollectionCreateArtwork.jest.tsx": [
@@ -538,5 +538,5 @@
       }
     ]
   },
-  "generated_at": "2024-04-11T22:08:08Z"
+  "generated_at": "2024-06-14T16:10:47Z"
 }

--- a/src/Apps/ArtAdvisor/06-Discovery-Neartext/App.tsx
+++ b/src/Apps/ArtAdvisor/06-Discovery-Neartext/App.tsx
@@ -1,6 +1,148 @@
-import { FC } from "react"
-import { Text } from "@artsy/palette"
+import { FC, useEffect, useState } from "react"
+import { Box, Select, SkeletonBox, Spacer, Text } from "@artsy/palette"
+import {
+  DiscoveryArtwork,
+  DiscoveryUser,
+  UUID,
+} from "Apps/ArtAdvisor/06-Discovery-Neartext/types"
+import { Rail } from "Components/Rail/Rail"
+import _ from "lodash"
+import { Artwork } from "Apps/ArtAdvisor/06-Discovery-Neartext/components/Artwork"
+import { Concepts } from "Apps/ArtAdvisor/06-Discovery-Neartext/components/Concepts"
 
 export const App: FC = () => {
-  return <Text as="h1">Hello, world</Text>
+  const [isLoading, setIsLoading] = useState<boolean>(false)
+  const [users, setUsers] = useState<DiscoveryUser[]>([])
+  const [userId, setUserId] = useState<UUID>()
+  const [user, setUser] = useState<DiscoveryUser>()
+  const [conceptText, setConceptText] = useState<string>("")
+  const [concepts, setConcepts] = useState<string[]>([])
+  const [artworks, setArtworks] = useState<DiscoveryArtwork[]>([])
+
+  useEffect(() => {
+    console.log("[Discovery] mount effect")
+
+    async function fetchUsers() {
+      const response = await fetch("/api/advisor/6/users")
+      const users = await response.json()
+      return users
+    }
+
+    fetchUsers().then(setUsers)
+  }, [])
+
+  useEffect(() => {
+    console.log("[Discovery] user effect for", userId)
+    async function fetchUser(id: UUID) {
+      const response = await fetch(`/api/advisor/6/users/${id}`)
+      const user = await response.json()
+      return user
+    }
+
+    if (userId) fetchUser(userId).then(setUser)
+  }, [userId])
+
+  useEffect(() => {
+    console.group("[Discovery] artwork effect for", concepts, user)
+    async function fetchArtworks(options: {
+      concepts: string[]
+      likedArtworkIds: string[]
+      dislikedArtworkIds: string[]
+    }) {
+      const { concepts, likedArtworkIds, dislikedArtworkIds } = options
+      setIsLoading(true)
+      const params = new URLSearchParams()
+      concepts.forEach(concept => {
+        params.append("concepts", concept)
+      })
+      // TODO: pull these right off the user?
+      likedArtworkIds.forEach(id => {
+        params.append("likedArtworkIds", id)
+      })
+      dislikedArtworkIds.forEach(id => {
+        params.append("dislikedArtworkIds", id)
+      })
+      console.log("[Discovery] fetchArtworks() querystring", params.toString())
+
+      const url = `/api/advisor/6/artworks?${params.toString()}`
+      const response = await fetch(url)
+      const data = await response.json()
+      setIsLoading(false)
+      return data
+    }
+
+    if (user && concepts.length > 0) {
+      const options = {
+        concepts,
+        likedArtworkIds: user.likedArtworkIds,
+        dislikedArtworkIds: user.dislikedArtworkIds,
+      }
+      console.log("[Discovery] fetchArtworks()", options)
+      fetchArtworks(options).then(setArtworks)
+    }
+    console.groupEnd()
+  }, [concepts, user])
+
+  return (
+    <Box>
+      <Spacer y={2} />
+      <Select
+        title={"Pick A User"}
+        width={"25%"}
+        options={users.map(u => ({ value: u.id, text: u.name }))}
+        disabled={isLoading}
+        onSelect={value => {
+          console.log("[Discovery] Selected user: ", value)
+          setUserId(value)
+        }}
+      />
+      <Spacer y={2} />
+      {user ? (
+        <>
+          {artworks.length ? (
+            <Box opacity={isLoading ? 0.2 : 1}>
+              <Rail
+                title="Recommended Artworks (Near Concepts)"
+                getItems={() => {
+                  return artworks.map((artwork: DiscoveryArtwork) => {
+                    return (
+                      <Artwork
+                        key={artwork.id}
+                        artwork={artwork}
+                        user={user}
+                        setUser={setUser}
+                      />
+                    )
+                  })
+                }}
+              />
+            </Box>
+          ) : (
+            <SkeletonBox height={460} />
+          )}
+
+          <Concepts
+            conceptText={conceptText}
+            setConceptText={setConceptText}
+            setConcepts={setConcepts}
+          />
+        </>
+      ) : (
+        <Text py={6} variant={"lg"}>
+          Select a user to get started
+        </Text>
+      )}
+      <hr />
+      <details>
+        <summary>Debug</summary>
+        <pre>
+          {JSON.stringify(
+            { users, userId, user, conceptText, concepts, artworks },
+            null,
+            2
+          )}
+        </pre>
+      </details>
+    </Box>
+  )
 }

--- a/src/Apps/ArtAdvisor/06-Discovery-Neartext/App.tsx
+++ b/src/Apps/ArtAdvisor/06-Discovery-Neartext/App.tsx
@@ -1,0 +1,6 @@
+import { FC } from "react"
+import { Text } from "@artsy/palette"
+
+export const App: FC = () => {
+  return <Text as="h1">Hello, world</Text>
+}

--- a/src/Apps/ArtAdvisor/06-Discovery-Neartext/components/Artwork.tsx
+++ b/src/Apps/ArtAdvisor/06-Discovery-Neartext/components/Artwork.tsx
@@ -1,0 +1,124 @@
+import CheckmarkFillIcon from "@artsy/icons/CheckmarkFillIcon"
+import CloseFillIcon from "@artsy/icons/CloseFillIcon"
+import {
+  Column,
+  Text,
+  Image,
+  Clickable,
+  Flex,
+  Spacer,
+  useToasts,
+} from "@artsy/palette"
+import {
+  DiscoveryArtwork,
+  DiscoveryUser,
+} from "Apps/ArtAdvisor/06-Discovery-Neartext/types"
+import _ from "lodash"
+import { FC } from "react"
+
+type ArtworkProps = {
+  artwork: DiscoveryArtwork
+  user: DiscoveryUser
+  setUser: (user: DiscoveryUser) => void
+}
+
+export const Artwork: FC<ArtworkProps> = ({ artwork, user, setUser }) => {
+  const { sendToast } = useToasts()
+
+  if (!artwork.imageUrl) {
+    return null
+  }
+
+  const handleClickLike = async () => {
+    try {
+      const like = await fetch("/api/advisor/6/artworks/likes", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          userId: user.id,
+          artworkId: artwork.internalID,
+        }),
+      })
+
+      if (like.ok) {
+        // optimistic update of user state
+        setUser({
+          ...user,
+          likedArtworkIds: _.uniq([
+            ...user.likedArtworkIds,
+            artwork.internalID,
+          ]),
+        })
+      }
+
+      sendToast({
+        message: `Liked ${artwork.title}`,
+      })
+    } catch (error) {
+      console.error(error)
+      sendToast({
+        variant: "error",
+        message: `Something went wrong liking artwork: ${artwork.title}`,
+      })
+    }
+  }
+
+  const handleClickDislike = async () => {
+    try {
+      const dislike = await fetch("/api/advisor/6/artworks/dislikes", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          userId: user.id,
+          artworkId: artwork.internalID,
+        }),
+      })
+
+      if (dislike.ok) {
+        // optimistic update of user state
+        setUser({
+          ...user,
+          dislikedArtworkIds: _.uniq([
+            ...user.dislikedArtworkIds,
+            artwork.internalID,
+          ]),
+        })
+      }
+
+      sendToast({
+        message: `Disliked ${artwork.title}`,
+      })
+    } catch (error) {
+      console.error(error)
+      sendToast({
+        variant: "error",
+        message: `Something went wrong disliking artwork: ${artwork.title}`,
+      })
+    }
+  }
+
+  return (
+    <Column span={[6, 4]}>
+      <Flex flexDirection={"column"} alignItems={"center"}>
+        <Image src={artwork.imageUrl} height={300} />
+        <Spacer y={1} />
+        <Text py={1} variant="sm-display" color="black60" overflowEllipsis>
+          {artwork.title}
+        </Text>
+
+        <Flex py={1} gap={1} justifyContent={"center"}>
+          <Clickable onClick={handleClickLike}>
+            <CheckmarkFillIcon fill={"black60"} size={30} />
+          </Clickable>
+          <Clickable onClick={handleClickDislike}>
+            <CloseFillIcon fill={"black60"} size={30} />
+          </Clickable>
+        </Flex>
+      </Flex>
+    </Column>
+  )
+}

--- a/src/Apps/ArtAdvisor/06-Discovery-Neartext/components/Concepts.tsx
+++ b/src/Apps/ArtAdvisor/06-Discovery-Neartext/components/Concepts.tsx
@@ -1,0 +1,39 @@
+import { FC } from "react"
+import _ from "lodash"
+import { Box, Button, Spacer, Text, TextArea } from "@artsy/palette"
+
+interface ConceptsProps {
+  conceptText: string
+  setConceptText: (text: string) => void
+  setConcepts: (concepts: string[]) => void
+}
+export const Concepts: FC<ConceptsProps> = props => {
+  const { conceptText, setConceptText, setConcepts } = props
+  return (
+    <Box py={2}>
+      <Text variant={"lg-display"}>Concepts</Text>
+      <Spacer y={1} />
+
+      <Text>Enter one or more "user concepts", one concept per line:</Text>
+      <Spacer y={1} />
+
+      <TextArea
+        placeholder="street art, e.g."
+        defaultValue={conceptText}
+        rows={5}
+        onChange={({ value }) => setConceptText(value)}
+      ></TextArea>
+      <Spacer y={1} />
+
+      <Button
+        onClick={e => {
+          let concepts = (conceptText || "").split("\n")
+          concepts = _.reject(concepts, c => _.isEmpty(c.trim()))
+          setConcepts(concepts)
+        }}
+      >
+        Update
+      </Button>
+    </Box>
+  )
+}

--- a/src/Apps/ArtAdvisor/06-Discovery-Neartext/server.ts
+++ b/src/Apps/ArtAdvisor/06-Discovery-Neartext/server.ts
@@ -5,6 +5,8 @@ import { WeaviateDB } from "./weaviate-db"
 
 const ROOP_TESTER_ID = "64724d9a-920f-4814-bf3f-bf1c45e02725"
 
+const w = new WeaviateDB()
+
 const getArtworks = async (req: ArtsyRequest, res: ArtsyResponse) => {
   res.json({ hello: "world " })
 }
@@ -24,8 +26,6 @@ router.post("/artworks/likes", createArtworkLike)
 router.post("/artworks/dislikes", createArtworkDislike)
 
 router.get("/test", async (req: ArtsyRequest, res: ArtsyResponse) => {
-  const w = new WeaviateDB()
-
   const like = await w.reactToArtwork({
     artworkInternalID: "662fa0a76db981000e0725ff",
     userId: ROOP_TESTER_ID,

--- a/src/Apps/ArtAdvisor/06-Discovery-Neartext/server.ts
+++ b/src/Apps/ArtAdvisor/06-Discovery-Neartext/server.ts
@@ -19,6 +19,11 @@ const getArtworks = async (req: ArtsyRequest, res: ArtsyResponse) => {
   res.json(artworks)
 }
 
+const getUsers = async (req: ArtsyRequest, res: ArtsyResponse) => {
+  const users = await w.getUsers()
+  res.json(users)
+}
+
 const createArtworkLike = async (req: ArtsyRequest, res: ArtsyResponse) => {
   let { userId, userInternalID, artworkId } = req.body
   if (userInternalID) {
@@ -51,6 +56,7 @@ const createArtworkDislike = async (req: ArtsyRequest, res: ArtsyResponse) => {
 
 export const router = express.Router()
 
+router.get("/users", getUsers)
 router.get("/artworks", getArtworks)
 router.post("/artworks/likes", createArtworkLike)
 router.post("/artworks/dislikes", createArtworkDislike)

--- a/src/Apps/ArtAdvisor/06-Discovery-Neartext/server.ts
+++ b/src/Apps/ArtAdvisor/06-Discovery-Neartext/server.ts
@@ -3,7 +3,7 @@ import { ArtsyRequest, ArtsyResponse } from "Server/middleware/artsyExpress"
 import _ from "lodash"
 import { WeaviateDB } from "./weaviate-db"
 
-const ROOP_TESTER_ID = "b0fa5a51-6ab1-4576-8404-544834e521af"
+const ROOP_TESTER_ID = "64724d9a-920f-4814-bf3f-bf1c45e02725"
 
 const getArtworks = async (req: ArtsyRequest, res: ArtsyResponse) => {
   res.json({ hello: "world " })
@@ -26,22 +26,30 @@ router.post("/artworks/dislikes", createArtworkDislike)
 router.get("/test", async (req: ArtsyRequest, res: ArtsyResponse) => {
   const w = new WeaviateDB()
 
-  const user = await w.getUser({ id: ROOP_TESTER_ID })
-
   const like = await w.reactToArtwork({
     artworkInternalID: "662fa0a76db981000e0725ff",
     userId: ROOP_TESTER_ID,
     reaction: "like",
   })
   const dislike = await w.reactToArtwork({
-    artworkInternalID: "660ecffeb7efdb000e8bb024",
+    artworkInternalID: "66266a4b1275a600124aeba8",
     userId: ROOP_TESTER_ID,
     reaction: "dislike",
   })
 
+  const user = await w.getUser({ id: ROOP_TESTER_ID })
+
+  const artworks = await w.getArtworksNearConcepts({
+    concepts: ["flower"],
+    likedArtworkIds: user.likedArtworkUuids,
+    dislikedArtworkIds: user.dislikedArtworkUuids,
+    limit: 3,
+  })
+
   res.json({
-    user,
     like,
     dislike,
+    user,
+    artworks,
   })
 })

--- a/src/Apps/ArtAdvisor/06-Discovery-Neartext/server.ts
+++ b/src/Apps/ArtAdvisor/06-Discovery-Neartext/server.ts
@@ -4,13 +4,11 @@ import _ from "lodash"
 import { WeaviateDB } from "./weaviate-db"
 import { generateUuid5 } from "weaviate-ts-client"
 
-const ROOP_TESTER_ID = "64724d9a-920f-4814-bf3f-bf1c45e02725"
-
-const w = new WeaviateDB()
+const weaviateDB = new WeaviateDB()
 
 const getArtworks = async (req: ArtsyRequest, res: ArtsyResponse) => {
   const { concepts, likedArtworkIds, dislikedArtworkIds, limit } = req.query
-  const artworks = await w.getArtworksNearConcepts({
+  const artworks = await weaviateDB.getArtworksNearConcepts({
     concepts: concepts as string[],
     likedArtworkIds: likedArtworkIds as string[],
     dislikedArtworkIds: dislikedArtworkIds as string[],
@@ -20,13 +18,13 @@ const getArtworks = async (req: ArtsyRequest, res: ArtsyResponse) => {
 }
 
 const getUsers = async (req: ArtsyRequest, res: ArtsyResponse) => {
-  const users = await w.getUsers()
+  const users = await weaviateDB.getUsers()
   res.json(users)
 }
 
 const getUser = async (req: ArtsyRequest, res: ArtsyResponse) => {
   const { id } = req.params // assumed to be UUID
-  const user = await w.getUser({ id })
+  const user = await weaviateDB.getUser({ id })
   res.json(user)
 }
 
@@ -37,7 +35,7 @@ const createArtworkLike = async (req: ArtsyRequest, res: ArtsyResponse) => {
   }
   if (!userId) throw new Error("Provide either userId (UUID) or userInternalID")
 
-  const result = await w.reactToArtwork({
+  const result = await weaviateDB.reactToArtwork({
     userId,
     artworkInternalID: artworkId,
     reaction: "like",
@@ -52,7 +50,7 @@ const createArtworkDislike = async (req: ArtsyRequest, res: ArtsyResponse) => {
   }
   if (!userId) throw new Error("Provide either userId (UUID) or userInternalID")
 
-  const result = await w.reactToArtwork({
+  const result = await weaviateDB.reactToArtwork({
     userId,
     artworkInternalID: artworkId,
     reaction: "dislike",
@@ -69,27 +67,29 @@ router.post("/artworks/likes", createArtworkLike)
 router.post("/artworks/dislikes", createArtworkDislike)
 
 router.get("/test", async (req: ArtsyRequest, res: ArtsyResponse) => {
-  const like = await w.reactToArtwork({
+  const TEST_ID = "64724d9a-920f-4814-bf3f-bf1c45e02725"
+
+  const like = await weaviateDB.reactToArtwork({
     artworkInternalID: "662fa0a76db981000e0725ff",
-    userId: ROOP_TESTER_ID,
+    userId: TEST_ID,
     reaction: "like",
   })
-  const dislike = await w.reactToArtwork({
+  const dislike = await weaviateDB.reactToArtwork({
     artworkInternalID: "66266a4b1275a600124aeba8",
-    userId: ROOP_TESTER_ID,
+    userId: TEST_ID,
     reaction: "dislike",
   })
 
-  const user = await w.getUser({ id: ROOP_TESTER_ID })
+  const user = await weaviateDB.getUser({ id: TEST_ID })
 
-  const artworks = await w.getArtworksNearConcepts({
+  const artworks = await weaviateDB.getArtworksNearConcepts({
     concepts: ["flower"],
     likedArtworkIds: user.likedArtworkIds,
     dislikedArtworkIds: user.dislikedArtworkIds,
     limit: 3,
   })
 
-  const users = await w.getUsers()
+  const users = await weaviateDB.getUsers()
 
   res.json({
     like,

--- a/src/Apps/ArtAdvisor/06-Discovery-Neartext/server.ts
+++ b/src/Apps/ArtAdvisor/06-Discovery-Neartext/server.ts
@@ -24,6 +24,12 @@ const getUsers = async (req: ArtsyRequest, res: ArtsyResponse) => {
   res.json(users)
 }
 
+const getUser = async (req: ArtsyRequest, res: ArtsyResponse) => {
+  const { id } = req.params // assumed to be UUID
+  const user = await w.getUser({ id })
+  res.json(user)
+}
+
 const createArtworkLike = async (req: ArtsyRequest, res: ArtsyResponse) => {
   let { userId, userInternalID, artworkId } = req.body
   if (userInternalID) {
@@ -57,6 +63,7 @@ const createArtworkDislike = async (req: ArtsyRequest, res: ArtsyResponse) => {
 export const router = express.Router()
 
 router.get("/users", getUsers)
+router.get("/users/:id", getUser)
 router.get("/artworks", getArtworks)
 router.post("/artworks/likes", createArtworkLike)
 router.post("/artworks/dislikes", createArtworkDislike)

--- a/src/Apps/ArtAdvisor/06-Discovery-Neartext/server.ts
+++ b/src/Apps/ArtAdvisor/06-Discovery-Neartext/server.ts
@@ -1,0 +1,21 @@
+import express from "express"
+import { ArtsyRequest, ArtsyResponse } from "Server/middleware/artsyExpress"
+import _ from "lodash"
+
+const getArtworks = async (req: ArtsyRequest, res: ArtsyResponse) => {
+  res.json({ hello: "world " })
+}
+
+const createArtworkLike = async (req: ArtsyRequest, res: ArtsyResponse) => {
+  res.json({ hello: "world " })
+}
+
+const createArtworkDislike = async (req: ArtsyRequest, res: ArtsyResponse) => {
+  res.json({ hello: "world " })
+}
+
+export const router = express.Router()
+
+router.get("/artworks", getArtworks)
+router.post("/artworks/likes", createArtworkLike)
+router.post("/artworks/dislikes", createArtworkDislike)

--- a/src/Apps/ArtAdvisor/06-Discovery-Neartext/server.ts
+++ b/src/Apps/ArtAdvisor/06-Discovery-Neartext/server.ts
@@ -1,6 +1,9 @@
 import express from "express"
 import { ArtsyRequest, ArtsyResponse } from "Server/middleware/artsyExpress"
 import _ from "lodash"
+import { WeaviateDB } from "./weaviate-db"
+
+const ROOP_TESTER_ID = "b0fa5a51-6ab1-4576-8404-544834e521af"
 
 const getArtworks = async (req: ArtsyRequest, res: ArtsyResponse) => {
   res.json({ hello: "world " })
@@ -19,3 +22,12 @@ export const router = express.Router()
 router.get("/artworks", getArtworks)
 router.post("/artworks/likes", createArtworkLike)
 router.post("/artworks/dislikes", createArtworkDislike)
+
+router.get("/test", async (req: ArtsyRequest, res: ArtsyResponse) => {
+  const w = new WeaviateDB()
+  const user = await w.getUser({ id: ROOP_TESTER_ID })
+
+  res.json({
+    user,
+  })
+})

--- a/src/Apps/ArtAdvisor/06-Discovery-Neartext/server.ts
+++ b/src/Apps/ArtAdvisor/06-Discovery-Neartext/server.ts
@@ -76,10 +76,13 @@ router.get("/test", async (req: ArtsyRequest, res: ArtsyResponse) => {
     limit: 3,
   })
 
+  const users = await w.getUsers()
+
   res.json({
     like,
     dislike,
     user,
     artworks,
+    users,
   })
 })

--- a/src/Apps/ArtAdvisor/06-Discovery-Neartext/server.ts
+++ b/src/Apps/ArtAdvisor/06-Discovery-Neartext/server.ts
@@ -2,21 +2,51 @@ import express from "express"
 import { ArtsyRequest, ArtsyResponse } from "Server/middleware/artsyExpress"
 import _ from "lodash"
 import { WeaviateDB } from "./weaviate-db"
+import { generateUuid5 } from "weaviate-ts-client"
 
 const ROOP_TESTER_ID = "64724d9a-920f-4814-bf3f-bf1c45e02725"
 
 const w = new WeaviateDB()
 
 const getArtworks = async (req: ArtsyRequest, res: ArtsyResponse) => {
-  res.json({ hello: "world " })
+  const { concepts, likedArtworkIds, dislikedArtworkIds, limit } = req.query
+  const artworks = await w.getArtworksNearConcepts({
+    concepts: concepts as string[],
+    likedArtworkIds: likedArtworkIds as string[],
+    dislikedArtworkIds: dislikedArtworkIds as string[],
+    limit: limit as number,
+  })
+  res.json(artworks)
 }
 
 const createArtworkLike = async (req: ArtsyRequest, res: ArtsyResponse) => {
-  res.json({ hello: "world " })
+  let { userId, userInternalID, artworkId } = req.body
+  if (userInternalID) {
+    userId = generateUuid5(userInternalID)
+  }
+  if (!userId) throw new Error("Provide either userId (UUID) or userInternalID")
+
+  const result = await w.reactToArtwork({
+    userId,
+    artworkInternalID: artworkId,
+    reaction: "like",
+  })
+  res.json(result)
 }
 
 const createArtworkDislike = async (req: ArtsyRequest, res: ArtsyResponse) => {
-  res.json({ hello: "world " })
+  let { userId, userInternalID, artworkId } = req.body
+  if (userInternalID) {
+    userId = generateUuid5(userInternalID)
+  }
+  if (!userId) throw new Error("Provide either userId (UUID) or userInternalID")
+
+  const result = await w.reactToArtwork({
+    userId,
+    artworkInternalID: artworkId,
+    reaction: "dislike",
+  })
+  res.json(result)
 }
 
 export const router = express.Router()

--- a/src/Apps/ArtAdvisor/06-Discovery-Neartext/server.ts
+++ b/src/Apps/ArtAdvisor/06-Discovery-Neartext/server.ts
@@ -25,9 +25,23 @@ router.post("/artworks/dislikes", createArtworkDislike)
 
 router.get("/test", async (req: ArtsyRequest, res: ArtsyResponse) => {
   const w = new WeaviateDB()
+
   const user = await w.getUser({ id: ROOP_TESTER_ID })
+
+  const like = await w.reactToArtwork({
+    artworkInternalID: "662fa0a76db981000e0725ff",
+    userId: ROOP_TESTER_ID,
+    reaction: "like",
+  })
+  const dislike = await w.reactToArtwork({
+    artworkInternalID: "660ecffeb7efdb000e8bb024",
+    userId: ROOP_TESTER_ID,
+    reaction: "dislike",
+  })
 
   res.json({
     user,
+    like,
+    dislike,
   })
 })

--- a/src/Apps/ArtAdvisor/06-Discovery-Neartext/server.ts
+++ b/src/Apps/ArtAdvisor/06-Discovery-Neartext/server.ts
@@ -41,8 +41,8 @@ router.get("/test", async (req: ArtsyRequest, res: ArtsyResponse) => {
 
   const artworks = await w.getArtworksNearConcepts({
     concepts: ["flower"],
-    likedArtworkIds: user.likedArtworkUuids,
-    dislikedArtworkIds: user.dislikedArtworkUuids,
+    likedArtworkIds: user.likedArtworkIds,
+    dislikedArtworkIds: user.dislikedArtworkIds,
     limit: 3,
   })
 

--- a/src/Apps/ArtAdvisor/06-Discovery-Neartext/types.ts
+++ b/src/Apps/ArtAdvisor/06-Discovery-Neartext/types.ts
@@ -1,5 +1,5 @@
-type MongoID = string
-type UUID = string
+export type MongoID = string
+export type UUID = string
 
 export type DiscoveryUser = {
   id: UUID

--- a/src/Apps/ArtAdvisor/06-Discovery-Neartext/types.ts
+++ b/src/Apps/ArtAdvisor/06-Discovery-Neartext/types.ts
@@ -6,9 +6,8 @@ export type DiscoveryUser = {
   internalID: MongoID
   // properties
   name: string
-  // references
-  likedArtworkUuids: UUID[]
-  dislikedArtworkUuids: UUID[]
+  likedArtworkIds: MongoID[]
+  dislikedArtworkIds: MongoID[]
 }
 
 export type DiscoveryArtwork = {

--- a/src/Apps/ArtAdvisor/06-Discovery-Neartext/types.ts
+++ b/src/Apps/ArtAdvisor/06-Discovery-Neartext/types.ts
@@ -4,7 +4,24 @@ export type UUID = string
 export type DiscoveryUser = {
   id: UUID
   internalID: MongoID
+  // properties
   name: string
+  // references
   likedArtworkUuids: UUID[]
   dislikedArtworkUuids: UUID[]
+}
+
+export type DiscoveryArtwork = {
+  id: UUID
+  internalID: MongoID
+  // properties
+  slug: string
+  title: string
+  date: string
+  rarity: string
+  medium: string
+  materials: string
+  price: string
+  dimensions: string
+  imageUrl: string
 }

--- a/src/Apps/ArtAdvisor/06-Discovery-Neartext/types.ts
+++ b/src/Apps/ArtAdvisor/06-Discovery-Neartext/types.ts
@@ -1,0 +1,10 @@
+type MongoID = string
+type UUID = string
+
+export type DiscoveryUser = {
+  id: UUID
+  internalID: MongoID
+  name: string
+  likedArtworkUuids: UUID[]
+  dislikedArtworkUuids: UUID[]
+}

--- a/src/Apps/ArtAdvisor/06-Discovery-Neartext/weaviate-db.ts
+++ b/src/Apps/ArtAdvisor/06-Discovery-Neartext/weaviate-db.ts
@@ -39,6 +39,23 @@ export class WeaviateDB {
     this.userClass = options.userClass || DEFAULT_USERS_CLASS
   }
 
+  async getUsers() {
+    const response = await this.client.graphql
+      .get()
+      .withClassName(this.userClass)
+      .withFields("name _additional { id }")
+      .do()
+
+    const users = response.data.Get.DiscoveryUsers.map(user => {
+      return {
+        id: user._additional.id,
+        name: user.name,
+      }
+    })
+
+    return users
+  }
+
   /**
    * Fetch a user
    */

--- a/src/Apps/ArtAdvisor/06-Discovery-Neartext/weaviate-db.ts
+++ b/src/Apps/ArtAdvisor/06-Discovery-Neartext/weaviate-db.ts
@@ -187,6 +187,13 @@ export class WeaviateDB {
     /** Max number of artworks to return */
     limit?: number
   }) {
+    console.log("[WeaviateDB] getArtworksNearConcepts", {
+      concepts,
+      likedArtworkIds,
+      dislikedArtworkIds,
+      limit,
+    })
+
     const conceptArray = ensureValidConcepts(concepts)
 
     const response = await this.client.graphql

--- a/src/Apps/ArtAdvisor/06-Discovery-Neartext/weaviate-db.ts
+++ b/src/Apps/ArtAdvisor/06-Discovery-Neartext/weaviate-db.ts
@@ -109,8 +109,8 @@ export class WeaviateDB {
       id,
       // internalID, // TODO: once we create real Gravity users
       name,
-      likedArtworkIds: likedArtworks.map(w => w.internalID),
-      dislikedArtworkIds: dislikedArtworks.map(w => w.internalID),
+      likedArtworkIds: (likedArtworks || []).map(w => w.internalID),
+      dislikedArtworkIds: (dislikedArtworks || []).map(w => w.internalID),
     } as DiscoveryUser
   }
 
@@ -252,6 +252,6 @@ function ensureValidConcepts(concepts: string[]) {
  * @param force weight of the move
  */
 function getMoveObjects(ids: MongoID[], force = 1) {
-  const objects = ids.map(id => ({ id: generateUuid5(id), force }))
+  const objects = _.castArray(ids).map(id => ({ id: generateUuid5(id), force }))
   return { objects, force }
 }

--- a/src/Apps/ArtAdvisor/06-Discovery-Neartext/weaviate-db.ts
+++ b/src/Apps/ArtAdvisor/06-Discovery-Neartext/weaviate-db.ts
@@ -1,0 +1,75 @@
+import { DiscoveryUser } from "Apps/ArtAdvisor/06-Discovery-Neartext/types"
+import _ from "lodash"
+import weaviate, { WeaviateClient } from "weaviate-ts-client"
+
+export class WeaviateDB {
+  private client: WeaviateClient
+
+  constructor() {
+    if (!process.env.WEAVIATE_URL) throw new Error("WEAVIATE_URL is not set")
+
+    this.client = weaviate.client({
+      host: process.env.WEAVIATE_URL,
+    })
+  }
+
+  /**
+   * Fetch a user
+   */
+  async getUser({
+    internalID,
+    id,
+  }: {
+    /** Mongo ID for Gravity User */
+    internalID?: string
+    /** Weaviate UUID for DiscoveryUser */
+    id?: string
+  }): Promise<DiscoveryUser> {
+    if (!internalID && !id)
+      throw new Error("Must provide either internalID or id (UUID)")
+
+    if (internalID) throw new Error("Not implemented yet")
+
+    if (!id) {
+      // temporary, while using test users
+      throw new Error("Missing id")
+    }
+
+    const response = await this.client.data
+      .getterById()
+      .withClassName("DiscoveryUsers")
+      .withId(id)
+      .do()
+
+    const {
+      internalID: _internalID,
+      name,
+      likedArtworks,
+      dislikedArtworks,
+    } = response.properties as any
+
+    const likedArtworkUuids = likedArtworks.map(a =>
+      getUUIDFromBeacon(a.beacon)
+    )
+
+    const dislikedArtworkUuids = dislikedArtworks.map(a =>
+      getUUIDFromBeacon(a.beacon)
+    )
+
+    return {
+      id,
+      internalID: _internalID,
+      name,
+      likedArtworkUuids,
+      dislikedArtworkUuids,
+    } as DiscoveryUser
+  }
+}
+
+function getUUIDFromBeacon(beacon: string) {
+  const parts = beacon.split("/")
+  const uuid = parts[parts.length - 1]
+  if (uuid.length !== 36) throw new Error("Invalid UUID")
+
+  return uuid
+}

--- a/src/Apps/ArtAdvisor/ArtAdvisorApp.tsx
+++ b/src/Apps/ArtAdvisor/ArtAdvisorApp.tsx
@@ -50,6 +50,15 @@ export const ArtAdvisorApp: FC = () => {
           disliking an artwork)
         </Description>
       </Experiment>
+
+      <Experiment href="/advisor/6">
+        <Name>Near Concept Search Rail</Name>
+        <Description>
+          A artwork rail that demonstrates neartext search functionality. It
+          retrieves artwork recommendations based on a list of concepts, as well
+          as by moving toward/away from the user's liked/disliked artworks.
+        </Description>
+      </Experiment>
     </Box>
   )
 }

--- a/src/Apps/ArtAdvisor/ArtAdvisorRoutes.tsx
+++ b/src/Apps/ArtAdvisor/ArtAdvisorRoutes.tsx
@@ -48,6 +48,16 @@ const ArtAdvisorApp05 = loadable(
   }
 )
 
+const ArtAdvisorApp06 = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "advisorBundle" */ "./06-Discovery-Neartext/App"
+    ),
+  {
+    resolveComponent: component => component.App,
+  }
+)
+
 export const artAdvisorRoutes: AppRouteConfig[] = [
   {
     path: "/advisor",
@@ -89,6 +99,13 @@ export const artAdvisorRoutes: AppRouteConfig[] = [
     getComponent: () => ArtAdvisorApp05,
     onClientSideRender: () => {
       ArtAdvisorApp05.preload()
+    },
+  },
+  {
+    path: "/advisor/6",
+    getComponent: () => ArtAdvisorApp06,
+    onClientSideRender: () => {
+      ArtAdvisorApp06.preload()
     },
   },
 ]

--- a/src/Apps/ArtAdvisor/ArtAdvisorServerRoutes.ts
+++ b/src/Apps/ArtAdvisor/ArtAdvisorServerRoutes.ts
@@ -4,6 +4,7 @@ import { router as router2 } from "./02-Markdown/server"
 import { router as router3 } from "./03-Instruction-Experiments/server"
 import { router as router4 } from "./04-Bio-Follows-Alerts/server"
 import { router as router5 } from "./05-Near-Object-Rail/server"
+import { router as router6 } from "./06-Discovery-Neartext/server"
 
 /*
  * Define API routes that can be collocated with each app experiment
@@ -16,3 +17,4 @@ artAdvisorServerRoutes.use("/api/advisor/2", router2)
 artAdvisorServerRoutes.use("/api/advisor/3", router3)
 artAdvisorServerRoutes.use("/api/advisor/4", router4)
 artAdvisorServerRoutes.use("/api/advisor/5", router5)
+artAdvisorServerRoutes.use("/api/advisor/6", router6)


### PR DESCRIPTION
Adds an experiment to source artwork discovery recommendations for a user based on:

- a list of plaintext "concepts" that describes the user
- a list of liked artworks
- a list of disliked artworks

The concepts act as a semantic search over the Weaviate `DiscoveryArtworks` collection (a few hundred artworks from our curated collections, as of this writing)

The dis/likes serve to refine the results based on explicit user signals.


https://github.com/artsy/force/assets/140521/e6aa165f-ee64-4ebc-92ed-4e6dcf390438

