### PR TITLE
fix(caching): Dont cache auth check

### DIFF
--- a/src/Utils/Hooks/useAuthValidation.ts
+++ b/src/Utils/Hooks/useAuthValidation.ts
@@ -16,7 +16,8 @@ export const useAuthValidation = () => {
             authenticationStatus
           }
         `,
-        {}
+        {},
+        { networkCacheConfig: { force: true } }
       ).toPromise()
 
       if (data?.authenticationStatus === "INVALID") {


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

We should never cache the auth validation query since that manages invalid token behavior.
