### PR TITLE
feat: add availability filter to other artwork grids

### DIFF
--- a/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters.tsx
@@ -14,14 +14,12 @@ import { KeywordFilter } from "Components/ArtworkFilter/ArtworkFilters/KeywordFi
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import { Join, Spacer } from "@artsy/palette"
 import { ArtistSeriesFilter } from "Components/ArtworkFilter/ArtworkFilters/ArtistSeriesFilter"
-import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
 import { AvailabilityFilter } from "Components/ArtworkFilter/ArtworkFilters/AvailabilityFilter"
 
 interface ArtistArtworkFiltersProps {}
 
 export const ArtistArtworkFilters: React.FC<ArtistArtworkFiltersProps> = props => {
   const { user } = useSystemContext()
-  const isAvailabilityFilterEnabled = useFeatureFlag("onyx_availability-filter")
 
   return (
     <Join separator={<Spacer y={4} />}>
@@ -32,7 +30,7 @@ export const ArtistArtworkFilters: React.FC<ArtistArtworkFiltersProps> = props =
       <PriceRangeFilter expanded />
       <ArtistSeriesFilter expanded />
       <SizeFilter expanded />
-      {isAvailabilityFilterEnabled && <AvailabilityFilter />}
+      <AvailabilityFilter />
       <WaysToBuyFilter expanded />
       <MaterialsFilter />
       <ArtistNationalityFilter />

--- a/src/Apps/Artist/Routes/WorksForSale/Components/__tests__/ArtistArtworkFilters.jest.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/__tests__/ArtistArtworkFilters.jest.tsx
@@ -6,7 +6,6 @@ import {
 import { ArtistArtworkFilters } from "Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters"
 import { ArtworkFilterContextProvider } from "Components/ArtworkFilter/ArtworkFilterContext"
 import { ReactElement } from "react"
-import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
 
 const render = (ui: ReactElement, options: RenderOptions = {}) =>
   originalRender(ui, { wrapper: Wrapper, ...options })
@@ -53,33 +52,11 @@ it("renders all expected filters", () => {
   expect(screen.getByText("Price")).toBeInTheDocument()
   expect(screen.getByText("Artist Series")).toBeInTheDocument()
   expect(screen.getByText("Size")).toBeInTheDocument()
+  expect(screen.getByText("Availability")).toBeInTheDocument()
   expect(screen.getByText("Ways to Buy")).toBeInTheDocument()
   expect(screen.getByText("Material")).toBeInTheDocument()
   expect(screen.getByText("Artwork Location")).toBeInTheDocument()
   expect(screen.getByText("Time Period")).toBeInTheDocument()
   expect(screen.getByText("Color")).toBeInTheDocument()
   expect(screen.getByText("Galleries and Institutions")).toBeInTheDocument()
-})
-
-describe("feature flag: onyx_availability", () => {
-  const mockUseFeatureFlag = useFeatureFlag as jest.Mock
-
-  describe("when the feature flag is enabled", () => {
-    beforeEach(() => {
-      mockUseFeatureFlag.mockImplementation(() => true)
-    })
-    it("renders the Availability filter", () => {
-      render(<ArtistArtworkFilters />)
-      expect(screen.getByText("Availability")).toBeInTheDocument()
-    })
-  })
-  describe("when the feature flag is disabled", () => {
-    beforeEach(() => {
-      mockUseFeatureFlag.mockImplementation(() => false)
-    })
-    it("does not render the Availability filter", () => {
-      render(<ArtistArtworkFilters />)
-      expect(screen.queryByText("Availability")).not.toBeInTheDocument()
-    })
-  })
 })

--- a/src/Apps/ArtistSeries/__tests__/ArtistSeriesArtworksFilter.jest.tsx
+++ b/src/Apps/ArtistSeries/__tests__/ArtistSeriesArtworksFilter.jest.tsx
@@ -10,6 +10,7 @@ import {
   mediumAggregation,
   partnerAggregation,
 } from "Apps/__tests__/Fixtures/aggregations"
+import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
 
 jest.unmock("react-relay")
 jest.mock("System/Hooks/useRouter", () => ({
@@ -22,6 +23,9 @@ jest.mock("System/Hooks/useRouter", () => ({
 jest.mock("react-tracking")
 jest.mock("Utils/Hooks/useMatchMedia", () => ({
   __internal__useMatchMedia: () => ({}),
+}))
+jest.mock("System/Hooks/useFeatureFlag", () => ({
+  useFeatureFlag: jest.fn(() => false),
 }))
 
 const { getWrapper } = setupTestWrapper<ArtistSeriesArtworksFilter_Query>({
@@ -50,6 +54,7 @@ const { getWrapper } = setupTestWrapper<ArtistSeriesArtworksFilter_Query>({
 
 describe("ArtistSeriesArtworksFilter", () => {
   const trackEvent = jest.fn()
+  const mockUseFeatureFlag = useFeatureFlag as jest.Mock
 
   beforeAll(() => {
     ;(useTracking as jest.Mock).mockImplementation(() => {
@@ -57,6 +62,7 @@ describe("ArtistSeriesArtworksFilter", () => {
         trackEvent,
       }
     })
+    mockUseFeatureFlag.mockImplementation(() => true)
   })
 
   it("renders correctly", () => {
@@ -93,6 +99,10 @@ describe("ArtistSeriesArtworksFilter", () => {
       },
       {
         label: "Size",
+        expanded: true,
+      },
+      {
+        label: "Availability",
         expanded: true,
       },
       {

--- a/src/Apps/Collect/Routes/Collection/Components/CollectionArtworksFilter.tsx
+++ b/src/Apps/Collect/Routes/Collection/Components/CollectionArtworksFilter.tsx
@@ -25,6 +25,8 @@ import { ArtistsFilter } from "Components/ArtworkFilter/ArtworkFilters/ArtistsFi
 import { __internal__useMatchMedia } from "Utils/Hooks/useMatchMedia"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import { Join, Spacer } from "@artsy/palette"
+import { AvailabilityFilter } from "Components/ArtworkFilter/ArtworkFilters/AvailabilityFilter"
+import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
 
 interface CollectionArtworksFilterProps {
   relay: RelayRefetchProp
@@ -42,6 +44,8 @@ export const CollectionArtworksFilter: React.FC<CollectionArtworksFilterProps> =
   const { pathname } = usePathnameComplete()
   const { userPreferences } = useSystemContext()
 
+  const isAvailabilityFilterEnabled = useFeatureFlag("onyx_availability-filter")
+
   const Filters = (
     <Join separator={<Spacer y={4} />}>
       {!isArtistCollection && <ArtistsFilter expanded />}
@@ -49,6 +53,7 @@ export const CollectionArtworksFilter: React.FC<CollectionArtworksFilterProps> =
       <MediumFilter expanded />
       <PriceRangeFilter expanded />
       <SizeFilter expanded />
+      {isAvailabilityFilterEnabled && <AvailabilityFilter expanded />}
       <WaysToBuyFilter expanded />
       <MaterialsFilter expanded />
       {!isArtistCollection && <ArtistNationalityFilter expanded />}

--- a/src/Apps/Collect/Routes/Collection/Components/__tests__/CollectionArtworksFilter.jest.tsx
+++ b/src/Apps/Collect/Routes/Collection/Components/__tests__/CollectionArtworksFilter.jest.tsx
@@ -12,6 +12,7 @@ import {
   mediumAggregation,
   partnerAggregation,
 } from "Apps/__tests__/Fixtures/aggregations"
+import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
 
 jest.unmock("react-relay")
 jest.mock("System/Hooks/useRouter", () => ({
@@ -24,6 +25,9 @@ jest.mock("System/Hooks/useRouter", () => ({
 jest.mock("react-tracking")
 jest.mock("Utils/Hooks/useMatchMedia", () => ({
   __internal__useMatchMedia: () => ({}),
+}))
+jest.mock("System/Hooks/useFeatureFlag", () => ({
+  useFeatureFlag: jest.fn(() => false),
 }))
 
 const { getWrapper } = setupTestWrapper<CollectionArtworksFilter_Query>({
@@ -60,6 +64,7 @@ const { getWrapper } = setupTestWrapper<CollectionArtworksFilter_Query>({
 
 describe("CollectionArtworksFilter", () => {
   const trackEvent = jest.fn()
+  const mockUseFeatureFlag = useFeatureFlag as jest.Mock
 
   beforeAll(() => {
     ;(useTracking as jest.Mock).mockImplementation(() => {
@@ -67,6 +72,7 @@ describe("CollectionArtworksFilter", () => {
         trackEvent,
       }
     })
+    mockUseFeatureFlag.mockImplementation(() => true)
   })
 
   it("renders correctly", () => {
@@ -101,6 +107,10 @@ describe("CollectionArtworksFilter", () => {
       },
       {
         label: "Size",
+        expanded: true,
+      },
+      {
+        label: "Availability",
         expanded: true,
       },
       {
@@ -163,6 +173,10 @@ describe("CollectionArtworksFilter", () => {
       },
       {
         label: "Size",
+        expanded: true,
+      },
+      {
+        label: "Availability",
         expanded: true,
       },
       {

--- a/src/Apps/Fair/Routes/FairArtworks.tsx
+++ b/src/Apps/Fair/Routes/FairArtworks.tsx
@@ -24,6 +24,8 @@ import { SizeFilter } from "Components/ArtworkFilter/ArtworkFilters/SizeFilter"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import { KeywordFilter } from "Components/ArtworkFilter/ArtworkFilters/KeywordFilter"
 import { Join, Spacer } from "@artsy/palette"
+import { AvailabilityFilter } from "Components/ArtworkFilter/ArtworkFilters/AvailabilityFilter"
+import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
 
 interface FairArtworksFilterProps {
   fair: FairArtworks_fair$data
@@ -35,6 +37,8 @@ const FairArtworksFilter: React.FC<FairArtworksFilterProps> = props => {
   const { match } = useRouter()
   const { userPreferences } = useSystemContext()
   const { filtered_artworks, sidebarAggregations } = fair
+
+  const isAvailabilityFilterEnabled = useFeatureFlag("onyx_availability-filter")
 
   const hasFilter = filtered_artworks && filtered_artworks.id
 
@@ -57,6 +61,7 @@ const FairArtworksFilter: React.FC<FairArtworksFilterProps> = props => {
       <MediumFilter expanded />
       <PriceRangeFilter expanded />
       <SizeFilter expanded />
+      {isAvailabilityFilterEnabled && <AvailabilityFilter expanded />}
       <WaysToBuyFilter expanded />
       <MaterialsFilter expanded />
       <ArtistNationalityFilter expanded />

--- a/src/Apps/Gene/Components/__tests__/GeneArtworkFilter.jest.tsx
+++ b/src/Apps/Gene/Components/__tests__/GeneArtworkFilter.jest.tsx
@@ -12,6 +12,7 @@ import {
   mediumAggregation,
   partnerAggregation,
 } from "Apps/__tests__/Fixtures/aggregations"
+import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
 
 jest.unmock("react-relay")
 jest.mock("System/Hooks/useRouter", () => ({
@@ -24,6 +25,9 @@ jest.mock("System/Hooks/useRouter", () => ({
 jest.mock("react-tracking")
 jest.mock("Utils/Hooks/useMatchMedia", () => ({
   __internal__useMatchMedia: () => ({}),
+}))
+jest.mock("System/Hooks/useFeatureFlag", () => ({
+  useFeatureFlag: jest.fn(() => false),
 }))
 
 const { getWrapper } = setupTestWrapper<GeneArtworkFilter_Query>({
@@ -44,6 +48,7 @@ const { getWrapper } = setupTestWrapper<GeneArtworkFilter_Query>({
 
 describe("GeneArtworkFilter", () => {
   const trackEvent = jest.fn()
+  const mockUseFeatureFlag = useFeatureFlag as jest.Mock
 
   beforeAll(() => {
     ;(useTracking as jest.Mock).mockImplementation(() => {
@@ -51,6 +56,7 @@ describe("GeneArtworkFilter", () => {
         trackEvent,
       }
     })
+    mockUseFeatureFlag.mockImplementation(() => true)
   })
 
   it("renders correctly", () => {
@@ -99,6 +105,10 @@ describe("GeneArtworkFilter", () => {
       },
       {
         label: "Size",
+        expanded: true,
+      },
+      {
+        label: "Availability",
         expanded: true,
       },
       {

--- a/src/Apps/Partner/Routes/__tests__/Works.jest.tsx
+++ b/src/Apps/Partner/Routes/__tests__/Works.jest.tsx
@@ -13,6 +13,7 @@ import {
 import { fireEvent, screen, within } from "@testing-library/react"
 import { useRouter } from "System/Hooks/useRouter"
 import { getENV } from "Utils/getENV"
+import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
 
 jest.unmock("react-relay")
 jest.mock("react-tracking")
@@ -22,6 +23,9 @@ jest.mock("Utils/Hooks/useMatchMedia", () => ({
 }))
 jest.mock("Utils/getENV", () => ({
   getENV: jest.fn(),
+}))
+jest.mock("System/Hooks/useFeatureFlag", () => ({
+  useFeatureFlag: jest.fn(() => false),
 }))
 
 const { getWrapper } = setupTestWrapper<Works_Query>({
@@ -60,6 +64,7 @@ describe("PartnerArtworks", () => {
   const trackEvent = jest.fn()
   const mockUseRouter = useRouter as jest.Mock
   const mockGetENV = getENV as jest.Mock
+  const mockUseFeatureFlag = useFeatureFlag as jest.Mock
 
   beforeAll(() => {
     ;(useTracking as jest.Mock).mockImplementation(() => {
@@ -76,6 +81,7 @@ describe("PartnerArtworks", () => {
         },
       },
     }))
+    mockUseFeatureFlag.mockImplementation(() => true)
   })
 
   it("renders correctly", () => {
@@ -122,6 +128,10 @@ describe("PartnerArtworks", () => {
       },
       {
         label: "Size",
+        expanded: true,
+      },
+      {
+        label: "Availability",
         expanded: true,
       },
       {

--- a/src/Apps/Search/Components/SearchResultsArtworksFilters.tsx
+++ b/src/Apps/Search/Components/SearchResultsArtworksFilters.tsx
@@ -3,6 +3,7 @@ import { ArtistNationalityFilter } from "Components/ArtworkFilter/ArtworkFilters
 import { ArtistsFilter } from "Components/ArtworkFilter/ArtworkFilters/ArtistsFilter"
 import { ArtworkLocationFilter } from "Components/ArtworkFilter/ArtworkFilters/ArtworkLocationFilter"
 import { AttributionClassFilter } from "Components/ArtworkFilter/ArtworkFilters/AttributionClassFilter"
+import { AvailabilityFilter } from "Components/ArtworkFilter/ArtworkFilters/AvailabilityFilter"
 import { ColorFilter } from "Components/ArtworkFilter/ArtworkFilters/ColorFilter"
 import { MaterialsFilter } from "Components/ArtworkFilter/ArtworkFilters/MaterialsFilter"
 import { MediumFilter } from "Components/ArtworkFilter/ArtworkFilters/MediumFilter"
@@ -11,8 +12,11 @@ import { PriceRangeFilter } from "Components/ArtworkFilter/ArtworkFilters/PriceR
 import { SizeFilter } from "Components/ArtworkFilter/ArtworkFilters/SizeFilter"
 import { TimePeriodFilter } from "Components/ArtworkFilter/ArtworkFilters/TimePeriodFilter"
 import { WaysToBuyFilter } from "Components/ArtworkFilter/ArtworkFilters/WaysToBuyFilter"
+import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
 
 export const SearchResultsArtworksFilters = () => {
+  const isAvailabilityFilterEnabled = useFeatureFlag("onyx_availability-filter")
+
   return (
     <Join separator={<Spacer y={4} />}>
       <ArtistsFilter expanded />
@@ -20,6 +24,7 @@ export const SearchResultsArtworksFilters = () => {
       <MediumFilter expanded />
       <PriceRangeFilter expanded />
       <SizeFilter expanded />
+      {isAvailabilityFilterEnabled && <AvailabilityFilter expanded />}
       <WaysToBuyFilter expanded />
       <MaterialsFilter expanded />
       <ArtistNationalityFilter expanded />

--- a/src/Apps/Show/__tests__/ShowArtworks.jest.tsx
+++ b/src/Apps/Show/__tests__/ShowArtworks.jest.tsx
@@ -10,6 +10,7 @@ import {
   materialsTermsAggregation,
   mediumAggregation,
 } from "Apps/__tests__/Fixtures/aggregations"
+import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
 
 jest.unmock("react-relay")
 jest.mock("System/Hooks/useRouter", () => ({
@@ -20,6 +21,9 @@ jest.mock("System/Hooks/useRouter", () => ({
 jest.mock("react-tracking")
 jest.mock("Utils/Hooks/useMatchMedia", () => ({
   __internal__useMatchMedia: () => ({}),
+}))
+jest.mock("System/Hooks/useFeatureFlag", () => ({
+  useFeatureFlag: jest.fn(() => false),
 }))
 
 const { getWrapper } = setupTestWrapper<ShowArtworks_Test_Query>({
@@ -50,6 +54,7 @@ const { getWrapper } = setupTestWrapper<ShowArtworks_Test_Query>({
 
 describe("ShowArtworks", () => {
   const trackEvent = jest.fn()
+  const mockUseFeatureFlag = useFeatureFlag as jest.Mock
 
   beforeAll(() => {
     ;(useTracking as jest.Mock).mockImplementation(() => {
@@ -57,6 +62,7 @@ describe("ShowArtworks", () => {
         trackEvent,
       }
     })
+    mockUseFeatureFlag.mockImplementation(() => true)
   })
 
   it("renders correctly", () => {
@@ -98,6 +104,10 @@ describe("ShowArtworks", () => {
       },
       {
         label: "Size",
+        expanded: true,
+      },
+      {
+        label: "Availability",
         expanded: true,
       },
       {

--- a/src/Apps/Tag/Components/__tests__/TagArtworkFilter.jest.tsx
+++ b/src/Apps/Tag/Components/__tests__/TagArtworkFilter.jest.tsx
@@ -12,6 +12,7 @@ import {
   mediumAggregation,
   partnerAggregation,
 } from "Apps/__tests__/Fixtures/aggregations"
+import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
 
 jest.unmock("react-relay")
 jest.mock("System/Hooks/useRouter", () => ({
@@ -24,6 +25,9 @@ jest.mock("System/Hooks/useRouter", () => ({
 jest.mock("react-tracking")
 jest.mock("Utils/Hooks/useMatchMedia", () => ({
   __internal__useMatchMedia: () => ({}),
+}))
+jest.mock("System/Hooks/useFeatureFlag", () => ({
+  useFeatureFlag: jest.fn(() => false),
 }))
 
 const { getWrapper } = setupTestWrapper<TagArtworkFilter_Query>({
@@ -44,6 +48,7 @@ const { getWrapper } = setupTestWrapper<TagArtworkFilter_Query>({
 
 describe("TagArtworkFilter", () => {
   const trackEvent = jest.fn()
+  const mockUseFeatureFlag = useFeatureFlag as jest.Mock
 
   beforeAll(() => {
     ;(useTracking as jest.Mock).mockImplementation(() => {
@@ -51,6 +56,7 @@ describe("TagArtworkFilter", () => {
         trackEvent,
       }
     })
+    mockUseFeatureFlag.mockImplementation(() => true)
   })
 
   it("renders correctly", () => {
@@ -99,6 +105,10 @@ describe("TagArtworkFilter", () => {
       },
       {
         label: "Size",
+        expanded: true,
+      },
+      {
+        label: "Availability",
         expanded: true,
       },
       {

--- a/src/Components/ArtworkFilter/ArtworkFilters/AvailabilityFilter.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/AvailabilityFilter.tsx
@@ -7,7 +7,11 @@ import {
 import { FilterExpandable } from "Components/ArtworkFilter/ArtworkFilters/FilterExpandable"
 import { useFilterLabelCountByKey } from "Components/ArtworkFilter/Utils/useFilterLabelCountByKey"
 
-export const AvailabilityFilter: React.FC = () => {
+interface AvailabilityFilterProps {
+  expanded?: boolean
+}
+
+export const AvailabilityFilter: React.FC<AvailabilityFilterProps> = ({ expanded }) => {
   const { setFilter } = useArtworkFilterContext()
   const currentSelectedFilters = useCurrentlySelectedFilters()
 
@@ -16,8 +20,10 @@ export const AvailabilityFilter: React.FC = () => {
   )
   const label = `Availability${filtersCount}`
 
+  const isSelected = currentSelectedFilters?.forSale
+
   return (
-    <FilterExpandable label={label} expanded>
+    <FilterExpandable label={label} expanded={isSelected || expanded}>
       <Checkbox
         selected={!!currentSelectedFilters?.forSale}
         onSelect={selected => setFilter("forSale", selected)}

--- a/src/Components/ArtworkFilter/ArtworkFilters/__tests__/AvailabilityFilter.jest.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/__tests__/AvailabilityFilter.jest.tsx
@@ -15,12 +15,12 @@ const render = createArtworkFilterTestRenderer()
 
 describe(AvailabilityFilter, () => {
   it("renders a for-sale toggle", () => {
-    render(<AvailabilityFilter />)
+    render(<AvailabilityFilter expanded />)
     expect(screen.getByText("Only works for sale")).toBeInTheDocument()
   })
 
   it("updates context on filter change", () => {
-    render(<AvailabilityFilter />)
+    render(<AvailabilityFilter expanded />)
     expect(currentArtworkFilterContext().filters?.forSale).toBeFalsy()
 
     userEvent.click(screen.getAllByRole("checkbox")[0])
@@ -31,7 +31,7 @@ describe(AvailabilityFilter, () => {
   })
 
   it("clears local input state after Clear All", () => {
-    render(<AvailabilityFilter />)
+    render(<AvailabilityFilter expanded />)
     userEvent.click(screen.getAllByRole("checkbox")[0])
     expect(currentArtworkFilterContext().filters?.forSale).toBeTruthy()
 
@@ -62,7 +62,7 @@ describe(AvailabilityFilter, () => {
           // eslint-disable-next-line react-hooks/exhaustive-deps
         }, [])
 
-        return <AvailabilityFilter />
+        return <AvailabilityFilter expanded />
       }
       render(<MobileVersionOfAvailabilityFilter />)
     })
@@ -87,6 +87,23 @@ describe(AvailabilityFilter, () => {
       userEvent.click(screen.getAllByRole("checkbox")[0])
 
       expect(screen.getByText("Availability • 1")).toBeInTheDocument()
+    })
+  })
+
+  describe("the `expanded` prop", () => {
+    it("hides the filter controls when not set", () => {
+      render(<AvailabilityFilter />)
+      expect(screen.queryAllByRole("checkbox").length).toBe(0)
+    })
+
+    it("hides the filter controls when `false`", () => {
+      render(<AvailabilityFilter expanded={false} />)
+      expect(screen.queryAllByRole("checkbox").length).toBe(0)
+    })
+
+    it("shows the filter controls when `true`", () => {
+      render(<AvailabilityFilter expanded />)
+      expect(screen.queryAllByRole("checkbox").length).not.toBe(0)
     })
   })
 })

--- a/src/Components/ArtworkFilter/ArtworkFilters/index.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/index.tsx
@@ -13,6 +13,8 @@ import { PartnersFilter } from "./PartnersFilter"
 import { ArtistsFilter } from "./ArtistsFilter"
 import { Join, Spacer } from "@artsy/palette"
 import { KeywordFilter } from "Components/ArtworkFilter/ArtworkFilters/KeywordFilter"
+import { AvailabilityFilter } from "Components/ArtworkFilter/ArtworkFilters/AvailabilityFilter"
+import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
 
 interface ArtworkFiltersProps {
   user?: User
@@ -22,6 +24,8 @@ interface ArtworkFiltersProps {
 export const ArtworkFilters: React.FC<ArtworkFiltersProps> = props => {
   const { user } = props
 
+  const isAvailabilityFilterEnabled = useFeatureFlag("onyx_availability-filter")
+
   return (
     <Join separator={<Spacer y={4} />}>
       <KeywordFilter />
@@ -30,6 +34,7 @@ export const ArtworkFilters: React.FC<ArtworkFiltersProps> = props => {
       <MediumFilter expanded />
       <PriceRangeFilter expanded />
       <SizeFilter expanded />
+      {isAvailabilityFilterEnabled && <AvailabilityFilter expanded />}
       <WaysToBuyFilter expanded />
       <MaterialsFilter expanded />
       <ArtistNationalityFilter expanded />


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [ONYX-887]

### Description

This PR implements the recommendations in [ONYX-887][] and rolls out the availability filter to the following artwork grids:
- Standard artwork grids (Artist series, Artworks (/collect), Gene, Show, Tag)
- Fair
- Marketing Collection
- Search Results

This repurposes the existing `onyx_availability-filter` Unleash feature flag so before deploy we should switch that to staging only so we can poke around other grids before a user-facing release on production.

[ONYX-887]: https://artsyproduct.atlassian.net/browse/ONYX-887


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ