### PR TITLE
ci(kick): Kick the staging push 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -252,7 +252,7 @@ workflows:
           yarn-run: bundle-stats
 
       - artsy-remote-docker/build:
-          <<: *not_main_or_staging_or_release
+          <<: *not_staging_or_release
           name: build-and-push-docker
           context:
             - bundle-github


### PR DESCRIPTION
Since we cache docker build pushes, its safe to run on merges to main just in case a dev quick-merges a PR before its done. Then it will rebuild and send out ensuring some resiliency. 