### PR TITLE
fix: update help article link for taxes

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarShippingInformation.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarShippingInformation.tsx
@@ -48,7 +48,7 @@ const ArtworkSidebarShippingInformation: React.FC<ShippingInformationProps> = ({
             {taxInfo.displayText}{" "}
             <RouterLink
               inline
-              to="https://support.artsy.net/s/article/How-are-taxes-customs-VAT-and-import-fees-handled-on-works-listed-with-secure-checkout"
+              to="https://support.artsy.net/s/article/How-are-taxes-and-customs-fees-calculated"
               target="_blank"
               rel="noopener noreferrer"
               onClick={handleMoreInfoClick}
@@ -87,7 +87,7 @@ const ArtworkSidebarShippingInformation: React.FC<ShippingInformationProps> = ({
           {taxInfo.displayText}{" "}
           <RouterLink
             inline
-            to="https://support.artsy.net/s/article/How-are-taxes-customs-VAT-and-import-fees-handled-on-works-listed-with-secure-checkout"
+            to="https://support.artsy.net/s/article/How-are-taxes-and-customs-fees-calculated"
             target="_blank"
             rel="noopener noreferrer"
             onClick={handleMoreInfoClick}

--- a/src/Apps/Order/Components/TransactionDetailsSummaryItem.tsx
+++ b/src/Apps/Order/Components/TransactionDetailsSummaryItem.tsx
@@ -288,7 +288,7 @@ export const TransactionDetailsSummaryItem: FC<TransactionDetailsSummaryItemProp
         {taxPrefix()}
         <RouterLink
           inline
-          to="https://support.artsy.net/s/article/How-are-taxes-customs-VAT-and-import-fees-handled-on-works-listed-with-secure-checkout"
+          to="https://support.artsy.net/s/article/How-are-taxes-and-customs-fees-calculated"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
Similar to https://github.com/artsy/metaphysics/pull/5995, the "learn more" link in the shipping and taxes section of the artwork page is broken. The team has merged some articles and this updates the link accordingly.

See [Slack](https://artsy.slack.com/archives/C03N12SR0RK/p1726063808864249?thread_ts=1725961290.888429&cid=C03N12SR0RK) for context.

![Screenshot 2024-09-11 at 10 08 17 AM](https://github.com/user-attachments/assets/874d9a01-63e4-4070-a7af-ef4f95585176)
