### PR TITLE
Implements app download banner

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -1,7 +1,7 @@
 import { injectGlobalStyles, Theme } from "@artsy/palette"
 import { MediaContextProvider } from "Utils/Responsive"
 import { createRelaySSREnvironment } from "System/Relay/createRelaySSREnvironment"
-import { SystemContextProvider } from "System/Hooks/useSystemContext"
+import { SystemContextProvider } from "System/Contexts/SystemContext"
 import { track } from "react-tracking"
 
 const { GlobalStyles } = injectGlobalStyles()
@@ -17,12 +17,12 @@ export const decorators = [
 
     return (
       <SystemContextProvider relayEnvironment={relayEnvironment}>
-        <MediaContextProvider>
-          <Theme>
+        <Theme>
+          <MediaContextProvider>
             <GlobalStyles />
             <Tracked />
-          </Theme>
-        </MediaContextProvider>
+          </MediaContextProvider>
+        </Theme>
       </SystemContextProvider>
     )
   },

--- a/src/Apps/Debug/debugRoutes.tsx
+++ b/src/Apps/Debug/debugRoutes.tsx
@@ -4,6 +4,7 @@ import { HttpError } from "found"
 import { useState } from "react"
 import { RouteProps } from "System/Router/Route"
 import { RouterLink } from "System/Components/RouterLink"
+import { Default as AppDownloadBannerStory } from "Components/__stories__/AppDownloadBanner.story"
 
 const DebugApp = loadable(
   () => import(/* webpackChunkName: "debugBundle" */ "./DebugApp"),
@@ -80,6 +81,11 @@ export const debugRoutes: RouteProps[] = [
             </>
           )
         },
+      },
+
+      {
+        path: "app-download-banner",
+        Component: AppDownloadBannerStory,
       },
     ],
   },

--- a/src/Components/AppDownloadBanner.tsx
+++ b/src/Components/AppDownloadBanner.tsx
@@ -1,0 +1,78 @@
+import { Box, Clickable, Text } from "@artsy/palette"
+import { FC, useEffect } from "react"
+import ChevronSmallRightIcon from "@artsy/icons/ChevronSmallRightIcon"
+import { useCursor } from "use-cursor"
+
+const TEXTS = [
+  "Get the app, get the art.",
+  "Get the app, and find the art you love.",
+  "Get the app, and artworks tailored to you.",
+  "Get the app, and discover works our curators love.",
+  "Get the app, and keep up with your favorite artists",
+  "Get the app, and be alerted about new artworks.",
+  "Get the app, and stay connected with galleries.",
+  "Get the app, and build your art world profile.",
+  "Get the app, and keep track of your collection.",
+  "Get the app, and stay informed on your artists’ markets.",
+]
+
+export interface AppDownloadBannerProps {
+  transitionDuration: number
+  idleDuration: number
+}
+
+export const AppDownloadBanner: FC<AppDownloadBannerProps> = ({
+  transitionDuration,
+  idleDuration,
+}) => {
+  const { index, handleNext } = useCursor({
+    max: TEXTS.length,
+  })
+
+  useEffect(() => {
+    const interval = setInterval(handleNext, transitionDuration + idleDuration)
+    return () => {
+      clearInterval(interval)
+    }
+  }, [handleNext, idleDuration, transitionDuration])
+
+  return (
+    <Text
+      as={Clickable}
+      variant="xs"
+      bg="black100"
+      color="white100"
+      py={1}
+      px={2}
+      display="flex"
+      justifyContent="space-between"
+      alignItems="center"
+      width="100%"
+    >
+      <Box position="relative" flex={1}>
+        {TEXTS.map((text, i) => {
+          return (
+            <Box
+              key={i}
+              aria-hidden={i !== index}
+              top={0}
+              left={0}
+              right={0}
+              bottom={0}
+              style={{
+                transition: `opacity ${transitionDuration}ms`,
+                ...(i === index
+                  ? { opacity: 1, position: "relative" }
+                  : { opacity: 0, position: "absolute" }),
+              }}
+            >
+              {text}
+            </Box>
+          )
+        })}
+      </Box>
+
+      <ChevronSmallRightIcon />
+    </Text>
+  )
+}

--- a/src/Components/__stories__/AppDownloadBanner.story.tsx
+++ b/src/Components/__stories__/AppDownloadBanner.story.tsx
@@ -1,0 +1,47 @@
+import { States } from "storybook-states"
+import {
+  AppDownloadBanner,
+  AppDownloadBannerProps,
+} from "Components/AppDownloadBanner"
+import { Input, Stack } from "@artsy/palette"
+import { useState } from "react"
+
+export default {
+  title: "Components/AppDownloadBanner",
+}
+
+export const Default = () => {
+  const [transitionDuration, setTransitionDuration] = useState(1000)
+  const [idleDuration, setIdleDuration] = useState(3000)
+
+  return (
+    <Stack gap={2}>
+      <Stack gap={1} flexDirection="row" maxWidth={400}>
+        <Input
+          title="Transition duration"
+          type="number"
+          value={transitionDuration}
+          onChange={event => {
+            setTransitionDuration(parseInt(event.target.value))
+          }}
+        />
+
+        <Input
+          title="Idle duration"
+          type="number"
+          value={idleDuration}
+          onChange={event => {
+            setIdleDuration(parseInt(event.target.value))
+          }}
+        />
+      </Stack>
+
+      <States<Partial<AppDownloadBannerProps>> states={[{}]}>
+        <AppDownloadBanner
+          transitionDuration={transitionDuration}
+          idleDuration={idleDuration}
+        />
+      </States>
+    </Stack>
+  )
+}


### PR DESCRIPTION
Closes [DIA-733](https://artsyproduct.atlassian.net/browse/DIA-733)

This just implements the banner. Not placing it yet. This PR also sets up a simple route at `/debug/app-download-banner` to render the story with some configuration parameters for design to tweak the timings.

![](https://capture.static.damonzucconi.com/Screen-Shot-2024-07-22-07-37-43.43-loX3LHJqtorLSHloArv6llUgEPEh5q4aobEnoS141u2p0hHDGOjOVesdRG6EowvL9woi6AlbGQSfecElki6tL8oXiOYoLskPpqBl.png)