### PR TITLE
docs: update example Jira reference in PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -2,7 +2,7 @@ The type of this PR is: **TYPE**
 
 <!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->
 
-<!-- If applicable, write the Jira ticket number in square brackets e.g. `[GRO-434]`
+<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
      The Jira integration will turn it into a clickable link for you. -->
 
 This PR solves [PROJECT-XX]


### PR DESCRIPTION
The type of this PR is: **Docs**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

### Description

This specific Jira ticket (an epic) has become linked to many pull requests because it's referenced in the example reference:
https://artsyproduct.atlassian.net/browse/GRO-434

This commit updates the example reference to one that's simply instructional and will not trigger the actual linking logic.
