### PR TITLE
fix: Display preview images in reverse order in Sell flow

### DIFF
--- a/src/Apps/Sell/Components/ImagePreviewsGrid.tsx
+++ b/src/Apps/Sell/Components/ImagePreviewsGrid.tsx
@@ -15,7 +15,8 @@ export const ImagePreviewsGrid: React.FC = () => {
       <Spacer y={2} />
 
       <Flex gap={1} flexWrap="wrap">
-        {photos.map(photo => (
+        {/* Displaying the images in reverse order to ensure the most recent image is visible. */}
+        {[...photos].reverse().map(photo => (
           <ImagePreviewItem key={photo.id} photo={photo} />
         ))}
       </Flex>


### PR DESCRIPTION
Solves https://www.notion.so/artsy/Photo-upload-given-that-on-small-screens-the-whole-grid-of-uploaded-photos-is-not-visible-does-it-828252b08d5049cbad9ae71b734a2ccb?pvs=4
## Description

Display preview images in reverse order in the Sell flow to ensure that the most recent photos are always visible. This is helpful when many photos are uploaded and not all preview images fit on the screen.