### PR TITLE
chore: defer auth prompt in redesigned submission flow

### DIFF
--- a/src/Apps/Sell/Components/BottomFormNavigation.tsx
+++ b/src/Apps/Sell/Components/BottomFormNavigation.tsx
@@ -1,12 +1,14 @@
 import { ContextModule, Intent } from "@artsy/cohesion"
 import { Box, Button, Flex } from "@artsy/palette"
 import { useSubmissionTracking } from "Apps/Sell/Hooks/useSubmissionTracking"
+import { useAssociateSubmission } from "Apps/Sell/Mutations/useAssociateSubmission"
 import { useSellFlowContext } from "Apps/Sell/SellFlowContext"
 import { useAuthDialog } from "Components/AuthDialog"
 import { useSystemContext } from "System/Hooks/useSystemContext"
+import { useAuthIntent } from "Utils/Hooks/useAuthIntent"
 import createLogger from "Utils/logger"
 import { useFormikContext } from "formik"
-import { useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 
 const logger = createLogger("BottomFormNavigation.tsx")
 
@@ -33,7 +35,7 @@ const BottomFormBackButton = () => {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const { submitForm } = useFormikContext()
   const {
-    actions,
+    actions: { goToPreviousStep },
     state: { loading, isFirstStep, submission, step },
   } = useSellFlowContext()
 
@@ -45,7 +47,7 @@ const BottomFormBackButton = () => {
     try {
       await submitForm()
 
-      await actions.goToPreviousStep()
+      await goToPreviousStep()
     } catch (error) {
       logger.error("Error submitting form", error)
     } finally {
@@ -75,55 +77,94 @@ const BottomFormNextButton = () => {
   const { isLoggedIn } = useSystemContext()
   const { showAuthDialog } = useAuthDialog()
   const { trackTappedContinueSubmission } = useSubmissionTracking()
+  const {
+    submitMutation: associateSubmissionMutation,
+  } = useAssociateSubmission()
+  const { value, clearValue } = useAuthIntent()
 
   const {
-    state: { loading },
+    actions: { goToNextStep},
+    state: { submission, isSubmitStep, nextStep, loading },
   } = useSellFlowContext()
 
-  const {
-    actions,
-    state: { submission, isSubmitStep, nextStep },
-  } = useSellFlowContext()
+  const onContinue = async () => {
+    trackTappedContinueSubmission(submission?.internalID, nextStep)
 
-  const onNext = async () => {
-    if (!isLoggedIn) {
+    if (!isLoggedIn && isSubmitStep) {
+      await submitForm()
+
       showAuthDialog({
-        mode: "Login",
+        mode: "SignUp",
         options: {
-          title: () => {
-            return "Log in to submit an artwork for sale"
+          title: mode =>
+            mode === "Login"
+              ? "Log in to complete your submission"
+              : "Sign up to complete your submission",
+          afterAuthAction: {
+            action: "submitSubmission",
+            kind: "submission",
+            objectId: submission?.externalId as string,
           },
         },
         analytics: {
-          contextModule: ContextModule.consignSubmissionFlow,
-          intent: Intent.login,
+          contextModule: ContextModule.sell,
+          intent: Intent.consign,
+          trigger: "click",
         },
       })
 
       return
+    } else {
+      await submitAndNavigateToNextStepCallback()
     }
+  }
 
+  const goToNextStepCallback = useCallback(async () => {
+    await goToNextStep()
+  }, [goToNextStep])
+
+  const submitAndNavigateToNextStepCallback = useCallback(async () => {
     setIsSubmitting(true)
-
-    trackTappedContinueSubmission(submission?.internalID, nextStep)
 
     try {
       await submitForm()
 
-      await actions.goToNextStep()
+      await goToNextStep()
     } catch (error) {
       logger.error("Error submitting form", error)
     } finally {
       setIsSubmitting(false)
     }
-  }
+  }, [submitForm, goToNextStepCallback])
+
+  const onAfterAuthCallback = useCallback(async () => {
+    try {
+      setIsSubmitting(true)
+      await associateSubmissionMutation({
+        variables: { input: { id: submission?.externalId as string } },
+      })
+      await submitAndNavigateToNextStepCallback()
+    } catch (error) {
+      logger.error("Something went wrong.", error)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }, [associateSubmissionMutation, submitAndNavigateToNextStepCallback, submission])
+
+  useEffect(() => {
+    if (value?.action === "submitSubmission") {
+      clearValue()
+
+      onAfterAuthCallback()
+    }
+  }, [value, clearValue, onAfterAuthCallback])
 
   return (
     <Button
       variant="primaryBlack"
       disabled={!isValid || isSubmitting || loading}
       loading={isSubmitting || loading}
-      onClick={onNext}
+      onClick={onContinue}
       data-testid="bottom-form-next-button"
     >
       {isSubmitStep ? "Submit Artwork" : "Continue"}

--- a/src/Apps/Sell/Components/SubmissionHeader.tsx
+++ b/src/Apps/Sell/Components/SubmissionHeader.tsx
@@ -1,50 +1,118 @@
+import { AuthIntent, ContextModule } from "@artsy/cohesion"
 import ArtsyLogoIcon from "@artsy/icons/ArtsyLogoIcon"
 import CloseIcon from "@artsy/icons/CloseIcon"
 import { Button, Flex, FullBleed } from "@artsy/palette"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
 import { useSubmissionTracking } from "Apps/Sell/Hooks/useSubmissionTracking"
+import { useAssociateSubmission } from "Apps/Sell/Mutations/useAssociateSubmission"
 import { useSellFlowContext } from "Apps/Sell/SellFlowContext"
 import { storePreviousSubmission } from "Apps/Sell/Utils/previousSubmissionUtils"
+import { useAuthDialog } from "Components/AuthDialog"
 import { Sticky } from "Components/Sticky"
 import { RouterLink } from "System/Components/RouterLink"
 import { useRouter } from "System/Hooks/useRouter"
+import { useSystemContext } from "System/Hooks/useSystemContext"
+import { useAuthIntent } from "Utils/Hooks/useAuthIntent"
 import { Media } from "Utils/Responsive"
 import createLogger from "Utils/logger"
 import { useFormikContext } from "formik"
-import { useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 
 const HEADER_HEIGHT = 40
 const logger = createLogger("BottomFormNavigation.tsx")
 
 export const SubmissionHeader: React.FC = () => {
-  const { router } = useRouter()
+  const {
+    router: { push: routerPush },
+  } = useRouter()
   const [isSubmitting, setIsSubmitting] = useState(false)
   const { trackTappedSubmissionSaveExit } = useSubmissionTracking()
+  const { isLoggedIn } = useSystemContext()
+  const { showAuthDialog } = useAuthDialog()
+  const { value, clearValue } = useAuthIntent()
+  const {
+    submitMutation: associateSubmissionMutation,
+  } = useAssociateSubmission()
   const context = useSellFlowContext()
   const formik = useFormikContext()
   const { isLastStep, submission, step } = context?.state || {}
 
   const handleSaveAndExit = async () => {
     if (!submission?.externalId) return
+    trackTappedSubmissionSaveExit(submission?.internalID, step)
+
+    if (isLoggedIn) {
+      await submitAndSaveCallback()
+    } else {
+      await submitForm()
+
+      showAuthDialog({
+        mode: "SignUp",
+        options: {
+          title: mode =>
+            mode === "Login"
+              ? "Log in to save your submission"
+              : "Sign up to save your submission",
+          afterAuthAction: {
+            action: "saveAndExitSubmission",
+            kind: "submission",
+            objectId: submission?.externalId as string,
+            step,
+          },
+        },
+        analytics: {
+          contextModule: ContextModule.sell,
+          // TODO: Add to artsy/cohesion to use Intent.saveAndExit here
+          intent: "saveAndExitSubmission" as AuthIntent,
+          trigger: "click",
+        },
+      })
+    }
+  }
+
+  const submitForm = formik?.submitForm
+
+  const submitAndSaveCallback = useCallback(async () => {
+    if (!submission) return
 
     setIsSubmitting(true)
 
     try {
-      await formik?.submitForm()
+      await submitForm()
+
+      // Save the submission and current step to local storage
+      storePreviousSubmission(submission?.externalId as string, step)
+
+      routerPush("/sell")
     } catch (error) {
       logger.error("Something went wrong.", error)
+    } finally {
+      setIsSubmitting(false)
     }
+  }, [submitForm, submission, step, routerPush])
 
-    // Save the submission and current step to local storage
-    storePreviousSubmission(submission?.externalId, step)
+  const onAfterAuthCallback = useCallback(async () => {
+    try {
+      setIsSubmitting(true)
+      await associateSubmissionMutation({
+        variables: { input: { id: submission?.externalId as string } },
+      })
+      await submitAndSaveCallback()
+    } catch (error) {
+      logger.error("Something went wrong.", error)
+    } finally {
+      setIsSubmitting(false)
+    }
+  }, [associateSubmissionMutation, submitAndSaveCallback, submission])
 
-    trackTappedSubmissionSaveExit(submission?.internalID, step)
+  useEffect(() => {
+    if (value?.action === "saveAndExitSubmission") {
+      clearValue()
 
-    setIsSubmitting(false)
-
-    router.push("/sell")
-  }
+      onAfterAuthCallback()
+    }
+  }, [value, clearValue, onAfterAuthCallback])
 
   return (
     <Sticky withoutHeaderOffset>

--- a/src/Apps/Sell/Mutations/useAssociateSubmission.tsx
+++ b/src/Apps/Sell/Mutations/useAssociateSubmission.tsx
@@ -1,0 +1,17 @@
+import { useMutation } from "Utils/Hooks/useMutation"
+import { graphql } from "react-relay"
+import { useAssociateSubmissionMutation } from "__generated__/useAssociateSubmissionMutation.graphql"
+
+export const useAssociateSubmission = () => {
+  return useMutation<useAssociateSubmissionMutation>({
+    mutation: graphql`
+      mutation useAssociateSubmissionMutation(
+        $input: AddUserToSubmissionMutationInput!
+      ) {
+        addUserToSubmission(input: $input) {
+          clientMutationId
+        }
+      }
+    `,
+  })
+}

--- a/src/Apps/Sell/Routes/ArtistRoute.tsx
+++ b/src/Apps/Sell/Routes/ArtistRoute.tsx
@@ -1,4 +1,3 @@
-import { ContextModule, Intent } from "@artsy/cohesion"
 import { Box, Text, useToasts } from "@artsy/palette"
 import {
   ArtistAutoComplete,
@@ -9,10 +8,8 @@ import { DevDebug } from "Apps/Sell/Components/DevDebug"
 import { SubmissionLayout } from "Apps/Sell/Components/SubmissionLayout"
 import { SubmissionStepTitle } from "Apps/Sell/Components/SubmissionStepTitle"
 import { useSellFlowContext } from "Apps/Sell/SellFlowContext"
-import { useAuthDialog } from "Components/AuthDialog"
 import { RouterLink } from "System/Components/RouterLink"
 import { useRouter } from "System/Hooks/useRouter"
-import { useSystemContext } from "System/Hooks/useSystemContext"
 import createLogger from "Utils/logger"
 import {
   ArtistRoute_submission$data,
@@ -63,8 +60,6 @@ export const ArtistRouteFragmentContainer: React.FC<ArtistRouteProps> = props =>
 export const ArtistRoute: React.FC<{
   submission?: ArtistRoute_submission$data
 }> = ({ submission }) => {
-  const { isLoggedIn } = useSystemContext()
-  const { showAuthDialog } = useAuthDialog()
   const { router } = useRouter()
   const { actions } = useSellFlowContext()
   const { sendToast } = useToasts()
@@ -72,23 +67,6 @@ export const ArtistRoute: React.FC<{
   const isNewSubmission = !submission?.internalID
 
   const createSubmission = async (artist: AutocompleteArtist) => {
-    if (!isLoggedIn) {
-      showAuthDialog({
-        mode: "Login",
-        options: {
-          title: () => {
-            return "Log in to submit an artwork for sale"
-          },
-        },
-        analytics: {
-          contextModule: ContextModule.sellFooter,
-          intent: Intent.login,
-        },
-      })
-
-      return
-    }
-
     if (!artist?.internalID) return
 
     const isTargetSupply = artist?.targetSupply?.isTargetSupply

--- a/src/Apps/Sell/Routes/PhoneNumberRoute.tsx
+++ b/src/Apps/Sell/Routes/PhoneNumberRoute.tsx
@@ -54,10 +54,10 @@ export const PhoneNumberRoute: React.FC<PhoneNumberRouteProps> = props => {
 
   const initialValues: FormValues = {
     userPhone:
-      submission.userPhoneNumber?.display ?? me.phoneNumber?.display ?? "",
+      submission.userPhoneNumber?.display ?? me?.phoneNumber?.display ?? "",
     phoneNumberRegionCode:
       submission.userPhoneNumber?.regionCode ??
-      me.phoneNumber?.regionCode ??
+      me?.phoneNumber?.regionCode ??
       "us",
   }
 

--- a/src/Apps/Sell/SellFlowContext.tsx
+++ b/src/Apps/Sell/SellFlowContext.tsx
@@ -17,6 +17,7 @@ import { createContext, useContext, useEffect, useMemo, useState } from "react"
 import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
 import { useRouter } from "System/Hooks/useRouter"
 import { useCursor } from "use-cursor"
+import { getENV } from "Utils/getENV"
 import createLogger from "Utils/logger"
 
 const logger = createLogger("SellFlowContext.tsx")
@@ -198,7 +199,10 @@ export const SellFlowContextProvider: React.FC<SellFlowContextProviderProps> = (
   const createSubmission = (values: CreateSubmissionMutationInput) => {
     const response = submitCreateSubmissionMutation({
       variables: {
-        input: values,
+        input: {
+          sessionID: getENV("SESSION_ID"),
+          ...values,
+        },
       },
     })
 
@@ -221,6 +225,7 @@ export const SellFlowContextProvider: React.FC<SellFlowContextProviderProps> = (
       variables: {
         input: {
           externalId: submission?.externalId,
+          sessionID: getENV("SESSION_ID"),
           ...values,
         } as UpdateSubmissionMutationInput,
       },

--- a/src/Apps/Sell/sellRoutes.tsx
+++ b/src/Apps/Sell/sellRoutes.tsx
@@ -1,5 +1,6 @@
 import loadable from "@loadable/component"
 import { RouteProps } from "System/Router/Route"
+import { getENV } from "Utils/getENV"
 import { graphql } from "react-relay"
 
 const IntroRoute = loadable(
@@ -197,14 +198,14 @@ export const sellRoutes: RouteProps[] = [
           SubmissionRoute.preload()
         },
         query: graphql`
-          query sellRoutes_SubmissionRouteQuery($id: ID!) {
-            submission(id: $id) @principalField {
+          query sellRoutes_SubmissionRouteQuery($id: ID!, $sessionID: String!) {
+            submission(id: $id, sessionID: $sessionID) @principalField {
               ...SubmissionRoute_submission
             }
           }
         `,
         prepareVariables: ({ id }) => {
-          return { id }
+          return { id, sessionID: getENV("SESSION_ID") }
         },
         children: [
           {
@@ -215,14 +216,14 @@ export const sellRoutes: RouteProps[] = [
               ArtistRoute.preload()
             },
             query: graphql`
-              query sellRoutes_ArtistRouteQuery($id: ID!) {
-                submission(id: $id) @principalField {
+              query sellRoutes_ArtistRouteQuery($id: ID!, $sessionID: String!) {
+                submission(id: $id, sessionID: $sessionID) @principalField {
                   ...ArtistRoute_submission
                 }
               }
             `,
             prepareVariables: ({ id }) => {
-              return { id }
+              return { id, sessionID: getENV("SESSION_ID") }
             },
           },
           {
@@ -233,14 +234,14 @@ export const sellRoutes: RouteProps[] = [
               TitleRoute.preload()
             },
             query: graphql`
-              query sellRoutes_TitleRouteQuery($id: ID!) {
-                submission(id: $id) @principalField {
+              query sellRoutes_TitleRouteQuery($id: ID!, $sessionID: String!) {
+                submission(id: $id, sessionID: $sessionID) @principalField {
                   ...TitleRoute_submission
                 }
               }
             `,
             prepareVariables: ({ id }) => {
-              return { id }
+              return { id, sessionID: getENV("SESSION_ID") }
             },
           },
           {
@@ -251,14 +252,14 @@ export const sellRoutes: RouteProps[] = [
               PhotosRoute.preload()
             },
             query: graphql`
-              query sellRoutes_PhotosRouteQuery($id: ID!) {
-                submission(id: $id) @principalField {
+              query sellRoutes_PhotosRouteQuery($id: ID!, $sessionID: String!) {
+                submission(id: $id, sessionID: $sessionID) @principalField {
                   ...PhotosRoute_submission
                 }
               }
             `,
             prepareVariables: ({ id }) => {
-              return { id }
+              return { id, sessionID: getENV("SESSION_ID") }
             },
           },
           {
@@ -269,14 +270,17 @@ export const sellRoutes: RouteProps[] = [
               DetailsRoute.preload()
             },
             query: graphql`
-              query sellRoutes_DetailsRouteQuery($id: ID!) {
-                submission(id: $id) @principalField {
+              query sellRoutes_DetailsRouteQuery(
+                $id: ID!
+                $sessionID: String!
+              ) {
+                submission(id: $id, sessionID: $sessionID) @principalField {
                   ...DetailsRoute_submission
                 }
               }
             `,
             prepareVariables: ({ id }) => {
-              return { id }
+              return { id, sessionID: getENV("SESSION_ID") }
             },
           },
           {
@@ -287,14 +291,17 @@ export const sellRoutes: RouteProps[] = [
               PurchaseHistoryRoute.preload()
             },
             query: graphql`
-              query sellRoutes_PurchaseHistoryRouteQuery($id: ID!) {
-                submission(id: $id) @principalField {
+              query sellRoutes_PurchaseHistoryRouteQuery(
+                $id: ID!
+                $sessionID: String!
+              ) {
+                submission(id: $id, sessionID: $sessionID) @principalField {
                   ...PurchaseHistoryRoute_submission
                 }
               }
             `,
             prepareVariables: ({ id }) => {
-              return { id }
+              return { id, sessionID: getENV("SESSION_ID") }
             },
           },
           {
@@ -305,14 +312,17 @@ export const sellRoutes: RouteProps[] = [
               DimensionsRoute.preload()
             },
             query: graphql`
-              query sellRoutes_DimensionsRouteQuery($id: ID!) {
-                submission(id: $id) @principalField {
+              query sellRoutes_DimensionsRouteQuery(
+                $id: ID!
+                $sessionID: String!
+              ) {
+                submission(id: $id, sessionID: $sessionID) @principalField {
                   ...DimensionsRoute_submission
                 }
               }
             `,
             prepareVariables: ({ id }) => {
-              return { id }
+              return { id, sessionID: getENV("SESSION_ID") }
             },
           },
           {
@@ -323,8 +333,11 @@ export const sellRoutes: RouteProps[] = [
               PhoneNumberRoute.preload()
             },
             query: graphql`
-              query sellRoutes_PhoneNumberRouteQuery($id: ID!) {
-                submission(id: $id) @principalField {
+              query sellRoutes_PhoneNumberRouteQuery(
+                $id: ID!
+                $sessionID: String!
+              ) {
+                submission(id: $id, sessionID: $sessionID) @principalField {
                   ...PhoneNumberRoute_submission
                 }
                 me {
@@ -333,7 +346,7 @@ export const sellRoutes: RouteProps[] = [
               }
             `,
             prepareVariables: ({ id }) => {
-              return { id }
+              return { id, sessionID: getENV("SESSION_ID") }
             },
           },
           {

--- a/src/Utils/Hooks/useAuthIntent/__tests__/useAuthIntent.jest.ts
+++ b/src/Utils/Hooks/useAuthIntent/__tests__/useAuthIntent.jest.ts
@@ -383,6 +383,8 @@ describe("isValid", () => {
       isValid({ action: "save", kind: "artworks", objectId: "example" })
     ).toBe(true)
     expect(isValid({ action: "createAlert" })).toBe(true)
+    expect(isValid({ action: "saveAndExitSubmission", kind: "submission", objectId: "example" })).toBe(true)
+    expect(isValid({ action: "submitSubmission", kind: "submission", objectId: "example" })).toBe(true)
     expect(
       isValid({ action: "follow", kind: "invalid", objectId: "example" })
     ).toBe(false)

--- a/src/Utils/Hooks/useAuthIntent/index.tsx
+++ b/src/Utils/Hooks/useAuthIntent/index.tsx
@@ -8,9 +8,10 @@ import { followProfileMutation } from "./mutations/AuthIntentFollowProfileMutati
 import { saveArtworkMutation } from "./mutations/AuthIntentSaveArtworkMutation"
 import { createOrderMutation } from "./mutations/AuthIntentCreateOrderMutation"
 import { createOfferOrderMutation } from "./mutations/AuthIntentCreateOfferOrderMutation"
-import { associateSubmissionMutation } from "./mutations/AuthIntentAssociateSubmissionMutation"
 import { Environment } from "react-relay"
 import { useDismissibleContext } from "@artsy/dismissible"
+import { SellFlowStep } from "Apps/Sell/SellFlowContext"
+import { associateSubmissionMutation } from "Utils/Hooks/useAuthIntent/mutations/AuthIntentAssociateSubmissionMutation"
 
 export const AFTER_AUTH_ACTION_KEY = "afterSignUpAction"
 
@@ -35,6 +36,17 @@ export type AfterAuthAction =
       kind: "artworks"
       objectId: string
       secondaryObjectId: string | null | undefined
+    }
+  | {
+      action: "saveAndExitSubmission"
+      kind: "submission"
+      objectId: string
+      step: SellFlowStep
+    }
+  | {
+      action: "submitSubmission"
+      kind: "submission"
+      objectId: string
     }
 
 export const runAuthIntent = async ({
@@ -100,6 +112,11 @@ export const runAuthIntent = async ({
 
         case "associateSubmission":
           return associateSubmissionMutation(relayEnvironment, value.objectId)
+
+        case "saveAndExitSubmission" ||
+          "submitSubmission":
+          // Do nothing. Value update triggers UI which handles mutation.
+          break
       }
     })()
 
@@ -194,6 +211,8 @@ const schema = Yup.object({
       "saveArtworkToLists",
       "buyNow",
       "makeOffer",
+      "submitSubmission",
+      "saveAndExitSubmission",
     ])
     .required(),
   kind: Yup.string()
@@ -205,6 +224,7 @@ const schema = Yup.object({
     return action === "createAlert" ? schema.notRequired() : schema.required()
   }),
   secondaryObjectId: Yup.string(),
+  step: Yup.string(),
 })
 
 export const isValid = (value: any): value is AfterAuthAction => {

--- a/src/__generated__/sellRoutes_ArtistRouteQuery.graphql.ts
+++ b/src/__generated__/sellRoutes_ArtistRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6e94064e0a43668b0766b4efd4cecfef>>
+ * @generated SignedSource<<386a6b434368a92fb296f8c81a649155>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,7 @@ import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type sellRoutes_ArtistRouteQuery$variables = {
   id: string;
+  sessionID: string;
 };
 export type sellRoutes_ArtistRouteQuery$data = {
   readonly submission: {
@@ -29,6 +30,11 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "id"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "sessionID"
   }
 ],
 v1 = [
@@ -36,6 +42,11 @@ v1 = [
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
+  },
+  {
+    "kind": "Variable",
+    "name": "sessionID",
+    "variableName": "sessionID"
   }
 ],
 v2 = {
@@ -139,16 +150,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f9cc0979cfbbc7699bec4a1670ad2fb7",
+    "cacheID": "d01d446ade18834a29bc63e928474d62",
     "id": null,
     "metadata": {},
     "name": "sellRoutes_ArtistRouteQuery",
     "operationKind": "query",
-    "text": "query sellRoutes_ArtistRouteQuery(\n  $id: ID!\n) {\n  submission(id: $id) @principalField {\n    ...ArtistRoute_submission\n    id\n  }\n}\n\nfragment ArtistRoute_submission on ConsignmentSubmission {\n  internalID\n  artist {\n    internalID\n    targetSupply {\n      isTargetSupply\n    }\n    name\n    id\n  }\n}\n"
+    "text": "query sellRoutes_ArtistRouteQuery(\n  $id: ID!\n  $sessionID: String!\n) {\n  submission(id: $id, sessionID: $sessionID) @principalField {\n    ...ArtistRoute_submission\n    id\n  }\n}\n\nfragment ArtistRoute_submission on ConsignmentSubmission {\n  internalID\n  artist {\n    internalID\n    targetSupply {\n      isTargetSupply\n    }\n    name\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "45d0577595aaac4b3851de2c920f2805";
+(node as any).hash = "9ec00e294e0875f54c147660bb99ae6d";
 
 export default node;

--- a/src/__generated__/sellRoutes_DetailsRouteQuery.graphql.ts
+++ b/src/__generated__/sellRoutes_DetailsRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a1d6c7081475bf0cb04872f6adf55ce2>>
+ * @generated SignedSource<<332fd21f5e5107bdfed550c0642207ba>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,7 @@ import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type sellRoutes_DetailsRouteQuery$variables = {
   id: string;
+  sessionID: string;
 };
 export type sellRoutes_DetailsRouteQuery$data = {
   readonly submission: {
@@ -29,6 +30,11 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "id"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "sessionID"
   }
 ],
 v1 = [
@@ -36,6 +42,11 @@ v1 = [
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
+  },
+  {
+    "kind": "Variable",
+    "name": "sessionID",
+    "variableName": "sessionID"
   }
 ];
 return {
@@ -113,16 +124,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c9f8d2ac30568fc47c4830f31f57721b",
+    "cacheID": "d59bb2e7100c552c243f66c6e5d0a307",
     "id": null,
     "metadata": {},
     "name": "sellRoutes_DetailsRouteQuery",
     "operationKind": "query",
-    "text": "query sellRoutes_DetailsRouteQuery(\n  $id: ID!\n) {\n  submission(id: $id) @principalField {\n    ...DetailsRoute_submission\n    id\n  }\n}\n\nfragment DetailsRoute_submission on ConsignmentSubmission {\n  year\n  category\n  medium\n}\n"
+    "text": "query sellRoutes_DetailsRouteQuery(\n  $id: ID!\n  $sessionID: String!\n) {\n  submission(id: $id, sessionID: $sessionID) @principalField {\n    ...DetailsRoute_submission\n    id\n  }\n}\n\nfragment DetailsRoute_submission on ConsignmentSubmission {\n  year\n  category\n  medium\n}\n"
   }
 };
 })();
 
-(node as any).hash = "2d7114d35f4ddfea13f371185dc55c93";
+(node as any).hash = "484309e7e72a9304a5404c0497364f54";
 
 export default node;

--- a/src/__generated__/sellRoutes_DimensionsRouteQuery.graphql.ts
+++ b/src/__generated__/sellRoutes_DimensionsRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ef7ca6b55c7b7abd384ce1e796975939>>
+ * @generated SignedSource<<5db4f44831e2a004f8c75d5ef55aafff>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,7 @@ import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type sellRoutes_DimensionsRouteQuery$variables = {
   id: string;
+  sessionID: string;
 };
 export type sellRoutes_DimensionsRouteQuery$data = {
   readonly submission: {
@@ -29,6 +30,11 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "id"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "sessionID"
   }
 ],
 v1 = [
@@ -36,6 +42,11 @@ v1 = [
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
+  },
+  {
+    "kind": "Variable",
+    "name": "sessionID",
+    "variableName": "sessionID"
   }
 ];
 return {
@@ -120,16 +131,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a5144f41b8f50f98eaa08de0a44d5376",
+    "cacheID": "c3849405043bdc18cd6bf71eb2f8c48b",
     "id": null,
     "metadata": {},
     "name": "sellRoutes_DimensionsRouteQuery",
     "operationKind": "query",
-    "text": "query sellRoutes_DimensionsRouteQuery(\n  $id: ID!\n) {\n  submission(id: $id) @principalField {\n    ...DimensionsRoute_submission\n    id\n  }\n}\n\nfragment DimensionsRoute_submission on ConsignmentSubmission {\n  width\n  height\n  depth\n  dimensionsMetric\n}\n"
+    "text": "query sellRoutes_DimensionsRouteQuery(\n  $id: ID!\n  $sessionID: String!\n) {\n  submission(id: $id, sessionID: $sessionID) @principalField {\n    ...DimensionsRoute_submission\n    id\n  }\n}\n\nfragment DimensionsRoute_submission on ConsignmentSubmission {\n  width\n  height\n  depth\n  dimensionsMetric\n}\n"
   }
 };
 })();
 
-(node as any).hash = "dbfcd8396147e68b824d880b3f7f69c8";
+(node as any).hash = "1915f6c0d7136f0076817946bd58e871";
 
 export default node;

--- a/src/__generated__/sellRoutes_PhoneNumberRouteQuery.graphql.ts
+++ b/src/__generated__/sellRoutes_PhoneNumberRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<188326c0c00b27b70d954f1ef71af0f7>>
+ * @generated SignedSource<<cc97b04b741e3f68046f4a5371c05f79>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,7 @@ import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type sellRoutes_PhoneNumberRouteQuery$variables = {
   id: string;
+  sessionID: string;
 };
 export type sellRoutes_PhoneNumberRouteQuery$data = {
   readonly me: {
@@ -32,6 +33,11 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "id"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "sessionID"
   }
 ],
 v1 = [
@@ -39,6 +45,11 @@ v1 = [
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
+  },
+  {
+    "kind": "Variable",
+    "name": "sessionID",
+    "variableName": "sessionID"
   }
 ],
 v2 = {
@@ -182,16 +193,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ce23cead280d7bbe9d458113ea0b1455",
+    "cacheID": "16685ffb7ccaf9976969fba57f3cdb87",
     "id": null,
     "metadata": {},
     "name": "sellRoutes_PhoneNumberRouteQuery",
     "operationKind": "query",
-    "text": "query sellRoutes_PhoneNumberRouteQuery(\n  $id: ID!\n) {\n  submission(id: $id) @principalField {\n    ...PhoneNumberRoute_submission\n    id\n  }\n  me {\n    ...PhoneNumberRoute_me\n    id\n  }\n}\n\nfragment PhoneNumberRoute_me on Me {\n  internalID\n  phoneNumber {\n    regionCode\n    display(format: NATIONAL)\n  }\n}\n\nfragment PhoneNumberRoute_submission on ConsignmentSubmission {\n  userPhoneNumber {\n    display\n    regionCode\n  }\n}\n"
+    "text": "query sellRoutes_PhoneNumberRouteQuery(\n  $id: ID!\n  $sessionID: String!\n) {\n  submission(id: $id, sessionID: $sessionID) @principalField {\n    ...PhoneNumberRoute_submission\n    id\n  }\n  me {\n    ...PhoneNumberRoute_me\n    id\n  }\n}\n\nfragment PhoneNumberRoute_me on Me {\n  internalID\n  phoneNumber {\n    regionCode\n    display(format: NATIONAL)\n  }\n}\n\nfragment PhoneNumberRoute_submission on ConsignmentSubmission {\n  userPhoneNumber {\n    display\n    regionCode\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "2f2d86cfeebe72cc425b2279e385f247";
+(node as any).hash = "305158c463aade169d1876ebd174fbbd";
 
 export default node;

--- a/src/__generated__/sellRoutes_PhotosRouteQuery.graphql.ts
+++ b/src/__generated__/sellRoutes_PhotosRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<cd2523d1b1cdeceeea0697020ee368fb>>
+ * @generated SignedSource<<45fcffb57cfb646f584b0139bf45d5b9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,7 @@ import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type sellRoutes_PhotosRouteQuery$variables = {
   id: string;
+  sessionID: string;
 };
 export type sellRoutes_PhotosRouteQuery$data = {
   readonly submission: {
@@ -29,6 +30,11 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "id"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "sessionID"
   }
 ],
 v1 = [
@@ -36,6 +42,11 @@ v1 = [
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
+  },
+  {
+    "kind": "Variable",
+    "name": "sessionID",
+    "variableName": "sessionID"
   }
 ],
 v2 = {
@@ -176,16 +187,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f66ec34fd97c5e4aba03f3ffca3da7cc",
+    "cacheID": "33f86c5b3ff2f6bc63d82f52fa8a31d8",
     "id": null,
     "metadata": {},
     "name": "sellRoutes_PhotosRouteQuery",
     "operationKind": "query",
-    "text": "query sellRoutes_PhotosRouteQuery(\n  $id: ID!\n) {\n  submission(id: $id) @principalField {\n    ...PhotosRoute_submission\n    id\n  }\n}\n\nfragment PhotosRoute_submission on ConsignmentSubmission {\n  externalId\n  myCollectionArtwork {\n    images {\n      url(version: \"large\")\n    }\n    id\n  }\n  assets {\n    id\n    size\n    filename\n    geminiToken\n    imageUrls\n  }\n}\n"
+    "text": "query sellRoutes_PhotosRouteQuery(\n  $id: ID!\n  $sessionID: String!\n) {\n  submission(id: $id, sessionID: $sessionID) @principalField {\n    ...PhotosRoute_submission\n    id\n  }\n}\n\nfragment PhotosRoute_submission on ConsignmentSubmission {\n  externalId\n  myCollectionArtwork {\n    images {\n      url(version: \"large\")\n    }\n    id\n  }\n  assets {\n    id\n    size\n    filename\n    geminiToken\n    imageUrls\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "0b9b193f461e9136d8a145c9067e3900";
+(node as any).hash = "3a841dd794ceb756f6ca9ce597f9bdff";
 
 export default node;

--- a/src/__generated__/sellRoutes_PurchaseHistoryRouteQuery.graphql.ts
+++ b/src/__generated__/sellRoutes_PurchaseHistoryRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b9de60fd0170279b0924c0f269e037f8>>
+ * @generated SignedSource<<4324c6f53a473dfc3c8f23e9dca5dd78>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,7 @@ import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type sellRoutes_PurchaseHistoryRouteQuery$variables = {
   id: string;
+  sessionID: string;
 };
 export type sellRoutes_PurchaseHistoryRouteQuery$data = {
   readonly submission: {
@@ -29,6 +30,11 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "id"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "sessionID"
   }
 ],
 v1 = [
@@ -36,6 +42,11 @@ v1 = [
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
+  },
+  {
+    "kind": "Variable",
+    "name": "sessionID",
+    "variableName": "sessionID"
   }
 ];
 return {
@@ -106,16 +117,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "99e2f40b36070661f43fbf3a33a5ccbe",
+    "cacheID": "fe685ddc81a113b98fdaf1cf1846eae1",
     "id": null,
     "metadata": {},
     "name": "sellRoutes_PurchaseHistoryRouteQuery",
     "operationKind": "query",
-    "text": "query sellRoutes_PurchaseHistoryRouteQuery(\n  $id: ID!\n) {\n  submission(id: $id) @principalField {\n    ...PurchaseHistoryRoute_submission\n    id\n  }\n}\n\nfragment PurchaseHistoryRoute_submission on ConsignmentSubmission {\n  provenance\n  signature\n}\n"
+    "text": "query sellRoutes_PurchaseHistoryRouteQuery(\n  $id: ID!\n  $sessionID: String!\n) {\n  submission(id: $id, sessionID: $sessionID) @principalField {\n    ...PurchaseHistoryRoute_submission\n    id\n  }\n}\n\nfragment PurchaseHistoryRoute_submission on ConsignmentSubmission {\n  provenance\n  signature\n}\n"
   }
 };
 })();
 
-(node as any).hash = "edce7fd445c83ea3ee42e959040cba6c";
+(node as any).hash = "7ef056639d38f2a19fc9c955143eb848";
 
 export default node;

--- a/src/__generated__/sellRoutes_SubmissionRouteQuery.graphql.ts
+++ b/src/__generated__/sellRoutes_SubmissionRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<76738f21908220d4b34a31bf5aa14b36>>
+ * @generated SignedSource<<0d79d23c6de65bd58860d4162d26115d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,7 @@ import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type sellRoutes_SubmissionRouteQuery$variables = {
   id: string;
+  sessionID: string;
 };
 export type sellRoutes_SubmissionRouteQuery$data = {
   readonly submission: {
@@ -29,6 +30,11 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "id"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "sessionID"
   }
 ],
 v1 = [
@@ -36,6 +42,11 @@ v1 = [
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
+  },
+  {
+    "kind": "Variable",
+    "name": "sessionID",
+    "variableName": "sessionID"
   }
 ];
 return {
@@ -113,16 +124,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "67d133b1209a390fa53706a28ccdc079",
+    "cacheID": "bf4b8c95905f83b773e8ea2704a4bd5e",
     "id": null,
     "metadata": {},
     "name": "sellRoutes_SubmissionRouteQuery",
     "operationKind": "query",
-    "text": "query sellRoutes_SubmissionRouteQuery(\n  $id: ID!\n) {\n  submission(id: $id) @principalField {\n    ...SubmissionRoute_submission\n    id\n  }\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n}\n"
+    "text": "query sellRoutes_SubmissionRouteQuery(\n  $id: ID!\n  $sessionID: String!\n) {\n  submission(id: $id, sessionID: $sessionID) @principalField {\n    ...SubmissionRoute_submission\n    id\n  }\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n}\n"
   }
 };
 })();
 
-(node as any).hash = "9207f5acb78269476cc9d3e18dcb983d";
+(node as any).hash = "347f3bdb6900f32dd4a0657aad7bc84f";
 
 export default node;

--- a/src/__generated__/sellRoutes_ThankYouRouteQuery.graphql.ts
+++ b/src/__generated__/sellRoutes_ThankYouRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<60b64f8d788dcae12aff770fa6a81320>>
+ * @generated SignedSource<<d5b556bef87de45a47d5c9c11196c3e9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,7 @@ import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type sellRoutes_ThankYouRouteQuery$variables = {
   id: string;
+  sessionID: string;
 };
 export type sellRoutes_ThankYouRouteQuery$data = {
   readonly submission: {
@@ -29,6 +30,11 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "id"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "sessionID"
   }
 ],
 v1 = [
@@ -36,6 +42,11 @@ v1 = [
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
+  },
+  {
+    "kind": "Variable",
+    "name": "sessionID",
+    "variableName": "sessionID"
   }
 ];
 return {
@@ -113,16 +124,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "400bc17b5cf564c2a35327bcde86e22c",
+    "cacheID": "deb7a6269f27444d8865a03de3bed1d2",
     "id": null,
     "metadata": {},
     "name": "sellRoutes_ThankYouRouteQuery",
     "operationKind": "query",
-    "text": "query sellRoutes_ThankYouRouteQuery(\n  $id: ID!\n) {\n  submission(id: $id) @principalField {\n    ...ThankYouRoute_submission\n    id\n  }\n}\n\nfragment ThankYouRoute_submission on ConsignmentSubmission {\n  internalID\n  state\n  myCollectionArtworkID\n}\n"
+    "text": "query sellRoutes_ThankYouRouteQuery(\n  $id: ID!\n  $sessionID: String!\n) {\n  submission(id: $id, sessionID: $sessionID) @principalField {\n    ...ThankYouRoute_submission\n    id\n  }\n}\n\nfragment ThankYouRoute_submission on ConsignmentSubmission {\n  internalID\n  state\n  myCollectionArtworkID\n}\n"
   }
 };
 })();
 
-(node as any).hash = "1ee99eecd482885887ede24b0f8f936d";
+(node as any).hash = "18cf4f5a7225d4844d5e67d5fd0e9c4b";
 
 export default node;

--- a/src/__generated__/sellRoutes_TitleRouteQuery.graphql.ts
+++ b/src/__generated__/sellRoutes_TitleRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ebc611cf2b9002c6693a9546f4f3ae3e>>
+ * @generated SignedSource<<56d49e009fea58733a71c39719152398>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,7 @@ import { ConcreteRequest, Query } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type sellRoutes_TitleRouteQuery$variables = {
   id: string;
+  sessionID: string;
 };
 export type sellRoutes_TitleRouteQuery$data = {
   readonly submission: {
@@ -29,6 +30,11 @@ var v0 = [
     "defaultValue": null,
     "kind": "LocalArgument",
     "name": "id"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "sessionID"
   }
 ],
 v1 = [
@@ -36,6 +42,11 @@ v1 = [
     "kind": "Variable",
     "name": "id",
     "variableName": "id"
+  },
+  {
+    "kind": "Variable",
+    "name": "sessionID",
+    "variableName": "sessionID"
   }
 ],
 v2 = {
@@ -238,16 +249,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "3238a2c7db256b5147897a834e026833",
+    "cacheID": "cb0fe9ed5fcf9cf2d939481649815f0b",
     "id": null,
     "metadata": {},
     "name": "sellRoutes_TitleRouteQuery",
     "operationKind": "query",
-    "text": "query sellRoutes_TitleRouteQuery(\n  $id: ID!\n) {\n  submission(id: $id) @principalField {\n    ...TitleRoute_submission\n    id\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  coverArtwork {\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment TitleRoute_submission on ConsignmentSubmission {\n  title\n  artist {\n    ...EntityHeaderArtist_artist\n    id\n  }\n}\n"
+    "text": "query sellRoutes_TitleRouteQuery(\n  $id: ID!\n  $sessionID: String!\n) {\n  submission(id: $id, sessionID: $sessionID) @principalField {\n    ...TitleRoute_submission\n    id\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  coverArtwork {\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment TitleRoute_submission on ConsignmentSubmission {\n  title\n  artist {\n    ...EntityHeaderArtist_artist\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "90ebd56d298e56d80ee2fd9d3b311149";
+(node as any).hash = "7574ea0e6101cfa20bcbdcc8cb9a2d24";
 
 export default node;

--- a/src/__generated__/useAssociateSubmissionMutation.graphql.ts
+++ b/src/__generated__/useAssociateSubmissionMutation.graphql.ts
@@ -1,0 +1,93 @@
+/**
+ * @generated SignedSource<<b8338587d3150008fa2016d5c0e2abe3>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Mutation } from 'relay-runtime';
+export type AddUserToSubmissionMutationInput = {
+  clientMutationId?: string | null | undefined;
+  id: string;
+};
+export type useAssociateSubmissionMutation$variables = {
+  input: AddUserToSubmissionMutationInput;
+};
+export type useAssociateSubmissionMutation$data = {
+  readonly addUserToSubmission: {
+    readonly clientMutationId: string | null | undefined;
+  } | null | undefined;
+};
+export type useAssociateSubmissionMutation = {
+  response: useAssociateSubmissionMutation$data;
+  variables: useAssociateSubmissionMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": [
+      {
+        "kind": "Variable",
+        "name": "input",
+        "variableName": "input"
+      }
+    ],
+    "concreteType": "AddUserToSubmissionMutationPayload",
+    "kind": "LinkedField",
+    "name": "addUserToSubmission",
+    "plural": false,
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "kind": "ScalarField",
+        "name": "clientMutationId",
+        "storageKey": null
+      }
+    ],
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "useAssociateSubmissionMutation",
+    "selections": (v1/*: any*/),
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "useAssociateSubmissionMutation",
+    "selections": (v1/*: any*/)
+  },
+  "params": {
+    "cacheID": "d2fc6ab769cf03ef3f5ea9e702893461",
+    "id": null,
+    "metadata": {},
+    "name": "useAssociateSubmissionMutation",
+    "operationKind": "mutation",
+    "text": "mutation useAssociateSubmissionMutation(\n  $input: AddUserToSubmissionMutationInput!\n) {\n  addUserToSubmission(input: $input) {\n    clientMutationId\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "1ff210dae781b61a1b3effc7df1169f0";
+
+export default node;


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

### Description

Defer auth prompt to either "Save and Exit" or "Submit Artwork".

### Screen Recordings

| Name | Video |
|--------|--------|
| Before | <video src="https://github.com/user-attachments/assets/7b28c20e-5eaa-4b1e-90d5-8c8114d107e6" /> |
| After (Save & Exit) | <video src="https://github.com/user-attachments/assets/e5aac9a9-5598-438d-b1b9-a34f44d6e259" /> |
| After (Submit) | <video src="https://github.com/user-attachments/assets/35b6ca48-6dae-4298-bd12-5e974ed1c1e0" /> | 