### PR TITLE
fix: use TTL of prefetched route, rather than current route, for setting max-age

### DIFF
--- a/src/System/Hooks/usePrefetchRoute.tsx
+++ b/src/System/Hooks/usePrefetchRoute.tsx
@@ -39,6 +39,7 @@ export const usePrefetchRoute = (
 
         const {
           match: { params },
+          route: { serverCacheTTL },
         } = foundRoute
 
         const {
@@ -63,6 +64,9 @@ export const usePrefetchRoute = (
           fetchPolicy: "store-or-network",
           networkCacheConfig: {
             force: false,
+            metadata: {
+              maxAge: serverCacheTTL,
+            },
           },
         }).subscribe({
           start: () => {


### PR DESCRIPTION
Noticing this, when we prefetch, we need to inject the custom TTL (if any).

Then, in middleware, if we're in the pre-fetch context we propagate that TTL (even if there was none set). Without any `max-age` we'd default to the worker 1 hour.