### PR TITLE
refactor(onyx-1307): use viewingRoomsConnection instead of deprecated viewingRooms query

### DIFF
--- a/src/Apps/ViewingRoom/Components/ViewingRoomsFeaturedRail.tsx
+++ b/src/Apps/ViewingRoom/Components/ViewingRoomsFeaturedRail.tsx
@@ -65,7 +65,7 @@ export const ViewingRoomsFeaturedRailFragmentContainer = createFragmentContainer
   ViewingRoomsFeaturedRail,
   {
     featuredViewingRooms: graphql`
-      fragment ViewingRoomsFeaturedRail_featuredViewingRooms on ViewingRoomConnection {
+      fragment ViewingRoomsFeaturedRail_featuredViewingRooms on ViewingRoomsConnection {
         edges {
           node {
             status

--- a/src/Apps/ViewingRoom/ViewingRoomsApp.tsx
+++ b/src/Apps/ViewingRoom/ViewingRoomsApp.tsx
@@ -55,7 +55,7 @@ export const ViewingRoomsAppFragmentContainer = createFragmentContainer(
       }
     `,
     featuredViewingRooms: graphql`
-      fragment ViewingRoomsApp_featuredViewingRooms on ViewingRoomConnection {
+      fragment ViewingRoomsApp_featuredViewingRooms on ViewingRoomsConnection {
         ...ViewingRoomsFeaturedRail_featuredViewingRooms
       }
     `,

--- a/src/Apps/ViewingRoom/__tests__/ViewingRoomsApp.jest.tsx
+++ b/src/Apps/ViewingRoom/__tests__/ViewingRoomsApp.jest.tsx
@@ -41,7 +41,7 @@ describe("ViewingRoomsApp", () => {
             allViewingRooms: viewer {
               ...ViewingRoomsApp_allViewingRooms
             }
-            featuredViewingRooms: viewingRooms(featured: true) {
+            featuredViewingRooms: viewingRoomsConnection(featured: true) {
               ...ViewingRoomsApp_featuredViewingRooms
             }
           }

--- a/src/Apps/ViewingRoom/viewingRoomRoutes.tsx
+++ b/src/Apps/ViewingRoom/viewingRoomRoutes.tsx
@@ -57,7 +57,7 @@ export const viewingRoomRoutes: RouteProps[] = [
             @arguments(count: $count, after: $after)
         }
 
-        featuredViewingRooms: viewingRooms(featured: true) {
+        featuredViewingRooms: viewingRoomsConnection(featured: true) {
           ...ViewingRoomsApp_featuredViewingRooms
         }
       }

--- a/src/__generated__/ViewingRoomsApp_Test_Query.graphql.ts
+++ b/src/__generated__/ViewingRoomsApp_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<728014666c09ad8bed6198b78c1ce1bb>>
+ * @generated SignedSource<<ea6035bbe5be90881008a4e3c4eb93da>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -181,19 +181,19 @@ v8 = {
 },
 v9 = {
   "enumValues": null,
-  "nullable": false,
+  "nullable": true,
   "plural": false,
-  "type": "String"
+  "type": "ViewingRoomsConnection"
 },
 v10 = {
   "enumValues": null,
   "nullable": true,
-  "plural": false,
-  "type": "ViewingRoom"
+  "plural": true,
+  "type": "ViewingRoomsEdge"
 },
 v11 = {
   "enumValues": null,
-  "nullable": true,
+  "nullable": false,
   "plural": false,
   "type": "String"
 },
@@ -201,21 +201,33 @@ v12 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "ARImage"
+  "type": "ViewingRoom"
 },
 v13 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "ImageURLs"
+  "type": "String"
 },
 v14 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Partner"
+  "type": "ARImage"
 },
 v15 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "ImageURLs"
+},
+v16 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Partner"
+},
+v17 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
@@ -247,9 +259,9 @@ return {
       {
         "alias": "featuredViewingRooms",
         "args": (v0/*: any*/),
-        "concreteType": "ViewingRoomConnection",
+        "concreteType": "ViewingRoomsConnection",
         "kind": "LinkedField",
-        "name": "viewingRooms",
+        "name": "viewingRoomsConnection",
         "plural": false,
         "selections": [
           {
@@ -258,7 +270,7 @@ return {
             "name": "ViewingRoomsApp_featuredViewingRooms"
           }
         ],
-        "storageKey": "viewingRooms(featured:true)"
+        "storageKey": "viewingRoomsConnection(featured:true)"
       }
     ],
     "type": "Query",
@@ -372,15 +384,15 @@ return {
       {
         "alias": "featuredViewingRooms",
         "args": (v0/*: any*/),
-        "concreteType": "ViewingRoomConnection",
+        "concreteType": "ViewingRoomsConnection",
         "kind": "LinkedField",
-        "name": "viewingRooms",
+        "name": "viewingRoomsConnection",
         "plural": false,
         "selections": [
           {
             "alias": null,
             "args": null,
-            "concreteType": "ViewingRoomEdge",
+            "concreteType": "ViewingRoomsEdge",
             "kind": "LinkedField",
             "name": "edges",
             "plural": true,
@@ -407,12 +419,12 @@ return {
             "storageKey": null
           }
         ],
-        "storageKey": "viewingRooms(featured:true)"
+        "storageKey": "viewingRoomsConnection(featured:true)"
       }
     ]
   },
   "params": {
-    "cacheID": "53e3bf63daf2dd0330e5f28853b03b3d",
+    "cacheID": "f24b33c4be8d74288f4ce64e8c71e5d2",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -422,78 +434,58 @@ return {
           "plural": false,
           "type": "Viewer"
         },
-        "allViewingRooms.viewingRoomsConnection": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ViewingRoomsConnection"
-        },
-        "allViewingRooms.viewingRoomsConnection.edges": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": true,
-          "type": "ViewingRoomsEdge"
-        },
-        "allViewingRooms.viewingRoomsConnection.edges.cursor": (v9/*: any*/),
-        "allViewingRooms.viewingRoomsConnection.edges.node": (v10/*: any*/),
-        "allViewingRooms.viewingRoomsConnection.edges.node.__typename": (v9/*: any*/),
-        "allViewingRooms.viewingRoomsConnection.edges.node.distanceToClose": (v11/*: any*/),
-        "allViewingRooms.viewingRoomsConnection.edges.node.distanceToOpen": (v11/*: any*/),
-        "allViewingRooms.viewingRoomsConnection.edges.node.image": (v12/*: any*/),
-        "allViewingRooms.viewingRoomsConnection.edges.node.image.imageURLs": (v13/*: any*/),
-        "allViewingRooms.viewingRoomsConnection.edges.node.image.imageURLs.normalized": (v11/*: any*/),
-        "allViewingRooms.viewingRoomsConnection.edges.node.partner": (v14/*: any*/),
-        "allViewingRooms.viewingRoomsConnection.edges.node.partner.id": (v15/*: any*/),
-        "allViewingRooms.viewingRoomsConnection.edges.node.partner.name": (v11/*: any*/),
-        "allViewingRooms.viewingRoomsConnection.edges.node.slug": (v9/*: any*/),
-        "allViewingRooms.viewingRoomsConnection.edges.node.status": (v9/*: any*/),
-        "allViewingRooms.viewingRoomsConnection.edges.node.title": (v9/*: any*/),
+        "allViewingRooms.viewingRoomsConnection": (v9/*: any*/),
+        "allViewingRooms.viewingRoomsConnection.edges": (v10/*: any*/),
+        "allViewingRooms.viewingRoomsConnection.edges.cursor": (v11/*: any*/),
+        "allViewingRooms.viewingRoomsConnection.edges.node": (v12/*: any*/),
+        "allViewingRooms.viewingRoomsConnection.edges.node.__typename": (v11/*: any*/),
+        "allViewingRooms.viewingRoomsConnection.edges.node.distanceToClose": (v13/*: any*/),
+        "allViewingRooms.viewingRoomsConnection.edges.node.distanceToOpen": (v13/*: any*/),
+        "allViewingRooms.viewingRoomsConnection.edges.node.image": (v14/*: any*/),
+        "allViewingRooms.viewingRoomsConnection.edges.node.image.imageURLs": (v15/*: any*/),
+        "allViewingRooms.viewingRoomsConnection.edges.node.image.imageURLs.normalized": (v13/*: any*/),
+        "allViewingRooms.viewingRoomsConnection.edges.node.partner": (v16/*: any*/),
+        "allViewingRooms.viewingRoomsConnection.edges.node.partner.id": (v17/*: any*/),
+        "allViewingRooms.viewingRoomsConnection.edges.node.partner.name": (v13/*: any*/),
+        "allViewingRooms.viewingRoomsConnection.edges.node.slug": (v11/*: any*/),
+        "allViewingRooms.viewingRoomsConnection.edges.node.status": (v11/*: any*/),
+        "allViewingRooms.viewingRoomsConnection.edges.node.title": (v11/*: any*/),
         "allViewingRooms.viewingRoomsConnection.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "allViewingRooms.viewingRoomsConnection.pageInfo.endCursor": (v11/*: any*/),
+        "allViewingRooms.viewingRoomsConnection.pageInfo.endCursor": (v13/*: any*/),
         "allViewingRooms.viewingRoomsConnection.pageInfo.hasNextPage": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "Boolean"
         },
-        "featuredViewingRooms": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ViewingRoomConnection"
-        },
-        "featuredViewingRooms.edges": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": true,
-          "type": "ViewingRoomEdge"
-        },
-        "featuredViewingRooms.edges.node": (v10/*: any*/),
-        "featuredViewingRooms.edges.node.distanceToClose": (v11/*: any*/),
-        "featuredViewingRooms.edges.node.distanceToOpen": (v11/*: any*/),
-        "featuredViewingRooms.edges.node.image": (v12/*: any*/),
-        "featuredViewingRooms.edges.node.image.imageURLs": (v13/*: any*/),
-        "featuredViewingRooms.edges.node.image.imageURLs.normalized": (v11/*: any*/),
-        "featuredViewingRooms.edges.node.partner": (v14/*: any*/),
-        "featuredViewingRooms.edges.node.partner.id": (v15/*: any*/),
-        "featuredViewingRooms.edges.node.partner.name": (v11/*: any*/),
-        "featuredViewingRooms.edges.node.slug": (v9/*: any*/),
-        "featuredViewingRooms.edges.node.status": (v9/*: any*/),
-        "featuredViewingRooms.edges.node.title": (v9/*: any*/)
+        "featuredViewingRooms": (v9/*: any*/),
+        "featuredViewingRooms.edges": (v10/*: any*/),
+        "featuredViewingRooms.edges.node": (v12/*: any*/),
+        "featuredViewingRooms.edges.node.distanceToClose": (v13/*: any*/),
+        "featuredViewingRooms.edges.node.distanceToOpen": (v13/*: any*/),
+        "featuredViewingRooms.edges.node.image": (v14/*: any*/),
+        "featuredViewingRooms.edges.node.image.imageURLs": (v15/*: any*/),
+        "featuredViewingRooms.edges.node.image.imageURLs.normalized": (v13/*: any*/),
+        "featuredViewingRooms.edges.node.partner": (v16/*: any*/),
+        "featuredViewingRooms.edges.node.partner.id": (v17/*: any*/),
+        "featuredViewingRooms.edges.node.partner.name": (v13/*: any*/),
+        "featuredViewingRooms.edges.node.slug": (v11/*: any*/),
+        "featuredViewingRooms.edges.node.status": (v11/*: any*/),
+        "featuredViewingRooms.edges.node.title": (v11/*: any*/)
       }
     },
     "name": "ViewingRoomsApp_Test_Query",
     "operationKind": "query",
-    "text": "query ViewingRoomsApp_Test_Query {\n  allViewingRooms: viewer {\n    ...ViewingRoomsApp_allViewingRooms\n  }\n  featuredViewingRooms: viewingRooms(featured: true) {\n    ...ViewingRoomsApp_featuredViewingRooms\n  }\n}\n\nfragment ViewingRoomsApp_allViewingRooms on Viewer {\n  ...ViewingRoomsLatestGrid_viewingRooms_9Znkm\n}\n\nfragment ViewingRoomsApp_featuredViewingRooms on ViewingRoomConnection {\n  ...ViewingRoomsFeaturedRail_featuredViewingRooms\n}\n\nfragment ViewingRoomsFeaturedRail_featuredViewingRooms on ViewingRoomConnection {\n  edges {\n    node {\n      status\n      slug\n      title\n      image {\n        imageURLs {\n          normalized\n        }\n      }\n      distanceToOpen(short: true)\n      distanceToClose(short: true)\n      partner {\n        name\n        id\n      }\n    }\n  }\n}\n\nfragment ViewingRoomsLatestGrid_viewingRooms_9Znkm on Viewer {\n  viewingRoomsConnection {\n    edges {\n      node {\n        slug\n        status\n        title\n        image {\n          imageURLs {\n            normalized\n          }\n        }\n        distanceToOpen(short: true)\n        distanceToClose(short: true)\n        partner {\n          name\n          id\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query ViewingRoomsApp_Test_Query {\n  allViewingRooms: viewer {\n    ...ViewingRoomsApp_allViewingRooms\n  }\n  featuredViewingRooms: viewingRoomsConnection(featured: true) {\n    ...ViewingRoomsApp_featuredViewingRooms\n  }\n}\n\nfragment ViewingRoomsApp_allViewingRooms on Viewer {\n  ...ViewingRoomsLatestGrid_viewingRooms_9Znkm\n}\n\nfragment ViewingRoomsApp_featuredViewingRooms on ViewingRoomsConnection {\n  ...ViewingRoomsFeaturedRail_featuredViewingRooms\n}\n\nfragment ViewingRoomsFeaturedRail_featuredViewingRooms on ViewingRoomsConnection {\n  edges {\n    node {\n      status\n      slug\n      title\n      image {\n        imageURLs {\n          normalized\n        }\n      }\n      distanceToOpen(short: true)\n      distanceToClose(short: true)\n      partner {\n        name\n        id\n      }\n    }\n  }\n}\n\nfragment ViewingRoomsLatestGrid_viewingRooms_9Znkm on Viewer {\n  viewingRoomsConnection {\n    edges {\n      node {\n        slug\n        status\n        title\n        image {\n          imageURLs {\n            normalized\n          }\n        }\n        distanceToOpen(short: true)\n        distanceToClose(short: true)\n        partner {\n          name\n          id\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "5e8709a6467d35395b4d7066db2c1669";
+(node as any).hash = "262ea939bd31cffe6000cc74d768694d";
 
 export default node;

--- a/src/__generated__/ViewingRoomsApp_featuredViewingRooms.graphql.ts
+++ b/src/__generated__/ViewingRoomsApp_featuredViewingRooms.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<82983b3abacdb66ba52807cca4a8c0b8>>
+ * @generated SignedSource<<fab98e750d5faefd525338da6d55143e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -31,10 +31,10 @@ const node: ReaderFragment = {
       "name": "ViewingRoomsFeaturedRail_featuredViewingRooms"
     }
   ],
-  "type": "ViewingRoomConnection",
+  "type": "ViewingRoomsConnection",
   "abstractKey": null
 };
 
-(node as any).hash = "25c9423c629024672425973f7b3d17ac";
+(node as any).hash = "22496eadfb02ab912add5fd7821bcb7f";
 
 export default node;

--- a/src/__generated__/ViewingRoomsFeaturedRail_featuredViewingRooms.graphql.ts
+++ b/src/__generated__/ViewingRoomsFeaturedRail_featuredViewingRooms.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f6eb23ab66ad1f77c819520aaaa49a99>>
+ * @generated SignedSource<<a38debd6d792fb72eb204965e0acf7ea>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -52,7 +52,7 @@ return {
     {
       "alias": null,
       "args": null,
-      "concreteType": "ViewingRoomEdge",
+      "concreteType": "ViewingRoomsEdge",
       "kind": "LinkedField",
       "name": "edges",
       "plural": true,
@@ -154,11 +154,11 @@ return {
       "storageKey": null
     }
   ],
-  "type": "ViewingRoomConnection",
+  "type": "ViewingRoomsConnection",
   "abstractKey": null
 };
 })();
 
-(node as any).hash = "9dd834600e28760b97b9b24b16f60122";
+(node as any).hash = "31c1c6e0cecf8dbb067bcda13c739aee";
 
 export default node;

--- a/src/__generated__/viewingRoomRoutes_ViewingRoomsAppQuery.graphql.ts
+++ b/src/__generated__/viewingRoomRoutes_ViewingRoomsAppQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2208a669d75c0684e032650cfdcb4594>>
+ * @generated SignedSource<<3e8b6800bff407d5f21a33aca20f323b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -190,9 +190,9 @@ return {
       {
         "alias": "featuredViewingRooms",
         "args": (v3/*: any*/),
-        "concreteType": "ViewingRoomConnection",
+        "concreteType": "ViewingRoomsConnection",
         "kind": "LinkedField",
-        "name": "viewingRooms",
+        "name": "viewingRoomsConnection",
         "plural": false,
         "selections": [
           {
@@ -201,7 +201,7 @@ return {
             "name": "ViewingRoomsApp_featuredViewingRooms"
           }
         ],
-        "storageKey": "viewingRooms(featured:true)"
+        "storageKey": "viewingRoomsConnection(featured:true)"
       }
     ],
     "type": "Query",
@@ -318,15 +318,15 @@ return {
       {
         "alias": "featuredViewingRooms",
         "args": (v3/*: any*/),
-        "concreteType": "ViewingRoomConnection",
+        "concreteType": "ViewingRoomsConnection",
         "kind": "LinkedField",
-        "name": "viewingRooms",
+        "name": "viewingRoomsConnection",
         "plural": false,
         "selections": [
           {
             "alias": null,
             "args": null,
-            "concreteType": "ViewingRoomEdge",
+            "concreteType": "ViewingRoomsEdge",
             "kind": "LinkedField",
             "name": "edges",
             "plural": true,
@@ -353,21 +353,21 @@ return {
             "storageKey": null
           }
         ],
-        "storageKey": "viewingRooms(featured:true)"
+        "storageKey": "viewingRoomsConnection(featured:true)"
       }
     ]
   },
   "params": {
-    "cacheID": "69423ab85da6562e5579eed68a36012c",
+    "cacheID": "e30762de4830b7adafec1ac4cbaf9c5e",
     "id": null,
     "metadata": {},
     "name": "viewingRoomRoutes_ViewingRoomsAppQuery",
     "operationKind": "query",
-    "text": "query viewingRoomRoutes_ViewingRoomsAppQuery(\n  $count: Int!\n  $after: String\n) @cacheable {\n  allViewingRooms: viewer {\n    ...ViewingRoomsApp_allViewingRooms_2QE1um\n  }\n  featuredViewingRooms: viewingRooms(featured: true) {\n    ...ViewingRoomsApp_featuredViewingRooms\n  }\n}\n\nfragment ViewingRoomsApp_allViewingRooms_2QE1um on Viewer {\n  ...ViewingRoomsLatestGrid_viewingRooms_2QE1um\n}\n\nfragment ViewingRoomsApp_featuredViewingRooms on ViewingRoomConnection {\n  ...ViewingRoomsFeaturedRail_featuredViewingRooms\n}\n\nfragment ViewingRoomsFeaturedRail_featuredViewingRooms on ViewingRoomConnection {\n  edges {\n    node {\n      status\n      slug\n      title\n      image {\n        imageURLs {\n          normalized\n        }\n      }\n      distanceToOpen(short: true)\n      distanceToClose(short: true)\n      partner {\n        name\n        id\n      }\n    }\n  }\n}\n\nfragment ViewingRoomsLatestGrid_viewingRooms_2QE1um on Viewer {\n  viewingRoomsConnection(first: $count, after: $after) {\n    edges {\n      node {\n        slug\n        status\n        title\n        image {\n          imageURLs {\n            normalized\n          }\n        }\n        distanceToOpen(short: true)\n        distanceToClose(short: true)\n        partner {\n          name\n          id\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query viewingRoomRoutes_ViewingRoomsAppQuery(\n  $count: Int!\n  $after: String\n) @cacheable {\n  allViewingRooms: viewer {\n    ...ViewingRoomsApp_allViewingRooms_2QE1um\n  }\n  featuredViewingRooms: viewingRoomsConnection(featured: true) {\n    ...ViewingRoomsApp_featuredViewingRooms\n  }\n}\n\nfragment ViewingRoomsApp_allViewingRooms_2QE1um on Viewer {\n  ...ViewingRoomsLatestGrid_viewingRooms_2QE1um\n}\n\nfragment ViewingRoomsApp_featuredViewingRooms on ViewingRoomsConnection {\n  ...ViewingRoomsFeaturedRail_featuredViewingRooms\n}\n\nfragment ViewingRoomsFeaturedRail_featuredViewingRooms on ViewingRoomsConnection {\n  edges {\n    node {\n      status\n      slug\n      title\n      image {\n        imageURLs {\n          normalized\n        }\n      }\n      distanceToOpen(short: true)\n      distanceToClose(short: true)\n      partner {\n        name\n        id\n      }\n    }\n  }\n}\n\nfragment ViewingRoomsLatestGrid_viewingRooms_2QE1um on Viewer {\n  viewingRoomsConnection(first: $count, after: $after) {\n    edges {\n      node {\n        slug\n        status\n        title\n        image {\n          imageURLs {\n            normalized\n          }\n        }\n        distanceToOpen(short: true)\n        distanceToClose(short: true)\n        partner {\n          name\n          id\n        }\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "8a6cf8baecf4bfe58aadf8367b520d06";
+(node as any).hash = "470ab6c46d06cc99a6625390d3d40719";
 
 export default node;


### PR DESCRIPTION
The type of this PR is: **Refactor**

This PR solves [ONYX-1307]

### Description

I want to remove viewingRooms (which is deprecated) query from gravity to simplify un-stitching

[ONYX-1307]: https://artsyproduct.atlassian.net/browse/ONYX-1307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ