### PR TITLE
fix: adjust add photos page

### DIFF
--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormImages.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormImages.tsx
@@ -177,7 +177,7 @@ export const MyCollectionArtworkFormImages: React.FC<MyCollectionArtworkFormImag
 
   return (
     <>
-      <Text variant="xs" mb={0.5}>
+      <Text variant="xs" mb={[2, 0.5]}>
         Upload Photos
       </Text>
       <PhotoDropzone

--- a/src/Apps/Sell/Components/UploadMoreMessage.tsx
+++ b/src/Apps/Sell/Components/UploadMoreMessage.tsx
@@ -1,4 +1,4 @@
-import { Message } from "@artsy/palette"
+import { Message, Text } from "@artsy/palette"
 import { PhotosFormValues } from "Apps/Sell/Routes/PhotosRoute"
 import { useFormikContext } from "formik"
 
@@ -13,8 +13,10 @@ export const UploadMoreMessage: React.FC = () => {
 
   return (
     <Message variant="success" title="Increase your chance of selling" mt={2}>
-      Make sure to include images of the back, corners, frame and any other
-      details if you can.
+      <Text variant="sm-display">
+        Make sure to include images of the back, corners, frame and any other
+        details if you can.
+      </Text>
     </Message>
   )
 }

--- a/src/Apps/Sell/Components/UploadPhotosForm.tsx
+++ b/src/Apps/Sell/Components/UploadPhotosForm.tsx
@@ -131,7 +131,6 @@ export const UploadPhotosForm: React.FC = () => {
       border="1px dashed"
       borderColor="black30"
       padding={4}
-      hideBoxOnMobile
     />
   )
 }

--- a/src/Apps/Sell/Components/UploadPhotosForm.tsx
+++ b/src/Apps/Sell/Components/UploadPhotosForm.tsx
@@ -8,7 +8,9 @@ import {
   normalizePhoto,
   uploadSubmissionPhoto,
 } from "Components/PhotoUpload/Utils/fileUtils"
+import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
 import { useSystemContext } from "System/Hooks/useSystemContext"
+import { Media } from "Utils/Responsive"
 import { getENV } from "Utils/getENV"
 import createLogger from "Utils/logger"
 import { useFormikContext } from "formik"
@@ -18,6 +20,7 @@ import { FileRejection } from "react-dropzone"
 const logger = createLogger("Sell/UploadPhotosForm.tsx")
 
 export const UploadPhotosForm: React.FC = () => {
+  const enableNewSubmissionFlow = useFeatureFlag("onyx_new_submission_flow")
   const { isLoggedIn, relayEnvironment } = useSystemContext()
   const { submitMutation: addAsset } = useAddAssetToConsignmentSubmission()
   const { setFieldValue, values } = useFormikContext<PhotosFormValues>()
@@ -123,14 +126,40 @@ export const UploadPhotosForm: React.FC = () => {
   }
 
   return (
-    <PhotoDropzone
-      allPhotos={values.photos}
-      maxTotalSize={30}
-      onDrop={onDrop}
-      onReject={onReject}
-      border="1px dashed"
-      borderColor="black30"
-      padding={4}
-    />
+    <>
+      {enableNewSubmissionFlow ? (
+        <>
+          <Media greaterThan="xs">
+            <PhotoDropzone
+              allPhotos={values.photos}
+              maxTotalSize={30}
+              onDrop={onDrop}
+              onReject={onReject}
+              border="1px dashed"
+              borderColor="black30"
+              padding={4}
+            />
+          </Media>
+          <Media at="xs">
+            <PhotoDropzone
+              allPhotos={values.photos}
+              maxTotalSize={30}
+              onDrop={onDrop}
+              onReject={onReject}
+            />
+          </Media>
+        </>
+      ) : (
+        <PhotoDropzone
+          allPhotos={values.photos}
+          maxTotalSize={30}
+          onDrop={onDrop}
+          onReject={onReject}
+          border="1px dashed"
+          borderColor="black30"
+          padding={4}
+        />
+      )}
+    </>
   )
 }

--- a/src/Apps/Sell/Components/UploadPhotosForm.tsx
+++ b/src/Apps/Sell/Components/UploadPhotosForm.tsx
@@ -8,9 +8,7 @@ import {
   normalizePhoto,
   uploadSubmissionPhoto,
 } from "Components/PhotoUpload/Utils/fileUtils"
-import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
 import { useSystemContext } from "System/Hooks/useSystemContext"
-import { Media } from "Utils/Responsive"
 import { getENV } from "Utils/getENV"
 import createLogger from "Utils/logger"
 import { useFormikContext } from "formik"
@@ -20,7 +18,6 @@ import { FileRejection } from "react-dropzone"
 const logger = createLogger("Sell/UploadPhotosForm.tsx")
 
 export const UploadPhotosForm: React.FC = () => {
-  const enableNewSubmissionFlow = useFeatureFlag("onyx_new_submission_flow")
   const { isLoggedIn, relayEnvironment } = useSystemContext()
   const { submitMutation: addAsset } = useAddAssetToConsignmentSubmission()
   const { setFieldValue, values } = useFormikContext<PhotosFormValues>()
@@ -126,40 +123,15 @@ export const UploadPhotosForm: React.FC = () => {
   }
 
   return (
-    <>
-      {enableNewSubmissionFlow ? (
-        <>
-          <Media greaterThan="xs">
-            <PhotoDropzone
-              allPhotos={values.photos}
-              maxTotalSize={30}
-              onDrop={onDrop}
-              onReject={onReject}
-              border="1px dashed"
-              borderColor="black30"
-              padding={4}
-            />
-          </Media>
-          <Media at="xs">
-            <PhotoDropzone
-              allPhotos={values.photos}
-              maxTotalSize={30}
-              onDrop={onDrop}
-              onReject={onReject}
-            />
-          </Media>
-        </>
-      ) : (
-        <PhotoDropzone
-          allPhotos={values.photos}
-          maxTotalSize={30}
-          onDrop={onDrop}
-          onReject={onReject}
-          border="1px dashed"
-          borderColor="black30"
-          padding={4}
-        />
-      )}
-    </>
+    <PhotoDropzone
+      allPhotos={values.photos}
+      maxTotalSize={30}
+      onDrop={onDrop}
+      onReject={onReject}
+      border="1px dashed"
+      borderColor="black30"
+      padding={4}
+      hideBoxOnMobile
+    />
   )
 }

--- a/src/Components/PhotoUpload/Components/PhotoDropzone.tsx
+++ b/src/Components/PhotoUpload/Components/PhotoDropzone.tsx
@@ -150,7 +150,6 @@ export const PhotoDropzone: React.FC<PhotoDropzoneProps> = ({
               ref={buttonRef}
               width={["100%", "auto"]}
               type="button"
-              mt={1}
               variant="secondaryBlack"
               onClick={open}
             >

--- a/src/Components/PhotoUpload/Components/PhotoDropzone.tsx
+++ b/src/Components/PhotoUpload/Components/PhotoDropzone.tsx
@@ -70,6 +70,7 @@ export interface PhotoDropzoneProps extends BoxProps {
   maxTotalSize: number
   onDrop: (files: File[]) => void
   onReject: (rejections: FileRejection[]) => void
+  hideBoxOnMobile?: boolean
 }
 
 export const PhotoDropzone: React.FC<PhotoDropzoneProps> = ({
@@ -77,6 +78,7 @@ export const PhotoDropzone: React.FC<PhotoDropzoneProps> = ({
   maxTotalSize,
   onDrop,
   onReject,
+  hideBoxOnMobile,
   ...rest
 }) => {
   const [customErrors, setCustomErrors] = useState<Array<FileRejection>>([])
@@ -118,10 +120,10 @@ export const PhotoDropzone: React.FC<PhotoDropzoneProps> = ({
 
   return (
     <>
-      <Box {...rest} data-test-id="image-dropzone" {...getRootProps()}>
-        <input data-testid="image-dropzone-input" {...getInputProps()} />
+      <Media greaterThan="xs">
+        <Box {...rest} data-test-id="image-dropzone" {...getRootProps()}>
+          <input data-testid="image-dropzone-input" {...getInputProps()} />
 
-        <Media greaterThan="xs">
           <Text variant="lg-display">Drag and drop photos here</Text>
           <Text variant={["xs", "sm-display"]} color="black60" mt={1}>
             Files Supported: JPG, PNG, HEIC <br />
@@ -137,25 +139,49 @@ export const PhotoDropzone: React.FC<PhotoDropzoneProps> = ({
           >
             Or Add Photos
           </Button>
-        </Media>
-        <Media at="xs">
-          <Text variant="lg-display">Add photos here</Text>
-          <Text variant={["xs", "sm-display"]} color="black60" mt={1}>
-            Files Supported: JPG, PNG, HEIC <br />
-            Total maximum size: {maxTotalSize} MB
-          </Text>
-          <Button
-            ref={buttonRef}
-            width={["100%", "auto"]}
-            type="button"
-            mt={[2, 2]}
-            variant="secondaryBlack"
-            onClick={open}
-          >
-            Add Photos
-          </Button>
-        </Media>
-      </Box>
+        </Box>
+      </Media>
+
+      <Media at="xs">
+        {!!hideBoxOnMobile ? (
+          <Box data-test-id="image-dropzone" {...getRootProps()}>
+            <input data-testid="image-dropzone-input" {...getInputProps()} />
+            <Button
+              ref={buttonRef}
+              width={["100%", "auto"]}
+              type="button"
+              mt={1}
+              variant="secondaryBlack"
+              onClick={open}
+            >
+              Add Photos
+            </Button>
+            <Text variant={["xs", "sm-display"]} color="black60" mt={1}>
+              Files Supported: JPG, PNG, HEIC <br />
+              Total maximum size: {maxTotalSize} MB
+            </Text>
+          </Box>
+        ) : (
+          <Box {...rest} data-test-id="image-dropzone" {...getRootProps()}>
+            <input data-testid="image-dropzone-input" {...getInputProps()} />
+            <Text variant="lg-display">Add photos here</Text>
+            <Text variant={["xs", "sm-display"]} color="black60" mt={1}>
+              Files Supported: JPG, PNG, HEIC <br />
+              Total maximum size: {maxTotalSize} MB
+            </Text>
+            <Button
+              ref={buttonRef}
+              width={["100%", "auto"]}
+              type="button"
+              mt={[2, 2]}
+              variant="secondaryBlack"
+              onClick={open}
+            >
+              Add Photos
+            </Button>
+          </Box>
+        )}
+      </Media>
     </>
   )
 }

--- a/src/Components/PhotoUpload/Components/PhotoDropzone.tsx
+++ b/src/Components/PhotoUpload/Components/PhotoDropzone.tsx
@@ -123,26 +123,38 @@ export const PhotoDropzone: React.FC<PhotoDropzoneProps> = ({
 
         <Media greaterThan="xs">
           <Text variant="lg-display">Drag and drop photos here</Text>
+          <Text variant={["xs", "sm-display"]} color="black60" mt={1}>
+            Files Supported: JPG, PNG, HEIC <br />
+            Total maximum size: {maxTotalSize} MB
+          </Text>
+          <Button
+            ref={buttonRef}
+            width={["100%", "auto"]}
+            type="button"
+            mt={[2, 2]}
+            variant="secondaryBlack"
+            onClick={open}
+          >
+            Or Add Photos
+          </Button>
         </Media>
         <Media at="xs">
           <Text variant="lg-display">Add photos here</Text>
+          <Text variant={["xs", "sm-display"]} color="black60" mt={1}>
+            Files Supported: JPG, PNG, HEIC <br />
+            Total maximum size: {maxTotalSize} MB
+          </Text>
+          <Button
+            ref={buttonRef}
+            width={["100%", "auto"]}
+            type="button"
+            mt={[2, 2]}
+            variant="secondaryBlack"
+            onClick={open}
+          >
+            Add Photos
+          </Button>
         </Media>
-
-        <Text variant={["xs", "sm-display"]} color="black60" mt={1}>
-          Files Supported: JPG, PNG, HEIC <br />
-          Total maximum size: {maxTotalSize} MB
-        </Text>
-
-        <Button
-          ref={buttonRef}
-          width={["100%", "auto"]}
-          type="button"
-          mt={[2, 2]}
-          variant="secondaryBlack"
-          onClick={open}
-        >
-          Or Add Photos
-        </Button>
       </Box>
     </>
   )

--- a/src/Components/PhotoUpload/Components/PhotoDropzone.tsx
+++ b/src/Components/PhotoUpload/Components/PhotoDropzone.tsx
@@ -70,7 +70,6 @@ export interface PhotoDropzoneProps extends BoxProps {
   maxTotalSize: number
   onDrop: (files: File[]) => void
   onReject: (rejections: FileRejection[]) => void
-  hideBoxOnMobile?: boolean
 }
 
 export const PhotoDropzone: React.FC<PhotoDropzoneProps> = ({
@@ -78,7 +77,6 @@ export const PhotoDropzone: React.FC<PhotoDropzoneProps> = ({
   maxTotalSize,
   onDrop,
   onReject,
-  hideBoxOnMobile,
   ...rest
 }) => {
   const [customErrors, setCustomErrors] = useState<Array<FileRejection>>([])
@@ -143,43 +141,21 @@ export const PhotoDropzone: React.FC<PhotoDropzoneProps> = ({
       </Media>
 
       <Media at="xs">
-        {!!hideBoxOnMobile ? (
-          <Box data-test-id="image-dropzone" {...getRootProps()}>
-            <input data-testid="image-dropzone-input" {...getInputProps()} />
-            <Button
-              ref={buttonRef}
-              width={["100%", "auto"]}
-              type="button"
-              variant="secondaryBlack"
-              onClick={open}
-            >
-              Add Photos
-            </Button>
-            <Text variant={["xs", "sm-display"]} color="black60" mt={1}>
-              Files Supported: JPG, PNG, HEIC <br />
-              Total maximum size: {maxTotalSize} MB
-            </Text>
-          </Box>
-        ) : (
-          <Box {...rest} data-test-id="image-dropzone" {...getRootProps()}>
-            <input data-testid="image-dropzone-input" {...getInputProps()} />
-            <Text variant="lg-display">Add photos here</Text>
-            <Text variant={["xs", "sm-display"]} color="black60" mt={1}>
-              Files Supported: JPG, PNG, HEIC <br />
-              Total maximum size: {maxTotalSize} MB
-            </Text>
-            <Button
-              ref={buttonRef}
-              width={["100%", "auto"]}
-              type="button"
-              mt={[2, 2]}
-              variant="secondaryBlack"
-              onClick={open}
-            >
-              Add Photos
-            </Button>
-          </Box>
-        )}
+        <input data-testid="image-dropzone-input" {...getInputProps()} />
+
+        <Button
+          ref={buttonRef}
+          width={["100%", "auto"]}
+          type="button"
+          variant="secondaryBlack"
+          onClick={open}
+        >
+          Add Photos
+        </Button>
+        <Text variant={["xs", "sm-display"]} color="black60" mt={1}>
+          Files Supported: JPG, PNG, HEIC <br />
+          Total maximum size: {maxTotalSize} MB
+        </Text>
       </Media>
     </>
   )

--- a/src/Components/PhotoUpload/__tests__/PhotoDropzone.jest.tsx
+++ b/src/Components/PhotoUpload/__tests__/PhotoDropzone.jest.tsx
@@ -1,6 +1,7 @@
 import { PhotoDropzone } from "Components/PhotoUpload/Components/PhotoDropzone"
 import { MBSize } from "Components/PhotoUpload/Utils/fileUtils"
 import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
+import { MediaContextProvider } from "Utils/Responsive"
 import { mount } from "enzyme"
 import { Formik } from "formik"
 
@@ -35,174 +36,335 @@ const tooBigPdf = {
 const onDropMock = jest.fn()
 const onRejectMock = jest.fn()
 
-const getWrapper = () => {
-  return mount(
-    <Formik initialValues={{ photos: [] }} onSubmit={jest.fn()}>
-      <PhotoDropzone
-        allPhotos={[]}
-        maxTotalSize={10}
-        onDrop={onDropMock}
-        onReject={onRejectMock}
-      />
-    </Formik>
-  )
-}
-
 describe("PhotoDropzone", () => {
-  beforeEach(() => {
-    onDropMock.mockClear()
-    onRejectMock.mockClear()
-  })
+  let breakpoint: "xs" | "md"
 
-  it("success uploading", async () => {
-    const wrapper = getWrapper()
-
-    const dropzoneInput = wrapper
-      .find("[data-test-id='image-dropzone']")
-      .find("input")
-
-    dropzoneInput.simulate("change", {
-      target: {
-        files: [validImage, validImage, validImage],
-      },
-    })
-
-    await flushPromiseQueue()
-    wrapper.update()
-
-    expect(onDropMock).toHaveBeenCalled()
-    expect(onDropMock).toHaveBeenCalledWith([
-      validImage,
-      validImage,
-      validImage,
-    ])
-  })
-
-  it("rejects not image files", async () => {
-    const wrapper = getWrapper()
-
-    const dropzoneInput = wrapper
-      .find("[data-test-id='image-dropzone']")
-      .find("input")
-
-    dropzoneInput.simulate("change", {
-      target: {
-        files: [pdfFile, pdfFile, pdfFile],
-      },
-    })
-
-    await flushPromiseQueue()
-    wrapper.update()
-
-    expect(onDropMock).not.toHaveBeenCalled()
-    expect(onRejectMock).toHaveBeenCalled()
-    expect(onRejectMock).toHaveBeenCalledWith(
-      [...Array(3)].map(() => ({
-        file: pdfFile,
-        errors: [
-          {
-            message:
-              "File type must be one of image/jpeg, image/png, image/heic",
-            code: "file-invalid-type",
-          },
-        ],
-      }))
+  const getWrapper = () => {
+    return mount(
+      <MediaContextProvider onlyMatch={[breakpoint]}>
+        <Formik initialValues={{ photos: [] }} onSubmit={jest.fn()}>
+          <PhotoDropzone
+            allPhotos={[]}
+            maxTotalSize={10}
+            onDrop={onDropMock}
+            onReject={onRejectMock}
+          />
+        </Formik>
+      </MediaContextProvider>
     )
-  })
+  }
 
-  it("rejects too big files", async () => {
-    const wrapper = getWrapper()
-
-    const dropzoneInput = wrapper
-      .find("[data-test-id='image-dropzone']")
-      .find("input")
-
-    dropzoneInput.simulate("change", {
-      target: {
-        files: [tooBigImage],
-      },
+  describe("md breakpoint", () => {
+    beforeEach(() => {
+      breakpoint = "md"
+      onDropMock.mockClear()
+      onRejectMock.mockClear()
     })
 
-    await flushPromiseQueue()
-    wrapper.update()
+    it("success uploading", async () => {
+      const wrapper = getWrapper()
 
-    expect(onDropMock).not.toHaveBeenCalled()
-    expect(onRejectMock).toHaveBeenCalled()
-    expect(onRejectMock).toHaveBeenCalledWith([
-      {
-        file: tooBigImage,
-        errors: [
-          {
-            message: "",
-            code: "total-size-limit",
-          },
-        ],
-      },
-    ])
-  })
+      const dropzoneInput = wrapper
+        .find("[data-test-id='image-dropzone']")
+        .find("input")
 
-  it("rejects too big pdf files", async () => {
-    const wrapper = getWrapper()
+      dropzoneInput.simulate("change", {
+        target: {
+          files: [validImage, validImage, validImage],
+        },
+      })
 
-    const dropzoneInput = wrapper
-      .find("[data-test-id='image-dropzone']")
-      .find("input")
+      await flushPromiseQueue()
+      wrapper.update()
 
-    dropzoneInput.simulate("change", {
-      target: {
-        files: [tooBigPdf],
-      },
+      expect(onDropMock).toHaveBeenCalled()
+      expect(onDropMock).toHaveBeenCalledWith([
+        validImage,
+        validImage,
+        validImage,
+      ])
     })
 
-    await flushPromiseQueue()
-    wrapper.update()
+    it("rejects not image files", async () => {
+      const wrapper = getWrapper()
 
-    expect(onDropMock).not.toHaveBeenCalled()
-    expect(onRejectMock).toHaveBeenCalled()
-    expect(onRejectMock).toHaveBeenCalledWith([
-      {
-        file: tooBigPdf,
-        errors: [
-          {
-            message:
-              "File type must be one of image/jpeg, image/png, image/heic",
-            code: "file-invalid-type",
-          },
-        ],
-      },
-    ])
-  })
+      const dropzoneInput = wrapper
+        .find("[data-test-id='image-dropzone']")
+        .find("input")
 
-  it("rejects image over size limit", async () => {
-    const wrapper = getWrapper()
+      dropzoneInput.simulate("change", {
+        target: {
+          files: [pdfFile, pdfFile, pdfFile],
+        },
+      })
 
-    const dropzoneInput = wrapper
-      .find("[data-test-id='image-dropzone']")
-      .find("input")
+      await flushPromiseQueue()
+      wrapper.update()
 
-    dropzoneInput.simulate("change", {
-      target: {
-        files: [...Array(6)].map(() => validImage),
-      },
+      expect(onDropMock).not.toHaveBeenCalled()
+      expect(onRejectMock).toHaveBeenCalled()
+      expect(onRejectMock).toHaveBeenCalledWith(
+        [...Array(3)].map(() => ({
+          file: pdfFile,
+          errors: [
+            {
+              message:
+                "File type must be one of image/jpeg, image/png, image/heic",
+              code: "file-invalid-type",
+            },
+          ],
+        }))
+      )
     })
 
-    await flushPromiseQueue()
-    wrapper.update()
+    it("rejects too big files", async () => {
+      const wrapper = getWrapper()
 
-    expect(onDropMock).toHaveBeenCalled()
+      const dropzoneInput = wrapper
+        .find("[data-test-id='image-dropzone']")
+        .find("input")
 
-    expect(onDropMock).toHaveBeenCalledWith([...Array(5)].map(() => validImage))
-    expect(onRejectMock).toHaveBeenCalled()
-    expect(onRejectMock).toHaveBeenCalledWith([
-      {
-        file: validImage,
-        errors: [
-          {
-            message: "",
-            code: "total-size-limit",
-          },
-        ],
-      },
-    ])
+      dropzoneInput.simulate("change", {
+        target: {
+          files: [tooBigImage],
+        },
+      })
+
+      await flushPromiseQueue()
+      wrapper.update()
+
+      expect(onDropMock).not.toHaveBeenCalled()
+      expect(onRejectMock).toHaveBeenCalled()
+      expect(onRejectMock).toHaveBeenCalledWith([
+        {
+          file: tooBigImage,
+          errors: [
+            {
+              message: "",
+              code: "total-size-limit",
+            },
+          ],
+        },
+      ])
+    })
+
+    it("rejects too big pdf files", async () => {
+      const wrapper = getWrapper()
+
+      const dropzoneInput = wrapper
+        .find("[data-test-id='image-dropzone']")
+        .find("input")
+
+      dropzoneInput.simulate("change", {
+        target: {
+          files: [tooBigPdf],
+        },
+      })
+
+      await flushPromiseQueue()
+      wrapper.update()
+
+      expect(onDropMock).not.toHaveBeenCalled()
+      expect(onRejectMock).toHaveBeenCalled()
+      expect(onRejectMock).toHaveBeenCalledWith([
+        {
+          file: tooBigPdf,
+          errors: [
+            {
+              message:
+                "File type must be one of image/jpeg, image/png, image/heic",
+              code: "file-invalid-type",
+            },
+          ],
+        },
+      ])
+    })
+
+    it("rejects image over size limit", async () => {
+      const wrapper = getWrapper()
+
+      const dropzoneInput = wrapper
+        .find("[data-test-id='image-dropzone']")
+        .find("input")
+
+      dropzoneInput.simulate("change", {
+        target: {
+          files: [...Array(6)].map(() => validImage),
+        },
+      })
+
+      await flushPromiseQueue()
+      wrapper.update()
+
+      expect(onDropMock).toHaveBeenCalled()
+
+      expect(onDropMock).toHaveBeenCalledWith(
+        [...Array(5)].map(() => validImage)
+      )
+      expect(onRejectMock).toHaveBeenCalled()
+      expect(onRejectMock).toHaveBeenCalledWith([
+        {
+          file: validImage,
+          errors: [
+            {
+              message: "",
+              code: "total-size-limit",
+            },
+          ],
+        },
+      ])
+    })
+  })
+
+  describe("xs breakpoint", () => {
+    beforeEach(() => {
+      breakpoint = "xs"
+      onDropMock.mockClear()
+      onRejectMock.mockClear()
+    })
+
+    it("success uploading", async () => {
+      const wrapper = getWrapper()
+
+      const dropzoneInput = wrapper.find("input")
+
+      dropzoneInput.simulate("change", {
+        target: {
+          files: [validImage, validImage, validImage],
+        },
+      })
+
+      await flushPromiseQueue()
+      wrapper.update()
+
+      expect(onDropMock).toHaveBeenCalled()
+      expect(onDropMock).toHaveBeenCalledWith([
+        validImage,
+        validImage,
+        validImage,
+      ])
+    })
+
+    it("rejects not image files", async () => {
+      const wrapper = getWrapper()
+
+      const dropzoneInput = wrapper.find("input")
+
+      dropzoneInput.simulate("change", {
+        target: {
+          files: [pdfFile, pdfFile, pdfFile],
+        },
+      })
+
+      await flushPromiseQueue()
+      wrapper.update()
+
+      expect(onDropMock).not.toHaveBeenCalled()
+      expect(onRejectMock).toHaveBeenCalled()
+      expect(onRejectMock).toHaveBeenCalledWith(
+        [...Array(3)].map(() => ({
+          file: pdfFile,
+          errors: [
+            {
+              message:
+                "File type must be one of image/jpeg, image/png, image/heic",
+              code: "file-invalid-type",
+            },
+          ],
+        }))
+      )
+    })
+
+    it("rejects too big files", async () => {
+      const wrapper = getWrapper()
+
+      const dropzoneInput = wrapper.find("input")
+
+      dropzoneInput.simulate("change", {
+        target: {
+          files: [tooBigImage],
+        },
+      })
+
+      await flushPromiseQueue()
+      wrapper.update()
+
+      expect(onDropMock).not.toHaveBeenCalled()
+      expect(onRejectMock).toHaveBeenCalled()
+      expect(onRejectMock).toHaveBeenCalledWith([
+        {
+          file: tooBigImage,
+          errors: [
+            {
+              message: "",
+              code: "total-size-limit",
+            },
+          ],
+        },
+      ])
+    })
+
+    it("rejects too big pdf files", async () => {
+      const wrapper = getWrapper()
+
+      const dropzoneInput = wrapper.find("input")
+
+      dropzoneInput.simulate("change", {
+        target: {
+          files: [tooBigPdf],
+        },
+      })
+
+      await flushPromiseQueue()
+      wrapper.update()
+
+      expect(onDropMock).not.toHaveBeenCalled()
+      expect(onRejectMock).toHaveBeenCalled()
+      expect(onRejectMock).toHaveBeenCalledWith([
+        {
+          file: tooBigPdf,
+          errors: [
+            {
+              message:
+                "File type must be one of image/jpeg, image/png, image/heic",
+              code: "file-invalid-type",
+            },
+          ],
+        },
+      ])
+    })
+
+    it("rejects image over size limit", async () => {
+      const wrapper = getWrapper()
+
+      const dropzoneInput = wrapper.find("input")
+
+      dropzoneInput.simulate("change", {
+        target: {
+          files: [...Array(6)].map(() => validImage),
+        },
+      })
+
+      await flushPromiseQueue()
+      wrapper.update()
+
+      expect(onDropMock).toHaveBeenCalled()
+
+      expect(onDropMock).toHaveBeenCalledWith(
+        [...Array(5)].map(() => validImage)
+      )
+      expect(onRejectMock).toHaveBeenCalled()
+      expect(onRejectMock).toHaveBeenCalledWith([
+        {
+          file: validImage,
+          errors: [
+            {
+              message: "",
+              code: "total-size-limit",
+            },
+          ],
+        },
+      ])
+    })
   })
 })


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PROJECT-XX]

### Description

<!-- Implementation description -->

As discussed with Barney and Ole, adjust the add photos page to make the uploaded images more visible when working with smaller screens
| iPhone SE | iPhone 12 Pro | iPad Pro |
| --- | --- | --- |
| <img width="374" alt="image" src="https://github.com/artsy/force/assets/36167539/5dd08310-31ce-457a-b6e6-32c38ccc6743"> | <img width="388" alt="image" src="https://github.com/artsy/force/assets/36167539/12ef4f48-4381-4803-94f3-4dd8c8f26a7a"> | <img width="511" alt="image" src="https://github.com/artsy/force/assets/36167539/80170941-c8a4-4d83-ab8a-c0030c73993c"> |

Also, adjust the photos drop component on the artwork add/edit page
<img width="250" alt="image" src="https://github.com/artsy/force/assets/36167539/9897a7d8-4a17-4361-a8d4-94ef803a3fdc">



[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ