### PR TITLE
fix(EMI-1924): user logged in to show expired banner

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkPageBanner.tsx
+++ b/src/Apps/Artwork/Components/ArtworkPageBanner.tsx
@@ -49,7 +49,10 @@ export const ArtworkPageBanner: FC<ArtworkPageBannerProps> = props => {
       return <ArtworkUnavailableBanner />
     }
 
-    if (!partnerOffer || partnerOffer.internalID !== expectedPartnerOfferID) {
+    if (
+      me &&
+      (!partnerOffer || partnerOffer.internalID !== expectedPartnerOfferID)
+    ) {
       return <ExpiredOfferBanner />
     }
   }


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [EMI-1924]

### Description

An alternative to #14058 where we only check that the user is logged in to avoid backend + app changes that need to be coordinated

[EMI-1924]: https://artsyproduct.atlassian.net/browse/EMI-1924?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ