### PR TITLE
fix(auth): Signin / Signup no longer 500 -> 4x

### DIFF
--- a/src/Server/passport/lib/app/lifecycle.ts
+++ b/src/Server/passport/lib/app/lifecycle.ts
@@ -31,7 +31,35 @@ module.exports.onLocalLogin = function (
   passport.authenticate("local-with-otp")(req, res, function (err: any) {
     if (req.xhr) {
       if (err) {
-        return res.status(500).send({ success: false, error: err.message })
+        switch (true) {
+          case err.message?.includes("invalid email or password"): {
+            return res.status(403).send({ success: false, error: err.message })
+          }
+          case err.message?.includes(
+            "missing two-factor authentication code"
+          ): {
+            return res.status(403).send({ success: false, error: err.message })
+          }
+          case err.message?.includes(
+            "invalid two-factor authentication code"
+          ): {
+            return res.status(403).send({ success: false, error: err.message })
+          }
+          case err.message?.includes(
+            "account locked, try again in a few minutes"
+          ): {
+            return res.status(403).send({ success: false, error: err.message })
+          }
+          case err.message?.includes("Unexpected token"): {
+            return res.status(500).send({
+              success: false,
+              error: "An error occurred. Please try again.",
+            })
+          }
+          default: {
+            return res.status(400).send({ success: false, error: err.message })
+          }
+        }
       } else {
         return next()
       }
@@ -105,7 +133,7 @@ module.exports.onLocalSignup = function (
         } else if (err.message) {
           msg = err.message
         }
-        return res.status(500).send({ success: false, error: msg })
+        return res.status(400).send({ success: false, error: msg })
       } else if (err) {
         return next(new Error(err))
       } else {

--- a/src/Server/passport/lib/app/lifecycle.ts
+++ b/src/Server/passport/lib/app/lifecycle.ts
@@ -33,17 +33,17 @@ module.exports.onLocalLogin = function (
       if (err) {
         switch (true) {
           case err.message?.includes("invalid email or password"): {
-            return res.status(403).send({ success: false, error: err.message })
+            return res.status(401).send({ success: false, error: err.message })
           }
           case err.message?.includes(
             "missing two-factor authentication code"
           ): {
-            return res.status(403).send({ success: false, error: err.message })
+            return res.status(401).send({ success: false, error: err.message })
           }
           case err.message?.includes(
             "invalid two-factor authentication code"
           ): {
-            return res.status(403).send({ success: false, error: err.message })
+            return res.status(401).send({ success: false, error: err.message })
           }
           case err.message?.includes(
             "account locked, try again in a few minutes"

--- a/src/Server/passport/lib/app/lifecycle.ts
+++ b/src/Server/passport/lib/app/lifecycle.ts
@@ -57,7 +57,7 @@ module.exports.onLocalLogin = function (
             })
           }
           default: {
-            return res.status(400).send({ success: false, error: err.message })
+            return res.status(500).send({ success: false, error: err.message })
           }
         }
       } else {
@@ -133,7 +133,7 @@ module.exports.onLocalSignup = function (
         } else if (err.message) {
           msg = err.message
         }
-        return res.status(400).send({ success: false, error: msg })
+        return res.status(500).send({ success: false, error: msg })
       } else if (err) {
         return next(new Error(err))
       } else {

--- a/src/Server/passport/test/app/lifecycle.jest.js
+++ b/src/Server/passport/test/app/lifecycle.jest.js
@@ -1,8 +1,7 @@
-/* eslint-disable no-restricted-imports */
-const sinon = require("sinon")
 const lifecycle = require("../../lib/app/lifecycle")
 
 import options from "Server/passport/lib/options"
+// eslint-disable-next-line no-restricted-imports
 import request from "superagent"
 import passport from "passport"
 
@@ -12,102 +11,154 @@ jest.mock("Server/passport/lib/options", () => ({
   APP_URL: "https://www.artsy.net",
   ARTSY_URL: "https://api.artsy.net",
 }))
+
 jest.mock("superagent")
 jest.mock("passport", () => {
-  const sinon = require("sinon")
   return {
-    authenticate: sinon.stub().returns((req, res, next) => next()),
+    authenticate: jest.fn().mockReturnValue((req, res, next) => next()),
   }
 })
 
-describe("lifecycle", function () {
+describe("lifecycle", () => {
   let req
   let res
   let next
   let err
   let send
 
-  beforeEach(function () {
-    next = sinon.stub()
-    send = sinon.stub()
+  beforeEach(() => {
+    next = jest.fn()
+    send = jest.fn()
 
     req = {
       body: {},
       params: {},
       query: {},
       session: {},
-      get: sinon.stub(),
+      get: jest.fn(),
       connection: { remoteAddress: "99.99.99.99" },
     }
+
     res = {
-      redirect: sinon.stub(),
+      redirect: jest.fn(),
       send,
-      status: sinon.stub().returns({
-        send,
-      }),
+      status: jest.fn().mockReturnValue({ send }),
     }
 
     for (let method of ["get", "end", "set", "post", "send", "status"]) {
-      request[method] = sinon.stub().returns(request)
+      request[method] = jest.fn().mockReturnValue(request)
     }
   })
 
   afterEach(() => {
-    sinon.restore()
-    jest.resetAllMocks()
+    jest.clearAllMocks()
   })
 
-  describe("#onLocalLogin", function () {
-    describe("when successful", function () {
-      it("authenticates locally and passes on - local", function () {
+  describe("#onLocalLogin", () => {
+    describe("when successful", () => {
+      it("authenticates locally and passes on - local", () => {
         options.APP_URL = "localhost"
         lifecycle.onLocalLogin(req, res, next)
-        expect(passport.authenticate.args[0][0]).toEqual("local-with-otp")
-        expect(next.called).toBeTruthy()
+        expect(passport.authenticate).toHaveBeenCalledWith("local-with-otp")
+        expect(next).toHaveBeenCalled()
       })
 
-      it("authenticates locally and passes on", function () {
+      it("authenticates locally and passes on", () => {
         options.APP_URL = "localhost"
         req.query["redirect-to"] = "/foobar"
         lifecycle.onLocalLogin(req, res, next)
-        expect(next.called).toBeTruthy()
+        expect(next).toHaveBeenCalled()
       })
     })
 
-    describe("when erroring", function () {
-      beforeEach(function () {
-        passport.authenticate.returns((req, res, next) => next(err))
+    describe("when erroring", () => {
+      beforeEach(() => {
+        passport.authenticate.mockReturnValueOnce((req, res, next) => next(err))
       })
 
-      it("redirects invalid passwords to login", function () {
+      it("redirects invalid passwords to login", () => {
         err = {
           response: {
             body: { error_description: "invalid email or password" },
           },
         }
         lifecycle.onLocalLogin(req, res, next)
-        expect(res.redirect.args[0][0]).toEqual(
+        expect(res.redirect).toHaveBeenCalledWith(
           "/login?error=Invalid email or password."
         )
       })
 
-      it("sends generic error to the error handler", function () {
+      it("sends generic error to the error handler", () => {
         err = new Error("moo")
         lifecycle.onLocalLogin(req, res, next)
-        expect(next.args[0][0].message).toEqual("moo")
+        expect(next).toHaveBeenCalledWith(
+          expect.objectContaining({ message: "moo" })
+        )
+      })
+
+      describe("status codes for login errors", () => {
+        beforeEach(() => {
+          req.xhr = true
+        })
+
+        it("invalid email or password", () => {
+          err = {
+            message: "invalid email or password",
+          }
+          lifecycle.onLocalLogin(req, res, next)
+          expect(res.status).toHaveBeenCalledWith(401)
+        })
+
+        it("missing two-factor authentication code", () => {
+          err = {
+            message: "missing two-factor authentication code",
+          }
+          lifecycle.onLocalLogin(req, res, next)
+          expect(res.status).toHaveBeenCalledWith(401)
+        })
+
+        it("invalid two-factor authentication code", () => {
+          err = {
+            message: "missing two-factor authentication code",
+          }
+          lifecycle.onLocalLogin(req, res, next)
+          expect(res.status).toHaveBeenCalledWith(401)
+        })
+
+        it("account locked, try again in a few minutes", () => {
+          err = {
+            message: "account locked, try again in a few minutes",
+          }
+          lifecycle.onLocalLogin(req, res, next)
+          expect(res.status).toHaveBeenCalledWith(403)
+        })
+
+        it("Unexpected token", () => {
+          err = {
+            message: "Unexpected token",
+          }
+          lifecycle.onLocalLogin(req, res, next)
+          expect(res.status).toHaveBeenCalledWith(500)
+        })
+
+        it("generic errors", () => {
+          err = new Error("generic error")
+          lifecycle.onLocalLogin(req, res, next)
+          expect(res.status).toHaveBeenCalledWith(500)
+        })
       })
     })
   })
 
-  describe("#onError", function () {
-    it("Nexts on error", function () {
+  describe("#onError", () => {
+    it("Nexts on error", () => {
       lifecycle.onError(new Error("access denied"), req, res, next)
-      expect(next.called).toBeTruthy()
+      expect(next).toHaveBeenCalled()
     })
   })
 
-  describe("#onLocalSignup", function () {
-    it("sends 500s as json for xhr requests", function () {
+  describe("#onLocalSignup", () => {
+    it("sends 500s as json for xhr requests", () => {
       req.xhr = true
       err = {
         response: {
@@ -118,101 +169,113 @@ describe("lifecycle", function () {
         },
       }
       lifecycle.onLocalSignup(req, res, next)
-      request.end.args[0][0](err)
-      expect(send.args[0][0].error).toEqual(
-        "Password must include at least one lowercase letter, one uppercase letter, and one digit."
+      request.end.mock.calls[0][0](err)
+      expect(send).toHaveBeenCalledWith({
+        error:
+          "Password must include at least one lowercase letter, one uppercase letter, and one digit.",
+        success: false,
+      })
+    })
+
+    it("passes the recaptcha_token through signup", () => {
+      req.body.recaptcha_token = "recaptcha_token"
+      lifecycle.onLocalSignup(req, res, next)
+      expect(request.send).toHaveBeenCalledWith(
+        expect.objectContaining({ recaptcha_token: "recaptcha_token" })
       )
     })
 
-    it("passes the recaptcha_token through signup", function () {
-      req.body.recaptcha_token = "recaptcha_token"
+    it("passes the user agent through signup", () => {
+      req.get.mockReturnValue("foo-agent")
       lifecycle.onLocalSignup(req, res, next)
-      expect(request.send.args[0][0].recaptcha_token).toEqual("recaptcha_token")
-    })
-
-    it("passes the user agent through signup", function () {
-      req.get.returns("foo-agent")
-      lifecycle.onLocalSignup(req, res, next)
-      expect(request.set.args[0][0]["User-Agent"]).toEqual("foo-agent")
+      expect(request.set).toHaveBeenCalledWith(
+        expect.objectContaining({ "User-Agent": "foo-agent" })
+      )
     })
   })
 
-  describe("#beforeSocialAuth", function () {
-    it("sets session redirect", function () {
+  describe("#beforeSocialAuth", () => {
+    it("sets session redirect", () => {
       req.query["redirect-to"] = "/foobar"
       lifecycle.beforeSocialAuth("facebook")(req, res, next)
       expect(req.session.redirectTo).toEqual("/foobar")
-      expect(passport.authenticate.args[4][1].scope).toEqual("email")
+      expect(passport.authenticate).toHaveBeenCalledWith(
+        "facebook",
+        expect.objectContaining({ scope: "email" })
+      )
     })
 
-    it("sets the session to skip onboarding", function () {
-      passport.authenticate.returns((req, res, next) => next())
+    it("sets the session to skip onboarding", () => {
+      passport.authenticate.mockReturnValueOnce((req, res, next) => next())
       req.query["skip-onboarding"] = true
       lifecycle.beforeSocialAuth("facebook")(req, res, next)
-      expect(req.session.skipOnboarding).toEqual(true)
+      expect(req.session.skipOnboarding).toBe(true)
     })
   })
 
-  describe("#afterSocialAuth", function () {
-    it("doesnt redirect to / if skip-onboarding is set", function () {
+  describe("#afterSocialAuth", () => {
+    it("doesn't redirect to / if skip-onboarding is set", () => {
       req.artsyPassportSignedUp = true
       req.session.skipOnboarding = true
-      passport.authenticate.returns((req, res, next) => next())
+      passport.authenticate.mockReturnValueOnce((req, res, next) => next())
       lifecycle.afterSocialAuth("facebook")(req, res, next)
-      expect(res.redirect.called).toBeFalsy()
+      expect(res.redirect).not.toHaveBeenCalled()
     })
 
-    it("surfaces blocked by facebook errors", function () {
-      passport.authenticate.returns((req, res, next) =>
+    it("surfaces blocked by facebook errors", () => {
+      passport.authenticate.mockReturnValueOnce((req, res, next) =>
         next(new Error("Unauthorized source IP address"))
       )
       lifecycle.afterSocialAuth("facebook")(req, res, next)
-      expect(res.redirect.args[0][0]).toEqual(
+      expect(res.redirect).toHaveBeenCalledWith(
         "/login?error_code=IP_BLOCKED&provider=facebook"
       )
     })
 
-    it("passes random errors to be rendered on the login screen", function () {
-      passport.authenticate.returns((req, res, next) =>
+    it("passes random errors to be rendered on the login screen", () => {
+      passport.authenticate.mockReturnValueOnce((req, res, next) =>
         next(new Error("Facebook authorization failed"))
       )
       lifecycle.afterSocialAuth("facebook")(req, res, next)
-      expect(res.redirect.args[0][0]).toEqual(
+      expect(res.redirect).toHaveBeenCalledWith(
         "/login?error_code=UNKNOWN&error=Facebook authorization failed"
       )
     })
   })
 
-  describe("#ensureLoggedInOnAfterSignupPage", function () {
-    it("redirects to the login page, and back, without a user", function () {
+  describe("#ensureLoggedInOnAfterSignupPage", () => {
+    it("redirects to the login page, and back, without a user", () => {
       lifecycle.ensureLoggedInOnAfterSignupPage(req, res, next)
-      expect(res.redirect.args[0][0]).toEqual("/login?redirect-to=/")
+      expect(res.redirect).toHaveBeenCalledWith("/login?redirect-to=/")
     })
   })
 
-  describe("#ssoAndRedirectBack", function () {
-    it("redirects signups to /", function () {
+  describe("#ssoAndRedirectBack", () => {
+    it("redirects signups to /", () => {
       req.user = { accessToken: "token" }
       req.artsyPassportSignedUp = true
       lifecycle.ssoAndRedirectBack(req, res, next)
-      expect(res.redirect.args[0][0]).toContainEqual("/")
+      expect(res.redirect).toHaveBeenCalledWith(expect.stringContaining("/"))
     })
 
-    it("passes on for xhrs", function () {
+    it("passes on for xhrs", () => {
       req.xhr = true
-      req.user = { toJSON() {} }
+      req.user = { toJSON: jest.fn() }
       lifecycle.ssoAndRedirectBack(req, res, next)
-      expect(res.send.args[0][0].success).toEqual(true)
+      expect(res.send).toHaveBeenCalledWith(
+        expect.objectContaining({ success: true })
+      )
     })
 
-    // FIXME: figure out this test
-    it.skip("single signs on to gravity", function () {
+    it.skip("single signs on to gravity", () => {
       req.user = { accessToken: "token" }
       req.query["redirect-to"] = "/artwork/andy-warhol-skull"
       lifecycle.ssoAndRedirectBack(req, res, next)
-      expect(request.post.args[0][0]).toContainEqual("me/trust_token")
-      request.end(null, { body: { trust_token: "foo-trust-token" } })
-      expect(res.redirect.args[0][0]).toEqual(
+      expect(request.post).toHaveBeenCalledWith(
+        expect.stringContaining("me/trust_token")
+      )
+      request.end.mock.calls[0][1]({ body: { trust_token: "foo-trust-token" } })
+      expect(res.redirect).toHaveBeenCalledWith(
         "https://api.artsy.net/users/sign_in" +
           "?trust_token=foo-trust-token" +
           "&redirect_uri=https://www.artsy.net/artwork/andy-warhol-skull"


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Looking through our datadog logs noticed that a lot of 500ish errors come from `sign_in` / `sign_up`. Digging in, noticed that we're sending 500s for 400-ish errors. This fixes that. 

Let me know if we should have more fine-grained status codes here. 

<img width="400" alt="Screenshot 2024-08-08 at 12 56 44 PM" src="https://github.com/user-attachments/assets/68488674-37fa-4c04-96a0-41e55dd97aed">



