### PR TITLE
Chore: add sell flow test submission state query param for Integrity tests

### DIFF
--- a/src/Apps/Sell/SellFlowContext.tsx
+++ b/src/Apps/Sell/SellFlowContext.tsx
@@ -334,7 +334,7 @@ export const useSellFlowContext = () => {
 
 export const useTestSubmissionState = () => {
   const { match } = useRouter()
-  const testSubmissionState = match.location.query?.testSubmissionState as
+  const testSubmissionState = match?.location?.query?.testSubmissionState as
     | ConsignmentSubmissionStateAggregation
     | undefined
 

--- a/src/Apps/Sell/SellFlowContext.tsx
+++ b/src/Apps/Sell/SellFlowContext.tsx
@@ -142,10 +142,15 @@ export const SellFlowContextProvider: React.FC<SellFlowContextProviderProps> = (
     ? INITIAL_STEP
     : (match.location.pathname.split("/").pop() as SellFlowStep)
 
+  // Setting the submission state from the URL query param only for testing purposes
+  const testSubmisionState = match.location.query
+    ?.testSubmisionState as ConsignmentSubmissionStateAggregation
+  const submissionState = testSubmisionState ?? submission?.state
+
   const isExtended =
     !!enablePostApprovalSubmissionFlow &&
-    !!submission?.state &&
-    !BASIC_FLOW_STATES.includes(submission?.state)
+    !!submissionState &&
+    !BASIC_FLOW_STATES.includes(submissionState)
 
   const steps = useMemo(
     () => [
@@ -176,11 +181,11 @@ export const SellFlowContextProvider: React.FC<SellFlowContextProviderProps> = (
   const finishFlow = async () => {
     trackConsignmentSubmitted(submission?.internalID, state.step)
 
-    if (submission?.state === "DRAFT") {
+    if (submissionState === "DRAFT") {
       await updateSubmission({
         state: "SUBMITTED",
       })
-    } else if (submission?.state === "APPROVED") {
+    } else if (submissionState === "APPROVED") {
       await updateSubmission({
         state: "RESUBMITTED",
       })
@@ -206,7 +211,15 @@ export const SellFlowContextProvider: React.FC<SellFlowContextProviderProps> = (
     )
       return
 
-    router.push(`/sell/submissions/${submission?.externalId}/${newStep}`)
+    // Setting the submission state from the URL query param only for testing purposes
+    const testSubmissionQueryParams = testSubmisionState
+      ? `?testSubmisionState=${testSubmisionState}`
+      : ""
+
+    router.push(
+      `/sell/submissions/${submission?.externalId}/${newStep}` +
+        testSubmissionQueryParams
+    )
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [index, isNewSubmission, submission, steps])
 

--- a/src/Apps/Sell/SellFlowContext.tsx
+++ b/src/Apps/Sell/SellFlowContext.tsx
@@ -142,10 +142,13 @@ export const SellFlowContextProvider: React.FC<SellFlowContextProviderProps> = (
     ? INITIAL_STEP
     : (match.location.pathname.split("/").pop() as SellFlowStep)
 
-  // Setting the submission state from the URL query param only for testing purposes
-  const testSubmisionState = match.location.query
-    ?.testSubmisionState as ConsignmentSubmissionStateAggregation
-  const submissionState = testSubmisionState ?? submission?.state
+  // Setting the submission state as the URL query parameter to allow testing the complete Sell flow with different submission states with integrity.
+  const {
+    testSubmissionState,
+    testSubmissionQueryParams,
+  } = useTestSubmissionState()
+
+  const submissionState = testSubmissionState ?? submission?.state
 
   const isExtended =
     !!enablePostApprovalSubmissionFlow &&
@@ -210,11 +213,6 @@ export const SellFlowContextProvider: React.FC<SellFlowContextProviderProps> = (
       match.location.pathname.includes(newStep)
     )
       return
-
-    // Setting the submission state from the URL query param only for testing purposes
-    const testSubmissionQueryParams = testSubmisionState
-      ? `?testSubmisionState=${testSubmisionState}`
-      : ""
 
     router.push(
       `/sell/submissions/${submission?.externalId}/${newStep}` +
@@ -332,4 +330,17 @@ export const SellFlowContextProvider: React.FC<SellFlowContextProviderProps> = (
 
 export const useSellFlowContext = () => {
   return useContext(SellFlowContext)
+}
+
+export const useTestSubmissionState = () => {
+  const { match } = useRouter()
+  const testSubmissionState = match.location.query?.testSubmissionState as
+    | ConsignmentSubmissionStateAggregation
+    | undefined
+
+  const testSubmissionQueryParams = testSubmissionState
+    ? `?testSubmissionState=${testSubmissionState}`
+    : ""
+
+  return { testSubmissionState, testSubmissionQueryParams }
 }


### PR DESCRIPTION
The type of this PR is: **Chore**


This PR solves [ONYX-1154](https://artsyproduct.atlassian.net/browse/ONYX-1154)

* [Slack Thread with discussion](https://artsy.slack.com/archives/C05EQL4R5N0/p1723540029364359?thread_ts=1723539761.516339&cid=C05EQL4R5N0)

### Description

With this PR, we allow overriding the submission state in the Sell flow to be able to access the post-approval Sell flow without having to approve a submission in Convection. This is for testing purposes only and allows us to test the new flow without admin access in Convection, which could create security issues.

<!-- Implementation description -->


[ONYX-1154]: https://artsyproduct.atlassian.net/browse/ONYX-1154?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ