### PR TITLE
fix: Sell flow Condition step link styling

### DIFF
--- a/src/Apps/Sell/Components/BottomFormNavigation.tsx
+++ b/src/Apps/Sell/Components/BottomFormNavigation.tsx
@@ -83,7 +83,7 @@ const BottomFormNextButton = () => {
   const { value, clearValue } = useAuthIntent()
 
   const {
-    actions: { goToNextStep},
+    actions: { goToNextStep },
     state: { submission, isSubmitStep, nextStep, loading },
   } = useSellFlowContext()
 
@@ -129,7 +129,7 @@ const BottomFormNextButton = () => {
     try {
       await submitForm()
 
-      await goToNextStep()
+      await goToNextStepCallback()
     } catch (error) {
       logger.error("Error submitting form", error)
     } finally {
@@ -149,7 +149,11 @@ const BottomFormNextButton = () => {
     } finally {
       setIsSubmitting(false)
     }
-  }, [associateSubmissionMutation, submitAndNavigateToNextStepCallback, submission])
+  }, [
+    associateSubmissionMutation,
+    submitAndNavigateToNextStepCallback,
+    submission,
+  ])
 
   useEffect(() => {
     if (value?.action === "submitSubmission") {

--- a/src/Apps/Sell/Routes/AdditionalRoutes/ConditionRoute.tsx
+++ b/src/Apps/Sell/Routes/AdditionalRoutes/ConditionRoute.tsx
@@ -1,8 +1,3 @@
-import { ConditionRoute_submission$key } from "__generated__/ConditionRoute_submission.graphql"
-import { ArtworkConditionEnumType } from "__generated__/useUpdateMyCollectionArtworkMutation.graphql"
-import { DevDebug } from "Apps/Sell/Components/DevDebug"
-import { Formik } from "formik"
-import { graphql, useFragment } from "react-relay"
 import {
   Box,
   Clickable,
@@ -13,14 +8,20 @@ import {
   Text,
   TextArea,
 } from "@artsy/palette"
+import { ConditionRoute_submission$key } from "__generated__/ConditionRoute_submission.graphql"
+import { ArtworkConditionEnumType } from "__generated__/useUpdateMyCollectionArtworkMutation.graphql"
+import { ConditionInfoModal } from "Apps/Artwork/Components/ArtworkDetails/ConditionInfoModal"
+import { DevDebug } from "Apps/Sell/Components/DevDebug"
 import { SubmissionLayout } from "Apps/Sell/Components/SubmissionLayout"
 import { SubmissionStepTitle } from "Apps/Sell/Components/SubmissionStepTitle"
 import { useSellFlowContext } from "Apps/Sell/SellFlowContext"
-import * as React from "react"
-import * as Yup from "yup"
-import { useState } from "react"
 import { conditionOptions } from "Apps/Sell/Utils/conditionOptions"
-import { ConditionInfoModal } from "Apps/Artwork/Components/ArtworkDetails/ConditionInfoModal"
+import { ErrorPage } from "Components/ErrorPage"
+import { Formik } from "formik"
+import * as React from "react"
+import { useState } from "react"
+import { graphql, useFragment } from "react-relay"
+import * as Yup from "yup"
 
 const FRAGMENT = graphql`
   fragment ConditionRoute_submission on ConsignmentSubmission {
@@ -52,16 +53,24 @@ interface ConditionRouteProps {
 }
 
 export const ConditionRoute: React.FC<ConditionRouteProps> = props => {
+  const { actions } = useSellFlowContext()
   const submission = useFragment(FRAGMENT, props.submission)
   const artwork = submission.myCollectionArtwork
-  const { actions } = useSellFlowContext()
 
   const [
     isConditionDefinitionModalOpen,
     setIsConditionDefinitionModalOpen,
   ] = useState(false)
 
-  if (!artwork) return null
+  if (!artwork) {
+    return (
+      <ErrorPage
+        code="Something went wrong."
+        message="The artwork could not be loaded. Please try again or contact support@artsy.net."
+        m={4}
+      />
+    )
+  }
 
   const onSubmit = async (values: FormValues) => {
     return await actions.updateMyCollectionArtwork({
@@ -102,13 +111,14 @@ export const ConditionRoute: React.FC<ConditionRouteProps> = props => {
             </Text>
 
             <Box>
-              <Flex justifyContent="flex-end">
+              <Flex justifyContent="flex-end" mb={-1}>
                 <Clickable
                   onClick={() => setIsConditionDefinitionModalOpen(true)}
                   data-test-id="open-rarity-modal"
+                  textDecoration="underline"
                 >
                   <Text variant="xs" color="black60">
-                    <u>Condition Definition</u>
+                    Condition Definition
                   </Text>
                 </Clickable>
               </Flex>


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves https://www.notion.so/artsy/Condition-Definition-link-on-the-field-should-match-the-design-system-spacing-see-image-f641d103ac3b430cb48dbf2ed415b9cd?pvs=4

### Description

This PR fixes the Sell flow Condition step link styling.

| Before | After |
| --- | --- |
|<img width="871" alt="Screenshot 2024-08-01 at 11 23 54" src="https://github.com/user-attachments/assets/1a314332-1090-48bf-9557-24db88a99a73"> |<img width="777" alt="Screenshot 2024-08-01 at 11 22 58" src="https://github.com/user-attachments/assets/ad9e684f-74b3-4683-945d-b2d7c674f6b2">| 





<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ