### PR TITLE
chore: Move Sell flow navigation logic to callback

### DIFF
--- a/src/Apps/Sell/SellFlowContext.tsx
+++ b/src/Apps/Sell/SellFlowContext.tsx
@@ -13,7 +13,14 @@ import { useSubmissionTracking } from "Apps/Sell/Hooks/useSubmissionTracking"
 import { useCreateSubmission } from "Apps/Sell/Mutations/useCreateSubmission"
 import { useUpdateMyCollectionArtwork } from "Apps/Sell/Mutations/useUpdateMyCollectionArtwork"
 import { useUpdateSubmission } from "Apps/Sell/Mutations/useUpdateSubmission"
-import { createContext, useContext, useEffect, useMemo, useState } from "react"
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react"
 import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
 import { useRouter } from "System/Hooks/useRouter"
 import { useCursor } from "use-cursor"
@@ -180,7 +187,7 @@ export const SellFlowContextProvider: React.FC<SellFlowContextProviderProps> = (
     handleNext()
   }
 
-  useEffect(() => {
+  const navigateToNewStep = useCallback(() => {
     const newStep = steps[index]
 
     // If we are navigating away from the Sell flow, we don't want to redirect
@@ -198,8 +205,18 @@ export const SellFlowContextProvider: React.FC<SellFlowContextProviderProps> = (
       return
 
     router.push(`/sell/submissions/${submission?.externalId}/${newStep}`)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [index, isNewSubmission, submission, steps])
+  }, [
+    index,
+    isNewSubmission,
+    match.location.pathname,
+    router,
+    steps,
+    submission,
+  ])
+
+  useEffect(() => {
+    navigateToNewStep()
+  }, [navigateToNewStep])
 
   const createSubmission = (values: CreateSubmissionMutationInput) => {
     const response = submitCreateSubmissionMutation({


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->


### Description

Follow-up for https://github.com/artsy/force/pull/14269

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ