### PR TITLE
feat(performance): Enable prefetching on enter for logged in

### DIFF
--- a/src/System/Components/RouterLink.tsx
+++ b/src/System/Components/RouterLink.tsx
@@ -31,13 +31,11 @@ export type RouterLinkProps = Omit<
 
 export const RouterLink: React.FC<RouterLinkProps> = React.forwardRef(
   ({ inline, to, ...rest }, _ref) => {
-    const systemContext = useSystemContext()
     const { router } = useRouter()
 
     // Right now, prefetching on viewport enter is only enabled for logged-out users
     // TODO: Remove feature flag
-    const isPrefetchOnEnterEnabled =
-      useFeatureFlag("diamond_prefetch-on-enter") && !systemContext?.user
+    const isPrefetchOnEnterEnabled = useFeatureFlag("diamond_prefetch-on-enter")
 
     const { prefetch } = usePrefetchRoute(to as string)
 


### PR DESCRIPTION
The type of this PR is: **Feat**

### Description

We've let prefetch-on-enter run for a bit for logged out and things are looking good! So lets enable it for logged-in users as well. 

cc @artsy/diamond-devs 