### PR TITLE
fix: details artist line overflow

### DIFF
--- a/src/Components/Artwork/Details.tsx
+++ b/src/Components/Artwork/Details.tsx
@@ -357,12 +357,10 @@ export const Details: React.FC<DetailsProps> = ({
       )}
 
       <Flex justifyContent="space-between">
-        <Flex flexDirection="column">
-          {showActivePartnerOfferLine && <CollectorSignalLine {...rest} />}
-          {!hideArtistName && (
-            <ArtistLine showSaveButton={showSaveButton} {...rest} />
-          )}
-        </Flex>
+        {showActivePartnerOfferLine && <CollectorSignalLine {...rest} />}
+        {!hideArtistName && (
+          <ArtistLine showSaveButton={showSaveButton} {...rest} />
+        )}
         {renderSaveButtonComponent()}
       </Flex>
 


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. -->

### Description
This fixes the artist line overflow for the art cards. 

BEFORE
<img width="236" alt="Screenshot 2024-08-21 at 2 45 06 PM" src="https://github.com/user-attachments/assets/7e864c3d-32ae-4ca1-84a3-207bf3ef44f8">

AFTER
<img width="229" alt="Screenshot 2024-08-21 at 2 42 00 PM" src="https://github.com/user-attachments/assets/ae69312c-25b8-476b-b1a6-9900d1c2e78a">


<!-- Implementation description -->


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ