### PR TITLE
fix: Update Sell flow `ArtistAutocomplete` `Artist#image` to `Artist#coverArtwork`

### DIFF
--- a/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtistAutocomplete.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/Components/ArtistAutocomplete.tsx
@@ -156,12 +156,12 @@ export const ArtistAutoComplete: React.FC<{
   }
 
   const renderOption = (option: ArtistAutocompleteOption) => {
-    const image = option.option?.image
+    const image = option.option?.coverArtwork?.image
 
     return (
       <Flex justifyContent="space-between">
         <Flex alignItems="center" p={1} width="100%">
-          {option.option?.image ? (
+          {image ? (
             <Image
               src={image?.cropped?.src}
               srcSet={image?.cropped?.srcSet}
@@ -235,12 +235,14 @@ const fetchSuggestions = async (
                 initials
                 internalID
                 isPersonalArtist
-                image {
-                  cropped(width: 50, height: 50) {
-                    height
-                    src
-                    srcSet
-                    width
+                coverArtwork {
+                  image {
+                    cropped(width: 50, height: 50) {
+                      height
+                      width
+                      src
+                      srcSet
+                    }
                   }
                 }
                 targetSupply {

--- a/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtistAutocomplete.jest.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/ArtworkDetails/__tests__/ArtistAutocomplete.jest.tsx
@@ -22,12 +22,14 @@ const results = {
           displayLabel: "Banksy",
           internalID: "111",
           formattedNationalityAndBirthday: "British, b. 1974",
-          image: {
-            cropped: {
-              height: 44,
-              src: "some-img",
-              srcSet: "some-img",
-              width: 44,
+          coverArtwork: {
+            image: {
+              cropped: {
+                height: 44,
+                src: "some-img",
+                srcSet: "some-img",
+                width: 44,
+              },
             },
           },
         },

--- a/src/__generated__/ArtistAutocomplete_SearchConnection_Query.graphql.ts
+++ b/src/__generated__/ArtistAutocomplete_SearchConnection_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d56db685f3ae0c55e282a585523f513f>>
+ * @generated SignedSource<<a2c916fd5034f86a06e783660208b564>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -19,16 +19,18 @@ export type ArtistAutocomplete_SearchConnection_Query$data = {
         readonly counts?: {
           readonly artworks: any | null | undefined;
         } | null | undefined;
-        readonly displayLabel: string | null | undefined;
-        readonly formattedNationalityAndBirthday?: string | null | undefined;
-        readonly image?: {
-          readonly cropped: {
-            readonly height: number;
-            readonly src: string;
-            readonly srcSet: string;
-            readonly width: number;
+        readonly coverArtwork?: {
+          readonly image: {
+            readonly cropped: {
+              readonly height: number;
+              readonly src: string;
+              readonly srcSet: string;
+              readonly width: number;
+            } | null | undefined;
           } | null | undefined;
         } | null | undefined;
+        readonly displayLabel: string | null | undefined;
+        readonly formattedNationalityAndBirthday?: string | null | undefined;
         readonly initials?: string | null | undefined;
         readonly internalID?: string;
         readonly isPersonalArtist?: boolean | null | undefined;
@@ -84,150 +86,150 @@ v2 = {
   "storageKey": null
 },
 v3 = {
-  "kind": "InlineFragment",
+  "alias": null,
+  "args": null,
+  "concreteType": "ArtistCounts",
+  "kind": "LinkedField",
+  "name": "counts",
+  "plural": false,
   "selections": [
     {
       "alias": null,
       "args": null,
-      "concreteType": "ArtistCounts",
+      "kind": "ScalarField",
+      "name": "artworks",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "formattedNationalityAndBirthday",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "initials",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isPersonalArtist",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Image",
+  "kind": "LinkedField",
+  "name": "image",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "height",
+          "value": 50
+        },
+        {
+          "kind": "Literal",
+          "name": "width",
+          "value": 50
+        }
+      ],
+      "concreteType": "CroppedImageUrl",
       "kind": "LinkedField",
-      "name": "counts",
+      "name": "cropped",
       "plural": false,
       "selections": [
         {
           "alias": null,
           "args": null,
           "kind": "ScalarField",
-          "name": "artworks",
-          "storageKey": null
-        }
-      ],
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "formattedNationalityAndBirthday",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "name",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "initials",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "internalID",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "isPersonalArtist",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "Image",
-      "kind": "LinkedField",
-      "name": "image",
-      "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": [
-            {
-              "kind": "Literal",
-              "name": "height",
-              "value": 50
-            },
-            {
-              "kind": "Literal",
-              "name": "width",
-              "value": 50
-            }
-          ],
-          "concreteType": "CroppedImageUrl",
-          "kind": "LinkedField",
-          "name": "cropped",
-          "plural": false,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "height",
-              "storageKey": null
-            },
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "src",
-              "storageKey": null
-            },
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "srcSet",
-              "storageKey": null
-            },
-            {
-              "alias": null,
-              "args": null,
-              "kind": "ScalarField",
-              "name": "width",
-              "storageKey": null
-            }
-          ],
-          "storageKey": "cropped(height:50,width:50)"
-        }
-      ],
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "ArtistTargetSupply",
-      "kind": "LinkedField",
-      "name": "targetSupply",
-      "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "isP1",
+          "name": "height",
           "storageKey": null
         },
         {
           "alias": null,
           "args": null,
           "kind": "ScalarField",
-          "name": "isTargetSupply",
+          "name": "width",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "src",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "srcSet",
           "storageKey": null
         }
       ],
+      "storageKey": "cropped(height:50,width:50)"
+    }
+  ],
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "ArtistTargetSupply",
+  "kind": "LinkedField",
+  "name": "targetSupply",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "isP1",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "isTargetSupply",
       "storageKey": null
     }
   ],
-  "type": "Artist",
-  "abstractKey": null
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -261,7 +263,32 @@ return {
                 "plural": false,
                 "selections": [
                   (v2/*: any*/),
-                  (v3/*: any*/)
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      (v3/*: any*/),
+                      (v4/*: any*/),
+                      (v5/*: any*/),
+                      (v6/*: any*/),
+                      (v7/*: any*/),
+                      (v8/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Artwork",
+                        "kind": "LinkedField",
+                        "name": "coverArtwork",
+                        "plural": false,
+                        "selections": [
+                          (v9/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      (v10/*: any*/)
+                    ],
+                    "type": "Artist",
+                    "abstractKey": null
+                  }
                 ],
                 "storageKey": null
               }
@@ -313,17 +340,37 @@ return {
                     "storageKey": null
                   },
                   (v2/*: any*/),
-                  (v3/*: any*/),
                   {
                     "kind": "InlineFragment",
                     "selections": [
+                      (v3/*: any*/),
+                      (v4/*: any*/),
+                      (v5/*: any*/),
+                      (v6/*: any*/),
+                      (v7/*: any*/),
+                      (v8/*: any*/),
                       {
                         "alias": null,
                         "args": null,
-                        "kind": "ScalarField",
-                        "name": "id",
+                        "concreteType": "Artwork",
+                        "kind": "LinkedField",
+                        "name": "coverArtwork",
+                        "plural": false,
+                        "selections": [
+                          (v9/*: any*/),
+                          (v11/*: any*/)
+                        ],
                         "storageKey": null
-                      }
+                      },
+                      (v10/*: any*/)
+                    ],
+                    "type": "Artist",
+                    "abstractKey": null
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      (v11/*: any*/)
                     ],
                     "type": "Node",
                     "abstractKey": "__isNode"
@@ -340,16 +387,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ee2ccb6e6f87d3048cfdf1388ff7002b",
+    "cacheID": "1a73f7e9ee3ba05feba5ea711738bc62",
     "id": null,
     "metadata": {},
     "name": "ArtistAutocomplete_SearchConnection_Query",
     "operationKind": "query",
-    "text": "query ArtistAutocomplete_SearchConnection_Query(\n  $searchQuery: String!\n) {\n  searchConnection(query: $searchQuery, entities: ARTIST, mode: AUTOSUGGEST, first: 6) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        ... on Artist {\n          counts {\n            artworks\n          }\n          formattedNationalityAndBirthday\n          name\n          initials\n          internalID\n          isPersonalArtist\n          image {\n            cropped(width: 50, height: 50) {\n              height\n              src\n              srcSet\n              width\n            }\n          }\n          targetSupply {\n            isP1\n            isTargetSupply\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query ArtistAutocomplete_SearchConnection_Query(\n  $searchQuery: String!\n) {\n  searchConnection(query: $searchQuery, entities: ARTIST, mode: AUTOSUGGEST, first: 6) {\n    edges {\n      node {\n        __typename\n        displayLabel\n        ... on Artist {\n          counts {\n            artworks\n          }\n          formattedNationalityAndBirthday\n          name\n          initials\n          internalID\n          isPersonalArtist\n          coverArtwork {\n            image {\n              cropped(width: 50, height: 50) {\n                height\n                width\n                src\n                srcSet\n              }\n            }\n            id\n          }\n          targetSupply {\n            isP1\n            isTargetSupply\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "c9b47ed053c75aafc0d1b475ccdfbe2c";
+(node as any).hash = "f2754a96a4fe874f25aa81cd5649d804";
 
 export default node;


### PR DESCRIPTION
## Description



This updates the new Sell flow's `ArtistAutocomplete` component to use `Artist#coverArtwork` instead of `Artist#image`. 

`coverImage` seems to be the new thing (https://github.com/artsy/force/pull/13004) and with this change the artist image is consistent with [EntityHeaderArtistFragmentContainer](https://github.com/artsy/force/blob/8a4d1ac03f7b59512442ce7fc068fdc4dbc45124/src/Components/EntityHeaders/EntityHeaderArtist.tsx#L107) which we display in following steps.

## Screenshots

**Before**
| | |
| --- | --- |
| <img width="832" alt="Screenshot 2024-06-14 at 17 23 39" src="https://github.com/artsy/force/assets/4691889/0d94eb26-4354-4293-857a-02d29eea3518">|<img width="905" alt="Screenshot 2024-06-14 at 17 24 06" src="https://github.com/artsy/force/assets/4691889/4fe7908e-bad3-48f3-8775-9aebbd19f044"> |

**After**

| | |
| --- | --- |
| <img width="973" alt="Screenshot 2024-06-14 at 17 26 00" src="https://github.com/artsy/force/assets/4691889/c5bba82b-74a9-40a4-8174-113800c32c6f">|<img width="905" alt="Screenshot 2024-06-14 at 17 24 06" src="https://github.com/artsy/force/assets/4691889/4fe7908e-bad3-48f3-8775-9aebbd19f044"> |



