### PR TITLE
fix: Add space above Sell flow purchase history select

### DIFF
--- a/src/Apps/Sell/Routes/PurchaseHistoryRoute.tsx
+++ b/src/Apps/Sell/Routes/PurchaseHistoryRoute.tsx
@@ -74,6 +74,7 @@ export const PurchaseHistoryRoute: React.FC<PurchaseHistoryRouteProps> = props =
               selected={values.provenance}
               onChange={handleChange}
               data-testid="provenance-input"
+              pt={1}
             />
 
             <Join separator={<Spacer y={2} />}>
@@ -106,6 +107,7 @@ export const PurchaseHistoryRoute: React.FC<PurchaseHistoryRouteProps> = props =
               </GridColumns>
             </Join>
           </Join>
+
           <DevDebug />
         </SubmissionLayout>
       )}


### PR DESCRIPTION
Resolves https://www.notion.so/artsy/Purchase-History-the-space-between-the-title-and-the-text-input-is-too-small-68b989c14dc242f9b2e6fc206301c1b3?pvs=4

## Description

Add space above Sell flow purchase history select. The other steps don't need extra space, it's just that the Select component is missing the top padding.

| Before | After |
| --- | --- |
|<img width="810" alt="Screenshot 2024-07-03 at 12 10 18" src="https://github.com/artsy/force/assets/4691889/d084a4c8-0bd9-4b80-b0d2-345704899572"> | <img width="687" alt="Screenshot 2024-07-03 at 12 08 59" src="https://github.com/artsy/force/assets/4691889/3d57f964-343c-47dc-937d-bda1ef024cf1">|



