### PR TITLE
fix(ONYX-1197): Make sure Sell flow intro page CTAs are visible on all window sizes

### DIFF
--- a/src/Apps/Conversations/components/ConversationLayout.tsx
+++ b/src/Apps/Conversations/components/ConversationLayout.tsx
@@ -1,11 +1,12 @@
-import { Media } from "Utils/Responsive"
 import { Box, Flex } from "@artsy/palette"
 import { Resizer } from "Apps/Conversations/components/Resizer"
 import { useMobileLayoutActions } from "Apps/Conversations/hooks/useMobileLayoutActions"
 import { DESKTOP_NAV_BAR_HEIGHT } from "Components/NavBar/constants"
+import { Media } from "Utils/Responsive"
 
 const DESKTOP_HEIGHT = `calc(100vh - ${DESKTOP_NAV_BAR_HEIGHT}px)`
 const MOBILE_HEIGHT = `calc(100dvh - 60px)` // 60 is the height of the reply box
+export const SUBMISSION_LAYOUT_TOP_NAV_HEIGHT = 270
 
 export interface ConversationsLayoutProps {
   renderSidebar: () => JSX.Element | null

--- a/src/Apps/Sell/Routes/IntroRoute.tsx
+++ b/src/Apps/Sell/Routes/IntroRoute.tsx
@@ -11,6 +11,7 @@ import {
   Text,
 } from "@artsy/palette"
 import { SellMeta } from "Apps/Consign/Routes/MarketingLanding/Components/SellMeta"
+import { SUBMISSION_LAYOUT_TOP_NAV_HEIGHT } from "Apps/Conversations/components/ConversationLayout"
 import { SubmissionLayout } from "Apps/Sell/Components/SubmissionLayout"
 import { SubmissionStepTitle } from "Apps/Sell/Components/SubmissionStepTitle"
 import { useSubmissionTracking } from "Apps/Sell/Hooks/useSubmissionTracking"
@@ -38,7 +39,7 @@ export const IntroRoute: React.FC = () => {
             flex={1}
             overflowY="auto"
             flexDirection="column"
-            maxHeight={`calc(100vh - ${270}px)`}
+            maxHeight={`calc(100vh - ${SUBMISSION_LAYOUT_TOP_NAV_HEIGHT}px)`}
             px={1}
             pb={[2, 4]}
           >

--- a/src/Apps/Sell/Routes/IntroRoute.tsx
+++ b/src/Apps/Sell/Routes/IntroRoute.tsx
@@ -32,8 +32,16 @@ export const IntroRoute: React.FC = () => {
           height={isMobile ? "100%" : undefined}
           flexDirection="column"
           overflowY="auto"
+          overflow="scroll"
         >
-          <Flex flex={1} overflowY="auto" flexDirection="column">
+          <Flex
+            flex={1}
+            overflowY="auto"
+            flexDirection="column"
+            maxHeight={`calc(100vh - ${270}px)`}
+            px={1}
+            pb={[2, 4]}
+          >
             <SubmissionStepTitle>
               It’s easy to sell on Artsy
             </SubmissionStepTitle>
@@ -66,7 +74,7 @@ export const IntroRoute: React.FC = () => {
             </Join>
           </Flex>
 
-          <Flex gap="2" width="100%" pt={[2, 6]}>
+          <Flex gap="2" width="100%" pt={2} px={1}>
             <Button
               // @ts-ignore
               as={RouterLink}


### PR DESCRIPTION

The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [ONYX-1197](https://artsyproduct.atlassian.net/browse/ONYX-1197)

### Description

Make sure the Sell Flow intro page CTAs are visible on all window sizes by setting a maximum height to the container.
| Before | After |
| --- | --- |
|<img width="1135" alt="Screenshot 2024-08-20 at 11 14 45" src="https://github.com/user-attachments/assets/6a3ab275-ccdd-47bd-9447-d6e1850ff9e3"> | <img width="1135" alt="Screenshot 2024-08-20 at 11 14 33" src="https://github.com/user-attachments/assets/9c3d38f7-0a7e-45f4-84b4-2b7386de83ab">|


<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-1197]: https://artsyproduct.atlassian.net/browse/ONYX-1197?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ