### PR TITLE
fix(search): Use coverImage first, then fallback

### DIFF
--- a/src/Apps/Search/Routes/SearchResultsArtists.tsx
+++ b/src/Apps/Search/Routes/SearchResultsArtists.tsx
@@ -42,11 +42,7 @@ export class SearchResultsArtistsRoute extends React.Component<Props, State> {
     const { viewer } = this.props
     const { searchConnection } = viewer
 
-    const {
-      pageInfo: { hasNextPage },
-    } = searchConnection!
-
-    if (hasNextPage) {
+    if (searchConnection?.pageInfo?.hasNextPage) {
       this.loadPage(this.state.page + 1)
     }
   }
@@ -61,7 +57,7 @@ export class SearchResultsArtistsRoute extends React.Component<Props, State> {
 
   getArtists = () => {
     const { viewer } = this.props
-    const artists = (viewer?.searchConnection?.edges ?? []).map(e => e!.node)
+    const artists = (viewer?.searchConnection?.edges ?? []).map(e => e?.node)
     return artists
   }
 
@@ -104,7 +100,7 @@ export class SearchResultsArtistsRoute extends React.Component<Props, State> {
     return (
       <>
         {artists?.map((artist, index) => {
-          const { name, bio, imageUrl, internalID } = artist || {}
+          const { name, bio, imageUrl, coverArtwork, internalID } = artist || {}
 
           if (!name || !internalID) {
             return null
@@ -115,9 +111,9 @@ export class SearchResultsArtistsRoute extends React.Component<Props, State> {
               <GenericSearchResultItem
                 name={name}
                 description={bio ?? ""}
-                imageUrl={imageUrl ?? ""}
+                imageUrl={coverArtwork?.image?.src ?? imageUrl ?? ""}
                 entityType="Artist"
-                href={artist?.href!}
+                href={artist?.href as string}
                 index={index}
                 term={term}
                 id={internalID}
@@ -128,11 +124,11 @@ export class SearchResultsArtistsRoute extends React.Component<Props, State> {
         })}
 
         <Pagination
-          pageCursors={searchConnection!.pageCursors}
+          pageCursors={searchConnection?.pageCursors}
           onClick={(_cursor, page) => this.loadPage(page)}
           onNext={this.loadNext}
           scrollTo="searchResultTabs"
-          hasNextPage={searchConnection!.pageInfo.hasNextPage}
+          hasNextPage={!!searchConnection?.pageInfo.hasNextPage}
         />
       </>
     )
@@ -144,7 +140,7 @@ export class SearchResultsArtistsRoute extends React.Component<Props, State> {
 
     return (
       <LoadingArea isLoading={this.state.isLoading}>
-        {artists!.length === 0 ? (
+        {artists?.length === 0 ? (
           <Box mt={3}>
             <ZeroState term={term} />
           </Box>
@@ -184,8 +180,13 @@ export const SearchResultsArtistsRouteFragmentContainer = createRefetchContainer
                 name
                 internalID
                 href
-                imageUrl
                 bio
+                imageUrl
+                coverArtwork {
+                  image {
+                    src: url(version: ["square"])
+                  }
+                }
               }
             }
           }

--- a/src/__generated__/SearchResultsArtistsQuery.graphql.ts
+++ b/src/__generated__/SearchResultsArtistsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ca9c47b16cc163c6ead745805027b4c7>>
+ * @generated SignedSource<<9fc4b8f9812278ddf3e6e451a0409642>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -75,7 +75,14 @@ v7 = [
     "name": "isCurrent",
     "storageKey": null
   }
-];
+],
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": [
@@ -279,14 +286,52 @@ return {
                             "alias": null,
                             "args": null,
                             "kind": "ScalarField",
-                            "name": "imageUrl",
+                            "name": "bio",
                             "storageKey": null
                           },
                           {
                             "alias": null,
                             "args": null,
                             "kind": "ScalarField",
-                            "name": "bio",
+                            "name": "imageUrl",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Artwork",
+                            "kind": "LinkedField",
+                            "name": "coverArtwork",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Image",
+                                "kind": "LinkedField",
+                                "name": "image",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": "src",
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "version",
+                                        "value": [
+                                          "square"
+                                        ]
+                                      }
+                                    ],
+                                    "kind": "ScalarField",
+                                    "name": "url",
+                                    "storageKey": "url(version:[\"square\"])"
+                                  }
+                                ],
+                                "storageKey": null
+                              },
+                              (v8/*: any*/)
+                            ],
                             "storageKey": null
                           }
                         ],
@@ -296,13 +341,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "id",
-                            "storageKey": null
-                          }
+                          (v8/*: any*/)
                         ],
                         "type": "Node",
                         "abstractKey": "__isNode"
@@ -322,12 +361,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1f63996a762e7a565c2c8ba7909eecfd",
+    "cacheID": "6869334e3263c2dcbc4cea19b12f8349",
     "id": null,
     "metadata": {},
     "name": "SearchResultsArtistsQuery",
     "operationKind": "query",
-    "text": "query SearchResultsArtistsQuery(\n  $first: Int\n  $term: String!\n  $page: Int\n) {\n  viewer {\n    ...SearchResultsArtists_viewer_2aqsc5\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SearchResultsArtists_viewer_2aqsc5 on Viewer {\n  searchConnection(query: $term, first: $first, page: $page, entities: [ARTIST]) @principalField {\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          name\n          internalID\n          href\n          imageUrl\n          bio\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query SearchResultsArtistsQuery(\n  $first: Int\n  $term: String!\n  $page: Int\n) {\n  viewer {\n    ...SearchResultsArtists_viewer_2aqsc5\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SearchResultsArtists_viewer_2aqsc5 on Viewer {\n  searchConnection(query: $term, first: $first, page: $page, entities: [ARTIST]) @principalField {\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          name\n          internalID\n          href\n          bio\n          imageUrl\n          coverArtwork {\n            image {\n              src: url(version: [\"square\"])\n            }\n            id\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SearchResultsArtists_viewer.graphql.ts
+++ b/src/__generated__/SearchResultsArtists_viewer.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<80e26600e6d97b2c3fdb5b9f30ff05a2>>
+ * @generated SignedSource<<8004413ba166ac2bcf1823390d7625a9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,6 +15,11 @@ export type SearchResultsArtists_viewer$data = {
     readonly edges: ReadonlyArray<{
       readonly node: {
         readonly bio?: string | null | undefined;
+        readonly coverArtwork?: {
+          readonly image: {
+            readonly src: string | null | undefined;
+          } | null | undefined;
+        } | null | undefined;
         readonly href?: string | null | undefined;
         readonly imageUrl?: string | null | undefined;
         readonly internalID?: string;
@@ -166,14 +171,51 @@ const node: ReaderFragment = {
                       "alias": null,
                       "args": null,
                       "kind": "ScalarField",
-                      "name": "imageUrl",
+                      "name": "bio",
                       "storageKey": null
                     },
                     {
                       "alias": null,
                       "args": null,
                       "kind": "ScalarField",
-                      "name": "bio",
+                      "name": "imageUrl",
+                      "storageKey": null
+                    },
+                    {
+                      "alias": null,
+                      "args": null,
+                      "concreteType": "Artwork",
+                      "kind": "LinkedField",
+                      "name": "coverArtwork",
+                      "plural": false,
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "concreteType": "Image",
+                          "kind": "LinkedField",
+                          "name": "image",
+                          "plural": false,
+                          "selections": [
+                            {
+                              "alias": "src",
+                              "args": [
+                                {
+                                  "kind": "Literal",
+                                  "name": "version",
+                                  "value": [
+                                    "square"
+                                  ]
+                                }
+                              ],
+                              "kind": "ScalarField",
+                              "name": "url",
+                              "storageKey": "url(version:[\"square\"])"
+                            }
+                          ],
+                          "storageKey": null
+                        }
+                      ],
                       "storageKey": null
                     }
                   ],
@@ -194,6 +236,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "e56ba60404a845353821326cf3f1a678";
+(node as any).hash = "a0b364b18c2a3f33247daa6aac2639c0";
 
 export default node;

--- a/src/__generated__/searchRoutes_SearchResultsArtistsQuery.graphql.ts
+++ b/src/__generated__/searchRoutes_SearchResultsArtistsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<84bccbfaa1da310f0ca8650532739db0>>
+ * @generated SignedSource<<22f1e7e76bc85fb85f9b3987c839f06c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -66,7 +66,14 @@ v4 = [
     "name": "isCurrent",
     "storageKey": null
   }
-];
+],
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -265,14 +272,52 @@ return {
                             "alias": null,
                             "args": null,
                             "kind": "ScalarField",
-                            "name": "imageUrl",
+                            "name": "bio",
                             "storageKey": null
                           },
                           {
                             "alias": null,
                             "args": null,
                             "kind": "ScalarField",
-                            "name": "bio",
+                            "name": "imageUrl",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Artwork",
+                            "kind": "LinkedField",
+                            "name": "coverArtwork",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Image",
+                                "kind": "LinkedField",
+                                "name": "image",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": "src",
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "version",
+                                        "value": [
+                                          "square"
+                                        ]
+                                      }
+                                    ],
+                                    "kind": "ScalarField",
+                                    "name": "url",
+                                    "storageKey": "url(version:[\"square\"])"
+                                  }
+                                ],
+                                "storageKey": null
+                              },
+                              (v5/*: any*/)
+                            ],
                             "storageKey": null
                           }
                         ],
@@ -282,13 +327,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "id",
-                            "storageKey": null
-                          }
+                          (v5/*: any*/)
                         ],
                         "type": "Node",
                         "abstractKey": "__isNode"
@@ -308,12 +347,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "85cbc8bf5ec2caf0406fafdf8ea33743",
+    "cacheID": "b98bff32a83f654b7fd43a61def114c1",
     "id": null,
     "metadata": {},
     "name": "searchRoutes_SearchResultsArtistsQuery",
     "operationKind": "query",
-    "text": "query searchRoutes_SearchResultsArtistsQuery(\n  $keyword: String!\n  $page: Int\n) {\n  viewer {\n    ...SearchResultsArtists_viewer_2zsz5P\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SearchResultsArtists_viewer_2zsz5P on Viewer {\n  searchConnection(query: $keyword, first: 10, page: $page, entities: [ARTIST]) @principalField {\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          name\n          internalID\n          href\n          imageUrl\n          bio\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query searchRoutes_SearchResultsArtistsQuery(\n  $keyword: String!\n  $page: Int\n) {\n  viewer {\n    ...SearchResultsArtists_viewer_2zsz5P\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SearchResultsArtists_viewer_2zsz5P on Viewer {\n  searchConnection(query: $keyword, first: 10, page: $page, entities: [ARTIST]) @principalField {\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        ... on Artist {\n          name\n          internalID\n          href\n          bio\n          imageUrl\n          coverArtwork {\n            image {\n              src: url(version: [\"square\"])\n            }\n            id\n          }\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Noticed that we weren't using the artists cover image, via this [bug report](https://artsy.slack.com/archives/C03N12SR0RK/p1724348520629639). 

Now, coverImage, then fallback, then none. 

<img width="519" alt="Screenshot 2024-08-22 at 12 37 28 PM" src="https://github.com/user-attachments/assets/fb94d9ed-a1af-46ae-aec1-761c03c6b34e">

cc @artsy/amber-devs 
