### PR TITLE
fix: address form validation inconsistencies

### DIFF
--- a/src/Apps/Order/Routes/Shipping2/Components/FulfillmentDetailsForm.tsx
+++ b/src/Apps/Order/Routes/Shipping2/Components/FulfillmentDetailsForm.tsx
@@ -18,6 +18,7 @@ import {
 import { SavedAddresses2 } from "Apps/Order/Routes/Shipping2/Components/SavedAddresses2"
 import {
   ADDRESS_VALIDATION_SHAPE,
+  BASIC_PHONE_VALIDATION_SHAPE,
   FulfillmentType,
   FulfillmentValues,
   ShipValues,
@@ -617,18 +618,9 @@ const VALIDATION_SCHEMA = Yup.object().shape({
     FulfillmentType.SHIP,
   ]),
 
-  attributes: Yup.object()
-    .shape({
-      phoneNumber: Yup.string()
-        .required("Phone number is required")
-        .matches(/^[+\-\d]+$/, "Phone number is required"),
-    })
-    .when("fulfillmentType", {
-      is: FulfillmentType.SHIP,
-      then: schema =>
-        schema.shape({
-          ...ADDRESS_VALIDATION_SHAPE,
-          name: Yup.string().required("Full name is required"),
-        }),
-    }),
+  attributes: Yup.object().when("fulfillmentType", {
+    is: FulfillmentType.SHIP,
+    then: schema => schema.shape(ADDRESS_VALIDATION_SHAPE),
+    otherwise: schema => schema.shape(BASIC_PHONE_VALIDATION_SHAPE),
+  }),
 })

--- a/src/Apps/Order/Routes/Shipping2/Components/__tests__/AddressModal2.jest.tsx
+++ b/src/Apps/Order/Routes/Shipping2/Components/__tests__/AddressModal2.jest.tsx
@@ -79,7 +79,7 @@ afterEach(() => {
   globalWrapper?.unmount()
 })
 
-// FIXME: CI Timeouts likely due to fillAddressForm() duration
+// FIXME: CI Timeouts
 // eslint-disable-next-line jest/no-disabled-tests
 describe.skip("AddressModal", () => {
   beforeEach(() => {

--- a/src/Apps/Order/Routes/Shipping2/Utils/shippingUtils.ts
+++ b/src/Apps/Order/Routes/Shipping2/Utils/shippingUtils.ts
@@ -57,7 +57,17 @@ export interface ShippingAddressFormValues {
   postalCode: string
 }
 
+// TODO: Replace with what we use in SettingsShippingAddressForm when we have
+// a rich phone input
+export const BASIC_PHONE_VALIDATION_SHAPE = {
+  phoneNumber: Yup.string()
+    .required("Phone number is required")
+    .matches(/^[+\-\d]+$/, "Phone number is required"),
+}
+
 export const ADDRESS_VALIDATION_SHAPE = {
+  ...BASIC_PHONE_VALIDATION_SHAPE,
+  name: Yup.string().required("Full name is required"),
   addressLine1: Yup.string().required("Street address is required"),
   addressLine2: Yup.string().nullable(),
   city: Yup.string().required("City is required"),


### PR DESCRIPTION
The type of this PR is: **fix**

This PR completes [EMI-1941] by giving us identical address validation shapes in both of the refactored shipping route's address forms.

#minor

[EMI-1941]: https://artsyproduct.atlassian.net/browse/EMI-1941?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ