### PR TITLE
fix(loading-bar): Improve perf for safari

### DIFF
--- a/src/System/Components/PageLoadingBar.tsx
+++ b/src/System/Components/PageLoadingBar.tsx
@@ -1,8 +1,6 @@
+import React, { useState, useEffect, useRef } from "react"
 import styled, { keyframes, css } from "styled-components"
-import { useState, useEffect, useRef } from "react"
 import { Box } from "@artsy/palette"
-import { isServer } from "Server/isServer"
-import { useDidMount } from "Utils/Hooks/useDidMount"
 import { Z } from "Apps/Components/constants"
 
 interface PageLoadingBarProps {
@@ -12,22 +10,27 @@ interface PageLoadingBarProps {
 export const PageLoadingBar: React.FC<PageLoadingBarProps> = ({
   loadingState = "resting",
 }) => {
+  const firstMount = useRef(true)
   const [isComplete, setIsComplete] = useState(false)
   const [loading, setLoading] = useState(loadingState)
-  const isMounted = useDidMount()
   const barRef = useRef<HTMLDivElement>(null)
+  const [scaleX, setScaleX] = useState(0)
 
   useEffect(() => {
+    firstMount.current = false
+
     if (loadingState === "complete") {
       setIsComplete(true)
       setLoading("complete")
+      setScaleX(1)
     } else {
       setIsComplete(false)
       setLoading(loadingState)
+      setScaleX(loadingState === "loading" ? 0.3 : 0)
     }
-  }, [loadingState])
+  }, [loadingState, firstMount])
 
-  if (isServer || !isMounted) {
+  if (firstMount.current) {
     return null
   }
 
@@ -44,18 +47,19 @@ export const PageLoadingBar: React.FC<PageLoadingBarProps> = ({
         ref={barRef as any}
         loading={loading}
         isComplete={isComplete}
+        scaleX={scaleX}
         backgroundColor="brand"
         height={2}
         top="1px"
-        left={0}
-        width={isComplete ? barRef.current?.clientWidth : 0}
-        zIndex={100}
+        left="0px"
+        zIndex={1000}
         overflow="hidden"
         position="fixed"
         onAnimationEnd={() => {
           if (isComplete) {
             setLoading("resting")
             setIsComplete(false)
+            setScaleX(0)
           }
         }}
       />
@@ -68,31 +72,35 @@ const easeOutExpo = "cubic-bezier(0.19, 1, 0.22, 1)"
 
 const loadingAnimation = keyframes`
   from {
-    width: 0%;
-    left: -15%;
+    transform: translateX(-10%) scaleX(0);
   }
   to {
-    width: 30%;
-    left: 0%;
+    transform: translateX(0) scaleX(0.3);
   }
 `
 
 const completeAnimation = keyframes`
   to {
-    width: 100%;
+    transform: scaleX(1);
   }
 `
 
 const fadeInAnimation = keyframes`
   from {
-    opacity: 0;
+    opacity: 1;
   }
   to {
     opacity: 1;
   }
 `
 
-const LoadingBar = styled(Box)<{ loading: string; isComplete: boolean; width }>`
+const LoadingBar = styled(Box)<{
+  loading: string
+  isComplete: boolean
+  scaleX: number
+}>`
+  transform-origin: left;
+  transform: scaleX(${({ scaleX }) => scaleX});
   ${({ loading }) =>
     loading === "loading" &&
     css`
@@ -105,6 +113,8 @@ const LoadingBar = styled(Box)<{ loading: string; isComplete: boolean; width }>`
       animation: ${completeAnimation} 1s ${easeOutExpo} forwards;
     `}
   opacity: ${({ isComplete }) => (isComplete ? 0 : 1)};
-  transition: opacity 0.7s;
-  width: ${({ width }) => width}px;
+  width: 100%;
+  transition:
+    opacity 0.7s,
+    transform 0.7s;
 `


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Noticed that the loading bar was a bit shaky on safari, so moved the css animations to the GPU via `transform`. 
