### PR TITLE
feat: Set submission state when completing tier 2 flow

### DIFF
--- a/src/Apps/Sell/Routes/__tests__/ConditionRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/ConditionRoute.jest.tsx
@@ -182,6 +182,30 @@ describe("ConditionRoute", () => {
         screen.getByText("Submit Artwork").click()
 
         await waitFor(() => {
+          expect(submitMutation).toHaveBeenCalledWith(
+            expect.objectContaining({
+              variables: {
+                input: {
+                  artworkId: "artworkId",
+                  condition: "GOOD",
+                  conditionDescription: "description",
+                },
+              },
+            })
+          )
+
+          expect(submitMutation).toHaveBeenCalledWith(
+            expect.objectContaining({
+              variables: {
+                input: {
+                  externalId: "externalId",
+                  sessionID: undefined,
+                  state: "RESUBMITTED",
+                },
+              },
+            })
+          )
+
           expect(mockPush).toHaveBeenCalledWith(
             "/sell/submissions/externalId/thank-you"
           )

--- a/src/Apps/Sell/SellFlowContext.tsx
+++ b/src/Apps/Sell/SellFlowContext.tsx
@@ -171,6 +171,10 @@ export const SellFlowContextProvider: React.FC<SellFlowContextProviderProps> = (
       await updateSubmission({
         state: "SUBMITTED",
       })
+    } else if (submission?.state === "APPROVED") {
+      await updateSubmission({
+        state: "RESUBMITTED",
+      })
     }
 
     handleNext()


### PR DESCRIPTION
Addresses [ONYX-1146]

- Related Eigen PR: https://github.com/artsy/eigen/pull/10512

## Description

We want to set the submission state to "RESUBMITTED" when completing the Tier 2 submission flow (similar to when the user completes the Tier 1 flow and we set the state to "SUBMITTED").

[ONYX-1146]: https://artsyproduct.atlassian.net/browse/ONYX-1146?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ