### PR TITLE
feat: add rudimentary 07 artworks rail

### DIFF
--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/Artwork.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/Artwork.tsx
@@ -1,0 +1,22 @@
+import { FC } from "react"
+import { Box, Flex, Image } from "@artsy/palette"
+import { DiscoveryArtwork } from "Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/ArtworksRail"
+
+interface ArtworkProps {
+  artwork: DiscoveryArtwork
+}
+
+export const Artwork: FC<ArtworkProps> = props => {
+  const { artwork } = props
+
+  return (
+    <Box>
+      <Image src={artwork.imageUrl} height={300} />
+      <Flex justifyContent="center">
+        <a href={`/artwork/${artwork.slug}`} target="_blank">
+          {artwork.title}
+        </a>
+      </Flex>
+    </Box>
+  )
+}

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/ArtworksRail.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/ArtworksRail.tsx
@@ -1,0 +1,70 @@
+import React, { FC, useEffect, useState } from "react"
+import { Box, SkeletonBox, Text } from "@artsy/palette"
+import { Rail } from "Components/Rail/Rail"
+import { State } from "Apps/ArtAdvisor/07-Curated-Discovery/App"
+import { Artwork } from "Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/Artwork"
+
+interface ArtworksRailProps {
+  state: State
+}
+
+export type DiscoveryArtwork = {
+  id: string
+  internalID: string
+  slug: string
+  title: string
+  date: string
+  rarity: string
+  medium: string
+  materials: string
+  price: string
+  dimensions: string
+  imageUrl: string
+}
+
+export const ArtworksRail: FC<ArtworksRailProps> = props => {
+  const { state } = props
+  const [artworks, setArtworks] = useState<DiscoveryArtwork[]>([])
+  const [isLoading, setIsLoading] = useState<boolean>(true)
+
+  useEffect(() => {
+    const params = new URLSearchParams()
+    state.interests.forEach(concept => {
+      params.append("concepts", concept)
+    })
+
+    const fetchArtworks = async () => {
+      const response = await fetch(
+        `/api/advisor/7/artworks?${params.toString()}`
+      )
+      const data = await response.json()
+      setArtworks(data)
+      setIsLoading(false)
+    }
+
+    fetchArtworks()
+  }, [state.interests, state.goal, state.budgetIntent])
+
+  if (isLoading) {
+    return <Text>Loading...</Text>
+  }
+
+  return (
+    <>
+      {artworks.length ? (
+        <Box opacity={isLoading ? 0.2 : 1}>
+          <Rail
+            title="Artworks"
+            getItems={() => {
+              return artworks.map((artwork: DiscoveryArtwork) => {
+                return <Artwork key={artwork.id} artwork={artwork} />
+              })
+            }}
+          />
+        </Box>
+      ) : (
+        <SkeletonBox height={460} />
+      )}
+    </>
+  )
+}

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/Result.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/Result.tsx
@@ -4,6 +4,7 @@ import { FC } from "react"
 import { MarketingCollectionsRail } from "Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/MarketingCollectionsRail"
 import { Links } from "Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/Links"
 import { ArticlesRail } from "Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/ArticlesRail"
+import { ArtworksRail } from "Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/ArtworksRail"
 
 interface ResultProps {
   state: State
@@ -20,6 +21,7 @@ export const Result: FC<ResultProps> = props => {
         <Box>
           <pre>{JSON.stringify(state, null, 2)}</pre>
         </Box>
+        <ArtworksRail state={state} />
         <MarketingCollectionsRail state={state} />
         <ArticlesRail state={state} />
       </Join>

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/server.ts
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/server.ts
@@ -12,6 +12,15 @@ const getBudgetIntent = async (req: ArtsyRequest, res: ArtsyResponse) => {
   res.json(intent)
 }
 
+const getArtworks = async (req: ArtsyRequest, res: ArtsyResponse) => {
+  const { concepts, limit } = req.query
+  const artworks = await weaviateDB.getNearArtworks({
+    concepts: concepts as string[],
+    limit: limit as number,
+  })
+  res.json(artworks)
+}
+
 const getMarketingCollections = async (
   req: ArtsyRequest,
   res: ArtsyResponse
@@ -44,4 +53,5 @@ export const router = express.Router()
 
 router.get("/articles", getNearArticles)
 router.get("/budget/intent", getBudgetIntent)
+router.get("/artworks", getArtworks)
 router.get("/marketing_collections", getMarketingCollections)


### PR DESCRIPTION
Brings over a simple Artworks rail from 06 into 07.

Deliberately pared down and simplified to match the existing Collections rails so that we can incrementally, in future PRs:
- add the price filtering (once we've re-ingested [with better data](https://artsy.slack.com/archives/C06SSV1K10D/p1719323396490219))
- add liking/disliking back in
- do a design pass over all the rails

For now, pretty straighforward:


https://github.com/artsy/force/assets/140521/5976765e-03e4-4af3-8d01-6ac173dbcebc

