### PR TITLE
fix: Make artist on Sell flow "Title" step non-clickable

### DIFF
--- a/src/Apps/Sell/Routes/TitleRoute.tsx
+++ b/src/Apps/Sell/Routes/TitleRoute.tsx
@@ -61,6 +61,7 @@ export const TitleRoute: React.FC<TitleRouteProps> = props => {
               <EntityHeaderArtistFragmentContainer
                 artist={submission.artist}
                 displayFollowButton={false}
+                displayLink={false}
               />
             )}
 


### PR DESCRIPTION
Resolves https://www.notion.so/artsy/Odd-behavior-when-clicking-on-Artist-component-on-title-page-get-taken-directly-to-thank-you-page-b6a9bace58e24fcb9f616cfecabde6f5?pvs=4

## Description

This PR makes the artist on the Sell flow "Title" step non-clickable.

<img width="985" alt="Screenshot 2024-07-02 at 14 12 07" src="https://github.com/artsy/force/assets/4691889/389a6c55-15b4-4bbc-8199-f33616af0bfc">
