### PR TITLE
fix: ensure cached graphql responses are invalidated upon query changes

### DIFF
--- a/src/Server/middleware/__tests__/graphqlProxyMiddleware.jest.ts
+++ b/src/Server/middleware/__tests__/graphqlProxyMiddleware.jest.ts
@@ -13,6 +13,7 @@ import {
   RELAY_CACHE_PATH_HEADER_KEY,
 } from "System/Relay/middleware/cacheHeaderMiddleware"
 import { findRoutesByPath } from "System/Router/Utils/routeUtils"
+import { createHash } from "crypto"
 
 jest.mock("Server/config", () => ({
   METAPHYSICS_ENDPOINT: "https://metaphysics.artsy.net",
@@ -137,11 +138,15 @@ describe("readCache", () => {
   const mockCacheGet = cache.get as jest.Mock
 
   beforeEach(() => {
-    req = { body: { id: "test", variables: {} } }
+    req = { body: { id: "test", query: "", variables: {} } }
   })
 
   it("should return parsed cached response if cache is enabled and hit", async () => {
-    const cacheKey = JSON.stringify({ queryId: "test", variables: {} })
+    const cacheKey = JSON.stringify({
+      queryId: "test",
+      digest: createHash("sha1").update("").digest("hex"),
+      variables: {},
+    })
     const cachedResponse = JSON.stringify({ data: "cached", cached: true })
     mockCacheGet.mockResolvedValueOnce(cachedResponse)
 
@@ -184,7 +189,7 @@ describe("writeCache", () => {
       pipe: jest.fn(),
       headers: { "content-encoding": "gzip" },
     }
-    req = { body: { id: "test", variables: {} }, headers: {} }
+    req = { body: { id: "test", query: "", variables: {} }, headers: {} }
     res = { end: jest.fn() }
 
     mockFindRoutesByPath.mockReturnValue([])
@@ -195,7 +200,11 @@ describe("writeCache", () => {
   })
 
   it("should set cache if cache is enabled and response is 200", async () => {
-    const cacheKey = JSON.stringify({ queryId: "test", variables: {} })
+    const cacheKey = JSON.stringify({
+      queryId: "test",
+      digest: createHash("sha1").update("").digest("hex"),
+      variables: {},
+    })
     const responseBody = '{"data":"response"}'
 
     proxyRes = {
@@ -226,7 +235,11 @@ describe("writeCache", () => {
   })
 
   it("should set cache with route-level cache config TTLs", async () => {
-    const cacheKey = JSON.stringify({ queryId: "test", variables: {} })
+    const cacheKey = JSON.stringify({
+      queryId: "test",
+      digest: createHash("sha1").update("").digest("hex"),
+      variables: {},
+    })
     const responseBody = '{"data":"response"}'
 
     proxyRes = {


### PR DESCRIPTION
The type of this PR is: **fix**

Currently, a graphql response can be cached by one release, and served by a later release. That's fine, and even intentional, as long as the query hasn't changed. If the query has changed, cached responses to the old query should be invalidated. This PR adds a `digest` property to the cache key that's computed over the query itself. When a query changes, the digest will change and requests will be cache misses until the updated query's responses are cached.

Those old responses will be evicted by redis in the usual course of things. This also allows review apps to employ slightly different queries with the same identifier. Their responses will be cached in isolation.

Example verbose logging output:
```
[1] [graphqlProxyMiddleware # writeCache] 
[1]  [cacheKey]: {"queryId":"SearchBarInputSuggestQuery","digest":"27031aefbeee826cc2590e069bfd2d77af967a81","variables":{"term":"","hasTerm":false,"entities":[]}} 

...

[1] [graphqlProxyMiddleware # get] Cache hit: 
[1]  [cacheKey]: {"queryId":"SearchBarInputSuggestQuery","digest":"27031aefbeee826cc2590e069bfd2d77af967a81","variables":{"term":"","hasTerm":false,"entities":[]}} 
```
