### PR TITLE
chore: second part of defaulting to save address.

### DIFF
--- a/src/Apps/Order/Routes/Shipping2/Components/SavedAddresses2.tsx
+++ b/src/Apps/Order/Routes/Shipping2/Components/SavedAddresses2.tsx
@@ -77,7 +77,11 @@ export const SavedAddresses2: FC<SavedAddressesProps> = props => {
     }
     automaticallySelectBestAddress()
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [props.active])
+  }, [
+    props.active,
+    addressList.length,
+    shippingContext.state.selectedSavedAddressID,
+  ])
 
   /*
    * Select an address radio button and pass the address to the parent.

--- a/src/Apps/Order/Routes/Shipping2/__tests__/Shipping2.jest.tsx
+++ b/src/Apps/Order/Routes/Shipping2/__tests__/Shipping2.jest.tsx
@@ -266,7 +266,7 @@ const getAllPendingOperationNames = (env: MockEnvironment) => {
 let mockTrackEvent: jest.Mock
 
 // FIXME: CI Timeouts likely due to fillAddressForm() duration...
-describe("Shipping", () => {
+describe.skip("Shipping", () => {
   const mockUseRouter = useRouter as jest.Mock
   const mockPush = jest.fn()
 

--- a/src/Apps/Order/Routes/Shipping2/__tests__/Shipping2.jest.tsx
+++ b/src/Apps/Order/Routes/Shipping2/__tests__/Shipping2.jest.tsx
@@ -266,7 +266,7 @@ const getAllPendingOperationNames = (env: MockEnvironment) => {
 let mockTrackEvent: jest.Mock
 
 // FIXME: CI Timeouts likely due to fillAddressForm() duration...
-describe.skip("Shipping", () => {
+describe("Shipping", () => {
   const mockUseRouter = useRouter as jest.Mock
   const mockPush = jest.fn()
 


### PR DESCRIPTION
This is a second case I found that should fix https://artsyproduct.atlassian.net/browse/EMI-1939

It's a bit roundabout way to fix it but I believe it's a proper condition to call this `useEffect` regardless of this bug even. But looks like it works here because when the last address deleted on the page the length of addresses change and the previous case that I fixed (default to save address when address is present on the order but there is no addresses in context - default to save address).

It's all a bit confusing but seems to work. Also not sure how to test any of this stuff cause the setup is pretty complicated. But maybe can tested with integration run after.