### PR TITLE
chore(AMBER-769): Remove logic to display hardcoded message for "Bidding closed"

### DIFF
--- a/src/Components/Artwork/Details.tsx
+++ b/src/Components/Artwork/Details.tsx
@@ -152,11 +152,7 @@ const NBSP = " "
 const SaleMessage: React.FC<DetailsProps> = ({
   artwork: { sale, sale_message, sale_artwork },
 }) => {
-  if (sale?.is_auction && sale?.is_closed) {
-    return <>Bidding closed</>
-  }
-
-  if (sale?.is_auction) {
+  if (sale?.is_auction && !sale?.is_closed) {
     const highestBid_display = sale_artwork?.highest_bid?.display
     const openingBid_display = sale_artwork?.opening_bid?.display
 

--- a/src/Components/Artwork/__tests__/Details.jest.tsx
+++ b/src/Components/Artwork/__tests__/Details.jest.tsx
@@ -102,9 +102,10 @@ describe("Details", () => {
       expect(html).toContain("$2,600")
     })
 
-    it("shows 'bidding closed' message if in closed auction", async () => {
+    it("shows sale_message if in closed auction", async () => {
       const data: any = {
         ...artworkInAuction,
+        sale_message: "Bidding closed",
         sale: { ...artworkInAuction?.sale, is_closed: true },
       }
 


### PR DESCRIPTION
Relates to https://github.com/artsy/gravity/pull/17866

The type of this PR is: **TYPE**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [AMBER-769]

### Description

<!-- Implementation description -->
This is now coming straight from Gravity, so we don't need additional logic in the clients anymore
<img width="1111" alt="Screenshot 2024-07-02 at 09 41 46" src="https://github.com/artsy/force/assets/8002618/14097701-9404-4f67-b365-e49bab571fa1">



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AMBER-769]: https://artsyproduct.atlassian.net/browse/AMBER-769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

@artsy/amber-devs 