### PR TITLE
feat: update "last update prompt at" timestamp when user sees post-inquiry prompts

### DIFF
--- a/src/Components/Inquiry/Views/InquiryArtistsInCollection.tsx
+++ b/src/Components/Inquiry/Views/InquiryArtistsInCollection.tsx
@@ -9,13 +9,19 @@ import {
 import { Box, Stack, Text } from "@artsy/palette"
 import { CollectorProfileArtistsAdd } from "Components/CollectorProfile/CollectorProfileArtistsAdd"
 import { useInquiryContext } from "Components/Inquiry/Hooks/useInquiryContext"
+import { useUpdateMyUserProfile } from "Components/Inquiry/Hooks/useUpdateMyUserProfile"
 import { FC } from "react"
+import { Environment } from "react-relay"
 import { useTracking } from "react-tracking"
 import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
 import { useOnce } from "Utils/Hooks/useOnce"
 
 export const InquiryArtistsInCollection: FC = () => {
   const { next, relayEnvironment, context } = useInquiryContext()
+
+  const { submitUpdateMyUserProfile } = useUpdateMyUserProfile({
+    relayEnvironment: relayEnvironment.current as Environment,
+  })
 
   const {
     contextPageOwnerId,
@@ -24,7 +30,11 @@ export const InquiryArtistsInCollection: FC = () => {
   } = useAnalyticsContext()
   const { trackEvent } = useTracking()
 
-  useOnce(() => {
+  useOnce(async () => {
+    await submitUpdateMyUserProfile({
+      promptedForUpdate: true,
+    })
+
     const payload: EditProfileModalViewed = {
       action: ActionType.editProfileModalViewed,
       context_module: ContextModule.inquiry,

--- a/src/Components/Inquiry/Views/InquiryArtistsInCollection.tsx
+++ b/src/Components/Inquiry/Views/InquiryArtistsInCollection.tsx
@@ -30,8 +30,8 @@ export const InquiryArtistsInCollection: FC = () => {
   } = useAnalyticsContext()
   const { trackEvent } = useTracking()
 
-  useOnce(async () => {
-    await submitUpdateMyUserProfile({
+  useOnce(() => {
+    submitUpdateMyUserProfile({
       promptedForUpdate: true,
     })
 

--- a/src/Components/Inquiry/Views/InquiryBasicInfo.tsx
+++ b/src/Components/Inquiry/Views/InquiryBasicInfo.tsx
@@ -48,8 +48,8 @@ const InquiryBasicInfo: React.FC<InquiryBasicInfoProps> = ({ artwork, me }) => {
 
   const { contextPageOwnerType } = useAnalyticsContext()
 
-  useOnce(async () => {
-    await submitUpdateMyUserProfile({
+  useOnce(() => {
+    submitUpdateMyUserProfile({
       promptedForUpdate: true,
     })
 

--- a/src/Components/Inquiry/__tests__/Views/InquiryBasicInfo.jest.tsx
+++ b/src/Components/Inquiry/__tests__/Views/InquiryBasicInfo.jest.tsx
@@ -42,6 +42,7 @@ describe("InquiryBasicInfo", () => {
       next: mockNext,
       setContext: () => {},
       relayEnvironment: { current: null },
+      context: { current: null },
     }))
   })
 
@@ -69,7 +70,11 @@ describe("InquiryBasicInfo", () => {
       }),
     })
 
-    expect(mockSubmitUpdateMyUserProfile).not.toBeCalled()
+    await flushPromiseQueue()
+
+    expect(mockSubmitUpdateMyUserProfile).toBeCalledWith({
+      promptedForUpdate: true,
+    })
     expect(mockNext).not.toBeCalled()
 
     const input = screen.getByPlaceholderText(
@@ -109,7 +114,11 @@ describe("InquiryBasicInfo", () => {
       }),
     })
 
-    expect(mockSubmitUpdateMyUserProfile).not.toBeCalled()
+    await flushPromiseQueue()
+
+    expect(mockSubmitUpdateMyUserProfile).toBeCalledWith({
+      promptedForUpdate: true,
+    })
     expect(mockNext).not.toBeCalled()
 
     const professionInput = screen.getByPlaceholderText("Profession")


### PR DESCRIPTION
This PR updates the post-inquiry prompts to fire a mutation that will update the "last update prompt at" timestamp when the prompt is displayed. Updating this timestamp will prevent the user from being prompted to update their profile for 30 days if they don't complete the prompt.