### PR TITLE
chore(loading-bar): Less fade

### DIFF
--- a/src/System/Components/PageLoadingBar.tsx
+++ b/src/System/Components/PageLoadingBar.tsx
@@ -69,9 +69,11 @@ const easeOutExpo = "cubic-bezier(0.19, 1, 0.22, 1)"
 const loadingAnimation = keyframes`
   from {
     width: 0%;
+    left: -15%;
   }
   to {
     width: 30%;
+    left: 0%;
   }
 `
 


### PR DESCRIPTION
The type of this PR is: **Chore**

### Description

Somewhat endless faffing on this one. This animates things in from the left a bit, so that the fade in doesn't feel so abrupt. 
