### PR TITLE
fix(EMI-1935): Prefill address modal country and make sure it is visible

### DIFF
--- a/src/Apps/Order/Routes/Shipping2/Components/AddressModal2.tsx
+++ b/src/Apps/Order/Routes/Shipping2/Components/AddressModal2.tsx
@@ -90,7 +90,11 @@ export const AddressModal: FC<AddressModalProps> = ({
         isDefault: incomingAddress?.isDefault ?? false,
 
         ...addressWithFallbackValues(
-          addressModalAction.type === "edit" ? addressModalAction.address : {}
+          addressModalAction.type === "edit"
+            ? addressModalAction.address
+            : addressWithFallbackValues({
+                country: shippingContext.orderData.shipsFrom,
+              })
         ),
       },
       setAsDefault: false,

--- a/src/Apps/Order/Routes/Shipping2/Components/AddressModal2.tsx
+++ b/src/Apps/Order/Routes/Shipping2/Components/AddressModal2.tsx
@@ -43,7 +43,7 @@ export type AddressModalAction =
 export interface AddressModalProps {
   closeModal: () => void
   onSuccess: (address: SavedAddressType) => void
-  addressModalAction: AddressModalAction | null
+  addressModalAction: AddressModalAction
 }
 
 interface FormValues {
@@ -71,34 +71,22 @@ export const AddressModal: FC<AddressModalProps> = ({
 
   const { executeUserAddressAction } = useUserAddressUpdates()
 
-  let initialValues: FormValues
+  const incomingAddress =
+    addressModalAction.type === "edit" ? addressModalAction.address : null
 
-  if (!addressModalAction) {
-    initialValues = {
-      attributes: {
-        isDefault: false,
-        ...addressWithFallbackValues({}),
-      },
-      setAsDefault: false,
-    }
-  } else {
-    const incomingAddress =
-      addressModalAction.type === "edit" ? addressModalAction.address : null
+  const initialValues: FormValues = {
+    attributes: {
+      isDefault: incomingAddress?.isDefault ?? false,
 
-    initialValues = {
-      attributes: {
-        isDefault: incomingAddress?.isDefault ?? false,
-
-        ...addressWithFallbackValues(
-          addressModalAction.type === "edit"
-            ? addressModalAction.address
-            : addressWithFallbackValues({
-                country: shippingContext.orderData.shipsFrom,
-              })
-        ),
-      },
-      setAsDefault: false,
-    }
+      ...addressWithFallbackValues(
+        addressModalAction.type === "edit"
+          ? addressModalAction.address
+          : {
+              country: shippingContext.orderData.shipsFrom,
+            }
+      ),
+    },
+    setAsDefault: false,
   }
 
   const handleSubmit = async (

--- a/src/Apps/Order/Routes/Shipping2/Components/AddressModal2.tsx
+++ b/src/Apps/Order/Routes/Shipping2/Components/AddressModal2.tsx
@@ -456,10 +456,7 @@ const handleGravityErrors = (
     SERVER_ERROR_MAP[errors[0].message]
 
   if (userMessage) {
-    helpers.setFieldError(
-      `attributes.${userMessage.field}`,
-      userMessage.message
-    )
+    helpers.setFieldError(userMessage.field, userMessage.message)
   } else {
     helpers.setStatus(GENERIC_FAIL_MESSAGE)
   }

--- a/src/Apps/Order/Routes/Shipping2/Components/SavedAddresses2.tsx
+++ b/src/Apps/Order/Routes/Shipping2/Components/SavedAddresses2.tsx
@@ -150,13 +150,15 @@ export const SavedAddresses2: FC<SavedAddressesProps> = props => {
           Add a new address
         </AddAddressButton>
       )}
-      <AddressModal
-        addressModalAction={addressModalAction}
-        closeModal={() => {
-          setAddressModalAction(null)
-        }}
-        onSuccess={handleAddressModalSuccess}
-      />
+      {addressModalAction && (
+        <AddressModal
+          addressModalAction={addressModalAction}
+          closeModal={() => {
+            setAddressModalAction(null)
+          }}
+          onSuccess={handleAddressModalSuccess}
+        />
+      )}
       <Spacer y={4} />
     </>
   )

--- a/src/Apps/Order/Routes/Shipping2/Components/__tests__/AddressModal2.jest.tsx
+++ b/src/Apps/Order/Routes/Shipping2/Components/__tests__/AddressModal2.jest.tsx
@@ -328,7 +328,7 @@ describe.skip("AddressModal", () => {
 
       await flushPromiseQueue()
       expect(setFieldError).toHaveBeenCalledWith(
-        "phoneNumber",
+        "attributes.phoneNumber",
         "Please enter a valid phone number"
       )
     })


### PR DESCRIPTION
The type of this PR is: **Chore**

This PR solves [EMI-1935]

### Description

This PR accomplishes a but where the address modal does not show a country on render for two reasons [[slack](https://artsy.slack.com/archives/C2TQ4PT8R/p1724882978745289) 🔒]
- For new addresses, we need to get the default country from the order's possible locations. We start with the location of the artwork.
- For updating addresses, the value actually was already there, but not rendered correctly. This is fixed by not rendering the modal until the address modal actually has something to do and real initial values are ready.

[EMI-1935]: https://artsyproduct.atlassian.net/browse/EMI-1935?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ