### PR TITLE
fix: Display previous submission on Sell page when in APPROVED state

### DIFF
--- a/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/PreviousSubmission.tsx
+++ b/src/Apps/Consign/Routes/MarketingLanding/Components/LandingPage/PreviousSubmission.tsx
@@ -1,5 +1,9 @@
 import { Clickable, Flex, Text } from "@artsy/palette"
-import { INITIAL_STEP, SellFlowStep } from "Apps/Sell/SellFlowContext"
+import {
+  INITIAL_STEP,
+  PRE_SUBMITTED_STEPS,
+  SellFlowStep,
+} from "Apps/Sell/SellFlowContext"
 import { usePreviousSubmission } from "Apps/Sell/Utils/previousSubmissionUtils"
 import { EntityHeaderSubmissionFragmentContainer } from "Components/EntityHeaders/EntityHeaderSubmission"
 import { FadeInBox } from "Components/FadeInBox"
@@ -48,7 +52,8 @@ const PreviousSubmission: React.FC<PreviousSubmissionProps> = ({
     router.push(`/sell/submissions/${submissionID}/${currentStep}`)
   }
 
-  if (!submission || submission.state !== "DRAFT") return null
+  if (!submission?.state || !PRE_SUBMITTED_STEPS.includes(submission.state))
+    return null
 
   return (
     <FadeInBox

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSWASubmissionStatus.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkSWASubmissionStatus.tsx
@@ -18,6 +18,7 @@ import {
   BASIC_STEPS,
   INITIAL_EDIT_STEP,
   INITIAL_POST_APPROVAL_STEP,
+  PRE_SUBMITTED_STEPS,
 } from "Apps/Sell/SellFlowContext"
 import { usePreviousSubmission } from "Apps/Sell/Utils/previousSubmissionUtils"
 import React, { useState } from "react"
@@ -50,7 +51,7 @@ export const MyCollectionArtworkSWASubmissionStatus: React.FC<Props> = props => 
   const stateLabel = isListed ? "Listed" : submission.stateLabel
   const buttonLabel = isListed ? "View Listing" : submission.buttonLabel
 
-  const buttonVariant = ["DRAFT", "APPROVED"].includes(submission.state)
+  const buttonVariant = PRE_SUBMITTED_STEPS.includes(submission.state)
     ? "primaryBlack"
     : "secondaryBlack"
   const stateHelpMessage = getStateHelpMessage(submission, isListed)

--- a/src/Apps/Sell/SellFlowContext.tsx
+++ b/src/Apps/Sell/SellFlowContext.tsx
@@ -27,6 +27,11 @@ const BASIC_FLOW_STATES: ConsignmentSubmissionStateAggregation[] = [
   "DRAFT",
   "SUBMITTED",
 ]
+// If a submission is in one of these states, additional information is required.
+export const PRE_SUBMITTED_STEPS: ConsignmentSubmissionStateAggregation[] = [
+  "DRAFT",
+  "APPROVED",
+]
 
 export const BASIC_STEPS = [
   "artist",


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->


### Description

With this change, we also display the previous submission on the Sell page when it is in the `APPROVED` state. With this change, I consider `draft` and `approved` submissions as non-completed submissions (`PRE_SUBMITTED_STEPS`) that require additional information.

<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ