### PR TITLE
fix:add elipses for long fair names

### DIFF
--- a/src/Apps/Home/Components/HomeCurrentFairs.tsx
+++ b/src/Apps/Home/Components/HomeCurrentFairs.tsx
@@ -79,7 +79,7 @@ const HomeCurrentFairs: React.FC<HomeCurrentFairsProps> = ({ viewer }) => {
                   </ResponsiveBox>
                 )}
 
-                <Text variant="lg-display" mt={1}>
+                <Text variant="lg-display" overflowEllipsis mt={1}>
                   {fair.name}
                 </Text>
 


### PR DESCRIPTION
The type of this PR is: **fix**


### Description

This PR adds an elipses to overflowing text on the home screen view of current fairs to address an issue where the fair name is one very long string without whitespace.