### PR TITLE
fix: Add HEIC support to Sell flow

### DIFF
--- a/src/Components/PhotoUpload/Components/PhotoDropzone.tsx
+++ b/src/Components/PhotoUpload/Components/PhotoDropzone.tsx
@@ -1,13 +1,13 @@
 import { Box, BoxProps, Button, Text } from "@artsy/palette"
-import { cloneDeep } from "lodash"
-import React, { useEffect, useRef, useState } from "react"
-import { FileRejection, useDropzone } from "react-dropzone"
-import { Media } from "Utils/Responsive"
 import {
   CustomErrorCode,
   MBSize,
   Photo,
 } from "Components/PhotoUpload/Utils/fileUtils"
+import { Media } from "Utils/Responsive"
+import { cloneDeep } from "lodash"
+import React, { useEffect, useRef, useState } from "react"
+import { FileRejection, useDropzone } from "react-dropzone"
 
 const validateTotalMaxSize = (
   currentFiles: Array<Photo>,
@@ -102,7 +102,7 @@ export const PhotoDropzone: React.FC<PhotoDropzoneProps> = ({
     onDropRejected: () => {
       buttonRef.current?.blur()
     },
-    accept: ["image/jpeg", "image/png"],
+    accept: ["image/jpeg", "image/png", "image/heic"],
     noClick: true,
     noKeyboard: true,
     multiple: true,
@@ -129,7 +129,7 @@ export const PhotoDropzone: React.FC<PhotoDropzoneProps> = ({
         </Media>
 
         <Text variant={["xs", "sm-display"]} color="black60" mt={1}>
-          Files supported: JPG, PNG <br />
+          Files Supported: JPG, PNG, HEIC <br />
           Total maximum size: {maxTotalSize} MB
         </Text>
 

--- a/src/Components/PhotoUpload/__tests__/PhotoDropzone.jest.tsx
+++ b/src/Components/PhotoUpload/__tests__/PhotoDropzone.jest.tsx
@@ -1,8 +1,8 @@
+import { PhotoDropzone } from "Components/PhotoUpload/Components/PhotoDropzone"
+import { MBSize } from "Components/PhotoUpload/Utils/fileUtils"
 import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
 import { mount } from "enzyme"
 import { Formik } from "formik"
-import { PhotoDropzone } from "Components/PhotoUpload/Components/PhotoDropzone"
-import { MBSize } from "Components/PhotoUpload/Utils/fileUtils"
 
 const validImage = {
   name: "foo.png",
@@ -101,7 +101,8 @@ describe("PhotoDropzone", () => {
         file: pdfFile,
         errors: [
           {
-            message: "File type must be one of image/jpeg, image/png",
+            message:
+              "File type must be one of image/jpeg, image/png, image/heic",
             code: "file-invalid-type",
           },
         ],
@@ -163,7 +164,8 @@ describe("PhotoDropzone", () => {
         file: tooBigPdf,
         errors: [
           {
-            message: "File type must be one of image/jpeg, image/png",
+            message:
+              "File type must be one of image/jpeg, image/png, image/heic",
             code: "file-invalid-type",
           },
         ],


### PR DESCRIPTION
https://www.notion.so/artsy/It-doesn-t-support-upload-of-heic-photos-I-understand-we-brought-this-in-elsewhere-c55ae750075f40869d9505ab6701792f?pvs=4

## Description

Add HEIC support to Sell flow.


<img width="769" alt="Screenshot 2024-07-01 at 10 06 03" src="https://github.com/artsy/force/assets/4691889/0ef4bc43-3b1a-434c-acf4-19c3be80de1e">

