### PR TITLE
fix: move data-testid to correct container

### DIFF
--- a/src/Apps/Order/Routes/Shipping2/Components/ShippingQuotes2.tsx
+++ b/src/Apps/Order/Routes/Shipping2/Components/ShippingQuotes2.tsx
@@ -85,6 +85,7 @@ export const ShippingQuotes2: React.FC<ShippingQuotesProps> = ({ order }) => {
 
       <RadioGroup
         onSelect={handleShippingQuoteSelected}
+        data-testid="shipping-quotes"
         defaultValue={shippingContext.state.selectedShippingQuoteID}
       >
         {quotes.map(shippingQuote => {
@@ -95,7 +96,6 @@ export const ShippingQuotes2: React.FC<ShippingQuotesProps> = ({ order }) => {
 
           return (
             <BorderedRadio
-              data-testid="shipping-quotes"
               value={shippingQuote?.id}
               key={shippingQuote?.id}
               position="relative"


### PR DESCRIPTION
The type of this PR is: **fix** #minor

This PR is related to [EMI-1516]. A data-testid attribute is sent to the wrong element, causing tests to fail.

[EMI-1516]: https://artsyproduct.atlassian.net/browse/EMI-1516?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ