### PR TITLE
fix: Navigate to My Collection artwork page on the Sell flow "Save & Exit"

### DIFF
--- a/src/Apps/Sell/Components/SubmissionHeader.tsx
+++ b/src/Apps/Sell/Components/SubmissionHeader.tsx
@@ -84,7 +84,11 @@ export const SubmissionHeader: React.FC = () => {
       // Save the submission and current step to local storage
       storePreviousSubmission(submission?.externalId as string, step)
 
-      routerPush("/sell")
+      routerPush(
+        submission.myCollectionArtworkID
+          ? `/my-collection/artwork/${submission.myCollectionArtworkID}`
+          : "/sell"
+      )
     } catch (error) {
       logger.error("Something went wrong.", error)
     } finally {

--- a/src/Apps/Sell/Routes/SubmissionRoute.tsx
+++ b/src/Apps/Sell/Routes/SubmissionRoute.tsx
@@ -11,6 +11,7 @@ const FRAGMENT = graphql`
     internalID
     externalId
     state
+    myCollectionArtworkID
   }
 `
 

--- a/src/__generated__/AdditionalDocumentsRoute_Test_Query.graphql.ts
+++ b/src/__generated__/AdditionalDocumentsRoute_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f5fb4f614071fbc5439e78be0b07b7e8>>
+ * @generated SignedSource<<df6d35e500ce51c39094b014772a83ce>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -30,6 +30,7 @@ export type AdditionalDocumentsRoute_Test_Query$rawResponse = {
     readonly externalId: string;
     readonly id: string;
     readonly internalID: string | null | undefined;
+    readonly myCollectionArtworkID: string | null | undefined;
     readonly state: ConsignmentSubmissionStateAggregation | null | undefined;
   } | null | undefined;
 };
@@ -123,6 +124,13 @@ return {
           },
           {
             "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "myCollectionArtworkID",
+            "storageKey": null
+          },
+          {
+            "alias": null,
             "args": [
               {
                 "kind": "Literal",
@@ -183,12 +191,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ba51a5a21a430a6734a07d980fad1656",
+    "cacheID": "fa5b5e28f5ac000a391ec74ae975ed19",
     "id": null,
     "metadata": {},
     "name": "AdditionalDocumentsRoute_Test_Query",
     "operationKind": "query",
-    "text": "query AdditionalDocumentsRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...SubmissionRoute_submission\n    ...AdditionalDocumentsRoute_submission\n    id\n  }\n}\n\nfragment AdditionalDocumentsRoute_submission on ConsignmentSubmission {\n  externalId\n  assets(assetType: [ADDITIONAL_FILE]) {\n    id\n    size\n    filename\n    documentPath\n    s3Path\n    s3Bucket\n  }\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n}\n"
+    "text": "query AdditionalDocumentsRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...SubmissionRoute_submission\n    ...AdditionalDocumentsRoute_submission\n    id\n  }\n}\n\nfragment AdditionalDocumentsRoute_submission on ConsignmentSubmission {\n  externalId\n  assets(assetType: [ADDITIONAL_FILE]) {\n    id\n    size\n    filename\n    documentPath\n    s3Path\n    s3Bucket\n  }\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n  myCollectionArtworkID\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistRoute_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistRoute_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d2a361fc6786ca33c20e39d99f9de09c>>
+ * @generated SignedSource<<3a4ac76ed43191855e453ae1c7a5fe6a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -30,6 +30,7 @@ export type ArtistRoute_Test_Query$rawResponse = {
     readonly externalId: string;
     readonly id: string;
     readonly internalID: string | null | undefined;
+    readonly myCollectionArtworkID: string | null | undefined;
     readonly state: ConsignmentSubmissionStateAggregation | null | undefined;
   } | null | undefined;
 };
@@ -125,6 +126,13 @@ return {
           {
             "alias": null,
             "args": null,
+            "kind": "ScalarField",
+            "name": "myCollectionArtworkID",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "concreteType": "Artist",
             "kind": "LinkedField",
             "name": "artist",
@@ -167,12 +175,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "062bc1cd8730c03b48d9a513922aea69",
+    "cacheID": "19f22da6e4e8aa965f191e3b51072346",
     "id": null,
     "metadata": {},
     "name": "ArtistRoute_Test_Query",
     "operationKind": "query",
-    "text": "query ArtistRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...SubmissionRoute_submission\n    ...ArtistRoute_submission\n    id\n  }\n}\n\nfragment ArtistRoute_submission on ConsignmentSubmission {\n  internalID\n  artist {\n    internalID\n    targetSupply {\n      isTargetSupply\n    }\n    name\n    id\n  }\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n}\n"
+    "text": "query ArtistRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...SubmissionRoute_submission\n    ...ArtistRoute_submission\n    id\n  }\n}\n\nfragment ArtistRoute_submission on ConsignmentSubmission {\n  internalID\n  artist {\n    internalID\n    targetSupply {\n      isTargetSupply\n    }\n    name\n    id\n  }\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n  myCollectionArtworkID\n}\n"
   }
 };
 })();

--- a/src/__generated__/ConditionRoute_Test_Query.graphql.ts
+++ b/src/__generated__/ConditionRoute_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<05d654b38f9f652d20d0b743997e85d0>>
+ * @generated SignedSource<<f50b417c476e7df418e3c6584d12920e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -32,6 +32,7 @@ export type ConditionRoute_Test_Query$rawResponse = {
       } | null | undefined;
       readonly id: string;
     } | null | undefined;
+    readonly myCollectionArtworkID: string | null | undefined;
     readonly state: ConsignmentSubmissionStateAggregation | null | undefined;
   } | null | undefined;
 };
@@ -178,6 +179,13 @@ return {
             "name": "state",
             "storageKey": null
           },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "myCollectionArtworkID",
+            "storageKey": null
+          },
           (v1/*: any*/)
         ],
         "storageKey": "submission(id:\"submission-id\")"
@@ -185,12 +193,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f96956400df9c34cf952ad05146609b1",
+    "cacheID": "a49b93f5bb950af4f11a409735c78bd7",
     "id": null,
     "metadata": {},
     "name": "ConditionRoute_Test_Query",
     "operationKind": "query",
-    "text": "query ConditionRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...ConditionRoute_submission\n    ...SubmissionRoute_submission\n    id\n  }\n}\n\nfragment ConditionRoute_submission on ConsignmentSubmission {\n  myCollectionArtwork {\n    artworkId: internalID\n    condition {\n      value\n    }\n    conditionDescription {\n      details\n    }\n    id\n  }\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n}\n"
+    "text": "query ConditionRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...ConditionRoute_submission\n    ...SubmissionRoute_submission\n    id\n  }\n}\n\nfragment ConditionRoute_submission on ConsignmentSubmission {\n  myCollectionArtwork {\n    artworkId: internalID\n    condition {\n      value\n    }\n    conditionDescription {\n      details\n    }\n    id\n  }\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n  myCollectionArtworkID\n}\n"
   }
 };
 })();

--- a/src/__generated__/DetailsRoute_Test_Query.graphql.ts
+++ b/src/__generated__/DetailsRoute_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e97619c804b8f3666e7ac8f756bb0dfe>>
+ * @generated SignedSource<<91f5de9da1f720a5b92d24925cbbf45e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -24,6 +24,7 @@ export type DetailsRoute_Test_Query$rawResponse = {
     readonly id: string;
     readonly internalID: string | null | undefined;
     readonly medium: string | null | undefined;
+    readonly myCollectionArtworkID: string | null | undefined;
     readonly state: ConsignmentSubmissionStateAggregation | null | undefined;
     readonly year: string | null | undefined;
   } | null | undefined;
@@ -113,6 +114,13 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "myCollectionArtworkID",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "year",
             "storageKey": null
           },
@@ -143,12 +151,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d6439b0fe1ee67f18fa07fd6e1d62f17",
+    "cacheID": "6facb5d5928a33ffd714f88cae1b0098",
     "id": null,
     "metadata": {},
     "name": "DetailsRoute_Test_Query",
     "operationKind": "query",
-    "text": "query DetailsRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...SubmissionRoute_submission\n    ...DetailsRoute_submission\n    id\n  }\n}\n\nfragment DetailsRoute_submission on ConsignmentSubmission {\n  year\n  category\n  medium\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n}\n"
+    "text": "query DetailsRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...SubmissionRoute_submission\n    ...DetailsRoute_submission\n    id\n  }\n}\n\nfragment DetailsRoute_submission on ConsignmentSubmission {\n  year\n  category\n  medium\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n  myCollectionArtworkID\n}\n"
   }
 };
 })();

--- a/src/__generated__/DimensionsRoute_Test_Query.graphql.ts
+++ b/src/__generated__/DimensionsRoute_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e7a108cded5b83e87c2d747f34ce2dff>>
+ * @generated SignedSource<<f15a373832e57d437b8722ca57844229>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -25,6 +25,7 @@ export type DimensionsRoute_Test_Query$rawResponse = {
     readonly height: string | null | undefined;
     readonly id: string;
     readonly internalID: string | null | undefined;
+    readonly myCollectionArtworkID: string | null | undefined;
     readonly state: ConsignmentSubmissionStateAggregation | null | undefined;
     readonly width: string | null | undefined;
   } | null | undefined;
@@ -114,6 +115,13 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "myCollectionArtworkID",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "width",
             "storageKey": null
           },
@@ -151,12 +159,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "9f5574f60353632eb4e2b4f91ea6b642",
+    "cacheID": "f149fc467f69a8f9c052822c4a66893b",
     "id": null,
     "metadata": {},
     "name": "DimensionsRoute_Test_Query",
     "operationKind": "query",
-    "text": "query DimensionsRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...SubmissionRoute_submission\n    ...DimensionsRoute_submission\n    id\n  }\n}\n\nfragment DimensionsRoute_submission on ConsignmentSubmission {\n  width\n  height\n  depth\n  dimensionsMetric\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n}\n"
+    "text": "query DimensionsRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...SubmissionRoute_submission\n    ...DimensionsRoute_submission\n    id\n  }\n}\n\nfragment DimensionsRoute_submission on ConsignmentSubmission {\n  width\n  height\n  depth\n  dimensionsMetric\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n  myCollectionArtworkID\n}\n"
   }
 };
 })();

--- a/src/__generated__/FrameRoute_Test_Query.graphql.ts
+++ b/src/__generated__/FrameRoute_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d282428b8972b25e0a3303dea626b77c>>
+ * @generated SignedSource<<dbb2690af8727c778f0b47aabec2bcdc>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -31,6 +31,7 @@ export type FrameRoute_Test_Query$rawResponse = {
       readonly id: string;
       readonly isFramed: boolean | null | undefined;
     } | null | undefined;
+    readonly myCollectionArtworkID: string | null | undefined;
     readonly state: ConsignmentSubmissionStateAggregation | null | undefined;
   } | null | undefined;
 };
@@ -176,6 +177,13 @@ return {
             "name": "state",
             "storageKey": null
           },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "myCollectionArtworkID",
+            "storageKey": null
+          },
           (v1/*: any*/)
         ],
         "storageKey": "submission(id:\"submission-id\")"
@@ -183,12 +191,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "2823a61501c20df422714e7a2946d4e9",
+    "cacheID": "bfebd378c9ccb7682d6d454cd46392eb",
     "id": null,
     "metadata": {},
     "name": "FrameRoute_Test_Query",
     "operationKind": "query",
-    "text": "query FrameRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...FrameRoute_submission\n    ...SubmissionRoute_submission\n    id\n  }\n}\n\nfragment FrameRoute_submission on ConsignmentSubmission {\n  myCollectionArtwork {\n    artworkId: internalID\n    isFramed\n    framedMetric\n    framedWidth\n    framedHeight\n    framedDepth\n    id\n  }\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n}\n"
+    "text": "query FrameRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...FrameRoute_submission\n    ...SubmissionRoute_submission\n    id\n  }\n}\n\nfragment FrameRoute_submission on ConsignmentSubmission {\n  myCollectionArtwork {\n    artworkId: internalID\n    isFramed\n    framedMetric\n    framedWidth\n    framedHeight\n    framedDepth\n    id\n  }\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n  myCollectionArtworkID\n}\n"
   }
 };
 })();

--- a/src/__generated__/PhoneNumberRoute_Test_Query.graphql.ts
+++ b/src/__generated__/PhoneNumberRoute_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f4c7873e2607abbf671db2392cfa583b>>
+ * @generated SignedSource<<52d4dceccba893fc8687c913b47ff91c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -33,6 +33,7 @@ export type PhoneNumberRoute_Test_Query$rawResponse = {
     readonly externalId: string;
     readonly id: string;
     readonly internalID: string | null | undefined;
+    readonly myCollectionArtworkID: string | null | undefined;
     readonly state: ConsignmentSubmissionStateAggregation | null | undefined;
     readonly userPhoneNumber: {
       readonly display: string | null | undefined;
@@ -171,6 +172,13 @@ return {
             "name": "state",
             "storageKey": null
           },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "myCollectionArtworkID",
+            "storageKey": null
+          },
           (v3/*: any*/)
         ],
         "storageKey": "submission(id:\"submission-id\")"
@@ -216,12 +224,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "0c8ee08600966b80e333ba172ff942ab",
+    "cacheID": "1773a95e478361f6fc2d0aa4e2b36057",
     "id": null,
     "metadata": {},
     "name": "PhoneNumberRoute_Test_Query",
     "operationKind": "query",
-    "text": "query PhoneNumberRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...PhoneNumberRoute_submission\n    ...SubmissionRoute_submission\n    id\n  }\n  me {\n    ...PhoneNumberRoute_me\n    id\n  }\n}\n\nfragment PhoneNumberRoute_me on Me {\n  internalID\n  phoneNumber {\n    regionCode\n    display(format: NATIONAL)\n  }\n}\n\nfragment PhoneNumberRoute_submission on ConsignmentSubmission {\n  userPhoneNumber {\n    display\n    regionCode\n  }\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n}\n"
+    "text": "query PhoneNumberRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...PhoneNumberRoute_submission\n    ...SubmissionRoute_submission\n    id\n  }\n  me {\n    ...PhoneNumberRoute_me\n    id\n  }\n}\n\nfragment PhoneNumberRoute_me on Me {\n  internalID\n  phoneNumber {\n    regionCode\n    display(format: NATIONAL)\n  }\n}\n\nfragment PhoneNumberRoute_submission on ConsignmentSubmission {\n  userPhoneNumber {\n    display\n    regionCode\n  }\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n  myCollectionArtworkID\n}\n"
   }
 };
 })();

--- a/src/__generated__/PhotosRoute_Test_Query.graphql.ts
+++ b/src/__generated__/PhotosRoute_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b5d656ea0de91f1604cc98f92b23d8c3>>
+ * @generated SignedSource<<0a0bf15cc6cbd82efca54485d7b056fc>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -35,6 +35,7 @@ export type PhotosRoute_Test_Query$rawResponse = {
         readonly url: string | null | undefined;
       } | null | undefined> | null | undefined;
     } | null | undefined;
+    readonly myCollectionArtworkID: string | null | undefined;
     readonly state: ConsignmentSubmissionStateAggregation | null | undefined;
   } | null | undefined;
 };
@@ -129,6 +130,13 @@ return {
           {
             "alias": null,
             "args": null,
+            "kind": "ScalarField",
+            "name": "myCollectionArtworkID",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "concreteType": "Artwork",
             "kind": "LinkedField",
             "name": "myCollectionArtwork",
@@ -209,12 +217,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f487ab4f419a507ba5673d7dddad8ec4",
+    "cacheID": "3b955119945204fcd7e4d03799c2c54b",
     "id": null,
     "metadata": {},
     "name": "PhotosRoute_Test_Query",
     "operationKind": "query",
-    "text": "query PhotosRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...SubmissionRoute_submission\n    ...PhotosRoute_submission\n    id\n  }\n}\n\nfragment PhotosRoute_submission on ConsignmentSubmission {\n  externalId\n  myCollectionArtwork {\n    images {\n      url(version: \"large\")\n    }\n    id\n  }\n  assets {\n    id\n    size\n    filename\n    geminiToken\n    imageUrls\n  }\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n}\n"
+    "text": "query PhotosRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...SubmissionRoute_submission\n    ...PhotosRoute_submission\n    id\n  }\n}\n\nfragment PhotosRoute_submission on ConsignmentSubmission {\n  externalId\n  myCollectionArtwork {\n    images {\n      url(version: \"large\")\n    }\n    id\n  }\n  assets {\n    id\n    size\n    filename\n    geminiToken\n    imageUrls\n  }\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n  myCollectionArtworkID\n}\n"
   }
 };
 })();

--- a/src/__generated__/PurchaseHistoryRoute_Test_Query.graphql.ts
+++ b/src/__generated__/PurchaseHistoryRoute_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d8a3ef9bfddffc99770f00227e275a87>>
+ * @generated SignedSource<<07cf6f550d5cac1a56886ad7de2a0725>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -22,6 +22,7 @@ export type PurchaseHistoryRoute_Test_Query$rawResponse = {
     readonly externalId: string;
     readonly id: string;
     readonly internalID: string | null | undefined;
+    readonly myCollectionArtworkID: string | null | undefined;
     readonly provenance: string | null | undefined;
     readonly signature: boolean | null | undefined;
     readonly state: ConsignmentSubmissionStateAggregation | null | undefined;
@@ -112,6 +113,13 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "myCollectionArtworkID",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "provenance",
             "storageKey": null
           },
@@ -135,12 +143,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "199264a29c9b1de31c0aea9276f72471",
+    "cacheID": "b6cd336c97e459dc816da72acbbf70e5",
     "id": null,
     "metadata": {},
     "name": "PurchaseHistoryRoute_Test_Query",
     "operationKind": "query",
-    "text": "query PurchaseHistoryRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...SubmissionRoute_submission\n    ...PurchaseHistoryRoute_submission\n    id\n  }\n}\n\nfragment PurchaseHistoryRoute_submission on ConsignmentSubmission {\n  provenance\n  signature\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n}\n"
+    "text": "query PurchaseHistoryRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...SubmissionRoute_submission\n    ...PurchaseHistoryRoute_submission\n    id\n  }\n}\n\nfragment PurchaseHistoryRoute_submission on ConsignmentSubmission {\n  provenance\n  signature\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n  myCollectionArtworkID\n}\n"
   }
 };
 })();

--- a/src/__generated__/ShippingLocationRoute_Test_Query.graphql.ts
+++ b/src/__generated__/ShippingLocationRoute_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<773c9b85444fc8f71303d1a7836e220b>>
+ * @generated SignedSource<<6ad4e6aeb7effe3997abb92fb131bb02>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -48,6 +48,7 @@ export type ShippingLocationRoute_Test_Query$rawResponse = {
     readonly locationCountry: string | null | undefined;
     readonly locationPostalCode: string | null | undefined;
     readonly locationState: string | null | undefined;
+    readonly myCollectionArtworkID: string | null | undefined;
     readonly state: ConsignmentSubmissionStateAggregation | null | undefined;
   } | null | undefined;
 };
@@ -197,6 +198,13 @@ return {
             "name": "state",
             "storageKey": null
           },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "myCollectionArtworkID",
+            "storageKey": null
+          },
           (v1/*: any*/)
         ],
         "storageKey": "submission(id:\"submission-id\")"
@@ -299,12 +307,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "dc64881d4e329e1c6d556a0c596ac9fc",
+    "cacheID": "38ee8a99c67331b8777927dbbf4d903c",
     "id": null,
     "metadata": {},
     "name": "ShippingLocationRoute_Test_Query",
     "operationKind": "query",
-    "text": "query ShippingLocationRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...ShippingLocationRoute_submission\n    ...SubmissionRoute_submission\n    id\n  }\n  me {\n    ...ShippingLocationRoute_me\n    id\n  }\n}\n\nfragment ShippingLocationRoute_me on Me {\n  addressConnection {\n    edges {\n      node {\n        addressLine1\n        addressLine2\n        city\n        country\n        isDefault\n        postalCode\n        region\n        id\n      }\n    }\n  }\n}\n\nfragment ShippingLocationRoute_submission on ConsignmentSubmission {\n  locationCity\n  locationCountry\n  locationState\n  locationPostalCode\n  locationAddress\n  locationAddress2\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n}\n"
+    "text": "query ShippingLocationRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...ShippingLocationRoute_submission\n    ...SubmissionRoute_submission\n    id\n  }\n  me {\n    ...ShippingLocationRoute_me\n    id\n  }\n}\n\nfragment ShippingLocationRoute_me on Me {\n  addressConnection {\n    edges {\n      node {\n        addressLine1\n        addressLine2\n        city\n        country\n        isDefault\n        postalCode\n        region\n        id\n      }\n    }\n  }\n}\n\nfragment ShippingLocationRoute_submission on ConsignmentSubmission {\n  locationCity\n  locationCountry\n  locationState\n  locationPostalCode\n  locationAddress\n  locationAddress2\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n  myCollectionArtworkID\n}\n"
   }
 };
 })();

--- a/src/__generated__/SubmissionRoute_submission.graphql.ts
+++ b/src/__generated__/SubmissionRoute_submission.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<52b8905df1a21925874c9a83aaf88c2e>>
+ * @generated SignedSource<<4848caf949b605d0c5febee56224fb1f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -14,6 +14,7 @@ import { FragmentRefs } from "relay-runtime";
 export type SubmissionRoute_submission$data = {
   readonly externalId: string;
   readonly internalID: string | null | undefined;
+  readonly myCollectionArtworkID: string | null | undefined;
   readonly state: ConsignmentSubmissionStateAggregation | null | undefined;
   readonly " $fragmentType": "SubmissionRoute_submission";
 };
@@ -48,12 +49,19 @@ const node: ReaderFragment = {
       "kind": "ScalarField",
       "name": "state",
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "myCollectionArtworkID",
+      "storageKey": null
     }
   ],
   "type": "ConsignmentSubmission",
   "abstractKey": null
 };
 
-(node as any).hash = "83e9465ac2bec4d1dd6dca1b2b5b0012";
+(node as any).hash = "1d0afd36b1e90364a7823b425e6abb55";
 
 export default node;

--- a/src/__generated__/ThankYouRoute_Test_Query.graphql.ts
+++ b/src/__generated__/ThankYouRoute_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<71c0acbff6a559dc4540ae95a44c866b>>
+ * @generated SignedSource<<5e261f8c00f2645495be8aab6a5ce6fd>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -127,12 +127,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "6fe494ad3a1e12391b8a7c55c4bed45c",
+    "cacheID": "8c6b59f9bd00ac00aef79894933110fe",
     "id": null,
     "metadata": {},
     "name": "ThankYouRoute_Test_Query",
     "operationKind": "query",
-    "text": "query ThankYouRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...SubmissionRoute_submission\n    ...ThankYouRoute_submission\n    id\n  }\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n}\n\nfragment ThankYouRoute_submission on ConsignmentSubmission {\n  internalID\n  state\n  myCollectionArtworkID\n}\n"
+    "text": "query ThankYouRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...SubmissionRoute_submission\n    ...ThankYouRoute_submission\n    id\n  }\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n  myCollectionArtworkID\n}\n\nfragment ThankYouRoute_submission on ConsignmentSubmission {\n  internalID\n  state\n  myCollectionArtworkID\n}\n"
   }
 };
 })();

--- a/src/__generated__/TitleRoute_Test_Query.graphql.ts
+++ b/src/__generated__/TitleRoute_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c495b806eed5a1f69515e12820829be9>>
+ * @generated SignedSource<<607cda80356a142d7419402a5e7c1e31>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -44,6 +44,7 @@ export type TitleRoute_Test_Query$rawResponse = {
     readonly externalId: string;
     readonly id: string;
     readonly internalID: string | null | undefined;
+    readonly myCollectionArtworkID: string | null | undefined;
     readonly state: ConsignmentSubmissionStateAggregation | null | undefined;
     readonly title: string | null | undefined;
   } | null | undefined;
@@ -276,6 +277,13 @@ return {
             "name": "state",
             "storageKey": null
           },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "myCollectionArtworkID",
+            "storageKey": null
+          },
           (v2/*: any*/)
         ],
         "storageKey": "submission(id:\"submission-id\")"
@@ -283,12 +291,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f58b003b179d0f4280f548ad2a1432af",
+    "cacheID": "5f5b0553cf4de2c3b6c077f15918e45d",
     "id": null,
     "metadata": {},
     "name": "TitleRoute_Test_Query",
     "operationKind": "query",
-    "text": "query TitleRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...TitleRoute_submission\n    ...SubmissionRoute_submission\n    id\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  coverArtwork {\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n}\n\nfragment TitleRoute_submission on ConsignmentSubmission {\n  title\n  artist {\n    ...EntityHeaderArtist_artist\n    id\n  }\n}\n"
+    "text": "query TitleRoute_Test_Query {\n  submission(id: \"submission-id\") {\n    ...TitleRoute_submission\n    ...SubmissionRoute_submission\n    id\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  coverArtwork {\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n  myCollectionArtworkID\n}\n\nfragment TitleRoute_submission on ConsignmentSubmission {\n  title\n  artist {\n    ...EntityHeaderArtist_artist\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/sellRoutes_SubmissionRouteQuery.graphql.ts
+++ b/src/__generated__/sellRoutes_SubmissionRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0d79d23c6de65bd58860d4162d26115d>>
+ * @generated SignedSource<<30178cbb88b0d2335fa3dd1941953c11>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -115,6 +115,13 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "myCollectionArtworkID",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "id",
             "storageKey": null
           }
@@ -124,12 +131,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "bf4b8c95905f83b773e8ea2704a4bd5e",
+    "cacheID": "a8df6760d33cbb13e9b79cdfafb50f6b",
     "id": null,
     "metadata": {},
     "name": "sellRoutes_SubmissionRouteQuery",
     "operationKind": "query",
-    "text": "query sellRoutes_SubmissionRouteQuery(\n  $id: ID!\n  $sessionID: String!\n) {\n  submission(id: $id, sessionID: $sessionID) @principalField {\n    ...SubmissionRoute_submission\n    id\n  }\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n}\n"
+    "text": "query sellRoutes_SubmissionRouteQuery(\n  $id: ID!\n  $sessionID: String!\n) {\n  submission(id: $id, sessionID: $sessionID) @principalField {\n    ...SubmissionRoute_submission\n    id\n  }\n}\n\nfragment SubmissionRoute_submission on ConsignmentSubmission {\n  internalID\n  externalId\n  state\n  myCollectionArtworkID\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Resolves https://www.notion.so/artsy/When-submitting-a-MyC-artwork-should-Save-Exit-navigate-back-to-the-artwork-Currently-it-opens--ebdf272100c94666ba75b1c943097327?pvs=4

## Description

Navigate to My Collection artwork page on the "Save & Exit" when associated My Collection artwork is present.

<img width="920" alt="Screenshot 2024-08-05 at 12 58 45" src="https://github.com/user-attachments/assets/7f54c98b-8f16-4b7f-9ec6-1cc82fdb69ac">
