### PR TITLE
fix(collection/id): fix weird grid flash

### DIFF
--- a/src/Apps/Collect/Routes/Collect/index.tsx
+++ b/src/Apps/Collect/Routes/Collect/index.tsx
@@ -1,5 +1,5 @@
-import { Box, Separator, Spacer, Text, Flex } from "@artsy/palette"
 import StaticContainer from "found/StaticContainer"
+import { Box, Separator, Spacer, Text, Flex } from "@artsy/palette"
 import { Match, Router } from "found"
 import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"

--- a/src/Apps/Collect/Routes/Collection/index.tsx
+++ b/src/Apps/Collect/Routes/Collection/index.tsx
@@ -1,3 +1,4 @@
+import StaticContainer from "found/StaticContainer"
 import { Spacer } from "@artsy/palette"
 import { Collection_collection$data } from "__generated__/Collection_collection.graphql"
 import { CollectionArtworksQuery } from "__generated__/CollectionArtworksQuery.graphql"
@@ -57,7 +58,7 @@ export const CollectionApp: React.FC<CollectionAppProps> = props => {
   const hideSignals = HIDE_SIGNAL_SLUGS.includes(collection.slug)
 
   return (
-    <>
+    <StaticContainer shouldUpdate={!!match.elements}>
       <Analytics contextPageOwnerId={context.contextPageOwnerId as string}>
         <MetaTags
           description={metadataDescription}
@@ -155,7 +156,7 @@ export const CollectionApp: React.FC<CollectionAppProps> = props => {
           </FrameWithRecentlyViewed>
         </>
       </Analytics>
-    </>
+    </StaticContainer>
   )
 }
 

--- a/src/Components/ArtworkGrid/ArtworkGrid.tsx
+++ b/src/Components/ArtworkGrid/ArtworkGrid.tsx
@@ -441,7 +441,7 @@ interface ArtworkGridPlaceholderProps extends MasonryProps {
 }
 
 export const ArtworkGridPlaceholder: React.FC<ArtworkGridPlaceholderProps> = ({
-  amount = 8,
+  amount = 20,
   ...rest
 }) => {
   return (


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Fixes issue where clicking an artwork grid item on collection/id would lead to a page flash rerender. This fixes that by leveraging found's StaticContainer, which will only rerender when there are route elements to display (which isn't true if a route is transitioning).
