### PR TITLE
fix: allow scrolling from any part of the add photos page

### DIFF
--- a/src/Apps/Sell/Components/SubmissionLayout.tsx
+++ b/src/Apps/Sell/Components/SubmissionLayout.tsx
@@ -5,6 +5,7 @@ import { SubmissionHeader } from "Apps/Sell/Components/SubmissionHeader"
 import { SubmissionProgressBar } from "Apps/Sell/Components/SubmissionProgressBar"
 import { useSellFlowContext } from "Apps/Sell/SellFlowContext"
 import { FadeInBox } from "Components/FadeInBox"
+import { useWindowSize } from "Utils/Hooks/useWindowSize"
 import { useEffect } from "react"
 
 const CONTENT_WIDTH = 640
@@ -24,6 +25,11 @@ export const SubmissionLayout: React.FC<SubmissionLayoutProps> = ({
   useEffect(() => {
     context.actions?.setLoading(loading)
   }, [context.actions, loading])
+
+  const { width } = useWindowSize()
+
+  // 40 is the padding on either side of the content
+  const size = width < 768 ? "100vw" : width - 40
 
   return (
     <Flex height="100dvh" flexDirection="column">
@@ -45,9 +51,11 @@ export const SubmissionLayout: React.FC<SubmissionLayoutProps> = ({
             </Column>
           </GridColumns>
         ) : (
-          <FadeInBox maxWidth="100vw" width={CONTENT_WIDTH} p={2} pt={[2, 4]}>
-            {children}
-          </FadeInBox>
+          <Flex width={size} justifyContent="center">
+            <FadeInBox maxWidth="100vw" width={CONTENT_WIDTH} p={2} pt={[2, 4]}>
+              {children}
+            </FadeInBox>
+          </Flex>
         )}
       </Flex>
 

--- a/src/Apps/Sell/Components/SubmissionLayout.tsx
+++ b/src/Apps/Sell/Components/SubmissionLayout.tsx
@@ -5,7 +5,6 @@ import { SubmissionHeader } from "Apps/Sell/Components/SubmissionHeader"
 import { SubmissionProgressBar } from "Apps/Sell/Components/SubmissionProgressBar"
 import { useSellFlowContext } from "Apps/Sell/SellFlowContext"
 import { FadeInBox } from "Components/FadeInBox"
-import { useWindowSize } from "Utils/Hooks/useWindowSize"
 import { useEffect } from "react"
 
 const CONTENT_WIDTH = 640
@@ -25,11 +24,6 @@ export const SubmissionLayout: React.FC<SubmissionLayoutProps> = ({
   useEffect(() => {
     context.actions?.setLoading(loading)
   }, [context.actions, loading])
-
-  const { width } = useWindowSize()
-
-  // 40 is the padding on either side of the content
-  const size = width < 768 ? "100vw" : width - 40
 
   return (
     <Flex height="100dvh" flexDirection="column">
@@ -51,7 +45,7 @@ export const SubmissionLayout: React.FC<SubmissionLayoutProps> = ({
             </Column>
           </GridColumns>
         ) : (
-          <Flex width={size} justifyContent="center">
+          <Flex width="100vw" justifyContent="center">
             <FadeInBox maxWidth="100vw" width={CONTENT_WIDTH} p={2} pt={[2, 4]}>
               {children}
             </FadeInBox>


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PROJECT-XX]

### Description

<!-- Implementation description -->
Allow scrolling from any part of the add photos page


https://github.com/artsy/force/assets/36167539/e5bf3338-9c57-4531-a491-ce4c857631ec


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ