### PR TITLE
fix: Filter out null notifications in Activity panel        

### DIFF
--- a/src/Components/Notifications/__tests__/NotificationsList.jest.tsx
+++ b/src/Components/Notifications/__tests__/NotificationsList.jest.tsx
@@ -1,8 +1,8 @@
 import { screen } from "@testing-library/react"
-import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
-import { graphql } from "react-relay"
 import { NotificationsListFragmentContainer } from "Components/Notifications/NotificationsList"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { NotificationsList_test_Query } from "__generated__/NotificationsList_test_Query.graphql"
+import { graphql } from "react-relay"
 
 jest.unmock("react-relay")
 
@@ -33,6 +33,18 @@ describe("NotificationsList", () => {
   it("should render notification items", () => {
     renderWithRelay({
       NotificationConnection: () => notifications,
+    })
+
+    expect(screen.getByText("Notification One")).toBeInTheDocument()
+    expect(screen.getByText("Notification Two")).toBeInTheDocument()
+    expect(screen.getByText("Notification Three")).toBeInTheDocument()
+  })
+
+  it("does not fail if a notification is null", () => {
+    renderWithRelay({
+      NotificationConnection: () => ({
+        edges: [...notifications.edges, { node: null }],
+      }),
     })
 
     expect(screen.getByText("Notification One")).toBeInTheDocument()

--- a/src/Components/Notifications/__tests__/util.jest.ts
+++ b/src/Components/Notifications/__tests__/util.jest.ts
@@ -6,24 +6,28 @@ describe("shouldDisplayNotification", () => {
     const result = shouldDisplayNotification({
       notificationType: "ARTWORK_ALERT",
       artworks: { totalCount: 1 },
+      item: null,
     })
     expect(result).toEqual(true)
 
     const result2 = shouldDisplayNotification({
       notificationType: "ARTWORK_PUBLISHED",
       artworks: { totalCount: 1 },
+      item: null,
     })
     expect(result2).toEqual(true)
 
     const result3 = shouldDisplayNotification({
       notificationType: "PARTNER_OFFER_CREATED",
       artworks: { totalCount: 1 },
+      item: null,
     })
     expect(result3).toEqual(true)
 
     // viewing room notification has viewing rooms
     const result4 = shouldDisplayNotification({
       notificationType: "VIEWING_ROOM_PUBLISHED",
+      artworks: undefined,
       item: { viewingRoomsConnection: { totalCount: 1 } },
     })
     expect(result4).toEqual(true)
@@ -31,7 +35,8 @@ describe("shouldDisplayNotification", () => {
     // editorial notification has article
     const result5 = shouldDisplayNotification({
       notificationType: "ARTICLE_FEATURED_ARTIST",
-      item: { article: { internalID: 1 } },
+      artworks: undefined,
+      item: { article: { internalID: "1" } },
     })
     expect(result5).toEqual(true)
   })
@@ -41,24 +46,28 @@ describe("shouldDisplayNotification", () => {
     const result = shouldDisplayNotification({
       notificationType: "ARTWORK_ALERT",
       artworks: { totalCount: 0 },
+      item: null,
     })
     expect(result).toEqual(false)
 
     const result2 = shouldDisplayNotification({
       notificationType: "ARTWORK_PUBLISHED",
       artworks: { totalCount: 0 },
+      item: null,
     })
     expect(result2).toEqual(false)
 
     const result3 = shouldDisplayNotification({
       notificationType: "PARTNER_OFFER_CREATED",
       artworks: { totalCount: 0 },
+      item: null,
     })
     expect(result3).toEqual(false)
 
     // viewing room notification has no viewing rooms
     const result4 = shouldDisplayNotification({
       notificationType: "VIEWING_ROOM_PUBLISHED",
+      artworks: undefined,
       item: { viewingRoomsConnection: { totalCount: 0 } },
     })
     expect(result4).toEqual(false)
@@ -66,6 +75,7 @@ describe("shouldDisplayNotification", () => {
     // editorial notification has no article
     const result5 = shouldDisplayNotification({
       notificationType: "ARTICLE_FEATURED_ARTIST",
+      artworks: undefined,
       item: {},
     })
     expect(result5).toEqual(false)

--- a/src/Components/Notifications/util.ts
+++ b/src/Components/Notifications/util.ts
@@ -9,7 +9,12 @@ export type Notification = NonNullable<
   >[0]
 >["node"]
 
-export const shouldDisplayNotification = (notification: Notification) => {
+export const shouldDisplayNotification = (
+  notification:
+    | Pick<NonNullable<Notification>, "notificationType" | "artworks" | "item">
+    | null
+    | undefined
+) => {
   if (!notification) return false
 
   if (isArtworksBasedNotification(notification.notificationType)) {

--- a/src/Components/Notifications/util.ts
+++ b/src/Components/Notifications/util.ts
@@ -1,6 +1,17 @@
-import { NotificationTypesEnum } from "__generated__/NotificationsList_viewer.graphql"
+import {
+  NotificationsList_viewer$data,
+  NotificationTypesEnum,
+} from "__generated__/NotificationsList_viewer.graphql"
 
-export const shouldDisplayNotification = notification => {
+export type Notification = NonNullable<
+  NonNullable<
+    NonNullable<NotificationsList_viewer$data["notifications"]>["edges"]
+  >[0]
+>["node"]
+
+export const shouldDisplayNotification = (notification: Notification) => {
+  if (!notification) return false
+
   if (isArtworksBasedNotification(notification.notificationType)) {
     const artworksCount = notification.artworks?.totalCount ?? 0
     return artworksCount > 0

--- a/src/Components/Notifications/util.ts
+++ b/src/Components/Notifications/util.ts
@@ -3,7 +3,7 @@ import {
   NotificationTypesEnum,
 } from "__generated__/NotificationsList_viewer.graphql"
 
-export type Notification = NonNullable<
+export type NotificationNode = NonNullable<
   NonNullable<
     NonNullable<NotificationsList_viewer$data["notifications"]>["edges"]
   >[0]
@@ -11,7 +11,10 @@ export type Notification = NonNullable<
 
 export const shouldDisplayNotification = (
   notification:
-    | Pick<NonNullable<Notification>, "notificationType" | "artworks" | "item">
+    | Pick<
+        NonNullable<NotificationNode>,
+        "notificationType" | "artworks" | "item"
+      >
     | null
     | undefined
 ) => {


### PR DESCRIPTION

The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves https://artsy.slack.com/archives/C05EQL4R5N0/p1721034091096429

### Description

We should filter out `null` notifications in the Activity panel. This PR fixes the types of `shouldDisplayNotification` and adds a check that filters out `null` notifications to avoid the following error:

![screenshot_2024-07-15_at_11 56 03_480](https://github.com/user-attachments/assets/a77511d7-f682-4616-a10f-1bbc42d0bbc2)


<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ