### PR TITLE
chore: Use submission's `internalID` for Sell flow tracking

### DIFF
--- a/src/Apps/Sell/Components/BottomFormNavigation.tsx
+++ b/src/Apps/Sell/Components/BottomFormNavigation.tsx
@@ -34,13 +34,13 @@ const BottomFormBackButton = () => {
   const { submitForm } = useFormikContext()
   const {
     actions,
-    state: { loading, isFirstStep, submissionID, step },
+    state: { loading, isFirstStep, internalSubmissionID, step },
   } = useSellFlowContext()
 
   const onBack = async () => {
     setIsSubmitting(true)
 
-    trackTappedSubmissionBack(submissionID, step)
+    trackTappedSubmissionBack(internalSubmissionID, step)
 
     try {
       await submitForm()
@@ -82,7 +82,7 @@ const BottomFormNextButton = () => {
 
   const {
     actions,
-    state: { submissionID, isSubmitStep, nextStep },
+    state: { internalSubmissionID, isSubmitStep, nextStep },
   } = useSellFlowContext()
 
   const onNext = async () => {
@@ -105,7 +105,7 @@ const BottomFormNextButton = () => {
 
     setIsSubmitting(true)
 
-    trackTappedContinueSubmission(submissionID, nextStep)
+    trackTappedContinueSubmission(internalSubmissionID, nextStep)
 
     try {
       await submitForm()

--- a/src/Apps/Sell/Components/BottomFormNavigation.tsx
+++ b/src/Apps/Sell/Components/BottomFormNavigation.tsx
@@ -34,13 +34,13 @@ const BottomFormBackButton = () => {
   const { submitForm } = useFormikContext()
   const {
     actions,
-    state: { loading, isFirstStep, internalSubmissionID, step },
+    state: { loading, isFirstStep, submission, step },
   } = useSellFlowContext()
 
   const onBack = async () => {
     setIsSubmitting(true)
 
-    trackTappedSubmissionBack(internalSubmissionID, step)
+    trackTappedSubmissionBack(submission?.internalID, step)
 
     try {
       await submitForm()
@@ -82,7 +82,7 @@ const BottomFormNextButton = () => {
 
   const {
     actions,
-    state: { internalSubmissionID, isSubmitStep, nextStep },
+    state: { submission, isSubmitStep, nextStep },
   } = useSellFlowContext()
 
   const onNext = async () => {
@@ -105,7 +105,7 @@ const BottomFormNextButton = () => {
 
     setIsSubmitting(true)
 
-    trackTappedContinueSubmission(internalSubmissionID, nextStep)
+    trackTappedContinueSubmission(submission?.internalID, nextStep)
 
     try {
       await submitForm()

--- a/src/Apps/Sell/Components/StepsNavigation.tsx
+++ b/src/Apps/Sell/Components/StepsNavigation.tsx
@@ -7,7 +7,7 @@ export const StepsNavigation: React.FC = () => {
   const { state } = useSellFlowContext()
 
   const pathForStep = (step: string) => {
-    return `/sell/submissions/${state.submissionID}/${step}`
+    return `/sell/submissions/${state.submission?.externalId}/${step}`
   }
 
   const steps = STEPS.filter(step => step !== "thank-you")

--- a/src/Apps/Sell/Components/SubmissionHeader.tsx
+++ b/src/Apps/Sell/Components/SubmissionHeader.tsx
@@ -23,9 +23,8 @@ export const SubmissionHeader: React.FC = () => {
   const { trackTappedSubmissionSaveExit } = useSubmissionTracking()
   const context = useSellFlowContext()
   const formik = useFormikContext()
-  const isLastStep = context?.state?.isLastStep
-  const submissionID = context?.state?.submissionID
-  const step = context?.state?.step
+  const { isLastStep, submissionID, internalSubmissionID, step } =
+    context?.state || {}
 
   const handleSaveAndExit = async () => {
     if (!submissionID) return
@@ -41,7 +40,7 @@ export const SubmissionHeader: React.FC = () => {
     // Save the submission and current step to local storage
     storePreviousSubmission(submissionID, step)
 
-    trackTappedSubmissionSaveExit(submissionID, step)
+    trackTappedSubmissionSaveExit(internalSubmissionID, step)
 
     setIsSubmitting(false)
 

--- a/src/Apps/Sell/Components/SubmissionHeader.tsx
+++ b/src/Apps/Sell/Components/SubmissionHeader.tsx
@@ -23,11 +23,10 @@ export const SubmissionHeader: React.FC = () => {
   const { trackTappedSubmissionSaveExit } = useSubmissionTracking()
   const context = useSellFlowContext()
   const formik = useFormikContext()
-  const { isLastStep, submissionID, internalSubmissionID, step } =
-    context?.state || {}
+  const { isLastStep, submission, step } = context?.state || {}
 
   const handleSaveAndExit = async () => {
-    if (!submissionID) return
+    if (!submission?.externalId) return
 
     setIsSubmitting(true)
 
@@ -38,9 +37,9 @@ export const SubmissionHeader: React.FC = () => {
     }
 
     // Save the submission and current step to local storage
-    storePreviousSubmission(submissionID, step)
+    storePreviousSubmission(submission?.externalId, step)
 
-    trackTappedSubmissionSaveExit(internalSubmissionID, step)
+    trackTappedSubmissionSaveExit(submission?.internalID, step)
 
     setIsSubmitting(false)
 
@@ -57,7 +56,7 @@ export const SubmissionHeader: React.FC = () => {
                 <Flex
                   flexDirection="row"
                   justifyContent={[
-                    submissionID ? "end" : "space-between",
+                    submission?.externalId ? "end" : "space-between",
                     "space-between",
                   ]}
                   alignItems="center"
@@ -71,7 +70,7 @@ export const SubmissionHeader: React.FC = () => {
                     </RouterLink>
                   </Media>
 
-                  {submissionID && !isLastStep ? (
+                  {submission?.externalId && !isLastStep ? (
                     <>
                       <Media at="xs">
                         <RouterLink
@@ -117,7 +116,7 @@ export const SubmissionHeader: React.FC = () => {
                           to="/sell"
                           data-testid="exit-link"
                         >
-                          {isLastStep || !submissionID ? "Exit" : ""}
+                          {isLastStep || !submission?.externalId ? "Exit" : ""}
                         </Button>
                       </Media>
                     </>

--- a/src/Apps/Sell/Components/__tests__/SubmissionLayout.jest.tsx
+++ b/src/Apps/Sell/Components/__tests__/SubmissionLayout.jest.tsx
@@ -84,7 +84,10 @@ describe("SubmissionLayout", () => {
     it("renders the 'Save & Exit'button'", async () => {
       render(
         <Formik<{}> initialValues={{}} onSubmit={onSubmitMock}>
-          <SellFlowContextProvider submissionID="123">
+          <SellFlowContextProvider
+            submissionID="123"
+            internalSubmissionID="123"
+          >
             <SubmissionLayout />
           </SellFlowContextProvider>
         </Formik>
@@ -119,7 +122,10 @@ describe("SubmissionLayout", () => {
     it("renders the 'Back' button", () => {
       render(
         <Formik<{}> initialValues={{}} onSubmit={onSubmitMock}>
-          <SellFlowContextProvider submissionID="123">
+          <SellFlowContextProvider
+            submissionID="123"
+            internalSubmissionID="123"
+          >
             <SubmissionLayout />
           </SellFlowContextProvider>
         </Formik>

--- a/src/Apps/Sell/Components/__tests__/SubmissionLayout.jest.tsx
+++ b/src/Apps/Sell/Components/__tests__/SubmissionLayout.jest.tsx
@@ -20,6 +20,11 @@ jest.unmock("react-relay")
 const setMock = jest.fn()
 Storage.prototype.setItem = setMock
 
+const submissionMock = {
+  internalID: "internal-id",
+  externalId: "external-id",
+}
+
 describe("SubmissionLayout", () => {
   beforeAll(() => {
     ;(useTracking as jest.Mock).mockImplementation(() => {
@@ -84,10 +89,7 @@ describe("SubmissionLayout", () => {
     it("renders the 'Save & Exit'button'", async () => {
       render(
         <Formik<{}> initialValues={{}} onSubmit={onSubmitMock}>
-          <SellFlowContextProvider
-            submissionID="123"
-            internalSubmissionID="123"
-          >
+          <SellFlowContextProvider submission={submissionMock}>
             <SubmissionLayout />
           </SellFlowContextProvider>
         </Formik>
@@ -104,11 +106,14 @@ describe("SubmissionLayout", () => {
           action: "tappedSubmissionSaveExit",
           context_module: "sell",
           context_owner_type: "submitArtworkStepAddDimensions",
-          submission_id: "123",
+          submission_id: "internal-id",
           submission_step: "dimensions",
         })
 
-        expect(setMock).toHaveBeenCalledWith("previousSubmissionID", "123")
+        expect(setMock).toHaveBeenCalledWith(
+          "previousSubmissionID",
+          "external-id"
+        )
         expect(setMock).toHaveBeenCalledWith(
           "previousSubmissionStep",
           "dimensions"
@@ -122,10 +127,7 @@ describe("SubmissionLayout", () => {
     it("renders the 'Back' button", () => {
       render(
         <Formik<{}> initialValues={{}} onSubmit={onSubmitMock}>
-          <SellFlowContextProvider
-            submissionID="123"
-            internalSubmissionID="123"
-          >
+          <SellFlowContextProvider submission={submissionMock}>
             <SubmissionLayout />
           </SellFlowContextProvider>
         </Formik>
@@ -141,7 +143,7 @@ describe("SubmissionLayout", () => {
         action: "tappedSubmissionBack",
         context_module: "sell",
         context_owner_type: "submitArtworkStepAddDimensions",
-        submission_id: "123",
+        submission_id: "internal-id",
         submission_step: "dimensions",
       })
     })

--- a/src/Apps/Sell/Routes/SubmissionRoute.tsx
+++ b/src/Apps/Sell/Routes/SubmissionRoute.tsx
@@ -28,10 +28,7 @@ export const SubmissionRoute: React.FC<SubmissionRouteProps> = props => {
       <AppContainer>
         <SellMeta />
 
-        <SellFlowContextProvider
-          submissionID={submission.externalId}
-          internalSubmissionID={submission.internalID}
-        >
+        <SellFlowContextProvider submission={submission}>
           {props.children}
         </SellFlowContextProvider>
       </AppContainer>

--- a/src/Apps/Sell/Routes/SubmissionRoute.tsx
+++ b/src/Apps/Sell/Routes/SubmissionRoute.tsx
@@ -28,7 +28,10 @@ export const SubmissionRoute: React.FC<SubmissionRouteProps> = props => {
       <AppContainer>
         <SellMeta />
 
-        <SellFlowContextProvider submissionID={submission.externalId}>
+        <SellFlowContextProvider
+          submissionID={submission.externalId}
+          internalSubmissionID={submission.internalID}
+        >
           {props.children}
         </SellFlowContextProvider>
       </AppContainer>

--- a/src/Apps/Sell/Routes/__tests__/DimensionsRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/DimensionsRoute.jest.tsx
@@ -114,7 +114,7 @@ describe("DimensionsRoute", () => {
           action: "tappedContinueSubmission",
           context_module: "sell",
           context_owner_type: "sell",
-          submission_id: '<mock-value-for-field-"externalId">',
+          submission_id: '<mock-value-for-field-"internalID">',
           destination_step: "phone-number",
         })
 

--- a/src/Apps/Sell/Routes/__tests__/PhoneNumberRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/PhoneNumberRoute.jest.tsx
@@ -99,7 +99,7 @@ describe("PhoneNumberRoute", () => {
           context_module: "sell",
           context_owner_type: "submitArtworkStepAddPhoneNumber",
           fieldsProvided: [],
-          submission_id: '<mock-value-for-field-"externalId">',
+          submission_id: '<mock-value-for-field-"internalID">',
         })
 
         expect(submitMutation).toHaveBeenCalledWith(

--- a/src/Apps/Sell/Routes/__tests__/PhoneNumberRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/PhoneNumberRoute.jest.tsx
@@ -93,6 +93,9 @@ describe("PhoneNumberRoute", () => {
 
       screen.getByText("Submit Artwork").click()
 
+      trackEvent.mockClear()
+      submitMutation.mockClear()
+
       await waitFor(() => {
         expect(trackEvent).toHaveBeenCalledWith({
           action: "consignmentSubmitted",

--- a/src/Apps/Sell/SellFlowContext.tsx
+++ b/src/Apps/Sell/SellFlowContext.tsx
@@ -49,7 +49,8 @@ interface State {
   index: number
   step: SellFlowStep
   nextStep: SellFlowStep
-  submissionID: string | undefined
+  submissionID?: string
+  internalSubmissionID: string | undefined | null
   devMode: boolean
   // loading is used to show a loading spinner on the bottom form navigation
   // when images are being uploaded
@@ -67,12 +68,14 @@ export const SellFlowContext = createContext<SellFlowContextProps>({
 interface SellFlowContextProviderProps {
   children: React.ReactNode
   submissionID?: string
+  internalSubmissionID?: string | null
   devMode?: boolean
 }
 
 export const SellFlowContextProvider: React.FC<SellFlowContextProviderProps> = ({
   children,
   submissionID,
+  internalSubmissionID,
   devMode = false,
 }) => {
   const {
@@ -110,13 +113,13 @@ export const SellFlowContextProvider: React.FC<SellFlowContextProviderProps> = (
   }
 
   const goToPreviousStep = () => {
-    trackTappedSubmissionBack(submissionID, state.step)
+    trackTappedSubmissionBack(internalSubmissionID, state.step)
 
     handlePrev()
   }
 
   const finishFlow = async () => {
-    trackConsignmentSubmitted(submissionID, state.step)
+    trackConsignmentSubmitted(internalSubmissionID, state.step)
 
     // When the user clicks on "Submit Artwork" and the Sell flow is finished, we set the state to "SUBMITTED".
     await updateSubmission({
@@ -194,6 +197,7 @@ export const SellFlowContextProvider: React.FC<SellFlowContextProviderProps> = (
     step: STEPS[index],
     nextStep: STEPS[index + 1],
     submissionID,
+    internalSubmissionID,
     devMode,
     loading,
   }

--- a/src/Apps/Sell/SellFlowContext.tsx
+++ b/src/Apps/Sell/SellFlowContext.tsx
@@ -115,13 +115,13 @@ export const SellFlowContextProvider: React.FC<SellFlowContextProviderProps> = (
   }
 
   const goToPreviousStep = () => {
-    trackTappedSubmissionBack(submission?.externalId, state.step)
+    trackTappedSubmissionBack(submission?.internalID, state.step)
 
     handlePrev()
   }
 
   const finishFlow = async () => {
-    trackConsignmentSubmitted(submission?.externalId, state.step)
+    trackConsignmentSubmitted(submission?.internalID, state.step)
 
     // When the user clicks on "Submit Artwork" and the Sell flow is finished, we set the state to "SUBMITTED".
     await updateSubmission({


### PR DESCRIPTION
Request from @daytavares  

## Description

Currently, we send the submission's `externalID` when tracking Sell flow events. Instead, we need to use the internal submission ID.