### PR TITLE
Revert "chore: immediately resolve empty search bar queries"

### DIFF
--- a/src/System/Relay/middleware/searchBarImmediateResolveMiddleware.ts
+++ b/src/System/Relay/middleware/searchBarImmediateResolveMiddleware.ts
@@ -1,10 +1,9 @@
 // TODO: Better introspection around if this is a SearchBar query,
 // or further refactoring to extract `addMiddlewareToEnvironment(environment)`,
 // to be used in the SearchBar QueryRenderer (for example).
-// Also - why does the SearchBar query always perform an empty query?
 export function searchBarImmediateResolveMiddleware() {
   return next => req => {
-    if (req.id === "SearchBarInputSuggestQuery" && req.variables.term === "")
+    if (req.id === "SearchBarSuggestQuery" && req.variables.term === "")
       return Promise.resolve({ data: { viewer: {} } })
     return next(req)
   }


### PR DESCRIPTION
Reverts artsy/force#14445

This fixes the issue (intercepts the empty query), but the shape of the resolved data is probably not 100% accurate leading to some Relay warnings.

The component should be patched by https://artsyproduct.atlassian.net/browse/ONYX-1281