### PR TITLE
Fix: return if artist associated with saved alert cannot be found

### DIFF
--- a/src/Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp.tsx
@@ -252,6 +252,9 @@ export const SavedSearchAlertsApp: React.FC<SavedSearchAlertsAppProps> = ({
       <>
         <Join separator={<Separator borderColor="black5" />}>
           {alerts.map(node => {
+            if (node === null) {
+              return
+            }
             const isCurrentEdgeSelected =
               editAlertEntity?.id === node.internalID
             let variant: SavedSearchAlertListItemVariant | undefined


### PR DESCRIPTION
The type of this PR is: Fix

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->



### Description
We had a report that /alerts page was returning 500 for some users

After pairing with @anandaroop, this is happening when an artist associated with some Saved alerts gets deleted
Thinking of ways to be a little more defensive on the client side so instead users can access their alerts instead of returning a 500 page exception

### Current experience
An artist for one of my saved alerts was deleted
<img width="600" alt="Screenshot 2024-06-24 at 3 13 14 PM" src="https://github.com/artsy/force/assets/12748344/5c708373-70bb-4a98-a24d-15b603413a5e">

After some console logging, the `node` itself is coming back as `null` if artist cannot be found, so we have an array of search criteria with null as the last value
<img width="600" alt="Screenshot 2024-06-24 at 3 27 07 PM" src="https://github.com/artsy/force/assets/12748344/eac2fa27-c74c-4b3b-ba08-2e2d4fa6ce3c">




### Experience After
Early Return if the node is `null`, that way users can at least view the page
<img width="600" alt="Screenshot 2024-06-24 at 3 17 29 PM" src="https://github.com/artsy/force/assets/12748344/5585c939-f30e-4d5b-8907-efeaff19f977">


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ