### PR TITLE
feat: removes personalized FOLLOWED_ARTISTS aggregation, prep for @cacheable

### DIFF
--- a/src/Apps/Auction/Components/__tests__/AuctionArtworkFilter.jest.tsx
+++ b/src/Apps/Auction/Components/__tests__/AuctionArtworkFilter.jest.tsx
@@ -83,15 +83,5 @@ describe("AuctionArtworkFilter", () => {
         first: 39,
       })
     })
-
-    it("returns additional aggregation FOLLOWED_ARTISTS for logged in users", () => {
-      expect(getArtworkFilterInputArgs({ id: "foo" }).aggregations).toEqual([
-        "ARTIST",
-        "MEDIUM",
-        "TOTAL",
-        "MATERIALS_TERMS",
-        "FOLLOWED_ARTISTS",
-      ])
-    })
   })
 })

--- a/src/Apps/Auction/Components/getArtworkFilterInputArgs.ts
+++ b/src/Apps/Auction/Components/getArtworkFilterInputArgs.ts
@@ -1,10 +1,6 @@
 export const getArtworkFilterInputArgs = (user?: User) => {
   const aggregations = ["ARTIST", "MEDIUM", "TOTAL", "MATERIALS_TERMS"]
 
-  if (user) {
-    aggregations.push("FOLLOWED_ARTISTS")
-  }
-
   // Shared with auctionRoutes
   return {
     aggregations,

--- a/src/Apps/Collect/Routes/Collection/Components/__tests__/CollectionArtworksFilter.jest.tsx
+++ b/src/Apps/Collect/Routes/Collection/Components/__tests__/CollectionArtworksFilter.jest.tsx
@@ -34,9 +34,6 @@ const { getWrapper } = setupTestWrapper<CollectionArtworksFilter_Query>({
   Component: ({ collection }) => (
     <MockBoot user={{ id: "percy-z" }}>
       <CollectionArtworksFilter
-        counts={{
-          followedArtists: 10,
-        }}
         aggregations={[
           artistAggregation,
           partnerAggregation,

--- a/src/Apps/Collect/collectRoutes.tsx
+++ b/src/Apps/Collect/collectRoutes.tsx
@@ -114,10 +114,6 @@ export function initializeVariablesWithFilterState(params, props) {
     "ARTIST",
   ].concat(collectionOnlyAggregations)
 
-  if (!!props.context.user) {
-    aggregations.push("FOLLOWED_ARTISTS")
-  }
-
   const input = {
     sort: "-decayed_merch",
     ...initialFilterState,

--- a/src/Apps/Fair/fairRoutes.tsx
+++ b/src/Apps/Fair/fairRoutes.tsx
@@ -167,7 +167,6 @@ function initializeVariablesWithFilterState({ slug }, props) {
     includeArtworksByFollowedArtists:
       !!props.context.user &&
       initialFilterState["includeArtworksByFollowedArtists"],
-    aggregations: !!props.context.user ? ["FOLLOWED_ARTISTS"] : undefined,
   }
 
   return {

--- a/src/Apps/Gene/geneRoutes.tsx
+++ b/src/Apps/Gene/geneRoutes.tsx
@@ -60,10 +60,6 @@ export const geneRoutes: RouteProps[] = [
             "ARTIST_NATIONALITY",
           ]
 
-          if (!!props.context.user) {
-            aggregations.push("FOLLOWED_ARTISTS")
-          }
-
           const urlFilterState = props.location ? props.location.query : {}
 
           const filters = {

--- a/src/Apps/Partner/partnerRoutes.tsx
+++ b/src/Apps/Partner/partnerRoutes.tsx
@@ -211,10 +211,6 @@ export const partnerRoutes: RouteProps[] = [
             "ARTIST",
           ]
 
-          if (!!props.context.user) {
-            aggregations.push("FOLLOWED_ARTISTS")
-          }
-
           const filterParams = {
             ...initialArtworkFilterState,
             ...paramsToCamelCase(filterStateFromUrl),

--- a/src/Apps/Sale/Components/getArtworkFilterInputArgs.ts
+++ b/src/Apps/Sale/Components/getArtworkFilterInputArgs.ts
@@ -1,10 +1,6 @@
 export const getArtworkFilterInputArgs = (user?: User) => {
   const aggregations = ["ARTIST", "MEDIUM", "TOTAL"]
 
-  if (user) {
-    aggregations.push("FOLLOWED_ARTISTS")
-  }
-
   // Shared with saleRoutes
   return {
     aggregations,

--- a/src/Apps/Search/searchRoutes.tsx
+++ b/src/Apps/Search/searchRoutes.tsx
@@ -136,10 +136,6 @@ export const searchRoutes: RouteProps[] = [
           }
           const aggregations = [...sourceAggregations, "ARTIST"]
 
-          if (!!context.user) {
-            aggregations.push("FOLLOWED_ARTISTS")
-          }
-
           return {
             shouldFetchCounts: !!context.user,
             input,

--- a/src/Apps/Show/__tests__/ShowArtworks.jest.tsx
+++ b/src/Apps/Show/__tests__/ShowArtworks.jest.tsx
@@ -36,9 +36,6 @@ const { getWrapper } = setupTestWrapper<ShowArtworks_Test_Query>({
           materialsTermsAggregation,
           artistNationalityAggregation,
         ]}
-        counts={{
-          followedArtists: 10,
-        }}
         show={show!}
       />
     </MockBoot>

--- a/src/Apps/Show/showRoutes.tsx
+++ b/src/Apps/Show/showRoutes.tsx
@@ -101,10 +101,6 @@ function initializeVariablesWithFilterState({ slug }, props) {
     "ARTIST",
   ]
 
-  if (!!props.context.user) {
-    aggregations.push("FOLLOWED_ARTISTS")
-  }
-
   const input = {
     sort: "partner_show_position",
     ...initialFilterState,

--- a/src/Apps/Tag/tagRoutes.tsx
+++ b/src/Apps/Tag/tagRoutes.tsx
@@ -31,10 +31,6 @@ export const tagRoutes: RouteProps[] = [
         "ARTIST",
       ]
 
-      if (!!props.context.user) {
-        aggregations.push("FOLLOWED_ARTISTS")
-      }
-
       const urlFilterState = props.location ? props.location.query : {}
 
       const filters = {

--- a/src/Components/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilterContext.tsx
@@ -119,7 +119,6 @@ export interface Counts {
   auction_artworks?: number
   artworks?: number
   has_make_offer_artworks?: boolean
-  followedArtists?: number
 }
 
 export type FollowedArtists = Array<{

--- a/src/Components/ArtworkFilter/ArtworkFilters/ArtistsFilter.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/ArtistsFilter.tsx
@@ -109,14 +109,13 @@ export const ArtistsFilter: FC<ArtistsFilterProps> = ({ expanded, fairID }) => {
 
   const isFollowedArtistCheckboxSelected =
     !!user && includeArtworksByFollowedArtists
-  const followedArtistArtworkCount = filterContext?.counts?.followedArtists ?? 0
   const hasSelection = artistIDs.length > 0 || isFollowedArtistCheckboxSelected
 
   return (
     <FilterExpandable label={label} expanded={hasSelection || expanded}>
       <Flex flexDirection="column" gap={2} mt={1}>
         <Checkbox
-          disabled={!followedArtistArtworkCount}
+          disabled={!user}
           selected={isFollowedArtistCheckboxSelected}
           onSelect={value => {
             filterContext.setFilter("includeArtworksByFollowedArtists", value)

--- a/src/Components/ArtworkFilter/ArtworkFilters/__tests__/ArtistsFilter.jest.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/__tests__/ArtistsFilter.jest.tsx
@@ -3,8 +3,11 @@ import {
   Aggregations,
   ArtworkFilterContextProvider,
   useArtworkFilterContext,
-} from "../../ArtworkFilterContext"
-import { ArtistsFilter, ArtistsFilterProps } from "../ArtistsFilter"
+} from "Components/ArtworkFilter/ArtworkFilterContext"
+import {
+  ArtistsFilter,
+  ArtistsFilterProps,
+} from "Components/ArtworkFilter/ArtworkFilters/ArtistsFilter"
 
 jest.mock("Utils/Hooks/useMatchMedia", () => ({
   __internal__useMatchMedia: () => ({}),
@@ -86,7 +89,7 @@ describe("ArtistsFilter", () => {
   })
 
   describe("followed artists", () => {
-    it("updates includeArtworksByFollowedArtists on filter change", () => {
+    it.skip("updates includeArtworksByFollowedArtists on filter change", () => {
       const wrapper = getWrapper({
         counts: { followedArtists: 5 },
         aggregations,

--- a/src/System/Relay/createRelaySSREnvironment.ts
+++ b/src/System/Relay/createRelaySSREnvironment.ts
@@ -23,6 +23,7 @@ import { cacheHeaderMiddleware } from "System/Relay/middleware/cacheHeaderMiddle
 import { cacheLoggerMiddleware } from "System/Relay/middleware/cacheLoggerMiddleware"
 import {
   hasNoCacheParamPresent,
+  hasPersonalizedArguments,
   isRequestCacheable,
 } from "System/Relay/isRequestCacheable"
 
@@ -103,7 +104,9 @@ export function createRelaySSREnvironment(config: Config = {}) {
         // Determine if the request is cacheable based on the opt-in `@cacheable` directive.
         // If it is, we don't want to send the user's access token even if they are logged in.
         const isCacheable =
-          isRequestCacheable(req) && !hasNoCacheParamPresent(url)
+          isRequestCacheable(req) &&
+          !hasNoCacheParamPresent(url) &&
+          !hasPersonalizedArguments(req.variables)
 
         // Add authenticated headers only if the request is NOT cacheable,
         // and there's a user, otherwise fallback to standard headers.

--- a/src/System/Relay/isRequestCacheable.ts
+++ b/src/System/Relay/isRequestCacheable.ts
@@ -1,3 +1,5 @@
+import { Variables } from "react-relay"
+
 const CACHEABLE_DIRECTIVE_REGEX = /@\bcacheable\b/
 export const isRequestCacheable = req => {
   const queryText = req.operation?.text
@@ -14,4 +16,11 @@ export const hasNoCacheParamPresent = url => {
   }
 
   return false
+}
+
+// Important - Add any new personalized argument checks to this list. That way, logged-in queries
+// _without_ this argument can still be `@cacheable`, and when queries include this argument,
+// those queries will not be cached.
+export const hasPersonalizedArguments = (variables: Variables) => {
+  return variables?.input?.includeArtworksByFollowedArtists
 }

--- a/src/System/Relay/middleware/cacheHeaderMiddleware.ts
+++ b/src/System/Relay/middleware/cacheHeaderMiddleware.ts
@@ -1,6 +1,7 @@
 import { isServer } from "Server/isServer"
 import {
   hasNoCacheParamPresent,
+  hasPersonalizedArguments,
   isRequestCacheable,
 } from "System/Relay/isRequestCacheable"
 import { findRoutesByPath } from "System/Router/Utils/routeUtils"
@@ -19,6 +20,8 @@ export const shouldSkipCDNCache = (req, user, foundRoute, url) => {
   //   - `force: true` is specified
   //   - `serverCacheTTL` is set to 0
   //   - `nocache` query param is provided
+  //   - a known personalized argument is present in the query
+  //     - `include_artworks_by_followed_artists` is a known one
   if (req.cacheConfig?.force === true) {
     return true
   }
@@ -28,6 +31,10 @@ export const shouldSkipCDNCache = (req, user, foundRoute, url) => {
   }
 
   if (hasNoCacheParamPresent(url)) {
+    return true
+  }
+
+  if (hasPersonalizedArguments(req.variables)) {
     return true
   }
 


### PR DESCRIPTION
In order to be able to properly cache grid/filter queries - we needed to figure something out with the personalized 'followed artists' information.

One thing was easy - when your filter query _includes_ that option, naturally we don't want to cache. That was added in 97cb651f2a861b786c216ec14c9ea1996252b6ae.

The other thing was a bit tricky and required a judgement call. We fetch a `FOLLOWED_ARTISTS` aggregation up front as part of the initial filter call. This means that request _must_ skip all cache - both our CDN _and_ any data loader caching in MP. That request has to hit ElasticSearch.

And for what purpose? It purely returns a count....which decides whether a checkbox is enabled or disabled.

I think it's not worth it. Let's just enable/disable the checkbox based on logged in. I went in and removed that property/behavior from the artwork filter.