### PR TITLE
ci(deploys): dont bust cache on deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "local-palette-dev": "./scripts/yalc-link-local-palette",
     "local-palette-dev:stop": "./scripts/yalc-unlink-local-palette",
     "open-consent-modal": "open http://localhost:5000?otreset=false&otpreview=true&otgeo=gb",
-    "pre-deploy": "yarn publish-assets && yarn invalidate-server-cache",
+    "pre-deploy": "yarn publish-assets",
     "prepare": "patch-package",
     "prettier-project": "yarn run prettier-write 'src/**/*.{ts,tsx,js,jsx}'",
     "prettier-write": "yarn run prettier --write",


### PR DESCRIPTION
The type of this PR is: **CI**

### Description

Per [this comment](https://github.com/artsy/force/pull/14254#discussion_r1696845308), this removes the cache invalidation on deploy in favor of adding our release number to the cache key. 
