### PR TITLE
fix: `fulfil` -> `fulfill`

### DIFF
--- a/src/Apps/Sell/Routes/ThankYouRoute.tsx
+++ b/src/Apps/Sell/Routes/ThankYouRoute.tsx
@@ -55,7 +55,7 @@ export const ThankYouRoute: React.FC<ThankYouRouteProps> = props => {
               <Text variant="sm">
                 {isSubmitted
                   ? "An Artsy Advisor will email you within 3-5 days to review your submission and discuss next steps. In the meantime your submission will appear in the feature, My Collection."
-                  : "This will be used to list, sell and fulfil your work. Additional information may be requested."}
+                  : "This will be used to list, sell and fulfill your work. Additional information may be requested."}
               </Text>
 
               {!!isSubmitted && (

--- a/src/Apps/Sell/Routes/__tests__/ThankYouRoute.jest.tsx
+++ b/src/Apps/Sell/Routes/__tests__/ThankYouRoute.jest.tsx
@@ -98,7 +98,7 @@ describe("ThankYouRoute", () => {
 
       expect(
         screen.getByText(
-          "This will be used to list, sell and fulfil your work. Additional information may be requested."
+          "This will be used to list, sell and fulfill your work. Additional information may be requested."
         )
       ).toBeInTheDocument()
 


### PR DESCRIPTION
Resolves https://www.notion.so/artsy/Web-Fulfil-or-Fulfill-f36f9af164cb4f59956b325a52a74511?pvs=4

## Description

`fulfil` -> `fulfill`.