### PR TITLE
feat: adds custom app download banner in place of smart banner

### DIFF
--- a/src/Apps/Debug/debugRoutes.tsx
+++ b/src/Apps/Debug/debugRoutes.tsx
@@ -4,7 +4,6 @@ import { HttpError } from "found"
 import { useState } from "react"
 import { RouteProps } from "System/Router/Route"
 import { RouterLink } from "System/Components/RouterLink"
-import { Default as AppDownloadBannerStory } from "Components/__stories__/AppDownloadBanner.story"
 
 const DebugApp = loadable(
   () => import(/* webpackChunkName: "debugBundle" */ "./DebugApp"),
@@ -81,11 +80,6 @@ export const debugRoutes: RouteProps[] = [
             </>
           )
         },
-      },
-
-      {
-        path: "app-download-banner",
-        Component: AppDownloadBannerStory,
       },
     ],
   },

--- a/src/Components/AppDownloadBanner.tsx
+++ b/src/Components/AppDownloadBanner.tsx
@@ -17,13 +17,13 @@ const TEXTS = [
 ]
 
 export interface AppDownloadBannerProps {
-  transitionDuration: number
-  idleDuration: number
+  transitionDuration?: number
+  idleDuration?: number
 }
 
 export const AppDownloadBanner: FC<AppDownloadBannerProps> = ({
-  transitionDuration,
-  idleDuration,
+  transitionDuration = 1500,
+  idleDuration = 4000,
 }) => {
   const { index, handleNext } = useCursor({
     max: TEXTS.length,

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -50,6 +50,8 @@ import { ProgressiveOnboardingAlertFind } from "Components/ProgressiveOnboarding
 import { SearchBar } from "Components/Search/SearchBar"
 import { NavBarMobileMenuProfile } from "Components/NavBar/NavBarMobileMenu/NavBarMobileMenuProfile"
 import styled from "styled-components"
+import { AppDownloadBanner } from "Components/AppDownloadBanner"
+import { Media } from "Utils/Responsive"
 
 /**
  * NOTE: Fresnel doesn't work correctly here because this is included
@@ -143,6 +145,10 @@ export const NavBar: React.FC = track(
   return (
     <>
       <NavBarSkipLink />
+
+      <Media at="xs">
+        <AppDownloadBanner />
+      </Media>
 
       <Box
         as="header"

--- a/src/Components/__stories__/AppDownloadBanner.story.tsx
+++ b/src/Components/__stories__/AppDownloadBanner.story.tsx
@@ -7,8 +7,8 @@ export default {
 }
 
 export const Default = () => {
-  const [transitionDuration, setTransitionDuration] = useState(1000)
-  const [idleDuration, setIdleDuration] = useState(3000)
+  const [transitionDuration, setTransitionDuration] = useState(1500)
+  const [idleDuration, setIdleDuration] = useState(4000)
 
   return (
     <Stack gap={2}>

--- a/src/System/Router/renderServerApp.tsx
+++ b/src/System/Router/renderServerApp.tsx
@@ -41,7 +41,7 @@ export const renderServerApp = ({
 
   const sharify = res.locals.sharify
 
-  const { APP_URL, CURRENT_PATH, WEBFONT_URL } = sharify.data
+  const { WEBFONT_URL } = sharify.data
 
   const options = {
     cdnUrl: NODE_ENV === "production" ? CDN_URL : "",
@@ -70,9 +70,6 @@ export const renderServerApp = ({
       browserConfig: MANIFEST.lookup("/images/browserconfig.xml"),
       openSearch: MANIFEST.lookup("/images/opensearch.xml"),
       webmanifest: MANIFEST.lookup("/images/manifest.webmanifest"),
-    },
-    meta: {
-      appleItunesApp: `${APP_URL}${CURRENT_PATH}`,
     },
     // TODO: Post-release review that sharify is still used in the template.
     sd: sharify.data,

--- a/src/html.ejs
+++ b/src/html.ejs
@@ -24,7 +24,6 @@
 
   <link rel='search' type='application/opensearchdescription+xml' href="<%%= manifest.openSearch %>" title='Artsy' />
 
-  <meta name="apple-itunes-app" content="app-id=703796080, app-argument=<%%= meta.appleItunesApp %>" />
   <meta name='msapplication-config' content="<%%= manifest.browserconfig %>" />
   <meta name='viewport' content='width=device-width, initial-scale=1, maximum-scale=5' />
 


### PR DESCRIPTION
Closes [DIA-733](https://artsyproduct.atlassian.net/browse/DIA-733), [DIA-734](https://artsyproduct.atlassian.net/browse/DIA-734)

This PR adds a custom app banner that rotates through a few bits of copy, in place of the [native smart banners](https://developer.apple.com/documentation/webkit/promoting_apps_with_smart_app_banners)

Will keep on draft until I know we can launch this separately from the footer popup.

![](https://capture.static.damonzucconi.com/Screen-Shot-2024-07-26-09-38-37.51-Pxd9SqngWyqchDMeOa37Wy44NzHIVj2i4fZiScYeB95pRCO7blr2iXDiXCAfDVMDfscYWJu3IOX2VcO3sVA1wiD7bcIGDdbJAKBk.png)

[DIA-733]: https://artsyproduct.atlassian.net/browse/DIA-733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DIA-734]: https://artsyproduct.atlassian.net/browse/DIA-734?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ