### PR TITLE
refactor: separates out and lazy loads onboarding code

### DIFF
--- a/src/Components/Onboarding/Components/OnboardingDialog.tsx
+++ b/src/Components/Onboarding/Components/OnboardingDialog.tsx
@@ -1,0 +1,22 @@
+import { OnboardingModal } from "Components/Onboarding/Components/OnboardingModal"
+import { OnboardingSteps } from "Components/Onboarding/Components/OnboardingSteps"
+import { OnboardingProvider } from "Components/Onboarding/Hooks/useOnboardingContext"
+import { FC } from "react"
+
+interface OnboardingDialogProps {
+  onClose(): void
+  onHide(): void
+}
+
+export const OnboardingDialog: FC<OnboardingDialogProps> = ({
+  onClose,
+  onHide,
+}) => {
+  return (
+    <OnboardingProvider onClose={onClose}>
+      <OnboardingModal onClose={onHide}>
+        <OnboardingSteps />
+      </OnboardingModal>
+    </OnboardingProvider>
+  )
+}

--- a/src/Components/Onboarding/Hooks/useOnboarding.tsx
+++ b/src/Components/Onboarding/Hooks/useOnboarding.tsx
@@ -1,7 +1,14 @@
-import { OnboardingModal } from "Components/Onboarding/Components/OnboardingModal"
-import { OnboardingSteps } from "Components/Onboarding/Components/OnboardingSteps"
-import { OnboardingProvider } from "./useOnboardingContext"
 import { useMemo, useState } from "react"
+import loadable from "@loadable/component"
+
+const OnboardingDialog = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "onboardingBundle" */
+      "Components/Onboarding/Components/OnboardingDialog"
+    ),
+  { resolveComponent: component => component.OnboardingDialog }
+)
 
 interface UseOnboarding {
   onClose(): void
@@ -22,11 +29,7 @@ export const useOnboarding = ({ onClose }: UseOnboarding) => {
     return (
       <>
         {isVisible && (
-          <OnboardingProvider onClose={onClose}>
-            <OnboardingModal onClose={hideDialog}>
-              <OnboardingSteps />
-            </OnboardingModal>
-          </OnboardingProvider>
+          <OnboardingDialog onClose={onClose} onHide={hideDialog} />
         )}
       </>
     )


### PR DESCRIPTION
Closes [DIA-796](https://artsyproduct.atlassian.net/browse/DIA-796)

Similar to https://github.com/artsy/force/pull/14351 — just separating out a large network of imports that isn't needed on every page. Here we obviously only need the onboarding experience once on sign up.

[DIA-796]: https://artsyproduct.atlassian.net/browse/DIA-796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ