### PR TITLE
feat: require login in new Sell flow

### DIFF
--- a/src/Apps/Sell/Components/BottomFormNavigation.tsx
+++ b/src/Apps/Sell/Components/BottomFormNavigation.tsx
@@ -1,5 +1,8 @@
+import { ContextModule, Intent } from "@artsy/cohesion"
 import { Box, Button, Flex } from "@artsy/palette"
 import { useSellFlowContext } from "Apps/Sell/SellFlowContext"
+import { useAuthDialog } from "Components/AuthDialog"
+import { useSystemContext } from "System/Hooks/useSystemContext"
 import createLogger from "Utils/logger"
 import { useFormikContext } from "formik"
 import { useState } from "react"
@@ -56,13 +59,34 @@ const BottomFormBackButton = () => {
 const BottomFormNextButton = () => {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const { isValid, submitForm } = useFormikContext()
+  const { isLoggedIn } = useSystemContext()
+  const { showAuthDialog } = useAuthDialog()
+
   const {
     actions,
     state: { isSubmitStep },
   } = useSellFlowContext()
 
   const onNext = async () => {
+    if (!isLoggedIn) {
+      showAuthDialog({
+        mode: "Login",
+        options: {
+          title: () => {
+            return "Log in to submit an artwork for sale"
+          },
+        },
+        analytics: {
+          contextModule: ContextModule.consignSubmissionFlow,
+          intent: Intent.login,
+        },
+      })
+
+      return
+    }
+
     setIsSubmitting(true)
+
     try {
       await submitForm()
 

--- a/src/Apps/Sell/Routes/ArtistRoute.tsx
+++ b/src/Apps/Sell/Routes/ArtistRoute.tsx
@@ -1,3 +1,4 @@
+import { ContextModule, Intent } from "@artsy/cohesion"
 import { Box, Text, useToasts } from "@artsy/palette"
 import {
   ArtistAutoComplete,
@@ -8,8 +9,10 @@ import { DevDebug } from "Apps/Sell/Components/DevDebug"
 import { SubmissionLayout } from "Apps/Sell/Components/SubmissionLayout"
 import { SubmissionStepTitle } from "Apps/Sell/Components/SubmissionStepTitle"
 import { useSellFlowContext } from "Apps/Sell/SellFlowContext"
+import { useAuthDialog } from "Components/AuthDialog"
 import { RouterLink } from "System/Components/RouterLink"
 import { useRouter } from "System/Hooks/useRouter"
+import { useSystemContext } from "System/Hooks/useSystemContext"
 import createLogger from "Utils/logger"
 import {
   ArtistRoute_submission$data,
@@ -60,6 +63,8 @@ export const ArtistRouteFragmentContainer: React.FC<ArtistRouteProps> = props =>
 export const ArtistRoute: React.FC<{
   submission?: ArtistRoute_submission$data
 }> = ({ submission }) => {
+  const { isLoggedIn } = useSystemContext()
+  const { showAuthDialog } = useAuthDialog()
   const { router } = useRouter()
   const { actions } = useSellFlowContext()
   const { sendToast } = useToasts()
@@ -69,6 +74,23 @@ export const ArtistRoute: React.FC<{
   const onSubmit = async () => {}
 
   const createSubmission = async (artist: AutocompleteArtist) => {
+    if (!isLoggedIn) {
+      showAuthDialog({
+        mode: "Login",
+        options: {
+          title: () => {
+            return "Log in to submit an artwork for sale"
+          },
+        },
+        analytics: {
+          contextModule: ContextModule.sellFooter,
+          intent: Intent.login,
+        },
+      })
+
+      return
+    }
+
     if (!artist?.internalID) return
 
     const isTargetSupply = artist?.targetSupply?.isTargetSupply

--- a/src/Apps/Sell/Routes/__tests__/ArtistNotEligibleRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/ArtistNotEligibleRoute.jest.tsx
@@ -2,17 +2,18 @@ import { screen } from "@testing-library/react"
 import { ArtistNotEligibleRoute } from "Apps/Sell/Routes/ArtistNotEligibleRoute"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { useRouter } from "System/Hooks/useRouter"
+import { useSystemContext } from "System/Hooks/useSystemContext"
 import { graphql } from "react-relay"
 
 const mockUseRouter = useRouter as jest.Mock
 const mockPush = jest.fn()
 const mockReplace = jest.fn()
 
+jest.unmock("react-relay")
 jest.mock("System/Hooks/useRouter", () => ({
   useRouter: jest.fn(),
 }))
-jest.unmock("react-relay")
-
+jest.mock("System/Hooks/useSystemContext")
 jest.mock("react-relay", () => ({
   ...jest.requireActual("react-relay"),
   fetchQuery: jest.fn(),
@@ -21,6 +22,10 @@ jest.mock("react-relay", () => ({
 let pathnameMock: string
 
 beforeAll(() => {
+  ;(useSystemContext as jest.Mock).mockImplementation(() => {
+    return { isLoggedIn: true }
+  })
+
   pathnameMock = "/artists/artist-id/artist"
 
   mockUseRouter.mockImplementation(() => ({

--- a/src/Apps/Sell/Routes/__tests__/ArtistRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/ArtistRoute.jest.tsx
@@ -3,17 +3,18 @@ import { ArtistRoute } from "Apps/Sell/Routes/ArtistRoute"
 import { SubmissionRoute } from "Apps/Sell/Routes/SubmissionRoute"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { useRouter } from "System/Hooks/useRouter"
+import { useSystemContext } from "System/Hooks/useSystemContext"
 import { graphql } from "react-relay"
 
 const mockUseRouter = useRouter as jest.Mock
 const mockPush = jest.fn()
 const mockReplace = jest.fn()
 
+jest.unmock("react-relay")
 jest.mock("System/Hooks/useRouter", () => ({
   useRouter: jest.fn(),
 }))
-jest.unmock("react-relay")
-
+jest.mock("System/Hooks/useSystemContext")
 jest.mock("react-relay", () => ({
   ...jest.requireActual("react-relay"),
   fetchQuery: jest.fn(),
@@ -22,6 +23,10 @@ jest.mock("react-relay", () => ({
 let pathnameMock: string
 
 beforeAll(() => {
+  ;(useSystemContext as jest.Mock).mockImplementation(() => {
+    return { isLoggedIn: true }
+  })
+
   pathnameMock = "/submissions/submission-id/artist"
 
   mockUseRouter.mockImplementation(() => ({

--- a/src/Apps/Sell/Routes/__tests__/DetailsRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/DetailsRoute.jest.tsx
@@ -4,6 +4,7 @@ import { SubmissionRoute } from "Apps/Sell/Routes/SubmissionRoute"
 import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { useRouter } from "System/Hooks/useRouter"
+import { useSystemContext } from "System/Hooks/useSystemContext"
 import { useMutation } from "Utils/Hooks/useMutation"
 import { DetailsRoute_Test_Query$rawResponse } from "__generated__/DetailsRoute_Test_Query.graphql"
 import { graphql } from "react-relay"
@@ -18,6 +19,7 @@ jest.mock("System/Hooks/useRouter", () => ({
   useRouter: jest.fn(),
 }))
 jest.mock("Utils/Hooks/useMutation")
+jest.mock("System/Hooks/useSystemContext")
 
 const submissionMock: Partial<
   DetailsRoute_Test_Query$rawResponse["submission"]
@@ -26,6 +28,10 @@ const submissionMock: Partial<
 }
 
 beforeEach(() => {
+  ;(useSystemContext as jest.Mock).mockImplementation(() => {
+    return { isLoggedIn: true }
+  })
+
   mockUseRouter.mockImplementation(() => ({
     router: {
       push: mockPush,

--- a/src/Apps/Sell/Routes/__tests__/DimensionsRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/DimensionsRoute.jest.tsx
@@ -4,6 +4,7 @@ import { SubmissionRoute } from "Apps/Sell/Routes/SubmissionRoute"
 import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { useRouter } from "System/Hooks/useRouter"
+import { useSystemContext } from "System/Hooks/useSystemContext"
 import { useMutation } from "Utils/Hooks/useMutation"
 import { DimensionsRoute_Test_Query$rawResponse } from "__generated__/DimensionsRoute_Test_Query.graphql"
 import { graphql } from "react-relay"
@@ -18,6 +19,7 @@ jest.mock("System/Hooks/useRouter", () => ({
   useRouter: jest.fn(),
 }))
 jest.mock("Utils/Hooks/useMutation")
+jest.mock("System/Hooks/useSystemContext")
 
 const submissionMock: Partial<
   DimensionsRoute_Test_Query$rawResponse["submission"]
@@ -26,6 +28,10 @@ const submissionMock: Partial<
 }
 
 beforeEach(() => {
+  ;(useSystemContext as jest.Mock).mockImplementation(() => {
+    return { isLoggedIn: true }
+  })
+
   mockUseRouter.mockImplementation(() => ({
     router: {
       push: mockPush,

--- a/src/Apps/Sell/Routes/__tests__/IntroRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/IntroRoute.jest.tsx
@@ -11,7 +11,7 @@ jest.mock("System/Hooks/useRouter", () => ({
 }))
 jest.unmock("react-relay")
 
-beforeEach(() => {
+beforeAll(() => {
   mockUseRouter.mockImplementation(() => ({
     router: {
       push: mockPush,

--- a/src/Apps/Sell/Routes/__tests__/NewRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/NewRoute.jest.tsx
@@ -1,17 +1,23 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { NewRoute } from "Apps/Sell/Routes/NewRoute"
 import { useRouter } from "System/Hooks/useRouter"
+import { useSystemContext } from "System/Hooks/useSystemContext"
 
 const mockUseRouter = useRouter as jest.Mock
 const mockPush = jest.fn()
 const mockReplace = jest.fn()
 
+jest.unmock("react-relay")
 jest.mock("System/Hooks/useRouter", () => ({
   useRouter: jest.fn(() => ({ match: { location: { query: {} } } })),
 }))
-jest.unmock("react-relay")
+jest.mock("System/Hooks/useSystemContext")
 
 beforeEach(() => {
+  ;(useSystemContext as jest.Mock).mockImplementation(() => {
+    return { isLoggedIn: true }
+  })
+
   mockUseRouter.mockImplementation(() => ({
     router: {
       push: mockPush,

--- a/src/Apps/Sell/Routes/__tests__/PurchaseHistoryRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/PurchaseHistoryRoute.jest.tsx
@@ -4,6 +4,7 @@ import { SubmissionRoute } from "Apps/Sell/Routes/SubmissionRoute"
 import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { useRouter } from "System/Hooks/useRouter"
+import { useSystemContext } from "System/Hooks/useSystemContext"
 import { useMutation } from "Utils/Hooks/useMutation"
 import { PurchaseHistoryRoute_Test_Query$rawResponse } from "__generated__/PurchaseHistoryRoute_Test_Query.graphql"
 import { graphql } from "react-relay"
@@ -18,6 +19,7 @@ jest.mock("System/Hooks/useRouter", () => ({
   useRouter: jest.fn(),
 }))
 jest.mock("Utils/Hooks/useMutation")
+jest.mock("System/Hooks/useSystemContext")
 
 const submissionMock: Partial<
   PurchaseHistoryRoute_Test_Query$rawResponse["submission"]
@@ -32,7 +34,11 @@ const submissionMock2: Partial<
   provenance: "",
 }
 
-beforeEach(() => {
+beforeAll(() => {
+  ;(useSystemContext as jest.Mock).mockImplementation(() => {
+    return { isLoggedIn: true }
+  })
+
   mockUseRouter.mockImplementation(() => ({
     router: {
       push: mockPush,

--- a/src/Apps/Sell/Routes/__tests__/ThankYouRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/ThankYouRoute.jest.tsx
@@ -1,8 +1,9 @@
+import { screen } from "@testing-library/react"
 import { SubmissionRoute } from "Apps/Sell/Routes/SubmissionRoute"
 import { ThankYouRoute } from "Apps/Sell/Routes/ThankYouRoute"
-import { screen } from "@testing-library/react"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { useRouter } from "System/Hooks/useRouter"
+import { useSystemContext } from "System/Hooks/useSystemContext"
 import { graphql } from "react-relay"
 
 const mockUseRouter = useRouter as jest.Mock
@@ -12,14 +13,17 @@ const mockReplace = jest.fn()
 jest.mock("System/Hooks/useRouter", () => ({
   useRouter: jest.fn(),
 }))
-jest.unmock("react-relay")
-
+jest.mock("System/Hooks/useSystemContext")
 jest.mock("react-relay", () => ({
   ...jest.requireActual("react-relay"),
   fetchQuery: jest.fn(),
 }))
 
 beforeEach(() => {
+  ;(useSystemContext as jest.Mock).mockImplementation(() => {
+    return { isLoggedIn: true }
+  })
+
   mockUseRouter.mockImplementation(() => ({
     router: {
       push: mockPush,

--- a/src/Apps/Sell/Routes/__tests__/TitleRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/TitleRoute.jest.tsx
@@ -1,10 +1,10 @@
-import { screen } from "@testing-library/react"
-import { fireEvent, waitFor } from "@testing-library/react"
+import { fireEvent, screen, waitFor } from "@testing-library/react"
+import { SubmissionRoute } from "Apps/Sell/Routes/SubmissionRoute"
 import { TitleRoute } from "Apps/Sell/Routes/TitleRoute"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
-import { graphql } from "react-relay"
-import { SubmissionRoute } from "Apps/Sell/Routes/SubmissionRoute"
 import { useRouter } from "System/Hooks/useRouter"
+import { useSystemContext } from "System/Hooks/useSystemContext"
+import { graphql } from "react-relay"
 
 const mockUseRouter = useRouter as jest.Mock
 const mockPush = jest.fn()
@@ -14,14 +14,17 @@ jest.mock("System/Hooks/useRouter", () => ({
   useRouter: jest.fn(),
 }))
 
-jest.unmock("react-relay")
-
+jest.mock("System/Hooks/useSystemContext")
 jest.mock("react-relay", () => ({
   ...jest.requireActual("react-relay"),
   fetchQuery: jest.fn(),
 }))
 
-beforeEach(() => {
+beforeAll(() => {
+  ;(useSystemContext as jest.Mock).mockImplementation(() => {
+    return { isLoggedIn: true }
+  })
+
   mockUseRouter.mockImplementation(() => ({
     router: {
       push: mockPush,


### PR DESCRIPTION
Addresses [ONYX-1058]

## Description

This change will require login in the new Sell flow. Creating a new submission by selecting an artist will open the auth modal and clicking "Next" in the flow will open the auth modal as well (even if it might not be needed, I thought this would be good to have).

## Screenshots

<img width="2056" alt="Screenshot 2024-06-25 at 11 49 22" src="https://github.com/artsy/force/assets/4691889/546b73a5-8ecd-4718-8ccb-cc9263ecf014">


[ONYX-1058]: https://artsyproduct.atlassian.net/browse/ONYX-1058?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ