### PR TITLE
fix(DIA-864): correct redirect/pass along error message

### DIFF
--- a/src/Server/passport/lib/app/__tests__/analytics.jest.ts
+++ b/src/Server/passport/lib/app/__tests__/analytics.jest.ts
@@ -1,7 +1,6 @@
-const sinon = require("sinon")
+import sinon from "sinon"
 
-let analytics = require("../../lib/app/analytics")
-import options from "Server/passport/lib/options"
+let analytics = require("../analytics")
 
 jest.mock("sharify", () => ({
   data: {

--- a/src/Server/passport/lib/app/__tests__/locals.jest.ts
+++ b/src/Server/passport/lib/app/__tests__/locals.jest.ts
@@ -1,5 +1,5 @@
 const sinon = require("sinon")
-const locals = require("../../lib/app/locals")
+const locals = require("../locals")
 
 describe("locals", function () {
   let req

--- a/src/Server/passport/lib/app/__tests__/token_login.jest.js
+++ b/src/Server/passport/lib/app/__tests__/token_login.jest.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-imports */
 const sinon = require("sinon")
-const tokenLogin = require("../../lib/app/token_login")
+const tokenLogin = require("../token_login")
 const { headerLogin, trustTokenLogin } = tokenLogin
 
 import request from "superagent"

--- a/src/Server/passport/lib/app/lifecycle.ts
+++ b/src/Server/passport/lib/app/lifecycle.ts
@@ -176,6 +176,7 @@ module.exports.afterSocialAuth = (provider: Provider) =>
     // Determine if we're linking the account and handle any Gravity errors
     // that we can do a better job explaining and redirecting for.
     const linkingAccount = req.user != null
+    const redirectPath = req.user ? opts.settingsPagePath : opts.loginPagePath
 
     passport.authenticate(provider)(req, res, function (err: any) {
       if (
@@ -186,7 +187,7 @@ module.exports.afterSocialAuth = (provider: Provider) =>
         // Log in to Artsy via email and password and link ${providerName} in your settings instead.
         // Redirect back to login page.
         return res.redirect(
-          `${opts.loginPagePath}?error_code=ALREADY_EXISTS&email=${req.socialProfileEmail}&provider=${provider}`
+          `${redirectPath}?error_code=ALREADY_EXISTS&email=${req.socialProfileEmail}&provider=${provider}`
         )
       }
 
@@ -195,21 +196,21 @@ module.exports.afterSocialAuth = (provider: Provider) =>
         // Log in to your Artsy account via email and password and link the provider in your settings instead.
         // Redirect back to login page.
         return res.redirect(
-          `${opts.loginPagePath}?error_code=PREVIOUSLY_LINKED_SETTINGS&provider=${provider}`
+          `${redirectPath}?error_code=PREVIOUSLY_LINKED_SETTINGS&provider=${provider}`
         )
       }
 
       if (err?.response?.body?.error === "Another Account Already Linked") {
         // Provider account previously linked to Artsy. Redirect back to settings page.
         return res.redirect(
-          `${opts.settingsPagePath}?error_code=PREVIOUSLY_LINKED&provider=${provider}`
+          `${redirectPath}?error_code=PREVIOUSLY_LINKED&provider=${provider}`
         )
       }
 
       if (err?.message?.match("Unauthorized source IP address")) {
         // Your IP address was blocked by the provider. Redirect back to login page.
         return res.redirect(
-          `${opts.loginPagePath}?error_code=IP_BLOCKED&provider=${provider}`
+          `${redirectPath}?error_code=IP_BLOCKED&provider=${provider}`
         )
       }
 
@@ -219,7 +220,7 @@ module.exports.afterSocialAuth = (provider: Provider) =>
           (typeof err.toString === "function" ? err.toString() : undefined)
         // Unknown error. Redirect back to login page. Do not show error message to user; log to console.
         return res.redirect(
-          `${opts.loginPagePath}?error_code=UNKNOWN&error=${message}`
+          `${redirectPath}?error_code=UNKNOWN&error=${message}`
         )
       }
 

--- a/src/Server/passport/lib/passport/__tests__/callbacks.jest.js
+++ b/src/Server/passport/lib/passport/__tests__/callbacks.jest.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-imports */
 const rewire = require("rewire")
 const sinon = require("sinon")
-const cbs = require("../../lib/passport/callbacks")
+const cbs = require("../callbacks")
 
 import options from "Server/passport/lib/options"
 import request from "superagent"

--- a/src/Server/passport/lib/passport/__tests__/serializers.jest.js
+++ b/src/Server/passport/lib/passport/__tests__/serializers.jest.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-imports */
 const sinon = require("sinon")
-const serializers = require("../../lib/passport/serializers")
+const serializers = require("../serializers")
 const { serialize, deserialize } = serializers
 
 import options from "Server/passport/lib/options"


### PR DESCRIPTION
Closes [DIA-864](https://artsyproduct.atlassian.net/browse/DIA-864)

Ultimately there were two issues here:

When you tried to link the account, there was only one error that was explicitly handled for 3rd-party auth errors when logged in: `"Provider account previously linked to Artsy. Redirect back to settings page"`

As a result, when we encountered any other kind of error it would fall into the UNKNOWN error condition which would redirect to the login page. If you were logged out this would have popped up a toast that just said "Bad Request". But since you're logged in it would then throw away the query param and redirect to the homepage.

So this just sets the correct redirect path regardless now.

In addition we were swallowing this error message, which is a useful one. So now we dig into the error response to extract out the actual message.

![](https://capture.static.damonzucconi.com/Screen-Shot-2024-09-20-08-34-45.35-EmMGIwIOL7wdy2EiXiohZn61rihsGOYYmghnQP5q573y9hjUE1NdK8q6fb9fSWCk4UUKU07Q8690PQDTippQwqfcRZ23qloDRUdW.png)

-----

In doing this I also noticed that none of the specs for the Passport related code were running in CI due to the folder structure from when this was ported over. So I moved those over and got them passing as well.

[DIA-864]: https://artsyproduct.atlassian.net/browse/DIA-864?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ