### PR TITLE
chore: remove unneeded fragment since a QueryRenderer is being used

### DIFF
--- a/src/Apps/Auctions/Routes/CurrentAuctions.tsx
+++ b/src/Apps/Auctions/Routes/CurrentAuctions.tsx
@@ -8,8 +8,8 @@ import {
 } from "react-relay"
 import { CurrentAuctions_viewer$data } from "__generated__/CurrentAuctions_viewer.graphql"
 import { extractNodes } from "Utils/extractNodes"
-import { AuctionArtworkRailQueryRenderer } from "../Components/AuctionArtworksRail"
-import { AuctionsZeroState } from "../Components/AuctionsZeroState"
+import { AuctionArtworkRailQueryRenderer } from "Apps/Auctions/Components/AuctionArtworksRail"
+import { AuctionsZeroState } from "Apps/Auctions/Components/AuctionsZeroState"
 
 export interface CurrentAuctionsProps {
   viewer: CurrentAuctions_viewer$data
@@ -102,7 +102,6 @@ export const CurrentAuctionsPaginationContainer = createPaginationContainer(
               href
               liveStartAt
               isLiveOpen
-              ...AuctionArtworksRail_sale
             }
           }
         }

--- a/src/Apps/Auctions/Routes/PastAuctions.tsx
+++ b/src/Apps/Auctions/Routes/PastAuctions.tsx
@@ -7,7 +7,7 @@ import {
   RelayPaginationProp,
 } from "react-relay"
 import { PastAuctions_viewer$data } from "__generated__/PastAuctions_viewer.graphql"
-import { AuctionArtworksRailFragmentContainer } from "Apps/Auctions/Components/AuctionArtworksRail"
+import { AuctionArtworkRailQueryRenderer } from "Apps/Auctions/Components/AuctionArtworksRail"
 import { extractNodes } from "Utils/extractNodes"
 import { AuctionsZeroState } from "Apps/Auctions/Components/AuctionsZeroState"
 
@@ -53,7 +53,7 @@ const PastAuctions: React.FC<PastAuctionsProps> = ({ viewer, relay }) => {
       {nodes.map((node, index) => {
         return (
           <Box my={6} key={index}>
-            <AuctionArtworksRailFragmentContainer sale={node} tabType="past" />
+            <AuctionArtworkRailQueryRenderer slug={node.slug} tabType="past" />
           </Box>
         )
       })}
@@ -97,7 +97,6 @@ export const PastAuctionsPaginationContainer = createPaginationContainer(
               name
               href
               endAt
-              ...AuctionArtworksRail_sale
             }
           }
         }

--- a/src/Apps/Auctions/Routes/UpcomingAuctions.tsx
+++ b/src/Apps/Auctions/Routes/UpcomingAuctions.tsx
@@ -7,7 +7,7 @@ import {
   RelayPaginationProp,
 } from "react-relay"
 import { UpcomingAuctions_viewer$data } from "__generated__/UpcomingAuctions_viewer.graphql"
-import { AuctionArtworksRailFragmentContainer } from "Apps/Auctions/Components/AuctionArtworksRail"
+import { AuctionArtworkRailQueryRenderer } from "Apps/Auctions/Components/AuctionArtworksRail"
 import { extractNodes } from "Utils/extractNodes"
 import { AuctionsZeroState } from "Apps/Auctions/Components/AuctionsZeroState"
 
@@ -56,8 +56,8 @@ const UpcomingAuctions: React.FC<UpcomingAuctionsProps> = ({
       {nodes.map((node, index) => {
         return (
           <Box my={6} key={index}>
-            <AuctionArtworksRailFragmentContainer
-              sale={node}
+            <AuctionArtworkRailQueryRenderer
+              slug={node.slug}
               tabType="upcoming"
             />
           </Box>
@@ -105,7 +105,6 @@ export const UpcomingAuctionsPaginationContainer = createPaginationContainer(
               formattedStartDateTime
               eventStartAt
               isLiveOpen
-              ...AuctionArtworksRail_sale
             }
           }
         }

--- a/src/__generated__/CurrentAuctionsQuery.graphql.ts
+++ b/src/__generated__/CurrentAuctionsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8ede82065bb344a4097d29561d9da1e5>>
+ * @generated SignedSource<<26c1e68c593da331bc4e2b04ecfb19bd>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -68,68 +68,6 @@ v4 = [
     "name": "sort",
     "value": "LICENSED_TIMELY_AT_NAME_DESC"
   }
-],
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "slug",
-  "storageKey": null
-},
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-},
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "href",
-  "storageKey": null
-},
-v8 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v9 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "endAt",
-  "storageKey": null
-},
-v10 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "display",
-    "storageKey": null
-  }
-],
-v11 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v12 = [
-  {
-    "kind": "Literal",
-    "name": "shallow",
-    "value": true
-  }
-],
-v13 = [
-  (v6/*: any*/),
-  (v11/*: any*/)
 ];
 return {
   "fragment": {
@@ -212,9 +150,27 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v5/*: any*/),
-                      (v6/*: any*/),
-                      (v7/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "name",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "href",
+                        "storageKey": null
+                      },
                       {
                         "alias": null,
                         "args": null,
@@ -231,519 +187,11 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "first",
-                            "value": 20
-                          }
-                        ],
-                        "concreteType": "ArtworkConnection",
-                        "kind": "LinkedField",
-                        "name": "artworksConnection",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "ArtworkEdge",
-                            "kind": "LinkedField",
-                            "name": "edges",
-                            "plural": true,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "Artwork",
-                                "kind": "LinkedField",
-                                "name": "node",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isUnlisted",
-                                    "storageKey": null
-                                  },
-                                  (v8/*: any*/),
-                                  (v7/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "title",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "date",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "CollectorSignals",
-                                    "kind": "LinkedField",
-                                    "name": "collectorSignals",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "AuctionCollectorSignals",
-                                        "kind": "LinkedField",
-                                        "name": "auction",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "bidCount",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "lotClosesAt",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "liveBiddingStarted",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "registrationEndsAt",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "onlineBiddingExtended",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "lotWatcherCount",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "PartnerOfferToCollector",
-                                        "kind": "LinkedField",
-                                        "name": "partnerOffer",
-                                        "plural": false,
-                                        "selections": [
-                                          (v9/*: any*/),
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "concreteType": "Money",
-                                            "kind": "LinkedField",
-                                            "name": "priceWithDiscount",
-                                            "plural": false,
-                                            "selections": (v10/*: any*/),
-                                            "storageKey": null
-                                          },
-                                          (v11/*: any*/)
-                                        ],
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "sale_message",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "saleMessage",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "cultural_maker",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "culturalMaker",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v12/*: any*/),
-                                    "concreteType": "Artist",
-                                    "kind": "LinkedField",
-                                    "name": "artist",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "ArtistTargetSupply",
-                                        "kind": "LinkedField",
-                                        "name": "targetSupply",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "isP1",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      (v11/*: any*/)
-                                    ],
-                                    "storageKey": "artist(shallow:true)"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "ArtworkPriceInsights",
-                                    "kind": "LinkedField",
-                                    "name": "marketPriceInsights",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "demandRank",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v12/*: any*/),
-                                    "concreteType": "Artist",
-                                    "kind": "LinkedField",
-                                    "name": "artists",
-                                    "plural": true,
-                                    "selections": [
-                                      (v11/*: any*/),
-                                      (v7/*: any*/),
-                                      (v6/*: any*/)
-                                    ],
-                                    "storageKey": "artists(shallow:true)"
-                                  },
-                                  {
-                                    "alias": "collecting_institution",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "collectingInstitution",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v12/*: any*/),
-                                    "concreteType": "Partner",
-                                    "kind": "LinkedField",
-                                    "name": "partner",
-                                    "plural": false,
-                                    "selections": [
-                                      (v6/*: any*/),
-                                      (v7/*: any*/),
-                                      (v11/*: any*/)
-                                    ],
-                                    "storageKey": "partner(shallow:true)"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Sale",
-                                    "kind": "LinkedField",
-                                    "name": "sale",
-                                    "plural": false,
-                                    "selections": [
-                                      (v9/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "cascadingEndTimeIntervalMinutes",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "extendedBiddingIntervalMinutes",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "startAt",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_auction",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isAuction",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_closed",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isClosed",
-                                        "storageKey": null
-                                      },
-                                      (v11/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "sale_artwork",
-                                    "args": null,
-                                    "concreteType": "SaleArtwork",
-                                    "kind": "LinkedField",
-                                    "name": "saleArtwork",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "lotID",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "lotLabel",
-                                        "storageKey": null
-                                      },
-                                      (v9/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "extendedBiddingEndAt",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "formattedEndDateTime",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "SaleArtworkCounts",
-                                        "kind": "LinkedField",
-                                        "name": "counts",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": "bidder_positions",
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "bidderPositions",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "highest_bid",
-                                        "args": null,
-                                        "concreteType": "SaleArtworkHighestBid",
-                                        "kind": "LinkedField",
-                                        "name": "highestBid",
-                                        "plural": false,
-                                        "selections": (v10/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "opening_bid",
-                                        "args": null,
-                                        "concreteType": "SaleArtworkOpeningBid",
-                                        "kind": "LinkedField",
-                                        "name": "openingBid",
-                                        "plural": false,
-                                        "selections": (v10/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      (v11/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  (v11/*: any*/),
-                                  (v5/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isSaved",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "artistNames",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "preview",
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": "square"
-                                          }
-                                        ],
-                                        "kind": "ScalarField",
-                                        "name": "url",
-                                        "storageKey": "url(version:\"square\")"
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isInAuction",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isSavedToList",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "AttributionClass",
-                                    "kind": "LinkedField",
-                                    "name": "attributionClass",
-                                    "plural": false,
-                                    "selections": (v13/*: any*/),
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "ArtworkMedium",
-                                    "kind": "LinkedField",
-                                    "name": "mediumType",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "Gene",
-                                        "kind": "LinkedField",
-                                        "name": "filterGene",
-                                        "plural": false,
-                                        "selections": (v13/*: any*/),
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": "src",
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": [
-                                              "larger",
-                                              "large"
-                                            ]
-                                          }
-                                        ],
-                                        "kind": "ScalarField",
-                                        "name": "url",
-                                        "storageKey": "url(version:[\"larger\",\"large\"])"
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "width",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "height",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "blurhashDataURL",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": "artworksConnection(first:20)"
-                      },
-                      (v8/*: any*/),
-                      {
-                        "alias": null,
                         "args": null,
                         "kind": "ScalarField",
-                        "name": "formattedStartDateTime",
+                        "name": "id",
                         "storageKey": null
                       },
-                      (v11/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -812,12 +260,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d5a0a5dbba2661421f6ca5ac87fe00db",
+    "cacheID": "d7369d82bfbd471bb0a15a1061e382a4",
     "id": null,
     "metadata": {},
     "name": "CurrentAuctionsQuery",
     "operationKind": "query",
-    "text": "query CurrentAuctionsQuery(\n  $first: Int!\n  $after: String\n) {\n  viewer {\n    ...CurrentAuctions_viewer_2HEEH6\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment CurrentAuctions_viewer_2HEEH6 on Viewer {\n  salesConnection(first: $first, after: $after, live: true, published: true, sort: LICENSED_TIMELY_AT_NAME_DESC, auctionState: OPEN) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        liveStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...BidTimerLine_artwork\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isInAuction\n  isSavedToList\n  collectorSignals {\n    auction {\n      lotWatcherCount\n      lotClosesAt\n      liveBiddingStarted\n    }\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n  collectorSignals {\n    auction {\n      lotWatcherCount\n      lotClosesAt\n    }\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...ExclusiveAccessBadge_artwork\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  isUnlisted\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n    blurhashDataURL\n  }\n}\n"
+    "text": "query CurrentAuctionsQuery(\n  $first: Int!\n  $after: String\n) {\n  viewer {\n    ...CurrentAuctions_viewer_2HEEH6\n  }\n}\n\nfragment CurrentAuctions_viewer_2HEEH6 on Viewer {\n  salesConnection(first: $first, after: $after, live: true, published: true, sort: LICENSED_TIMELY_AT_NAME_DESC, auctionState: OPEN) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        liveStartAt\n        isLiveOpen\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/CurrentAuctions_Test_Query.graphql.ts
+++ b/src/__generated__/CurrentAuctions_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ebe1c060e375c7b471d42c30ce154cca>>
+ * @generated SignedSource<<15de12514d1ffff155664776237153ae>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -50,120 +50,22 @@ var v0 = [
   }
 ],
 v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "slug",
-  "storageKey": null
-},
-v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-},
-v3 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "href",
-  "storageKey": null
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "endAt",
-  "storageKey": null
-},
-v6 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "display",
-    "storageKey": null
-  }
-],
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v8 = [
-  {
-    "kind": "Literal",
-    "name": "shallow",
-    "value": true
-  }
-],
-v9 = [
-  (v2/*: any*/),
-  (v7/*: any*/)
-],
-v10 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v11 = {
+v2 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Sale"
+  "type": "String"
 },
-v12 = {
+v3 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
-},
-v13 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Boolean"
-},
-v14 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "String"
-},
-v15 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "Int"
-},
-v16 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "Boolean"
-},
-v17 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Image"
-},
-v18 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Int"
 };
 return {
   "fragment": {
@@ -237,9 +139,27 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v1/*: any*/),
-                      (v2/*: any*/),
-                      (v3/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "name",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "href",
+                        "storageKey": null
+                      },
                       {
                         "alias": null,
                         "args": null,
@@ -256,519 +176,11 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "first",
-                            "value": 20
-                          }
-                        ],
-                        "concreteType": "ArtworkConnection",
-                        "kind": "LinkedField",
-                        "name": "artworksConnection",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "ArtworkEdge",
-                            "kind": "LinkedField",
-                            "name": "edges",
-                            "plural": true,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "Artwork",
-                                "kind": "LinkedField",
-                                "name": "node",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isUnlisted",
-                                    "storageKey": null
-                                  },
-                                  (v4/*: any*/),
-                                  (v3/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "title",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "date",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "CollectorSignals",
-                                    "kind": "LinkedField",
-                                    "name": "collectorSignals",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "AuctionCollectorSignals",
-                                        "kind": "LinkedField",
-                                        "name": "auction",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "bidCount",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "lotClosesAt",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "liveBiddingStarted",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "registrationEndsAt",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "onlineBiddingExtended",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "lotWatcherCount",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "PartnerOfferToCollector",
-                                        "kind": "LinkedField",
-                                        "name": "partnerOffer",
-                                        "plural": false,
-                                        "selections": [
-                                          (v5/*: any*/),
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "concreteType": "Money",
-                                            "kind": "LinkedField",
-                                            "name": "priceWithDiscount",
-                                            "plural": false,
-                                            "selections": (v6/*: any*/),
-                                            "storageKey": null
-                                          },
-                                          (v7/*: any*/)
-                                        ],
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "sale_message",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "saleMessage",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "cultural_maker",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "culturalMaker",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v8/*: any*/),
-                                    "concreteType": "Artist",
-                                    "kind": "LinkedField",
-                                    "name": "artist",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "ArtistTargetSupply",
-                                        "kind": "LinkedField",
-                                        "name": "targetSupply",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "isP1",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      (v7/*: any*/)
-                                    ],
-                                    "storageKey": "artist(shallow:true)"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "ArtworkPriceInsights",
-                                    "kind": "LinkedField",
-                                    "name": "marketPriceInsights",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "demandRank",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v8/*: any*/),
-                                    "concreteType": "Artist",
-                                    "kind": "LinkedField",
-                                    "name": "artists",
-                                    "plural": true,
-                                    "selections": [
-                                      (v7/*: any*/),
-                                      (v3/*: any*/),
-                                      (v2/*: any*/)
-                                    ],
-                                    "storageKey": "artists(shallow:true)"
-                                  },
-                                  {
-                                    "alias": "collecting_institution",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "collectingInstitution",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v8/*: any*/),
-                                    "concreteType": "Partner",
-                                    "kind": "LinkedField",
-                                    "name": "partner",
-                                    "plural": false,
-                                    "selections": [
-                                      (v2/*: any*/),
-                                      (v3/*: any*/),
-                                      (v7/*: any*/)
-                                    ],
-                                    "storageKey": "partner(shallow:true)"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Sale",
-                                    "kind": "LinkedField",
-                                    "name": "sale",
-                                    "plural": false,
-                                    "selections": [
-                                      (v5/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "cascadingEndTimeIntervalMinutes",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "extendedBiddingIntervalMinutes",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "startAt",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_auction",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isAuction",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_closed",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isClosed",
-                                        "storageKey": null
-                                      },
-                                      (v7/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "sale_artwork",
-                                    "args": null,
-                                    "concreteType": "SaleArtwork",
-                                    "kind": "LinkedField",
-                                    "name": "saleArtwork",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "lotID",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "lotLabel",
-                                        "storageKey": null
-                                      },
-                                      (v5/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "extendedBiddingEndAt",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "formattedEndDateTime",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "SaleArtworkCounts",
-                                        "kind": "LinkedField",
-                                        "name": "counts",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": "bidder_positions",
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "bidderPositions",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "highest_bid",
-                                        "args": null,
-                                        "concreteType": "SaleArtworkHighestBid",
-                                        "kind": "LinkedField",
-                                        "name": "highestBid",
-                                        "plural": false,
-                                        "selections": (v6/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "opening_bid",
-                                        "args": null,
-                                        "concreteType": "SaleArtworkOpeningBid",
-                                        "kind": "LinkedField",
-                                        "name": "openingBid",
-                                        "plural": false,
-                                        "selections": (v6/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      (v7/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  (v7/*: any*/),
-                                  (v1/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isSaved",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "artistNames",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "preview",
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": "square"
-                                          }
-                                        ],
-                                        "kind": "ScalarField",
-                                        "name": "url",
-                                        "storageKey": "url(version:\"square\")"
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isInAuction",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isSavedToList",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "AttributionClass",
-                                    "kind": "LinkedField",
-                                    "name": "attributionClass",
-                                    "plural": false,
-                                    "selections": (v9/*: any*/),
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "ArtworkMedium",
-                                    "kind": "LinkedField",
-                                    "name": "mediumType",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "Gene",
-                                        "kind": "LinkedField",
-                                        "name": "filterGene",
-                                        "plural": false,
-                                        "selections": (v9/*: any*/),
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": "src",
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": [
-                                              "larger",
-                                              "large"
-                                            ]
-                                          }
-                                        ],
-                                        "kind": "ScalarField",
-                                        "name": "url",
-                                        "storageKey": "url(version:[\"larger\",\"large\"])"
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "width",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "height",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "blurhashDataURL",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": "artworksConnection(first:20)"
-                      },
-                      (v4/*: any*/),
-                      {
-                        "alias": null,
                         "args": null,
                         "kind": "ScalarField",
-                        "name": "formattedStartDateTime",
+                        "name": "id",
                         "storageKey": null
                       },
-                      (v7/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -837,7 +249,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "0df47e74b531d77468e3dc1ff9d7b67e",
+    "cacheID": "655e13ed32fa47b1f6878c209bcdf6bc",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -859,215 +271,49 @@ return {
           "plural": true,
           "type": "SaleEdge"
         },
-        "viewer.salesConnection.edges.cursor": (v10/*: any*/),
-        "viewer.salesConnection.edges.node": (v11/*: any*/),
-        "viewer.salesConnection.edges.node.__typename": (v10/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection": {
+        "viewer.salesConnection.edges.cursor": (v1/*: any*/),
+        "viewer.salesConnection.edges.node": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "ArtworkConnection"
+          "type": "Sale"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": true,
-          "type": "ArtworkEdge"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node": {
+        "viewer.salesConnection.edges.node.__typename": (v1/*: any*/),
+        "viewer.salesConnection.edges.node.href": (v2/*: any*/),
+        "viewer.salesConnection.edges.node.id": (v3/*: any*/),
+        "viewer.salesConnection.edges.node.isLiveOpen": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "Artwork"
+          "type": "Boolean"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artist": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Artist"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artist.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artist.targetSupply": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "ArtistTargetSupply"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artist.targetSupply.isP1": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artistNames": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": true,
-          "type": "Artist"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists.href": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists.name": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.attributionClass": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "AttributionClass"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.attributionClass.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.attributionClass.name": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collecting_institution": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "CollectorSignals"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.auction": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "AuctionCollectorSignals"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.auction.bidCount": (v15/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.auction.liveBiddingStarted": (v16/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.auction.lotClosesAt": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.auction.lotWatcherCount": (v15/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.auction.onlineBiddingExtended": (v16/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.auction.registrationEndsAt": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.partnerOffer": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "PartnerOfferToCollector"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.partnerOffer.endAt": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.partnerOffer.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.partnerOffer.priceWithDiscount": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Money"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.cultural_maker": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.date": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.href": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image": (v17/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.blurhashDataURL": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.height": (v18/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.src": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.width": (v18/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.internalID": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.isInAuction": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.isSaved": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.isSavedToList": (v16/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.isUnlisted": (v16/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.marketPriceInsights": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ArtworkPriceInsights"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.marketPriceInsights.demandRank": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Float"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.mediumType": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ArtworkMedium"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.mediumType.filterGene": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Gene"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.mediumType.filterGene.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.mediumType.filterGene.name": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Partner"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner.href": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner.name": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.preview": (v17/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.preview.url": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale": (v11/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v18/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.endAt": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v18/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.is_auction": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.is_closed": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.startAt": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "SaleArtwork"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.counts": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "SaleArtworkCounts"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.counts.bidder_positions": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "FormattedNumber"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.endAt": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.highest_bid": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "SaleArtworkHighestBid"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.highest_bid.display": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.lotID": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.lotLabel": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.opening_bid": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "SaleArtworkOpeningBid"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.opening_bid.display": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_message": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.slug": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.title": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.formattedStartDateTime": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.href": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.internalID": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.isLiveOpen": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.liveStartAt": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.name": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.slug": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.liveStartAt": (v2/*: any*/),
+        "viewer.salesConnection.edges.node.name": (v2/*: any*/),
+        "viewer.salesConnection.edges.node.slug": (v3/*: any*/),
         "viewer.salesConnection.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "viewer.salesConnection.pageInfo.endCursor": (v14/*: any*/),
-        "viewer.salesConnection.pageInfo.hasNextPage": (v16/*: any*/),
-        "viewer.salesConnection.totalCount": (v18/*: any*/)
+        "viewer.salesConnection.pageInfo.endCursor": (v2/*: any*/),
+        "viewer.salesConnection.pageInfo.hasNextPage": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "Boolean"
+        },
+        "viewer.salesConnection.totalCount": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Int"
+        }
       }
     },
     "name": "CurrentAuctions_Test_Query",
     "operationKind": "query",
-    "text": "query CurrentAuctions_Test_Query {\n  viewer {\n    ...CurrentAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment CurrentAuctions_viewer on Viewer {\n  salesConnection(first: 10, live: true, published: true, sort: LICENSED_TIMELY_AT_NAME_DESC, auctionState: OPEN) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        liveStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...BidTimerLine_artwork\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isInAuction\n  isSavedToList\n  collectorSignals {\n    auction {\n      lotWatcherCount\n      lotClosesAt\n      liveBiddingStarted\n    }\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n  collectorSignals {\n    auction {\n      lotWatcherCount\n      lotClosesAt\n    }\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...ExclusiveAccessBadge_artwork\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  isUnlisted\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n    blurhashDataURL\n  }\n}\n"
+    "text": "query CurrentAuctions_Test_Query {\n  viewer {\n    ...CurrentAuctions_viewer\n  }\n}\n\nfragment CurrentAuctions_viewer on Viewer {\n  salesConnection(first: 10, live: true, published: true, sort: LICENSED_TIMELY_AT_NAME_DESC, auctionState: OPEN) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        liveStartAt\n        isLiveOpen\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/CurrentAuctions_viewer.graphql.ts
+++ b/src/__generated__/CurrentAuctions_viewer.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<85fb3a137cd4c5dd084c888ba2f39a04>>
+ * @generated SignedSource<<69e477c940899766d8e208f356f7184d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -19,7 +19,6 @@ export type CurrentAuctions_viewer$data = {
         readonly liveStartAt: string | null | undefined;
         readonly name: string | null | undefined;
         readonly slug: string;
-        readonly " $fragmentSpreads": FragmentRefs<"AuctionArtworksRail_sale">;
       } | null | undefined;
     } | null | undefined> | null | undefined;
     readonly totalCount: number | null | undefined;
@@ -147,11 +146,6 @@ const node: ReaderFragment = {
                   "storageKey": null
                 },
                 {
-                  "args": null,
-                  "kind": "FragmentSpread",
-                  "name": "AuctionArtworksRail_sale"
-                },
-                {
                   "alias": null,
                   "args": null,
                   "kind": "ScalarField",
@@ -204,6 +198,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "492de60aa16e3326444bdeba6c18854e";
+(node as any).hash = "38c994c7874307977baafd577ec5cb05";
 
 export default node;

--- a/src/__generated__/PastAuctionsQuery.graphql.ts
+++ b/src/__generated__/PastAuctionsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bb8a01a067a1839fe2a070dc53f43755>>
+ * @generated SignedSource<<e93b48cd72cdedb87685b7c1513a7f00>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -63,68 +63,6 @@ v4 = [
     "name": "sort",
     "value": "TIMELY_AT_NAME_DESC"
   }
-],
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "slug",
-  "storageKey": null
-},
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-},
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "href",
-  "storageKey": null
-},
-v8 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "endAt",
-  "storageKey": null
-},
-v9 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v10 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "display",
-    "storageKey": null
-  }
-],
-v11 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v12 = [
-  {
-    "kind": "Literal",
-    "name": "shallow",
-    "value": true
-  }
-],
-v13 = [
-  (v6/*: any*/),
-  (v11/*: any*/)
 ];
 return {
   "fragment": {
@@ -207,525 +145,41 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v5/*: any*/),
-                      (v6/*: any*/),
-                      (v7/*: any*/),
-                      (v8/*: any*/),
-                      {
-                        "alias": null,
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "first",
-                            "value": 20
-                          }
-                        ],
-                        "concreteType": "ArtworkConnection",
-                        "kind": "LinkedField",
-                        "name": "artworksConnection",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "ArtworkEdge",
-                            "kind": "LinkedField",
-                            "name": "edges",
-                            "plural": true,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "Artwork",
-                                "kind": "LinkedField",
-                                "name": "node",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isUnlisted",
-                                    "storageKey": null
-                                  },
-                                  (v9/*: any*/),
-                                  (v7/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "title",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "date",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "CollectorSignals",
-                                    "kind": "LinkedField",
-                                    "name": "collectorSignals",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "AuctionCollectorSignals",
-                                        "kind": "LinkedField",
-                                        "name": "auction",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "bidCount",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "lotClosesAt",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "liveBiddingStarted",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "registrationEndsAt",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "onlineBiddingExtended",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "lotWatcherCount",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "PartnerOfferToCollector",
-                                        "kind": "LinkedField",
-                                        "name": "partnerOffer",
-                                        "plural": false,
-                                        "selections": [
-                                          (v8/*: any*/),
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "concreteType": "Money",
-                                            "kind": "LinkedField",
-                                            "name": "priceWithDiscount",
-                                            "plural": false,
-                                            "selections": (v10/*: any*/),
-                                            "storageKey": null
-                                          },
-                                          (v11/*: any*/)
-                                        ],
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "sale_message",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "saleMessage",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "cultural_maker",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "culturalMaker",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v12/*: any*/),
-                                    "concreteType": "Artist",
-                                    "kind": "LinkedField",
-                                    "name": "artist",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "ArtistTargetSupply",
-                                        "kind": "LinkedField",
-                                        "name": "targetSupply",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "isP1",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      (v11/*: any*/)
-                                    ],
-                                    "storageKey": "artist(shallow:true)"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "ArtworkPriceInsights",
-                                    "kind": "LinkedField",
-                                    "name": "marketPriceInsights",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "demandRank",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v12/*: any*/),
-                                    "concreteType": "Artist",
-                                    "kind": "LinkedField",
-                                    "name": "artists",
-                                    "plural": true,
-                                    "selections": [
-                                      (v11/*: any*/),
-                                      (v7/*: any*/),
-                                      (v6/*: any*/)
-                                    ],
-                                    "storageKey": "artists(shallow:true)"
-                                  },
-                                  {
-                                    "alias": "collecting_institution",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "collectingInstitution",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v12/*: any*/),
-                                    "concreteType": "Partner",
-                                    "kind": "LinkedField",
-                                    "name": "partner",
-                                    "plural": false,
-                                    "selections": [
-                                      (v6/*: any*/),
-                                      (v7/*: any*/),
-                                      (v11/*: any*/)
-                                    ],
-                                    "storageKey": "partner(shallow:true)"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Sale",
-                                    "kind": "LinkedField",
-                                    "name": "sale",
-                                    "plural": false,
-                                    "selections": [
-                                      (v8/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "cascadingEndTimeIntervalMinutes",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "extendedBiddingIntervalMinutes",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "startAt",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_auction",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isAuction",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_closed",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isClosed",
-                                        "storageKey": null
-                                      },
-                                      (v11/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "sale_artwork",
-                                    "args": null,
-                                    "concreteType": "SaleArtwork",
-                                    "kind": "LinkedField",
-                                    "name": "saleArtwork",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "lotID",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "lotLabel",
-                                        "storageKey": null
-                                      },
-                                      (v8/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "extendedBiddingEndAt",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "formattedEndDateTime",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "SaleArtworkCounts",
-                                        "kind": "LinkedField",
-                                        "name": "counts",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": "bidder_positions",
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "bidderPositions",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "highest_bid",
-                                        "args": null,
-                                        "concreteType": "SaleArtworkHighestBid",
-                                        "kind": "LinkedField",
-                                        "name": "highestBid",
-                                        "plural": false,
-                                        "selections": (v10/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "opening_bid",
-                                        "args": null,
-                                        "concreteType": "SaleArtworkOpeningBid",
-                                        "kind": "LinkedField",
-                                        "name": "openingBid",
-                                        "plural": false,
-                                        "selections": (v10/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      (v11/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  (v11/*: any*/),
-                                  (v5/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isSaved",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "artistNames",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "preview",
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": "square"
-                                          }
-                                        ],
-                                        "kind": "ScalarField",
-                                        "name": "url",
-                                        "storageKey": "url(version:\"square\")"
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isInAuction",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isSavedToList",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "AttributionClass",
-                                    "kind": "LinkedField",
-                                    "name": "attributionClass",
-                                    "plural": false,
-                                    "selections": (v13/*: any*/),
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "ArtworkMedium",
-                                    "kind": "LinkedField",
-                                    "name": "mediumType",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "Gene",
-                                        "kind": "LinkedField",
-                                        "name": "filterGene",
-                                        "plural": false,
-                                        "selections": (v13/*: any*/),
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": "src",
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": [
-                                              "larger",
-                                              "large"
-                                            ]
-                                          }
-                                        ],
-                                        "kind": "ScalarField",
-                                        "name": "url",
-                                        "storageKey": "url(version:[\"larger\",\"large\"])"
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "width",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "height",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "blurhashDataURL",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": "artworksConnection(first:20)"
-                      },
-                      (v9/*: any*/),
                       {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
-                        "name": "formattedStartDateTime",
+                        "name": "slug",
                         "storageKey": null
                       },
-                      (v11/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "name",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "href",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "endAt",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "id",
+                        "storageKey": null
+                      },
                       {
                         "alias": null,
                         "args": null,
@@ -793,12 +247,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "de8344b0725ab9bd54bd689c9151fdd6",
+    "cacheID": "2889188b3fd6ab90028716ba7d7ee76d",
     "id": null,
     "metadata": {},
     "name": "PastAuctionsQuery",
     "operationKind": "query",
-    "text": "query PastAuctionsQuery(\n  $first: Int!\n  $after: String\n) {\n  viewer {\n    ...PastAuctions_viewer_2HEEH6\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...BidTimerLine_artwork\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n}\n\nfragment PastAuctions_viewer_2HEEH6 on Viewer {\n  salesConnection(first: $first, after: $after, live: false, sort: TIMELY_AT_NAME_DESC, auctionState: CLOSED) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        endAt\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isInAuction\n  isSavedToList\n  collectorSignals {\n    auction {\n      lotWatcherCount\n      lotClosesAt\n      liveBiddingStarted\n    }\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n  collectorSignals {\n    auction {\n      lotWatcherCount\n      lotClosesAt\n    }\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...ExclusiveAccessBadge_artwork\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  isUnlisted\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n    blurhashDataURL\n  }\n}\n"
+    "text": "query PastAuctionsQuery(\n  $first: Int!\n  $after: String\n) {\n  viewer {\n    ...PastAuctions_viewer_2HEEH6\n  }\n}\n\nfragment PastAuctions_viewer_2HEEH6 on Viewer {\n  salesConnection(first: $first, after: $after, live: false, sort: TIMELY_AT_NAME_DESC, auctionState: CLOSED) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        endAt\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/PastAuctions_Test_Query.graphql.ts
+++ b/src/__generated__/PastAuctions_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e683fd336f7fff91f5eec8138ae16e10>>
+ * @generated SignedSource<<1d1affac2f59829ef24afc058fadc2c4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -45,120 +45,22 @@ var v0 = [
   }
 ],
 v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "slug",
-  "storageKey": null
-},
-v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-},
-v3 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "href",
-  "storageKey": null
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "endAt",
-  "storageKey": null
-},
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v6 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "display",
-    "storageKey": null
-  }
-],
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v8 = [
-  {
-    "kind": "Literal",
-    "name": "shallow",
-    "value": true
-  }
-],
-v9 = [
-  (v2/*: any*/),
-  (v7/*: any*/)
-],
-v10 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v11 = {
+v2 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Sale"
+  "type": "String"
 },
-v12 = {
+v3 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
-},
-v13 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Boolean"
-},
-v14 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "String"
-},
-v15 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "Int"
-},
-v16 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "Boolean"
-},
-v17 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Image"
-},
-v18 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Int"
 };
 return {
   "fragment": {
@@ -232,525 +134,41 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v1/*: any*/),
-                      (v2/*: any*/),
-                      (v3/*: any*/),
-                      (v4/*: any*/),
-                      {
-                        "alias": null,
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "first",
-                            "value": 20
-                          }
-                        ],
-                        "concreteType": "ArtworkConnection",
-                        "kind": "LinkedField",
-                        "name": "artworksConnection",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "ArtworkEdge",
-                            "kind": "LinkedField",
-                            "name": "edges",
-                            "plural": true,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "Artwork",
-                                "kind": "LinkedField",
-                                "name": "node",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isUnlisted",
-                                    "storageKey": null
-                                  },
-                                  (v5/*: any*/),
-                                  (v3/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "title",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "date",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "CollectorSignals",
-                                    "kind": "LinkedField",
-                                    "name": "collectorSignals",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "AuctionCollectorSignals",
-                                        "kind": "LinkedField",
-                                        "name": "auction",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "bidCount",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "lotClosesAt",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "liveBiddingStarted",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "registrationEndsAt",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "onlineBiddingExtended",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "lotWatcherCount",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "PartnerOfferToCollector",
-                                        "kind": "LinkedField",
-                                        "name": "partnerOffer",
-                                        "plural": false,
-                                        "selections": [
-                                          (v4/*: any*/),
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "concreteType": "Money",
-                                            "kind": "LinkedField",
-                                            "name": "priceWithDiscount",
-                                            "plural": false,
-                                            "selections": (v6/*: any*/),
-                                            "storageKey": null
-                                          },
-                                          (v7/*: any*/)
-                                        ],
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "sale_message",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "saleMessage",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "cultural_maker",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "culturalMaker",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v8/*: any*/),
-                                    "concreteType": "Artist",
-                                    "kind": "LinkedField",
-                                    "name": "artist",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "ArtistTargetSupply",
-                                        "kind": "LinkedField",
-                                        "name": "targetSupply",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "isP1",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      (v7/*: any*/)
-                                    ],
-                                    "storageKey": "artist(shallow:true)"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "ArtworkPriceInsights",
-                                    "kind": "LinkedField",
-                                    "name": "marketPriceInsights",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "demandRank",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v8/*: any*/),
-                                    "concreteType": "Artist",
-                                    "kind": "LinkedField",
-                                    "name": "artists",
-                                    "plural": true,
-                                    "selections": [
-                                      (v7/*: any*/),
-                                      (v3/*: any*/),
-                                      (v2/*: any*/)
-                                    ],
-                                    "storageKey": "artists(shallow:true)"
-                                  },
-                                  {
-                                    "alias": "collecting_institution",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "collectingInstitution",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v8/*: any*/),
-                                    "concreteType": "Partner",
-                                    "kind": "LinkedField",
-                                    "name": "partner",
-                                    "plural": false,
-                                    "selections": [
-                                      (v2/*: any*/),
-                                      (v3/*: any*/),
-                                      (v7/*: any*/)
-                                    ],
-                                    "storageKey": "partner(shallow:true)"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Sale",
-                                    "kind": "LinkedField",
-                                    "name": "sale",
-                                    "plural": false,
-                                    "selections": [
-                                      (v4/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "cascadingEndTimeIntervalMinutes",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "extendedBiddingIntervalMinutes",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "startAt",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_auction",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isAuction",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_closed",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isClosed",
-                                        "storageKey": null
-                                      },
-                                      (v7/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "sale_artwork",
-                                    "args": null,
-                                    "concreteType": "SaleArtwork",
-                                    "kind": "LinkedField",
-                                    "name": "saleArtwork",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "lotID",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "lotLabel",
-                                        "storageKey": null
-                                      },
-                                      (v4/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "extendedBiddingEndAt",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "formattedEndDateTime",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "SaleArtworkCounts",
-                                        "kind": "LinkedField",
-                                        "name": "counts",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": "bidder_positions",
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "bidderPositions",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "highest_bid",
-                                        "args": null,
-                                        "concreteType": "SaleArtworkHighestBid",
-                                        "kind": "LinkedField",
-                                        "name": "highestBid",
-                                        "plural": false,
-                                        "selections": (v6/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "opening_bid",
-                                        "args": null,
-                                        "concreteType": "SaleArtworkOpeningBid",
-                                        "kind": "LinkedField",
-                                        "name": "openingBid",
-                                        "plural": false,
-                                        "selections": (v6/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      (v7/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  (v7/*: any*/),
-                                  (v1/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isSaved",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "artistNames",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "preview",
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": "square"
-                                          }
-                                        ],
-                                        "kind": "ScalarField",
-                                        "name": "url",
-                                        "storageKey": "url(version:\"square\")"
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isInAuction",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isSavedToList",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "AttributionClass",
-                                    "kind": "LinkedField",
-                                    "name": "attributionClass",
-                                    "plural": false,
-                                    "selections": (v9/*: any*/),
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "ArtworkMedium",
-                                    "kind": "LinkedField",
-                                    "name": "mediumType",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "Gene",
-                                        "kind": "LinkedField",
-                                        "name": "filterGene",
-                                        "plural": false,
-                                        "selections": (v9/*: any*/),
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": "src",
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": [
-                                              "larger",
-                                              "large"
-                                            ]
-                                          }
-                                        ],
-                                        "kind": "ScalarField",
-                                        "name": "url",
-                                        "storageKey": "url(version:[\"larger\",\"large\"])"
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "width",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "height",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "blurhashDataURL",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": "artworksConnection(first:20)"
-                      },
-                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
-                        "name": "formattedStartDateTime",
+                        "name": "slug",
                         "storageKey": null
                       },
-                      (v7/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "name",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "href",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "endAt",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "id",
+                        "storageKey": null
+                      },
                       {
                         "alias": null,
                         "args": null,
@@ -818,7 +236,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "65c6bb3025c254f5262de8b7db8517ac",
+    "cacheID": "4965ad429a28fedb8b0a381fec9325c4",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -840,214 +258,43 @@ return {
           "plural": true,
           "type": "SaleEdge"
         },
-        "viewer.salesConnection.edges.cursor": (v10/*: any*/),
-        "viewer.salesConnection.edges.node": (v11/*: any*/),
-        "viewer.salesConnection.edges.node.__typename": (v10/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection": {
+        "viewer.salesConnection.edges.cursor": (v1/*: any*/),
+        "viewer.salesConnection.edges.node": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "ArtworkConnection"
+          "type": "Sale"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": true,
-          "type": "ArtworkEdge"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Artwork"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artist": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Artist"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artist.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artist.targetSupply": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "ArtistTargetSupply"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artist.targetSupply.isP1": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artistNames": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": true,
-          "type": "Artist"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists.href": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists.name": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.attributionClass": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "AttributionClass"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.attributionClass.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.attributionClass.name": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collecting_institution": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "CollectorSignals"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.auction": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "AuctionCollectorSignals"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.auction.bidCount": (v15/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.auction.liveBiddingStarted": (v16/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.auction.lotClosesAt": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.auction.lotWatcherCount": (v15/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.auction.onlineBiddingExtended": (v16/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.auction.registrationEndsAt": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.partnerOffer": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "PartnerOfferToCollector"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.partnerOffer.endAt": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.partnerOffer.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.partnerOffer.priceWithDiscount": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Money"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.cultural_maker": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.date": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.href": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image": (v17/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.blurhashDataURL": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.height": (v18/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.src": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.width": (v18/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.internalID": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.isInAuction": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.isSaved": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.isSavedToList": (v16/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.isUnlisted": (v16/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.marketPriceInsights": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ArtworkPriceInsights"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.marketPriceInsights.demandRank": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Float"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.mediumType": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ArtworkMedium"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.mediumType.filterGene": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Gene"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.mediumType.filterGene.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.mediumType.filterGene.name": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Partner"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner.href": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner.name": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.preview": (v17/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.preview.url": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale": (v11/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v18/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.endAt": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v18/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.is_auction": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.is_closed": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.startAt": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "SaleArtwork"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.counts": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "SaleArtworkCounts"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.counts.bidder_positions": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "FormattedNumber"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.endAt": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.highest_bid": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "SaleArtworkHighestBid"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.highest_bid.display": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.lotID": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.lotLabel": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.opening_bid": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "SaleArtworkOpeningBid"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.opening_bid.display": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_message": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.slug": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.title": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.endAt": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.formattedStartDateTime": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.href": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.internalID": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.name": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.slug": (v12/*: any*/),
+        "viewer.salesConnection.edges.node.__typename": (v1/*: any*/),
+        "viewer.salesConnection.edges.node.endAt": (v2/*: any*/),
+        "viewer.salesConnection.edges.node.href": (v2/*: any*/),
+        "viewer.salesConnection.edges.node.id": (v3/*: any*/),
+        "viewer.salesConnection.edges.node.name": (v2/*: any*/),
+        "viewer.salesConnection.edges.node.slug": (v3/*: any*/),
         "viewer.salesConnection.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "viewer.salesConnection.pageInfo.endCursor": (v14/*: any*/),
-        "viewer.salesConnection.pageInfo.hasNextPage": (v16/*: any*/),
-        "viewer.salesConnection.totalCount": (v18/*: any*/)
+        "viewer.salesConnection.pageInfo.endCursor": (v2/*: any*/),
+        "viewer.salesConnection.pageInfo.hasNextPage": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "Boolean"
+        },
+        "viewer.salesConnection.totalCount": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Int"
+        }
       }
     },
     "name": "PastAuctions_Test_Query",
     "operationKind": "query",
-    "text": "query PastAuctions_Test_Query {\n  viewer {\n    ...PastAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...BidTimerLine_artwork\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n}\n\nfragment PastAuctions_viewer on Viewer {\n  salesConnection(first: 10, live: false, sort: TIMELY_AT_NAME_DESC, auctionState: CLOSED) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        endAt\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isInAuction\n  isSavedToList\n  collectorSignals {\n    auction {\n      lotWatcherCount\n      lotClosesAt\n      liveBiddingStarted\n    }\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n  collectorSignals {\n    auction {\n      lotWatcherCount\n      lotClosesAt\n    }\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...ExclusiveAccessBadge_artwork\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  isUnlisted\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n    blurhashDataURL\n  }\n}\n"
+    "text": "query PastAuctions_Test_Query {\n  viewer {\n    ...PastAuctions_viewer\n  }\n}\n\nfragment PastAuctions_viewer on Viewer {\n  salesConnection(first: 10, live: false, sort: TIMELY_AT_NAME_DESC, auctionState: CLOSED) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        endAt\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/PastAuctions_viewer.graphql.ts
+++ b/src/__generated__/PastAuctions_viewer.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<55e290699896e2eb41a5c2dcc0359805>>
+ * @generated SignedSource<<a5ac3ac2cab92aa559a9e4736ce7a8d1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,7 +18,6 @@ export type PastAuctions_viewer$data = {
         readonly href: string | null | undefined;
         readonly name: string | null | undefined;
         readonly slug: string;
-        readonly " $fragmentSpreads": FragmentRefs<"AuctionArtworksRail_sale">;
       } | null | undefined;
     } | null | undefined> | null | undefined;
     readonly totalCount: number | null | undefined;
@@ -134,11 +133,6 @@ const node: ReaderFragment = {
                   "storageKey": null
                 },
                 {
-                  "args": null,
-                  "kind": "FragmentSpread",
-                  "name": "AuctionArtworksRail_sale"
-                },
-                {
                   "alias": null,
                   "args": null,
                   "kind": "ScalarField",
@@ -191,6 +185,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "e488ae430e93d48cda1a365fdd145a14";
+(node as any).hash = "a05f47a95f14d47d9ece04cff159b77f";
 
 export default node;

--- a/src/__generated__/UpcomingAuctionsQuery.graphql.ts
+++ b/src/__generated__/UpcomingAuctionsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0588374426ca3eaf94e8eaa30eb25f92>>
+ * @generated SignedSource<<325aecf4ac390324fcb38b9f1af0609d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -58,68 +58,6 @@ v4 = [
     "name": "sort",
     "value": "START_AT_ASC"
   }
-],
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "slug",
-  "storageKey": null
-},
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-},
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "href",
-  "storageKey": null
-},
-v8 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v9 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "endAt",
-  "storageKey": null
-},
-v10 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "display",
-    "storageKey": null
-  }
-],
-v11 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v12 = [
-  {
-    "kind": "Literal",
-    "name": "shallow",
-    "value": true
-  }
-],
-v13 = [
-  (v6/*: any*/),
-  (v11/*: any*/)
 ];
 return {
   "fragment": {
@@ -202,9 +140,27 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v5/*: any*/),
-                      (v6/*: any*/),
-                      (v7/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "name",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "href",
+                        "storageKey": null
+                      },
                       {
                         "alias": null,
                         "args": null,
@@ -235,512 +191,11 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "first",
-                            "value": 20
-                          }
-                        ],
-                        "concreteType": "ArtworkConnection",
-                        "kind": "LinkedField",
-                        "name": "artworksConnection",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "ArtworkEdge",
-                            "kind": "LinkedField",
-                            "name": "edges",
-                            "plural": true,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "Artwork",
-                                "kind": "LinkedField",
-                                "name": "node",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isUnlisted",
-                                    "storageKey": null
-                                  },
-                                  (v8/*: any*/),
-                                  (v7/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "title",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "date",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "CollectorSignals",
-                                    "kind": "LinkedField",
-                                    "name": "collectorSignals",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "AuctionCollectorSignals",
-                                        "kind": "LinkedField",
-                                        "name": "auction",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "bidCount",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "lotClosesAt",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "liveBiddingStarted",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "registrationEndsAt",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "onlineBiddingExtended",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "lotWatcherCount",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "PartnerOfferToCollector",
-                                        "kind": "LinkedField",
-                                        "name": "partnerOffer",
-                                        "plural": false,
-                                        "selections": [
-                                          (v9/*: any*/),
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "concreteType": "Money",
-                                            "kind": "LinkedField",
-                                            "name": "priceWithDiscount",
-                                            "plural": false,
-                                            "selections": (v10/*: any*/),
-                                            "storageKey": null
-                                          },
-                                          (v11/*: any*/)
-                                        ],
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "sale_message",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "saleMessage",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "cultural_maker",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "culturalMaker",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v12/*: any*/),
-                                    "concreteType": "Artist",
-                                    "kind": "LinkedField",
-                                    "name": "artist",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "ArtistTargetSupply",
-                                        "kind": "LinkedField",
-                                        "name": "targetSupply",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "isP1",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      (v11/*: any*/)
-                                    ],
-                                    "storageKey": "artist(shallow:true)"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "ArtworkPriceInsights",
-                                    "kind": "LinkedField",
-                                    "name": "marketPriceInsights",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "demandRank",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v12/*: any*/),
-                                    "concreteType": "Artist",
-                                    "kind": "LinkedField",
-                                    "name": "artists",
-                                    "plural": true,
-                                    "selections": [
-                                      (v11/*: any*/),
-                                      (v7/*: any*/),
-                                      (v6/*: any*/)
-                                    ],
-                                    "storageKey": "artists(shallow:true)"
-                                  },
-                                  {
-                                    "alias": "collecting_institution",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "collectingInstitution",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v12/*: any*/),
-                                    "concreteType": "Partner",
-                                    "kind": "LinkedField",
-                                    "name": "partner",
-                                    "plural": false,
-                                    "selections": [
-                                      (v6/*: any*/),
-                                      (v7/*: any*/),
-                                      (v11/*: any*/)
-                                    ],
-                                    "storageKey": "partner(shallow:true)"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Sale",
-                                    "kind": "LinkedField",
-                                    "name": "sale",
-                                    "plural": false,
-                                    "selections": [
-                                      (v9/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "cascadingEndTimeIntervalMinutes",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "extendedBiddingIntervalMinutes",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "startAt",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_auction",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isAuction",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_closed",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isClosed",
-                                        "storageKey": null
-                                      },
-                                      (v11/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "sale_artwork",
-                                    "args": null,
-                                    "concreteType": "SaleArtwork",
-                                    "kind": "LinkedField",
-                                    "name": "saleArtwork",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "lotID",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "lotLabel",
-                                        "storageKey": null
-                                      },
-                                      (v9/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "extendedBiddingEndAt",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "formattedEndDateTime",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "SaleArtworkCounts",
-                                        "kind": "LinkedField",
-                                        "name": "counts",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": "bidder_positions",
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "bidderPositions",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "highest_bid",
-                                        "args": null,
-                                        "concreteType": "SaleArtworkHighestBid",
-                                        "kind": "LinkedField",
-                                        "name": "highestBid",
-                                        "plural": false,
-                                        "selections": (v10/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "opening_bid",
-                                        "args": null,
-                                        "concreteType": "SaleArtworkOpeningBid",
-                                        "kind": "LinkedField",
-                                        "name": "openingBid",
-                                        "plural": false,
-                                        "selections": (v10/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      (v11/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  (v11/*: any*/),
-                                  (v5/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isSaved",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "artistNames",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "preview",
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": "square"
-                                          }
-                                        ],
-                                        "kind": "ScalarField",
-                                        "name": "url",
-                                        "storageKey": "url(version:\"square\")"
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isInAuction",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isSavedToList",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "AttributionClass",
-                                    "kind": "LinkedField",
-                                    "name": "attributionClass",
-                                    "plural": false,
-                                    "selections": (v13/*: any*/),
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "ArtworkMedium",
-                                    "kind": "LinkedField",
-                                    "name": "mediumType",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "Gene",
-                                        "kind": "LinkedField",
-                                        "name": "filterGene",
-                                        "plural": false,
-                                        "selections": (v13/*: any*/),
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": "src",
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": [
-                                              "larger",
-                                              "large"
-                                            ]
-                                          }
-                                        ],
-                                        "kind": "ScalarField",
-                                        "name": "url",
-                                        "storageKey": "url(version:[\"larger\",\"large\"])"
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "width",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "height",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "blurhashDataURL",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": "artworksConnection(first:20)"
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "id",
+                        "storageKey": null
                       },
-                      (v8/*: any*/),
-                      (v11/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -807,12 +262,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "0e3fa6ff7c84be901ef106769601a97d",
+    "cacheID": "35a3fd1e045bfba2440e6eba2c66f16b",
     "id": null,
     "metadata": {},
     "name": "UpcomingAuctionsQuery",
     "operationKind": "query",
-    "text": "query UpcomingAuctionsQuery(\n  $first: Int!\n  $after: String\n) {\n  viewer {\n    ...UpcomingAuctions_viewer_2HEEH6\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...BidTimerLine_artwork\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isInAuction\n  isSavedToList\n  collectorSignals {\n    auction {\n      lotWatcherCount\n      lotClosesAt\n      liveBiddingStarted\n    }\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n  collectorSignals {\n    auction {\n      lotWatcherCount\n      lotClosesAt\n    }\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...ExclusiveAccessBadge_artwork\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  isUnlisted\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n    blurhashDataURL\n  }\n}\n\nfragment UpcomingAuctions_viewer_2HEEH6 on Viewer {\n  salesConnection(first: $first, after: $after, sort: START_AT_ASC, auctionState: UPCOMING) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        status\n        formattedStartDateTime\n        eventStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query UpcomingAuctionsQuery(\n  $first: Int!\n  $after: String\n) {\n  viewer {\n    ...UpcomingAuctions_viewer_2HEEH6\n  }\n}\n\nfragment UpcomingAuctions_viewer_2HEEH6 on Viewer {\n  salesConnection(first: $first, after: $after, sort: START_AT_ASC, auctionState: UPCOMING) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        status\n        formattedStartDateTime\n        eventStartAt\n        isLiveOpen\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/UpcomingAuctions_Test_Query.graphql.ts
+++ b/src/__generated__/UpcomingAuctions_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d48e26379029a9b33cb8f737a42645f4>>
+ * @generated SignedSource<<98eed153f5bb10d888814a29602b7da7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -40,120 +40,22 @@ var v0 = [
   }
 ],
 v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "slug",
-  "storageKey": null
-},
-v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-},
-v3 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "href",
-  "storageKey": null
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "endAt",
-  "storageKey": null
-},
-v6 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "display",
-    "storageKey": null
-  }
-],
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v8 = [
-  {
-    "kind": "Literal",
-    "name": "shallow",
-    "value": true
-  }
-],
-v9 = [
-  (v2/*: any*/),
-  (v7/*: any*/)
-],
-v10 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v11 = {
+v2 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Sale"
+  "type": "String"
 },
-v12 = {
+v3 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
-},
-v13 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Boolean"
-},
-v14 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "String"
-},
-v15 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "Int"
-},
-v16 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "Boolean"
-},
-v17 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Image"
-},
-v18 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Int"
 };
 return {
   "fragment": {
@@ -227,9 +129,27 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v1/*: any*/),
-                      (v2/*: any*/),
-                      (v3/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "name",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "href",
+                        "storageKey": null
+                      },
                       {
                         "alias": null,
                         "args": null,
@@ -260,512 +180,11 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "first",
-                            "value": 20
-                          }
-                        ],
-                        "concreteType": "ArtworkConnection",
-                        "kind": "LinkedField",
-                        "name": "artworksConnection",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "ArtworkEdge",
-                            "kind": "LinkedField",
-                            "name": "edges",
-                            "plural": true,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "Artwork",
-                                "kind": "LinkedField",
-                                "name": "node",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isUnlisted",
-                                    "storageKey": null
-                                  },
-                                  (v4/*: any*/),
-                                  (v3/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "title",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "date",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "CollectorSignals",
-                                    "kind": "LinkedField",
-                                    "name": "collectorSignals",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "AuctionCollectorSignals",
-                                        "kind": "LinkedField",
-                                        "name": "auction",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "bidCount",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "lotClosesAt",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "liveBiddingStarted",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "registrationEndsAt",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "onlineBiddingExtended",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "lotWatcherCount",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "PartnerOfferToCollector",
-                                        "kind": "LinkedField",
-                                        "name": "partnerOffer",
-                                        "plural": false,
-                                        "selections": [
-                                          (v5/*: any*/),
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "concreteType": "Money",
-                                            "kind": "LinkedField",
-                                            "name": "priceWithDiscount",
-                                            "plural": false,
-                                            "selections": (v6/*: any*/),
-                                            "storageKey": null
-                                          },
-                                          (v7/*: any*/)
-                                        ],
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "sale_message",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "saleMessage",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "cultural_maker",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "culturalMaker",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v8/*: any*/),
-                                    "concreteType": "Artist",
-                                    "kind": "LinkedField",
-                                    "name": "artist",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "ArtistTargetSupply",
-                                        "kind": "LinkedField",
-                                        "name": "targetSupply",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "isP1",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      (v7/*: any*/)
-                                    ],
-                                    "storageKey": "artist(shallow:true)"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "ArtworkPriceInsights",
-                                    "kind": "LinkedField",
-                                    "name": "marketPriceInsights",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "demandRank",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v8/*: any*/),
-                                    "concreteType": "Artist",
-                                    "kind": "LinkedField",
-                                    "name": "artists",
-                                    "plural": true,
-                                    "selections": [
-                                      (v7/*: any*/),
-                                      (v3/*: any*/),
-                                      (v2/*: any*/)
-                                    ],
-                                    "storageKey": "artists(shallow:true)"
-                                  },
-                                  {
-                                    "alias": "collecting_institution",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "collectingInstitution",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v8/*: any*/),
-                                    "concreteType": "Partner",
-                                    "kind": "LinkedField",
-                                    "name": "partner",
-                                    "plural": false,
-                                    "selections": [
-                                      (v2/*: any*/),
-                                      (v3/*: any*/),
-                                      (v7/*: any*/)
-                                    ],
-                                    "storageKey": "partner(shallow:true)"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Sale",
-                                    "kind": "LinkedField",
-                                    "name": "sale",
-                                    "plural": false,
-                                    "selections": [
-                                      (v5/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "cascadingEndTimeIntervalMinutes",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "extendedBiddingIntervalMinutes",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "startAt",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_auction",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isAuction",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_closed",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isClosed",
-                                        "storageKey": null
-                                      },
-                                      (v7/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "sale_artwork",
-                                    "args": null,
-                                    "concreteType": "SaleArtwork",
-                                    "kind": "LinkedField",
-                                    "name": "saleArtwork",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "lotID",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "lotLabel",
-                                        "storageKey": null
-                                      },
-                                      (v5/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "extendedBiddingEndAt",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "formattedEndDateTime",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "SaleArtworkCounts",
-                                        "kind": "LinkedField",
-                                        "name": "counts",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": "bidder_positions",
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "bidderPositions",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "highest_bid",
-                                        "args": null,
-                                        "concreteType": "SaleArtworkHighestBid",
-                                        "kind": "LinkedField",
-                                        "name": "highestBid",
-                                        "plural": false,
-                                        "selections": (v6/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "opening_bid",
-                                        "args": null,
-                                        "concreteType": "SaleArtworkOpeningBid",
-                                        "kind": "LinkedField",
-                                        "name": "openingBid",
-                                        "plural": false,
-                                        "selections": (v6/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      (v7/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  (v7/*: any*/),
-                                  (v1/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isSaved",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "artistNames",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "preview",
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": "square"
-                                          }
-                                        ],
-                                        "kind": "ScalarField",
-                                        "name": "url",
-                                        "storageKey": "url(version:\"square\")"
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isInAuction",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isSavedToList",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "AttributionClass",
-                                    "kind": "LinkedField",
-                                    "name": "attributionClass",
-                                    "plural": false,
-                                    "selections": (v9/*: any*/),
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "ArtworkMedium",
-                                    "kind": "LinkedField",
-                                    "name": "mediumType",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "Gene",
-                                        "kind": "LinkedField",
-                                        "name": "filterGene",
-                                        "plural": false,
-                                        "selections": (v9/*: any*/),
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": "src",
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": [
-                                              "larger",
-                                              "large"
-                                            ]
-                                          }
-                                        ],
-                                        "kind": "ScalarField",
-                                        "name": "url",
-                                        "storageKey": "url(version:[\"larger\",\"large\"])"
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "width",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "height",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "blurhashDataURL",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": "artworksConnection(first:20)"
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "id",
+                        "storageKey": null
                       },
-                      (v4/*: any*/),
-                      (v7/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -832,7 +251,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "20deef8f51354cd20726b89db219a16c",
+    "cacheID": "1ac0d4101149195bfad786360a81152e",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -854,216 +273,51 @@ return {
           "plural": true,
           "type": "SaleEdge"
         },
-        "viewer.salesConnection.edges.cursor": (v10/*: any*/),
-        "viewer.salesConnection.edges.node": (v11/*: any*/),
-        "viewer.salesConnection.edges.node.__typename": (v10/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection": {
+        "viewer.salesConnection.edges.cursor": (v1/*: any*/),
+        "viewer.salesConnection.edges.node": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "ArtworkConnection"
+          "type": "Sale"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": true,
-          "type": "ArtworkEdge"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Artwork"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artist": {
+        "viewer.salesConnection.edges.node.__typename": (v1/*: any*/),
+        "viewer.salesConnection.edges.node.eventStartAt": (v2/*: any*/),
+        "viewer.salesConnection.edges.node.formattedStartDateTime": (v2/*: any*/),
+        "viewer.salesConnection.edges.node.href": (v2/*: any*/),
+        "viewer.salesConnection.edges.node.id": (v3/*: any*/),
+        "viewer.salesConnection.edges.node.isLiveOpen": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "Artist"
+          "type": "Boolean"
         },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artist.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artist.targetSupply": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "ArtistTargetSupply"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artist.targetSupply.isP1": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artistNames": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": true,
-          "type": "Artist"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists.href": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.artists.name": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.attributionClass": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "AttributionClass"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.attributionClass.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.attributionClass.name": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collecting_institution": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "CollectorSignals"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.auction": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "AuctionCollectorSignals"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.auction.bidCount": (v15/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.auction.liveBiddingStarted": (v16/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.auction.lotClosesAt": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.auction.lotWatcherCount": (v15/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.auction.onlineBiddingExtended": (v16/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.auction.registrationEndsAt": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.partnerOffer": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "PartnerOfferToCollector"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.partnerOffer.endAt": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.partnerOffer.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.partnerOffer.priceWithDiscount": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Money"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.cultural_maker": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.date": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.href": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image": (v17/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.blurhashDataURL": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.height": (v18/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.src": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.image.width": (v18/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.internalID": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.isInAuction": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.isSaved": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.isSavedToList": (v16/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.isUnlisted": (v16/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.marketPriceInsights": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ArtworkPriceInsights"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.marketPriceInsights.demandRank": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Float"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.mediumType": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ArtworkMedium"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.mediumType.filterGene": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Gene"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.mediumType.filterGene.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.mediumType.filterGene.name": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Partner"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner.href": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.partner.name": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.preview": (v17/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.preview.url": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale": (v11/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v18/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.endAt": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v18/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.is_auction": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.is_closed": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale.startAt": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "SaleArtwork"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.counts": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "SaleArtworkCounts"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.counts.bidder_positions": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "FormattedNumber"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.endAt": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.highest_bid": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "SaleArtworkHighestBid"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.highest_bid.display": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.lotID": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.lotLabel": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.opening_bid": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "SaleArtworkOpeningBid"
-        },
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_artwork.opening_bid.display": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.sale_message": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.slug": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.artworksConnection.edges.node.title": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.eventStartAt": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.formattedStartDateTime": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.href": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.id": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.internalID": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.isLiveOpen": (v13/*: any*/),
-        "viewer.salesConnection.edges.node.name": (v14/*: any*/),
-        "viewer.salesConnection.edges.node.slug": (v12/*: any*/),
-        "viewer.salesConnection.edges.node.status": (v14/*: any*/),
+        "viewer.salesConnection.edges.node.name": (v2/*: any*/),
+        "viewer.salesConnection.edges.node.slug": (v3/*: any*/),
+        "viewer.salesConnection.edges.node.status": (v2/*: any*/),
         "viewer.salesConnection.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "viewer.salesConnection.pageInfo.endCursor": (v14/*: any*/),
-        "viewer.salesConnection.pageInfo.hasNextPage": (v16/*: any*/),
-        "viewer.salesConnection.totalCount": (v18/*: any*/)
+        "viewer.salesConnection.pageInfo.endCursor": (v2/*: any*/),
+        "viewer.salesConnection.pageInfo.hasNextPage": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "Boolean"
+        },
+        "viewer.salesConnection.totalCount": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Int"
+        }
       }
     },
     "name": "UpcomingAuctions_Test_Query",
     "operationKind": "query",
-    "text": "query UpcomingAuctions_Test_Query {\n  viewer {\n    ...UpcomingAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...BidTimerLine_artwork\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isInAuction\n  isSavedToList\n  collectorSignals {\n    auction {\n      lotWatcherCount\n      lotClosesAt\n      liveBiddingStarted\n    }\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n  collectorSignals {\n    auction {\n      lotWatcherCount\n      lotClosesAt\n    }\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...ExclusiveAccessBadge_artwork\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  isUnlisted\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n    blurhashDataURL\n  }\n}\n\nfragment UpcomingAuctions_viewer on Viewer {\n  salesConnection(first: 10, sort: START_AT_ASC, auctionState: UPCOMING) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        status\n        formattedStartDateTime\n        eventStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query UpcomingAuctions_Test_Query {\n  viewer {\n    ...UpcomingAuctions_viewer\n  }\n}\n\nfragment UpcomingAuctions_viewer on Viewer {\n  salesConnection(first: 10, sort: START_AT_ASC, auctionState: UPCOMING) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        status\n        formattedStartDateTime\n        eventStartAt\n        isLiveOpen\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/UpcomingAuctions_viewer.graphql.ts
+++ b/src/__generated__/UpcomingAuctions_viewer.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<303f843ea74a365f11b88618251e6beb>>
+ * @generated SignedSource<<6c45d4b14f2b48b07aadc527cdceb93d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -21,7 +21,6 @@ export type UpcomingAuctions_viewer$data = {
         readonly name: string | null | undefined;
         readonly slug: string;
         readonly status: string | null | undefined;
-        readonly " $fragmentSpreads": FragmentRefs<"AuctionArtworksRail_sale">;
       } | null | undefined;
     } | null | undefined> | null | undefined;
     readonly totalCount: number | null | undefined;
@@ -153,11 +152,6 @@ const node: ReaderFragment = {
                   "storageKey": null
                 },
                 {
-                  "args": null,
-                  "kind": "FragmentSpread",
-                  "name": "AuctionArtworksRail_sale"
-                },
-                {
                   "alias": null,
                   "args": null,
                   "kind": "ScalarField",
@@ -210,6 +204,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "2875ec4a03832fe0d075fa608daacfdc";
+(node as any).hash = "faf995cb34fea2e00c9cdef8c6706271";
 
 export default node;

--- a/src/__generated__/auctionsRoutes_Current_AuctionsQuery.graphql.ts
+++ b/src/__generated__/auctionsRoutes_Current_AuctionsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b858669ad0ddb6572e31db69553c6a6b>>
+ * @generated SignedSource<<6f93ba4f6346138c4d00230c8e0c0ca8>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -48,68 +48,6 @@ var v0 = [
     "name": "sort",
     "value": "LICENSED_TIMELY_AT_NAME_DESC"
   }
-],
-v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "slug",
-  "storageKey": null
-},
-v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-},
-v3 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "href",
-  "storageKey": null
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "endAt",
-  "storageKey": null
-},
-v6 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "display",
-    "storageKey": null
-  }
-],
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v8 = [
-  {
-    "kind": "Literal",
-    "name": "shallow",
-    "value": true
-  }
-],
-v9 = [
-  (v2/*: any*/),
-  (v7/*: any*/)
 ];
 return {
   "fragment": {
@@ -183,9 +121,27 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v1/*: any*/),
-                      (v2/*: any*/),
-                      (v3/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "name",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "href",
+                        "storageKey": null
+                      },
                       {
                         "alias": null,
                         "args": null,
@@ -202,519 +158,11 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "first",
-                            "value": 20
-                          }
-                        ],
-                        "concreteType": "ArtworkConnection",
-                        "kind": "LinkedField",
-                        "name": "artworksConnection",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "ArtworkEdge",
-                            "kind": "LinkedField",
-                            "name": "edges",
-                            "plural": true,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "Artwork",
-                                "kind": "LinkedField",
-                                "name": "node",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isUnlisted",
-                                    "storageKey": null
-                                  },
-                                  (v4/*: any*/),
-                                  (v3/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "title",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "date",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "CollectorSignals",
-                                    "kind": "LinkedField",
-                                    "name": "collectorSignals",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "AuctionCollectorSignals",
-                                        "kind": "LinkedField",
-                                        "name": "auction",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "bidCount",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "lotClosesAt",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "liveBiddingStarted",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "registrationEndsAt",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "onlineBiddingExtended",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "lotWatcherCount",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "PartnerOfferToCollector",
-                                        "kind": "LinkedField",
-                                        "name": "partnerOffer",
-                                        "plural": false,
-                                        "selections": [
-                                          (v5/*: any*/),
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "concreteType": "Money",
-                                            "kind": "LinkedField",
-                                            "name": "priceWithDiscount",
-                                            "plural": false,
-                                            "selections": (v6/*: any*/),
-                                            "storageKey": null
-                                          },
-                                          (v7/*: any*/)
-                                        ],
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "sale_message",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "saleMessage",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "cultural_maker",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "culturalMaker",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v8/*: any*/),
-                                    "concreteType": "Artist",
-                                    "kind": "LinkedField",
-                                    "name": "artist",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "ArtistTargetSupply",
-                                        "kind": "LinkedField",
-                                        "name": "targetSupply",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "isP1",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      (v7/*: any*/)
-                                    ],
-                                    "storageKey": "artist(shallow:true)"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "ArtworkPriceInsights",
-                                    "kind": "LinkedField",
-                                    "name": "marketPriceInsights",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "demandRank",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v8/*: any*/),
-                                    "concreteType": "Artist",
-                                    "kind": "LinkedField",
-                                    "name": "artists",
-                                    "plural": true,
-                                    "selections": [
-                                      (v7/*: any*/),
-                                      (v3/*: any*/),
-                                      (v2/*: any*/)
-                                    ],
-                                    "storageKey": "artists(shallow:true)"
-                                  },
-                                  {
-                                    "alias": "collecting_institution",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "collectingInstitution",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v8/*: any*/),
-                                    "concreteType": "Partner",
-                                    "kind": "LinkedField",
-                                    "name": "partner",
-                                    "plural": false,
-                                    "selections": [
-                                      (v2/*: any*/),
-                                      (v3/*: any*/),
-                                      (v7/*: any*/)
-                                    ],
-                                    "storageKey": "partner(shallow:true)"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Sale",
-                                    "kind": "LinkedField",
-                                    "name": "sale",
-                                    "plural": false,
-                                    "selections": [
-                                      (v5/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "cascadingEndTimeIntervalMinutes",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "extendedBiddingIntervalMinutes",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "startAt",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_auction",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isAuction",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_closed",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isClosed",
-                                        "storageKey": null
-                                      },
-                                      (v7/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "sale_artwork",
-                                    "args": null,
-                                    "concreteType": "SaleArtwork",
-                                    "kind": "LinkedField",
-                                    "name": "saleArtwork",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "lotID",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "lotLabel",
-                                        "storageKey": null
-                                      },
-                                      (v5/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "extendedBiddingEndAt",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "formattedEndDateTime",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "SaleArtworkCounts",
-                                        "kind": "LinkedField",
-                                        "name": "counts",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": "bidder_positions",
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "bidderPositions",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "highest_bid",
-                                        "args": null,
-                                        "concreteType": "SaleArtworkHighestBid",
-                                        "kind": "LinkedField",
-                                        "name": "highestBid",
-                                        "plural": false,
-                                        "selections": (v6/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "opening_bid",
-                                        "args": null,
-                                        "concreteType": "SaleArtworkOpeningBid",
-                                        "kind": "LinkedField",
-                                        "name": "openingBid",
-                                        "plural": false,
-                                        "selections": (v6/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      (v7/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  (v7/*: any*/),
-                                  (v1/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isSaved",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "artistNames",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "preview",
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": "square"
-                                          }
-                                        ],
-                                        "kind": "ScalarField",
-                                        "name": "url",
-                                        "storageKey": "url(version:\"square\")"
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isInAuction",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isSavedToList",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "AttributionClass",
-                                    "kind": "LinkedField",
-                                    "name": "attributionClass",
-                                    "plural": false,
-                                    "selections": (v9/*: any*/),
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "ArtworkMedium",
-                                    "kind": "LinkedField",
-                                    "name": "mediumType",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "Gene",
-                                        "kind": "LinkedField",
-                                        "name": "filterGene",
-                                        "plural": false,
-                                        "selections": (v9/*: any*/),
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": "src",
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": [
-                                              "larger",
-                                              "large"
-                                            ]
-                                          }
-                                        ],
-                                        "kind": "ScalarField",
-                                        "name": "url",
-                                        "storageKey": "url(version:[\"larger\",\"large\"])"
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "width",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "height",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "blurhashDataURL",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": "artworksConnection(first:20)"
-                      },
-                      (v4/*: any*/),
-                      {
-                        "alias": null,
                         "args": null,
                         "kind": "ScalarField",
-                        "name": "formattedStartDateTime",
+                        "name": "id",
                         "storageKey": null
                       },
-                      (v7/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -783,12 +231,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4ad5cffa10483761a473fa11fe398ac0",
+    "cacheID": "52e1b248618f45749cb9dca9c6b6118b",
     "id": null,
     "metadata": {},
     "name": "auctionsRoutes_Current_AuctionsQuery",
     "operationKind": "query",
-    "text": "query auctionsRoutes_Current_AuctionsQuery {\n  viewer {\n    ...CurrentAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment CurrentAuctions_viewer on Viewer {\n  salesConnection(first: 10, live: true, published: true, sort: LICENSED_TIMELY_AT_NAME_DESC, auctionState: OPEN) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        liveStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...BidTimerLine_artwork\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isInAuction\n  isSavedToList\n  collectorSignals {\n    auction {\n      lotWatcherCount\n      lotClosesAt\n      liveBiddingStarted\n    }\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n  collectorSignals {\n    auction {\n      lotWatcherCount\n      lotClosesAt\n    }\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...ExclusiveAccessBadge_artwork\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  isUnlisted\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n    blurhashDataURL\n  }\n}\n"
+    "text": "query auctionsRoutes_Current_AuctionsQuery {\n  viewer {\n    ...CurrentAuctions_viewer\n  }\n}\n\nfragment CurrentAuctions_viewer on Viewer {\n  salesConnection(first: 10, live: true, published: true, sort: LICENSED_TIMELY_AT_NAME_DESC, auctionState: OPEN) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        liveStartAt\n        isLiveOpen\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/auctionsRoutes_Past_AuctionsQuery.graphql.ts
+++ b/src/__generated__/auctionsRoutes_Past_AuctionsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2f9505e041606f94d4536af7b41b59ad>>
+ * @generated SignedSource<<2c84b1cc5ab6c1846bc60ec0d7ed7187>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -43,68 +43,6 @@ var v0 = [
     "name": "sort",
     "value": "TIMELY_AT_NAME_DESC"
   }
-],
-v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "slug",
-  "storageKey": null
-},
-v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-},
-v3 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "href",
-  "storageKey": null
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "endAt",
-  "storageKey": null
-},
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v6 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "display",
-    "storageKey": null
-  }
-],
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v8 = [
-  {
-    "kind": "Literal",
-    "name": "shallow",
-    "value": true
-  }
-],
-v9 = [
-  (v2/*: any*/),
-  (v7/*: any*/)
 ];
 return {
   "fragment": {
@@ -178,525 +116,41 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v1/*: any*/),
-                      (v2/*: any*/),
-                      (v3/*: any*/),
-                      (v4/*: any*/),
-                      {
-                        "alias": null,
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "first",
-                            "value": 20
-                          }
-                        ],
-                        "concreteType": "ArtworkConnection",
-                        "kind": "LinkedField",
-                        "name": "artworksConnection",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "ArtworkEdge",
-                            "kind": "LinkedField",
-                            "name": "edges",
-                            "plural": true,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "Artwork",
-                                "kind": "LinkedField",
-                                "name": "node",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isUnlisted",
-                                    "storageKey": null
-                                  },
-                                  (v5/*: any*/),
-                                  (v3/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "title",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "date",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "CollectorSignals",
-                                    "kind": "LinkedField",
-                                    "name": "collectorSignals",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "AuctionCollectorSignals",
-                                        "kind": "LinkedField",
-                                        "name": "auction",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "bidCount",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "lotClosesAt",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "liveBiddingStarted",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "registrationEndsAt",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "onlineBiddingExtended",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "lotWatcherCount",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "PartnerOfferToCollector",
-                                        "kind": "LinkedField",
-                                        "name": "partnerOffer",
-                                        "plural": false,
-                                        "selections": [
-                                          (v4/*: any*/),
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "concreteType": "Money",
-                                            "kind": "LinkedField",
-                                            "name": "priceWithDiscount",
-                                            "plural": false,
-                                            "selections": (v6/*: any*/),
-                                            "storageKey": null
-                                          },
-                                          (v7/*: any*/)
-                                        ],
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "sale_message",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "saleMessage",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "cultural_maker",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "culturalMaker",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v8/*: any*/),
-                                    "concreteType": "Artist",
-                                    "kind": "LinkedField",
-                                    "name": "artist",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "ArtistTargetSupply",
-                                        "kind": "LinkedField",
-                                        "name": "targetSupply",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "isP1",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      (v7/*: any*/)
-                                    ],
-                                    "storageKey": "artist(shallow:true)"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "ArtworkPriceInsights",
-                                    "kind": "LinkedField",
-                                    "name": "marketPriceInsights",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "demandRank",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v8/*: any*/),
-                                    "concreteType": "Artist",
-                                    "kind": "LinkedField",
-                                    "name": "artists",
-                                    "plural": true,
-                                    "selections": [
-                                      (v7/*: any*/),
-                                      (v3/*: any*/),
-                                      (v2/*: any*/)
-                                    ],
-                                    "storageKey": "artists(shallow:true)"
-                                  },
-                                  {
-                                    "alias": "collecting_institution",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "collectingInstitution",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v8/*: any*/),
-                                    "concreteType": "Partner",
-                                    "kind": "LinkedField",
-                                    "name": "partner",
-                                    "plural": false,
-                                    "selections": [
-                                      (v2/*: any*/),
-                                      (v3/*: any*/),
-                                      (v7/*: any*/)
-                                    ],
-                                    "storageKey": "partner(shallow:true)"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Sale",
-                                    "kind": "LinkedField",
-                                    "name": "sale",
-                                    "plural": false,
-                                    "selections": [
-                                      (v4/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "cascadingEndTimeIntervalMinutes",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "extendedBiddingIntervalMinutes",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "startAt",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_auction",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isAuction",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_closed",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isClosed",
-                                        "storageKey": null
-                                      },
-                                      (v7/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "sale_artwork",
-                                    "args": null,
-                                    "concreteType": "SaleArtwork",
-                                    "kind": "LinkedField",
-                                    "name": "saleArtwork",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "lotID",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "lotLabel",
-                                        "storageKey": null
-                                      },
-                                      (v4/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "extendedBiddingEndAt",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "formattedEndDateTime",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "SaleArtworkCounts",
-                                        "kind": "LinkedField",
-                                        "name": "counts",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": "bidder_positions",
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "bidderPositions",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "highest_bid",
-                                        "args": null,
-                                        "concreteType": "SaleArtworkHighestBid",
-                                        "kind": "LinkedField",
-                                        "name": "highestBid",
-                                        "plural": false,
-                                        "selections": (v6/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "opening_bid",
-                                        "args": null,
-                                        "concreteType": "SaleArtworkOpeningBid",
-                                        "kind": "LinkedField",
-                                        "name": "openingBid",
-                                        "plural": false,
-                                        "selections": (v6/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      (v7/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  (v7/*: any*/),
-                                  (v1/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isSaved",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "artistNames",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "preview",
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": "square"
-                                          }
-                                        ],
-                                        "kind": "ScalarField",
-                                        "name": "url",
-                                        "storageKey": "url(version:\"square\")"
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isInAuction",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isSavedToList",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "AttributionClass",
-                                    "kind": "LinkedField",
-                                    "name": "attributionClass",
-                                    "plural": false,
-                                    "selections": (v9/*: any*/),
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "ArtworkMedium",
-                                    "kind": "LinkedField",
-                                    "name": "mediumType",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "Gene",
-                                        "kind": "LinkedField",
-                                        "name": "filterGene",
-                                        "plural": false,
-                                        "selections": (v9/*: any*/),
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": "src",
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": [
-                                              "larger",
-                                              "large"
-                                            ]
-                                          }
-                                        ],
-                                        "kind": "ScalarField",
-                                        "name": "url",
-                                        "storageKey": "url(version:[\"larger\",\"large\"])"
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "width",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "height",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "blurhashDataURL",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": "artworksConnection(first:20)"
-                      },
-                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
-                        "name": "formattedStartDateTime",
+                        "name": "slug",
                         "storageKey": null
                       },
-                      (v7/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "name",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "href",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "endAt",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "id",
+                        "storageKey": null
+                      },
                       {
                         "alias": null,
                         "args": null,
@@ -764,12 +218,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4af1bd09f7b5579e7aa4beabedbdf6c8",
+    "cacheID": "46bb0e0722b4aa51b398920560cb2028",
     "id": null,
     "metadata": {},
     "name": "auctionsRoutes_Past_AuctionsQuery",
     "operationKind": "query",
-    "text": "query auctionsRoutes_Past_AuctionsQuery {\n  viewer {\n    ...PastAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...BidTimerLine_artwork\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n}\n\nfragment PastAuctions_viewer on Viewer {\n  salesConnection(first: 10, live: false, sort: TIMELY_AT_NAME_DESC, auctionState: CLOSED) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        endAt\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isInAuction\n  isSavedToList\n  collectorSignals {\n    auction {\n      lotWatcherCount\n      lotClosesAt\n      liveBiddingStarted\n    }\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n  collectorSignals {\n    auction {\n      lotWatcherCount\n      lotClosesAt\n    }\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...ExclusiveAccessBadge_artwork\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  isUnlisted\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n    blurhashDataURL\n  }\n}\n"
+    "text": "query auctionsRoutes_Past_AuctionsQuery {\n  viewer {\n    ...PastAuctions_viewer\n  }\n}\n\nfragment PastAuctions_viewer on Viewer {\n  salesConnection(first: 10, live: false, sort: TIMELY_AT_NAME_DESC, auctionState: CLOSED) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        endAt\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/auctionsRoutes_Upcoming_AuctionsQuery.graphql.ts
+++ b/src/__generated__/auctionsRoutes_Upcoming_AuctionsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b4eb5bff25be175a103f956762c05e2c>>
+ * @generated SignedSource<<31538d50cb0795ca7f9fd14ace7abb44>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -38,68 +38,6 @@ var v0 = [
     "name": "sort",
     "value": "START_AT_ASC"
   }
-],
-v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "slug",
-  "storageKey": null
-},
-v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-},
-v3 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "href",
-  "storageKey": null
-},
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "endAt",
-  "storageKey": null
-},
-v6 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "display",
-    "storageKey": null
-  }
-],
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v8 = [
-  {
-    "kind": "Literal",
-    "name": "shallow",
-    "value": true
-  }
-],
-v9 = [
-  (v2/*: any*/),
-  (v7/*: any*/)
 ];
 return {
   "fragment": {
@@ -173,9 +111,27 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v1/*: any*/),
-                      (v2/*: any*/),
-                      (v3/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "name",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "href",
+                        "storageKey": null
+                      },
                       {
                         "alias": null,
                         "args": null,
@@ -206,512 +162,11 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "first",
-                            "value": 20
-                          }
-                        ],
-                        "concreteType": "ArtworkConnection",
-                        "kind": "LinkedField",
-                        "name": "artworksConnection",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "ArtworkEdge",
-                            "kind": "LinkedField",
-                            "name": "edges",
-                            "plural": true,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "Artwork",
-                                "kind": "LinkedField",
-                                "name": "node",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isUnlisted",
-                                    "storageKey": null
-                                  },
-                                  (v4/*: any*/),
-                                  (v3/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "title",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "date",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "CollectorSignals",
-                                    "kind": "LinkedField",
-                                    "name": "collectorSignals",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "AuctionCollectorSignals",
-                                        "kind": "LinkedField",
-                                        "name": "auction",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "bidCount",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "lotClosesAt",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "liveBiddingStarted",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "registrationEndsAt",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "onlineBiddingExtended",
-                                            "storageKey": null
-                                          },
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "lotWatcherCount",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "PartnerOfferToCollector",
-                                        "kind": "LinkedField",
-                                        "name": "partnerOffer",
-                                        "plural": false,
-                                        "selections": [
-                                          (v5/*: any*/),
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "concreteType": "Money",
-                                            "kind": "LinkedField",
-                                            "name": "priceWithDiscount",
-                                            "plural": false,
-                                            "selections": (v6/*: any*/),
-                                            "storageKey": null
-                                          },
-                                          (v7/*: any*/)
-                                        ],
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "sale_message",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "saleMessage",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "cultural_maker",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "culturalMaker",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v8/*: any*/),
-                                    "concreteType": "Artist",
-                                    "kind": "LinkedField",
-                                    "name": "artist",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "ArtistTargetSupply",
-                                        "kind": "LinkedField",
-                                        "name": "targetSupply",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": null,
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "isP1",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      (v7/*: any*/)
-                                    ],
-                                    "storageKey": "artist(shallow:true)"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "ArtworkPriceInsights",
-                                    "kind": "LinkedField",
-                                    "name": "marketPriceInsights",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "demandRank",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v8/*: any*/),
-                                    "concreteType": "Artist",
-                                    "kind": "LinkedField",
-                                    "name": "artists",
-                                    "plural": true,
-                                    "selections": [
-                                      (v7/*: any*/),
-                                      (v3/*: any*/),
-                                      (v2/*: any*/)
-                                    ],
-                                    "storageKey": "artists(shallow:true)"
-                                  },
-                                  {
-                                    "alias": "collecting_institution",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "collectingInstitution",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": (v8/*: any*/),
-                                    "concreteType": "Partner",
-                                    "kind": "LinkedField",
-                                    "name": "partner",
-                                    "plural": false,
-                                    "selections": [
-                                      (v2/*: any*/),
-                                      (v3/*: any*/),
-                                      (v7/*: any*/)
-                                    ],
-                                    "storageKey": "partner(shallow:true)"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Sale",
-                                    "kind": "LinkedField",
-                                    "name": "sale",
-                                    "plural": false,
-                                    "selections": [
-                                      (v5/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "cascadingEndTimeIntervalMinutes",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "extendedBiddingIntervalMinutes",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "startAt",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_auction",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isAuction",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "is_closed",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isClosed",
-                                        "storageKey": null
-                                      },
-                                      (v7/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "sale_artwork",
-                                    "args": null,
-                                    "concreteType": "SaleArtwork",
-                                    "kind": "LinkedField",
-                                    "name": "saleArtwork",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "lotID",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "lotLabel",
-                                        "storageKey": null
-                                      },
-                                      (v5/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "extendedBiddingEndAt",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "formattedEndDateTime",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "SaleArtworkCounts",
-                                        "kind": "LinkedField",
-                                        "name": "counts",
-                                        "plural": false,
-                                        "selections": [
-                                          {
-                                            "alias": "bidder_positions",
-                                            "args": null,
-                                            "kind": "ScalarField",
-                                            "name": "bidderPositions",
-                                            "storageKey": null
-                                          }
-                                        ],
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "highest_bid",
-                                        "args": null,
-                                        "concreteType": "SaleArtworkHighestBid",
-                                        "kind": "LinkedField",
-                                        "name": "highestBid",
-                                        "plural": false,
-                                        "selections": (v6/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": "opening_bid",
-                                        "args": null,
-                                        "concreteType": "SaleArtworkOpeningBid",
-                                        "kind": "LinkedField",
-                                        "name": "openingBid",
-                                        "plural": false,
-                                        "selections": (v6/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      (v7/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  (v7/*: any*/),
-                                  (v1/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isSaved",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "artistNames",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "preview",
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": "square"
-                                          }
-                                        ],
-                                        "kind": "ScalarField",
-                                        "name": "url",
-                                        "storageKey": "url(version:\"square\")"
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isInAuction",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isSavedToList",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "AttributionClass",
-                                    "kind": "LinkedField",
-                                    "name": "attributionClass",
-                                    "plural": false,
-                                    "selections": (v9/*: any*/),
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "ArtworkMedium",
-                                    "kind": "LinkedField",
-                                    "name": "mediumType",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "Gene",
-                                        "kind": "LinkedField",
-                                        "name": "filterGene",
-                                        "plural": false,
-                                        "selections": (v9/*: any*/),
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Image",
-                                    "kind": "LinkedField",
-                                    "name": "image",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": "src",
-                                        "args": [
-                                          {
-                                            "kind": "Literal",
-                                            "name": "version",
-                                            "value": [
-                                              "larger",
-                                              "large"
-                                            ]
-                                          }
-                                        ],
-                                        "kind": "ScalarField",
-                                        "name": "url",
-                                        "storageKey": "url(version:[\"larger\",\"large\"])"
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "width",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "height",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "blurhashDataURL",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": "artworksConnection(first:20)"
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "id",
+                        "storageKey": null
                       },
-                      (v4/*: any*/),
-                      (v7/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -778,12 +233,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "542903febe86c9912183e5db51b1381f",
+    "cacheID": "517b7e1f0672cc3c864b7942ed0be3a9",
     "id": null,
     "metadata": {},
     "name": "auctionsRoutes_Upcoming_AuctionsQuery",
     "operationKind": "query",
-    "text": "query auctionsRoutes_Upcoming_AuctionsQuery {\n  viewer {\n    ...UpcomingAuctions_viewer\n  }\n}\n\nfragment AuctionArtworksRail_sale on Sale {\n  artworksConnection(first: 20) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        id\n      }\n    }\n  }\n  internalID\n  slug\n  href\n  name\n  formattedStartDateTime\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...BidTimerLine_artwork\n  ...SaveButton_artwork\n  ...SaveArtworkToListsButton_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  isSaved\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isInAuction\n  isSavedToList\n  collectorSignals {\n    auction {\n      lotWatcherCount\n      lotClosesAt\n      liveBiddingStarted\n    }\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n  collectorSignals {\n    auction {\n      lotWatcherCount\n      lotClosesAt\n    }\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...ExclusiveAccessBadge_artwork\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  isUnlisted\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n    blurhashDataURL\n  }\n}\n\nfragment UpcomingAuctions_viewer on Viewer {\n  salesConnection(first: 10, sort: START_AT_ASC, auctionState: UPCOMING) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        status\n        formattedStartDateTime\n        eventStartAt\n        isLiveOpen\n        ...AuctionArtworksRail_sale\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query auctionsRoutes_Upcoming_AuctionsQuery {\n  viewer {\n    ...UpcomingAuctions_viewer\n  }\n}\n\nfragment UpcomingAuctions_viewer on Viewer {\n  salesConnection(first: 10, sort: START_AT_ASC, auctionState: UPCOMING) {\n    totalCount\n    edges {\n      node {\n        slug\n        name\n        href\n        status\n        formattedStartDateTime\n        eventStartAt\n        isLiveOpen\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Also switches the other rails to be a query renderer just in case, on /auctions.

Locally the page is really fast now!