### PR TITLE
fix: revert artwork details overflow fix

### DIFF
--- a/src/Components/Artwork/Details.tsx
+++ b/src/Components/Artwork/Details.tsx
@@ -357,10 +357,12 @@ export const Details: React.FC<DetailsProps> = ({
       )}
 
       <Flex justifyContent="space-between">
-        {showActivePartnerOfferLine && <CollectorSignalLine {...rest} />}
-        {!hideArtistName && (
-          <ArtistLine showSaveButton={showSaveButton} {...rest} />
-        )}
+        <Flex flexDirection="column">
+          {showActivePartnerOfferLine && <CollectorSignalLine {...rest} />}
+          {!hideArtistName && (
+            <ArtistLine showSaveButton={showSaveButton} {...rest} />
+          )}
+        </Flex>
         {renderSaveButtonComponent()}
       </Flex>
 


### PR DESCRIPTION
The type of this PR is: FIX

By trying to fix the overflow issue I messed up the partner offer signal. Looks like it was a regression with the partner offer implementation after all. I'm going to revert my change and then push up another PR to with the overflow. Sorry y'all

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
     The Jira integration will turn it into a clickable link for you. --

### Description

By trying to fix the overflow issue I messed up the partner offer signal. Looks like it was a regression with the partner offer implementation after all. I'm going to revert my change and then push up another PR to with the overflow. 


[GRO-434]: https://artsyproduct.atlassian.net/browse/GRO-434?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ