### PR TITLE
fix: link behavior in 07

### DIFF
--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/Article.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/Article.tsx
@@ -17,7 +17,12 @@ export const Article: FC<ArticleRailsProps> = ({ article }) => {
   )
 
   return (
-    <RouterLink to={article.href} textDecoration="none" overflow="hidden">
+    <RouterLink
+      to={article.href}
+      target="_blank"
+      textDecoration="none"
+      overflow="hidden"
+    >
       <Box>
         <Image src={resizedImage} height={IMAGE_HEIGHT} />
         <Text height={"4em"}>{article.title}</Text>

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/MarketingCollection.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Result/MarketingCollection.tsx
@@ -22,6 +22,7 @@ export const MarketingCollection: FC<MarketingCollectionProps> = props => {
   return (
     <RouterLink
       to={`/collection/${marketingCollection.slug}`}
+      target="_blank"
       textDecoration="none"
       overflow="hidden"
     >


### PR DESCRIPTION
The type of this PR is: **Fix**

Makes the article and collection cards behave the same as artwork cards — opens the link in a new window. This is non-standard, but acceptable for our prototype so that we mitigate the awkwardness of navigating away from the results page and losing the page's state.