### PR TITLE
fix: make manual prepending of US account for possibility of 'under' in price

### DIFF
--- a/src/Apps/Order/Components/ArtworkSummaryItem.tsx
+++ b/src/Apps/Order/Components/ArtworkSummaryItem.tsx
@@ -21,18 +21,12 @@ export interface ArtworkSummaryItemProps extends Omit<FlexProps, "order"> {
 }
 
 const ArtworkSummaryItem: React.FC<ArtworkSummaryItemProps> = ({
-  order: {
-    lineItems,
-    currencyCode,
-    mode,
-    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-    sellerDetails: { name },
-    source,
-  },
+  order: { lineItems, currencyCode, mode, sellerDetails, source },
   ...others
 }) => {
   const firstLineItem = get({}, () => lineItems?.edges?.[0]?.node)
   const { artwork, artworkVersion } = firstLineItem || {}
+  const name = sellerDetails?.name
 
   const { artistNames, title, image, date } = artworkVersion || {}
   const { shippingOrigin, isUnlisted } = artwork || {}
@@ -100,9 +94,11 @@ const ArtworkSummaryItem: React.FC<ArtworkSummaryItemProps> = ({
         </Box>
         {!isPrivateSale && (
           <>
-            <Text variant="sm" overflowEllipsis color="black60">
-              {name}
-            </Text>
+            {name && (
+              <Text variant="sm" overflowEllipsis color="black60">
+                {name}
+              </Text>
+            )}
             <Text variant="sm" color="black60">
               {shippingOrigin}
             </Text>
@@ -110,7 +106,7 @@ const ArtworkSummaryItem: React.FC<ArtworkSummaryItemProps> = ({
         )}
         {!isPrivateSale && artworkPrice?.price && (
           <Text variant="sm">
-            {`${priceLabel} ${appendCurrencySymbol(
+            {`${priceLabel}: ${appendCurrencySymbol(
               artworkPrice.price,
               currencyCode
             )}`}

--- a/src/Apps/Order/Utils/currencyUtils.ts
+++ b/src/Apps/Order/Utils/currencyUtils.ts
@@ -5,7 +5,8 @@ export const appendCurrencySymbol = (
   const pricePresent: boolean =
     typeof price === "string" || typeof price == "number"
   if (currency === "USD" && pricePresent) {
-    return "US" + price
+    const parts = String(price).split("Under ")
+    return parts.length > 1 ? "Under US" + parts[1] : "US" + parts[0]
   }
   return price
 }


### PR DESCRIPTION
This should resolve [EMI-1843](https://artsyproduct.atlassian.net/browse/EMI-1843)

The solution here is pretty ugly but I think we need to maintain this custom function here as we can not use just streight 'saleMessage' for the artwork from the server. Sometimes this list price is not really the list price but rather 'last negotiated price' (there is a separate ticket to figure out proper display name here). But for now just modify this value client side to account for possible 'Under ' prefix there.

Before: 
<img width="1437" alt="Screen Shot 2024-07-11 at 2 22 58 PM" src="https://github.com/user-attachments/assets/0597ae9a-62ba-476f-84c6-b80f12b8cc33">

After:
<img width="1420" alt="Screen Shot 2024-07-11 at 2 22 36 PM" src="https://github.com/user-attachments/assets/22842c1a-4547-4d15-b1ff-1d7edee011e2">


Also in the process I encountered a strange crash with works with very high value. Seems like in this case for whatever reason the server does not give us partner information(?!) - did not track the cause but made UI a bit more bullet proof if that is the case.

[EMI-1843]: https://artsyproduct.atlassian.net/browse/EMI-1843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ