### PR TITLE
fix(proxy): Only use the proxy if logged out

### DIFF
--- a/src/System/Relay/getMetaphysicsEndpoint.ts
+++ b/src/System/Relay/getMetaphysicsEndpoint.ts
@@ -3,9 +3,11 @@ import { getENV } from "Utils/getENV"
 export const getMetaphysicsEndpoint = () => {
   const APP_URL = getENV("APP_URL") ?? "http://localhost:4000"
 
-  const endpoint = getENV("ENABLE_GRAPHQL_PROXY")
-    ? `${APP_URL}/api/metaphysics`
-    : `${getENV("METAPHYSICS_ENDPOINT")}/v2`
+  const endpoint =
+    // Only use the proxy if logged out
+    getENV("ENABLE_GRAPHQL_PROXY") && !getENV("CURRENT_USER")
+      ? `${APP_URL}/api/metaphysics`
+      : `${getENV("METAPHYSICS_ENDPOINT")}/v2`
 
   return endpoint
 }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -111,7 +111,10 @@ export function initializeMiddleware(app) {
   app.use(localsMiddleware)
   app.use(sameOriginMiddleware)
 
-  // Mount GraphQL proxy and cache
+  /**
+   * Mount GraphQL proxy and cache. If logged in we hit Metaphysics directly.
+   * @see: System/Relay/getMetaphysicsEndpoint.ts
+   */
   if (ENABLE_GRAPHQL_PROXY) {
     app.use("/api/metaphysics", graphqlProxyMiddleware)
   }


### PR DESCRIPTION
- Closes https://github.com/artsy/force/pull/14292

The type of this PR is: **Fix**

### Description

When logged in, we directly hit metaphysics, vs going through the proxy. This helps address the issue described in https://github.com/artsy/force/pull/14292, but in a simpler and less trap-like way. 
