### PR TITLE
fix: add Select option to the Select component values

### DIFF
--- a/src/Apps/Sell/Routes/PurchaseHistoryRoute.tsx
+++ b/src/Apps/Sell/Routes/PurchaseHistoryRoute.tsx
@@ -49,7 +49,7 @@ export const PurchaseHistoryRoute: React.FC<PurchaseHistoryRouteProps> = props =
   }
 
   const initialValues: FormValues = {
-    provenance: submission.provenance || "",
+    provenance: submission.provenance ?? "",
     signature: submission.signature ?? null,
   }
 

--- a/src/Apps/Sell/Routes/__tests__/PurchaseHistoryRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/PurchaseHistoryRoute.jest.tsx
@@ -93,7 +93,7 @@ describe("PurchaseHistoryRoute", () => {
     })
 
     await waitFor(() => {
-      expect(screen.getByTestId("provenance-input")).toHaveValue(undefined)
+      expect(screen.getByTestId("provenance-input")).toHaveValue("")
       expect(screen.getByTestId("signature-radio-no")).not.toBeChecked()
       expect(screen.getByTestId("signature-radio-yes")).not.toBeChecked()
     })

--- a/src/Apps/Sell/Utils/formUtils.ts
+++ b/src/Apps/Sell/Utils/formUtils.ts
@@ -1,15 +1,12 @@
 export const PROVENANCE_LIST = [
-  { value: "", text: "Select" },
-  {
-    value: "Purchased directly from gallery",
-    text: "Purchased directly from gallery",
-  },
-  {
-    value: "Purchased directly from artist",
-    text: "Purchased directly from artist",
-  },
-  { value: "Purchased at auction", text: "Purchased at auction" },
-  { value: "Gift from the artist", text: "Gift from the artist" },
-  { value: "Other", text: "Other" },
-  { value: "I don’t know", text: "I don’t know" },
-]
+  "",
+  "Purchased directly from gallery",
+  "Purchased directly from artist",
+  "Purchased at auction",
+  "Gift from the artist",
+  "Other",
+  "I don’t know",
+].map(provenance => ({
+  value: provenance,
+  text: provenance || "Select",
+}))

--- a/src/Apps/Sell/Utils/formUtils.ts
+++ b/src/Apps/Sell/Utils/formUtils.ts
@@ -1,11 +1,15 @@
 export const PROVENANCE_LIST = [
-  "Purchased directly from gallery",
-  "Purchased directly from artist",
-  "Purchased at auction",
-  "Gift from the artist",
-  "Other",
-  "I don’t know",
-].map(provenance => ({
-  value: provenance,
-  text: provenance,
-}))
+  { value: "", text: "Select" },
+  {
+    value: "Purchased directly from gallery",
+    text: "Purchased directly from gallery",
+  },
+  {
+    value: "Purchased directly from artist",
+    text: "Purchased directly from artist",
+  },
+  { value: "Purchased at auction", text: "Purchased at auction" },
+  { value: "Gift from the artist", text: "Gift from the artist" },
+  { value: "Other", text: "Other" },
+  { value: "I don’t know", text: "I don’t know" },
+]


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PROJECT-XX]

### Description

<!-- Implementation description -->
Addresses this [Notion ticket](https://www.notion.so/artsy/Is-this-the-correct-default-state-of-the-drop-down-Or-should-it-have-Purchase-information-inside--80be530b056b4bf5a5111b8cb2e99aef?pvs=4)
Add Select option to the Select component values to display empty value correctly

<img width="674" alt="image" src="https://github.com/artsy/force/assets/36167539/51132c9d-bbc3-4b7d-86f8-151d2bae0db9">


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ