### PR TITLE
chore(cache): Update TTLs / docs

### DIFF
--- a/docs/caching.md
+++ b/docs/caching.md
@@ -5,10 +5,20 @@ There are a few different layers of caching on Artsy.net, namely:
 - Caching at the Relay (GraphQL) level, which happens as users navigate from page to page on the client. This is typically configured via the route.
 - Caching at the server level, via Redis, while logged out.
 
-> ⚠️ If for whatever reason we need to disable the cache, unset the environment variables via hokusai: 
+> ⚠️ If for whatever reason we need to disable the cache, unset the environment variables via hokusai:
+>
 > ```
 > hokusai production env unset ENABLE_GRAPHQL_PROXY ENABLE_GRAPHQL_CACHE
 > ```
+
+#### Important Cache-related ENV vars:
+
+- `ENABLE_GRAPHQL_PROXY`: Enables the proxy in support of caching
+- `ENABLE_GRAPHQL_CACHE`: Enables the GraphQL cache
+- `GRAPHQL_CACHE_SIZE`: Total number of entries before eviction (on the client; server-cache sizes are memory dependent)
+- `GRAPHQL_CACHE_TTL`: Default expiration TTL (in milliseconds)
+
+Non-default route cache times are set in [`Apps/serverCacheTTLs.tsx`](src/Apps/serverCacheTTLs.tsx).
 
 ### General Cache Behavior
 

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -97,3 +97,9 @@ We should avoid needing to hand-manage individual Redis cache entries, but occas
 - Tell AE to reload page, which will return the latest version
 
 As a last resort, we can flush the entire Redis cache by clicking the "Clear entire cache" button. This should be avoided however as all of our previous cache keys will need to be reindexed, which will greatly slow down the site.
+
+### Useful Links for Monitoring Cache Performance
+
+- [Force-production redis cluster metrics](https://us-east-1.console.aws.amazon.com/elasticache/home?region=us-east-1#/redis/force-production) (hit rate, eviction rate, # items, etc.)
+- [Calibre scores over time](https://app.datadoghq.com/dashboard/qfh-2gu-td7/calibre-scores?fromUser=false&refresh_mode=sliding&view=spans&from_ts=1720285399034&to_ts=1722877399034&live=true) (by page, device type, just a few data points per day)
+- [Force end-user load times](https://app.datadoghq.com/dashboard/dt4-sdd-r6r/force-load-times?fromUser=false&refresh_mode=sliding&view=spans&from_ts=1722272630753&to_ts=1722877430753&live=true) (FP, FCP, TTI, etc.)

--- a/src/Apps/Artist/artistRoutes.tsx
+++ b/src/Apps/Artist/artistRoutes.tsx
@@ -8,6 +8,7 @@ import { getWorksForSaleRouteVariables } from "./Routes/WorksForSale/Utils/getWo
 import { enableArtistPageCTA } from "./Server/enableArtistPageCTA"
 import { redirectWithCanonicalParams } from "./Server/redirect"
 import { allowedAuctionResultFilters } from "./Utils/allowedAuctionResultFilters"
+import { serverCacheTTLs } from "Apps/serverCacheTTLs"
 
 const ArtistApp = loadable(
   () => import(/* webpackChunkName: "artistBundle" */ "./ArtistApp"),
@@ -111,6 +112,7 @@ export const artistRoutes: RouteProps[] = [
   {
     path: "/artist/:artistID",
     ignoreScrollBehaviorBetweenChildren: true,
+    serverCacheTTL: serverCacheTTLs.artist,
     getComponent: () => ArtistApp,
     onServerSideRender: enableArtistPageCTA,
     onClientSideRender: () => {
@@ -128,6 +130,7 @@ export const artistRoutes: RouteProps[] = [
     children: [
       {
         path: "",
+        serverCacheTTL: serverCacheTTLs.artist,
         getComponent: () => WorksForSaleRoute,
         onServerSideRender: redirectWithCanonicalParams,
         onClientSideRender: () => {
@@ -155,6 +158,7 @@ export const artistRoutes: RouteProps[] = [
       },
       {
         path: "auction-results",
+        serverCacheTTL: serverCacheTTLs.artist,
         getComponent: () => AuctionResultsRoute,
         onClientSideRender: () => {
           AuctionResultsRoute.preload()
@@ -211,6 +215,7 @@ export const artistRoutes: RouteProps[] = [
       },
       {
         path: "about",
+        serverCacheTTL: serverCacheTTLs.artist,
         getComponent: () => OverviewRoute,
         onServerSideRender: enableArtistPageCTA,
         onClientSideRender: () => {
@@ -228,6 +233,7 @@ export const artistRoutes: RouteProps[] = [
   },
   {
     path: "/artist/:artistID",
+    serverCacheTTL: serverCacheTTLs.artist,
     ignoreScrollBehaviorBetweenChildren: true,
     getComponent: () => ArtistSubApp,
     query: graphql`
@@ -240,6 +246,7 @@ export const artistRoutes: RouteProps[] = [
     children: [
       {
         path: "articles/:artworkId?",
+        serverCacheTTL: serverCacheTTLs.artist,
         getComponent: () => ArticlesRoute,
         onClientSideRender: () => {
           ArticlesRoute.preload()
@@ -286,6 +293,7 @@ export const artistRoutes: RouteProps[] = [
       },
       {
         path: "cv",
+        serverCacheTTL: serverCacheTTLs.artist,
         getComponent: () => CVRoute,
         onClientSideRender: () => {
           CVRoute.preload()
@@ -300,6 +308,7 @@ export const artistRoutes: RouteProps[] = [
       },
       {
         path: "series",
+        serverCacheTTL: serverCacheTTLs.artist,
         getComponent: () => ArtistSeriesRoute,
         onClientSideRender: () => {
           ArtistSeriesRoute.preload()
@@ -314,6 +323,7 @@ export const artistRoutes: RouteProps[] = [
       },
       {
         path: "shows",
+        serverCacheTTL: serverCacheTTLs.artist,
         getComponent: () => ShowsRoute,
         onClientSideRender: () => {
           ShowsRoute.preload()
@@ -340,6 +350,7 @@ export const artistRoutes: RouteProps[] = [
   },
   {
     path: "/auction-result/:auctionResultId",
+    serverCacheTTL: serverCacheTTLs.artist,
     getComponent: () => AuctionResultRoute,
     onServerSideRender: enableArtistPageCTA,
     onClientSideRender: () => {

--- a/src/Apps/ArtistSeries/artistSeriesRoutes.tsx
+++ b/src/Apps/ArtistSeries/artistSeriesRoutes.tsx
@@ -2,6 +2,7 @@ import loadable from "@loadable/component"
 import { graphql } from "react-relay"
 import { RouteProps } from "System/Router/Route"
 import { getInitialFilterState } from "Components/ArtworkFilter/Utils/getInitialFilterState"
+import { serverCacheTTLs } from "Apps/serverCacheTTLs"
 
 const ArtistSeriesApp = loadable(
   () => import(/* webpackChunkName: "artistBundle" */ "./ArtistSeriesApp"),
@@ -13,6 +14,7 @@ const ArtistSeriesApp = loadable(
 export const artistSeriesRoutes: RouteProps[] = [
   {
     path: "/artist-series/:slug",
+    serverCacheTTL: serverCacheTTLs.artistSeries,
     getComponent: () => ArtistSeriesApp,
     onClientSideRender: () => {
       ArtistSeriesApp.preload()

--- a/src/Apps/Artists/artistsRoutes.tsx
+++ b/src/Apps/Artists/artistsRoutes.tsx
@@ -1,4 +1,5 @@
 import loadable from "@loadable/component"
+import { serverCacheTTLs } from "Apps/serverCacheTTLs"
 import { graphql } from "react-relay"
 import { RouteProps } from "System/Router/Route"
 
@@ -27,6 +28,7 @@ const ArtistsByLetterRoute = loadable(
 export const artistsRoutes: RouteProps[] = [
   {
     path: "/artists",
+    serverCacheTTL: serverCacheTTLs.artists,
     getComponent: () => ArtistsApp,
     onClientSideRender: () => {
       return ArtistsApp.preload()
@@ -34,6 +36,7 @@ export const artistsRoutes: RouteProps[] = [
     children: [
       {
         path: "",
+        serverCacheTTL: serverCacheTTLs.artists,
         getComponent: () => ArtistsIndexRoute,
         onClientSideRender: () => {
           return ArtistsIndexRoute.preload()
@@ -51,6 +54,7 @@ export const artistsRoutes: RouteProps[] = [
       },
       {
         path: "artists-starting-with-:letter([a-zA-Z])",
+        serverCacheTTL: serverCacheTTLs.artists,
         getComponent: () => ArtistsByLetterRoute,
         onClientSideRender: () => {
           return ArtistsByLetterRoute.preload()

--- a/src/Apps/Auction/auctionRoutes.tsx
+++ b/src/Apps/Auction/auctionRoutes.tsx
@@ -4,6 +4,7 @@ import { graphql } from "react-relay"
 import { getInitialFilterState } from "Components/ArtworkFilter/Utils/getInitialFilterState"
 import { RouteProps } from "System/Router/Route"
 import { getArtworkFilterInputArgs } from "./Components/AuctionArtworkFilter"
+import { serverCacheTTLs } from "Apps/serverCacheTTLs"
 
 const AuctionApp = loadable(
   () => import(/* webpackChunkName: "auctionBundle" */ "./AuctionApp"),
@@ -52,7 +53,7 @@ export const auctionRoutes: RouteProps[] = [
   {
     path: "/auction/:slug?",
     getComponent: () => AuctionApp,
-    serverCacheTTL: 0,
+    serverCacheTTL: serverCacheTTLs.auction,
     onClientSideRender: () => {
       AuctionApp.preload()
     },

--- a/src/Apps/Categories/categoriesRoutes.tsx
+++ b/src/Apps/Categories/categoriesRoutes.tsx
@@ -1,4 +1,5 @@
 import loadable from "@loadable/component"
+import { serverCacheTTLs } from "Apps/serverCacheTTLs"
 import { graphql } from "react-relay"
 import { RouteProps } from "System/Router/Route"
 
@@ -12,6 +13,7 @@ const CategoriesApp = loadable(
 export const categoriesRoutes: RouteProps[] = [
   {
     path: "/categories",
+    serverCacheTTL: serverCacheTTLs.categories,
     getComponent: () => CategoriesApp,
     onClientSideRender: () => {
       CategoriesApp.preload()

--- a/src/Apps/Collect/collectRoutes.tsx
+++ b/src/Apps/Collect/collectRoutes.tsx
@@ -3,6 +3,7 @@ import { RouteProps } from "System/Router/Route"
 import { graphql } from "react-relay"
 import { redirectCollectionToArtistSeries } from "./Server/redirectCollectionToArtistSeries"
 import { getInitialFilterState } from "Components/ArtworkFilter/Utils/getInitialFilterState"
+import { serverCacheTTLs } from "Apps/serverCacheTTLs"
 
 const CollectApp = loadable(
   () => import(/* webpackChunkName: "collectBundle" */ "./Routes/Collect"),
@@ -26,6 +27,7 @@ const CollectionApp = loadable(
 export const collectRoutes: RouteProps[] = [
   {
     path: "/collect/:medium?",
+    serverCacheTTL: serverCacheTTLs.collect,
     getComponent: () => CollectApp,
     onClientSideRender: () => {
       CollectApp.preload()
@@ -35,6 +37,7 @@ export const collectRoutes: RouteProps[] = [
   },
   {
     path: "/collect/color/:color?",
+    serverCacheTTL: serverCacheTTLs.collect,
     getComponent: () => CollectApp,
     onClientSideRender: () => {
       CollectApp.preload()
@@ -44,6 +47,7 @@ export const collectRoutes: RouteProps[] = [
   },
   {
     path: "/collections",
+    serverCacheTTL: serverCacheTTLs.collections,
     getComponent: () => CollectionsApp,
     onClientSideRender: () => {
       CollectionsApp.preload()
@@ -58,6 +62,7 @@ export const collectRoutes: RouteProps[] = [
   },
   {
     path: "/collection/:slug",
+    serverCacheTTL: serverCacheTTLs.collections,
     getComponent: () => CollectionApp,
     onServerSideRender: redirectCollectionToArtistSeries,
     onClientSideRender: () => {

--- a/src/Apps/Gene/geneRoutes.tsx
+++ b/src/Apps/Gene/geneRoutes.tsx
@@ -6,6 +6,7 @@ import { paramsToCamelCase } from "Components/ArtworkFilter/Utils/urlBuilder"
 import { initialArtworkFilterState } from "Components/ArtworkFilter/ArtworkFilterContext"
 import { RouteProps } from "System/Router/Route"
 import { redirectGeneToCollection } from "./Server/redirectGeneToCollection"
+import { serverCacheTTLs } from "Apps/serverCacheTTLs"
 
 const GeneApp = loadable(
   () => import(/* webpackChunkName: "geneBundle" */ "./GeneApp"),
@@ -24,6 +25,7 @@ const GeneShowRoute = loadable(
 export const geneRoutes: RouteProps[] = [
   {
     path: "/gene/:slug",
+    serverCacheTTL: serverCacheTTLs.gene,
     getComponent: () => GeneApp,
     onServerSideRender: redirectGeneToCollection,
     onClientSideRender: () => {
@@ -42,6 +44,7 @@ export const geneRoutes: RouteProps[] = [
       },
       {
         path: "",
+        serverCacheTTL: serverCacheTTLs.gene,
         getComponent: () => GeneShowRoute,
         onClientSideRender: () => {
           return GeneShowRoute.preload()

--- a/src/Apps/Partners/partnersRoutes.ts
+++ b/src/Apps/Partners/partnersRoutes.ts
@@ -1,4 +1,5 @@
 import loadable from "@loadable/component"
+import { serverCacheTTLs } from "Apps/serverCacheTTLs"
 import { graphql } from "react-relay"
 import { RouteProps } from "System/Router/Route"
 
@@ -21,6 +22,7 @@ const InstitutionsRoute = loadable(
 export const partnersRoutes: RouteProps[] = [
   {
     path: "/galleries",
+    serverCacheTTL: serverCacheTTLs.partners,
     getComponent: () => GalleriesRoute,
     onClientSideRender: () => {
       return GalleriesRoute.preload()
@@ -35,6 +37,7 @@ export const partnersRoutes: RouteProps[] = [
   },
   {
     path: "/institutions",
+    serverCacheTTL: serverCacheTTLs.partners,
     getComponent: () => InstitutionsRoute,
     onClientSideRender: () => {
       return InstitutionsRoute.preload()

--- a/src/Apps/Partners/partnersRoutes.ts
+++ b/src/Apps/Partners/partnersRoutes.ts
@@ -1,5 +1,4 @@
 import loadable from "@loadable/component"
-import { serverCacheTTLs } from "Apps/serverCacheTTLs"
 import { graphql } from "react-relay"
 import { RouteProps } from "System/Router/Route"
 
@@ -22,7 +21,6 @@ const InstitutionsRoute = loadable(
 export const partnersRoutes: RouteProps[] = [
   {
     path: "/galleries",
-    serverCacheTTL: serverCacheTTLs.partners,
     getComponent: () => GalleriesRoute,
     onClientSideRender: () => {
       return GalleriesRoute.preload()
@@ -37,7 +35,6 @@ export const partnersRoutes: RouteProps[] = [
   },
   {
     path: "/institutions",
-    serverCacheTTL: serverCacheTTLs.partners,
     getComponent: () => InstitutionsRoute,
     onClientSideRender: () => {
       return InstitutionsRoute.preload()

--- a/src/Apps/Sale/saleRoutes.tsx
+++ b/src/Apps/Sale/saleRoutes.tsx
@@ -1,5 +1,6 @@
 import loadable from "@loadable/component"
 import { getArtworkFilterInputArgs } from "Apps/Sale/Components/SaleArtworks"
+import { serverCacheTTLs } from "Apps/serverCacheTTLs"
 import { getInitialFilterState } from "Components/ArtworkFilter/Utils/getInitialFilterState"
 import { RouteProps } from "System/Router/Route"
 import { RedirectException } from "found"
@@ -15,6 +16,7 @@ const SaleApp = loadable(
 export const saleRoutes: RouteProps[] = [
   {
     path: "/sale/:slug",
+    serverCacheTTL: serverCacheTTLs.sale,
     getComponent: () => SaleApp,
     onClientSideRender: () => {
       SaleApp.preload()

--- a/src/Apps/serverCacheTTLs.tsx
+++ b/src/Apps/serverCacheTTLs.tsx
@@ -1,0 +1,21 @@
+const NO_CACHE = 0
+const HOURS_24 = 86400000
+
+/**
+ * This defines non-default cache TTLs for specific routes. Default is typically
+ * 1 hour, is set via GRAPHQL_CACHE_TTL env var, and automatically applies to
+ * all routes not defined here.
+ */
+export const serverCacheTTLs = {
+  artist: HOURS_24,
+  artists: HOURS_24,
+  artistSeries: HOURS_24,
+  auction: NO_CACHE,
+  categories: HOURS_24,
+  collect: HOURS_24,
+  collection: HOURS_24,
+  collections: HOURS_24,
+  gene: HOURS_24,
+  partners: HOURS_24,
+  sale: NO_CACHE,
+}

--- a/src/Apps/serverCacheTTLs.tsx
+++ b/src/Apps/serverCacheTTLs.tsx
@@ -1,5 +1,5 @@
 const NO_CACHE = 0
-const HOURS_24 = 86400000
+const HOURS_24 = 86400000 // In milliseconds
 
 /**
  * This defines non-default cache TTLs for specific routes. Default is typically
@@ -16,6 +16,5 @@ export const serverCacheTTLs = {
   collection: HOURS_24,
   collections: HOURS_24,
   gene: HOURS_24,
-  partners: HOURS_24,
   sale: NO_CACHE,
 }


### PR DESCRIPTION
The type of this PR is: **Chore**

### Description

In an effort to improve our cache hit rate, this bumps our server-side TTLs for a number of routes via a new `Apps/serverCacheTTLs.tsx` index file. Most of these choices I believe are uncontroversial but let me know if anything should be tweaked, or if I missed a route that should be bumped up more appropriately! 
