### PR TITLE
feat: defer SWA login/signup prompt in SWAFooter/SWAStickyFooter

### DIFF
--- a/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/SWAFooter.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/SWAFooter.tsx
@@ -1,16 +1,11 @@
-import { ContextModule, Intent } from "@artsy/cohesion"
 import { Box, Button, Text } from "@artsy/palette"
 import { useMarketingLandingTracking } from "Apps/Consign/Routes/MarketingLanding/Utils/marketingLandingTracking"
-import { useAuthDialog } from "Components/AuthDialog"
 import { RouterLink } from "System/Components/RouterLink"
 import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
-import { useSystemContext } from "System/Hooks/useSystemContext"
 
 export const SWAFooter: React.FC = () => {
   const enableNewSubmissionFlow = useFeatureFlag("onyx_new_submission_flow")
   const { trackStartSellingClick } = useMarketingLandingTracking()
-  const { isLoggedIn } = useSystemContext()
-  const { showAuthDialog } = useAuthDialog()
 
   return (
     <>
@@ -27,25 +22,7 @@ export const SWAFooter: React.FC = () => {
           width={["100%", 300]}
           variant="primaryBlack"
           to={enableNewSubmissionFlow ? "sell2/intro" : "/sell/submission"}
-          onClick={event => {
-            if (!isLoggedIn) {
-              event.preventDefault()
-
-              showAuthDialog({
-                mode: "Login",
-                options: {
-                  title: () => {
-                    return "Log in to submit an artwork for sale"
-                  },
-                },
-                analytics: {
-                  contextModule: ContextModule.sellFooter,
-                  intent: Intent.login,
-                },
-              })
-
-              return
-            }
+          onClick={() => {
             trackStartSellingClick("Footer")
           }}
           data-testid="start-selling-button"

--- a/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/SWAStickyFooter.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/SWAStickyFooter.tsx
@@ -1,11 +1,9 @@
-import { ContextModule, Intent } from "@artsy/cohesion"
+import { ContextModule } from "@artsy/cohesion"
 import { Box, Button, Text, useTheme } from "@artsy/palette"
 import { Z } from "Apps/Components/constants"
 import { useMarketingLandingTracking } from "Apps/Consign/Routes/MarketingLanding/Utils/marketingLandingTracking"
-import { useAuthDialog } from "Components/AuthDialog"
 import { RouterLink } from "System/Components/RouterLink"
 import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
-import { useSystemContext } from "System/Hooks/useSystemContext"
 
 export const SWAStickyFooter = () => {
   const enableNewSubmissionFlow = useFeatureFlag("onyx_new_submission_flow")
@@ -14,8 +12,6 @@ export const SWAStickyFooter = () => {
     trackGetInTouchClick,
   } = useMarketingLandingTracking()
   const { theme } = useTheme()
-  const { isLoggedIn } = useSystemContext()
-  const { showAuthDialog } = useAuthDialog()
 
   const getInTouchRoute = "/sell/inquiry"
 
@@ -42,24 +38,6 @@ export const SWAStickyFooter = () => {
         variant="primaryBlack"
         to={enableNewSubmissionFlow ? "sell2/intro" : "/sell/submission"}
         onClick={event => {
-          if (!isLoggedIn) {
-            event.preventDefault()
-
-            showAuthDialog({
-              mode: "Login",
-              options: {
-                title: () => {
-                  return "Log in to submit an artwork for sale"
-                },
-              },
-              analytics: {
-                contextModule: ContextModule.sellStickyFooter,
-                intent: Intent.login,
-              },
-            })
-
-            return
-          }
           trackStartSellingClick(ContextModule.sellStickyFooter)
         }}
         mb={[1, 0]}

--- a/src/Apps/Consign/Routes/MarketingLanding/Components/__tests__/SWAFooter.jest.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/__tests__/SWAFooter.jest.tsx
@@ -1,19 +1,11 @@
 import { fireEvent, render, screen } from "@testing-library/react"
 import { useTracking } from "react-tracking"
-import { useSystemContext } from "System/Hooks/useSystemContext"
 import { SWAFooter } from "Apps/Consign/Routes/MarketingLanding/Components/LandingPage/SWAFooter"
 
 jest.mock("react-tracking")
-jest.mock("System/Hooks/useSystemContext")
 jest.mock("System/Hooks/useAnalyticsContext", () => ({
   useAnalyticsContext: jest.fn(() => ({
     contextPageOwnerType: "sell",
-  })),
-}))
-const mockShowAuthDialog = jest.fn()
-jest.mock("Components/AuthDialog", () => ({
-  useAuthDialog: jest.fn(() => ({
-    showAuthDialog: mockShowAuthDialog,
   })),
 }))
 const trackEvent = useTracking as jest.Mock
@@ -25,10 +17,6 @@ describe("SWAFooter", () => {
         trackEvent,
       }
     })
-    ;(useSystemContext as jest.Mock).mockImplementation(() => ({
-      user: { id: "user-id", email: "user-email@artsy.net" },
-      isLoggedIn: true,
-    }))
   })
 
   it("renders correctly", () => {
@@ -65,7 +53,6 @@ describe("SWAFooter", () => {
         context_page_owner_type: "sell",
         label: "Start Selling",
         destination_path: "/sell/submission",
-        user_id: "user-id",
       })
     })
   })


### PR DESCRIPTION


The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

Follow-up to [artsy/force#14049][].

[artsy/force#14049]: https://github.com/artsy/force/pull/14049

The login/signup prompt within the SWA flow is no deferred to right before a user is able to submit a draft. This earlier prompt is no longer necessary.


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ