### PR TITLE
fix: Add fading animation to Sell flow photo step message

### DIFF
--- a/src/Apps/Sell/Components/UploadMoreMessage.tsx
+++ b/src/Apps/Sell/Components/UploadMoreMessage.tsx
@@ -1,5 +1,6 @@
 import { Message, Text } from "@artsy/palette"
 import { PhotosFormValues } from "Apps/Sell/Routes/PhotosRoute"
+import { FadeInBox } from "Components/FadeInBox"
 import { useFormikContext } from "formik"
 
 export const UploadMoreMessage: React.FC = () => {
@@ -12,11 +13,13 @@ export const UploadMoreMessage: React.FC = () => {
   if (photosCount != 1 && photosCount != 2) return null
 
   return (
-    <Message variant="success" title="Increase your chance of selling" mt={2}>
-      <Text variant="sm-display">
-        Make sure to include images of the back, corners, frame and any other
-        details if you can.
-      </Text>
-    </Message>
+    <FadeInBox>
+      <Message variant="success" title="Increase your chance of selling" mt={2}>
+        <Text variant="sm-display">
+          Make sure to include images of the back, corners, frame and any other
+          details if you can.
+        </Text>
+      </Message>
+    </FadeInBox>
   )
 }


### PR DESCRIPTION

## Description

Adding a fading animation to the Sell flow "Photo" step message to make it appear a bit smoother when removing an image.

<img width="654" alt="Screenshot 2024-07-04 at 21 22 47" src="https://github.com/artsy/force/assets/4691889/27015ca6-2196-4e81-a619-87f6ff247d5f">
