### PR TITLE
feat(ai): simplify the list of interests

### DIFF
--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Form/Interests.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Form/Interests.tsx
@@ -25,12 +25,7 @@ export const INTERESTS = [
   "Design Objects and Furniture",
   // artist segments
   "Emerging artists",
-  "Critically acclaimed",
-  "Blue chip",
-  "New & Noteworthy",
-  "Trending Emerging",
-  "Street & urban artists",
-  "Ultra-high demand",
+  "Blue chip artists",
   // passions
   "Social issues",
   "Supporting local galleries",

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Form/Interests.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Form/Interests.tsx
@@ -6,7 +6,6 @@ import { SuggestionPill } from "./SuggestionPill"
 export const INTERESTS = [
   // movements
   "Contemporary Art",
-  "Emerging Art",
   "Post-War Art",
   "Abstract Art",
   "Figurative Art",

--- a/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Form/Interests.tsx
+++ b/src/Apps/ArtAdvisor/07-Curated-Discovery/Components/Form/Interests.tsx
@@ -16,12 +16,14 @@ export const INTERESTS = [
   // mediums
   "Painting",
   "Prints",
-  "Works on Paper",
+  "Drawings",
+  "Collage",
   "Photography",
   "Sculpture",
+  "Mixed media",
   "Ceramics",
   "Textile Art",
-  "Design Objects and Furniture",
+  "Design and Decorative Art",
   // artist segments
   "Emerging artists",
   "Blue chip artists",


### PR DESCRIPTION
Per [this comment](https://artsy.slack.com/archives/C06SSV1K10D/p1720551004527469?thread_ts=1720550997.373359&cid=C06SSV1K10D), this just slims down and slightly rationalizes the list of interests. 

Nothing gospel here, just an incremental improvement before the next demo.

## Before

![before](https://github.com/artsy/force/assets/140521/f3987e64-7203-46bc-89de-d4e5b03efa2e)

## After 

![after](https://github.com/artsy/force/assets/140521/23f0549c-1d71-490b-b344-ccbc226aa5e9)

