### PR TITLE
fix: Add background color to delete photo button on Sell flow

### DIFF
--- a/src/Apps/Sell/Components/ImagePreviewItem.tsx
+++ b/src/Apps/Sell/Components/ImagePreviewItem.tsx
@@ -88,7 +88,7 @@ export const ImagePreviewItem: React.FC<ImagePreviewItemProps> = ({
     >
       <Box
         position="relative"
-        backgroundColor="black5"
+        backgroundColor="black10"
         width={IMAGE_SIZES}
         height={IMAGE_SIZES}
       >
@@ -154,6 +154,8 @@ export const ImagePreviewItem: React.FC<ImagePreviewItemProps> = ({
           right={0.5}
           width="16px"
           height="16px"
+          backgroundColor="white100"
+          borderRadius="50%"
         >
           <CloseFillIcon
             width="16px"


### PR DESCRIPTION
Solves https://www.notion.so/artsy/Mweb-Photo-Upload-The-X-button-to-delete-a-photo-is-invisible-when-the-uploaded-image-is-black-871fc50a3e3c42309e2144d3131e3178?pvs=4

## Description

This adds a white background color to the "Delete photo" x button to make ensure it's visible on dark images.

| Before | After |
| --- | --- |
|<img width="623" alt="Screenshot 2024-07-04 at 19 22 55" src="https://github.com/artsy/force/assets/4691889/b5106263-34fd-4c3a-b24f-fc450a04087f"> |<img width="619" alt="Screenshot 2024-07-04 at 19 22 20" src="https://github.com/artsy/force/assets/4691889/0cb587ee-7e51-4321-9dae-dc093248d242"> |



