### PR TITLE
feat: add 07 curated discovery articles rail

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -28,5 +28,5 @@
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.formatOnSave": true,
   "typescript.preferences.importModuleSpecifier": "non-relative",
-  "cSpell.words": ["Neartext", "openai", "weaviate"]
+  "cSpell.words": ["deduped", "Neartext", "openai", "weaviate"]
 }

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/Article.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/Article.tsx
@@ -1,0 +1,18 @@
+import { Box, Image } from "@artsy/palette"
+import { ArticleType } from "Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/ArticlesRail"
+import { FC } from "react"
+
+interface ArticleRailsProps {
+  article: ArticleType
+}
+
+export const Article: FC<ArticleRailsProps> = ({ article }) => {
+  return (
+    <Box>
+      <Image src={article.imageUrl} height={300} />
+      <a href={`${article.href}`} target="_blank">
+        {article.title}
+      </a>
+    </Box>
+  )
+}

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/ArticlesRail.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/ArticlesRail.tsx
@@ -1,0 +1,61 @@
+import { Box, SkeletonBox } from "@artsy/palette"
+import { State } from "Apps/ArtAdvisor/07-Curated-Discovery/App"
+import { Article } from "Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/Article"
+import { Rail } from "Components/Rail/Rail"
+import { FC, useEffect, useState } from "react"
+
+interface ArticlesRailProps {
+  state: State
+}
+
+export interface ArticleType {
+  id: string
+  imageUrl?: string
+  href: string
+  title: string
+  articleDescription: string
+}
+
+export const ArticlesRail: FC<ArticlesRailProps> = ({ state }) => {
+  const [articles, setArticles] = useState<ArticleType[]>([])
+  const [isLoading, setIsLoading] = useState<boolean>(true)
+
+  useEffect(() => {
+    const params = new URLSearchParams()
+    params.append("limit", "100")
+    params.append("concepts", state.goal) //TODO: improve use of goal
+    state.interests.forEach(concept => {
+      params.append("concepts", concept)
+    })
+
+    const fetchArticles = async () => {
+      const response = await fetch(
+        `/api/advisor/7/articles?${params.toString()}`
+      )
+      const data = await response.json()
+      setArticles(data)
+      setIsLoading(false)
+    }
+
+    fetchArticles()
+  }, [state.interests, state.goal])
+
+  return (
+    <>
+      {articles.length ? (
+        <Box opacity={isLoading ? 0.2 : 1}>
+          <Rail
+            title="Artsy Editorial"
+            getItems={() => {
+              return articles.map((article: ArticleType) => {
+                return <Article key={article.id} article={article} />
+              })
+            }}
+          />
+        </Box>
+      ) : (
+        <SkeletonBox height={460} />
+      )}
+    </>
+  )
+}

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/ArticlesRail.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/ArticlesRail.tsx
@@ -22,7 +22,7 @@ export const ArticlesRail: FC<ArticlesRailProps> = ({ state }) => {
 
   useEffect(() => {
     const params = new URLSearchParams()
-    params.append("limit", "100")
+    params.append("limit", "25")
     params.append("concepts", state.goal) //TODO: improve use of goal
     state.interests.forEach(concept => {
       params.append("concepts", concept)

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/ArticlesRail.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/ArticlesRail.tsx
@@ -9,7 +9,7 @@ interface ArticlesRailProps {
 }
 
 export interface ArticleType {
-  id: string
+  internalID: string
   imageUrl?: string
   href: string
   title: string
@@ -48,7 +48,7 @@ export const ArticlesRail: FC<ArticlesRailProps> = ({ state }) => {
             title="Artsy Editorial"
             getItems={() => {
               return articles.map((article: ArticleType) => {
-                return <Article key={article.id} article={article} />
+                return <Article key={article.internalID} article={article} />
               })
             }}
           />

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/MarketingCollectionsRail.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/MarketingCollectionsRail.tsx
@@ -9,7 +9,7 @@ interface MarketingCollectionsRailProps {
 }
 
 export interface DiscoveryMarketingCollections {
-  id: string
+  internalID: string
   imageUrl: string
   slug: string
   title: string
@@ -53,7 +53,7 @@ export const MarketingCollectionsRail: FC<MarketingCollectionsRailProps> = ({
                 (marketingCollection: DiscoveryMarketingCollections) => {
                   return (
                     <MarketingCollection
-                      key={marketingCollection.id}
+                      key={marketingCollection.internalID}
                       marketingCollection={marketingCollection}
                     />
                   )

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/Result.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/Result.tsx
@@ -3,6 +3,7 @@ import { Action, State } from "Apps/ArtAdvisor/07-Curated-Discovery/App"
 import { FC } from "react"
 import { MarketingCollectionsRail } from "Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/MarketingCollectionsRail"
 import { Links } from "Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/Links"
+import { ArticlesRail } from "Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/ArticlesRail"
 
 interface ResultProps {
   state: State
@@ -20,6 +21,7 @@ export const Result: FC<ResultProps> = props => {
           <pre>{JSON.stringify(state, null, 2)}</pre>
         </Box>
         <MarketingCollectionsRail state={state} />
+        <ArticlesRail state={state} />
       </Join>
     </>
   )

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/server.ts
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/server.ts
@@ -28,7 +28,20 @@ const getMarketingCollections = async (
   res.json(result)
 }
 
+const getNearArticles = async (req: ArtsyRequest, res: ArtsyResponse) => {
+  let { concepts } = req.query
+
+  if (!concepts) throw new Error("Provide a concepts query string parameter")
+
+  const result = await weaviateDB.getNearArticles({
+    concepts: concepts as string[],
+  })
+
+  res.json(result)
+}
+
 export const router = express.Router()
 
+router.get("/articles", getNearArticles)
 router.get("/budget/intent", getBudgetIntent)
 router.get("/marketing_collections", getMarketingCollections)

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/weaviate-db.ts
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/weaviate-db.ts
@@ -62,7 +62,7 @@ export class WeaviateDB {
       .withFields("internalID slug title imageUrl _additional { id distance }")
       .do()
 
-    const result = response.data.Get.DiscoveryMarketingCollections
+    const result = response.data.Get[this.marketingCollectionClass]
 
     return result as DiscoveryMarketingCollections[]
   }
@@ -98,7 +98,7 @@ export class WeaviateDB {
       )
       .do()
 
-    const result: ArticleType[] = response.data.Get[DEFAULT_ARTICLES_CLASS]
+    const result: ArticleType[] = response.data.Get[this.articlesClass]
 
     /**
      * Note: Because we return article sections, a single article can appear


### PR DESCRIPTION
This PR follows #14050 and uses it as a template to wire up the articles rail.

### Considerations

- As part of this work, I ingested just under `9,000` articles into a new `weaviate` collection called `DiscoveryArticles` using the `quantum` [scripts](https://github.com/artsy/quantum/tree/main/src/06-positron-rag). I also expanded the script to also return the `imageUrl` (PR forthcoming). 
- In the current implementation of the `DiscoveryArticles` collection, we include "news" articles. And in testing this PR I noticed they tend to be a lot of the top results. It seems like we will want to exclude news articles (an article from 2012 about that years gallery shows probably doesn't have a ton of discovery value). This  should be possible by updating the `articlesConnection` [MP query](https://github.com/artsy/quantum/blob/main/src/06-positron-rag/lib/extract/fetchArticles.ts#L15) in `quantum` with a `isEditorialFeed: true` [argument](https://github.com/artsy/metaphysics/blob/e366721dd750eec827d93575159c084190cc3070/src/schema/v2/articlesConnection.ts#L24-L28). But this can all be done via quantum and won't require any changes to this force PR. 

---
https://github.com/artsy/force/assets/38149304/524e38a1-c395-4c95-b8d6-45a9a4c7f513

