### PR TITLE
chore(smoke-tests): undo temp change

### DIFF
--- a/cypress/e2e/artist.cy.ts
+++ b/cypress/e2e/artist.cy.ts
@@ -1,9 +1,8 @@
-/* eslint-disable jest/no-commented-out-tests */
 import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
 
 describe("/artist/:id", () => {
   before(() => {
-    visitWithStatusRetries("/artist/damon-zucconi/about", {
+    visitWithStatusRetries("/artist/pablo-picasso/about", {
       timeout: 30000,
     })
   })
@@ -11,44 +10,18 @@ describe("/artist/:id", () => {
   it("renders metadata", () => {
     cy.title().should(
       "contain",
-      "Damon Zucconi - Biography, Shows, Articles & More | Artsy"
+      "Pablo Picasso - Biography, Shows, Articles & More | Artsy"
     )
-    // cy.get("meta[name='description']")
-    //   .should("have.attr", "content")
-    //   .and(
-    //     "contain",
-    //     "Explore Damon Zucconi’s biography, achievements, artworks, auction results, and shows on Artsy. Perhaps the most influential artist of the 20th century, Pablo Picasso"
-    //   )
+    cy.get("meta[name='description']")
+      .should("have.attr", "content")
+      .and(
+        "contain",
+        "Explore Pablo Picasso’s biography, achievements, artworks, auction results, and shows on Artsy. Perhaps the most influential artist of the 20th century, Pablo Picasso"
+      )
   })
 
-  // it("renders page content", () => {
-  //   cy.get("h1").should("contain", "Damon Zucconi")
-  //   cy.get("h2").should("contain", "American, 1985")
-  // })
+  it("renders page content", () => {
+    cy.get("h1").should("contain", "Pablo Picasso")
+    cy.get("h2").should("contain", "Spanish, 1881–1973")
+  })
 })
-
-// describe("/artist/:id", () => {
-//   before(() => {
-//     visitWithStatusRetries("/artist/pablo-picasso/about", {
-//       timeout: 30000,
-//     })
-//   })
-
-//   it("renders metadata", () => {
-//     cy.title().should(
-//       "contain",
-//       "Pablo Picasso - Biography, Shows, Articles & More | Artsy"
-//     )
-//     cy.get("meta[name='description']")
-//       .should("have.attr", "content")
-//       .and(
-//         "contain",
-//         "Explore Pablo Picasso’s biography, achievements, artworks, auction results, and shows on Artsy. Perhaps the most influential artist of the 20th century, Pablo Picasso"
-//       )
-//   })
-
-//   it("renders page content", () => {
-//     cy.get("h1").should("contain", "Pablo Picasso")
-//     cy.get("h2").should("contain", "Spanish, 1881–1973")
-//   })
-// })


### PR DESCRIPTION
The type of this PR is: **Chore**

### Description

Now that staging is deployed with the new `errors` check for the cache, undo the temporary smoke test change so that we can diagnose whats going on with metaphysics staging, under a completely-filled-out artist/id page.

The issue is intermittent on staging; will try to get this merged so as to best reflect the current state of things. 
