### PR TITLE
fix: do not redirect to an artwork page when clicking on a save button and save button is not loaded yet

### DIFF
--- a/src/Components/Artwork/SaveButton/SaveButton.tsx
+++ b/src/Components/Artwork/SaveButton/SaveButton.tsx
@@ -56,6 +56,14 @@ export const SaveButtonBase: React.FC<SaveButtonBaseProps> = ({
     }
   }
 
+  const handleClick = (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => {
+    event.preventDefault()
+
+    onClick?.(event)
+  }
+
   return (
     <Flex alignItems="center">
       {shouldDisplayLotCount && (
@@ -71,7 +79,7 @@ export const SaveButtonBase: React.FC<SaveButtonBaseProps> = ({
         width={BTN_WIDTH}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
-        onClick={onClick}
+        onClick={handleClick}
       >
         {isSaved || isHovered ? (
           <HeartFillIcon


### PR DESCRIPTION
The type of this PR is: **FIX**

### Description

Recent integrity failures [uncovered](https://app.circleci.com/pipelines/github/artsy/integrity/25325/workflows/e6106519-afae-4dca-b27d-8a9baae2d526/jobs/124720/steps) a small issue with saves buttons. If user opens a page and clicks on a save page icon too fast (before query renderer is finished loading the data) - user gets redirected to an artwork page. Apparently this happens when there is a Clickable without onClick handler. When click happens - closest parent's onClick gets executed (sorry for confusing explanation). This PR should fix it - instead of redirecting a user to a separate page, nothing should happen. 