### PR TITLE
fix: Bring Back button back to Sell flow title step

### DIFF
--- a/src/Apps/Sell/Routes/__tests__/TitleRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/TitleRoute.jest.tsx
@@ -116,9 +116,9 @@ describe("TitleRoute", () => {
     })
   })
 
-  it("does not display the Back button", () => {
+  it("displays the Back button", () => {
     renderWithRelay({})
 
-    expect(screen.queryByText("Back")).not.toBeInTheDocument()
+    expect(screen.queryByText("Back")).toBeInTheDocument()
   })
 })

--- a/src/Apps/Sell/SellFlowContext.tsx
+++ b/src/Apps/Sell/SellFlowContext.tsx
@@ -185,8 +185,7 @@ export const SellFlowContextProvider: React.FC<SellFlowContextProviderProps> = (
   }
 
   const state = {
-    // Both the first and second steps are considered the first step because we don't want to allow going back to the artist step.
-    isFirstStep: index === 0 || index === 1,
+    isFirstStep: index === 0,
     isLastStep: index === STEPS.length - 1,
     isSubmitStep: index === STEPS.indexOf(SUBMIT_STEP),
     index,


### PR DESCRIPTION
The type of this PR is: **Fix**

Resolves https://www.notion.so/artsy/I-know-that-it-is-intentional-but-why-there-is-no-Back-button-on-Title-step-8d161a74f52a4b12aade2c12fd83b729?pvs=4

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

Bring Back button back to Sell flow title step.

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ