### PR TITLE
feat: Make Sell flow bottom navigation transparent

### DIFF
--- a/src/Apps/Sell/Components/BottomFormNavigation.tsx
+++ b/src/Apps/Sell/Components/BottomFormNavigation.tsx
@@ -1,5 +1,7 @@
 import { ContextModule, Intent } from "@artsy/cohesion"
 import { Box, Button, Flex } from "@artsy/palette"
+import { AppContainer } from "Apps/Components/AppContainer"
+import { Z } from "Apps/Components/constants"
 import { useSubmissionTracking } from "Apps/Sell/Hooks/useSubmissionTracking"
 import { useAssociateSubmission } from "Apps/Sell/Mutations/useAssociateSubmission"
 import {
@@ -15,20 +17,35 @@ import { useCallback, useEffect, useState } from "react"
 
 const logger = createLogger("BottomFormNavigation.tsx")
 
+export const BOTTOM_FORM_NAVIGATION_SAVE_AREA = 140
+
 export const BottomFormNavigation = () => {
   return (
     <Flex
+      position="absolute"
+      bottom={0}
+      left={0}
       width="100%"
-      p={[2, 4]}
-      pt={[2, 2]}
-      flexDirection="row"
-      justifyContent="space-between"
+      maxWidth="100vw"
+      background="rgba(255, 255, 255, 0.8)"
       alignItems="center"
-      borderTop="1px solid"
-      borderColor="black5"
+      zIndex={Z.globalNav}
     >
-      <BottomFormBackButton />
-      <BottomFormNextButton />
+      <AppContainer>
+        <Flex
+          width="100%"
+          p={[2, 4]}
+          pt={[2, 2]}
+          flexDirection="row"
+          justifyContent="space-between"
+          alignItems="center"
+          borderTop="1px solid"
+          borderColor="black5"
+        >
+          <BottomFormBackButton />
+          <BottomFormNextButton />
+        </Flex>
+      </AppContainer>
     </Flex>
   )
 }

--- a/src/Apps/Sell/Components/SubmissionLayout.tsx
+++ b/src/Apps/Sell/Components/SubmissionLayout.tsx
@@ -1,5 +1,8 @@
 import { Box, Column, Flex, GridColumns } from "@artsy/palette"
-import { BottomFormNavigation } from "Apps/Sell/Components/BottomFormNavigation"
+import {
+  BOTTOM_FORM_NAVIGATION_SAVE_AREA,
+  BottomFormNavigation,
+} from "Apps/Sell/Components/BottomFormNavigation"
 import { StepsNavigation } from "Apps/Sell/Components/StepsNavigation"
 import { SubmissionHeader } from "Apps/Sell/Components/SubmissionHeader"
 import { SubmissionProgressBar } from "Apps/Sell/Components/SubmissionProgressBar"
@@ -42,12 +45,15 @@ export const SubmissionLayout: React.FC<SubmissionLayoutProps> = ({
           </FadeInBox>
         ) : (
           <FadeInBox width={CONTENT_WIDTH} p={2} pt={[2, 4]} mx="auto">
-            {children}
+            <Box
+              style={{ paddingBottom: `${BOTTOM_FORM_NAVIGATION_SAVE_AREA}px` }}
+            >
+              {children}
+            </Box>
           </FadeInBox>
         )}
+        {!hideNavigation && <BottomFormNavigation />}
       </Flex>
-
-      {!hideNavigation && <BottomFormNavigation />}
     </Flex>
   )
 }


### PR DESCRIPTION
Addresses [ONYX-1196]

## Description

This change makes the bottom navigation of the Sell flow transparent, allowing the content below the fold to be visible to users.

<img width="1082" alt="Screenshot 2024-08-16 at 10 11 27" src="https://github.com/user-attachments/assets/b360371f-dc3a-4efa-9826-bb3708f334cd">

[ONYX-1196]: https://artsyproduct.atlassian.net/browse/ONYX-1196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ