### PR TITLE
feat: Navigate to MyC artwork page on Sell flow thank you step

### DIFF
--- a/src/Apps/Sell/Components/__tests__/SubmissionLayout.jest.tsx
+++ b/src/Apps/Sell/Components/__tests__/SubmissionLayout.jest.tsx
@@ -40,7 +40,7 @@ describe("SubmissionLayout", () => {
         replace: mockReplace,
       },
       match: {
-        location: { pathname: "/submissions/submission-id/dimensions" },
+        location: { pathname: "/sell/submissions/submission-id/dimensions" },
       },
     }))
   })

--- a/src/Apps/Sell/Routes/ThankYouRoute.tsx
+++ b/src/Apps/Sell/Routes/ThankYouRoute.tsx
@@ -12,6 +12,7 @@ const FRAGMENT = graphql`
   fragment ThankYouRoute_submission on ConsignmentSubmission {
     internalID
     state
+    myCollectionArtworkID
   }
 `
 interface ThankYouRouteProps {
@@ -19,14 +20,21 @@ interface ThankYouRouteProps {
 }
 
 export const ThankYouRoute: React.FC<ThankYouRouteProps> = props => {
-  const submission = useFragment(FRAGMENT, props.submission)
+  const { myCollectionArtworkID, internalID, state } = useFragment(
+    FRAGMENT,
+    props.submission
+  )
 
   const {
     trackTappedSubmitAnotherWork,
     trackTappedViewArtworkInMyCollection,
   } = useSubmissionTracking()
 
-  const isSubmitted = submission.state === "SUBMITTED"
+  const isSubmitted = state === "SUBMITTED"
+
+  const myCollectionUrl = myCollectionArtworkID
+    ? `/my-collection/artwork/${myCollectionArtworkID}`
+    : "/my-collection"
 
   return (
     <FullBleed>
@@ -61,7 +69,7 @@ export const ThankYouRoute: React.FC<ThankYouRouteProps> = props => {
                 as={RouterLink}
                 to="/sell/submissions/new"
                 onClick={() => {
-                  trackTappedSubmitAnotherWork(submission.internalID)
+                  trackTappedSubmitAnotherWork(internalID)
                 }}
                 width="100%"
                 data-testid="submit-another-work"
@@ -72,9 +80,9 @@ export const ThankYouRoute: React.FC<ThankYouRouteProps> = props => {
               <Button
                 // @ts-ignore
                 as={RouterLink}
-                to="/my-collection"
+                to={myCollectionUrl}
                 onClick={() => {
-                  trackTappedViewArtworkInMyCollection(submission.internalID)
+                  trackTappedViewArtworkInMyCollection(internalID)
                 }}
                 variant="secondaryBlack"
                 width="100%"

--- a/src/Apps/Sell/Routes/__tests__/AdditionalDocumentsRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/AdditionalDocumentsRoute.jest.tsx
@@ -36,7 +36,9 @@ beforeEach(() => {
       replace: mockReplace,
     },
     match: {
-      location: { pathname: "/submissions/submission-id/additional-documents" },
+      location: {
+        pathname: "/sell/submissions/submission-id/additional-documents",
+      },
     },
   }))
 

--- a/src/Apps/Sell/Routes/__tests__/ArtistRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/ArtistRoute.jest.tsx
@@ -30,7 +30,7 @@ beforeAll(() => {
     return { isLoggedIn: true }
   })
 
-  pathnameMock = "/submissions/submission-id/artist"
+  pathnameMock = "/sell/submissions/submission-id/artist"
 
   mockUseRouter.mockImplementation(() => ({
     router: {
@@ -104,7 +104,7 @@ describe("ArtistRoute", () => {
 
   describe("when creating a new submission", () => {
     beforeAll(() => {
-      pathnameMock = "/submissions/new"
+      pathnameMock = "/sell/submissions/new"
     })
 
     it("calls createSubmission when a new artist is selected", async () => {

--- a/src/Apps/Sell/Routes/__tests__/ConditionRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/ConditionRoute.jest.tsx
@@ -47,7 +47,9 @@ beforeEach(() => {
       push: mockPush,
       replace: mockReplace,
     },
-    match: { location: { pathname: "/submissions/submission-id/condition" } },
+    match: {
+      location: { pathname: "/sell/submissions/submission-id/condition" },
+    },
   }))
 
   submitMutation = jest.fn(() => ({ catch: () => {} }))

--- a/src/Apps/Sell/Routes/__tests__/DetailsRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/DetailsRoute.jest.tsx
@@ -41,7 +41,9 @@ beforeEach(() => {
       push: mockPush,
       replace: mockReplace,
     },
-    match: { location: { pathname: "submissions/submission-id/details" } },
+    match: {
+      location: { pathname: "/sell/submissions/submission-id/details" },
+    },
   }))
 
   submitMutation = jest.fn(() => ({ catch: () => {} }))

--- a/src/Apps/Sell/Routes/__tests__/DimensionsRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/DimensionsRoute.jest.tsx
@@ -45,7 +45,9 @@ beforeEach(() => {
       push: mockPush,
       replace: mockReplace,
     },
-    match: { location: { pathname: "submissions/submission-id/dimensions" } },
+    match: {
+      location: { pathname: "/sell/submissions/submission-id/dimensions" },
+    },
   }))
 
   submitMutation = jest.fn(() => ({ catch: () => {} }))

--- a/src/Apps/Sell/Routes/__tests__/FrameRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/FrameRoute.jest.tsx
@@ -35,7 +35,7 @@ beforeEach(() => {
       push: mockPush,
       replace: mockReplace,
     },
-    match: { location: { pathname: "/submissions/submission-id/frame" } },
+    match: { location: { pathname: "/sell/submissions/submission-id/frame" } },
   }))
 
   submitMutation = jest.fn(() => ({ catch: () => {} }))

--- a/src/Apps/Sell/Routes/__tests__/IntroRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/IntroRoute.jest.tsx
@@ -29,7 +29,7 @@ beforeAll(() => {
       push: mockPush,
       replace: mockReplace,
     },
-    match: { location: { pathname: "/intro" } },
+    match: { location: { pathname: "/sell/submissions/intro" } },
   }))
 })
 

--- a/src/Apps/Sell/Routes/__tests__/NewRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/NewRoute.jest.tsx
@@ -24,7 +24,7 @@ beforeEach(() => {
       push: mockPush,
       replace: mockReplace,
     },
-    match: { location: { pathname: "/submissions/new" } },
+    match: { location: { pathname: "/sell/submissions/new" } },
   }))
 })
 

--- a/src/Apps/Sell/Routes/__tests__/PhoneNumberRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/PhoneNumberRoute.jest.tsx
@@ -51,7 +51,7 @@ beforeAll(() => {
       replace: mockReplace,
     },
     match: {
-      location: { pathname: "/submissions/submission-id/phone-number" },
+      location: { pathname: "/sell/submissions/submission-id/phone-number" },
     },
   }))
 

--- a/src/Apps/Sell/Routes/__tests__/PhotosRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/PhotosRoute.jest.tsx
@@ -69,7 +69,7 @@ beforeEach(() => {
       push: mockPush,
       replace: mockReplace,
     },
-    match: { location: { pathname: "submissions/submission-id/photos" } },
+    match: { location: { pathname: "/sell/submissions/submission-id/photos" } },
   }))
 
   //@ts-ignore

--- a/src/Apps/Sell/Routes/__tests__/PurchaseHistoryRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/PurchaseHistoryRoute.jest.tsx
@@ -48,7 +48,9 @@ beforeAll(() => {
       replace: mockReplace,
     },
     match: {
-      location: { pathname: "submissions/submission-id/purchase-history" },
+      location: {
+        pathname: "/sell/submissions/submission-id/purchase-history",
+      },
     },
   }))
 

--- a/src/Apps/Sell/Routes/__tests__/ShippingLocationRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/ShippingLocationRoute.jest.tsx
@@ -36,7 +36,9 @@ beforeEach(() => {
       replace: mockReplace,
     },
     match: {
-      location: { pathname: "/submissions/submission-id/shipping-location" },
+      location: {
+        pathname: "/sell/submissions/submission-id/shipping-location",
+      },
     },
   }))
 

--- a/src/Apps/Sell/Routes/__tests__/ThankYouRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/ThankYouRoute.jest.tsx
@@ -40,7 +40,7 @@ beforeEach(() => {
       replace: mockReplace,
     },
     match: {
-      location: { pathname: "submissions/submission-id/thank-you" },
+      location: { pathname: "/sell/submissions/submission-id/thank-you" },
     },
   }))
 

--- a/src/Apps/Sell/Routes/__tests__/ThankYouRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/ThankYouRoute.jest.tsx
@@ -43,6 +43,9 @@ beforeEach(() => {
       location: { pathname: "submissions/submission-id/thank-you" },
     },
   }))
+
+  mockPush.mockClear()
+  trackEvent.mockClear()
 })
 
 const { renderWithRelay } = setupTestWrapperTL({
@@ -113,23 +116,52 @@ describe("ThankYouRoute", () => {
     })
   })
 
-  it("clicking on View Artwork in My Collection navigates to My Collection route", () => {
-    renderWithRelay({})
+  describe("View Artwork in My Collection button", () => {
+    it("navigates to artwork page & tracks the event", () => {
+      renderWithRelay()
 
-    expect(
-      screen.getByText("View Artwork in My Collection")
-    ).toBeInTheDocument()
+      expect(
+        screen.getByText("View Artwork in My Collection")
+      ).toBeInTheDocument()
 
-    const viewCollectionButton = screen.getByTestId("view-collection")
-    expect(viewCollectionButton).toHaveAttribute("href", "/my-collection")
+      const viewCollectionButton = screen.getByTestId("view-collection")
+      expect(viewCollectionButton).toHaveAttribute(
+        "href",
+        '/my-collection/artwork/<mock-value-for-field-"myCollectionArtworkID">'
+      )
 
-    viewCollectionButton.click()
+      viewCollectionButton.click()
 
-    expect(trackEvent).toHaveBeenCalledWith({
-      action: "tappedViewArtworkInMyCollection",
-      context_module: "sell",
-      context_owner_type: "submitArtworkStepCompleteYourSubmission",
-      submission_id: '<mock-value-for-field-"internalID">',
+      expect(trackEvent).toHaveBeenCalledWith({
+        action: "tappedViewArtworkInMyCollection",
+        context_module: "sell",
+        context_owner_type: "submitArtworkStepCompleteYourSubmission",
+        submission_id: '<mock-value-for-field-"internalID">',
+      })
+    })
+
+    describe("when My Collection artwork ID is NOT present", () => {
+      it("navigates to artwork grid", () => {
+        renderWithRelay({
+          ConsignmentSubmission: () => ({ myCollectionArtworkID: null }),
+        })
+
+        expect(
+          screen.getByText("View Artwork in My Collection")
+        ).toBeInTheDocument()
+
+        const viewCollectionButton = screen.getByTestId("view-collection")
+        expect(viewCollectionButton).toHaveAttribute("href", "/my-collection")
+
+        viewCollectionButton.click()
+
+        expect(trackEvent).toHaveBeenCalledWith({
+          action: "tappedViewArtworkInMyCollection",
+          context_module: "sell",
+          context_owner_type: "submitArtworkStepCompleteYourSubmission",
+          submission_id: '<mock-value-for-field-"internalID">',
+        })
+      })
     })
   })
 })

--- a/src/Apps/Sell/Routes/__tests__/TitleRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/TitleRoute.jest.tsx
@@ -33,7 +33,7 @@ beforeEach(() => {
       push: mockPush,
       replace: mockReplace,
     },
-    match: { location: { pathname: "/submissions/submission-id/title" } },
+    match: { location: { pathname: "/sell/submissions/submission-id/title" } },
   }))
 
   submitMutation = jest.fn(() => ({ catch: () => {} }))

--- a/src/Apps/Sell/SellFlowContext.tsx
+++ b/src/Apps/Sell/SellFlowContext.tsx
@@ -177,7 +177,14 @@ export const SellFlowContextProvider: React.FC<SellFlowContextProviderProps> = (
     if (isNewSubmission || !newStep || !isSellFlowRoute) return
 
     router.push(`/sell/submissions/${submission?.externalId}/${newStep}`)
-  }, [index, isNewSubmission, match, router, submission, steps])
+  }, [
+    index,
+    isNewSubmission,
+    match.location.pathname,
+    router,
+    submission,
+    steps,
+  ])
 
   const createSubmission = (values: CreateSubmissionMutationInput) => {
     const response = submitCreateSubmissionMutation({

--- a/src/Apps/Sell/SellFlowContext.tsx
+++ b/src/Apps/Sell/SellFlowContext.tsx
@@ -169,10 +169,15 @@ export const SellFlowContextProvider: React.FC<SellFlowContextProviderProps> = (
   useEffect(() => {
     const newStep = steps[index]
 
-    if (isNewSubmission || !newStep) return
+    // If we are navigating away from the Sell flow, we don't want to redirect
+    const isSellFlowRoute = match.location.pathname.includes(
+      "/sell/submissions"
+    )
+
+    if (isNewSubmission || !newStep || !isSellFlowRoute) return
 
     router.push(`/sell/submissions/${submission?.externalId}/${newStep}`)
-  }, [router, index, isNewSubmission, submission, steps])
+  }, [index, isNewSubmission, match, router, submission, steps])
 
   const createSubmission = (values: CreateSubmissionMutationInput) => {
     const response = submitCreateSubmissionMutation({

--- a/src/__generated__/ThankYouRoute_Test_Query.graphql.ts
+++ b/src/__generated__/ThankYouRoute_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fa2b89e318c88bdaa43222c61d2392a4>>
+ * @generated SignedSource<<6df5d99d78c3db659562a3bc36a9b8b9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -22,6 +22,7 @@ export type ThankYouRoute_Test_Query$rawResponse = {
     readonly externalId: string;
     readonly id: string;
     readonly internalID: string | null | undefined;
+    readonly myCollectionArtworkID: string | null | undefined;
     readonly state: ConsignmentSubmissionStateAggregation | null | undefined;
   } | null | undefined;
 };
@@ -110,6 +111,13 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "myCollectionArtworkID",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "id",
             "storageKey": null
           }
@@ -119,12 +127,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "2f8aaa5e5994737349e1af183b4db7fa",
+    "cacheID": "6fe494ad3a1e12391b8a7c55c4bed45c",
     "id": null,
     "metadata": {},
     "name": "ThankYouRoute_Test_Query",
     "operationKind": "query",
-    "text": "query ThankYouRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...SubmissionRoute_submission\n    ...ThankYouRoute_submission\n    id\n  }\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n}\n\nfragment ThankYouRoute_submission on ConsignmentSubmission {\n  internalID\n  state\n}\n"
+    "text": "query ThankYouRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...SubmissionRoute_submission\n    ...ThankYouRoute_submission\n    id\n  }\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n}\n\nfragment ThankYouRoute_submission on ConsignmentSubmission {\n  internalID\n  state\n  myCollectionArtworkID\n}\n"
   }
 };
 })();

--- a/src/__generated__/ThankYouRoute_submission.graphql.ts
+++ b/src/__generated__/ThankYouRoute_submission.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<05e921850282505b37483bce1764eb01>>
+ * @generated SignedSource<<921b582305d4c97863116c636b7af4b1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,6 +13,7 @@ export type ConsignmentSubmissionStateAggregation = "APPROVED" | "CLOSED" | "DRA
 import { FragmentRefs } from "relay-runtime";
 export type ThankYouRoute_submission$data = {
   readonly internalID: string | null | undefined;
+  readonly myCollectionArtworkID: string | null | undefined;
   readonly state: ConsignmentSubmissionStateAggregation | null | undefined;
   readonly " $fragmentType": "ThankYouRoute_submission";
 };
@@ -40,12 +41,19 @@ const node: ReaderFragment = {
       "kind": "ScalarField",
       "name": "state",
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "myCollectionArtworkID",
+      "storageKey": null
     }
   ],
   "type": "ConsignmentSubmission",
   "abstractKey": null
 };
 
-(node as any).hash = "171dba6fe796d0ab8c678e663e01238b";
+(node as any).hash = "23abbccc0a924ccac794f641333186d7";
 
 export default node;

--- a/src/__generated__/sellRoutes_ThankYouRouteQuery.graphql.ts
+++ b/src/__generated__/sellRoutes_ThankYouRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b0f538c3fae2ef1a6614dabf1c8937a1>>
+ * @generated SignedSource<<60b64f8d788dcae12aff770fa6a81320>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -97,6 +97,13 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "myCollectionArtworkID",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "id",
             "storageKey": null
           }
@@ -106,12 +113,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1efee06de6cb30fd961d3431ff02c33b",
+    "cacheID": "400bc17b5cf564c2a35327bcde86e22c",
     "id": null,
     "metadata": {},
     "name": "sellRoutes_ThankYouRouteQuery",
     "operationKind": "query",
-    "text": "query sellRoutes_ThankYouRouteQuery(\n  $id: ID!\n) {\n  submission(id: $id) @principalField {\n    ...ThankYouRoute_submission\n    id\n  }\n}\n\nfragment ThankYouRoute_submission on ConsignmentSubmission {\n  internalID\n  state\n}\n"
+    "text": "query sellRoutes_ThankYouRouteQuery(\n  $id: ID!\n) {\n  submission(id: $id) @principalField {\n    ...ThankYouRoute_submission\n    id\n  }\n}\n\nfragment ThankYouRoute_submission on ConsignmentSubmission {\n  internalID\n  state\n  myCollectionArtworkID\n}\n"
   }
 };
 })();


### PR DESCRIPTION

The type of this PR is: **Feature**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

With this change, we link directly to the MyC artwork page instead of the MyC artwork grid on the Sell flow "Thank You" step.
<img width="918" alt="Screenshot 2024-07-12 at 13 42 26" src="https://github.com/user-attachments/assets/7a587365-c062-453a-bade-b8f1d6a60518">

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ