### PR TITLE
chore(AMBER-769): Do not hide the sale message on the grid

### DIFF
--- a/src/Components/Artwork/Details.tsx
+++ b/src/Components/Artwork/Details.tsx
@@ -163,13 +163,6 @@ const SaleMessage: React.FC<DetailsProps> = ({
     return <>{highestBid_display || openingBid_display || ""}</>
   }
 
-  if (sale_message?.toLowerCase() === "contact for price") {
-    return <>Price on request</>
-  }
-
-  if (sale_message?.toLowerCase() === "inquire about availability") {
-    return <>{NBSP}</>
-  }
   // NBSP is used to prevent un-aligned carousels
   return <>{sale_message ?? NBSP}</>
 }

--- a/src/Components/Artwork/__tests__/Details.jest.tsx
+++ b/src/Components/Artwork/__tests__/Details.jest.tsx
@@ -129,10 +129,10 @@ describe("Details", () => {
       expect(html).toContain("$2,400")
     })
 
-    it("shows Contact for price if sale_message equals the same", async () => {
+    it("shows sale_message", async () => {
       const data: any = {
         ...artworkInAuction,
-        sale_message: "Contact For Price",
+        sale_message: "Price on request",
         sale: {
           ...artworkInAuction?.sale,
           is_auction: false,
@@ -142,21 +142,6 @@ describe("Details", () => {
       const wrapper = await getWrapper(data)
       const html = wrapper.html()
       expect(html).toContain("Price on request")
-    })
-
-    it("does not show sale message if sale_message is for inquire", async () => {
-      const data: any = {
-        ...artworkInAuction,
-        sale_message: "Inquire about availability",
-        sale: {
-          ...artworkInAuction?.sale,
-          is_auction: false,
-        },
-      }
-
-      const wrapper = await getWrapper(data)
-      const html = wrapper.html()
-      expect(html).not.toContain("Inquire about availability")
     })
 
     it("shows sale message if sale open and no bids", async () => {


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [AMBER-769]

### Description

We initially defined the sale message shouldn't be displayed in case of "Inquire about availability" (see https://github.com/artsy/force/pull/14002). This caused weirdness on the grid compared to other artworks. We're undoing this.

cc @artsy/amber-devs 

[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AMBER-769]: https://artsyproduct.atlassian.net/browse/AMBER-769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ