### PR TITLE
fix(partner): explicitly request articles sorted by pub date

### DIFF
--- a/src/Apps/Partner/Components/Overview/ArticlesRail.tsx
+++ b/src/Apps/Partner/Components/Overview/ArticlesRail.tsx
@@ -51,7 +51,7 @@ export const ArticlesRailFragmentContainer = createFragmentContainer(
     partner: graphql`
       fragment ArticlesRail_partner on Partner {
         slug
-        articlesConnection(first: 8) {
+        articlesConnection(first: 8, sort: PUBLISHED_AT_DESC) {
           totalCount
           edges {
             node {

--- a/src/__generated__/ArticlesRail_partner.graphql.ts
+++ b/src/__generated__/ArticlesRail_partner.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8d487e52ff65ab8832860b45a8a562e0>>
+ * @generated SignedSource<<e6cf0a06fd206a8c99a0c40550b24954>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -48,6 +48,11 @@ const node: ReaderFragment = {
           "kind": "Literal",
           "name": "first",
           "value": 8
+        },
+        {
+          "kind": "Literal",
+          "name": "sort",
+          "value": "PUBLISHED_AT_DESC"
         }
       ],
       "concreteType": "ArticleConnection",
@@ -97,13 +102,13 @@ const node: ReaderFragment = {
           "storageKey": null
         }
       ],
-      "storageKey": "articlesConnection(first:8)"
+      "storageKey": "articlesConnection(first:8,sort:\"PUBLISHED_AT_DESC\")"
     }
   ],
   "type": "Partner",
   "abstractKey": null
 };
 
-(node as any).hash = "09179c23e2649250a136cbb5629b2960";
+(node as any).hash = "fdacedb195b664f0661cb51f000e7c61";
 
 export default node;

--- a/src/__generated__/partnerRoutes_OverviewQuery.graphql.ts
+++ b/src/__generated__/partnerRoutes_OverviewQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<18a7f6645b804c8c31a362f601c9a8d7>>
+ * @generated SignedSource<<b258580d00ec328b1b4ca3c90a5e50d7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -436,6 +436,11 @@ return {
                 "kind": "Literal",
                 "name": "first",
                 "value": 8
+              },
+              {
+                "kind": "Literal",
+                "name": "sort",
+                "value": "PUBLISHED_AT_DESC"
               }
             ],
             "concreteType": "ArticleConnection",
@@ -552,7 +557,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "articlesConnection(first:8)"
+            "storageKey": "articlesConnection(first:8,sort:\"PUBLISHED_AT_DESC\")"
           },
           {
             "alias": null,
@@ -626,12 +631,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "8d45b4ad4e77bff662ff7fc8bc181cd5",
+    "cacheID": "5355f12e2c96005bbcfac0827e2e8242",
     "id": null,
     "metadata": {},
     "name": "partnerRoutes_OverviewQuery",
     "operationKind": "query",
-    "text": "query partnerRoutes_OverviewQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    ...Overview_partner\n    id\n  }\n}\n\nfragment AboutPartner_partner on Partner {\n  profile {\n    fullBio\n    bio\n    id\n  }\n  website\n  vatNumber\n  displayFullPartnerPage\n  slug\n  internalID\n}\n\nfragment ArticlesRail_partner on Partner {\n  slug\n  articlesConnection(first: 8) {\n    totalCount\n    edges {\n      node {\n        internalID\n        ...CellArticle_article\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistsRail_partner on Partner {\n  slug\n  profileArtistsLayout\n  displayFullPartnerPage\n  artistsWithPublishedArtworks: artistsConnection(hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  representedArtistsWithoutPublishedArtworks: artistsConnection(representedBy: true, hasPublishedArtworks: false, displayOnPartnerProfile: true) {\n    totalCount\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment CellShow_show on Show {\n  internalID\n  slug\n  name\n  href\n  startAt\n  endAt\n  isFairBooth\n  exhibitionPeriod\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  coverImage {\n    cropped(width: 445, height: 334, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment Overview_partner on Partner {\n  slug\n  partnerType\n  displayFullPartnerPage\n  profileBannerDisplay\n  displayArtistsSection\n  ...AboutPartner_partner\n  ...ShowsRail_partner\n  ...ArtistsRail_partner\n  ...SubscriberBanner_partner\n  ...ArticlesRail_partner\n  locationsConnection(first: 1) {\n    edges {\n      node {\n        coordinates {\n          lat\n          lng\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ShowsRail_partner on Partner {\n  slug\n  displayFullPartnerPage\n  showsConnection(status: ALL, first: 20, isDisplayable: true) {\n    totalCount\n    edges {\n      node {\n        ...CellShow_show\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment SubscriberBanner_partner on Partner {\n  name\n}\n"
+    "text": "query partnerRoutes_OverviewQuery(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) @principalField {\n    ...Overview_partner\n    id\n  }\n}\n\nfragment AboutPartner_partner on Partner {\n  profile {\n    fullBio\n    bio\n    id\n  }\n  website\n  vatNumber\n  displayFullPartnerPage\n  slug\n  internalID\n}\n\nfragment ArticlesRail_partner on Partner {\n  slug\n  articlesConnection(first: 8, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        internalID\n        ...CellArticle_article\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistsRail_partner on Partner {\n  slug\n  profileArtistsLayout\n  displayFullPartnerPage\n  artistsWithPublishedArtworks: artistsConnection(hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  representedArtistsWithoutPublishedArtworks: artistsConnection(representedBy: true, hasPublishedArtworks: false, displayOnPartnerProfile: true) {\n    totalCount\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment CellShow_show on Show {\n  internalID\n  slug\n  name\n  href\n  startAt\n  endAt\n  isFairBooth\n  exhibitionPeriod\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  coverImage {\n    cropped(width: 445, height: 334, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment Overview_partner on Partner {\n  slug\n  partnerType\n  displayFullPartnerPage\n  profileBannerDisplay\n  displayArtistsSection\n  ...AboutPartner_partner\n  ...ShowsRail_partner\n  ...ArtistsRail_partner\n  ...SubscriberBanner_partner\n  ...ArticlesRail_partner\n  locationsConnection(first: 1) {\n    edges {\n      node {\n        coordinates {\n          lat\n          lng\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ShowsRail_partner on Partner {\n  slug\n  displayFullPartnerPage\n  showsConnection(status: ALL, first: 20, isDisplayable: true) {\n    totalCount\n    edges {\n      node {\n        ...CellShow_show\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment SubscriberBanner_partner on Partner {\n  name\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves the issue reported [here](https://artsy.slack.com/archives/C03N12SR0RK/p1720172832143009)

### Description

Articles displayed on the partner profile page are not sorted, which means they use the [upstream default](https://github.com/artsy/positron/blob/9ea829fefe6bb1118131c0fc3ff429e357507afe/src/api/apps/articles/model/retrieve.js#L189-L191) of sorting by _last updated_ date, instead of the _publication_ date.

The updated date often matches the published date — but not always, as the report shows. We should instead by explicitly requesting these articles in order of publish date.

Note that we already do this everywhere else we request articles — the current case must have just been an oversight 🙈 

<img src="https://github.com/artsy/force/assets/140521/4caee4a8-4c0e-4337-8dd0-4a2c20f140f3" width=300 />


## Before

![bb](https://github.com/artsy/force/assets/140521/761f0d75-172d-4209-95ac-a028586afce6)

## After

![aa](https://github.com/artsy/force/assets/140521/a52cd116-957e-46bd-96d3-337b04cdcabd)
