### PR TITLE
fix: allow caching of IP geocoding queries (DIA-844)

### DIFF
--- a/src/Components/AuthDialog/Hooks/useCountryCode.ts
+++ b/src/Components/AuthDialog/Hooks/useCountryCode.ts
@@ -21,7 +21,9 @@ export const useCountryCode = () => {
       ip: getENV("IP_ADDRESS") || "0.0.0.0",
     },
     cacheConfig: {
-      fetchPolicy: "store-or-network",
+      networkCacheConfig: {
+        force: false,
+      },
     },
     // If the user is logged in, we don't need the country code
     skip: isLoggedIn,


### PR DESCRIPTION
Not sure if I did this correctly, but it seems to work in my local testing.

According to [relay docs](https://relay.dev/docs/guided-tour/reusing-cached-data/fetch-policies/), `store-or-network` is the default fetch policy, so hopefully we don't need that. With or without it, this query to geocode an IP address to a country gets a `force: true`, which ends up sending the `Cache-Control: no-cache` header. Setting `force: false` has the effect of removing that header and allowing the result (a single country) to be cached. I think that's OK, as IP<>country mappings don't change that often.