### PR TITLE
feat: extract budget intent via LLM

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,8 @@
     "superagent": "3.8.3"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^0.0.23",
+    "@ai-sdk/openai": "^0.0.33",
     "@artsy/cohesion": "4.189.0",
     "@artsy/commerce_helpers": "artsy/commerce_helpers",
     "@artsy/detect-responsive-traits": "^0.1.0",
@@ -106,6 +108,7 @@
     "@stripe/stripe-js": "^1.34.0",
     "@styled-system/theme-get": "5.1.2",
     "actioncable": "^5.2.7-1",
+    "ai": "^3.2.5",
     "analytics-node": "2.4.1",
     "async": "^3.2.4",
     "autosuggest-highlight": "3.1.1",
@@ -206,7 +209,8 @@
     "waypoints": "4.0.0",
     "weaviate-ts-client": "^2.2.0",
     "yargs": "11.0.0",
-    "yup": "0.32.6"
+    "yup": "0.32.6",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@babel/cli": "7.13.10",

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/App.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/App.tsx
@@ -11,7 +11,6 @@ export type BudgetIntent = {
 export type State = {
   currentStep: Step
   goal: string
-  goalFreeText: string
   budget: string
   budgetIntent: BudgetIntent | undefined
   interests: string[]
@@ -21,7 +20,6 @@ export type State = {
 const initialState: State = {
   currentStep: "form",
   goal: "",
-  goalFreeText: "",
   budget: "",
   budgetIntent: undefined,
   interests: [],

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/App.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/App.tsx
@@ -1,12 +1,12 @@
 import { FC, useReducer } from "react"
+import { z } from "zod"
 import { Form } from "./Components/Form/Form"
 import { Result } from "./Components/Result/Result"
+import { schema as budgetIntentSchema } from "Apps/ArtAdvisor/07-Curated-Discovery/llm/extractBudgetIntent"
 
 type Step = "form" | "result"
 
-export type BudgetIntent = {
-  amount: number
-}
+export type BudgetIntent = z.infer<typeof budgetIntentSchema>
 
 export type State = {
   currentStep: Step

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Form/Budget.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Form/Budget.tsx
@@ -8,7 +8,7 @@ interface BudgetProps {
 }
 
 export const Budget: FC<BudgetProps> = props => {
-  const { dispatch } = props
+  const { state, dispatch } = props
 
   return (
     <Box>
@@ -22,6 +22,7 @@ export const Budget: FC<BudgetProps> = props => {
         placeholder={
           "For example, “I will spend $500–$1,000 on this artwork,” or “I’d spend up to $100,000 this year on my collection.”"
         }
+        defaultValue={state.budget}
         rows={2}
         onChange={e => {
           const text = e.value

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Form/Form.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Form/Form.tsx
@@ -31,15 +31,11 @@ export const Form: React.FC<FormProps> = props => {
   const handleSubmit = async () => {
     try {
       setIsLoading(true)
-      const budgetIntent = await fetch("/api/advisor/7/budget/intent", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          budget: state.budget,
-        }),
-      })
+      const params = new URLSearchParams({ budget: state.budget })
+      const url = `/api/advisor/7/budget/intent?${params.toString()}`
+      const headers = { "Content-Type": "application/json" }
+      const options = { headers }
+      const budgetIntent = await fetch(url, options)
 
       if (budgetIntent.ok) {
         const intent = (await budgetIntent.json()) as BudgetIntent

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/Links.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/Links.tsx
@@ -1,0 +1,28 @@
+import { Clickable, Flex } from "@artsy/palette"
+import { Action } from "Apps/ArtAdvisor/07-Curated-Discovery/App"
+
+interface LinksProps {
+  dispatch: React.Dispatch<Action>
+}
+
+export const Links: React.FC<LinksProps> = props => {
+  const { dispatch } = props
+  return (
+    <Flex gap={1}>
+      <Clickable
+        textDecoration={"underline"}
+        py={1}
+        onClick={() => dispatch({ type: "SET_STEP", step: "form" })}
+      >
+        Back
+      </Clickable>
+      <Clickable
+        textDecoration={"underline"}
+        py={1}
+        onClick={() => dispatch({ type: "RESET" })}
+      >
+        Start over
+      </Clickable>
+    </Flex>
+  )
+}

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/Result.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/Result.tsx
@@ -2,6 +2,7 @@ import { Box, Join, Spacer } from "@artsy/palette"
 import { Action, State } from "Apps/ArtAdvisor/07-Curated-Discovery/App"
 import { FC } from "react"
 import { MarketingCollectionsRail } from "Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/MarketingCollectionsRail"
+import { Links } from "Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/Links"
 
 interface ResultProps {
   state: State
@@ -9,10 +10,11 @@ interface ResultProps {
 }
 
 export const Result: FC<ResultProps> = props => {
-  const { state } = props
+  const { state, dispatch } = props
 
   return (
     <>
+      <Links dispatch={dispatch} />
       <Join separator={<Spacer y={6} />}>
         <Box>
           <pre>{JSON.stringify(state, null, 2)}</pre>

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/llm/extractBudgetIntent.ts
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/llm/extractBudgetIntent.ts
@@ -33,7 +33,7 @@ const prompt = (statement: string) => dedent`
 
   BUDGET STATEMENT: ${statement}
 `
-const schema = z.object({
+export const schema = z.object({
   budget: z
     .object({
       currency: z

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/llm/extractBudgetIntent.ts
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/llm/extractBudgetIntent.ts
@@ -1,0 +1,85 @@
+import { generateObject } from "ai"
+import { openai } from "@ai-sdk/openai"
+import dedent from "dedent"
+import { z } from "zod"
+
+const model = openai("gpt-4o")
+
+const system = dedent`
+  Your task is to analyze a plaintext budget statement
+  from a collector who is interested in buying one or more artworks,
+  and to produce a structured object to describe it, containing:
+  - budget
+  - numberOfArtworks
+  - timeFrame
+
+  If a budget expresses a range, set min and max accordingly.
+
+  If a budget expresses a single amount, then set min to 0 and max to the amount.
+
+  If a budget cannot be inferred, omit it
+
+  If the number of artworks is stated or implied, set numberOfArtworks accordingly.
+
+  If the number of artworks is not stated or implied, omit numberOfArtworks.
+
+  If the time frame is expressed in relative terms, consider the current date: ${new Date().toISOString()}
+
+  If the time frame is not stated or implied, omit timeFrame.
+`
+
+const prompt = (statement: string) => dedent`
+  Analyze the following budget statement and produce a structured object to describe it.
+
+  BUDGET STATEMENT: ${statement}
+`
+const schema = z.object({
+  budget: z
+    .object({
+      currency: z
+        .string()
+        .default("USD")
+        .describe("ISO currency code. Assume USD if not otherwise specified."),
+      min: z
+        .number()
+        .default(0)
+        .describe(
+          "A minimum amount. Default to 0 if not otherwise specified. Set this to a non-zero number ONLY IF the user has explicitly specified a minimum."
+        ),
+      max: z.number().describe("A maximum amount."),
+    })
+    .optional()
+    .describe("The user's budget. Omit if unspecified."),
+  numberOfArtworks: z
+    .number()
+    .optional()
+    .describe(
+      "The number of artworks the user wishes to buy. Omit if unspecified."
+    ),
+  timeFrame: z
+    .object({
+      number: z.number().optional().describe("How many of the time units"),
+      unit: z
+        .enum(["day", "week", "month", "year"])
+        .optional()
+        .describe("The unit of time"),
+    })
+    .optional()
+    .describe(
+      "The time frame over which the user wishes to buy. Omit if unspecified."
+    ),
+})
+
+export async function extractBudgetIntent(budget: string) {
+  console.log("[LLM] extractBudgetIntent", { budget })
+
+  const result = await generateObject({
+    model,
+    temperature: 0,
+    system,
+    prompt: prompt(budget),
+    schema,
+  })
+
+  return result.object
+}

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/server.ts
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/server.ts
@@ -2,11 +2,14 @@ import express from "express"
 import { ArtsyRequest, ArtsyResponse } from "Server/middleware/artsyExpress"
 import _ from "lodash"
 import { WeaviateDB } from "./weaviate-db"
+import { extractBudgetIntent } from "./llm/extractBudgetIntent"
 
 const weaviateDB = new WeaviateDB()
 
-const inferBudgetIntent = async (req: ArtsyRequest, res: ArtsyResponse) => {
-  res.json({ amount: 42 })
+const getBudgetIntent = async (req: ArtsyRequest, res: ArtsyResponse) => {
+  const { budget } = req.query
+  const intent = await extractBudgetIntent(budget)
+  res.json(intent)
 }
 
 const getMarketingCollections = async (
@@ -27,5 +30,5 @@ const getMarketingCollections = async (
 
 export const router = express.Router()
 
-router.post("/budget/intent", inferBudgetIntent)
+router.get("/budget/intent", getBudgetIntent)
 router.get("/marketing_collections", getMarketingCollections)

--- a/yarn.lock
+++ b/yarn.lock
@@ -7,6 +7,82 @@
   resolved "https://registry.yarnpkg.com/@adobe/css-tools/-/css-tools-4.3.2.tgz#a6abc715fb6884851fca9dad37fc34739a04fd11"
   integrity sha512-DA5a1C0gD/pLOvhv33YMrbf2FK3oUzwNl9oOJqE4XVjuEtt6XIakRcsd7eLiOSPkp1kTRQGICTA8cKra/vFbjw==
 
+"@ai-sdk/anthropic@^0.0.23":
+  version "0.0.23"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/anthropic/-/anthropic-0.0.23.tgz#8a84e6f5575ca7294f43e28b6bd4c3289a13af01"
+  integrity sha512-vhcG5umNN21tLgMdsmCoyiJBG3QPu40RPkHKAO8HHwie40T8Gv5AynlswZsFNXLxumNbR0KvIzDpjVNPCqT4wA==
+  dependencies:
+    "@ai-sdk/provider" "0.0.10"
+    "@ai-sdk/provider-utils" "0.0.16"
+
+"@ai-sdk/openai@^0.0.33":
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/openai/-/openai-0.0.33.tgz#4584ac18f89aac9d237b8cd668fbbbd9c4de35ee"
+  integrity sha512-siVeHnagh08UFgdwflPdUKTdrVvfU/JWqSa8nCsMy6DvSri8T7zTzPZoCxXiMKPXkhQDd/KsaXhweOShGLQ1uQ==
+  dependencies:
+    "@ai-sdk/provider" "0.0.10"
+    "@ai-sdk/provider-utils" "0.0.16"
+
+"@ai-sdk/provider-utils@0.0.16":
+  version "0.0.16"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/provider-utils/-/provider-utils-0.0.16.tgz#515193209062fdcfc091ada0c3c0c6e134483465"
+  integrity sha512-W2zUZ+C5uDr2P9/KZwtV4r4F0l2RlD0AvtJyug7ER5g3hGHAfKrPM0y2hSlRxNfph5BTCC6YQX0nFLyBph+6bQ==
+  dependencies:
+    "@ai-sdk/provider" "0.0.10"
+    eventsource-parser "1.1.2"
+    nanoid "3.3.6"
+    secure-json-parse "2.7.0"
+
+"@ai-sdk/provider@0.0.10":
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/provider/-/provider-0.0.10.tgz#be84af0b4cb2dad0ebc85b1070b4f47404cfb1f1"
+  integrity sha512-NzkrtREQpHID1cTqY/C4CI30PVOaXWKYytDR2EcytmFgnP7Z6+CrGIA/YCnNhYAuUm6Nx+nGpRL/Hmyrv7NYzg==
+  dependencies:
+    json-schema "0.4.0"
+
+"@ai-sdk/react@0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/react/-/react-0.0.6.tgz#5c8516b66e92a89997e326c84e159dc02d485489"
+  integrity sha512-k0gpsiUxDTkDMYsdWl0WhujXVPMZvfPMCSbxZtzGvEao0YZNFQ/9ct+SZJvb5t9126oiNG0a344COO9CZ1OdLg==
+  dependencies:
+    "@ai-sdk/provider-utils" "0.0.16"
+    "@ai-sdk/ui-utils" "0.0.5"
+    swr "2.2.0"
+
+"@ai-sdk/solid@0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/solid/-/solid-0.0.5.tgz#d8b86f640a3f123b8aaf1f0473a1971eb9a4fff9"
+  integrity sha512-h43y+Vt4if2/6ms2u5OtPCzrA64FqyrpLJCnM2wcCF1WNiu11GGJI+GMHKWZrNPDqokD+PYeh1GG9Xd9DCppKA==
+  dependencies:
+    "@ai-sdk/ui-utils" "0.0.5"
+    solid-swr-store "0.10.7"
+    swr-store "0.10.6"
+
+"@ai-sdk/svelte@0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/svelte/-/svelte-0.0.5.tgz#652e1bd4e9e3992bcd6f118ef9ff49fb09dd900c"
+  integrity sha512-5Jqww5Jtuyyg5NGRxS4GjxnWaSG5bkLPd/lOQnCj+RhS1DqGfjw0Qz76OYNXnjR/5AeJoAU4FTU45P8z5Kmy2A==
+  dependencies:
+    "@ai-sdk/provider-utils" "0.0.16"
+    "@ai-sdk/ui-utils" "0.0.5"
+    sswr "2.1.0"
+
+"@ai-sdk/ui-utils@0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/ui-utils/-/ui-utils-0.0.5.tgz#e0cf161895a96e777d4fdb74ad62679cd3ecf797"
+  integrity sha512-Ug2qsKVLLxzZtJMu8Omw7wA1p8RqX82M4OeAZ2/oCPlZSAVAte+VnuXl6q6lUsAUfprVCDpzDDm9GJOOOYZg2Q==
+  dependencies:
+    "@ai-sdk/provider-utils" "0.0.16"
+    secure-json-parse "2.7.0"
+
+"@ai-sdk/vue@0.0.5":
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/@ai-sdk/vue/-/vue-0.0.5.tgz#503ee283edfe7a46d14aa909138a52511f56ec61"
+  integrity sha512-G4wdK2LKD7QevNvbnroatnkQ/V2X4H6iif4+wdFhlPo9am24+mgf4bXjvuIwNIgCVd0wwQ3hE+2kGuBDATu9gA==
+  dependencies:
+    "@ai-sdk/ui-utils" "0.0.5"
+    swrv "1.0.4"
+
 "@ampproject/remapping@^2.1.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
@@ -109,24 +185,6 @@
   integrity sha512-Iuq3hjvx6O2d1glmuoo1kFnMLOBJFW2OuQ4Q5fXS1Q/DMAvjwrBmmzZE6HVzwR5BwX5Xy6knRiD8FuPrldeo0Q==
 
 "@artsy/palette@38.13.1", "@artsy/palette@^38.13.1":
-  version "38.13.1"
-  resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-38.13.1.tgz#b3cc2903a3d532769b3505b2e717ccd37fb27912"
-  integrity sha512-Xlp3fJy3A3B3E2NiRu7m0xTTeYZiDniWhb5g0KkOAX/r4KzGE5qQ95yefaDpgY7CPTKdJJ/5/HkxatxSOyjh4w==
-  dependencies:
-    "@artsy/icons" "^3.2.2"
-    "@artsy/palette-tokens" "^6.0.3"
-    "@seznam/compose-react-refs" "^1.0.6"
-    "@styled-system/theme-get" "^5.1.2"
-    lodash "^4.17.21"
-    proportional-scale "^4.0.0"
-    react-focus-on "^3.7.0"
-    react-lazy-load-image-component "1.5.5"
-    styled-system "^5.1.5"
-    trunc-html "^1.1.2"
-    use-cursor "^1.2.3"
-    use-keyboard-list-navigation "2.4.2"
-
-"@artsy/palette@^38.13.1":
   version "38.13.1"
   resolved "https://registry.yarnpkg.com/@artsy/palette/-/palette-38.13.1.tgz#b3cc2903a3d532769b3505b2e717ccd37fb27912"
   integrity sha512-Xlp3fJy3A3B3E2NiRu7m0xTTeYZiDniWhb5g0KkOAX/r4KzGE5qQ95yefaDpgY7CPTKdJJ/5/HkxatxSOyjh4w==
@@ -4728,6 +4786,11 @@
   resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.5.tgz#14a3e83fa641beb169a2dd8422d91c3c345a9a78"
   integrity sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==
 
+"@types/diff-match-patch@^1.0.36":
+  version "1.0.36"
+  resolved "https://registry.yarnpkg.com/@types/diff-match-patch/-/diff-match-patch-1.0.36.tgz#dcef10a69d357fe9d43ac4ff2eca6b85dbf466af"
+  integrity sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg==
+
 "@types/enzyme@3.1.11":
   version "3.1.11"
   resolved "https://registry.yarnpkg.com/@types/enzyme/-/enzyme-3.1.11.tgz#0a059d2fe2c686f024ada911d24473cdb2e13903"
@@ -6200,6 +6263,26 @@ aggregate-error@^3.0.0:
   dependencies:
     clean-stack "^2.0.0"
     indent-string "^3.2.0"
+
+ai@^3.2.5:
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/ai/-/ai-3.2.5.tgz#d508bac3cf904018514544a35ff6ff0011fea00b"
+  integrity sha512-Af4prTiDL+PKGLuAkNmaCSc3JJWTefjYTuzoLqghj/jsHz61ldyV91JT0Lra3wa9Yt/uDBc8wf4wHd7vCOXbfg==
+  dependencies:
+    "@ai-sdk/provider" "0.0.10"
+    "@ai-sdk/provider-utils" "0.0.16"
+    "@ai-sdk/react" "0.0.6"
+    "@ai-sdk/solid" "0.0.5"
+    "@ai-sdk/svelte" "0.0.5"
+    "@ai-sdk/ui-utils" "0.0.5"
+    "@ai-sdk/vue" "0.0.5"
+    eventsource-parser "1.1.2"
+    json-schema "0.4.0"
+    jsondiffpatch "0.6.0"
+    nanoid "3.3.6"
+    secure-json-parse "2.7.0"
+    sswr "2.1.0"
+    zod-to-json-schema "3.22.5"
 
 airbnb-js-shims@^2.2.1:
   version "2.2.1"
@@ -8115,7 +8198,7 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@^5.2.0:
+chalk@^5.2.0, chalk@^5.3.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.3.0.tgz#67c20a7ebef70e7f3970a01f90fa210cb6860385"
   integrity sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==
@@ -9883,6 +9966,11 @@ diagnostics_channel@^1.1.0:
   resolved "https://registry.yarnpkg.com/diagnostics_channel/-/diagnostics_channel-1.1.0.tgz#bd66c49124ce3bac697dff57466464487f57cea5"
   integrity sha512-OE1ngLDjSBPG6Tx0YATELzYzy3RKHC+7veQ8gLa8yS7AAgw65mFbVdcsu3501abqOZCEZqZyAIemB0zXlqDSuw==
 
+diff-match-patch@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/diff-match-patch/-/diff-match-patch-1.0.5.tgz#abb584d5f10cd1196dfc55aa03701592ae3f7b37"
+  integrity sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw==
+
 diff-sequences@^25.2.6:
   version "25.2.6"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-25.2.6.tgz#5f467c00edd35352b7bca46d7927d60e687a76dd"
@@ -11160,6 +11248,11 @@ events@^3.0.0, events@^3.2.0, events@^3.3.0:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/events/-/events-3.3.0.tgz#31a95ad0a924e2d2c419a813aeb2c4e878ea7400"
   integrity sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==
+
+eventsource-parser@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/eventsource-parser/-/eventsource-parser-1.1.2.tgz#ed6154a4e3dbe7cda9278e5e35d2ffc58b309f89"
+  integrity sha512-v0eOBUbiaFojBu2s2NPBfYUoRR9GjcDNvCXVaqEf5vVfpIAh9f8RCo4vXTP8c63QRKCFwoLpMpTdPwwhEKVgzA==
 
 evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
   version "1.0.3"
@@ -15754,6 +15847,15 @@ jsonc-parser@^3.2.0:
   resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-3.2.0.tgz#31ff3f4c2b9793f89c67212627c51c6394f88e76"
   integrity sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==
 
+jsondiffpatch@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/jsondiffpatch/-/jsondiffpatch-0.6.0.tgz#daa6a25bedf0830974c81545568d5f671c82551f"
+  integrity sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ==
+  dependencies:
+    "@types/diff-match-patch" "^1.0.36"
+    chalk "^5.3.0"
+    diff-match-patch "^1.0.5"
+
 jsonfile@^2.1.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-2.4.0.tgz#3736a2b428b87bbda0cc83b53fa3d633a35c2ae8"
@@ -17169,6 +17271,11 @@ nanoclone@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/nanoclone/-/nanoclone-0.2.1.tgz#dd4090f8f1a110d26bb32c49ed2f5b9235209ed4"
   integrity sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==
+
+nanoid@3.3.6:
+  version "3.3.6"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.6.tgz#443380c856d6e9f9824267d960b4236ad583ea4c"
+  integrity sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==
 
 nanoid@^1.0.2:
   version "1.3.4"
@@ -20657,6 +20764,11 @@ scroll-behavior@^0.11.0:
     invariant "^2.2.4"
     page-lifecycle "^0.1.2"
 
+secure-json-parse@2.7.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/secure-json-parse/-/secure-json-parse-2.7.0.tgz#5a5f9cd6ae47df23dba3151edd06855d47e09862"
+  integrity sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw==
+
 semver-compare@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/semver-compare/-/semver-compare-1.0.0.tgz#0dee216a1c941ab37e9efb1788f6afc5ff5537fc"
@@ -21123,6 +21235,11 @@ socks@^2.6.1:
     ip "^1.1.5"
     smart-buffer "^4.2.0"
 
+solid-swr-store@0.10.7:
+  version "0.10.7"
+  resolved "https://registry.yarnpkg.com/solid-swr-store/-/solid-swr-store-0.10.7.tgz#9511308f01250a1509efbfaad5b481be7517e436"
+  integrity sha512-A6d68aJmRP471aWqKKPE2tpgOiR5fH4qXQNfKIec+Vap+MGQm3tvXlT8n0I8UgJSlNAsSAUuw2VTviH2h3Vv5g==
+
 source-list-map@^2.0.0, source-list-map@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
@@ -21320,6 +21437,13 @@ ssri@^8.0.0, ssri@^8.0.1:
   integrity sha512-97qShzy1AiyxvPNIkLWoGua7xoQzzPjQ0HAH4B0rWKo7SZ6USuPcrUiAFrws0UH8RrbWmgq3LMTObhPIHbbBeQ==
   dependencies:
     minipass "^3.1.1"
+
+sswr@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/sswr/-/sswr-2.1.0.tgz#1eb64cd647cc9e11f871e7f43554abd8c64e1103"
+  integrity sha512-Cqc355SYlTAaUt8iDPaC/4DPPXK925PePLMxyBKuWd5kKc5mwsG3nT9+Mq2tyguL5s7b4Jg+IRMpTRsNTAfpSQ==
+  dependencies:
+    swrev "^4.0.0"
 
 stable@^0.1.8:
   version "0.1.8"
@@ -21990,6 +22114,30 @@ swc-loader@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/swc-loader/-/swc-loader-0.2.3.tgz#6792f1c2e4c9ae9bf9b933b3e010210e270c186d"
   integrity sha512-D1p6XXURfSPleZZA/Lipb3A8pZ17fP4NObZvFCDjK/OKljroqDpPmsBdTraWhVBqUNpcWBQY1imWdoPScRlQ7A==
+
+swr-store@0.10.6:
+  version "0.10.6"
+  resolved "https://registry.yarnpkg.com/swr-store/-/swr-store-0.10.6.tgz#1856bda886e87dbed40c8c9874c1b1624d2e502d"
+  integrity sha512-xPjB1hARSiRaNNlUQvWSVrG5SirCjk2TmaUyzzvk69SZQan9hCJqw/5rG9iL7xElHU784GxRPISClq4488/XVw==
+  dependencies:
+    dequal "^2.0.3"
+
+swr@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/swr/-/swr-2.2.0.tgz#575c6ac1bec087847f4c86a39ccbc0043c834d6a"
+  integrity sha512-AjqHOv2lAhkuUdIiBu9xbuettzAzWXmCEcLONNKJRba87WAefz8Ca9d6ds/SzrPc235n1IxWYdhJ2zF3MNUaoQ==
+  dependencies:
+    use-sync-external-store "^1.2.0"
+
+swrev@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/swrev/-/swrev-4.0.0.tgz#83da6983c7ef9d71ac984a9b169fc197cbf18ff8"
+  integrity sha512-LqVcOHSB4cPGgitD1riJ1Hh4vdmITOp+BkmfmXRh4hSF/t7EnS4iD+SOTmq7w5pPm/SiPeto4ADbKS6dHUDWFA==
+
+swrv@1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/swrv/-/swrv-1.0.4.tgz#278b4811ed4acbb1ae46654972a482fd1847e480"
+  integrity sha512-zjEkcP8Ywmj+xOJW3lIT65ciY/4AL4e/Or7Gj0MzU3zBJNMdJiT8geVZhINavnlHRMMCcJLHhraLTAiDOTmQ9g==
 
 symbol-observable@^1.0.4, symbol-observable@^1.2.0:
   version "1.2.0"
@@ -23268,7 +23416,7 @@ use-sidecar@^1.1.2:
     detect-node-es "^1.1.0"
     tslib "^2.0.0"
 
-use-sync-external-store@^1.0.0:
+use-sync-external-store@^1.0.0, use-sync-external-store@^1.2.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz#c3b6390f3a30eba13200d2302dcdf1e7b57b2ef9"
   integrity sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==
@@ -24432,6 +24580,16 @@ zen-observable@^0.8.0:
   version "0.8.11"
   resolved "https://registry.yarnpkg.com/zen-observable/-/zen-observable-0.8.11.tgz#d3415885eeeb42ee5abb9821c95bb518fcd6d199"
   integrity sha512-N3xXQVr4L61rZvGMpWe8XoCGX8vhU35dPyQ4fm5CY/KDlG0F75un14hjbckPXTDuKUY6V0dqR2giT6xN8Y4GEQ==
+
+zod-to-json-schema@3.22.5:
+  version "3.22.5"
+  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.22.5.tgz#3646e81cfc318dbad2a22519e5ce661615418673"
+  integrity sha512-+akaPo6a0zpVCCseDed504KBJUQpEW5QZw7RMneNmKw+fGaML1Z9tUNLnHHAC8x6dzVRO1eB2oEMyZRnuBZg7Q==
+
+zod@^3.23.8:
+  version "3.23.8"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.23.8.tgz#e37b957b5d52079769fb8097099b592f0ef4067d"
+  integrity sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==
 
 zwitch@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
Completes the budget inference step that was stubbed in #14044 

The LLM logic was developed over in https://github.com/artsy/quantum/pull/30 and is re-used in slightly modified form here.

Upon submitting messy free text such as “**idk maybe 5k by the end of the year**” the intent will be parsed as shown in the global state object here:

```js
{
  "currentStep": "result",
  "goal": "Decorate my home",

  // 👇🏽 messy input
  "budget": "idk maybe 5k by the end of the year",   

  // 👇🏽 extracted intent
  "budgetIntent": {                
    "budget": {
      "currency": "USD",
      "min": 0,
      "max": 5000
    },
    "timeFrame": {
      "number": 6,
      "unit": "month"
    }
  },

  "interests": [
    "Prints"
  ],
  "interestsFreeText": ""
}
```

https://github.com/artsy/force/assets/140521/bd9a9d5a-1644-4420-9983-64cedc343cbd
