### PR TITLE
fix: allow all accounts to add cards (reverts #14046)

### DIFF
--- a/src/Apps/Settings/Routes/Payments/Components/SettingsPaymentsMethods.tsx
+++ b/src/Apps/Settings/Routes/Payments/Components/SettingsPaymentsMethods.tsx
@@ -49,7 +49,7 @@ const SettingsPaymentsMethods: FC<SettingsPaymentsMethodsProps> = ({ me }) => {
 
       {creditCards.length === 0 ? (
         <Message variant="info">
-          You can manage any saved payment methods from here.
+          Please add a payment method for faster checkout in the future.
         </Message>
       ) : (
         <GridColumns gridRowGap={0}>
@@ -63,7 +63,7 @@ const SettingsPaymentsMethods: FC<SettingsPaymentsMethodsProps> = ({ me }) => {
         </GridColumns>
       )}
 
-      <Button mt={4} onClick={handleClick} disabled={creditCards.length === 0}>
+      <Button mt={4} onClick={handleClick}>
         Add New Card
       </Button>
 

--- a/src/Apps/Settings/Routes/__tests__/SettingsPaymentsRoute.jest.tsx
+++ b/src/Apps/Settings/Routes/__tests__/SettingsPaymentsRoute.jest.tsx
@@ -54,7 +54,9 @@ describe("SettingsPaymentsRoute", () => {
     expect(screen.getByText("Saved Payment Details")).toBeInTheDocument()
     expect(screen.getByText("Credit cards")).toBeInTheDocument()
     expect(
-      screen.getByText("You can manage any saved payment methods from here.")
+      screen.getByText(
+        "Please add a payment method for faster checkout in the future."
+      )
     ).toBeInTheDocument()
   })
 


### PR DESCRIPTION
Reverts https://github.com/artsy/force/pull/14046, now that other safeguards have proven effective. This also fixes a typo in the original copy.

Follow-up to: https://artsyproduct.atlassian.net/browse/PHIRE-1013
