### PR TITLE
chore: remove diamond_new-terms-and-conditions feature flag

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarLinks.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarLinks.tsx
@@ -5,7 +5,6 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import { RouterLink } from "System/Router/RouterLink"
 import { ArtworkSidebarLinks_artwork$data } from "__generated__/ArtworkSidebarLinks_artwork.graphql"
-import { useFeatureFlag } from "System/useFeatureFlag"
 
 interface ArtworkSidebarLinksProps {
   artwork: ArtworkSidebarLinks_artwork$data
@@ -17,8 +16,6 @@ const ArtworkSidebarLinks: React.FC<ArtworkSidebarLinksProps> = ({
   const { t } = useTranslation()
   const tracking = useTracking()
   const { sale, isInAuction, isUnlisted } = artwork
-
-  const showNewDisclaimer = useFeatureFlag("diamond_new-terms-and-conditions")
 
   const isInOpenAuction = isInAuction && sale && !sale.isClosed
 
@@ -52,12 +49,10 @@ const ArtworkSidebarLinks: React.FC<ArtworkSidebarLinksProps> = ({
             {t("artworkPage.sidebar.conditionsOfSale")}{" "}
             <RouterLink
               inline
-              to={showNewDisclaimer ? "/terms" : "/conditions-of-sale"}
+              to={"/terms"}
               onClick={trackClickedConditionsOfSale}
             >
-              {showNewDisclaimer
-                ? t("artworkPage.sidebar.generalTermsAndConditionsOfSaleLink")
-                : t("artworkPage.sidebar.conditionsOfSaleLink")}
+              {t("artworkPage.sidebar.generalTermsAndConditionsOfSaleLink")}
             </RouterLink>
           </Text>
 

--- a/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarLinks.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarLinks.jest.tsx
@@ -78,28 +78,7 @@ describe("ArtworkSidebarLinks", () => {
         })
       })
 
-      it("shows conditions of sale link", () => {
-        expect(
-          screen.queryByText("By placing your bid you agree to Artsy's")
-        ).toBeInTheDocument()
-        expect(
-          screen.getByRole("link", {
-            name: "Conditions of Sale",
-          })
-        ).toHaveAttribute("href", "/conditions-of-sale")
-      })
-
       describe("new disclaimer is shown", () => {
-        beforeAll(() => {
-          ;(useFeatureFlag as jest.Mock).mockImplementation(
-            (f: string) => f === "diamond_new-terms-and-conditions"
-          )
-        })
-
-        afterAll(() => {
-          ;(useFeatureFlag as jest.Mock).mockReset()
-        })
-
         it("shows general terms and conditions of sale link", () => {
           expect(
             screen.getByRole("link", {

--- a/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarLinks.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarLinks.jest.tsx
@@ -4,7 +4,6 @@ import { ArtworkSidebarLinksFragmentContainer } from "Apps/Artwork/Components/Ar
 import { fireEvent, screen } from "@testing-library/react"
 import { ArtworkSidebarLinks_Test_Query } from "__generated__/ArtworkSidebarLinks_Test_Query.graphql"
 import { useTracking } from "react-tracking"
-import { useFeatureFlag } from "System/useFeatureFlag"
 
 jest.mock("react-tracking")
 jest.unmock("react-relay")

--- a/src/Apps/Auction/Components/Form/ConditionsOfSaleCheckbox.tsx
+++ b/src/Apps/Auction/Components/Form/ConditionsOfSaleCheckbox.tsx
@@ -1,7 +1,6 @@
 import { Checkbox, Spacer, Text } from "@artsy/palette"
 import { useFormContext } from "Apps/Auction/Hooks/useFormContext"
 import { RouterLink } from "System/Router/RouterLink"
-import { useFeatureFlag } from "System/useFeatureFlag"
 
 export const ConditionsOfSaleCheckbox: React.FC = () => {
   const {

--- a/src/Apps/Auction/Components/Form/ConditionsOfSaleCheckbox.tsx
+++ b/src/Apps/Auction/Components/Form/ConditionsOfSaleCheckbox.tsx
@@ -12,8 +12,6 @@ export const ConditionsOfSaleCheckbox: React.FC = () => {
     setFieldValue,
   } = useFormContext()
 
-  const showNewDisclaimer = useFeatureFlag("diamond_new-terms-and-conditions")
-
   const showErrorMessage = !!(touched.agreeToTerms && errors.agreeToTerms)
 
   const handleCheckboxSelect = value => {
@@ -28,35 +26,19 @@ export const ConditionsOfSaleCheckbox: React.FC = () => {
         onSelect={handleCheckboxSelect}
         data-testid="disclaimer"
       >
-        {showNewDisclaimer ? (
-          <Text variant="sm-display" ml={0.5}>
-            I agree to Artsy's{" "}
-            <RouterLink
-              inline
-              display="inline"
-              color="black100"
-              to="/terms"
-              target="_blank"
-            >
-              General Terms and Conditions of Sale
-            </RouterLink>
-            . I understand that all bids are binding and may not be retracted.
-          </Text>
-        ) : (
-          <Text variant="sm-display" ml={0.5}>
-            I agree to the{" "}
-            <RouterLink
-              inline
-              display="inline"
-              color="black100"
-              to="/conditions-of-sale"
-              target="_blank"
-            >
-              Conditions of Sale
-            </RouterLink>
-            . I understand that all bids are binding and may not be retracted.
-          </Text>
-        )}
+        <Text variant="sm-display" ml={0.5}>
+          I agree to Artsy's{" "}
+          <RouterLink
+            inline
+            display="inline"
+            color="black100"
+            to="/terms"
+            target="_blank"
+          >
+            General Terms and Conditions of Sale
+          </RouterLink>
+          . I understand that all bids are binding and may not be retracted.
+        </Text>
       </Checkbox>
 
       <Spacer y={1} />

--- a/src/Apps/Auction/Components/Form/IdentityVerificationWarning.tsx
+++ b/src/Apps/Auction/Components/Form/IdentityVerificationWarning.tsx
@@ -1,12 +1,6 @@
 import { Spacer, Text } from "@artsy/palette"
-import { RouterLink } from "System/Router/RouterLink"
-import { useFeatureFlag } from "System/useFeatureFlag"
 
-export const IdentityVerificationWarning: React.FC<{
-  additionalText?: string
-}> = ({ additionalText }) => {
-  const showNewDisclaimer = useFeatureFlag("diamond_new-terms-and-conditions")
-
+export const IdentityVerificationWarning: React.FC = () => {
   return (
     <>
       <Text variant="sm-display">
@@ -21,21 +15,6 @@ export const IdentityVerificationWarning: React.FC<{
       </Text>
 
       <Spacer y={1} />
-
-      {!showNewDisclaimer && (
-        <Text variant="sm-display">
-          To complete your registration, please confirm that you agree to the{" "}
-          <RouterLink
-            inline
-            color="black100"
-            to="/conditions-of-sale"
-            target="_blank"
-          >
-            Conditions of Sale
-          </RouterLink>
-          {additionalText}.
-        </Text>
-      )}
     </>
   )
 }

--- a/src/Apps/Auction/Components/Form/__tests__/ConditionsOfSaleCheckbox.jest.tsx
+++ b/src/Apps/Auction/Components/Form/__tests__/ConditionsOfSaleCheckbox.jest.tsx
@@ -29,42 +29,17 @@ describe("ConditionsOfSaleCheckbox", () => {
     })
   })
 
-  it("renders a disclaimer", () => {
+  it("renders the disclaimer", () => {
     render(<ConditionsOfSaleCheckbox />)
 
     expect(screen.getByTestId("disclaimer")).toHaveTextContent(
-      "I agree to the Conditions of Sale. I understand that all bids are binding and may not be retracted."
+      "I agree to Artsy's General Terms and Conditions of Sale. I understand that all bids are binding and may not be retracted."
     )
     expect(
       screen.getByRole("link", {
-        name: "Conditions of Sale",
+        name: "General Terms and Conditions of Sale",
       })
-    ).toHaveAttribute("href", "/conditions-of-sale")
-  })
-
-  describe("when the new disclaimer is enabled", () => {
-    beforeAll(() => {
-      ;(useFeatureFlag as jest.Mock).mockImplementation(
-        (f: string) => f === "diamond_new-terms-and-conditions"
-      )
-    })
-
-    afterAll(() => {
-      ;(useFeatureFlag as jest.Mock).mockReset()
-    })
-
-    it("renders the new disclaimer", () => {
-      render(<ConditionsOfSaleCheckbox />)
-
-      expect(screen.getByTestId("disclaimer")).toHaveTextContent(
-        "I agree to Artsy's General Terms and Conditions of Sale. I understand that all bids are binding and may not be retracted."
-      )
-      expect(
-        screen.getByRole("link", {
-          name: "General Terms and Conditions of Sale",
-        })
-      ).toHaveAttribute("href", "/terms")
-    })
+    ).toHaveAttribute("href", "/terms")
   })
 
   it("shows error message if error", () => {

--- a/src/Apps/Auction/Components/Form/__tests__/ConditionsOfSaleCheckbox.jest.tsx
+++ b/src/Apps/Auction/Components/Form/__tests__/ConditionsOfSaleCheckbox.jest.tsx
@@ -1,7 +1,6 @@
 import { mount } from "enzyme"
 import { useFormContext } from "Apps/Auction/Hooks/useFormContext"
 import { ConditionsOfSaleCheckbox } from "Apps/Auction/Components/Form/ConditionsOfSaleCheckbox"
-import { useFeatureFlag } from "System/useFeatureFlag"
 import { render, screen } from "@testing-library/react"
 
 jest.mock("Apps/Auction/Hooks/useFormContext")

--- a/src/Apps/Auction/Components/Form/__tests__/IdentityVerificationWarning.jest.tsx
+++ b/src/Apps/Auction/Components/Form/__tests__/IdentityVerificationWarning.jest.tsx
@@ -1,8 +1,5 @@
 import { render, screen } from "@testing-library/react"
 import { IdentityVerificationWarning } from "Apps/Auction/Components/Form/IdentityVerificationWarning"
-import { useFeatureFlag } from "System/useFeatureFlag"
-
-jest.mock("System/useFeatureFlag")
 
 describe("IdentityVerificationWarning", () => {
   it("renders correct components", () => {
@@ -12,35 +9,10 @@ describe("IdentityVerificationWarning", () => {
         "This auction requires Artsy to verify your identity before bidding."
       )
     ).toBeInTheDocument()
-  })
-
-  it("shows /conditions-of-sale link", () => {
-    render(<IdentityVerificationWarning />)
     expect(
-      screen.getByRole("link", {
-        name: "Conditions of Sale",
-      })
-    ).toHaveAttribute("href", "/conditions-of-sale")
-  })
-
-  describe("when showNewDisclaimer is true", () => {
-    beforeAll(() => {
-      ;(useFeatureFlag as jest.Mock).mockImplementation(
-        (f: string) => f === "diamond_new-terms-and-conditions"
+      screen.getByText(
+        "After you register, you’ll receive an email with a link to complete identity verification."
       )
-    })
-
-    afterAll(() => {
-      ;(useFeatureFlag as jest.Mock).mockReset()
-    })
-
-    it("does not show /conditions-of-sale link", () => {
-      render(<IdentityVerificationWarning />)
-      expect(
-        screen.queryByRole("link", {
-          name: "Conditions of Sale",
-        })
-      ).not.toBeInTheDocument()
-    })
+    ).toBeInTheDocument()
   })
 })

--- a/src/Apps/Auction/Routes/AuctionConfirmRegistrationRoute.tsx
+++ b/src/Apps/Auction/Routes/AuctionConfirmRegistrationRoute.tsx
@@ -116,9 +116,7 @@ const AuctionConfirmRegistrationRoute: React.FC<AuctionConfirmRegistrationRouteP
             <Form>
               <Join separator={<Spacer y={2} />}>
                 {needsIdentityVerification ? (
-                  <IdentityVerificationWarning
-                    additionalText={additionalText}
-                  />
+                  <IdentityVerificationWarning />
                 ) : (
                   <ConditionsOfSaleMessage additionalText={additionalText} />
                 )}

--- a/src/Apps/Auction/Routes/__tests__/AuctionConfirmRegistrationRoute.jest.tsx
+++ b/src/Apps/Auction/Routes/__tests__/AuctionConfirmRegistrationRoute.jest.tsx
@@ -202,7 +202,6 @@ describe("AuctionConfirmRegistrationRoute", () => {
 
       expect(wrapper.text()).toContain("Phone Number*Required")
       expect(wrapper.text()).toContain("Required for shipping logistics")
-      expect(wrapper.text()).toContain("and provide a valid phone number")
     }
   )
 

--- a/src/Apps/Order/Components/ConditionsOfSaleDisclaimer.tsx
+++ b/src/Apps/Order/Components/ConditionsOfSaleDisclaimer.tsx
@@ -1,7 +1,6 @@
 import { Text, TextProps } from "@artsy/palette"
 import * as React from "react"
 import { RouterLink } from "System/Router/RouterLink"
-import { useFeatureFlag } from "System/useFeatureFlag"
 
 interface Props {
   textProps?: Partial<TextProps>
@@ -12,8 +11,6 @@ export const ConditionsOfSaleDisclaimer: React.FC<Props> = ({
   textProps,
   orderSource,
 }) => {
-  const showNewDisclaimer = useFeatureFlag("diamond_new-terms-and-conditions")
-
   if (orderSource === "private_sale") {
     return (
       <Text variant="sm" color="black60" {...textProps}>
@@ -34,18 +31,11 @@ export const ConditionsOfSaleDisclaimer: React.FC<Props> = ({
     )
   }
 
-  return showNewDisclaimer ? (
+  return (
     <Text variant="xs" color="black60" {...textProps}>
       By clicking Submit, I agree to Artsy’s{" "}
       <RouterLink inline to="/terms" target="_blank">
         General Terms and Conditions of Sale.
-      </RouterLink>
-    </Text>
-  ) : (
-    <Text variant="xs" color="black60" {...textProps}>
-      By clicking Submit, I agree to Artsy’s{" "}
-      <RouterLink inline to="/conditions-of-sale" target="_blank">
-        Conditions of Sale.
       </RouterLink>
     </Text>
   )

--- a/src/Apps/Order/Routes/__tests__/Accept.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Accept.jest.tsx
@@ -166,38 +166,20 @@ describe("Accept seller offer", () => {
       )
       expect(page.buyerGuarantee.length).toBe(1)
       expect(page.submitButton.text()).toBe("Submit")
-      expect(page.conditionsOfSaleDisclaimer.text()).toMatchInlineSnapshot(
-        `"By clicking Submit, I agree to Artsy’s Conditions of Sale."`
+    })
+
+    it("renders the disclaimer", () => {
+      const { wrapper } = getWrapper({
+        CommerceOrder: () => testOrder,
+      })
+      const page = new OrderAppTestPage(wrapper)
+
+      expect(page.conditionsOfSaleDisclaimer.text()).toMatch(
+        "By clicking Submit, I agree to Artsy’s General Terms and Conditions of Sale."
       )
       expect(
         page.conditionsOfSaleDisclaimer.find(RouterLink).props().to
-      ).toEqual("/conditions-of-sale")
-    })
-
-    describe("when the new disclaimer is enabled", () => {
-      beforeAll(() => {
-        ;(useFeatureFlag as jest.Mock).mockImplementation(
-          (f: string) => f === "diamond_new-terms-and-conditions"
-        )
-      })
-
-      afterAll(() => {
-        ;(useFeatureFlag as jest.Mock).mockReset()
-      })
-
-      it("renders the new disclaimer", () => {
-        const { wrapper } = getWrapper({
-          CommerceOrder: () => testOrder,
-        })
-        const page = new OrderAppTestPage(wrapper)
-
-        expect(page.conditionsOfSaleDisclaimer.text()).toMatch(
-          "By clicking Submit, I agree to Artsy’s General Terms and Conditions of Sale."
-        )
-        expect(
-          page.conditionsOfSaleDisclaimer.find(RouterLink).props().to
-        ).toEqual("/terms")
-      })
+      ).toEqual("/terms")
     })
   })
 

--- a/src/Apps/Order/Routes/__tests__/Accept.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Accept.jest.tsx
@@ -23,7 +23,6 @@ import {
   acceptOfferInsufficientInventoryFailure,
   acceptOfferWithActionRequired,
 } from "Apps/Order/Routes/__fixtures__/MutationResults/acceptOffer"
-import { useFeatureFlag } from "System/useFeatureFlag"
 import { RouterLink } from "System/Router/RouterLink"
 
 jest.unmock("react-relay")

--- a/src/Apps/Order/Routes/__tests__/Counter.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Counter.jest.tsx
@@ -149,37 +149,11 @@ describe("Submit Pending Counter Offer", () => {
       expect(page.buyerGuarantee.length).toBe(1)
       expect(page.submitButton.text()).toBe("Submit")
       expect(page.conditionsOfSaleDisclaimer.text()).toMatch(
-        "By clicking Submit, I agree to Artsy’s Conditions of Sale."
+        "By clicking Submit, I agree to Artsy’s General Terms and Conditions of Sale."
       )
       expect(
         page.conditionsOfSaleDisclaimer.find(RouterLink).props().to
-      ).toEqual("/conditions-of-sale")
-    })
-
-    describe("when the new disclaimer is enabled", () => {
-      beforeAll(() => {
-        ;(useFeatureFlag as jest.Mock).mockImplementation(
-          (f: string) => f === "diamond_new-terms-and-conditions"
-        )
-      })
-
-      afterAll(() => {
-        ;(useFeatureFlag as jest.Mock).mockReset()
-      })
-
-      it("renders the new disclaimer", () => {
-        const { wrapper } = getWrapper({
-          CommerceOrder: () => testOrder,
-        })
-        const page = new OrderAppTestPage(wrapper)
-
-        expect(page.conditionsOfSaleDisclaimer.text()).toMatch(
-          "By clicking Submit, I agree to Artsy’s General Terms and Conditions of Sale."
-        )
-        expect(
-          page.conditionsOfSaleDisclaimer.find(RouterLink).props().to
-        ).toEqual("/terms")
-      })
+      ).toEqual("/terms")
     })
 
     it("loading given isCommitingMutation", async () => {

--- a/src/Apps/Order/Routes/__tests__/Counter.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Counter.jest.tsx
@@ -16,7 +16,6 @@ import { OrderAppTestPage } from "./Utils/OrderAppTestPage"
 import { useTracking } from "react-tracking"
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
 import { MockBoot } from "DevTools/MockBoot"
-import { useFeatureFlag } from "System/useFeatureFlag"
 import { RouterLink } from "System/Router/RouterLink"
 
 jest.mock("Utils/getCurrentTimeAsIsoString")

--- a/src/Apps/Order/Routes/__tests__/Reject.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Reject.jest.tsx
@@ -11,7 +11,6 @@ import { RejectFragmentContainer } from "Apps/Order/Routes/Reject"
 import { OrderAppTestPage } from "./Utils/OrderAppTestPage"
 import { setupTestWrapper } from "DevTools/setupTestWrapper"
 import { MockBoot } from "DevTools/MockBoot"
-import { useFeatureFlag } from "System/useFeatureFlag"
 import { RouterLink } from "System/Router/RouterLink"
 
 jest.mock("Utils/getCurrentTimeAsIsoString")

--- a/src/Apps/Order/Routes/__tests__/Reject.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Reject.jest.tsx
@@ -116,38 +116,20 @@ describe("Buyer rejects seller offer", () => {
       expect(page.find(StepSummaryItem).text()).toContain(
         "Declining an offer permanently ends the negotiation process."
       )
+    })
+
+    it("renders the disclaimer", () => {
+      const { wrapper } = getWrapper({
+        CommerceOrder: () => testOrder,
+      })
+      const page = new OrderAppTestPage(wrapper)
+
       expect(page.conditionsOfSaleDisclaimer.text()).toMatch(
-        "By clicking Submit, I agree to Artsy’s Conditions of Sale."
+        "By clicking Submit, I agree to Artsy’s General Terms and Conditions of Sale."
       )
       expect(
         page.conditionsOfSaleDisclaimer.find(RouterLink).props().to
-      ).toEqual("/conditions-of-sale")
-    })
-
-    describe("when new disclaimers are enabled", () => {
-      beforeAll(() => {
-        ;(useFeatureFlag as jest.Mock).mockImplementation(
-          (f: string) => f === "diamond_new-terms-and-conditions"
-        )
-      })
-
-      afterAll(() => {
-        ;(useFeatureFlag as jest.Mock).mockReset()
-      })
-
-      it("renders the new disclaimer", () => {
-        const { wrapper } = getWrapper({
-          CommerceOrder: () => testOrder,
-        })
-        const page = new OrderAppTestPage(wrapper)
-
-        expect(page.conditionsOfSaleDisclaimer.text()).toMatch(
-          "By clicking Submit, I agree to Artsy’s General Terms and Conditions of Sale."
-        )
-        expect(
-          page.conditionsOfSaleDisclaimer.find(RouterLink).props().to
-        ).toEqual("/terms")
-      })
+      ).toEqual("/terms")
     })
 
     it("Shows a change link that takes the user back to the respond page", () => {

--- a/src/Apps/Order/Routes/__tests__/Review.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Review.jest.tsx
@@ -48,7 +48,6 @@ import {
   ErrorDialogs,
   getErrorDialogCopy,
 } from "Apps/Order/Utils/getErrorDialogCopy"
-import { useFeatureFlag } from "System/useFeatureFlag"
 import { RouterLink } from "System/Router/RouterLink"
 
 jest.unmock("react-relay")

--- a/src/Apps/Order/Routes/__tests__/Review.jest.tsx
+++ b/src/Apps/Order/Routes/__tests__/Review.jest.tsx
@@ -192,44 +192,18 @@ describe("Review", () => {
       expect(page.buyerGuarantee.length).toBe(1)
     })
 
-    it("shows the conditions of sale disclaimer", () => {
+    it("renders the disclaimer", () => {
       const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new ReviewTestPage(wrapper)
 
       expect(page.conditionsOfSaleDisclaimer.text()).toMatch(
-        "By clicking Submit, I agree to Artsy’s Conditions of Sale."
+        "By clicking Submit, I agree to Artsy’s General Terms and Conditions of Sale."
       )
       expect(
         page.conditionsOfSaleDisclaimer.find(RouterLink).props().to
-      ).toEqual("/conditions-of-sale")
-    })
-
-    describe("when the new disclaimer is enabled", () => {
-      beforeAll(() => {
-        ;(useFeatureFlag as jest.Mock).mockImplementation(
-          (f: string) => f === "diamond_new-terms-and-conditions"
-        )
-      })
-
-      afterAll(() => {
-        ;(useFeatureFlag as jest.Mock).mockReset()
-      })
-
-      it("renders the new disclaimer", () => {
-        const { wrapper } = getWrapper({
-          CommerceOrder: () => testOrder,
-        })
-        const page = new ReviewTestPage(wrapper)
-
-        expect(page.conditionsOfSaleDisclaimer.text()).toMatch(
-          "By clicking Submit, I agree to Artsy’s General Terms and Conditions of Sale."
-        )
-        expect(
-          page.conditionsOfSaleDisclaimer.find(RouterLink).props().to
-        ).toEqual("/terms")
-      })
+      ).toEqual("/terms")
     })
 
     it("shows an error modal when there is an error in submitOrderPayload", async () => {
@@ -477,41 +451,18 @@ describe("Review", () => {
       )
     })
 
-    it("shows the conditions of sale disclaimer", () => {
+    it("renders the disclaimer", () => {
       const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
       })
       const page = new ReviewTestPage(wrapper)
 
       expect(page.conditionsOfSaleDisclaimer.text()).toMatch(
-        "By clicking Submit, I agree to Artsy’s Conditions of Sale."
+        "By clicking Submit, I agree to Artsy’s General Terms and Conditions of Sale."
       )
-    })
-
-    describe("when the new disclaimer is enabled", () => {
-      beforeAll(() => {
-        ;(useFeatureFlag as jest.Mock).mockImplementation(
-          (f: string) => f === "diamond_new-terms-and-conditions"
-        )
-      })
-
-      afterAll(() => {
-        ;(useFeatureFlag as jest.Mock).mockReset()
-      })
-
-      it("renders the new disclaimer", () => {
-        const { wrapper } = getWrapper({
-          CommerceOrder: () => testOrder,
-        })
-        const page = new ReviewTestPage(wrapper)
-
-        expect(page.conditionsOfSaleDisclaimer.text()).toMatch(
-          "By clicking Submit, I agree to Artsy’s General Terms and Conditions of Sale."
-        )
-        expect(
-          page.conditionsOfSaleDisclaimer.find(RouterLink).props().to
-        ).toEqual("/terms")
-      })
+      expect(
+        page.conditionsOfSaleDisclaimer.find(RouterLink).props().to
+      ).toEqual("/terms")
     })
 
     it("shows an error modal when there is an error in submitOrderPayload", async () => {

--- a/src/Components/AuthDialog/Components/AuthDialogSignUpPlaceholder.tsx
+++ b/src/Components/AuthDialog/Components/AuthDialogSignUpPlaceholder.tsx
@@ -7,12 +7,9 @@ import {
   SkeletonText,
   Spacer,
 } from "@artsy/palette"
-import { useFeatureFlag } from "System/useFeatureFlag"
 import { FC } from "react"
 
 export const AuthDialogSignUpPlaceholder: FC = () => {
-  const showNewDisclaimer = useFeatureFlag("diamond_new-terms-and-conditions")
-
   return (
     <Skeleton>
       <Join separator={<Spacer y={2} />}>
@@ -50,9 +47,9 @@ export const AuthDialogSignUpPlaceholder: FC = () => {
           textAlign="center"
           data-testid="skeleton-disclaimer"
         >
-          {showNewDisclaimer
-            ? "By clicking Sign Up or Continue with Email, Apple, Google, or Facebook, you agree to Artsy’s Terms and Conditions and Privacy Policy and to receiving emails from Artsy."
-            : "By clicking Sign Up or Continue with Apple, Google, or Facebook, you agree to Artsy’s Terms of Use and Privacy Policy and to receiving emails from Artsy."}
+          By clicking Sign Up or Continue with Email, Apple, Google, or
+          Facebook, you agree to Artsy’s Terms and Conditions and Privacy Policy
+          and to receiving emails from Artsy.
         </SkeletonText>
 
         <SkeletonText variant="xs" textAlign="center">

--- a/src/Components/AuthDialog/Views/AuthDialogSignUp.tsx
+++ b/src/Components/AuthDialog/Views/AuthDialogSignUp.tsx
@@ -23,7 +23,6 @@ import { useAuthDialogTracking } from "Components/AuthDialog/Hooks/useAuthDialog
 import { AuthDialogSignUpPlaceholder } from "Components/AuthDialog/Components/AuthDialogSignUpPlaceholder"
 import { useCountryCode } from "Components/AuthDialog/Hooks/useCountryCode"
 import { RouterLink } from "System/Router/RouterLink"
-import { useFeatureFlag } from "System/useFeatureFlag"
 
 export const AuthDialogSignUp: FC = () => {
   const {
@@ -36,8 +35,6 @@ export const AuthDialogSignUp: FC = () => {
   const track = useAuthDialogTracking()
 
   const { loading, countryCode } = useCountryCode()
-
-  const showNewDisclaimer = useFeatureFlag("diamond_new-terms-and-conditions")
 
   const isAutomaticallySubscribed = !!(
     countryCode && !GDPR_COUNTRY_CODES.includes(countryCode)
@@ -197,10 +194,10 @@ export const AuthDialogSignUp: FC = () => {
                 data-testid="disclaimer"
               >
                 By {isTouch ? "tapping" : "clicking"} Sign Up or Continue with
-                {showNewDisclaimer ? " Email, " : " "}
+                {" Email, "}
                 Apple, Google, or Facebook, you agree to Artsy’s{" "}
                 <RouterLink inline to="/terms" target="_blank">
-                  {showNewDisclaimer ? "Terms and Conditions" : "Terms of Use"}
+                  Terms and Conditions
                 </RouterLink>{" "}
                 and{" "}
                 <RouterLink inline to="/privacy" target="_blank">

--- a/src/Components/AuthDialog/Views/__tests__/AuthDialogSignUp.jest.tsx
+++ b/src/Components/AuthDialog/Views/__tests__/AuthDialogSignUp.jest.tsx
@@ -54,21 +54,6 @@ describe("AuthDialogSignUp", () => {
     expect(screen.getByText("Continue with Apple")).toBeInTheDocument()
   })
 
-  it("renders a disclaimer", () => {
-    render(<AuthDialogSignUp />)
-
-    expect(screen.getByTestId("disclaimer")).toHaveTextContent(
-      "By clicking Sign Up or Continue with Apple, Google, or Facebook, you agree to Artsy’s Terms of Use and Privacy Policy and to receiving emails from Artsy."
-    )
-    expect(screen.getByRole("link", { name: "Terms of Use" })).toHaveAttribute(
-      "href",
-      "/terms"
-    )
-    expect(
-      screen.getByRole("link", { name: "Privacy Policy" })
-    ).toHaveAttribute("href", "/privacy")
-  })
-
   describe("when the user is on a touch device", () => {
     beforeEach(() => {
       mockIsTouch = true
@@ -82,7 +67,7 @@ describe("AuthDialogSignUp", () => {
       render(<AuthDialogSignUp />)
 
       expect(screen.getByTestId("disclaimer")).toHaveTextContent(
-        "By tapping Sign Up or Continue with Apple, Google, or Facebook, you agree to Artsy’s Terms of Use and Privacy Policy and to receiving emails from Artsy."
+        "By tapping Sign Up or Continue with Email, Apple, Google, or Facebook, you agree to Artsy’s Terms and Conditions and Privacy Policy and to receiving emails from Artsy."
       )
     })
   })
@@ -106,7 +91,7 @@ describe("AuthDialogSignUp", () => {
       render(<AuthDialogSignUp />)
 
       expect(screen.getByTestId("disclaimer")).toHaveTextContent(
-        "By clicking Sign Up or Continue with Apple, Google, or Facebook, you agree to Artsy’s Terms of Use and Privacy Policy."
+        "By clicking Sign Up or Continue with Email, Apple, Google, or Facebook, you agree to Artsy’s Terms and Conditions and Privacy Policy."
       )
     })
   })
@@ -130,43 +115,13 @@ describe("AuthDialogSignUp", () => {
       render(<AuthDialogSignUp />)
 
       expect(screen.getByTestId("skeleton-disclaimer")).toHaveTextContent(
-        "By clicking Sign Up or Continue with Apple, Google, or Facebook, you agree to Artsy’s Terms of Use and Privacy Policy and to receiving emails from Artsy."
+        "By clicking Sign Up or Continue with Email, Apple, Google, or Facebook, you agree to Artsy’s Terms and Conditions and Privacy Policy and to receiving emails from Artsy."
       )
-    })
-
-    describe("when the new disclaimer is enabled", () => {
-      beforeAll(() => {
-        ;(useFeatureFlag as jest.Mock).mockImplementation(
-          (f: string) => f === "diamond_new-terms-and-conditions"
-        )
-      })
-
-      afterAll(() => {
-        ;(useFeatureFlag as jest.Mock).mockReset()
-      })
-
-      it("renders a disclaimer with the new text", () => {
-        render(<AuthDialogSignUp />)
-
-        expect(screen.getByTestId("skeleton-disclaimer")).toHaveTextContent(
-          "By clicking Sign Up or Continue with Email, Apple, Google, or Facebook, you agree to Artsy’s Terms and Conditions and Privacy Policy and to receiving emails from Artsy."
-        )
-      })
     })
   })
 
-  describe("when the new disclaimer is enabled", () => {
-    beforeAll(() => {
-      ;(useFeatureFlag as jest.Mock).mockImplementation(
-        (f: string) => f === "diamond_new-terms-and-conditions"
-      )
-    })
-
-    afterAll(() => {
-      ;(useFeatureFlag as jest.Mock).mockReset()
-    })
-
-    it("renders a disclaimer with the new text", () => {
+  describe("when the links are correct", () => {
+    it("renders a disclaimer with the text", () => {
       render(<AuthDialogSignUp />)
 
       expect(screen.getByTestId("disclaimer")).toHaveTextContent(

--- a/src/Components/AuthDialog/Views/__tests__/AuthDialogSignUp.jest.tsx
+++ b/src/Components/AuthDialog/Views/__tests__/AuthDialogSignUp.jest.tsx
@@ -1,7 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { useCountryCode } from "Components/AuthDialog/Hooks/useCountryCode"
 import { AuthDialogSignUp } from "Components/AuthDialog/Views/AuthDialogSignUp"
-import { useFeatureFlag } from "System/useFeatureFlag"
 import { signUp } from "Utils/auth"
 
 jest.mock("Utils/getENV", () => ({

--- a/src/Components/Footer/Footer.tsx
+++ b/src/Components/Footer/Footer.tsx
@@ -379,8 +379,6 @@ const ThemeSelectOption = styled(Text).attrs({
 
 const PolicyLinks = () => {
   const { CCPARequestComponent, showCCPARequest } = useCCPARequest()
-  const showNewDisclaimer = useFeatureFlag("diamond_new-terms-and-conditions")
-
   return (
     <>
       {CCPARequestComponent}
@@ -394,59 +392,25 @@ const PolicyLinks = () => {
       >
         <Flex mr={1}>© {new Date().getFullYear()} Artsy</Flex>
 
-        {showNewDisclaimer ? (
-          <>
-            <FooterLink color="black60" mr={1} to="/terms">
-              Terms and Conditions
-            </FooterLink>
+        <FooterLink color="black60" mr={1} to="/terms">
+          Terms and Conditions
+        </FooterLink>
 
-            <FooterLink color="black60" mr={1} to="/supplemental-cos">
-              Auction Supplement
-            </FooterLink>
+        <FooterLink color="black60" mr={1} to="/supplemental-cos">
+          Auction Supplement
+        </FooterLink>
 
-            <FooterLink color="black60" mr={1} to="/buyer-guarantee">
-              Buyer Guarantee
-            </FooterLink>
+        <FooterLink color="black60" mr={1} to="/buyer-guarantee">
+          Buyer Guarantee
+        </FooterLink>
 
-            <FooterLink color="black60" mr={1} to="/privacy">
-              Privacy Policy
-            </FooterLink>
+        <FooterLink color="black60" mr={1} to="/privacy">
+          Privacy Policy
+        </FooterLink>
 
-            <FooterLink color="black60" mr={1} to="/security">
-              Security
-            </FooterLink>
-          </>
-        ) : (
-          <>
-            <FooterLink color="black60" mr={1} to="/terms">
-              Terms of Use
-            </FooterLink>
-
-            <FooterLink color="black60" mr={1} to="/privacy">
-              Privacy Policy
-            </FooterLink>
-
-            <FooterLink color="black60" mr={1} to="/security">
-              Security
-            </FooterLink>
-
-            <FooterLink color="black60" mr={1} to="/conditions-of-sale">
-              Conditions of Sale
-            </FooterLink>
-
-            <FooterLink
-              color="black60"
-              mr={1}
-              to="/page/artsy-curated-auctions-listing-agreement"
-            >
-              ACA Seller’s Agreement
-            </FooterLink>
-
-            <FooterLink color="black60" mr={1} to="/buyer-guarantee">
-              Buyer Guarantee
-            </FooterLink>
-          </>
-        )}
+        <FooterLink color="black60" mr={1} to="/security">
+          Security
+        </FooterLink>
 
         <Clickable onClick={showCCPARequest}>
           Do not sell my personal information

--- a/src/Components/Footer/__tests__/Footer.jest.tsx
+++ b/src/Components/Footer/__tests__/Footer.jest.tsx
@@ -3,7 +3,6 @@ import { mount } from "enzyme"
 import { Footer } from "Components/Footer/Footer"
 import { Breakpoint } from "@artsy/palette/dist/themes/types"
 import { useRouter } from "System/Router/useRouter"
-import { useFeatureFlag } from "System/useFeatureFlag"
 import { fetchQuery } from "react-relay"
 import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
 

--- a/src/Components/Footer/__tests__/Footer.jest.tsx
+++ b/src/Components/Footer/__tests__/Footer.jest.tsx
@@ -110,56 +110,20 @@ describe("Footer", () => {
     it("renders footer links", () => {
       const wrapper = getWrapper("lg")
 
-      expect(wrapper.text()).toContain("Terms of Use")
+      expect(wrapper.text()).toContain("Terms and Conditions")
       expect(wrapper.html()).toContain("/terms")
+
+      expect(wrapper.text()).toContain("Auction Supplement")
+      expect(wrapper.html()).toContain("/supplemental-cos")
+
+      expect(wrapper.text()).toContain("Buyer Guarantee")
+      expect(wrapper.html()).toContain("/buyer-guarantee")
 
       expect(wrapper.text()).toContain("Privacy Policy")
       expect(wrapper.html()).toContain("/privacy")
 
       expect(wrapper.text()).toContain("Security")
       expect(wrapper.html()).toContain("/security")
-
-      expect(wrapper.text()).toContain("Conditions of Sale")
-      expect(wrapper.html()).toContain("/conditions-of-sale")
-
-      expect(wrapper.text()).toContain("ACA Seller’s Agreement")
-      expect(wrapper.html()).toContain(
-        "/page/artsy-curated-auctions-listing-agreement"
-      )
-
-      expect(wrapper.text()).toContain("Buyer Guarantee")
-      expect(wrapper.html()).toContain("/buyer-guarantee")
-    })
-
-    describe("when new footer links are enabled", () => {
-      beforeAll(() => {
-        ;(useFeatureFlag as jest.Mock).mockImplementation(
-          (f: string) => f === "diamond_new-terms-and-conditions"
-        )
-      })
-
-      afterAll(() => {
-        ;(useFeatureFlag as jest.Mock).mockReset()
-      })
-
-      it("renders the new footer links", () => {
-        const wrapper = getWrapper("lg")
-
-        expect(wrapper.text()).toContain("Terms and Conditions")
-        expect(wrapper.html()).toContain("/terms")
-
-        expect(wrapper.text()).toContain("Auction Supplement")
-        expect(wrapper.html()).toContain("/supplemental-cos")
-
-        expect(wrapper.text()).toContain("Buyer Guarantee")
-        expect(wrapper.html()).toContain("/buyer-guarantee")
-
-        expect(wrapper.text()).toContain("Privacy Policy")
-        expect(wrapper.html()).toContain("/privacy")
-
-        expect(wrapper.text()).toContain("Security")
-        expect(wrapper.html()).toContain("/security")
-      })
     })
   })
 
@@ -174,59 +138,23 @@ describe("Footer", () => {
       expect(wrapper.find("button").length).toEqual(1)
     })
 
-    it("renders footer links", () => {
+    it("renders the footer links", () => {
       const wrapper = getWrapper("xs")
 
-      expect(wrapper.text()).toContain("Terms of Use")
+      expect(wrapper.text()).toContain("Terms and Conditions")
       expect(wrapper.html()).toContain("/terms")
+
+      expect(wrapper.text()).toContain("Auction Supplement")
+      expect(wrapper.html()).toContain("/supplemental-cos")
+
+      expect(wrapper.text()).toContain("Buyer Guarantee")
+      expect(wrapper.html()).toContain("/buyer-guarantee")
 
       expect(wrapper.text()).toContain("Privacy Policy")
       expect(wrapper.html()).toContain("/privacy")
 
       expect(wrapper.text()).toContain("Security")
       expect(wrapper.html()).toContain("/security")
-
-      expect(wrapper.text()).toContain("Conditions of Sale")
-      expect(wrapper.html()).toContain("/conditions-of-sale")
-
-      expect(wrapper.text()).toContain("ACA Seller’s Agreement")
-      expect(wrapper.html()).toContain(
-        "/page/artsy-curated-auctions-listing-agreement"
-      )
-
-      expect(wrapper.text()).toContain("Buyer Guarantee")
-      expect(wrapper.html()).toContain("/buyer-guarantee")
-    })
-
-    describe("when diamond_new-terms-and-conditions is enabled", () => {
-      beforeAll(() => {
-        ;(useFeatureFlag as jest.Mock).mockImplementation(
-          (f: string) => f === "diamond_new-terms-and-conditions"
-        )
-      })
-
-      afterAll(() => {
-        ;(useFeatureFlag as jest.Mock).mockReset()
-      })
-
-      it("renders the new footer links", () => {
-        const wrapper = getWrapper("xs")
-
-        expect(wrapper.text()).toContain("Terms and Conditions")
-        expect(wrapper.html()).toContain("/terms")
-
-        expect(wrapper.text()).toContain("Auction Supplement")
-        expect(wrapper.html()).toContain("/supplemental-cos")
-
-        expect(wrapper.text()).toContain("Buyer Guarantee")
-        expect(wrapper.html()).toContain("/buyer-guarantee")
-
-        expect(wrapper.text()).toContain("Privacy Policy")
-        expect(wrapper.html()).toContain("/privacy")
-
-        expect(wrapper.text()).toContain("Security")
-        expect(wrapper.html()).toContain("/security")
-      })
     })
   })
 })

--- a/src/Components/Inquiry/Views/InquirySignUp.tsx
+++ b/src/Components/Inquiry/Views/InquirySignUp.tsx
@@ -32,7 +32,6 @@ import {
   useInquiryAccountContext,
 } from "Components/Inquiry/Views/InquiryAccount"
 import { formatErrorMessage } from "Components/AuthDialog/Utils/formatErrorMessage"
-import { useFeatureFlag } from "System/useFeatureFlag"
 
 type Mode = "Pending" | "Loading" | "Error" | "Done" | "Success"
 

--- a/src/Components/Inquiry/Views/InquirySignUp.tsx
+++ b/src/Components/Inquiry/Views/InquirySignUp.tsx
@@ -60,8 +60,6 @@ export const InquirySignUp: React.FC = () => {
 
   const { submitArtworkInquiryRequest } = useArtworkInquiryRequest()
 
-  const showNewDisclaimer = useFeatureFlag("diamond_new-terms-and-conditions")
-
   const [state, setState] = useState<InquirySignUpState>({
     name: "",
     email: inquiry.email ?? "",
@@ -203,22 +201,14 @@ export const InquirySignUp: React.FC = () => {
         <Spacer y={2} />
 
         <Text variant="xs" color="black60" data-testid="disclaimer">
-          By signing up, you agree to {showNewDisclaimer ? "Artsy's" : "our"}{" "}
+          By signing up, you agree to Artsy's{" "}
           <RouterLink inline to="/terms" target="_blank">
-            {showNewDisclaimer ? "Terms and Conditions" : "Terms of Use"}
+            Terms and Conditions
           </RouterLink>
           ,{" "}
           <RouterLink inline to="/privacy" target="_blank">
-            Privacy Policy
+            Privacy Policy{" "}
           </RouterLink>
-          {!showNewDisclaimer && (
-            <>
-              {", "}
-              <RouterLink inline to="/conditions-of-sale" target="_blank">
-                Conditions of Sale
-              </RouterLink>
-            </>
-          )}{" "}
           and to receiving emails from Artsy.
         </Text>
 

--- a/src/Components/Inquiry/__tests__/Views/InquirySignUp.jest.tsx
+++ b/src/Components/Inquiry/__tests__/Views/InquirySignUp.jest.tsx
@@ -59,53 +59,18 @@ describe("InquirySignUp", () => {
     expect(wrapper.html()).toContain("Sign up to send your message")
   })
 
-  it("renders a disclaimer", () => {
+  it("renders the new disclaimer", () => {
     render(<InquirySignUp />)
 
     expect(screen.getByTestId("disclaimer")).toHaveTextContent(
-      "By signing up, you agree to our Terms of Use, Privacy Policy, Conditions of Sale and to receiving emails from Artsy."
+      "By signing up, you agree to Artsy's Terms and Conditions, Privacy Policy and to receiving emails from Artsy."
     )
-    expect(screen.getByRole("link", { name: "Terms of Use" })).toHaveAttribute(
-      "href",
-      "/terms"
-    )
+    expect(
+      screen.getByRole("link", { name: "Terms and Conditions" })
+    ).toHaveAttribute("href", "/terms")
     expect(
       screen.getByRole("link", { name: "Privacy Policy" })
     ).toHaveAttribute("href", "/privacy")
-    expect(
-      screen.getByRole("link", { name: "Conditions of Sale" })
-    ).toHaveAttribute("href", "/conditions-of-sale")
-  })
-
-  describe("when the new disclaimer is enabled", () => {
-    beforeAll(() => {
-      ;(useFeatureFlag as jest.Mock).mockImplementation(
-        (f: string) => f === "diamond_new-terms-and-conditions"
-      )
-    })
-
-    afterAll(() => {
-      ;(useFeatureFlag as jest.Mock).mockReset()
-    })
-
-    it("renders the new disclaimer", () => {
-      render(<InquirySignUp />)
-
-      expect(screen.getByTestId("disclaimer")).toHaveTextContent(
-        "By signing up, you agree to Artsy's Terms and Conditions, Privacy Policy and to receiving emails from Artsy."
-      )
-      expect(
-        screen.getByRole("link", { name: "Terms and Conditions" })
-      ).toHaveAttribute("href", "/terms")
-      expect(
-        screen.getByRole("link", { name: "Privacy Policy" })
-      ).toHaveAttribute("href", "/privacy")
-
-      // TODO: remove this assertion when deprecating diamond_new-terms-and-conditions
-      expect(
-        screen.queryByRole("link", { name: "Conditions of Sale" })
-      ).not.toBeInTheDocument()
-    })
   })
 
   describe("success", () => {

--- a/src/Components/Inquiry/__tests__/Views/InquirySignUp.jest.tsx
+++ b/src/Components/Inquiry/__tests__/Views/InquirySignUp.jest.tsx
@@ -7,7 +7,6 @@ import { useInquiryContext } from "Components/Inquiry/Hooks/useInquiryContext"
 import { fill } from "Components/Inquiry/__tests__/util"
 import { useTracking } from "react-tracking"
 import { render, screen } from "@testing-library/react"
-import { useFeatureFlag } from "System/useFeatureFlag"
 
 jest.mock("Utils/auth")
 jest.mock("../../Hooks/useArtworkInquiryRequest")


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR removes `diamond_new-terms-and-conditions` from the codebase.


<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ