### PR TITLE
feat(onyx-944): activity panel navigates directly to entity page whenonly one entity in notification row

### DIFF
--- a/src/Components/Notifications/NotificationItem.tsx
+++ b/src/Components/Notifications/NotificationItem.tsx
@@ -156,13 +156,13 @@ export const NotificationItemFragmentContainer = createFragmentContainer(
   }
 )
 
-interface NotificationItemLinkProps {
+interface NotificationItemWrapperProps {
   item: NotificationItem_item$data
   mode?: NotificationListMode
   children: React.ReactNode
 }
 
-const NotificationItemWrapper: FC<NotificationItemLinkProps> = ({
+const NotificationItemWrapper: FC<NotificationItemWrapperProps> = ({
   item,
   mode,
   children,

--- a/src/Components/Notifications/NotificationsList.tsx
+++ b/src/Components/Notifications/NotificationsList.tsx
@@ -97,6 +97,7 @@ export const NotificationsList: React.FC<NotificationsListProps> = ({
           <NotificationItemFragmentContainer
             key={node.internalID}
             item={node}
+            mode={mode}
           />
         ))}
       </Join>


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [ONYX-944]

### Description

When tapping on an Activity Panel notification containing one artwork (or show/etc), we want to redirect the user directly to the artwork page rather than the notifications app with the notification selected in the preview pane. The only exception I made is Partner offer notification, because it always has 1 object.

| mWeb | Desktop |
|---|---|
| <video src="https://github.com/artsy/force/assets/3934579/92854e7b-2994-434c-ad51-f75416149688" /> |  <video src="https://github.com/artsy/force/assets/3934579/a9ce17ad-bf03-4209-b8d7-7d8e99b17a11" /> |

[ONYX-944]: https://artsyproduct.atlassian.net/browse/ONYX-944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ