### PR TITLE
feat(cache): Add cache logger middleware

### DIFF
--- a/src/Server/middleware/__tests__/graphqlProxyMiddleware.jest.ts
+++ b/src/Server/middleware/__tests__/graphqlProxyMiddleware.jest.ts
@@ -60,7 +60,7 @@ describe("graphqlProxyMiddleware", () => {
 
   describe("cache lookup", () => {
     it("should return cached response if available", async () => {
-      const cachedResponse = JSON.stringify({ data: "cached" })
+      const cachedResponse = JSON.stringify({ data: "cached", cached: true })
       mockCacheGet.mockResolvedValueOnce(cachedResponse)
 
       await graphqlProxyMiddleware(req, res, next)
@@ -128,7 +128,7 @@ describe("readCache", () => {
 
   it("should return parsed cached response if cache is enabled and hit", async () => {
     const cacheKey = JSON.stringify({ queryId: "test", variables: {} })
-    const cachedResponse = JSON.stringify({ data: "cached" })
+    const cachedResponse = JSON.stringify({ data: "cached", cached: true })
     mockCacheGet.mockResolvedValueOnce(cachedResponse)
 
     const result = await readCache(req)

--- a/src/Server/middleware/graphqlProxyMiddleware.ts
+++ b/src/Server/middleware/graphqlProxyMiddleware.ts
@@ -77,6 +77,10 @@ export const readCache = async (req: ArtsyRequest) => {
 
         const parsedResponse = JSON.parse(response)
 
+        // Add debug log flag to response
+        // TODO: Remove this once cache layer stabilizes
+        parsedResponse.cached = true
+
         return parsedResponse
       }
     } catch (error) {

--- a/src/System/Relay/createRelaySSREnvironment.ts
+++ b/src/System/Relay/createRelaySSREnvironment.ts
@@ -22,6 +22,7 @@ import { principalFieldErrorHandlerMiddleware } from "./middleware/principalFiel
 import { searchBarImmediateResolveMiddleware } from "./middleware/searchBarImmediateResolveMiddleware"
 import { getMetaphysicsEndpoint } from "System/Relay/getMetaphysicsEndpoint"
 import { cacheHeaderMiddleware } from "System/Relay/middleware/cacheHeaderMiddleware"
+import { cacheLoggerMiddleware } from "System/Relay/middleware/cacheLoggerMiddleware"
 
 const logger = createLogger("System/Relay/createRelaySSREnvironment")
 
@@ -122,6 +123,7 @@ export function createRelaySSREnvironment(config: Config = {}) {
     principalFieldErrorHandlerMiddleware(),
     metaphysicsErrorHandlerMiddleware({ checkStatus }),
     cacheHeaderMiddleware({ url }),
+    cacheLoggerMiddleware(),
     loggingEnabled && loggerMiddleware(),
     loggingEnabled && metaphysicsExtensionsLoggerMiddleware(),
     loggingEnabled && errorMiddleware({ disableServerMiddlewareTip: true }),

--- a/src/System/Relay/middleware/cacheLoggerMiddleware.ts
+++ b/src/System/Relay/middleware/cacheLoggerMiddleware.ts
@@ -1,0 +1,19 @@
+import { isServer } from "Server/isServer"
+
+/**
+ * Logs whether the response was cached at the Metaphysics proxy level.
+ *
+ * @see src/Server/middleware/graphqlProxyMiddleware.ts
+ */
+export const cacheLoggerMiddleware = () => {
+  return next => async req => {
+    const res = await next(req)
+
+    // If cached, log out the GraphQL query ID
+    if (res.json?.cached && !isServer) {
+      console.log("[Force] Cached Response:", req.id)
+    }
+
+    return res
+  }
+}


### PR DESCRIPTION
The type of this PR is: **Feat**

### Description

This adds a tiny log on the client for debugging cache hits. Maybe we can also do something with this flag analytics-wise / in volley? We can remove this once things stabilize: 

<img width="472" alt="Screenshot 2024-08-05 at 10 33 20 PM" src="https://github.com/user-attachments/assets/3e46ec51-722d-4bfe-b818-3bb5db0162fc">
