### PR TITLE
chore(page-loader): Improve it a bit more

### DIFF
--- a/src/Apps/Components/AppShell.tsx
+++ b/src/Apps/Components/AppShell.tsx
@@ -11,6 +11,7 @@ import { useSetupAuth } from "Utils/Hooks/useSetupAuth"
 import { AnalyticsContextProvider } from "System/Contexts/AnalyticsContext"
 import { useDarkModeToggle } from "Utils/Hooks/useDarkModeToggle"
 import { findCurrentRoute } from "System/Router/Utils/routeUtils"
+import { PageLoadingBar } from "System/Components/PageLoadingBar"
 
 const logger = createLogger("Apps/Components/AppShell")
 interface AppShellProps {
@@ -25,6 +26,8 @@ export const AppShell: React.FC<AppShellProps> = props => {
 
   const { children, match } = props
   const routeConfig = match ? findCurrentRoute(match) : null
+
+  const showLoader = !match?.elements
 
   // Check to see if a route has a onServerSideRender key; if so call it. Used
   // typically to preload bundle-split components (import()) while the route is
@@ -50,10 +53,14 @@ export const AppShell: React.FC<AppShellProps> = props => {
   useProductionEnvironmentWarning()
 
   return (
-    <AnalyticsContextProvider path={match?.location?.pathname}>
-      <Layout variant={routeConfig?.layout}>{children}</Layout>
+    <>
+      <PageLoadingBar loadingState={showLoader ? "loading" : "complete"} />
 
-      {onboardingComponent}
-    </AnalyticsContextProvider>
+      <AnalyticsContextProvider path={match?.location?.pathname}>
+        <Layout variant={routeConfig?.layout}>{children}</Layout>
+
+        {onboardingComponent}
+      </AnalyticsContextProvider>
+    </>
   )
 }

--- a/src/Apps/Components/constants.ts
+++ b/src/Apps/Components/constants.ts
@@ -1,6 +1,7 @@
 export const Z = {
   dropdown: 200,
   globalNav: 100,
+  pageLoadingBar: 300,
   popover: 75,
   toasts: 150,
   footer: 1,

--- a/src/System/Router/RenderStates.tsx
+++ b/src/System/Router/RenderStates.tsx
@@ -5,9 +5,6 @@ import { HttpError } from "found"
 import { getENV } from "Utils/getENV"
 import { AppShell } from "Apps/Components/AppShell"
 import { ErrorPage } from "Components/ErrorPage"
-import { PageLoadingBar } from "System/Components/PageLoadingBar"
-
-let isInitialized = false
 
 export const renderStates = {
   /**
@@ -18,11 +15,6 @@ export const renderStates = {
     return (
       <>
         <Renderer>{null}</Renderer>
-
-        {/* Don't show loader on first SSR pass */}
-        {isInitialized && (
-          <PageLoadingBar loadingState="loading" key="loading" />
-        )}
       </>
     )
   },
@@ -30,17 +22,13 @@ export const renderStates = {
   /**
    * Once request is complete, render the page
    */
-  renderReady: ({ elements, location }) => {
+  renderReady: ({ elements }) => {
     return (
-      <>
-        <Renderer shouldUpdate>
-          <RenderReady elements={elements} />
-        </Renderer>
-
-        {isInitialized && (
-          <PageLoadingBar loadingState="complete" key="complete" />
-        )}
-      </>
+      <Renderer shouldUpdate>
+        <Box width="100%">
+          <ElementsRenderer elements={elements} />
+        </Box>
+      </Renderer>
     )
   },
 
@@ -66,21 +54,6 @@ export const renderStates = {
       </AppShell>
     )
   },
-}
-
-const RenderReady = ({ elements }) => {
-  // No access to hooks at this level of the stack
-  if (!isInitialized) {
-    setTimeout(() => {
-      isInitialized = true
-    }, 0)
-  }
-
-  return (
-    <Box width="100%">
-      <ElementsRenderer elements={elements} />
-    </Box>
-  )
 }
 
 const Renderer = ({ children, ...props }) => {

--- a/src/Typings/found.d.ts
+++ b/src/Typings/found.d.ts
@@ -20,6 +20,10 @@ declare module "found" {
     routeConfig: RouteProps[]
   }
 
+  interface MatcherResult {
+    elements: any[] | undefined | null
+  }
+
   interface RouteRenderArgs {
     resolving: boolean
   }


### PR DESCRIPTION
The type of this PR is: **Chore**

### Description

After updating the page loader, it really brought to light a lot of our slow loading pages, particularly around collections (which was kinda masked before). This improves the loader a bit by never really stopping -- there's always motion -- as well as animating out from where it was currently at. This was possible by leveraging the `match.elements == undefined` recent discovery which means the page is loading, and moving the bar into the appshell, vs being depending on the weird found router render states.


https://github.com/artsy/force/assets/236943/f9a27c53-7af1-4f3a-bf38-49808fca1178



