### PR TITLE
chore: immediately resolve empty search bar queries

### DIFF
--- a/src/System/Relay/middleware/searchBarImmediateResolveMiddleware.ts
+++ b/src/System/Relay/middleware/searchBarImmediateResolveMiddleware.ts
@@ -1,9 +1,10 @@
 // TODO: Better introspection around if this is a SearchBar query,
 // or further refactoring to extract `addMiddlewareToEnvironment(environment)`,
 // to be used in the SearchBar QueryRenderer (for example).
+// Also - why does the SearchBar query always perform an empty query?
 export function searchBarImmediateResolveMiddleware() {
   return next => req => {
-    if (req.id === "SearchBarSuggestQuery" && req.variables.term === "")
+    if (req.id === "SearchBarInputSuggestQuery" && req.variables.term === "")
       return Promise.resolve({ data: { viewer: {} } })
     return next(req)
   }


### PR DESCRIPTION
This is silly, but we have precedence for it - apparently this component has fired 'empty' queries for a while?!

At some point, the name of the query changed - so this simple thing fixes it.

I tried to put the query name in a constant for a single source of truth, but you can't do string interpolation within the `graphql` tags [here](https://github.com/artsy/force/blob/db4e4a8c6a800e3f081530f3f9b1a80ce1a498ca/src/Components/Search/SearchBarInput.tsx#L336).

Of course a question about _why_ the component behaves like this is valid - but this is a complicated custom input component that's owned by Onyx, so any larger tweak should sit with them. Since there's already precedent to suppress the query and it just had the wrong name, making that small change.

Confirmed locally this query no longer happens.