### PR TITLE
fix: Center Sell flow layout on large screens

### DIFF
--- a/src/Apps/Sell/Components/SubmissionLayout.tsx
+++ b/src/Apps/Sell/Components/SubmissionLayout.tsx
@@ -31,7 +31,7 @@ export const SubmissionLayout: React.FC<SubmissionLayoutProps> = ({
 
       <SubmissionProgressBar />
 
-      <Flex flex={1} overflowY="auto" mx="auto">
+      <Flex flex={1} overflowY="auto">
         {!!context?.state?.devMode && !hideNavigation ? (
           <GridColumns>
             <Column span={[4]}>
@@ -45,11 +45,9 @@ export const SubmissionLayout: React.FC<SubmissionLayoutProps> = ({
             </Column>
           </GridColumns>
         ) : (
-          <Flex width="100vw" justifyContent="center">
-            <FadeInBox maxWidth="100vw" width={CONTENT_WIDTH} p={2} pt={[2, 4]}>
-              {children}
-            </FadeInBox>
-          </Flex>
+          <FadeInBox width={CONTENT_WIDTH} p={2} pt={[2, 4]} mx="auto">
+            {children}
+          </FadeInBox>
         )}
       </Flex>
 


### PR DESCRIPTION
Follow-Up for https://github.com/artsy/force/pull/14141

## Description
With this change, the Sell flow layout centers the content on large screens and keeps the larger scroll area introduced in https://github.com/artsy/force/pull/14141.

| Before | After |
| --- | --- |
|![Screenshot 2024-07-04 at 11 28 53](https://github.com/artsy/force/assets/4691889/ce4b0101-cc27-4ec6-adc3-6b646ab7ea7e) |![Screenshot 2024-07-04 at 11 29 03](https://github.com/artsy/force/assets/4691889/e64f896e-0a61-4a45-914a-a59791d81467) |




