### PR TITLE
feat: wire up marketing collections rail to 07-Curated-Discovery

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,5 +28,5 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "typescript.preferences.importModuleSpecifier": "non-relative",
-  "cSpell.words": ["openai", "weaviate"]
+  "cSpell.words": ["Neartext", "openai", "weaviate"]
 }

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/MarketingCollection.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/MarketingCollection.tsx
@@ -1,4 +1,4 @@
-import { Box, Image } from "@artsy/palette"
+import { Box, Flex, Image } from "@artsy/palette"
 import { DiscoveryMarketingCollections } from "Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/MarketingCollectionsRail"
 import { FC } from "react"
 
@@ -12,9 +12,11 @@ export const MarketingCollection: FC<MarketingCollectionProps> = ({
   return (
     <Box>
       <Image src={marketingCollection.imageUrl} height={300} />
-      <a href={`/collection/${marketingCollection.slug}`} target="_blank">
-        {marketingCollection.title}
-      </a>
+      <Flex justifyContent="center">
+        <a href={`/collection/${marketingCollection.slug}`} target="_blank">
+          {marketingCollection.title}
+        </a>
+      </Flex>
     </Box>
   )
 }

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/MarketingCollection.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/MarketingCollection.tsx
@@ -1,0 +1,20 @@
+import { Box, Image } from "@artsy/palette"
+import { DiscoveryMarketingCollections } from "Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/MarketingCollectionsRail"
+import { FC } from "react"
+
+interface MarketingCollectionProps {
+  marketingCollection: DiscoveryMarketingCollections
+}
+
+export const MarketingCollection: FC<MarketingCollectionProps> = ({
+  marketingCollection,
+}) => {
+  return (
+    <Box>
+      <Image src={marketingCollection.imageUrl} height={300} />
+      <a href={`/collection/${marketingCollection.slug}`} target="_blank">
+        {marketingCollection.title}
+      </a>
+    </Box>
+  )
+}

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/MarketingCollectionsRail.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/MarketingCollectionsRail.tsx
@@ -1,0 +1,70 @@
+import { Box, SkeletonBox } from "@artsy/palette"
+import { State } from "Apps/ArtAdvisor/07-Curated-Discovery/App"
+import { MarketingCollection } from "Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/MarketingCollection"
+import { Rail } from "Components/Rail/Rail"
+import { FC, useEffect, useState } from "react"
+
+interface MarketingCollectionsRailProps {
+  state: State
+}
+
+export interface DiscoveryMarketingCollections {
+  id: string
+  imageUrl: string
+  slug: string
+  title: string
+}
+
+export const MarketingCollectionsRail: FC<MarketingCollectionsRailProps> = ({
+  state,
+}) => {
+  const [marketingCollections, setMarketingCollections] = useState<
+    DiscoveryMarketingCollections[]
+  >([])
+  const [isLoading, setIsLoading] = useState<boolean>(true)
+
+  useEffect(() => {
+    const params = new URLSearchParams()
+    params.append("concept", state.goal) //TODO: improve use of goal
+    state.interests.forEach(concept => {
+      params.append("concepts", concept)
+    })
+
+    const fetchMarketingCollections = async () => {
+      const response = await fetch(
+        `/api/advisor/7/marketing_collections?${params.toString()}`
+      )
+      const data = await response.json()
+      setMarketingCollections(data)
+      setIsLoading(false)
+    }
+
+    fetchMarketingCollections()
+  }, [state.interests, state.goal])
+
+  return (
+    <>
+      {marketingCollections.length ? (
+        <Box opacity={isLoading ? 0.2 : 1}>
+          <Rail
+            title="Marketing Collections"
+            getItems={() => {
+              return marketingCollections.map(
+                (marketingCollection: DiscoveryMarketingCollections) => {
+                  return (
+                    <MarketingCollection
+                      key={marketingCollection.id}
+                      marketingCollection={marketingCollection}
+                    />
+                  )
+                }
+              )
+            }}
+          />
+        </Box>
+      ) : (
+        <SkeletonBox height={460} />
+      )}
+    </>
+  )
+}

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/MarketingCollectionsRail.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/MarketingCollectionsRail.tsx
@@ -25,7 +25,7 @@ export const MarketingCollectionsRail: FC<MarketingCollectionsRailProps> = ({
 
   useEffect(() => {
     const params = new URLSearchParams()
-    params.append("concept", state.goal) //TODO: improve use of goal
+    params.append("concepts", state.goal) //TODO: improve use of goal
     state.interests.forEach(concept => {
       params.append("concepts", concept)
     })

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/Result.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/Result.tsx
@@ -1,6 +1,7 @@
-import { Box } from "@artsy/palette"
+import { Box, Join, Spacer } from "@artsy/palette"
 import { Action, State } from "Apps/ArtAdvisor/07-Curated-Discovery/App"
 import { FC } from "react"
+import { MarketingCollectionsRail } from "Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/MarketingCollectionsRail"
 
 interface ResultProps {
   state: State
@@ -11,8 +12,13 @@ export const Result: FC<ResultProps> = props => {
   const { state } = props
 
   return (
-    <Box>
-      <pre>{JSON.stringify(state, null, 2)}</pre>
-    </Box>
+    <>
+      <Join separator={<Spacer y={6} />}>
+        <Box>
+          <pre>{JSON.stringify(state, null, 2)}</pre>
+        </Box>
+        <MarketingCollectionsRail state={state} />
+      </Join>
+    </>
   )
 }

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/server.ts
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/server.ts
@@ -1,11 +1,31 @@
 import express from "express"
 import { ArtsyRequest, ArtsyResponse } from "Server/middleware/artsyExpress"
 import _ from "lodash"
+import { WeaviateDB } from "./weaviate-db"
+
+const weaviateDB = new WeaviateDB()
 
 const inferBudgetIntent = async (req: ArtsyRequest, res: ArtsyResponse) => {
   res.json({ amount: 42 })
 }
 
+const getMarketingCollections = async (
+  req: ArtsyRequest,
+  res: ArtsyResponse
+) => {
+  let { concepts, budget } = req.query
+
+  if (!concepts) throw new Error("Provide a concepts query string parameter")
+
+  const result = await weaviateDB.getNearMarketingCollections({
+    concepts: concepts as string[],
+    budget: budget as number,
+  })
+
+  res.json(result)
+}
+
 export const router = express.Router()
 
 router.post("/budget/intent", inferBudgetIntent)
+router.get("/marketing_collections", getMarketingCollections)

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/weaviate-db.ts
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/weaviate-db.ts
@@ -1,0 +1,309 @@
+import {
+  DiscoveryArtwork,
+  DiscoveryUser,
+  MongoID,
+  UUID,
+} from "Apps/ArtAdvisor/06-Discovery-Neartext/types"
+import { DiscoveryMarketingCollections } from "Apps/ArtAdvisor/07-Curated-Discovery/Components/CollectionsRail"
+import _ from "lodash"
+import weaviate, { WeaviateClient, generateUuid5 } from "weaviate-ts-client"
+
+const DEFAULT_ARTWORKS_CLASS = "DiscoveryArtworks"
+const DEFAULT_USERS_CLASS = "DiscoveryUsers"
+const DEFAULT_MARKETING_COLLECTIONS_CLASS = "DiscoveryMarketingCollections"
+
+export class WeaviateDB {
+  private client: WeaviateClient
+  private artworkClass: string
+  private userClass: string
+  private marketingCollectionClass: string
+
+  constructor(
+    options: {
+      /** Weaviate host url */
+      url?: string
+      /** Name of artwork class to use.
+       * Be sure this class maps to the likes/dislikes of the
+       * user class that is being supplied here.
+       */
+      artworkClass?: string
+      /** Name of user class to use.
+       * Be sure this class's likes/dislikes are mapped to the
+       * same artwork class that is being supplied here.
+       */
+      userClass?: string
+      /** Name of marketingCollection class to use. */
+      marketingCollectionClass?: string
+    } = {}
+  ) {
+    const url = options.url || process.env.WEAVIATE_URL
+    if (!url) throw new Error("Please provide url or set WEAVIATE_URL")
+
+    this.client = weaviate.client({ host: url })
+    this.artworkClass = options.artworkClass || DEFAULT_ARTWORKS_CLASS
+    this.userClass = options.userClass || DEFAULT_USERS_CLASS
+    this.marketingCollectionClass =
+      options.marketingCollectionClass || DEFAULT_MARKETING_COLLECTIONS_CLASS
+  }
+
+  async getUsers() {
+    const response = await this.client.graphql
+      .get()
+      .withClassName(this.userClass)
+      .withFields("name _additional { id }")
+      .do()
+
+    const users = response.data.Get.DiscoveryUsers.map(user => {
+      return {
+        id: user._additional.id,
+        name: user.name,
+      }
+    })
+
+    return users
+  }
+
+  /**
+   * Fetch a user
+   */
+  async getUser({
+    internalID,
+    id,
+  }: {
+    /** Mongo ID for Gravity User */
+    internalID?: string
+    /** Weaviate UUID for DiscoveryUser */
+    id?: string
+  }): Promise<DiscoveryUser> {
+    if (!internalID && !id)
+      throw new Error("Must provide either internalID or id (UUID)")
+
+    if (internalID) throw new Error("Not implemented yet")
+
+    if (!id) {
+      // temporary, while using test users
+      throw new Error("Missing id")
+    }
+
+    const response = await this.client.graphql
+      .get()
+      .withClassName(this.userClass)
+      .withWhere({
+        path: ["id"],
+        operator: "Equal",
+        valueString: id,
+      })
+      .withFields(
+        `
+        name
+        likedArtworks {
+          ... on DiscoveryArtworks { internalID }
+        }
+        dislikedArtworks {
+          ... on DiscoveryArtworks { internalID }
+        }
+        `
+      )
+      .do()
+
+    const {
+      name,
+      likedArtworks,
+      dislikedArtworks,
+    } = response.data.Get.DiscoveryUsers[0]
+
+    return {
+      id,
+      // internalID, // TODO: once we create real Gravity users
+      name,
+      likedArtworkIds: (likedArtworks || []).map(w => w.internalID),
+      dislikedArtworkIds: (dislikedArtworks || []).map(w => w.internalID),
+    } as DiscoveryUser
+  }
+
+  /**
+   * Create a liked or disliked artwork for a user
+   *
+   * @returns true on success, false if user already liked or disliked artwork
+   */
+  async reactToArtwork({
+    userId,
+    userInternalID,
+    artworkInternalID,
+    reaction,
+  }: {
+    userId?: UUID
+    userInternalID?: MongoID
+    artworkInternalID: MongoID
+    reaction: "like" | "dislike"
+  }) {
+    if (userInternalID) {
+      userId = generateUuid5(userInternalID)
+    }
+    if (!userId)
+      throw new Error("Provide either userId (UUID) or userInternalID")
+
+    // bail if user already liked or disliked artwork
+
+    const user = await this.getUser({ id: userId })
+    if (user.likedArtworkIds.includes(artworkInternalID)) return false
+    if (user.dislikedArtworkIds.includes(artworkInternalID)) return false
+
+    // else go ahead and create
+
+    const artworkId = generateUuid5(artworkInternalID)
+
+    const referenceProperty = {
+      like: "likedArtworks",
+      dislike: "dislikedArtworks",
+    }[reaction]
+
+    await this.client.data
+      .referenceCreator()
+      .withClassName(this.userClass)
+      .withId(userId)
+      .withReferenceProperty(referenceProperty)
+      .withReference(
+        this.client.data
+          .referencePayloadBuilder()
+          .withClassName(this.artworkClass)
+          .withId(artworkId)
+          .payload()
+      )
+      .do()
+
+    return true
+  }
+
+  /**
+   * Fetch artworks by semantic search on an array of concepts,
+   * optionally with liked and disliked artworks to move to/away from.
+   */
+  async getArtworksNearConcepts({
+    concepts,
+    likedArtworkIds = [],
+    dislikedArtworkIds = [],
+    limit = 10,
+  }: {
+    /** List of concepts for semantic search */
+    concepts: string[]
+    /** List of liked artwork Mongo ids */
+    likedArtworkIds?: MongoID[]
+    /** List of liked artwork Mongo ids */
+    dislikedArtworkIds?: MongoID[]
+    /** Max number of artworks to return */
+    limit?: number
+  }) {
+    console.log("[WeaviateDB] getArtworksNearConcepts", {
+      concepts,
+      likedArtworkIds,
+      dislikedArtworkIds,
+      limit,
+    })
+
+    const conceptArray = ensureValidConcepts(concepts)
+
+    const response = await this.client.graphql
+      .get()
+      .withClassName(this.artworkClass)
+      .withNearText({
+        concepts: conceptArray,
+        moveTo: getMoveObjects(likedArtworkIds),
+        moveAwayFrom: getMoveObjects(dislikedArtworkIds),
+      })
+      .withLimit(limit)
+      .withFields(
+        "internalID slug title date rarity medium materials price dimensions imageUrl _additional { id distance }"
+      )
+      .do()
+
+    const result = response.data.Get.DiscoveryArtworks.map(artwork => {
+      const properties = _.pick(artwork, [
+        "internalID",
+        "slug",
+        "title",
+        "date",
+        "rarity",
+        "medium",
+        "materials",
+        "price",
+        "dimensions",
+        "imageUrl",
+      ])
+
+      return {
+        id: artwork._additional.id,
+        ...properties,
+        distance: artwork._additional.distance,
+      }
+    })
+
+    return result as DiscoveryArtwork[]
+  }
+
+  /**
+   * Fetch artworks by semantic search on an array of concepts,
+   * optionally with liked and disliked artworks to move to/away from.
+   */
+  async getNearMarketingCollections({
+    concepts,
+    budget,
+    limit = 10,
+  }: {
+    /** List of concepts for semantic search */
+    concepts: string[]
+    /** Budget on which to filter */
+    budget?: number
+    /** List of liked artwork Mongo ids */
+    limit?: number
+  }) {
+    console.log("[WeaviateDB] getNearCollections", {
+      concepts,
+      limit,
+    })
+
+    const conceptArray = ensureValidConcepts(concepts)
+
+    const response = await this.client.graphql
+      .get()
+      .withClassName(this.marketingCollectionClass)
+      .withNearText({
+        concepts: conceptArray,
+      })
+      .withLimit(limit)
+      .withFields("internalID slug title imageUrl _additional { id distance }")
+      .do()
+
+    const result = response.data.Get.DiscoveryMarketingCollections
+
+    return result as DiscoveryMarketingCollections[]
+  }
+}
+
+/**
+ * Ensure that the concepts are valid for nearText(concepts: […])
+ * queries, to avoid Weaviate errors.
+ *
+ * @returns a non-empty array of non-empty strings
+ */
+function ensureValidConcepts(concepts: string[]) {
+  let conceptsArray = _.castArray(concepts)
+  conceptsArray = _.reject(conceptsArray, _.isEmpty)
+
+  if (_.isEmpty(conceptsArray)) {
+    conceptsArray.push("art") // TODO: better default?
+  }
+
+  return conceptsArray
+}
+
+/**
+ * Format a list of Mongo IDs for moveTo/moveAwayFrom
+ *
+ * @param ids list of Mongo IDs
+ * @param force weight of the move
+ */
+function getMoveObjects(ids: MongoID[], force = 1) {
+  const objects = _.castArray(ids).map(id => ({ id: generateUuid5(id), force }))
+  return { objects, force }
+}

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/weaviate-db.ts
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/weaviate-db.ts
@@ -1,37 +1,17 @@
-import {
-  DiscoveryArtwork,
-  DiscoveryUser,
-  MongoID,
-  UUID,
-} from "Apps/ArtAdvisor/06-Discovery-Neartext/types"
-import { DiscoveryMarketingCollections } from "Apps/ArtAdvisor/07-Curated-Discovery/Components/CollectionsRail"
+import { DiscoveryMarketingCollections } from "Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/MarketingCollectionsRail"
 import _ from "lodash"
-import weaviate, { WeaviateClient, generateUuid5 } from "weaviate-ts-client"
+import weaviate, { WeaviateClient } from "weaviate-ts-client"
 
-const DEFAULT_ARTWORKS_CLASS = "DiscoveryArtworks"
-const DEFAULT_USERS_CLASS = "DiscoveryUsers"
 const DEFAULT_MARKETING_COLLECTIONS_CLASS = "DiscoveryMarketingCollections"
 
 export class WeaviateDB {
   private client: WeaviateClient
-  private artworkClass: string
-  private userClass: string
   private marketingCollectionClass: string
 
   constructor(
     options: {
       /** Weaviate host url */
       url?: string
-      /** Name of artwork class to use.
-       * Be sure this class maps to the likes/dislikes of the
-       * user class that is being supplied here.
-       */
-      artworkClass?: string
-      /** Name of user class to use.
-       * Be sure this class's likes/dislikes are mapped to the
-       * same artwork class that is being supplied here.
-       */
-      userClass?: string
       /** Name of marketingCollection class to use. */
       marketingCollectionClass?: string
     } = {}
@@ -40,205 +20,8 @@ export class WeaviateDB {
     if (!url) throw new Error("Please provide url or set WEAVIATE_URL")
 
     this.client = weaviate.client({ host: url })
-    this.artworkClass = options.artworkClass || DEFAULT_ARTWORKS_CLASS
-    this.userClass = options.userClass || DEFAULT_USERS_CLASS
     this.marketingCollectionClass =
       options.marketingCollectionClass || DEFAULT_MARKETING_COLLECTIONS_CLASS
-  }
-
-  async getUsers() {
-    const response = await this.client.graphql
-      .get()
-      .withClassName(this.userClass)
-      .withFields("name _additional { id }")
-      .do()
-
-    const users = response.data.Get.DiscoveryUsers.map(user => {
-      return {
-        id: user._additional.id,
-        name: user.name,
-      }
-    })
-
-    return users
-  }
-
-  /**
-   * Fetch a user
-   */
-  async getUser({
-    internalID,
-    id,
-  }: {
-    /** Mongo ID for Gravity User */
-    internalID?: string
-    /** Weaviate UUID for DiscoveryUser */
-    id?: string
-  }): Promise<DiscoveryUser> {
-    if (!internalID && !id)
-      throw new Error("Must provide either internalID or id (UUID)")
-
-    if (internalID) throw new Error("Not implemented yet")
-
-    if (!id) {
-      // temporary, while using test users
-      throw new Error("Missing id")
-    }
-
-    const response = await this.client.graphql
-      .get()
-      .withClassName(this.userClass)
-      .withWhere({
-        path: ["id"],
-        operator: "Equal",
-        valueString: id,
-      })
-      .withFields(
-        `
-        name
-        likedArtworks {
-          ... on DiscoveryArtworks { internalID }
-        }
-        dislikedArtworks {
-          ... on DiscoveryArtworks { internalID }
-        }
-        `
-      )
-      .do()
-
-    const {
-      name,
-      likedArtworks,
-      dislikedArtworks,
-    } = response.data.Get.DiscoveryUsers[0]
-
-    return {
-      id,
-      // internalID, // TODO: once we create real Gravity users
-      name,
-      likedArtworkIds: (likedArtworks || []).map(w => w.internalID),
-      dislikedArtworkIds: (dislikedArtworks || []).map(w => w.internalID),
-    } as DiscoveryUser
-  }
-
-  /**
-   * Create a liked or disliked artwork for a user
-   *
-   * @returns true on success, false if user already liked or disliked artwork
-   */
-  async reactToArtwork({
-    userId,
-    userInternalID,
-    artworkInternalID,
-    reaction,
-  }: {
-    userId?: UUID
-    userInternalID?: MongoID
-    artworkInternalID: MongoID
-    reaction: "like" | "dislike"
-  }) {
-    if (userInternalID) {
-      userId = generateUuid5(userInternalID)
-    }
-    if (!userId)
-      throw new Error("Provide either userId (UUID) or userInternalID")
-
-    // bail if user already liked or disliked artwork
-
-    const user = await this.getUser({ id: userId })
-    if (user.likedArtworkIds.includes(artworkInternalID)) return false
-    if (user.dislikedArtworkIds.includes(artworkInternalID)) return false
-
-    // else go ahead and create
-
-    const artworkId = generateUuid5(artworkInternalID)
-
-    const referenceProperty = {
-      like: "likedArtworks",
-      dislike: "dislikedArtworks",
-    }[reaction]
-
-    await this.client.data
-      .referenceCreator()
-      .withClassName(this.userClass)
-      .withId(userId)
-      .withReferenceProperty(referenceProperty)
-      .withReference(
-        this.client.data
-          .referencePayloadBuilder()
-          .withClassName(this.artworkClass)
-          .withId(artworkId)
-          .payload()
-      )
-      .do()
-
-    return true
-  }
-
-  /**
-   * Fetch artworks by semantic search on an array of concepts,
-   * optionally with liked and disliked artworks to move to/away from.
-   */
-  async getArtworksNearConcepts({
-    concepts,
-    likedArtworkIds = [],
-    dislikedArtworkIds = [],
-    limit = 10,
-  }: {
-    /** List of concepts for semantic search */
-    concepts: string[]
-    /** List of liked artwork Mongo ids */
-    likedArtworkIds?: MongoID[]
-    /** List of liked artwork Mongo ids */
-    dislikedArtworkIds?: MongoID[]
-    /** Max number of artworks to return */
-    limit?: number
-  }) {
-    console.log("[WeaviateDB] getArtworksNearConcepts", {
-      concepts,
-      likedArtworkIds,
-      dislikedArtworkIds,
-      limit,
-    })
-
-    const conceptArray = ensureValidConcepts(concepts)
-
-    const response = await this.client.graphql
-      .get()
-      .withClassName(this.artworkClass)
-      .withNearText({
-        concepts: conceptArray,
-        moveTo: getMoveObjects(likedArtworkIds),
-        moveAwayFrom: getMoveObjects(dislikedArtworkIds),
-      })
-      .withLimit(limit)
-      .withFields(
-        "internalID slug title date rarity medium materials price dimensions imageUrl _additional { id distance }"
-      )
-      .do()
-
-    const result = response.data.Get.DiscoveryArtworks.map(artwork => {
-      const properties = _.pick(artwork, [
-        "internalID",
-        "slug",
-        "title",
-        "date",
-        "rarity",
-        "medium",
-        "materials",
-        "price",
-        "dimensions",
-        "imageUrl",
-      ])
-
-      return {
-        id: artwork._additional.id,
-        ...properties,
-        distance: artwork._additional.distance,
-      }
-    })
-
-    return result as DiscoveryArtwork[]
   }
 
   /**
@@ -295,15 +78,4 @@ function ensureValidConcepts(concepts: string[]) {
   }
 
   return conceptsArray
-}
-
-/**
- * Format a list of Mongo IDs for moveTo/moveAwayFrom
- *
- * @param ids list of Mongo IDs
- * @param force weight of the move
- */
-function getMoveObjects(ids: MongoID[], force = 1) {
-  const objects = _.castArray(ids).map(id => ({ id: generateUuid5(id), force }))
-  return { objects, force }
 }

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/weaviate-db.ts
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/weaviate-db.ts
@@ -25,8 +25,7 @@ export class WeaviateDB {
   }
 
   /**
-   * Fetch artworks by semantic search on an array of concepts,
-   * optionally with liked and disliked artworks to move to/away from.
+   * Fetch marketing collections by semantic search on an array of concepts.
    */
   async getNearMarketingCollections({
     concepts,
@@ -35,9 +34,9 @@ export class WeaviateDB {
   }: {
     /** List of concepts for semantic search */
     concepts: string[]
-    /** Budget on which to filter */
+    /** Budget on which to filter collections */
     budget?: number
-    /** List of liked artwork Mongo ids */
+    /** Max number of collections to return */
     limit?: number
   }) {
     console.log("[WeaviateDB] getNearCollections", {


### PR DESCRIPTION
The type of this PR is: Feat

### Description

This PR wires up the marketing collections rail to the `07-Curated-Discovery` result page, taking input from the form page. Similar to #14044, this isn't the final representation of the collections rail, but stubs it out and allows us to keep iterating and avoid duplicative work.

I've punted on UI polish considerations.

---

https://github.com/artsy/force/assets/38149304/1452330a-d51e-4ab9-88f5-dde44bcb1751



