### PR TITLE
chore: if form ends up on the shipping step with details saved the address should save by default

### DIFF
--- a/src/Apps/Order/Routes/Shipping2/Components/FulfillmentDetails.tsx
+++ b/src/Apps/Order/Routes/Shipping2/Components/FulfillmentDetails.tsx
@@ -311,6 +311,7 @@ const getInitialValues = (
         ),
       },
       meta: {
+        saveAddress: true,
         userAddressAction: null,
         addressVerifiedBy: null,
       },


### PR DESCRIPTION
Believe this fixes: [EMI-1939](https://artsyproduct.atlassian.net/browse/EMI-1939)

If I understand the current flow correctly - the only way we can end up on a shipping step with the shipping details already saved on the order is if the page is reloaded with address already saved on order but this address is not saved as a default user addresses. In this case we should fall back to checking 'saveAddress' on the form to be true as if the user clicks 'save and continue' we want the address to be preserved in settings.

I might be missing some cases here but I believe that is a legit change here.


[EMI-1939]: https://artsyproduct.atlassian.net/browse/EMI-1939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ