### PR TITLE
feat: in addition to cloudflare IPs, allow k8s internal IPs

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -241,7 +241,7 @@ kind: Ingress
 metadata:
   name: force
   annotations:
-    nginx.ingress.kubernetes.io/whitelist-source-range: {{ cloudflareIpSourceRanges|join(',') }}
+    nginx.ingress.kubernetes.io/whitelist-source-range: {{ externalIngressAllowSourceIP|join(',') }}
 spec:
   ingressClassName: nginx
   rules:

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -255,7 +255,7 @@ kind: Ingress
 metadata:
   name: force
   annotations:
-    nginx.ingress.kubernetes.io/whitelist-source-range: {{ cloudflareIpSourceRanges|join(',') }}
+    nginx.ingress.kubernetes.io/whitelist-source-range: {{ externalIngressAllowSourceIP|join(',') }}
 spec:
   ingressClassName: nginx
   rules:


### PR DESCRIPTION
The type of this PR is: **Feat**

### Description

https://github.com/artsy/substance/pull/395 makes k8s-internal clients hit Force directly, bypassing Cloudflare. Force sees this traffic coming from k8s IPs.

Ingress allow-list currently allows Cloudflare IPs only. This PR adds k8s IPs.