### PR TITLE
feat: defer forced login / sign up to end of SWA submission flow

### DIFF
--- a/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/HeaderSWA.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/HeaderSWA.tsx
@@ -1,4 +1,3 @@
-import { ContextModule, Intent } from "@artsy/cohesion"
 import {
   Button,
   Column,
@@ -9,17 +8,13 @@ import {
   Text,
 } from "@artsy/palette"
 import { useMarketingLandingTracking } from "Apps/Consign/Routes/MarketingLanding/Utils/marketingLandingTracking"
-import { useAuthDialog } from "Components/AuthDialog"
 import { RouterLink } from "System/Components/RouterLink"
 import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
-import { useSystemContext } from "System/Hooks/useSystemContext"
 import { Media } from "Utils/Responsive"
 import { resized } from "Utils/resized"
 
 export const HeaderSWA = () => {
   const getInTouchRoute = "/sell/inquiry"
-  const { isLoggedIn } = useSystemContext()
-  const { showAuthDialog } = useAuthDialog()
 
   const {
     trackStartSellingClick,
@@ -61,24 +56,6 @@ export const HeaderSWA = () => {
                   enableNewSubmissionFlow ? "sell2/intro" : "/sell/submission"
                 }
                 onClick={event => {
-                  if (!isLoggedIn) {
-                    event.preventDefault()
-
-                    showAuthDialog({
-                      mode: "Login",
-                      options: {
-                        title: () => {
-                          return "Log in to submit an artwork for sale"
-                        },
-                      },
-                      analytics: {
-                        contextModule: ContextModule.sellHeader,
-                        intent: Intent.login,
-                      },
-                    })
-
-                    return
-                  }
                   trackStartSellingClick("Header")
                 }}
                 mb={[1, 0]}

--- a/src/Apps/Consign/Routes/MarketingLanding/Components/__tests__/HeaderSWA.jest.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/__tests__/HeaderSWA.jest.tsx
@@ -1,10 +1,8 @@
 import { fireEvent, render, screen } from "@testing-library/react"
 import { useTracking } from "react-tracking"
-import { useSystemContext } from "System/Hooks/useSystemContext"
 import { HeaderSWA } from "Apps/Consign/Routes/MarketingLanding/Components/LandingPage/HeaderSWA"
 
 jest.mock("react-tracking")
-jest.mock("System/Hooks/useSystemContext")
 jest.mock("System/Hooks/useAnalyticsContext", () => ({
   useAnalyticsContext: jest.fn(() => ({
     contextPageOwnerType: "sell",
@@ -13,12 +11,6 @@ jest.mock("System/Hooks/useAnalyticsContext", () => ({
 jest.mock("System/Hooks/useRouter", () => ({
   useRouter: jest.fn(() => ({
     match: { params: { id: "1" } },
-  })),
-}))
-const mockShowAuthDialog = jest.fn()
-jest.mock("Components/AuthDialog", () => ({
-  useAuthDialog: jest.fn(() => ({
-    showAuthDialog: mockShowAuthDialog,
   })),
 }))
 
@@ -31,10 +23,6 @@ describe("HeaderSWA", () => {
         trackEvent,
       }
     })
-    ;(useSystemContext as jest.Mock).mockImplementation(() => ({
-      user: { id: "user-id", email: "user-email@artsy.net" },
-      isLoggedIn: true,
-    }))
   })
 
   it("renders correctly", () => {
@@ -48,58 +36,28 @@ describe("HeaderSWA", () => {
   })
 
   describe("Start Selling button", () => {
-    describe("when user is not logged in", () => {
-      beforeAll(() => {
-        ;(useSystemContext as jest.Mock).mockImplementation(() => ({
-          user: { id: "user-id", email: "user-email@artsy.net" },
-          isLoggedIn: false,
-        }))
-      })
+    it("links out to submission flow", () => {
+      render(<HeaderSWA />)
 
-      it("links out to the auth flow when pressed", async () => {
-        render(<HeaderSWA />)
+      const link = screen.getByTestId("start-selling-button")
 
-        const link = screen.getByTestId("start-selling-button")
-
-        expect(link).toBeInTheDocument()
-        fireEvent.click(link)
-
-        expect(mockShowAuthDialog).toHaveBeenCalled()
-      })
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveTextContent("Start Selling")
+      expect(link).toHaveAttribute("href", "/sell/submission")
     })
 
-    describe("when user is logged in", () => {
-      beforeAll(() => {
-        ;(useSystemContext as jest.Mock).mockImplementation(() => ({
-          user: { id: "user-id", email: "user-email@artsy.net" },
-          isLoggedIn: true,
-        }))
-      })
+    it("tracks click", () => {
+      render(<HeaderSWA />)
 
-      it("links out to submission flow", () => {
-        render(<HeaderSWA />)
+      fireEvent.click(screen.getByTestId("start-selling-button"))
 
-        const link = screen.getByTestId("start-selling-button")
-
-        expect(link).toBeInTheDocument()
-        expect(link).toHaveTextContent("Start Selling")
-        expect(link).toHaveAttribute("href", "/sell/submission")
-      })
-
-      it("tracks click", () => {
-        render(<HeaderSWA />)
-
-        fireEvent.click(screen.getByTestId("start-selling-button"))
-
-        expect(trackEvent).toHaveBeenCalled()
-        expect(trackEvent).toHaveBeenCalledWith({
-          action: "tappedConsign",
-          context_module: "Header",
-          context_page_owner_type: "sell",
-          label: "Start Selling",
-          destination_path: "/sell/submission",
-          user_id: "user-id",
-        })
+      expect(trackEvent).toHaveBeenCalled()
+      expect(trackEvent).toHaveBeenCalledWith({
+        action: "tappedConsign",
+        context_module: "Header",
+        context_page_owner_type: "sell",
+        label: "Start Selling",
+        destination_path: "/sell/submission",
       })
     })
   })
@@ -116,16 +74,10 @@ describe("HeaderSWA", () => {
         context_module: "Header",
         context_page_owner_type: "sell",
         label: "Get in Touch",
-        user_id: "user-id",
-        user_email: "user-email@artsy.net",
       })
     })
 
     it("links out to email provider", () => {
-      ;(useSystemContext as jest.Mock).mockImplementation(() => ({
-        user: { id: "user-id", email: "user-email@artsy.net" },
-      }))
-
       render(<HeaderSWA />)
 
       const link = screen.getByTestId("get-in-touch-button")

--- a/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/UploadPhotos.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/UploadPhotos.tsx
@@ -397,12 +397,17 @@ export const UploadPhotos: React.FC<UploadPhotosProps> = ({
                     event.preventDefault()
 
                     showAuthDialog({
-                      mode: "Login",
+                      mode: "SignUp",
                       options: {
                         title: mode =>
                           mode === "Login"
                             ? "Log in to submit for sale"
                             : "Sign up to submit for sale",
+                        afterAuthAction: {
+                          action: "associateSubmission",
+                          kind: "submission",
+                          objectId: submission?.externalId as string,
+                        },
                       },
                       analytics: {
                         contextModule: ContextModule.uploadPhotos as AuthContextModule,

--- a/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/UploadPhotos.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/UploadPhotos.tsx
@@ -1,4 +1,10 @@
-import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
+import {
+  ActionType,
+  AuthContextModule,
+  ContextModule,
+  Intent,
+  OwnerType,
+} from "@artsy/cohesion"
 import { Box, Button, Spacer, Text } from "@artsy/palette"
 import { SubmissionStepper } from "Apps/Consign/Components/SubmissionStepper"
 import { useSubmissionFlowSteps } from "Apps/Consign/Hooks/useSubmissionFlowSteps"
@@ -47,6 +53,7 @@ import {
   getPhotoUrlFromAsset,
   shouldRefetchPhotoUrls,
 } from "Apps/Consign/Routes/SubmissionFlow/Utils/formHelpers"
+import { useAuthDialog } from "Components/AuthDialog"
 
 const logger = createLogger("SubmissionFlow/UploadPhotos.tsx")
 
@@ -95,6 +102,7 @@ export const UploadPhotos: React.FC<UploadPhotosProps> = ({
 }) => {
   const { router } = useRouter()
   const { isLoggedIn, relayEnvironment } = useSystemContext()
+  const { showAuthDialog } = useAuthDialog()
   const [isPhotosRefetchStarted, setIsPhotosRefetchStarted] = useState(false)
   const photosRefetchingCount = useRef(0)
   const {
@@ -240,7 +248,7 @@ export const UploadPhotos: React.FC<UploadPhotosProps> = ({
         initialValues={initialValue}
         initialErrors={initialErrors}
       >
-        {({ values, setFieldValue, isValid, isSubmitting }) => {
+        {({ values, setFieldValue, isValid, isSubmitting, submitForm }) => {
           const handlePhotoDelete = (photo: Photo) => {
             photo.removed = true
             photo.abortUploading?.()
@@ -384,6 +392,27 @@ export const UploadPhotos: React.FC<UploadPhotosProps> = ({
                 disabled={isSubmitting || !isValid}
                 loading={isSubmitting || values.photos.some(c => c.loading)}
                 type="submit"
+                onClick={event => {
+                  if (!isLoggedIn) {
+                    event.preventDefault()
+
+                    showAuthDialog({
+                      mode: "Login",
+                      options: {
+                        title: mode =>
+                          mode === "Login"
+                            ? "Log in to submit for sale"
+                            : "Sign up to submit for sale",
+                      },
+                      analytics: {
+                        contextModule: ContextModule.uploadPhotos as AuthContextModule,
+                        intent: Intent.login,
+                      },
+                    })
+
+                    return
+                  }
+                }}
               >
                 {isLastStep ? "Submit Artwork" : "Save and Continue"}
               </Button>

--- a/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/__tests__/UploadPhotos.jest.tsx
+++ b/src/Apps/Consign/Routes/SubmissionFlow/UploadPhotos/__tests__/UploadPhotos.jest.tsx
@@ -6,7 +6,9 @@ import {
 } from "Components/PhotoUpload/Utils/fileUtils"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { fetchQuery, graphql } from "react-relay"
+import { createMockEnvironment, MockEnvironment } from "relay-test-utils"
 import { SystemContextProvider } from "System/Contexts/SystemContext"
+import { useSystemContext } from "System/Hooks/useSystemContext"
 
 jest.unmock("react-relay")
 
@@ -60,6 +62,15 @@ jest.mock("react-relay", () => ({
 }))
 
 const mockFetchQuery = fetchQuery as jest.Mock
+const mockShowAuthDialog = jest.fn()
+jest.mock("Components/AuthDialog", () => ({
+  useAuthDialog: jest.fn(() => ({
+    showAuthDialog: mockShowAuthDialog,
+  })),
+}))
+
+jest.mock("System/Hooks/useSystemContext")
+let relayEnv: MockEnvironment = createMockEnvironment()
 
 const { renderWithRelay } = setupTestWrapperTL({
   Component: props => {
@@ -129,6 +140,11 @@ describe("UploadPhotos", () => {
       },
     })
     mockRemoveAsset.mockImplementation(() => Promise.resolve())
+    ;(useSystemContext as jest.Mock).mockImplementation(() => ({
+      user: { id: "user-id", email: "user-email@artsy.net" },
+      isLoggedIn: true,
+      relayEnvironment: relayEnv,
+    }))
   })
 
   afterEach(() => {
@@ -332,6 +348,31 @@ describe("UploadPhotos", () => {
     })
 
     expect(mockFetchQuery).toHaveBeenCalled()
+  })
+
+  it("prompts for login / sign up if unauthenticated", async () => {
+    ;(useSystemContext as jest.Mock).mockImplementation(() => ({
+      isLoggedIn: false,
+    }))
+
+    renderWithRelay({
+      ConsignmentSubmission: () => ({
+        ...submission,
+        assets: [
+          {
+            id: "id",
+            imageUrls: {},
+            geminiToken: "geminiToken",
+            size: "111084",
+            filename: "foo.png",
+          },
+        ],
+      }),
+    })
+
+    fireEvent.click(screen.getByText("Submit Artwork"))
+
+    expect(mockShowAuthDialog).toHaveBeenCalled()
   })
 
   describe("show error message", () => {


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR addresses [ONYX-1089](https://artsyproduct.atlassian.net/browse/ONYX-1089)

### Description

Instead of forcing a user to login or sign up directly on the /sell landing page, we'd like to allow the user to start and progress through the submission and only force an authenticated state at the end, right before the submission graduates from draft > submitted. At that point in the flow we want to make sure we have an Artsy user account to link the submission to but we're okay with letting visitor / unauthenticated users start and experience the submission flow before the final step.

### Screen Recordings

| Title | Video |
|--------|--------|
| Current (Visitor) | <video src="https://github.com/artsy/force/assets/123595/dd0d1364-f50d-4c5c-a0a4-4833d9b07717" /> |
| New (Vistor) | <video src="https://github.com/artsy/force/assets/123595/c4642a74-c1f6-42e3-b004-7f9150ff7c92" /> | 
| New (User) | <video src="https://github.com/artsy/force/assets/123595/88250efd-4815-48ac-93cc-ec13e8b20c85" /> |

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-1089]: https://artsyproduct.atlassian.net/browse/ONYX-1089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ