### PR TITLE
chore: removes feature flags

### DIFF
--- a/src/Apps/Artist/Routes/WorksForSale/Utils/getWorksForSaleRouteVariables.ts
+++ b/src/Apps/Artist/Routes/WorksForSale/Utils/getWorksForSaleRouteVariables.ts
@@ -1,5 +1,4 @@
 import { getInitialFilterState } from "Components/ArtworkFilter/Utils/getInitialFilterState"
-import { getFeatureFlag } from "System/Hooks/useFeatureFlag"
 
 export function getWorksForSaleRouteVariables({ artistID }, { location }) {
   // FIXME: The initial render includes `location` in props, but subsequent
@@ -22,12 +21,10 @@ export function getWorksForSaleRouteVariables({ artistID }, { location }) {
     "ARTIST_SERIES",
   ]
 
-  const includeBlurHash = !!getFeatureFlag("diamond_blurhash-on-artist-pages")
-
   return {
     input: filterParams,
     aggregations,
     artistID,
-    includeBlurHash,
+    includeBlurHash: false,
   }
 }

--- a/src/Apps/Artwork/artworkRoutes.tsx
+++ b/src/Apps/Artwork/artworkRoutes.tsx
@@ -1,9 +1,7 @@
 import loadable from "@loadable/component"
-import { HttpError } from "found"
 import { graphql } from "react-relay"
 import { updateContext } from "Server/middleware/bootstrapSharifyAndContextLocalsMiddleware"
 import { RouteProps } from "System/Router/Route"
-import { getFeatureFlag } from "System/Hooks/useFeatureFlag"
 
 const ArtworkApp = loadable(
   () => import(/* webpackChunkName: "artworkBundle" */ "./ArtworkApp"),
@@ -33,16 +31,8 @@ export const artworkRoutes: RouteProps[] = [
       const requestError = (props as any).artworkResult?.requestError
       const requestErrorStatusCode = requestError?.statusCode
 
-      const enableCustomErrorPage = getFeatureFlag(
-        "onyx_custom_artwork_error_page"
-      )
-
       if (requestErrorStatusCode) {
-        if (enableCustomErrorPage) {
-          updateContext("statusCode", requestErrorStatusCode)
-        } else {
-          throw new HttpError(requestErrorStatusCode)
-        }
+        updateContext("statusCode", requestErrorStatusCode)
       }
 
       return <Component {...props} />

--- a/src/System/Hooks/useFeatureFlag.tsx
+++ b/src/System/Hooks/useFeatureFlag.tsx
@@ -5,6 +5,7 @@ import { getENV } from "Utils/getENV"
 import { pathToOwnerType } from "System/Contexts/AnalyticsContext"
 import { useRef } from "react"
 import { useRouter } from "System/Hooks/useRouter"
+import { warnInDevelopment } from "Utils/warnInDevelopment"
 
 export type FeatureFlags = Record<string, FeatureFlagDetails>
 
@@ -73,22 +74,6 @@ export const getFeatureVariant = (
   return variant
 }
 
-export const getFeatureFlag = (featureName: string): boolean | null => {
-  const featureFlags = getENV("FEATURE_FLAGS")
-  const flagEnabled = featureFlags?.[featureName]?.flagEnabled
-
-  if (flagEnabled === undefined) {
-    warnInDevelopment(
-      `[Force] Warning: cannot find ${featureName} in featureFlags: `,
-      featureFlags
-    )
-
-    return null
-  }
-
-  return flagEnabled
-}
-
 export function useTrackFeatureVariant({
   experimentName,
   variantName,
@@ -126,10 +111,4 @@ export function useTrackFeatureVariant({
   }
 
   return { trackFeatureVariant }
-}
-
-const warnInDevelopment = (...args: Parameters<typeof console.warn>) => {
-  if (getENV("NODE_ENV") === "development") {
-    console.warn(...args)
-  }
 }

--- a/src/Utils/getFeatureFlag.ts
+++ b/src/Utils/getFeatureFlag.ts
@@ -1,0 +1,18 @@
+import { getENV } from "Utils/getENV"
+import { warnInDevelopment } from "Utils/warnInDevelopment"
+
+export const getFeatureFlag = (featureName: string): boolean | null => {
+  const featureFlags = getENV("FEATURE_FLAGS")
+  const flagEnabled = featureFlags?.[featureName]?.flagEnabled
+
+  if (flagEnabled === undefined) {
+    warnInDevelopment(
+      `[Force] Warning: cannot find ${featureName} in featureFlags: `,
+      featureFlags
+    )
+
+    return null
+  }
+
+  return flagEnabled
+}

--- a/src/Utils/warnInDevelopment.ts
+++ b/src/Utils/warnInDevelopment.ts
@@ -1,0 +1,7 @@
+import { getENV } from "Utils/getENV"
+
+export const warnInDevelopment = (...args: Parameters<typeof console.warn>) => {
+  if (getENV("NODE_ENV") === "development") {
+    console.warn(...args)
+  }
+}


### PR DESCRIPTION
I noticed this looking at the load flame graph. Importing `getFeatureFlag` would also bring with it all of `SystemContext`. I pulled that function out into its own file to prevent that, but might as well remove these flags anyway.