### PR TITLE
fix: Align Sell flow exit button on mobile

### DIFF
--- a/src/Apps/Sell/Components/SubmissionHeader.tsx
+++ b/src/Apps/Sell/Components/SubmissionHeader.tsx
@@ -73,14 +73,29 @@ export const SubmissionHeader: React.FC = () => {
                   </Media>
 
                   {submissionID && !isLastStep ? (
-                    <Button
-                      variant="tertiary"
-                      onClick={handleSaveAndExit}
-                      display="block"
-                      loading={isSubmitting}
-                    >
-                      Save & Exit
-                    </Button>
+                    <>
+                      <Media at="xs">
+                        <RouterLink
+                          to={null}
+                          textDecoration={["none", "underline"]}
+                          onClick={handleSaveAndExit}
+                          display="block"
+                        >
+                          Save & Exit
+                        </RouterLink>
+                      </Media>
+                      <Media greaterThan="xs">
+                        <Button
+                          variant="tertiary"
+                          // @ts-ignore
+                          as={RouterLink}
+                          to={null}
+                          onClick={handleSaveAndExit}
+                        >
+                          Save & Exit
+                        </Button>
+                      </Media>
+                    </>
                   ) : (
                     <>
                       <Media at="xs">

--- a/src/Apps/Sell/Components/SubmissionHeader.tsx
+++ b/src/Apps/Sell/Components/SubmissionHeader.tsx
@@ -91,6 +91,7 @@ export const SubmissionHeader: React.FC = () => {
                           as={RouterLink}
                           to={null}
                           onClick={handleSaveAndExit}
+                          loading={isSubmitting}
                         >
                           Save & Exit
                         </Button>


### PR DESCRIPTION


The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves https://www.notion.so/artsy/Position-of-Save-Exit-is-not-right-aligned-with-the-rest-of-the-content-0ee4259ccf544af98a62bf693c198bad?pvs=4

### Description

Align Sell flow exit button on mobile.

| Before | After |
| --- | --- |
|<img width="412" alt="Screenshot 2024-07-08 at 10 06 21" src="https://github.com/artsy/force/assets/4691889/d3e418ec-84b6-4ed2-8ba5-222b41e1544a"> | <img width="416" alt="Screenshot 2024-07-08 at 10 04 42" src="https://github.com/artsy/force/assets/4691889/2c36d898-78df-44d8-be2c-3a57698b448e">|


<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ