### PR TITLE
ci(test): fix jest error output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
           command: |
             yarn test --reporters=default --reporters=jest-junit --shard=$(expr $CIRCLE_NODE_INDEX + 1)/$CIRCLE_NODE_TOTAL
           environment:
-            JEST_JUNIT_OUTPUT_DIR: reports
+            JEST_JUNIT_OUTPUT_DIR: reports/junit
             JEST_JUNIT_ADD_FILE_ATTRIBUTE: "true"
       - store_artifacts:
           path: ./reports/junit/
@@ -301,8 +301,10 @@ workflows:
           project-name: force
           executor: hokusai/beta
           requires:
+            - build-and-push-docker
             - type-check
             - test
+            - smoke-tests
           post-steps:
             - slack/notify:
                 event: fail

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,9 +70,9 @@ jobs:
             JEST_JUNIT_OUTPUT_DIR: reports
             JEST_JUNIT_ADD_FILE_ATTRIBUTE: "true"
       - store_artifacts:
-          path: /app/reports/junit/
+          path: ./reports/junit/
       - store_test_results:
-          path: /app/reports/junit/
+          path: ./reports/junit/
 
   smoke-tests:
     executor: cypress/default

--- a/src/Utils/__tests__/url.jest.ts
+++ b/src/Utils/__tests__/url.jest.ts
@@ -1,6 +1,7 @@
 import { getInternalHref, getURLHost } from "Utils/url"
 
-describe("getURLHost", () => {
+// eslint-disable-next-line jest/no-focused-tests
+describe.only("getURLHost", () => {
   it("returns host for url with host", () => {
     const url = "https://cms.artsy.net"
     expect(getURLHost(url)).toEqual("cms.artsy.net")

--- a/src/Utils/__tests__/url.jest.ts
+++ b/src/Utils/__tests__/url.jest.ts
@@ -1,7 +1,6 @@
 import { getInternalHref, getURLHost } from "Utils/url"
 
-// eslint-disable-next-line jest/no-focused-tests
-describe.only("getURLHost", () => {
+describe("getURLHost", () => {
   it("returns host for url with host", () => {
     const url = "https://cms.artsy.net"
     expect(getURLHost(url)).toEqual("cms.artsy.net")


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Fixes missing Jest error output from https://github.com/artsy/force/pull/14553, and also ensures that all required steps run before pushing a staging image. 

<img width="751" alt="Screenshot 2024-09-24 at 8 28 59 AM" src="https://github.com/user-attachments/assets/4c2bf552-e145-4d7a-987b-00aba3da66e5">

