### PR TITLE
chore: remove unused x-relay cache headers

### DIFF
--- a/src/System/Relay/middleware/__tests__/cacheHeaderMiddleware.jest.ts
+++ b/src/System/Relay/middleware/__tests__/cacheHeaderMiddleware.jest.ts
@@ -23,34 +23,6 @@ describe("cacheHeaderMiddleware", () => {
     jest.clearAllMocks()
   })
 
-  it("should add x-relay-cache-config header", async () => {
-    next.mockResolvedValue({ status: 200 })
-
-    const middleware = cacheHeaderMiddleware()(next)
-    const res = await middleware(req)
-
-    expect(req.fetchOpts.headers["x-relay-cache-config"]).toBe(
-      JSON.stringify(req.cacheConfig)
-    )
-    expect(next).toHaveBeenCalledWith(req)
-    expect(res).toEqual({ status: 200 })
-  })
-
-  it("should add x-relay-cache-path header", async () => {
-    jest.spyOn(window as any, "location", "get").mockImplementation(() => ({
-      pathname: "/foo",
-    }))
-
-    next.mockResolvedValue({ status: 200 })
-
-    const middleware = cacheHeaderMiddleware()(next)
-    const res = await middleware(req)
-
-    expect(req.fetchOpts.headers["x-relay-cache-path"]).toBe("/foo")
-    expect(next).toHaveBeenCalledWith(req)
-    expect(res).toEqual({ status: 200 })
-  })
-
   describe("Cache-Control headers", () => {
     describe("allowing a request to be cached by the CDN", () => {
       it("allows caching even when logged in if the @cacheable directive was used", async () => {

--- a/src/System/Relay/middleware/cacheHeaderMiddleware.ts
+++ b/src/System/Relay/middleware/cacheHeaderMiddleware.ts
@@ -6,9 +6,6 @@ import {
 } from "System/Relay/isRequestCacheable"
 import { findRoutesByPath } from "System/Router/Utils/routeUtils"
 
-export const RELAY_CACHE_CONFIG_HEADER_KEY = "x-relay-cache-config"
-export const RELAY_CACHE_PATH_HEADER_KEY = "x-relay-cache-path"
-
 interface CacheHeaderMiddlewareProps {
   url?: string | null
   user: User
@@ -57,21 +54,6 @@ export const cacheHeaderMiddleware = (props?: CacheHeaderMiddlewareProps) => {
   return next => async req => {
     const url = isServer ? props?.url : window.location.pathname
 
-    const cacheHeaders = {
-      [RELAY_CACHE_CONFIG_HEADER_KEY]: JSON.stringify(req.cacheConfig),
-    }
-
-    /**
-     * We need to dynamically set a path header, because after the SSR pass we
-     * only have access to the initial req.url _entrypoint_; from there our
-     * client-side SPA intializes, which manages URL updates. Setting headers
-     * at the relay network level lets us configure queries to be sent to the
-     * graphql backend and CDN.
-     */
-    if (url) {
-      cacheHeaders[RELAY_CACHE_PATH_HEADER_KEY] = url
-    }
-
     const cacheControlHeader = (() => {
       const foundRoute = findRoutesByPath({ path: url ?? "" })[0]
 
@@ -100,7 +82,6 @@ export const cacheHeaderMiddleware = (props?: CacheHeaderMiddlewareProps) => {
 
     req.fetchOpts.headers = {
       ...req.fetchOpts.headers,
-      ...cacheHeaders,
       ...cacheControlHeader,
     }
 


### PR DESCRIPTION
Little cleanup now that the caching behavior in Force that used this is gone. We're actually setting these headers and sending them off on MP/CDN requests (not that it matters there, just we don't need to).