### PR TITLE
chore: Replace new Sell flow routes: `/sell2` - `/sell`

### DIFF
--- a/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/HeaderSWA.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/HeaderSWA.tsx
@@ -63,9 +63,7 @@ export const HeaderSWA = () => {
                 as={RouterLink}
                 width="100%"
                 variant="primaryBlack"
-                to={
-                  enableNewSubmissionFlow ? "sell2/intro" : "/sell/submission"
-                }
+                to={enableNewSubmissionFlow ? "sell/intro" : "/sell/submission"}
                 onClick={event => {
                   trackStartSellingClick("Header")
                 }}

--- a/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/PreviousSubmission.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/PreviousSubmission.tsx
@@ -45,7 +45,7 @@ const PreviousSubmission: React.FC<PreviousSubmissionProps> = ({
   const handlePreviousSubmissionClick = () => {
     if (!submissionID) return
 
-    router.push(`/sell2/submissions/${submissionID}/${currentStep}`)
+    router.push(`/sell/submissions/${submissionID}/${currentStep}`)
   }
 
   if (!submission || submission.state !== "DRAFT") return null

--- a/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/SWAFooter.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/SWAFooter.tsx
@@ -21,7 +21,7 @@ export const SWAFooter: React.FC = () => {
           as={RouterLink}
           width={["100%", 300]}
           variant="primaryBlack"
-          to={enableNewSubmissionFlow ? "sell2/intro" : "/sell/submission"}
+          to={enableNewSubmissionFlow ? "sell/intro" : "/sell/submission"}
           onClick={() => {
             trackStartSellingClick("Footer")
           }}

--- a/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/SWAStickyFooter.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/SWAStickyFooter.tsx
@@ -36,7 +36,7 @@ export const SWAStickyFooter = () => {
         as={RouterLink}
         width="100%"
         variant="primaryBlack"
-        to={enableNewSubmissionFlow ? "sell2/intro" : "/sell/submission"}
+        to={enableNewSubmissionFlow ? "sell/intro" : "/sell/submission"}
         onClick={event => {
           trackStartSellingClick(ContextModule.sellStickyFooter)
         }}

--- a/src/Apps/Consign/Routes/MarketingLanding/Components/__tests__/HeaderSWA.jest.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/__tests__/HeaderSWA.jest.tsx
@@ -52,7 +52,7 @@ describe("HeaderSWA", () => {
 
       expect(link).toBeInTheDocument()
       expect(link).toHaveTextContent("Start Selling")
-      expect(link).toHaveAttribute("href", "sell2/intro")
+      expect(link).toHaveAttribute("href", "sell/intro")
     })
 
     it("tracks click", () => {

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSWASection.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSWASection.tsx
@@ -58,7 +58,7 @@ export const MyCollectionArtworkSWASection: React.FC<MyCollectionArtworkSWASecti
         })
       }
 
-      router.push(`/sell2/submissions/${submissionID}/artist`)
+      router.push(`/sell/submissions/${submissionID}/artist`)
     } catch (error) {
       console.error(error)
     } finally {

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/__tests__/MyCollectionArtworkSWASection.jest.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/__tests__/MyCollectionArtworkSWASection.jest.tsx
@@ -74,7 +74,7 @@ describe("MyCollection Artwork SWA Section", () => {
           fireEvent.click(screen.getByTestId("submit-for-sale-link"))
 
           expect(mockPush).toBeCalledWith(
-            '/sell2/submissions/<mock-value-for-field-"internalID">/artist'
+            '/sell/submissions/<mock-value-for-field-"internalID">/artist'
           )
 
           expect(createOrUpdateConsignSubmission).not.toBeCalled()
@@ -95,7 +95,7 @@ describe("MyCollection Artwork SWA Section", () => {
             expect(createOrUpdateConsignSubmission).toHaveBeenCalled()
 
             expect(mockPush).toBeCalledWith(
-              "/sell2/submissions/submission-id/artist"
+              "/sell/submissions/submission-id/artist"
             )
           })
         })

--- a/src/Apps/Sell/Components/StepsNavigation.tsx
+++ b/src/Apps/Sell/Components/StepsNavigation.tsx
@@ -1,13 +1,13 @@
-import React from "react"
 import { Join, Spacer } from "@artsy/palette"
-import { RouterLink } from "System/Components/RouterLink"
 import { STEPS, useSellFlowContext } from "Apps/Sell/SellFlowContext"
+import React from "react"
+import { RouterLink } from "System/Components/RouterLink"
 
 export const StepsNavigation: React.FC = () => {
   const { state } = useSellFlowContext()
 
   const pathForStep = (step: string) => {
-    return `/sell2/submissions/${state.submissionID}/${step}`
+    return `/sell/submissions/${state.submissionID}/${step}`
   }
 
   const steps = STEPS.filter(step => step !== "thank-you")

--- a/src/Apps/Sell/Routes/ArtistNotEligibleRoute.tsx
+++ b/src/Apps/Sell/Routes/ArtistNotEligibleRoute.tsx
@@ -55,7 +55,7 @@ export const ArtistNotEligibleRoute: React.FC<ArtistNotEligibleRouteProps> = pro
             <Button
               // @ts-ignore
               as={RouterLink}
-              to="/sell2/submissions/new"
+              to="/sell/submissions/new"
               variant="secondaryBlack"
               data-testid="view-collection"
             >

--- a/src/Apps/Sell/Routes/ArtistRoute.tsx
+++ b/src/Apps/Sell/Routes/ArtistRoute.tsx
@@ -94,7 +94,7 @@ export const ArtistRoute: React.FC<{
     const isTargetSupply = artist?.targetSupply?.isTargetSupply
 
     if (!isTargetSupply) {
-      router.push(`/sell2/artist-not-eligible/${artist.internalID}`)
+      router.push(`/sell/artist-not-eligible/${artist.internalID}`)
       return
     }
 
@@ -114,8 +114,8 @@ export const ArtistRoute: React.FC<{
         throw new Error("Submission ID not found.")
       }
 
-      router.replace(`/sell2/submissions/${submissionID}/artist`)
-      router.push(`/sell2/submissions/${submissionID}/title`)
+      router.replace(`/sell/submissions/${submissionID}/artist`)
+      router.push(`/sell/submissions/${submissionID}/title`)
     } catch (error) {
       logger.error("Error creating submission.", error)
     }
@@ -152,7 +152,7 @@ export const ArtistRoute: React.FC<{
 
     if (isNewSubmission) {
       if (!isTargetSupply) {
-        router.push(`/sell2/artist-not-eligible/${artist.internalID}`)
+        router.push(`/sell/artist-not-eligible/${artist.internalID}`)
         return
       }
 

--- a/src/Apps/Sell/Routes/IntroRoute.tsx
+++ b/src/Apps/Sell/Routes/IntroRoute.tsx
@@ -72,7 +72,7 @@ export const IntroRoute: React.FC = () => {
               onClick={() => {
                 trackTappedNewSubmission()
               }}
-              to="/sell2/submissions/new"
+              to="/sell/submissions/new"
               width="100%"
               data-testid="start-new-submission"
             >
@@ -88,7 +88,7 @@ export const IntroRoute: React.FC = () => {
                   onClick={() => {
                     trackTappedStartMyCollection()
                   }
-                  to="/sell2/submissions/new/collection"
+                  to="/sell/submissions/new/collection"
                   width="100%"
                 >
                   New from My Collection

--- a/src/Apps/Sell/Routes/ThankYouRoute.tsx
+++ b/src/Apps/Sell/Routes/ThankYouRoute.tsx
@@ -51,7 +51,7 @@ export const ThankYouRoute: React.FC<ThankYouRouteProps> = props => {
               <Button
                 // @ts-ignore
                 as={RouterLink}
-                to="/sell2/submissions/new"
+                to="/sell/submissions/new"
                 onClick={() => {
                   trackTappedSubmitAnotherWork(submission.internalID)
                 }}

--- a/src/Apps/Sell/Routes/__tests__/ArtistNotEligibleRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/ArtistNotEligibleRoute.jest.tsx
@@ -71,7 +71,7 @@ describe("ArtistNotEligibleRoute", () => {
 
     expect(screen.getByTestId("view-collection")).toHaveAttribute(
       "href",
-      "/sell2/submissions/new"
+      "/sell/submissions/new"
     )
   })
 

--- a/src/Apps/Sell/Routes/__tests__/DetailsRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/DetailsRoute.jest.tsx
@@ -100,7 +100,7 @@ describe("DetailsRoute", () => {
 
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith(
-        '/sell2/submissions/<mock-value-for-field-"externalId">/details'
+        '/sell/submissions/<mock-value-for-field-"externalId">/details'
       )
 
       expect(submitMutation).toHaveBeenCalledWith(
@@ -127,7 +127,7 @@ describe("DetailsRoute", () => {
 
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith(
-        '/sell2/submissions/<mock-value-for-field-"externalId">/photos'
+        '/sell/submissions/<mock-value-for-field-"externalId">/photos'
       )
 
       expect(submitMutation).toHaveBeenCalledWith(

--- a/src/Apps/Sell/Routes/__tests__/DimensionsRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/DimensionsRoute.jest.tsx
@@ -133,7 +133,7 @@ describe("DimensionsRoute", () => {
         )
 
         expect(mockPush).toHaveBeenCalledWith(
-          '/sell2/submissions/<mock-value-for-field-"externalId">/phone-number'
+          '/sell/submissions/<mock-value-for-field-"externalId">/phone-number'
         )
       })
     })
@@ -149,7 +149,7 @@ describe("DimensionsRoute", () => {
 
       await waitFor(() => {
         expect(mockPush).toHaveBeenCalledWith(
-          '/sell2/submissions/<mock-value-for-field-"externalId">/purchase-history'
+          '/sell/submissions/<mock-value-for-field-"externalId">/purchase-history'
         )
 
         expect(submitMutation).toHaveBeenCalledWith(

--- a/src/Apps/Sell/Routes/__tests__/IntroRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/IntroRoute.jest.tsx
@@ -69,7 +69,7 @@ describe("IntroRoute", () => {
     expect(startNewSubmissionButton).toBeInTheDocument()
     expect(startNewSubmissionButton).toHaveAttribute(
       "href",
-      "/sell2/submissions/new"
+      "/sell/submissions/new"
     )
 
     fireEvent.click(startNewSubmissionButton)

--- a/src/Apps/Sell/Routes/__tests__/PhoneNumberRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/PhoneNumberRoute.jest.tsx
@@ -1,12 +1,12 @@
 import { screen, waitFor } from "@testing-library/react"
-import { SubmissionRoute } from "Apps/Sell/Routes/SubmissionRoute"
 import { PhoneNumberRoute } from "Apps/Sell/Routes/PhoneNumberRoute"
+import { SubmissionRoute } from "Apps/Sell/Routes/SubmissionRoute"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { useRouter } from "System/Hooks/useRouter"
 import { useSystemContext } from "System/Hooks/useSystemContext"
-import { graphql } from "react-relay"
 import { useMutation } from "Utils/Hooks/useMutation"
 import { PhoneNumberRoute_Test_Query$rawResponse } from "__generated__/PhoneNumberRoute_Test_Query.graphql"
+import { graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 
 const mockUseRouter = useRouter as jest.Mock
@@ -125,7 +125,7 @@ describe("PhoneNumberRoute", () => {
         )
 
         expect(mockPush).toHaveBeenCalledWith(
-          '/sell2/submissions/<mock-value-for-field-"externalId">/thank-you'
+          '/sell/submissions/<mock-value-for-field-"externalId">/thank-you'
         )
       })
     })

--- a/src/Apps/Sell/Routes/__tests__/PhotosRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/PhotosRoute.jest.tsx
@@ -296,7 +296,7 @@ describe("PhotosRoute", () => {
 
       await waitFor(() => {
         expect(mockPush).toHaveBeenCalledWith(
-          "/sell2/submissions/externalId/details"
+          "/sell/submissions/externalId/details"
         )
       })
     })
@@ -310,7 +310,7 @@ describe("PhotosRoute", () => {
 
       await waitFor(() => {
         expect(mockPush).toHaveBeenCalledWith(
-          "/sell2/submissions/externalId/title"
+          "/sell/submissions/externalId/title"
         )
       })
     })

--- a/src/Apps/Sell/Routes/__tests__/PurchaseHistoryRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/PurchaseHistoryRoute.jest.tsx
@@ -120,7 +120,7 @@ describe("PurchaseHistoryRoute", () => {
 
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith(
-        '/sell2/submissions/<mock-value-for-field-"externalId">/dimensions'
+        '/sell/submissions/<mock-value-for-field-"externalId">/dimensions'
       )
 
       expect(submitMutation).toHaveBeenCalledWith(
@@ -146,7 +146,7 @@ describe("PurchaseHistoryRoute", () => {
 
     await waitFor(() => {
       expect(mockPush).toHaveBeenCalledWith(
-        '/sell2/submissions/<mock-value-for-field-"externalId">/details'
+        '/sell/submissions/<mock-value-for-field-"externalId">/details'
       )
 
       expect(submitMutation).toHaveBeenCalledWith(

--- a/src/Apps/Sell/Routes/__tests__/ThankYouRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/ThankYouRoute.jest.tsx
@@ -77,7 +77,7 @@ describe("ThankYouRoute", () => {
     const submitAnotherWorkButton = screen.getByTestId("submit-another-work")
     expect(submitAnotherWorkButton).toHaveAttribute(
       "href",
-      "/sell2/submissions/new"
+      "/sell/submissions/new"
     )
 
     submitAnotherWorkButton.click()

--- a/src/Apps/Sell/SellFlowContext.tsx
+++ b/src/Apps/Sell/SellFlowContext.tsx
@@ -123,7 +123,7 @@ export const SellFlowContextProvider: React.FC<SellFlowContextProviderProps> = (
       state: "SUBMITTED",
     })
 
-    push(`/sell2/submissions/${submissionID}/thank-you`)
+    push(`/sell/submissions/${submissionID}/thank-you`)
   }
 
   useEffect(() => {
@@ -131,7 +131,7 @@ export const SellFlowContextProvider: React.FC<SellFlowContextProviderProps> = (
 
     if (isNewSubmission || !newStep) return
 
-    push(`/sell2/submissions/${submissionID}/${newStep}`)
+    push(`/sell/submissions/${submissionID}/${newStep}`)
   }, [push, index, isNewSubmission, submissionID])
 
   const createSubmission = (values: CreateSubmissionMutationInput) => {

--- a/src/Apps/Sell/sellRoutes.tsx
+++ b/src/Apps/Sell/sellRoutes.tsx
@@ -105,7 +105,7 @@ const ArtistNotEligibleRoute = loadable(
 
 export const sellRoutes: RouteProps[] = [
   {
-    path: "/sell2",
+    path: "/sell",
     children: [
       {
         path: "intro",


### PR DESCRIPTION
Solves https://artsyproduct.atlassian.net/browse/ONYX-1106

## Description

This updates all the routes for the new Sell flow from `/sell2` to `/sell`. We want to do this before the release to ensure screen tracking works as expected.

There is already a ticket for cleaning up the old `/sell` routes ([ONYX-1074](https://artsyproduct.atlassian.net/browse/ONYX-1074)).

[ONYX-1074]: https://artsyproduct.atlassian.net/browse/ONYX-1074?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ