### PR TITLE
chore: AMBER-724 - hide inquire on artworks grid

### DIFF
--- a/src/Components/Artwork/Details.tsx
+++ b/src/Components/Artwork/Details.tsx
@@ -167,6 +167,9 @@ const SaleMessage: React.FC<DetailsProps> = ({
     return <>Price on request</>
   }
 
+  if (sale_message?.toLowerCase() === "inquire about availability") {
+    return <>{NBSP}</>
+  }
   // NBSP is used to prevent un-aligned carousels
   return <>{sale_message ?? NBSP}</>
 }

--- a/src/Components/Artwork/__tests__/Details.jest.tsx
+++ b/src/Components/Artwork/__tests__/Details.jest.tsx
@@ -144,6 +144,21 @@ describe("Details", () => {
       expect(html).toContain("Price on request")
     })
 
+    it("does not show sale message if sale_message is for inquire", async () => {
+      const data: any = {
+        ...artworkInAuction,
+        sale_message: "Inquire about availability",
+        sale: {
+          ...artworkInAuction?.sale,
+          is_auction: false,
+        },
+      }
+
+      const wrapper = await getWrapper(data)
+      const html = wrapper.html()
+      expect(html).not.toContain("Inquire about availability")
+    })
+
     it("shows sale message if sale open and no bids", async () => {
       const data: any = {
         ...artworkInAuction,


### PR DESCRIPTION
The type of this PR is: **CHORE**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [AMBER-724]

### Description

<!-- Implementation description -->

As part of the changes made in https://github.com/artsy/gravity/pull/17819 we now have a new `sale_message` which will be displayed on the Artworks page. We do not want this, however, to appear in the artwork grid. This change ensures it will not be shown.

<details>
<summary>Before</summary>
<img width="1573" alt="Screenshot 2024-06-14 at 14 28 43" src="https://github.com/artsy/force/assets/6280410/4cce89fd-ee12-4ebb-a87e-84139945ab7b">
</details>


<details>
<summary>After</summary>
<img width="1670" alt="Screenshot 2024-06-14 at 13 36 08" src="https://github.com/artsy/force/assets/6280410/6b3ea8ec-b632-41ce-b7d2-a5c8a06cfc2c">
</details>

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AMBER-724]: https://artsyproduct.atlassian.net/browse/AMBER-724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ