### PR TITLE
feat: Add phone number validation to Sell flow

### DIFF
--- a/src/Apps/Sell/Routes/PhoneNumberRoute.tsx
+++ b/src/Apps/Sell/Routes/PhoneNumberRoute.tsx
@@ -3,14 +3,12 @@ import { DevDebug } from "Apps/Sell/Components/DevDebug"
 import { SubmissionLayout } from "Apps/Sell/Components/SubmissionLayout"
 import { SubmissionStepTitle } from "Apps/Sell/Components/SubmissionStepTitle"
 import { useSellFlowContext } from "Apps/Sell/SellFlowContext"
-import { validatePhoneNumber } from "Components/PhoneNumberInput"
+import { useValidatePhoneNumber } from "Components/PhoneNumberInput"
 import { COUNTRY_CODES, countries } from "Utils/countries"
 import { PhoneNumberRoute_me$key } from "__generated__/PhoneNumberRoute_me.graphql"
 import { PhoneNumberRoute_submission$key } from "__generated__/PhoneNumberRoute_submission.graphql"
-import { Formik } from "formik"
-import { throttle } from "lodash"
+import { Formik, useFormikContext } from "formik"
 import * as React from "react"
-import { useEffect } from "react"
 import { graphql, useFragment } from "react-relay"
 import * as Yup from "yup"
 
@@ -81,62 +79,54 @@ export const PhoneNumberRoute: React.FC<PhoneNumberRouteProps> = props => {
       validateOnMount
       validationSchema={Schema}
     >
-      {({ handleChange, setFieldValue, values }) => {
-        const [isPhoneNumberValid, setIsPhoneNumberValid] = React.useState(true)
+      <SubmissionLayout>
+        <SubmissionStepTitle>Add phone number</SubmissionStepTitle>
 
-        const validate = throttle(async () => {
-          const isValid = await validatePhoneNumber({
-            national: values.userPhone,
-            regionCode: values.phoneNumberRegionCode,
-          })
+        <PhoneNumberRouteForm />
 
-          setIsPhoneNumberValid(isValid)
-        }, 500)
-
-        useEffect(() => {
-          validate()
-        }, [values.userPhone, values.phoneNumberRegionCode])
-
-        return (
-          <SubmissionLayout>
-            <SubmissionStepTitle>Add phone number</SubmissionStepTitle>
-
-            <Join separator={<Spacer y={4} />}>
-              <Text variant={["xs", "sm"]} textColor={["black60", "black100"]}>
-                Add your number (optional) so an Artsy Advisor can contact you
-                directly by phone.
-              </Text>
-
-              <PhoneInput
-                options={countries}
-                onSelect={option => {
-                  setFieldValue("phoneNumberRegionCode", option.value)
-                }}
-                name="userPhone"
-                onChange={handleChange}
-                dropdownValue={values.phoneNumberRegionCode}
-                defaultValue={values.userPhone}
-                placeholder="(000) 000 0000"
-                data-testid="phone-input"
-                type="tel"
-                // error={
-                //   values.userPhone && !isPhoneNumberValid
-                //     ? "Invalid phone number"
-                //     : undefined
-                // }
-              />
-
-              {values.userPhone && !isPhoneNumberValid && (
-                <Message
-                  variant="warning"
-                  title="Please add a valid phone number."
-                />
-              )}
-            </Join>
-            <DevDebug />
-          </SubmissionLayout>
-        )
-      }}
+        <DevDebug />
+      </SubmissionLayout>
     </Formik>
+  )
+}
+
+const PhoneNumberRouteForm: React.FC = () => {
+  const { values, handleChange, setFieldValue } = useFormikContext<FormValues>()
+
+  const isPhoneNumberValid = useValidatePhoneNumber({
+    national: values.userPhone,
+    regionCode: values.phoneNumberRegionCode,
+  })
+
+  return (
+    <Join separator={<Spacer y={4} />}>
+      <Text variant={["xs", "sm"]} textColor={["black60", "black100"]}>
+        Add your number (optional) so an Artsy Advisor can contact you directly
+        by phone.
+      </Text>
+
+      <PhoneInput
+        options={countries}
+        onSelect={option => {
+          setFieldValue("phoneNumberRegionCode", option.value)
+        }}
+        name="userPhone"
+        onChange={handleChange}
+        dropdownValue={values.phoneNumberRegionCode}
+        defaultValue={values.userPhone}
+        placeholder="(000) 000 0000"
+        data-testid="phone-input"
+        type="tel"
+        // error={
+        //   values.userPhone && !isPhoneNumberValid
+        //     ? "Invalid phone number"
+        //     : undefined
+        // }
+      />
+
+      {values.userPhone && !isPhoneNumberValid && (
+        <Message variant="warning" title="Please add a valid phone number." />
+      )}
+    </Join>
   )
 }

--- a/src/Apps/Sell/Routes/PhoneNumberRoute.tsx
+++ b/src/Apps/Sell/Routes/PhoneNumberRoute.tsx
@@ -1,7 +1,8 @@
-import { Join, Message, PhoneInput, Spacer, Text } from "@artsy/palette"
+import { Join, PhoneInput, Spacer, Text } from "@artsy/palette"
 import { DevDebug } from "Apps/Sell/Components/DevDebug"
 import { SubmissionLayout } from "Apps/Sell/Components/SubmissionLayout"
 import { SubmissionStepTitle } from "Apps/Sell/Components/SubmissionStepTitle"
+import { useFocusInput } from "Apps/Sell/Hooks/useFocusInput"
 import { useSellFlowContext } from "Apps/Sell/SellFlowContext"
 import { useValidatePhoneNumber } from "Components/PhoneNumberInput"
 import { COUNTRY_CODES, countries } from "Utils/countries"
@@ -91,6 +92,7 @@ export const PhoneNumberRoute: React.FC<PhoneNumberRouteProps> = props => {
 }
 
 const PhoneNumberRouteForm: React.FC = () => {
+  const focusedInputRef = useFocusInput()
   const { values, handleChange, setFieldValue } = useFormikContext<FormValues>()
 
   const isPhoneNumberValid = useValidatePhoneNumber({
@@ -106,6 +108,7 @@ const PhoneNumberRouteForm: React.FC = () => {
       </Text>
 
       <PhoneInput
+        ref={focusedInputRef}
         options={countries}
         onSelect={option => {
           setFieldValue("phoneNumberRegionCode", option.value)
@@ -117,16 +120,12 @@ const PhoneNumberRouteForm: React.FC = () => {
         placeholder="(000) 000 0000"
         data-testid="phone-input"
         type="tel"
-        // error={
-        //   values.userPhone && !isPhoneNumberValid
-        //     ? "Invalid phone number"
-        //     : undefined
-        // }
+        error={
+          !!values.userPhone &&
+          !isPhoneNumberValid &&
+          "The phone number does not seem to be valid."
+        }
       />
-
-      {values.userPhone && !isPhoneNumberValid && (
-        <Message variant="warning" title="Please add a valid phone number." />
-      )}
     </Join>
   )
 }

--- a/src/Apps/Sell/SellFlowContext.tsx
+++ b/src/Apps/Sell/SellFlowContext.tsx
@@ -143,7 +143,7 @@ export const SellFlowContextProvider: React.FC<SellFlowContextProviderProps> = (
       logger.error("Error creating submission.", err)
       sendToast({
         variant: "error",
-        message: err?.[0]?.message || "Something went wrong.",
+        message: "Something went wrong." + ` ${err?.[0]?.message} || ""`,
       })
       throw err
     })
@@ -167,7 +167,7 @@ export const SellFlowContextProvider: React.FC<SellFlowContextProviderProps> = (
       logger.error("Error updating submission.", err)
       sendToast({
         variant: "error",
-        message: err?.[0]?.message || "Something went wrong.",
+        message: "Something went wrong." + ` ${err?.[0]?.message || ""}`,
       })
       throw err
     })

--- a/src/Components/PhoneNumberInput/validatePhoneNumber.ts
+++ b/src/Components/PhoneNumberInput/validatePhoneNumber.ts
@@ -1,7 +1,8 @@
-import { debounce } from "lodash"
-import { fetchQuery, graphql } from "react-relay"
 import { createRelaySSREnvironment } from "System/Relay/createRelaySSREnvironment"
 import { validatePhoneNumberQuery } from "__generated__/validatePhoneNumberQuery.graphql"
+import { debounce } from "lodash"
+import { useCallback, useEffect, useState } from "react"
+import { fetchQuery, graphql } from "react-relay"
 
 const relayEnvironment = createRelaySSREnvironment()
 
@@ -58,4 +59,23 @@ export const validatePhoneNumber = (
   return new Promise(resolve => {
     validator(phoneNumber, resolve)
   })
+}
+
+export const useValidatePhoneNumber = ({ national, regionCode }) => {
+  const [isPhoneNumberValid, setIsPhoneNumberValid] = useState(true)
+
+  const validate = useCallback(async () => {
+    const isValid = await validatePhoneNumber({
+      national,
+      regionCode,
+    })
+
+    setIsPhoneNumberValid(isValid)
+  }, [national, regionCode])
+
+  useEffect(() => {
+    validate()
+  }, [national, regionCode, validate])
+
+  return isPhoneNumberValid
 }


### PR DESCRIPTION
Resolves https://www.notion.so/artsy/Phone-number-can-take-letters-without-any-invalidation-message-e358107930ac4df680b78869210b86d3?pvs=4

## Description

This adds phone number validation to the Sell flow. The validation only results in a warning, and it will still be possible to submit with an invalid number.

<img width="994" alt="Screenshot 2024-07-03 at 11 53 24" src="https://github.com/artsy/force/assets/4691889/dd4f36a3-3ebc-49e8-9a05-97188acc41ba">
