### PR TITLE
fix: Sell flow navigation logic

### DIFF
--- a/src/Apps/Sell/SellFlowContext.tsx
+++ b/src/Apps/Sell/SellFlowContext.tsx
@@ -199,14 +199,7 @@ export const SellFlowContextProvider: React.FC<SellFlowContextProviderProps> = (
 
     router.push(`/sell/submissions/${submission?.externalId}/${newStep}`)
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    index,
-    isNewSubmission,
-    match.location.pathname,
-    router,
-    submission,
-    steps,
-  ])
+  }, [index, isNewSubmission, submission, steps])
 
   const createSubmission = (values: CreateSubmissionMutationInput) => {
     const response = submitCreateSubmissionMutation({


### PR DESCRIPTION

## Description

This PR addresses a bug in the Sell flow navigation logic. The bug caused some redirects when accessing a step directly by pasting the URL in the browser.