### PR TITLE
feat: add artwork like and dislike functionality

### DIFF
--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/Artwork.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/Artwork.tsx
@@ -1,23 +1,96 @@
 import { FC } from "react"
-import { Box, Image, Link, Text } from "@artsy/palette"
+import { Box, Clickable, Flex, Image, useToasts, Text } from "@artsy/palette"
 import { DiscoveryArtwork } from "Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/ArtworksRail"
+import CheckmarkFillIcon from "@artsy/icons/CheckmarkFillIcon"
+import CloseFillIcon from "@artsy/icons/CloseFillIcon"
+import { useSystemContext } from "System/Hooks/useSystemContext"
+import _ from "lodash"
 
 interface ArtworkProps {
   artwork: DiscoveryArtwork
+  setExcludeArtworkIds: any
 }
 
 export const Artwork: FC<ArtworkProps> = props => {
-  const { artwork } = props
+  const { artwork, setExcludeArtworkIds } = props
+  const { sendToast } = useToasts()
+  const { user } = useSystemContext()
+
+  const handleClickLike = async () => {
+    try {
+      const like = await fetch("/api/advisor/7/artworks/likes", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          userId: user?.id,
+          artworkId: artwork.internalID,
+        }),
+      })
+
+      if (like.ok) {
+        setExcludeArtworkIds(prevState => [...prevState, artwork.internalID])
+      }
+
+      sendToast({
+        message: `Liked ${artwork.title}`,
+      })
+    } catch (error) {
+      console.error(error)
+      sendToast({
+        variant: "error",
+        message: `Something went wrong liking artwork: ${artwork.title}`,
+      })
+    }
+  }
+
+  const handleClickDislike = async () => {
+    try {
+      const dislike = await fetch("/api/advisor/7/artworks/dislikes", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          userId: user?.id,
+          artworkId: artwork.internalID,
+        }),
+      })
+
+      if (dislike.ok) {
+        setExcludeArtworkIds(prevState => [...prevState, artwork.internalID])
+      }
+
+      sendToast({
+        message: `Disliked ${artwork.title}`,
+      })
+    } catch (error) {
+      console.error(error)
+      sendToast({
+        variant: "error",
+        message: `Something went wrong disliking artwork: ${artwork.title}`,
+      })
+    }
+  }
 
   return (
-    <Link href={`/artwork/${artwork.slug}`} target="artwork">
-      <Box>
-        <Image src={artwork.imageUrl} height={300} />
-        <Box textAlign={"center"}>
-          <Text>{artwork.title}</Text>
-          <Text>{artwork.price}</Text>
-        </Box>
-      </Box>
-    </Link>
+    <Box>
+      <Image src={artwork.imageUrl} height={300} />
+      <Flex flexDirection="column" alignItems="center">
+        <a href={`/artwork/${artwork.slug}`} target="_blank">
+          {artwork.title}
+        </a>
+        <Text>{artwork.price}</Text>
+        <Flex py={1} gap={1} justifyContent={"center"}>
+          <Clickable onClick={handleClickLike}>
+            <CheckmarkFillIcon fill={"black60"} size={30} />
+          </Clickable>
+          <Clickable onClick={handleClickDislike}>
+            <CloseFillIcon fill={"black60"} size={30} />
+          </Clickable>
+        </Flex>
+      </Flex>
+    </Box>
   )
 }

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/Artwork.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/Artwork.tsx
@@ -77,19 +77,19 @@ export const Artwork: FC<ArtworkProps> = props => {
   return (
     <Box>
       <Image src={artwork.imageUrl} height={300} />
+      <Flex py={1} gap={1} justifyContent={"center"}>
+        <Clickable onClick={handleClickLike}>
+          <CheckmarkFillIcon fill={"black60"} size={30} />
+        </Clickable>
+        <Clickable onClick={handleClickDislike}>
+          <CloseFillIcon fill={"black60"} size={30} />
+        </Clickable>
+      </Flex>
       <Flex flexDirection="column" alignItems="center">
         <a href={`/artwork/${artwork.slug}`} target="_blank">
           {artwork.title}
         </a>
         <Text>{artwork.price}</Text>
-        <Flex py={1} gap={1} justifyContent={"center"}>
-          <Clickable onClick={handleClickLike}>
-            <CheckmarkFillIcon fill={"black60"} size={30} />
-          </Clickable>
-          <Clickable onClick={handleClickDislike}>
-            <CloseFillIcon fill={"black60"} size={30} />
-          </Clickable>
-        </Flex>
       </Flex>
     </Box>
   )

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/ArtworksRail.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/ArtworksRail.tsx
@@ -1,8 +1,9 @@
 import React, { FC, useEffect, useState } from "react"
-import { Box, SkeletonBox, Text } from "@artsy/palette"
+import { Box, SkeletonBox } from "@artsy/palette"
 import { Rail } from "Components/Rail/Rail"
 import { BudgetIntent, State } from "Apps/ArtAdvisor/07-Curated-Discovery/App"
 import { Artwork } from "Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/Artwork"
+import { useSystemContext } from "System/Hooks/useSystemContext"
 
 interface ArtworksRailProps {
   state: State
@@ -39,31 +40,52 @@ export const ArtworksRail: FC<ArtworksRailProps> = props => {
   const { state } = props
   const [artworks, setArtworks] = useState<DiscoveryArtwork[]>([])
   const [isLoading, setIsLoading] = useState<boolean>(true)
+  const [excludeArtworkIds, setExcludeArtworkIds] = useState<string[]>([])
+
+  const { user } = useSystemContext()
 
   useEffect(() => {
-    const params = new URLSearchParams()
-    state.interests.forEach(concept => {
-      params.append("concepts", concept)
-    })
+    const fetchArtworks = async (options: {
+      concepts: string[]
+      excludeArtworkIds: string[]
+    }) => {
+      setIsLoading(true)
 
-    const { priceMinUSD, priceMaxUSD } = getPriceRange(state.budgetIntent)
-    if (priceMinUSD) params.append("priceMinUSD", priceMinUSD.toString())
-    if (priceMaxUSD) params.append("priceMaxUSD", priceMaxUSD.toString())
+      const { concepts, excludeArtworkIds } = options
+      const { priceMinUSD, priceMaxUSD } = getPriceRange(state.budgetIntent)
 
-    const fetchArtworks = async () => {
+      const params = new URLSearchParams()
+
+      if (priceMinUSD) params.append("priceMinUSD", priceMinUSD.toString())
+      if (priceMaxUSD) params.append("priceMaxUSD", priceMaxUSD.toString())
+      concepts.forEach(concept => {
+        params.append("concepts", concept)
+      })
+      excludeArtworkIds.forEach(id => {
+        params.append("excludeArtworkIds", id)
+      })
+      params.append("userId", user?.id || "")
+      params.append("goal", state.goal)
+
       const response = await fetch(
         `/api/advisor/7/artworks?${params.toString()}`
       )
       const data = await response.json()
-      setArtworks(data)
       setIsLoading(false)
+      return data
     }
 
-    fetchArtworks()
-  }, [state.interests, state.goal, state.budgetIntent])
+    const options = {
+      concepts: state.interests,
+      userId: user?.id,
+      excludeArtworkIds,
+    }
+
+    fetchArtworks(options).then(setArtworks)
+  }, [state.interests, state.goal, state.budgetIntent, excludeArtworkIds, user])
 
   if (isLoading) {
-    return <Text>Loading...</Text>
+    return <SkeletonBox height="400px">Loading...</SkeletonBox>
   }
 
   return (
@@ -74,7 +96,13 @@ export const ArtworksRail: FC<ArtworksRailProps> = props => {
             title="Artworks"
             getItems={() => {
               return artworks.map((artwork: DiscoveryArtwork) => {
-                return <Artwork key={artwork.id} artwork={artwork} />
+                return (
+                  <Artwork
+                    key={artwork.id}
+                    artwork={artwork}
+                    setExcludeArtworkIds={setExcludeArtworkIds}
+                  />
+                )
               })
             }}
           />

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/ArtworksRail.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/ArtworksRail.tsx
@@ -1,9 +1,10 @@
 import React, { FC, useEffect, useState } from "react"
-import { Box, SkeletonBox } from "@artsy/palette"
+import { Box, Shelf, Skeleton } from "@artsy/palette"
 import { Rail } from "Components/Rail/Rail"
 import { BudgetIntent, State } from "Apps/ArtAdvisor/07-Curated-Discovery/App"
 import { Artwork } from "Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/Artwork"
 import { useSystemContext } from "System/Hooks/useSystemContext"
+import { ShelfArtworkPlaceholder } from "Components/Artwork/ShelfArtwork"
 
 interface ArtworksRailProps {
   state: State
@@ -84,13 +85,24 @@ export const ArtworksRail: FC<ArtworksRailProps> = props => {
     fetchArtworks(options).then(setArtworks)
   }, [state.interests, state.goal, state.budgetIntent, excludeArtworkIds, user])
 
-  if (isLoading) {
-    return <SkeletonBox height="400px">Loading...</SkeletonBox>
-  }
-
   return (
     <>
-      {artworks.length ? (
+      {isLoading && artworks.length ? (
+        <Skeleton>
+          <Shelf>
+            {[...new Array(8)].map((_, i) => {
+              return (
+                <ShelfArtworkPlaceholder
+                  key={i}
+                  index={i}
+                  hideSaleInfo={true}
+                  maxImageHeight={400}
+                />
+              )
+            })}
+          </Shelf>
+        </Skeleton>
+      ) : (
         <Box opacity={isLoading ? 0.2 : 1}>
           <Rail
             title="Artworks"
@@ -107,8 +119,6 @@ export const ArtworksRail: FC<ArtworksRailProps> = props => {
             }}
           />
         </Box>
-      ) : (
-        <SkeletonBox height={460} />
       )}
     </>
   )

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/server.ts
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/server.ts
@@ -68,12 +68,21 @@ const getBudgetIntent = async (req: ArtsyRequest, res: ArtsyResponse) => {
 }
 
 const getArtworks = async (req: ArtsyRequest, res: ArtsyResponse) => {
-  const { concepts, limit, priceMinUSD, priceMaxUSD } = req.query
+  const {
+    concepts,
+    excludeArtworkIds,
+    priceMinUSD,
+    priceMaxUSD,
+    userId,
+    limit,
+  } = req.query
 
   if (!concepts) throw new Error("Provide a concepts query string parameter")
 
   const artworks = await weaviateDB.getNearArtworks({
     concepts: concepts as string[],
+    excludeArtworkIds: excludeArtworkIds as string[],
+    userId: userId as string,
     limit: limit as number,
     priceMinUSD: parseFloat(priceMinUSD),
     priceMaxUSD: parseFloat(priceMaxUSD),

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/types.ts
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/types.ts
@@ -1,6 +1,15 @@
 export type MongoID = string
 export type UUID = string
 
+export type DiscoveryUser = {
+  id: UUID
+  internalID: MongoID
+  // properties
+  name: string
+  likedArtworkIds: MongoID[]
+  dislikedArtworkIds: MongoID[]
+}
+
 export type DiscoveryArtwork = {
   id: UUID
   internalID: MongoID

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/types.ts
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/types.ts
@@ -1,15 +1,6 @@
 export type MongoID = string
 export type UUID = string
 
-export type DiscoveryUser = {
-  id: UUID
-  internalID: MongoID
-  // properties
-  name: string
-  likedArtworkIds: MongoID[]
-  dislikedArtworkIds: MongoID[]
-}
-
 export type DiscoveryArtwork = {
   id: UUID
   internalID: MongoID

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/weaviate-db.ts
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/weaviate-db.ts
@@ -194,6 +194,8 @@ export class WeaviateDB {
 
     const user = await this.getUser({ internalID: userId })
 
+    if (!user) throw new Error("Weaviate user not found")
+
     let query = this.client.graphql
       .get()
       .withClassName(this.artworkClass)

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/weaviate-db.ts
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/weaviate-db.ts
@@ -162,12 +162,18 @@ export class WeaviateDB {
    */
   async getNearArtworks({
     concepts,
+    excludeArtworkIds,
+    userId,
     limit = 10,
     priceMinUSD,
     priceMaxUSD,
   }: {
     /** List of concepts for semantic search */
     concepts: string[]
+    /** List of Gravity Artwork IDs to exclude from the results */
+    excludeArtworkIds?: string[]
+    /** Gravity ID of the user */
+    userId: string
     /** Max number of artworks to return */
     limit?: number
     /** Minimum price (USD) by which to filter artworks */
@@ -177,6 +183,8 @@ export class WeaviateDB {
   }) {
     console.log("[WeaviateDB] getArtworksNearConcepts", {
       concepts,
+      excludeArtworkIds,
+      userId,
       limit,
       priceMinUSD,
       priceMaxUSD,
@@ -184,11 +192,15 @@ export class WeaviateDB {
 
     const conceptArray = ensureValidConcepts(concepts)
 
+    const user = await this.getUser({ internalID: userId })
+
     let query = this.client.graphql
       .get()
       .withClassName(this.artworkClass)
       .withNearText({
         concepts: conceptArray,
+        moveTo: getMoveObjects(user.likedArtworkIds),
+        moveAwayFrom: getMoveObjects(user.dislikedArtworkIds),
       })
       .withLimit(limit)
       .withFields(
@@ -235,7 +247,16 @@ export class WeaviateDB {
 
     const response = await query.do()
 
-    const result = response.data.Get.DiscoveryArtworks.map(artwork => {
+    let filteredResponse
+    if (excludeArtworkIds) {
+      filteredResponse = response.data.Get.DiscoveryArtworks.filter(artwork => {
+        return !excludeArtworkIds.includes(artwork.internalID)
+      })
+    } else {
+      filteredResponse = response.data.Get.DiscoveryArtworks
+    }
+
+    const result = filteredResponse.map(artwork => {
       const properties = _.pick(artwork, [
         "internalID",
         "slug",
@@ -357,4 +378,15 @@ function ensureValidConcepts(concepts: string[]) {
   }
 
   return conceptsArray
+}
+
+/**
+ * Format a list of Mongo IDs for moveTo/moveAwayFrom
+ *
+ * @param ids list of Mongo IDs
+ * @param force weight of the move
+ */
+function getMoveObjects(ids: MongoID[], force = 1) {
+  const objects = _.castArray(ids).map(id => ({ id: generateUuid5(id), force }))
+  return { objects, force }
 }


### PR DESCRIPTION
This PR updates the `07-curated-discovery` app with functionality to allow a user to like or dislike artworks so that we may refine what is shown to them in the `ArtworksRail`. It largely ports over the implementation from #13992, with some exceptions, which are noted in the comments.

Follow-ups:

- UI shifting on refetch
- Handling different artwork sizes


https://github.com/artsy/force/assets/38149304/a3eba88b-4107-4369-b7bc-5dd9c7581e5e


