### PR TITLE
chore: Make "Start Selling" button ready for new sell flow

### DIFF
--- a/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/HeaderSWA.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/HeaderSWA.tsx
@@ -11,6 +11,7 @@ import {
 import { useMarketingLandingTracking } from "Apps/Consign/Routes/MarketingLanding/Utils/marketingLandingTracking"
 import { useAuthDialog } from "Components/AuthDialog"
 import { RouterLink } from "System/Components/RouterLink"
+import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import { Media } from "Utils/Responsive"
 import { resized } from "Utils/resized"
@@ -29,6 +30,8 @@ export const HeaderSWA = () => {
     "https://files.artsy.net/images/content-card-swa-landing-page.jpg",
     { width: 1104, height: 833 }
   )
+
+  const enableNewSubmissionFlow = useFeatureFlag("onyx_new_submission_flow")
 
   return (
     <GridColumns gridRowGap={[2, 4]} alignItems="center">
@@ -54,7 +57,11 @@ export const HeaderSWA = () => {
                 as={RouterLink}
                 width="100%"
                 variant="primaryBlack"
-                to="/sell/submission"
+                to={
+                  enableNewSubmissionFlow
+                    ? "sell2/submissions/new"
+                    : "/sell/submission"
+                }
                 onClick={event => {
                   if (!isLoggedIn) {
                     event.preventDefault()


### PR DESCRIPTION
Resolves [ONYX-1058](https://artsyproduct.atlassian.net/browse/ONYX-1058)

## Description

Make the "Start Selling" button ready for the new sales flow (behind a feature flag).

<img width="1831" alt="Screenshot 2024-06-24 at 13 17 55" src="https://github.com/artsy/force/assets/4691889/d7e8f5eb-5166-4bc6-8b04-687dc0ff3a72">


[ONYX-1058]: https://artsyproduct.atlassian.net/browse/ONYX-1058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ