### PR TITLE
fix: Sell flow submit button

### DIFF
--- a/src/Apps/Sell/Components/BottomFormNavigation.tsx
+++ b/src/Apps/Sell/Components/BottomFormNavigation.tsx
@@ -45,7 +45,7 @@ const BottomFormBackButton = () => {
     try {
       await submitForm()
 
-      actions.goToPreviousStep()
+      await actions.goToPreviousStep()
     } catch (error) {
       logger.error("Error submitting form", error)
     } finally {
@@ -110,7 +110,7 @@ const BottomFormNextButton = () => {
     try {
       await submitForm()
 
-      actions.goToNextStep()
+      await actions.goToNextStep()
     } catch (error) {
       logger.error("Error submitting form", error)
     } finally {

--- a/src/Apps/Sell/SellFlowContext.tsx
+++ b/src/Apps/Sell/SellFlowContext.tsx
@@ -106,7 +106,7 @@ export const SellFlowContextProvider: React.FC<SellFlowContextProviderProps> = (
   })
 
   const goToNextStep = async () => {
-    state.isSubmitStep ? finishFlow() : handleNext()
+    state.isSubmitStep ? await finishFlow() : await handleNext()
   }
 
   const goToPreviousStep = () => {


### PR DESCRIPTION
Resolves https://www.notion.so/artsy/Had-to-press-several-times-on-Submit-CTA-on-the-phone-input-screen-before-it-navigated-to-the-Than-b28e105c16534075a33ffaaef68181a3?pvs=4

## Description

This correctly disables the "Submit" button in the Sell flow until the submission is updated. Before, it was possible to click the button multiple times.