### PR TITLE
feat: prompt for authentication for SWA > Add to MyC

### DIFF
--- a/src/Apps/Sell/Routes/ArtistNotEligibleRoute.tsx
+++ b/src/Apps/Sell/Routes/ArtistNotEligibleRoute.tsx
@@ -1,10 +1,14 @@
+import { AuthIntent, ContextModule } from "@artsy/cohesion"
 import { Button, Flex, FullBleed, Spacer } from "@artsy/palette"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { ArtistNotEligiblText } from "Apps/Sell/Components/ArtistNotEligibleText"
 import { SubmissionLayout } from "Apps/Sell/Components/SubmissionLayout"
 import { SubmissionStepTitle } from "Apps/Sell/Components/SubmissionStepTitle"
+import { useAuthDialog } from "Components/AuthDialog"
 import { EntityHeaderArtistFragmentContainer } from "Components/EntityHeaders/EntityHeaderArtist"
 import { RouterLink } from "System/Components/RouterLink"
+import { useRouter } from "System/Hooks/useRouter"
+import { useSystemContext } from "System/Hooks/useSystemContext"
 import { ArtistNotEligibleRoute_artist$key } from "__generated__/ArtistNotEligibleRoute_artist.graphql"
 import * as React from "react"
 import { graphql, useFragment } from "react-relay"
@@ -20,6 +24,40 @@ interface ArtistNotEligibleRouteProps {
 
 export const ArtistNotEligibleRoute: React.FC<ArtistNotEligibleRouteProps> = props => {
   const artist = useFragment(FRAGMENT, props.artist)
+  const { showAuthDialog } = useAuthDialog()
+  const { router } = useRouter()
+  const { isLoggedIn } = useSystemContext()
+
+  const triggerAuthDialog = () => {
+    showAuthDialog({
+      mode: "SignUp",
+      options: {
+        title: mode =>
+          mode === "Login"
+            ? "Log in to add to My Collection"
+            : "Sign up to add to My Collection",
+        redirectTo: "/collector-profile/my-collection/artworks/new",
+      },
+      analytics: {
+        contextModule: ContextModule.sell,
+        // TODO: This should be `Intent.addToMyCollection`
+        intent: "addToMyCollection" as AuthIntent,
+        trigger: "click",
+      },
+    })
+  }
+
+  const onAddToMyCollection = (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => {
+    event.preventDefault()
+
+    if (!isLoggedIn) {
+      return triggerAuthDialog()
+    }
+
+    router.push("/collector-profile/my-collection/artworks/new")
+  }
 
   return (
     <FullBleed>
@@ -46,6 +84,7 @@ export const ArtistNotEligibleRoute: React.FC<ArtistNotEligibleRouteProps> = pro
               as={RouterLink}
               to="/collector-profile/my-collection/artworks/new"
               data-testid="add-to-collection"
+              onClick={onAddToMyCollection}
             >
               Add to My Collection
             </Button>

--- a/src/Apps/Sell/Routes/__tests__/ArtistNotEligibleRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/ArtistNotEligibleRoute.jest.tsx
@@ -1,11 +1,13 @@
-import { screen } from "@testing-library/react"
+import { screen, waitFor } from "@testing-library/react"
 import { ArtistNotEligibleRoute } from "Apps/Sell/Routes/ArtistNotEligibleRoute"
+import { useAuthDialog } from "Components/AuthDialog/useAuthDialog"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { useRouter } from "System/Hooks/useRouter"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import { graphql } from "react-relay"
 
 const mockUseRouter = useRouter as jest.Mock
+const mockUseSystemContext = useSystemContext as jest.Mock
 const mockPush = jest.fn()
 const mockReplace = jest.fn()
 
@@ -20,6 +22,9 @@ jest.mock("react-relay", () => ({
 }))
 jest.mock("System/Hooks/useFeatureFlag", () => ({
   useFeatureFlag: jest.fn(() => true),
+}))
+jest.mock("Components/AuthDialog/useAuthDialog", () => ({
+  useAuthDialog: jest.fn().mockReturnValue({ showAuthDialog: jest.fn() }),
 }))
 
 let pathnameMock: string
@@ -67,11 +72,6 @@ describe("ArtistNotEligibleRoute", () => {
 
     expect(screen.getByText("Add Another Artist")).toBeInTheDocument()
 
-    expect(screen.getByTestId("add-to-collection")).toHaveAttribute(
-      "href",
-      "/collector-profile/my-collection/artworks/new"
-    )
-
     expect(screen.getByTestId("view-collection")).toHaveAttribute(
       "href",
       "/sell/submissions/new"
@@ -89,5 +89,39 @@ describe("ArtistNotEligibleRoute", () => {
     expect(
       screen.getByText("what our specialists are looking for")
     ).toHaveAttribute("href", "/sell/faq")
+  })
+
+  describe("while logged out", () => {
+    const mockUseAuthDialog = useAuthDialog as jest.Mock
+
+    beforeEach(() => {
+      mockUseSystemContext.mockImplementation(() => {
+        return { isLoggedIn: false }
+      })
+    })
+
+    it("prompts for authentication", async () => {
+      const showAuthDialog = jest.fn()
+      mockUseAuthDialog.mockImplementation(() => ({ showAuthDialog }))
+
+      renderWithRelay({})
+
+      screen.getByText("Add to My Collection").click()
+
+      await waitFor(() => {
+        expect(showAuthDialog).toBeCalledWith({
+          mode: "SignUp",
+          options: {
+            title: expect.any(Function),
+            redirectTo: "/collector-profile/my-collection/artworks/new",
+          },
+          analytics: {
+            contextModule: "sell",
+            intent: "addToMyCollection",
+            trigger: "click",
+          },
+        })
+      })
+    })
   })
 })

--- a/src/Apps/Sell/sellRoutes.tsx
+++ b/src/Apps/Sell/sellRoutes.tsx
@@ -189,6 +189,7 @@ export const sellRoutes: RouteProps[] = [
         onClientSideRender: () => {
           NewFromMyCollectionRoute.preload()
         },
+        onServerSideRender: checkIfLoggedIn,
       },
 
       {
@@ -356,6 +357,7 @@ export const sellRoutes: RouteProps[] = [
             onClientSideRender: () => {
               ThankYouRoute.preload()
             },
+            onServerSideRender: checkIfLoggedIn,
             query: graphql`
               query sellRoutes_ThankYouRouteQuery($id: ID!) {
                 submission(id: $id) @principalField {
@@ -377,6 +379,7 @@ export const sellRoutes: RouteProps[] = [
             onClientSideRender: () => {
               ShippingLocationRoute.preload()
             },
+            onServerSideRender: checkIfLoggedIn,
             query: graphql`
               query sellRoutes_ShippingLocationRouteQuery($id: ID!) {
                 submission(id: $id) @principalField {
@@ -398,6 +401,7 @@ export const sellRoutes: RouteProps[] = [
             onClientSideRender: () => {
               FrameRoute.preload()
             },
+            onServerSideRender: checkIfLoggedIn,
             query: graphql`
               query sellRoutes_FrameRouteQuery($id: ID!) {
                 submission(id: $id) @principalField {
@@ -416,6 +420,7 @@ export const sellRoutes: RouteProps[] = [
             onClientSideRender: () => {
               AdditionalDocumentsRoute.preload()
             },
+            onServerSideRender: checkIfLoggedIn,
             query: graphql`
               query sellRoutes_AdditionalDocumentsRouteQuery($id: ID!) {
                 submission(id: $id) @principalField {
@@ -434,6 +439,7 @@ export const sellRoutes: RouteProps[] = [
             onClientSideRender: () => {
               ConditionRoute.preload()
             },
+            onServerSideRender: checkIfLoggedIn,
             query: graphql`
               query sellRoutes_ConditionRouteQuery($id: ID!) {
                 submission(id: $id) @principalField {
@@ -450,3 +456,9 @@ export const sellRoutes: RouteProps[] = [
     ],
   },
 ]
+
+function checkIfLoggedIn({ req, res }) {
+  if (!req.user) {
+    res.redirect(`/login?redirectTo=${req.originalUrl}`)
+  }
+}


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [ONYX-1145](https://artsyproduct.atlassian.net/browse/ONYX-1145)

### Description

- feat: prompt for authentication for SWA > Add to MyC

  After selecting an artist ineligible for submission, we suggest that the user
can add the artwork to My Collection instead. Since those surfaces require
authentication, trigger the auth modal in response to that button click.

- feat: redirect to login page if navigating to authenticated SWA route

  Applies some server-side redirects if we're navigating to /sell route known to
require authentication.

[ONYX-1145]: https://artsyproduct.atlassian.net/browse/ONYX-1145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

## Screen Recording


https://github.com/user-attachments/assets/0b93cc04-a472-4219-b2e9-4eece4b9e117

