### PR TITLE
fix: Do not link to artist step when editing submissions

### DIFF
--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSWASubmissionStatus.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSWASubmissionStatus.tsx
@@ -16,8 +16,8 @@ import {
 } from "__generated__/MyCollectionArtworkSWASubmissionStatus_artwork.graphql"
 import {
   BASIC_STEPS,
+  INITIAL_EDIT_STEP,
   INITIAL_POST_APPROVAL_STEP,
-  INITIAL_STEP,
 } from "Apps/Sell/SellFlowContext"
 import { usePreviousSubmission } from "Apps/Sell/Utils/previousSubmissionUtils"
 import React, { useState } from "react"
@@ -230,7 +230,7 @@ const useGetButtonURL = (
   const previousStep = submissionID === submission.externalID && step
 
   // This does not work in all cases because we only store the current step for the most recent submission.
-  const currentStep = previousStep || INITIAL_STEP
+  const currentStep = previousStep || INITIAL_EDIT_STEP
   const currentPostApprovalStep =
     (!BASIC_STEPS.includes(previousStep as any) && previousStep) ||
     INITIAL_POST_APPROVAL_STEP

--- a/src/Apps/Sell/SellFlowContext.tsx
+++ b/src/Apps/Sell/SellFlowContext.tsx
@@ -56,6 +56,7 @@ export const ALL_STEPS = [
 ]
 
 export const INITIAL_STEP: SellFlowStep = BASIC_STEPS[0]
+export const INITIAL_EDIT_STEP: SellFlowStep = "title"
 export const INITIAL_POST_APPROVAL_STEP: SellFlowStep = POST_APPROVAL_STEPS[0]
 export type SellFlowStep =
   | typeof BASIC_STEPS[number]


### PR DESCRIPTION
Resolves https://www.notion.so/artsy/Web-We-should-not-allow-the-user-to-edit-artwork-s-Artist-and-title-13745a26be404bd5b9c0f5755dd31693?pvs=4

## Description
With this change, we link to the Title step instead of the Artist step when editing a submission. This approach discourages users from updating the artist of an already existing submission.