### PR TITLE
fix: Correctly link to Sell flow intro page

### DIFF
--- a/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/HeaderSWA.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/HeaderSWA.tsx
@@ -58,9 +58,7 @@ export const HeaderSWA = () => {
                 width="100%"
                 variant="primaryBlack"
                 to={
-                  enableNewSubmissionFlow
-                    ? "sell2/submissions/new"
-                    : "/sell/submission"
+                  enableNewSubmissionFlow ? "sell2/intro" : "/sell/submission"
                 }
                 onClick={event => {
                   if (!isLoggedIn) {


### PR DESCRIPTION

## Description

Correctly link to the Sell Flow **intro** page when clicking "Start Selling" on the `/sell` page.