### PR TITLE
fix(proxy): Reload on useAuthValidationQuery error

### DIFF
--- a/src/Utils/Hooks/useAuthValidation.ts
+++ b/src/Utils/Hooks/useAuthValidation.ts
@@ -7,28 +7,37 @@ import { useAuthValidationQuery } from "__generated__/useAuthValidationQuery.gra
 export const useAuthValidation = () => {
   const { relayEnvironment } = useSystemContext()
 
+  const logoutAndReload = async () => {
+    try {
+      await logout()
+    } catch (e) {
+      console.error(e)
+    }
+
+    window.location.reload()
+    return
+  }
+
   useEffect(() => {
     const exec = async () => {
-      const data = await fetchQuery<useAuthValidationQuery>(
-        relayEnvironment,
-        graphql`
-          query useAuthValidationQuery {
-            authenticationStatus
-          }
-        `,
-        {},
-        { networkCacheConfig: { force: true } }
-      ).toPromise()
+      try {
+        const data = await fetchQuery<useAuthValidationQuery>(
+          relayEnvironment,
+          graphql`
+            query useAuthValidationQuery {
+              authenticationStatus
+            }
+          `,
+          {},
+          { networkCacheConfig: { force: true } }
+        ).toPromise()
 
-      if (data?.authenticationStatus === "INVALID") {
-        try {
-          await logout()
-        } catch (e) {
-          console.error(e)
+        if (data?.authenticationStatus === "INVALID") {
+          await logoutAndReload()
+          return
         }
-
-        window.location.reload()
-        return
+      } catch (error) {
+        await logoutAndReload()
       }
     }
 


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

#### Problem 
- **Proxy is enabled** 
- User has the site open in two tabs
- User logs out in one tab
- Second tab focuses, auth attempts a revalidation by querying MP
- 401 unauthorized error, because the auth token is invalid

However, **with the proxy disabled**, even though we have an invalid token we can still query MP and receive a valid auth status back, which triggers a reload in order to resync auth state. 

It is a bit unclear why this is the case, and we need to investigate more. In the meantime, so as to avoid users running into inconsistent states between logged in / logged out, we guard the query around a try / catch and if we get back a 401 (error) then reload the page. 

The tradeoff here is that if this query were to ever (consistently) return an error (bug / 400-500 / outage in MP?) it could lead to a reload loop. So not sure if this is mergable as is (or if it is, only temporarily to fix the immediate problem). 

Thoughts? 
