### PR TITLE
fix: Use dvh for Sell flow layout to correctly set height on mobile

### DIFF
--- a/src/Apps/Sell/Components/SubmissionLayout.tsx
+++ b/src/Apps/Sell/Components/SubmissionLayout.tsx
@@ -18,7 +18,7 @@ export const SubmissionLayout: React.FC<SubmissionLayoutProps> = ({
   const context = useSellFlowContext()
 
   return (
-    <Flex height="100vh" flexDirection="column">
+    <Flex height="100dvh" flexDirection="column">
       <SubmissionHeader />
 
       <SubmissionProgressBar />


### PR DESCRIPTION
## Description

Use [`100dvh` instead of `100dv`](https://developer.mozilla.org/en-US/docs/Web/CSS/length) in the Sell flow layout to correctly set height on mobile .

| Before | After |
| --- | --- |
|![IMG_E02836EC05E3-1](https://github.com/artsy/force/assets/4691889/4f0498fe-f3b8-44d6-85ec-7e2f620fb5d9) |<img width="461" alt="Screenshot 2024-06-25 at 12 07 25" src="https://github.com/artsy/force/assets/4691889/f393f092-4c08-4da5-b088-8d77b8849a03"> |



