### PR TITLE
fix: switching from saved pickup back to shipping

### DIFF
--- a/src/Apps/Order/Routes/Shipping2/Components/FulfillmentDetails.tsx
+++ b/src/Apps/Order/Routes/Shipping2/Components/FulfillmentDetails.tsx
@@ -300,8 +300,7 @@ const ME_FRAGMENT = graphql`
  */
 const getInitialValues = (
   meData: ShippingContextProps["meData"],
-  orderData: ShippingContextProps["orderData"],
-  forceNewAddressFormMode?: boolean
+  orderData: ShippingContextProps["orderData"]
 ): FulfillmentValues => {
   if (orderData.savedFulfillmentDetails) {
     return {

--- a/src/Apps/Order/Routes/Shipping2/Components/FulfillmentDetails.tsx
+++ b/src/Apps/Order/Routes/Shipping2/Components/FulfillmentDetails.tsx
@@ -82,29 +82,28 @@ export const FulfillmentDetails: FC<FulfillmentDetailsProps> = ({
   }, [hasSavedAddresses])
 
   /*
-   * Re-save fulfillment details on load if they are already saved
-   * and shipping quotes need refreshing for new address mode only
+   * Re-save fulfillment details on load if they are already saved &
+   * require artsy shipping (new address form mode only - saved addresses
+   * handle this separately)
    */
   useEffect(() => {
-    const existingFulfillmentDetails =
-      shippingContext.orderData.savedFulfillmentDetails
+    const { savedFulfillmentDetails } = shippingContext.orderData
 
     const isArtsyShippingSaved =
-      existingFulfillmentDetails?.fulfillmentType === FulfillmentType.SHIP &&
-      shippingContext.orderData.requiresArtsyShippingTo(
-        existingFulfillmentDetails.attributes.country
-      )
+      savedFulfillmentDetails?.fulfillmentType === FulfillmentType.SHIP &&
+      savedFulfillmentDetails.isArtsyShipping &&
+      shippingContext.meData.addressList.length === 0
 
     if (isArtsyShippingSaved) {
       const refreshShippingQuotes = async () => {
         // instead of handleSubmit, call the save fulfillment details function
         // directly
         const result = await handleSaveFulfillmentDetails({
-          attributes: existingFulfillmentDetails.attributes,
+          attributes: savedFulfillmentDetails.attributes,
           fulfillmentType: FulfillmentType.SHIP,
           meta: {
             // FIXME: Will clobber previous address verification (but we can't
-            // know what the previous status was unless we read from server)
+            // know what the previous status was until we can read from server)
             addressVerifiedBy: null,
           },
         })

--- a/src/Apps/Order/Routes/Shipping2/Components/FulfillmentDetails.tsx
+++ b/src/Apps/Order/Routes/Shipping2/Components/FulfillmentDetails.tsx
@@ -83,17 +83,19 @@ export const FulfillmentDetails: FC<FulfillmentDetailsProps> = ({
 
   /*
    * Re-save fulfillment details on load if they are already saved
-   * and shipping quotes need refreshing for new address mode only ?? Is this correct?
+   * and shipping quotes need refreshing for new address mode only
    */
   useEffect(() => {
     const existingFulfillmentDetails =
       shippingContext.orderData.savedFulfillmentDetails
-    if (
+
+    const isArtsyShippingSaved =
       existingFulfillmentDetails?.fulfillmentType === FulfillmentType.SHIP &&
       shippingContext.orderData.requiresArtsyShippingTo(
         existingFulfillmentDetails.attributes.country
       )
-    ) {
+
+    if (isArtsyShippingSaved) {
       const refreshShippingQuotes = async () => {
         // instead of handleSubmit, call the save fulfillment details function
         // directly

--- a/src/Apps/Order/Routes/Shipping2/Components/FulfillmentDetails.tsx
+++ b/src/Apps/Order/Routes/Shipping2/Components/FulfillmentDetails.tsx
@@ -10,7 +10,7 @@ import {
   FulfillmentValues,
   ShipValues,
   addressWithFallbackValues,
-  getDefaultUserAddress,
+  getInitialShippingValues,
 } from "Apps/Order/Routes/Shipping2/Utils/shippingUtils"
 import { FulfillmentDetailsForm_me$key } from "__generated__/FulfillmentDetailsForm_me.graphql"
 import createLogger from "Utils/logger"
@@ -83,7 +83,7 @@ export const FulfillmentDetails: FC<FulfillmentDetailsProps> = ({
 
   /*
    * Re-save fulfillment details on load if they are already saved
-   * and shipping quotes need refreshing for new address mode only
+   * and shipping quotes need refreshing for new address mode only ?? Is this correct?
    */
   useEffect(() => {
     const existingFulfillmentDetails =
@@ -319,40 +319,9 @@ const getInitialValues = (
 
   const savedAddresses = meData.addressList
 
-  // The default ship-to address should be the first one that
-  // can be shipped-to, preferring the default
-
-  const defaultUserAddress = getDefaultUserAddress(
+  return getInitialShippingValues(
     savedAddresses,
+    orderData.shipsFrom,
     orderData.availableShippingCountries
   )
-
-  if (defaultUserAddress) {
-    return {
-      fulfillmentType: FulfillmentType.SHIP,
-      attributes: addressWithFallbackValues(defaultUserAddress),
-      meta: {
-        saveAddress: false,
-        addressVerifiedBy: null,
-      },
-    }
-  }
-
-  // The user doesn't have a valid ship-to address, so we'll return empty values.
-  // TODO: This doesn't account for matching the saved address id
-  // (that is still in parsedOrderData). In addition the initial values
-  // are less relevant if the user has saved addresses - Setting country
-  // doesn't matter.
-  const initialFulfillmentValues: ShipValues["attributes"] = addressWithFallbackValues(
-    { country: orderData.shipsFrom }
-  )
-
-  return {
-    fulfillmentType: FulfillmentType.SHIP,
-    attributes: initialFulfillmentValues,
-    meta: {
-      addressVerifiedBy: null,
-      saveAddress: true,
-    },
-  }
 }

--- a/src/Apps/Order/Routes/Shipping2/Components/FulfillmentDetailsForm.tsx
+++ b/src/Apps/Order/Routes/Shipping2/Components/FulfillmentDetailsForm.tsx
@@ -205,7 +205,6 @@ const FulfillmentDetailsFormLayout = (
 
     if (newValue === FulfillmentType.PICKUP) {
       const initialValuesForPickup: PickupValues = {
-        // ...values,
         fulfillmentType: FulfillmentType.PICKUP,
         attributes: {
           name: "",

--- a/src/Apps/Order/Routes/Shipping2/Components/FulfillmentDetailsForm.tsx
+++ b/src/Apps/Order/Routes/Shipping2/Components/FulfillmentDetailsForm.tsx
@@ -21,8 +21,10 @@ import {
   BASIC_PHONE_VALIDATION_SHAPE,
   FulfillmentType,
   FulfillmentValues,
+  PickupValues,
   ShipValues,
   addressWithFallbackValues,
+  getInitialShippingValues,
 } from "Apps/Order/Routes/Shipping2/Utils/shippingUtils"
 import { CountrySelect } from "Components/CountrySelect"
 import { RouterLink } from "System/Components/RouterLink"
@@ -107,6 +109,7 @@ const FulfillmentDetailsFormLayout = (
     handleBlur,
     setFieldValue,
     setValues,
+    setTouched,
   } = formikContext
 
   const addressFormMode: AddressFormMode =
@@ -190,47 +193,49 @@ const FulfillmentDetailsFormLayout = (
     formikContext.submitForm()
   }
 
-  /**
-   * Effects
-   */
+  const previousFulfillmentType = usePrevious(values.fulfillmentType)
 
-  // Reset form fields when switching between ship/pickup
-  const previousValues = usePrevious(values)
-
-  useEffect(() => {
-    const resetAttributesOnFulfillmentTypeChange = async () => {
-      if (values.fulfillmentType !== previousValues.fulfillmentType) {
-        if (values.fulfillmentType === FulfillmentType.PICKUP) {
-          await setValues({
-            ...values,
-            attributes: {
-              name: "",
-              phoneNumber: "",
-              addressLine1: "",
-              addressLine2: "",
-              city: "",
-              region: "",
-              postalCode: "",
-              country: "",
-            },
-          })
-          return
-        }
-
-        if (values.fulfillmentType === FulfillmentType.SHIP) {
-          // reset to current initialValues (based on calculation in FulfillmentDetails.tsx)
-          formikContext.resetForm()
-        }
-      }
+  const handleChangeFulfillmentType = async (newValue: FulfillmentType) => {
+    if (newValue === previousFulfillmentType) {
+      return
     }
-    resetAttributesOnFulfillmentTypeChange()
-  }, [
-    setValues,
-    previousValues.fulfillmentType,
-    formikContext,
-    values,
-    shippingContext.actions,
-  ])
+
+    shippingContext.actions.goBackToFulfillmentDetails()
+    await setTouched({})
+
+    if (newValue === FulfillmentType.PICKUP) {
+      const initialValuesForPickup: PickupValues = {
+        // ...values,
+        fulfillmentType: FulfillmentType.PICKUP,
+        attributes: {
+          name: "",
+          phoneNumber: "",
+          addressLine1: "",
+          addressLine2: "",
+          city: "",
+          region: "",
+          postalCode: "",
+          country: "",
+        },
+        meta: {},
+      }
+
+      await setValues(initialValuesForPickup)
+      return
+    }
+
+    if (newValue === FulfillmentType.SHIP) {
+      const savedAddresses = shippingContext.meData.addressList
+
+      await setValues(
+        getInitialShippingValues(
+          savedAddresses,
+          shippingContext.orderData.shipsFrom,
+          shippingContext.orderData.availableShippingCountries
+        )
+      )
+    }
+  }
 
   // When not showing the form/creating a new address,
   // inputs should not be tabbable
@@ -261,12 +266,9 @@ const FulfillmentDetailsFormLayout = (
         <>
           <RadioGroup
             data-testid="shipping-options"
-            onSelect={withBackToFulfillmentDetails(value => {
-              setFieldValue("fulfillmentType", value)
-              if (value === FulfillmentType.PICKUP) {
-                shippingContext.actions.goBackToFulfillmentDetails()
-              }
-            })}
+            onSelect={value => {
+              handleChangeFulfillmentType(value)
+            }}
             defaultValue={values.fulfillmentType}
           >
             <Text variant="lg-display" mb="1">
@@ -538,7 +540,7 @@ const FulfillmentDetailsFormLayout = (
                         touched.attributes?.phoneNumber &&
                         errors.attributes?.phoneNumber
                       }
-                      data-testid="AddressForm_phoneNumber"
+                      data-testid="AddressForm_shipPhoneNumber"
                     />
                   </Column>
                 </>
@@ -581,7 +583,7 @@ const FulfillmentDetailsFormLayout = (
                 touched.attributes?.phoneNumber &&
                 errors.attributes?.phoneNumber
               }
-              data-testid="AddressForm_phoneNumber"
+              data-testid="AddressForm_pickupPhoneNumber"
             />
             <Spacer y={4} />
           </>

--- a/src/Apps/Order/Routes/Shipping2/Components/__tests__/FulfillmentDetailsForm.jest.tsx
+++ b/src/Apps/Order/Routes/Shipping2/Components/__tests__/FulfillmentDetailsForm.jest.tsx
@@ -105,6 +105,8 @@ beforeEach(() => {
     orderData: {
       shippingQuotes: [],
     },
+    meData: { addressList: [] },
+
     state: {
       shippingFormMode: "saved_addresses",
     },
@@ -261,9 +263,28 @@ describe("FulfillmentDetailsForm", () => {
       })
     })
 
-    it.todo(
-      "user can select shipping if pickup fulfillment is already saved to order"
-    )
+    it("user can select shipping if pickup fulfillment is already saved to order", async () => {
+      testProps.initialValues!.fulfillmentType = FulfillmentType.PICKUP
+      testProps.initialValues!.attributes = {
+        name: "John Doe",
+        phoneNumber: "1234567890",
+        addressLine1: "401 Broadway",
+        city: "New York",
+        region: "NY",
+        postalCode: "10013",
+        country: "US",
+      }
+      renderTree(testProps)
+
+      let shippingRadio: HTMLElement = await screen.findByRole("radio", {
+        name: "Shipping",
+      })
+
+      await userEvent.click(shippingRadio)
+      await waitFor(() => {
+        expect(screen.getByPlaceholderText("City")).toBeVisible()
+      })
+    })
   })
 
   describe("Pickup not available", () => {

--- a/src/Apps/Order/Routes/Shipping2/Components/__tests__/FulfillmentDetailsForm.jest.tsx
+++ b/src/Apps/Order/Routes/Shipping2/Components/__tests__/FulfillmentDetailsForm.jest.tsx
@@ -159,8 +159,8 @@ describe("FulfillmentDetailsForm", () => {
         screen.getByRole("radio", { name: /Arrange for pickup/ })
       )
 
-      const phoneNumberField = await screen.findByPlaceholderText(
-        "Add phone number including country code"
+      const phoneNumberField = await screen.findByTestId(
+        "AddressForm_pickupPhoneNumber"
       )
 
       expect(phoneNumberField).toBeVisible()
@@ -210,8 +210,8 @@ describe("FulfillmentDetailsForm", () => {
       await userEvent.click(
         screen.getByRole("radio", { name: /Arrange for pickup/ })
       )
-      const phoneNumberField = await screen.findByPlaceholderText(
-        "Add phone number including country code"
+      const phoneNumberField = await screen.findByTestId(
+        "AddressForm_pickupPhoneNumber"
       )
 
       await userEvent.type(phoneNumberField, "1234567890")
@@ -260,6 +260,10 @@ describe("FulfillmentDetailsForm", () => {
         expect(screen.getByPlaceholderText("City")).toBeVisible()
       })
     })
+
+    it.todo(
+      "user can select shipping if pickup fulfillment is already saved to order"
+    )
   })
 
   describe("Pickup not available", () => {

--- a/src/Apps/Order/Routes/Shipping2/Utils/shippingUtils.ts
+++ b/src/Apps/Order/Routes/Shipping2/Utils/shippingUtils.ts
@@ -12,7 +12,7 @@ export enum FulfillmentType {
 export interface PickupValues {
   fulfillmentType: FulfillmentType.PICKUP
   attributes: {
-    name: string
+    name: ""
     phoneNumber: string
     // Even though these don't appear on the form
     // we want values to not mess with the controlled/
@@ -135,9 +135,59 @@ export const getDefaultUserAddress = (
     if (!filterCountries) return true
     return filterCountries.includes(node.country)
   })
+
+  if (shippableAddresses.length === 0) {
+    return null
+  }
+
   return (
     shippableAddresses.find(node => node.isDefault) || shippableAddresses[0]
   )
+}
+
+export const getInitialShippingValues = (
+  savedAddresses: SavedAddressType[],
+  defaultCountry,
+  filterCountries?: string[]
+): ShipValues => {
+  const defaultUserAddress = getDefaultUserAddress(
+    savedAddresses,
+    filterCountries
+  )
+
+  // The default ship-to address should be the first one that
+  // can be shipped-to, preferring the default address if it exists.
+  const attributesFromDefaultAddress: ShipValues["attributes"] = addressWithFallbackValues(
+    defaultUserAddress
+  )
+  if (defaultUserAddress) {
+    return {
+      fulfillmentType: FulfillmentType.SHIP,
+      attributes: attributesFromDefaultAddress,
+      meta: {
+        saveAddress: false,
+        addressVerifiedBy: null,
+      },
+    }
+  }
+
+  // The user doesn't have a valid ship-to address, so we'll return empty values.
+  // TODO: This doesn't account for matching the saved address id
+  // (that is still in parsedOrderData). In addition the initial values
+  // are less relevant if the user has saved addresses - Setting country
+  // doesn't matter.
+  const initialFulfillmentValues: ShipValues["attributes"] = addressWithFallbackValues(
+    { country: defaultCountry }
+  )
+
+  return {
+    fulfillmentType: FulfillmentType.SHIP,
+    attributes: initialFulfillmentValues,
+    meta: {
+      addressVerifiedBy: null,
+      saveAddress: true,
+    },
+  }
 }
 
 export const matchAddressFields = (...addressPair: [object, object]) => {

--- a/src/Apps/Order/Routes/Shipping2/Utils/shippingUtils.ts
+++ b/src/Apps/Order/Routes/Shipping2/Utils/shippingUtils.ts
@@ -172,10 +172,6 @@ export const getInitialShippingValues = (
   }
 
   // The user doesn't have a valid ship-to address, so we'll return empty values.
-  // TODO: This doesn't account for matching the saved address id
-  // (that is still in parsedOrderData). In addition the initial values
-  // are less relevant if the user has saved addresses - Setting country
-  // doesn't matter.
   const initialFulfillmentValues: ShipValues["attributes"] = addressWithFallbackValues(
     { country: defaultCountry }
   )

--- a/src/Apps/Order/Routes/Shipping2/__tests__/Shipping2.jest.tsx
+++ b/src/Apps/Order/Routes/Shipping2/__tests__/Shipping2.jest.tsx
@@ -319,6 +319,14 @@ describe.skip("Shipping", () => {
     `,
   })
 
+  describe("initial load with order data", () => {
+    it.todo("loads with saved shipping fulfillment and no saved addresses")
+    it.todo(
+      "loads with saved shipping fulfillment and matching saved addresses"
+    )
+    it.todo("loads with saved pickup fulfillment")
+  })
+
   describe("with partner shipping", () => {
     describe("with no saved address", () => {
       it("shows an active offer stepper if it's an offer order", async () => {
@@ -2289,8 +2297,8 @@ describe.skip("Shipping", () => {
         screen.getByRole("radio", { name: /Arrange for pickup/ })
       )
 
-      const phoneNumber = screen.getByPlaceholderText(
-        "Add phone number including country code"
+      const phoneNumber = await screen.findByTestId(
+        "AddressForm_pickupPhoneNumber"
       )
       // TODO: need a better way to check the input is displayed/expanded (height > 0)
       expect(phoneNumber).toHaveAttribute("tabindex", "0")

--- a/src/Apps/Order/Routes/Shipping2/__tests__/Shipping2.jest.tsx
+++ b/src/Apps/Order/Routes/Shipping2/__tests__/Shipping2.jest.tsx
@@ -320,11 +320,88 @@ describe.skip("Shipping", () => {
   })
 
   describe("initial load with order data", () => {
-    it.todo("loads with saved shipping fulfillment and no saved addresses")
-    it.todo(
-      "loads with saved shipping fulfillment and matching saved addresses"
-    )
-    it.todo("loads with saved pickup fulfillment")
+    it("loads with saved shipping fulfillment and no saved addresses", async () => {
+      ;(order.requestedFulfillment as any) = {
+        __typename: "CommerceShip",
+        name: "Dr Collector",
+        addressLine1: "1 Main St",
+        addressLine2: "",
+        city: "Madrid",
+        country: "ES",
+        postalCode: "28001",
+        region: "",
+        phoneNumber: "555-555-5555",
+      }
+      renderWithRelay({
+        CommerceOrder: () => order,
+        Me: () => meWithoutAddress,
+      })
+
+      const renderedFullName = await screen.findByDisplayValue("Dr Collector")
+      expect(renderedFullName).toHaveValue("Dr Collector")
+      expect(screen.getByPlaceholderText("Street address")).toHaveValue(
+        "1 Main St"
+      )
+      expect(screen.getByPlaceholderText("City")).toHaveValue("Madrid")
+      expect(screen.getByPlaceholderText("ZIP/Postal code")).toHaveValue(
+        "28001"
+      )
+      expect(
+        screen.getByPlaceholderText("Add phone number including country code")
+      ).toHaveValue("555-555-5555")
+    })
+
+    it("loads with saved shipping fulfillment and matching saved addresses", async () => {
+      const expectedAddress = meWithAddresses.addressConnection!.edges![1]!
+        .node!
+      const unexpectedAddress = meWithAddresses.addressConnection!.edges![0]!
+        .node!
+
+      ;(order.requestedFulfillment as any) = {
+        __typename: "CommerceShip",
+        name: expectedAddress.name,
+        addressLine1: expectedAddress.addressLine1,
+        addressLine2: expectedAddress.addressLine2,
+        city: expectedAddress.city,
+        country: expectedAddress.country,
+        postalCode: expectedAddress.postalCode,
+        region: expectedAddress.region,
+        phoneNumber: expectedAddress.phoneNumber,
+      }
+
+      renderWithRelay({
+        CommerceOrder: () => order,
+        Me: () => meWithAddresses,
+      })
+
+      expect(expectedAddress.addressLine1).toEqual("401 Broadway")
+      expect(unexpectedAddress.addressLine1).toEqual("1 Main St")
+
+      expect(screen.getByRole("radio", { name: /401 Broadway/ })).toBeChecked()
+      expect(screen.getByRole("radio", { name: /1 Main St/ })).not.toBeChecked()
+    })
+    it("loads with saved pickup fulfillment", async () => {
+      ;(order.requestedFulfillment as any) = {
+        __typename: "CommercePickup",
+        fulfillmentType: "PICKUP",
+        phoneNumber: "555-555-5555",
+      }
+
+      renderWithRelay({
+        CommerceOrder: () => order,
+        Me: () => meWithoutAddress,
+      })
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole("radio", { name: /Arrange for pickup/ })
+        ).toBeChecked()
+      })
+
+      expect(
+        screen.getByPlaceholderText("Add phone number including country code")
+      ).toHaveValue("555-555-5555")
+    })
   })
 
   describe("with partner shipping", () => {

--- a/src/Apps/Order/Routes/Shipping2/__tests__/Shipping2.jest.tsx
+++ b/src/Apps/Order/Routes/Shipping2/__tests__/Shipping2.jest.tsx
@@ -321,19 +321,22 @@ describe.skip("Shipping", () => {
 
   describe("initial load with order data", () => {
     it("loads with saved shipping fulfillment and no saved addresses", async () => {
-      ;(order.requestedFulfillment as any) = {
-        __typename: "CommerceShip",
-        name: "Dr Collector",
-        addressLine1: "1 Main St",
-        addressLine2: "",
-        city: "Madrid",
-        country: "ES",
-        postalCode: "28001",
-        region: "",
-        phoneNumber: "555-555-5555",
+      const orderWithFulfillment = {
+        ...order,
+        requestedFulfillment: {
+          __typename: "CommerceShip",
+          name: "Dr Collector",
+          addressLine1: "1 Main St",
+          addressLine2: "",
+          city: "Madrid",
+          country: "ES",
+          postalCode: "28001",
+          region: "",
+          phoneNumber: "555-555-5555",
+        },
       }
       renderWithRelay({
-        CommerceOrder: () => order,
+        CommerceOrder: () => orderWithFulfillment,
         Me: () => meWithoutAddress,
       })
 
@@ -357,20 +360,23 @@ describe.skip("Shipping", () => {
       const unexpectedAddress = meWithAddresses.addressConnection!.edges![0]!
         .node!
 
-      ;(order.requestedFulfillment as any) = {
-        __typename: "CommerceShip",
-        name: expectedAddress.name,
-        addressLine1: expectedAddress.addressLine1,
-        addressLine2: expectedAddress.addressLine2,
-        city: expectedAddress.city,
-        country: expectedAddress.country,
-        postalCode: expectedAddress.postalCode,
-        region: expectedAddress.region,
-        phoneNumber: expectedAddress.phoneNumber,
+      const orderWithFulfillment = {
+        ...order,
+        requestedFulfillment: {
+          __typename: "CommerceShip",
+          name: expectedAddress.name,
+          addressLine1: expectedAddress.addressLine1,
+          addressLine2: expectedAddress.addressLine2,
+          city: expectedAddress.city,
+          country: expectedAddress.country,
+          postalCode: expectedAddress.postalCode,
+          region: expectedAddress.region,
+          phoneNumber: expectedAddress.phoneNumber,
+        },
       }
 
       renderWithRelay({
-        CommerceOrder: () => order,
+        CommerceOrder: () => orderWithFulfillment,
         Me: () => meWithAddresses,
       })
 
@@ -381,14 +387,17 @@ describe.skip("Shipping", () => {
       expect(screen.getByRole("radio", { name: /1 Main St/ })).not.toBeChecked()
     })
     it("loads with saved pickup fulfillment", async () => {
-      ;(order.requestedFulfillment as any) = {
-        __typename: "CommercePickup",
-        fulfillmentType: "PICKUP",
-        phoneNumber: "555-555-5555",
+      const orderWithFulfillment = {
+        ...order,
+        requestedFulfillment: {
+          __typename: "CommercePickup",
+          fulfillmentType: "PICKUP",
+          phoneNumber: "555-555-5555",
+        },
       }
 
       renderWithRelay({
-        CommerceOrder: () => order,
+        CommerceOrder: () => orderWithFulfillment,
         Me: () => meWithoutAddress,
       })
 


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->


This PR solves [EMI-1957]

### Description

This PR fixes a bug where you cannot switch from pickup back to shipping if the order loads with a saved pickup fulfillment. The issue was that we were resetting the form to its initial values when changing from pickup to shipping, but those initial values were for a pickup fulfillment if that was what was saved to the order.

Added tests as todos, but existing tests passed.

[EMI-1957]: https://artsyproduct.atlassian.net/browse/EMI-1957?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ