### PR TITLE
chore: removes dark mode feature flag

### DIFF
--- a/src/Apps/Components/__tests__/AppShell.jest.tsx
+++ b/src/Apps/Components/__tests__/AppShell.jest.tsx
@@ -18,7 +18,6 @@ jest.mock("react-tracking", () => ({
 }))
 
 jest.mock("Utils/Hooks/useAuthValidation")
-jest.mock("Utils/Hooks/useDarkModeToggle")
 
 jest.mock("Components/Footer/FooterDownloadAppBanner", () => ({
   FooterDownloadAppBanner: () => "Meet your new art advisor.",

--- a/src/Apps/Settings/Routes/EditSettings/SettingsEditSettingsRoute.tsx
+++ b/src/Apps/Settings/Routes/EditSettings/SettingsEditSettingsRoute.tsx
@@ -9,15 +9,12 @@ import { SettingsEditSettingsLinkedAccountsFragmentContainer } from "./Component
 import { SettingsEditSettingsEmailPreferences } from "./Components/SettingsEditSettingsEmailPreferences/SettingsEditSettingsEmailPreferences"
 import { SettingsEditSettingsInformationFragmentContainer } from "Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsInformation"
 import { SettingsEditSettingsThemeSelect } from "Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsThemeSelect"
-import { useFeatureFlag } from "System/useFeatureFlag"
 
 interface SettingsEditRouteProps {
   me: SettingsEditSettingsRoute_me$data
 }
 
 const SettingsEditRoute: React.FC<SettingsEditRouteProps> = ({ me }) => {
-  const isDarkModeEnabled = useFeatureFlag("diamond_dark-mode")
-
   return (
     <GridColumns>
       <Column span={8}>
@@ -32,7 +29,7 @@ const SettingsEditRoute: React.FC<SettingsEditRouteProps> = ({ me }) => {
 
           <SettingsEditSettingsEmailPreferences />
 
-          {isDarkModeEnabled && <SettingsEditSettingsThemeSelect />}
+          <SettingsEditSettingsThemeSelect />
 
           <SettingsEditSettingsDeleteAccount />
         </Join>

--- a/src/Components/Footer/Footer.tsx
+++ b/src/Components/Footer/Footer.tsx
@@ -37,8 +37,6 @@ import EmptyCheckCircleIcon from "@artsy/icons/EmptyCheckCircleIcon"
 interface FooterProps extends BoxProps {}
 
 export const Footer: React.FC<FooterProps> = props => {
-  const isDarkModeEnabled = useFeatureFlag("diamond_dark-mode")
-
   const { isEigen } = useSystemContext()
 
   if (isEigen) {
@@ -175,12 +173,6 @@ export const Footer: React.FC<FooterProps> = props => {
           <Column span={12} display={["flex", "none"]} flexWrap="wrap">
             <PolicyLinks />
           </Column>
-
-          {isDarkModeEnabled && (
-            <Column span={12} display={["flex", "none"]}>
-              <ThemeSelect />
-            </Column>
-          )}
         </GridColumns>
 
         <Separator />
@@ -206,14 +198,6 @@ export const Footer: React.FC<FooterProps> = props => {
 
               <Flex flexDirection="row" flexGrow={1}>
                 <PolicyLinks />
-
-                {isDarkModeEnabled && (
-                  <>
-                    <Spacer x={1} />
-
-                    <ThemeSelect />
-                  </>
-                )}
               </Flex>
             </Flex>
           </Media>
@@ -448,9 +432,11 @@ const PolicyLinks = () => {
           </>
         )}
 
-        <Clickable onClick={showCCPARequest}>
+        <Clickable onClick={showCCPARequest} mr={1}>
           Do not sell my personal information
         </Clickable>
+
+        <ThemeSelect />
       </Text>
     </>
   )

--- a/src/Components/Footer/__tests__/Footer.jest.tsx
+++ b/src/Components/Footer/__tests__/Footer.jest.tsx
@@ -72,7 +72,11 @@ describe("Footer", () => {
 
     it("renders the CCPA request button", () => {
       const wrapper = getWrapper("xs")
-      expect(wrapper.find("button").length).toEqual(1)
+      expect(
+        wrapper.find("button").map(button => {
+          return button.text()
+        })
+      ).toContain("Do not sell my personal information")
     })
 
     it("renders the app download banner", () => {
@@ -171,7 +175,11 @@ describe("Footer", () => {
 
     it("renders the CCPA request button", () => {
       const wrapper = getWrapper("xs")
-      expect(wrapper.find("button").length).toEqual(1)
+      expect(
+        wrapper.find("button").map(button => {
+          return button.text()
+        })
+      ).toContain("Do not sell my personal information")
     })
 
     it("renders footer links", () => {


### PR DESCRIPTION
Closes [DIA-684](https://artsyproduct.atlassian.net/browse/DIA-684)

Removes dark mode feature flag. Also adjusts the footer theme selector to wrap better.

[DIA-684]: https://artsyproduct.atlassian.net/browse/DIA-684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Once deployed we'll archive the flag completely.