### PR TITLE
chore(loading-bar): fade in top bar

### DIFF
--- a/src/System/Components/PageLoadingBar.tsx
+++ b/src/System/Components/PageLoadingBar.tsx
@@ -81,11 +81,21 @@ const completeAnimation = keyframes`
   }
 `
 
+const fadeInAnimation = keyframes`
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+`
+
 const LoadingBar = styled(Box)<{ loading: string; isComplete: boolean; width }>`
   ${({ loading }) =>
     loading === "loading" &&
     css`
-      animation: ${loadingAnimation} 12s ${startEase} forwards;
+      animation: ${loadingAnimation} 12s ${startEase} forwards,
+        ${fadeInAnimation} 0.2s linear;
     `}
   ${({ isComplete }) =>
     isComplete &&
@@ -93,6 +103,6 @@ const LoadingBar = styled(Box)<{ loading: string; isComplete: boolean; width }>`
       animation: ${completeAnimation} 1s ${easeOutExpo} forwards;
     `}
   opacity: ${({ isComplete }) => (isComplete ? 0 : 1)};
-  transition: opacity .7s;
+  transition: opacity 0.7s;
   width: ${({ width }) => width}px;
 `


### PR DESCRIPTION
The type of this PR is: **Chore**

### Description

One more small improvement - quickly fades the bar in on show so that the initial appearance isn't so abrupt. 


https://github.com/artsy/force/assets/236943/fc821d3d-98c0-4d9e-92e1-4e13f3532d0f


