### PR TITLE
chore(proxy): Bring back the proxy logged in, logout on 401

### DIFF
--- a/src/Apps/Conversations/conversationsRoutes.tsx
+++ b/src/Apps/Conversations/conversationsRoutes.tsx
@@ -51,6 +51,7 @@ export const conversationsRoutes: RouteProps[] = [
   },
   {
     path: "/user/conversations/:conversationId",
+    fetchPolicy: "store-and-network",
     layout: "FullBleed",
     ignoreScrollBehavior: true,
     getComponent: () => ConversationApp,

--- a/src/System/Relay/getMetaphysicsEndpoint.ts
+++ b/src/System/Relay/getMetaphysicsEndpoint.ts
@@ -5,7 +5,7 @@ export const getMetaphysicsEndpoint = () => {
 
   const endpoint =
     // Only use the proxy if logged out
-    getENV("ENABLE_GRAPHQL_PROXY") && !getENV("CURRENT_USER")
+    getENV("ENABLE_GRAPHQL_PROXY")
       ? `${APP_URL}/api/metaphysics`
       : `${getENV("METAPHYSICS_ENDPOINT")}/v2`
 


### PR DESCRIPTION
The type of this PR is: **Chore**

### Description

Follow-up to https://github.com/artsy/force/pull/14293. @dzucconi had the idea that rather than split the proxy between logged in and logged out, we check for 401 errors from the proxy and log out then (on auth validation).
