### PR TITLE
chore(proxy): Bring back the proxy, move above passport

### DIFF
--- a/src/System/Relay/getMetaphysicsEndpoint.ts
+++ b/src/System/Relay/getMetaphysicsEndpoint.ts
@@ -5,7 +5,7 @@ export const getMetaphysicsEndpoint = () => {
 
   const endpoint =
     // Only use the proxy if logged out
-    getENV("ENABLE_GRAPHQL_PROXY") && !getENV("CURRENT_USER")
+    getENV("ENABLE_GRAPHQL_PROXY")
       ? `${APP_URL}/api/metaphysics`
       : `${getENV("METAPHYSICS_ENDPOINT")}/v2`
 


### PR DESCRIPTION
The type of this PR is: **Chore**

### Description

This brings back the proxy for logged in / out. The issue with 401s turned out to be related to the order of operations in our middleware stack, and specifically our proxy middleware being after passport. Moving it above, it behaves like a normal MP endpoint, independent of force-specific auth. Thanks @joeyAghion for figuring this one out! 
