### PR TITLE
fix(artwork-filter): Hide dropdown on sort click

### DIFF
--- a/src/Components/ArtworkFilter/ArtworkFilterSort.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilterSort.tsx
@@ -22,6 +22,8 @@ export const ArtworkFilterSort: FC<ArtworkFilterSortProps> = props => {
     return value === (filters?.sort ?? "-decayed_merch")
   }) || { text: "Default", value: "-decayed_merch" }
 
+  let hideDropdown
+
   return (
     <Dropdown
       dropdown={
@@ -29,6 +31,7 @@ export const ArtworkFilterSort: FC<ArtworkFilterSortProps> = props => {
           defaultValue={filters?.sort}
           onSelect={option => {
             setFilter("sort", option)
+            hideDropdown?.()
           }}
           p={2}
           gap={2}
@@ -42,7 +45,10 @@ export const ArtworkFilterSort: FC<ArtworkFilterSortProps> = props => {
       placement="bottom-end"
       {...props}
     >
-      {({ anchorRef, anchorProps }) => {
+      {({ anchorRef, anchorProps, onHide }) => {
+        // Store ref to hide action to access up above
+        hideDropdown = onHide
+
         return (
           <Button ref={anchorRef as any} {...anchorProps}>
             <SortIcon />


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Fixes artwork filter issue where ever click to the sort requires two clicks to close the filter. Now close automatically on select:

https://github.com/user-attachments/assets/eaa49308-d4ff-468b-bba0-3cf867b4a65c

