### PR TITLE
chore: copy changes for auction pages

### DIFF
--- a/src/Apps/Auction/Components/AuctionDetails/AuctionInfoSidebar.tsx
+++ b/src/Apps/Auction/Components/AuctionDetails/AuctionInfoSidebar.tsx
@@ -17,7 +17,7 @@ const AuctionInfoSidebar: React.FC<AuctionInfoSidebarProps> = ({ sale }) => {
         <Text variant="sm">Questions?</Text>
 
         <RouterLink inline to="/how-auctions-work" target="_blank">
-          <Text variant="sm">How to bid on Artsy?</Text>
+          <Text variant="sm">How to bid on Artsy</Text>
         </RouterLink>
       </Box>
 
@@ -26,6 +26,17 @@ const AuctionInfoSidebar: React.FC<AuctionInfoSidebarProps> = ({ sale }) => {
 
         <RouterLink inline to="mailto:specialist@artsy.net">
           <Text variant="sm">specialist@artsy.net</Text>
+        </RouterLink>
+      </Box>
+
+      <Box>
+        <Text variant="sm">More Information</Text>
+
+        <RouterLink inline to="/terms" target="_blank">
+          <Text variant="sm">Terms</Text>
+        </RouterLink>
+        <RouterLink inline to="/supplemental-cos" target="_blank">
+          <Text variant="sm">Supplemental Conditions of Sale</Text>
         </RouterLink>
       </Box>
     </Join>

--- a/src/Apps/Auction/Components/AuctionDetails/__tests__/AuctionInfoSidebar.jest.tsx
+++ b/src/Apps/Auction/Components/AuctionDetails/__tests__/AuctionInfoSidebar.jest.tsx
@@ -22,8 +22,10 @@ describe("AuctionInfoSidebar", () => {
   it("renders correct components", () => {
     const { wrapper } = getWrapper()
     expect(wrapper.find("LiveAuctionToolTip")).toHaveLength(1)
-    expect(wrapper.text()).toContain("How to bid on Artsy?")
+    expect(wrapper.text()).toContain("How to bid on Artsy")
     expect(wrapper.html()).toContain("/how-auctions-work")
     expect(wrapper.html()).toContain("mailto:specialist@artsy.net")
+    expect(wrapper.html()).toContain("/terms")
+    expect(wrapper.html()).toContain("/supplemental-cos")
   })
 })


### PR DESCRIPTION
The type of this PR is: **Chore**

This PR solves [DIA-718]

### Description

Changing/adding elements to the auctions sidebar:
* How to bid on artsy? -> How to bid on artsy
* New "More information" section

<img width="326" alt="Screenshot 2024-06-17 at 2 28 54 PM" src="https://github.com/artsy/force/assets/6969180/f175aca6-897e-41e1-9ef1-d2876f48d3aa">


[DIA-718]: https://artsyproduct.atlassian.net/browse/DIA-718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ