### PR TITLE
fix(proxy): Use X-Access-Token for checking logged-in

### DIFF
--- a/src/Server/middleware/__tests__/graphqlProxyMiddleware.jest.ts
+++ b/src/Server/middleware/__tests__/graphqlProxyMiddleware.jest.ts
@@ -53,7 +53,7 @@ describe("graphqlProxyMiddleware", () => {
   const mockCacheGet = cache.get as jest.Mock
 
   beforeEach(() => {
-    req = { body: {}, user: null, headers: {} }
+    req = { body: {}, headers: {} }
     res = { json: jest.fn(), end: jest.fn() }
     next = jest.fn()
   })
@@ -86,7 +86,7 @@ describe("graphqlProxyMiddleware", () => {
   })
 
   it("should call createProxyMiddleware with correct config if user is logged in", async () => {
-    req.user = { id: "user" }
+    req.headers = { "x-access-token": "some-token" }
 
     await graphqlProxyMiddleware(req, res, next)
 
@@ -101,7 +101,7 @@ describe("graphqlProxyMiddleware", () => {
   })
 
   it("should call createProxyMiddleware with correct if shouldSkipCache returns true", async () => {
-    req.user = { id: "user" }
+    req.headers["x-access-token"] = "some-token"
     req.headers["x-relay-cache-config"] = JSON.stringify({ force: true })
 
     await graphqlProxyMiddleware(req, res, next)
@@ -123,7 +123,7 @@ describe("readCache", () => {
   const mockCacheGet = cache.get as jest.Mock
 
   beforeEach(() => {
-    req = { body: { id: "test", variables: {} }, user: null }
+    req = { body: { id: "test", variables: {} } }
   })
 
   it("should return parsed cached response if cache is enabled and hit", async () => {
@@ -138,7 +138,7 @@ describe("readCache", () => {
   })
 
   it("should return undefined if cache is not enabled", async () => {
-    req.user = { id: "user" }
+    req["x-access-token"] = "some-token"
 
     const result = await readCache(req)
 
@@ -170,7 +170,7 @@ describe("writeCache", () => {
       pipe: jest.fn(),
       headers: { "content-encoding": "gzip" },
     }
-    req = { body: { id: "test", variables: {} }, user: null, headers: {} }
+    req = { body: { id: "test", variables: {} }, headers: {} }
     res = { end: jest.fn() }
 
     mockFindRoutesByPath.mockReturnValue([])

--- a/src/Server/middleware/graphqlProxyMiddleware.ts
+++ b/src/Server/middleware/graphqlProxyMiddleware.ts
@@ -23,7 +23,7 @@ export const graphqlProxyMiddleware = async (
   res: ArtsyResponse,
   next: NextFunction
 ) => {
-  const skipCache = !!req.user || shouldSkipCache(req)
+  const skipCache = shouldSkipCache(req)
 
   if (!skipCache) {
     const cachedResponse = await readCache(req)
@@ -204,6 +204,12 @@ const getCacheKey = (props: GetCacheKeyProps) => {
 }
 
 export const shouldSkipCache = (req: ArtsyRequest) => {
+  const isLoggedIn = req.headers["x-access-token"]
+
+  if (isLoggedIn) {
+    return true
+  }
+
   const relayCacheHeader = req.headers[RELAY_CACHE_CONFIG_HEADER_KEY] as string
 
   if (!relayCacheHeader) {


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Ran into an issue with https://github.com/artsy/force/pull/14306 due to the proxy middleware being above passport, which injects `req.user` (ie, logged-in) into the req/res cycle. With the middleware above it, we lost access to this property, which then led to erroneous cache behavior. 

This fixes things by instead checking for our x-access-token header, which is present regardless of passport. 

https://github.com/user-attachments/assets/f0e95e0a-e9ef-4781-a80f-1b3af9fd2b02

