### PR TITLE
fix: Add `objectFit: contain` to Sell flow photo preview.

### DIFF
--- a/src/Apps/Sell/Components/ImagePreviewItem.tsx
+++ b/src/Apps/Sell/Components/ImagePreviewItem.tsx
@@ -1,11 +1,11 @@
 import CloseFillIcon from "@artsy/icons/CloseFillIcon"
 import {
-  Image,
   Box,
-  Flex,
-  Spinner,
-  ProgressBar,
   Clickable,
+  Flex,
+  Image,
+  ProgressBar,
+  Spinner,
 } from "@artsy/palette"
 import { Z } from "Apps/Components/constants"
 import { useRemoveAssetFromConsignmentSubmission } from "Apps/Consign/Routes/SubmissionFlow/Mutations"
@@ -92,7 +92,14 @@ export const ImagePreviewItem: React.FC<ImagePreviewItemProps> = ({
       >
         {photoSrc && (
           <Box opacity={photo.loading ? 0.3 : 1}>
-            <Image src={photoSrc} width={IMAGE_SIZES} height={IMAGE_SIZES} />
+            <Image
+              src={photoSrc}
+              width={IMAGE_SIZES}
+              height={IMAGE_SIZES}
+              style={{
+                objectFit: "contain",
+              }}
+            />
           </Box>
         )}
 


### PR DESCRIPTION
https://www.notion.so/artsy/Images-skewed-when-uploaded-dada7142bf2343e498cd6d5dc6973550?pvs=4




## Description

Add `objectFit: contain` to Sell flow photo preview.



| Before | After |
| --- | --- |
|<img width="745" alt="Screenshot 2024-07-01 at 10 36 37" src="https://github.com/artsy/force/assets/4691889/8a8f4475-158c-4eae-a2b9-20b8900b0948"> | <img width="755" alt="Screenshot 2024-07-01 at 10 34 31" src="https://github.com/artsy/force/assets/4691889/e7095749-d97a-4cba-8353-9a9e077f9e78">|

