### PR TITLE
feat(ONYX-1019): add artwork dimensions step

### DIFF
--- a/src/Apps/Sell/Routes/DimensionsRoute.tsx
+++ b/src/Apps/Sell/Routes/DimensionsRoute.tsx
@@ -2,9 +2,11 @@ import * as React from "react"
 import * as Yup from "yup"
 import { DimensionsRoute_submission$key } from "__generated__/DimensionsRoute_submission.graphql"
 import {
-  BorderedRadio,
+  Column,
+  GridColumns,
   Input,
   Join,
+  Radio,
   RadioGroup,
   Spacer,
   Text,
@@ -69,33 +71,55 @@ export const DimensionsRoute: React.FC<DimensionsRouteProps> = props => {
           <Text mb={2} variant="xl">
             Artwork dimensions
           </Text>
-          <RadioGroup
-            onSelect={option => setFieldValue("dimensionsMetric", option)}
-            defaultValue={values.dimensionsMetric}
-          >
-            <BorderedRadio value="in" label="in" />
-            <BorderedRadio value="cm" label="cm" />
-          </RadioGroup>
-          <Spacer y={2} />
-          <Join separator={<Spacer y={2} />}>
-            <Input
-              onChange={handleChange}
-              name="width"
-              title="Width"
-              defaultValue={values.width}
-            ></Input>
-            <Input
-              onChange={handleChange}
-              name="height"
-              title="Height"
-              defaultValue={values.height}
-            ></Input>
-            <Input
-              onChange={handleChange}
-              name="depth"
-              title="Depth"
-              defaultValue={values.depth}
-            ></Input>
+          <Join separator={<Spacer y={4} />}>
+            <GridColumns>
+              <Column span={[4, 3]}>
+                <RadioGroup
+                  flexDirection="row"
+                  onSelect={option => setFieldValue("dimensionsMetric", option)}
+                  defaultValue={values.dimensionsMetric}
+                  justifyContent={"space-between"}
+                >
+                  <Radio value="cm" label="cm" />
+                  <Spacer x={2} />
+                  <Radio value="in" label="in" />
+                </RadioGroup>
+              </Column>
+            </GridColumns>
+
+            <GridColumns>
+              <Column span={[6, 6]}>
+                <Input
+                  onChange={handleChange}
+                  name="width"
+                  title="Width"
+                  defaultValue={values.width || ""}
+                  required
+                  data-testid="width-input"
+                />
+              </Column>
+
+              <Column span={[6, 6]}>
+                <Input
+                  onChange={handleChange}
+                  name="height"
+                  title="Height"
+                  defaultValue={values.height || ""}
+                  required
+                  data-testid="height-input"
+                />
+              </Column>
+
+              <Column span={[6, 6]}>
+                <Input
+                  onChange={handleChange}
+                  name="depth"
+                  title="Depth"
+                  defaultValue={values.depth || ""}
+                  data-testid="depth-input"
+                />
+              </Column>
+            </GridColumns>
           </Join>
           <DevDebug />
         </SubmissionLayout>

--- a/src/Apps/Sell/Routes/DimensionsRoute.tsx
+++ b/src/Apps/Sell/Routes/DimensionsRoute.tsx
@@ -16,6 +16,7 @@ import { Formik } from "formik"
 import { DevDebug } from "Apps/Sell/Components/DevDebug"
 import { useSellFlowContext } from "Apps/Sell/SellFlowContext"
 import { SubmissionLayout } from "Apps/Sell/Components/SubmissionLayout"
+import { useSystemContext } from "System/useSystemContext"
 
 const FRAGMENT = graphql`
   fragment DimensionsRoute_submission on ConsignmentSubmission {
@@ -27,10 +28,10 @@ const FRAGMENT = graphql`
 `
 
 const Schema = Yup.object().shape({
-  width: Yup.string().trim(),
-  height: Yup.string().trim(),
+  width: Yup.string().required().trim(),
+  height: Yup.string().required().trim(),
   depth: Yup.string().trim(),
-  dimensionsMetric: Yup.string().trim(),
+  dimensionsMetric: Yup.string().required().trim(),
 })
 
 interface FormValues {
@@ -47,6 +48,8 @@ interface DimensionsRouteProps {
 export const DimensionsRoute: React.FC<DimensionsRouteProps> = props => {
   const { actions } = useSellFlowContext()
   const submission = useFragment(FRAGMENT, props.submission)
+  const { userPreferences } = useSystemContext()
+  const userPreferredMetric = userPreferences?.metric
 
   const onSubmit = async (values: FormValues) => {
     return actions.updateSubmission(values)
@@ -56,7 +59,8 @@ export const DimensionsRoute: React.FC<DimensionsRouteProps> = props => {
     height: submission.height ?? "",
     width: submission.width ?? "",
     depth: submission.depth ?? "",
-    dimensionsMetric: submission.dimensionsMetric ?? "in",
+    dimensionsMetric:
+      submission.dimensionsMetric ?? userPreferredMetric ?? "in",
   }
 
   return (
@@ -78,7 +82,8 @@ export const DimensionsRoute: React.FC<DimensionsRouteProps> = props => {
                   flexDirection="row"
                   onSelect={option => setFieldValue("dimensionsMetric", option)}
                   defaultValue={values.dimensionsMetric}
-                  justifyContent={"space-between"}
+                  justifyContent="space-between"
+                  data-testid="dimensionsMetric-radio"
                 >
                   <Radio value="cm" label="cm" />
                   <Spacer x={2} />
@@ -94,7 +99,6 @@ export const DimensionsRoute: React.FC<DimensionsRouteProps> = props => {
                   name="width"
                   title="Width"
                   defaultValue={values.width || ""}
-                  required
                   data-testid="width-input"
                 />
               </Column>
@@ -105,7 +109,6 @@ export const DimensionsRoute: React.FC<DimensionsRouteProps> = props => {
                   name="height"
                   title="Height"
                   defaultValue={values.height || ""}
-                  required
                   data-testid="height-input"
                 />
               </Column>

--- a/src/Apps/Sell/Routes/DimensionsRoute.tsx
+++ b/src/Apps/Sell/Routes/DimensionsRoute.tsx
@@ -28,8 +28,8 @@ const FRAGMENT = graphql`
 `
 
 const Schema = Yup.object().shape({
-  width: Yup.string().required().trim(),
-  height: Yup.string().required().trim(),
+  width: Yup.string().trim(),
+  height: Yup.string().trim(),
   depth: Yup.string().trim(),
   dimensionsMetric: Yup.string().required().trim(),
 })
@@ -75,6 +75,7 @@ export const DimensionsRoute: React.FC<DimensionsRouteProps> = props => {
           <Text mb={2} variant="xl">
             Artwork dimensions
           </Text>
+
           <Join separator={<Spacer y={4} />}>
             <GridColumns>
               <Column span={[4, 3]}>
@@ -124,6 +125,7 @@ export const DimensionsRoute: React.FC<DimensionsRouteProps> = props => {
               </Column>
             </GridColumns>
           </Join>
+
           <DevDebug />
         </SubmissionLayout>
       )}

--- a/src/Apps/Sell/Routes/__tests__/DimensionsRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/DimensionsRoute.jest.tsx
@@ -1,0 +1,166 @@
+import { fireEvent, screen, waitFor } from "@testing-library/react"
+import { DimensionsRoute } from "Apps/Sell/Routes/DimensionsRoute"
+import { SubmissionRoute } from "Apps/Sell/Routes/SubmissionRoute"
+import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
+import { useRouter } from "System/Router/useRouter"
+import { useMutation } from "Utils/Hooks/useMutation"
+import { graphql } from "react-relay"
+import { DimensionsRoute_Test_Query$rawResponse } from "__generated__/DimensionsRoute_Test_Query.graphql"
+
+const mockUseRouter = useRouter as jest.Mock
+const mockPush = jest.fn()
+const mockReplace = jest.fn()
+let submitMutation: jest.Mock
+
+jest.unmock("react-relay")
+jest.mock("System/Router/useRouter", () => ({
+  useRouter: jest.fn(),
+}))
+jest.mock("Utils/Hooks/useMutation")
+
+const submissionMock: Partial<
+  DimensionsRoute_Test_Query$rawResponse["submission"]
+> = {
+  dimensionsMetric: "in",
+}
+
+beforeEach(() => {
+  mockUseRouter.mockImplementation(() => ({
+    router: {
+      push: mockPush,
+      replace: mockReplace,
+    },
+    match: { location: { pathname: "submissions/submission-id/dimensions" } },
+  }))
+
+  submitMutation = jest.fn(() => ({ catch: () => {} }))
+  ;(useMutation as jest.Mock).mockImplementation(() => {
+    return { submitMutation }
+  })
+})
+
+const { renderWithRelay } = setupTestWrapperTL({
+  Component: (props: any) => {
+    return (
+      <SubmissionRoute submission={props.submission}>
+        <DimensionsRoute submission={props.submission} />
+      </SubmissionRoute>
+    )
+  },
+  query: graphql`
+    query DimensionsRoute_Test_Query @raw_response_type {
+      submission(id: "submission-id") {
+        ...SubmissionRoute_submission
+        ...DimensionsRoute_submission
+      }
+    }
+  `,
+})
+
+describe("DimensionsRoute", () => {
+  it("renders the Dimensions step", () => {
+    renderWithRelay({
+      ConsignmentSubmission: () => submissionMock,
+    })
+
+    expect(screen.getByText("Artwork dimensions")).toBeInTheDocument()
+    expect(screen.getByText("Back")).toBeInTheDocument()
+    expect(screen.getByText("Submit")).toBeInTheDocument()
+    expect(screen.getByText("Save & Exit")).toBeInTheDocument()
+  })
+
+  it("initializes the form with the submission data", async () => {
+    renderWithRelay({
+      ConsignmentSubmission: () => submissionMock,
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("width-input")).toHaveValue(
+        '<mock-value-for-field-"width">'
+      )
+      expect(screen.getByTestId("height-input")).toHaveValue(
+        '<mock-value-for-field-"height">'
+      )
+      expect(screen.getByTestId("depth-input")).toHaveValue(
+        '<mock-value-for-field-"depth">'
+      )
+    })
+  })
+
+  it("saves the submission & navigates to the confirmation step when Submit button is clicked", async () => {
+    renderWithRelay({
+      ConsignmentSubmission: () => submissionMock,
+    })
+
+    screen.getByText("Submit").click()
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith(
+        '/sell2/submissions/<mock-value-for-field-"externalId">/thank-you'
+      )
+
+      expect(submitMutation).toHaveBeenCalledWith(
+        expect.objectContaining({
+          variables: {
+            input: {
+              externalId: '<mock-value-for-field-"externalId">',
+              height: '<mock-value-for-field-"height">',
+              width: '<mock-value-for-field-"width">',
+              depth: '<mock-value-for-field-"depth">',
+              dimensionsMetric: "in",
+            },
+          },
+        })
+      )
+    })
+  })
+  it("does not save the submission & navigates to the previous step when the back button is clicked", async () => {
+    renderWithRelay({
+      ConsignmentSubmission: () => submissionMock,
+    })
+
+    screen.getByText("Back").click()
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith(
+        '/sell2/submissions/<mock-value-for-field-"externalId">/purchase-history'
+      )
+
+      expect(submitMutation).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          variables: {
+            input: {
+              externalId: '<mock-value-for-field-"externalId">',
+              height: '<mock-value-for-field-"height">',
+              width: '<mock-value-for-field-"width">',
+              depth: '<mock-value-for-field-"depth">',
+              dimensionsMetric: "in",
+            },
+          },
+        })
+      )
+    })
+  })
+
+  describe("when form is not valid", () => {
+    it("disables the continue button", async () => {
+      renderWithRelay({
+        ConsignmentSubmission: () => ({
+          ...submissionMock,
+          category: "default",
+        }),
+      })
+
+      const widthInput = screen.getByTestId("width-input")
+
+      fireEvent.change(widthInput, { target: { value: "" } })
+
+      await flushPromiseQueue()
+
+      await waitFor(() => {
+        expect(submitMutation).not.toHaveBeenCalled()
+      })
+    })
+  })
+})

--- a/src/__generated__/DimensionsRoute_Test_Query.graphql.ts
+++ b/src/__generated__/DimensionsRoute_Test_Query.graphql.ts
@@ -1,0 +1,157 @@
+/**
+ * @generated SignedSource<<7f92aa7bcf36c4bf2f063a4799a9512e>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type DimensionsRoute_Test_Query$variables = Record<PropertyKey, never>;
+export type DimensionsRoute_Test_Query$data = {
+  readonly submission: {
+    readonly " $fragmentSpreads": FragmentRefs<"DimensionsRoute_submission" | "SubmissionRoute_submission">;
+  } | null | undefined;
+};
+export type DimensionsRoute_Test_Query$rawResponse = {
+  readonly submission: {
+    readonly depth: string | null | undefined;
+    readonly dimensionsMetric: string | null | undefined;
+    readonly externalId: string;
+    readonly height: string | null | undefined;
+    readonly id: string;
+    readonly internalID: string | null | undefined;
+    readonly width: string | null | undefined;
+  } | null | undefined;
+};
+export type DimensionsRoute_Test_Query = {
+  rawResponse: DimensionsRoute_Test_Query$rawResponse;
+  response: DimensionsRoute_Test_Query$data;
+  variables: DimensionsRoute_Test_Query$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "submission-id"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "DimensionsRoute_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "ConsignmentSubmission",
+        "kind": "LinkedField",
+        "name": "submission",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "SubmissionRoute_submission"
+          },
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "DimensionsRoute_submission"
+          }
+        ],
+        "storageKey": "submission(id:\"submission-id\")"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "DimensionsRoute_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "ConsignmentSubmission",
+        "kind": "LinkedField",
+        "name": "submission",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "internalID",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "externalId",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "width",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "height",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "depth",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "dimensionsMetric",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": "submission(id:\"submission-id\")"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "3ad249d6845805f20627f5ab271251e3",
+    "id": null,
+    "metadata": {},
+    "name": "DimensionsRoute_Test_Query",
+    "operationKind": "query",
+    "text": "query DimensionsRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...SubmissionRoute_submission\n    ...DimensionsRoute_submission\n    id\n  }\n}\n\nfragment DimensionsRoute_submission on ConsignmentSubmission {\n  width\n  height\n  depth\n  dimensionsMetric\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "c454a2ccb797f504cb8f422625d21f3a";
+
+export default node;


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [ONYX-1019]

### Description

<!-- Implementation description -->
Implement artwork dimensions step for the new submission flow
| Web | mWeb |
| --- | --- |
| <img width="1444" alt="image" src="https://github.com/artsy/force/assets/36167539/b9e99317-799a-4ee0-9dbb-93ae3340620a"> | <img width="415" alt="image" src="https://github.com/artsy/force/assets/36167539/3328260a-edee-4b55-8cbf-8d8f0290bc1e"> |

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-1019]: https://artsyproduct.atlassian.net/browse/ONYX-1019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ