### PR TITLE
feat: expand auction artworks filter options

### DIFF
--- a/src/Apps/Auction/Components/AuctionArtworkFilter.tsx
+++ b/src/Apps/Auction/Components/AuctionArtworkFilter.tsx
@@ -13,6 +13,10 @@ import { useSystemContext } from "System/Hooks/useSystemContext"
 import { AuctionArtworkFilter_viewer$data } from "__generated__/AuctionArtworkFilter_viewer.graphql"
 import { KeywordFilter } from "Components/ArtworkFilter/ArtworkFilters/KeywordFilter"
 import { Join, Spacer } from "@artsy/palette"
+import { ColorFilter } from "Components/ArtworkFilter/ArtworkFilters/ColorFilter"
+import { SizeFilter } from "Components/ArtworkFilter/ArtworkFilters/SizeFilter"
+import { MaterialsFilter } from "Components/ArtworkFilter/ArtworkFilters/MaterialsFilter"
+import { TimePeriodFilter } from "Components/ArtworkFilter/ArtworkFilters/TimePeriodFilter"
 
 interface AuctionArtworkFilterProps {
   relay: RelayRefetchProp
@@ -54,6 +58,10 @@ const AuctionArtworkFilter: React.FC<AuctionArtworkFilterProps> = ({
             <ArtistsFilter expanded />
             <PriceRangeFilter expanded />
             <MediumFilter expanded />
+            <SizeFilter />
+            <MaterialsFilter />
+            <TimePeriodFilter />
+            <ColorFilter />
           </Join>
         }
       />
@@ -95,7 +103,7 @@ export const AuctionArtworkFilterRefetchContainer = createRefetchContainer(
 )
 
 export const getArtworkFilterInputArgs = (user?: User) => {
-  const aggregations = ["ARTIST", "MEDIUM", "TOTAL"]
+  const aggregations = ["ARTIST", "MEDIUM", "TOTAL", "MATERIALS_TERMS"]
 
   if (user) {
     aggregations.push("FOLLOWED_ARTISTS")

--- a/src/Apps/Auction/Components/AuctionArtworkFilter.tsx
+++ b/src/Apps/Auction/Components/AuctionArtworkFilter.tsx
@@ -58,10 +58,10 @@ const AuctionArtworkFilter: React.FC<AuctionArtworkFilterProps> = ({
             <ArtistsFilter expanded />
             <PriceRangeFilter expanded />
             <MediumFilter expanded />
-            <SizeFilter />
-            <MaterialsFilter />
-            <TimePeriodFilter />
-            <ColorFilter />
+            <SizeFilter expanded />
+            <MaterialsFilter expanded />
+            <TimePeriodFilter expanded />
+            <ColorFilter expanded />
           </Join>
         }
       />

--- a/src/Apps/Auction/Components/__tests__/AuctionArtworkFilter.jest.tsx
+++ b/src/Apps/Auction/Components/__tests__/AuctionArtworkFilter.jest.tsx
@@ -80,7 +80,7 @@ describe("AuctionArtworkFilter", () => {
   describe("#getArtworkFilterInputArgs", () => {
     it("returns default arguments", () => {
       expect(getArtworkFilterInputArgs()).toEqual({
-        aggregations: ["ARTIST", "MEDIUM", "TOTAL"],
+        aggregations: ["ARTIST", "MEDIUM", "TOTAL", "MATERIALS_TERMS"],
         first: 39,
       })
     })
@@ -90,6 +90,7 @@ describe("AuctionArtworkFilter", () => {
         "ARTIST",
         "MEDIUM",
         "TOTAL",
+        "MATERIALS_TERMS",
         "FOLLOWED_ARTISTS",
       ])
     })

--- a/src/Components/ArtworkFilter/ArtworkFilters/Utils/useFilterSelectResults.ts
+++ b/src/Components/ArtworkFilter/ArtworkFilters/Utils/useFilterSelectResults.ts
@@ -6,7 +6,7 @@ import {
   useArtworkFilterContext,
   useCurrentlySelectedFilters,
 } from "Components/ArtworkFilter/ArtworkFilterContext"
-import { useFilterLabelCountByKey } from "../../Utils/useFilterLabelCountByKey"
+import { useFilterLabelCountByKey } from "Components/ArtworkFilter/Utils/useFilterLabelCountByKey"
 
 export interface UseFilterSelectResultsProps {
   facetName: keyof MultiSelectArtworkFilters


### PR DESCRIPTION
The type of this PR is: Feat

### Description

This PR was inspired by this hackathon 14 project [suggestion](https://www.notion.so/artsy/Add-shoppable-curated-collections-like-gems-on-paper-or-small-and-special-and-better-filter-op-710f2df614484eae90fc57fecabcef9c?pvs=4) to include more filter options for auction artworks, which has significantly less than our other artwork surfaces. After spiking on this work, it seems like we can extend the auction artwork filter options with pre-existing filters (size, materials, time period and colors) with very few code changes. 

**In fact, there are so few code changes required, I'm wondering if we have limited the filter options intentionally? Any insight on this would be appreciated. If not, this seems like an easy win.**

### Current
| auctions | fairs |
| ------------- | ------------- |
| ![Screenshot 2024-08-02 at 2 28 43 PM](https://github.com/user-attachments/assets/f8965259-c470-465b-a650-7f3a86809928) | ![2024-08-02 15 03 50](https://github.com/user-attachments/assets/5d6df541-cc5c-49cd-8e69-04b215977082) |

### PR Demo

https://github.com/user-attachments/assets/2205c6a2-998b-4e17-aab1-78138945d83a





