### PR TITLE
fix: Make additional documents optional in Sell flow

### DIFF
--- a/src/Apps/Sell/Routes/AdditionalRoutes/AdditionalDocumentsRoute.tsx
+++ b/src/Apps/Sell/Routes/AdditionalRoutes/AdditionalDocumentsRoute.tsx
@@ -71,7 +71,7 @@ export const AdditionalDocumentsRoute: React.FC<AdditionalDocumentsRouteProps> =
 
         return (
           <SubmissionLayout>
-            <SubmissionStepTitle>Additional documents</SubmissionStepTitle>
+            <SubmissionStepTitle>Additional Documents</SubmissionStepTitle>
 
             <Text mb={2} variant={["xs", "sm"]} color="black60">
               Please add any of the following if you have them: Proof of
@@ -80,6 +80,7 @@ export const AdditionalDocumentsRoute: React.FC<AdditionalDocumentsRouteProps> =
             </Text>
 
             <UploadDocumentsForm />
+
             <DocumentPreviewsGrid />
 
             <DevDebug />

--- a/src/Apps/Sell/Routes/AdditionalRoutes/AdditionalDocumentsRoute.tsx
+++ b/src/Apps/Sell/Routes/AdditionalRoutes/AdditionalDocumentsRoute.tsx
@@ -1,17 +1,17 @@
+import { Text } from "@artsy/palette"
 import { DevDebug } from "Apps/Sell/Components/DevDebug"
+import { DocumentPreviewsGrid } from "Apps/Sell/Components/DocumentPreviewsGrid"
 import { SubmissionLayout } from "Apps/Sell/Components/SubmissionLayout"
 import { SubmissionStepTitle } from "Apps/Sell/Components/SubmissionStepTitle"
+import { UploadDocumentsForm } from "Apps/Sell/Components/UploadDocumentsForm"
+import { useSellFlowContext } from "Apps/Sell/SellFlowContext"
+import { Asset, dropzoneFileFromAsset } from "Apps/Sell/Utils/uploadUtils"
+import { DropzoneFile } from "Components/FileUpload/types"
 import { AdditionalDocumentsRoute_submission$key } from "__generated__/AdditionalDocumentsRoute_submission.graphql"
 import { Formik } from "formik"
 import * as React from "react"
 import { graphql, useFragment } from "react-relay"
 import * as Yup from "yup"
-import { Text } from "@artsy/palette"
-import { UploadDocumentsForm } from "Apps/Sell/Components/UploadDocumentsForm"
-import { DocumentPreviewsGrid } from "Apps/Sell/Components/DocumentPreviewsGrid"
-import { Asset, dropzoneFileFromAsset } from "Apps/Sell/Utils/uploadUtils"
-import { DropzoneFile } from "Components/FileUpload/types"
-import { useSellFlowContext } from "Apps/Sell/SellFlowContext"
 
 const FRAGMENT = graphql`
   fragment AdditionalDocumentsRoute_submission on ConsignmentSubmission {
@@ -29,7 +29,7 @@ const FRAGMENT = graphql`
 `
 
 const Schema = Yup.object().shape({
-  documents: Yup.array().min(1),
+  documents: Yup.array(),
 })
 
 export interface DocumentsFormValues {

--- a/src/Apps/Sell/Routes/__tests__/AdditionalDocumentsRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/AdditionalDocumentsRoute.jest.tsx
@@ -1,14 +1,14 @@
 import { Toasts, ToastsProvider } from "@artsy/palette"
 import { fireEvent, screen, waitFor } from "@testing-library/react"
+import { AdditionalDocumentsRoute_Test_Query$rawResponse } from "__generated__/AdditionalDocumentsRoute_Test_Query.graphql"
 import { AdditionalDocumentsRoute } from "Apps/Sell/Routes/AdditionalRoutes/AdditionalDocumentsRoute"
 import { SubmissionRoute } from "Apps/Sell/Routes/SubmissionRoute"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
-import { useRouter } from "System/Hooks/useRouter"
-import { useSystemContext } from "System/Hooks/useSystemContext"
-import { AdditionalDocumentsRoute_Test_Query$rawResponse } from "__generated__/AdditionalDocumentsRoute_Test_Query.graphql"
 import { graphql } from "react-relay"
 import { MockEnvironment, createMockEnvironment } from "relay-test-utils"
 import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
+import { useRouter } from "System/Hooks/useRouter"
+import { useSystemContext } from "System/Hooks/useSystemContext"
 
 const mockUseRouter = useRouter as jest.Mock
 const mockPush = jest.fn()
@@ -129,12 +129,12 @@ const { renderWithRelay } = setupTestWrapperTL({
 })
 
 describe("AdditionalDocumentsRoute", () => {
-  it("renders the Additional documents step", () => {
+  it("renders the Additional Documents step", () => {
     renderWithRelay({
       ConsignmentSubmission: () => submissionMock,
     })
 
-    expect(screen.getByText("Additional documents")).toBeInTheDocument()
+    expect(screen.getByText("Additional Documents")).toBeInTheDocument()
     expect(
       screen.getByText(
         /Please add any of the following if you have them: Proof of Purchase, Certificate of Authentication, Fact Sheet, Condition Report/


### PR DESCRIPTION
Resolves https://www.notion.so/artsy/A-user-should-be-able-to-move-past-Additional-Documents-without-uploading-a-document-28d98971106f465cb59dd1339c0ca6bd?pvs=4

## Description

Make additional documents optional in Sell flow and change title to match other steps.