### PR TITLE
fix: Make Artsy logo unclickable in Sell flow header

### DIFF
--- a/src/Apps/Sell/Components/SubmissionHeader.tsx
+++ b/src/Apps/Sell/Components/SubmissionHeader.tsx
@@ -138,9 +138,7 @@ export const SubmissionHeader: React.FC = () => {
                   height={HEADER_HEIGHT}
                 >
                   <Media greaterThan="xs">
-                    <RouterLink to="/sell" display="block">
-                      <ArtsyLogoIcon display="block" />
-                    </RouterLink>
+                    <ArtsyLogoIcon display="block" />
                   </Media>
 
                   {submission?.externalId && !isLastStep ? (


### PR DESCRIPTION
Resolves https://www.notion.so/artsy/Web-User-can-just-quit-the-flow-without-a-warning-should-we-add-an-alert-65052f96a3114861bd8da809d036ac24?pvs=4

## Description

Make the Artsy logo unclickable in the Sell flow header.

<img width="1169" alt="Screenshot 2024-08-09 at 16 41 03" src="https://github.com/user-attachments/assets/f9714131-e2d3-490a-9ee1-8dff199adb2d">
