### PR TITLE
fix(caching): Handle uncompressed cases from MP

### DIFF
--- a/src/Server/middleware/__tests__/graphqlProxyMiddleware.jest.ts
+++ b/src/Server/middleware/__tests__/graphqlProxyMiddleware.jest.ts
@@ -276,6 +276,33 @@ describe("writeCache", () => {
     expect(res.end).toHaveBeenCalled()
   })
 
+  it("should set cache if response is uncompressed", async () => {
+    proxyRes.statusCode = 200
+    proxyRes.headers = {}
+    const responseBody = '{"data":"response"}'
+
+    proxyRes = {
+      ...proxyRes,
+      pipe: jest.fn().mockReturnThis(),
+      on: (event, callback) => {
+        if (event === "data") {
+          callback(responseBody)
+        }
+        if (event === "end") {
+          callback()
+        }
+        return this
+      },
+    }
+
+    await writeCache(proxyRes, req, res)
+
+    expect(mockCreateGunzip).not.toHaveBeenCalled()
+    expect(mockCreateBrotliDecompress).not.toHaveBeenCalled()
+    expect(mockCacheSet).toHaveBeenCalled()
+    expect(res.end).toHaveBeenCalled()
+  })
+
   it("should not set cache if response is not 200", async () => {
     proxyRes.statusCode = 500
 


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Fixes an issue observed in staging (from https://github.com/artsy/force/pull/14247) around uncompressed responses from MP not being persisted to redis. Handles that case. 
