### PR TITLE
fix: fix 500 when creating artworks list (saves)

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves/CollectorProfileSavesRoute.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves/CollectorProfileSavesRoute.tsx
@@ -1,6 +1,5 @@
-import { Shelf, Spacer } from "@artsy/palette"
+import { Spacer } from "@artsy/palette"
 import { ArtworkListsHeader } from "./Components/ArtworkListsHeader"
-import { ArtworkListItemFragmentContainer } from "./Components/ArtworkListItem"
 import { FC, useEffect, useMemo, useRef } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useRouter } from "System/Hooks/useRouter"
@@ -15,6 +14,11 @@ import { Jump } from "Utils/Hooks/useJump"
 import { ArtworkListVisibilityProvider } from "Apps/CollectorProfile/Routes/Saves/Utils/useArtworkListVisibility"
 import { SavesArtworks } from "Apps/CollectorProfile/Routes/Saves/Components/SavesArtworks"
 import { SavesArtworksHeaderQueryRenderer } from "Apps/CollectorProfile/Routes/Saves/Components/SavesArtworksHeader"
+import {
+  ArtworkListItemsList,
+  ArtworkListItemsListPlaceholder,
+} from "Apps/CollectorProfile/Routes/Saves/Components/ArtworkListItemsList"
+import { ClientSuspense } from "Components/ClientSuspense"
 
 export const ARTWORK_LIST_SCROLL_TARGET_ID = "ArtworkListScrollTarget"
 
@@ -106,21 +110,9 @@ const CollectorProfileSavesRoute: FC<CollectorProfileSavesRouteProps> = ({
 
       <Spacer y={4} />
 
-      <Shelf>
-        {artworkLists.map(artworkList => {
-          const isDefaultArtworkList =
-            artworkList.internalID === savedArtworksArtworkList?.internalID
-
-          return (
-            <ArtworkListItemFragmentContainer
-              key={artworkList.internalID}
-              item={artworkList}
-              isSelected={artworkList.internalID === selectedArtworkListId}
-              imagesLayout={isDefaultArtworkList ? "grid" : "stacked"}
-            />
-          )
-        })}
-      </Shelf>
+      <ClientSuspense fallback={<ArtworkListItemsListPlaceholder />}>
+        <ArtworkListItemsList />
+      </ClientSuspense>
 
       <Spacer y={4} />
 

--- a/src/Apps/CollectorProfile/Routes/Saves/Components/ArtworkListItemsList.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves/Components/ArtworkListItemsList.tsx
@@ -1,0 +1,112 @@
+import { Shelf, SkeletonBox } from "@artsy/palette"
+import { ArtworkListItemFragmentContainer } from "Apps/CollectorProfile/Routes/Saves/Components/ArtworkListItem"
+import { FC, useRef } from "react"
+import { graphql, useLazyLoadQuery } from "react-relay"
+import { useRouter } from "System/Hooks/useRouter"
+import { extractNodes } from "Utils/extractNodes"
+import { ArtworkListItemsListQuery } from "__generated__/ArtworkListItemsListQuery.graphql"
+import { times } from "lodash"
+
+export const ArtworkListItemsList: FC = () => {
+  const { me } = useLazyLoadQuery<ArtworkListItemsListQuery>(query, {})
+
+  const {
+    match: { params },
+  } = useRouter()
+
+  const initialArtworkListId = useRef(params.id)
+
+  if (!me) {
+    return null
+  }
+
+  const savedArtworksArtworkList = me.savedArtworksArtworkList
+  const selectedArtworkListId =
+    params.id ?? savedArtworksArtworkList?.internalID
+
+  // FIXME: Avoid mutation directly in a render function
+  let customArtworkLists = extractNodes(me.customArtworkLists)
+
+  if (initialArtworkListId.current !== undefined) {
+    const index = customArtworkLists.findIndex(
+      artworkList => artworkList.internalID === initialArtworkListId.current
+    )
+
+    if (index !== -1) {
+      // Remove the initial artwork list from array
+      const initialArtworkList = customArtworkLists.splice(index, 1)
+
+      // "Locking" the initial artwork list in the first slot
+      customArtworkLists = [...initialArtworkList, ...customArtworkLists]
+    }
+  }
+
+  // Always display "Saved Artworks" artwork list first in the list
+  const artworkLists = savedArtworksArtworkList
+    ? [savedArtworksArtworkList, ...customArtworkLists]
+    : customArtworkLists
+
+  return (
+    <Shelf>
+      {artworkLists.map(artworkList => {
+        const isDefaultArtworkList =
+          artworkList.internalID === savedArtworksArtworkList?.internalID
+
+        return (
+          <ArtworkListItemFragmentContainer
+            key={artworkList.internalID}
+            item={artworkList}
+            isSelected={artworkList.internalID === selectedArtworkListId}
+            imagesLayout={isDefaultArtworkList ? "grid" : "stacked"}
+          />
+        )
+      })}
+    </Shelf>
+  )
+}
+
+const query = graphql`
+  query ArtworkListItemsListQuery {
+    me {
+      savedArtworksArtworkList: collection(id: "saved-artwork") {
+        internalID
+        ...ArtworkListItem_item
+      }
+
+      customArtworkLists: collectionsConnection(
+        first: 30
+        default: false
+        saves: true
+        sort: CREATED_AT_DESC
+      )
+        @connection(
+          key: "CollectorProfileSavesRoute_customArtworkLists"
+          filters: []
+        ) {
+        edges {
+          node {
+            internalID
+            ...ArtworkListItem_item
+          }
+        }
+      }
+    }
+  }
+`
+
+export const ArtworkListItemsListPlaceholder: FC = () => {
+  return (
+    <Shelf>
+      {times(3).map((_, index) => (
+        <SkeletonBox
+          p={1}
+          width={[138, 222]}
+          height={[188, 272]}
+          flexDirection="column"
+          justifyContent="space-between"
+          key={`artwork-list-item-placeholder-${index}`}
+        />
+      ))}
+    </Shelf>
+  )
+}

--- a/src/__generated__/ArtworkListItemsListQuery.graphql.ts
+++ b/src/__generated__/ArtworkListItemsListQuery.graphql.ts
@@ -1,0 +1,409 @@
+/**
+ * @generated SignedSource<<b4eac44e957e88c5ee96e78f29045b06>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest, Query } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ArtworkListItemsListQuery$variables = Record<PropertyKey, never>;
+export type ArtworkListItemsListQuery$data = {
+  readonly me: {
+    readonly customArtworkLists: {
+      readonly edges: ReadonlyArray<{
+        readonly node: {
+          readonly internalID: string;
+          readonly " $fragmentSpreads": FragmentRefs<"ArtworkListItem_item">;
+        } | null | undefined;
+      } | null | undefined> | null | undefined;
+    } | null | undefined;
+    readonly savedArtworksArtworkList: {
+      readonly internalID: string;
+      readonly " $fragmentSpreads": FragmentRefs<"ArtworkListItem_item">;
+    } | null | undefined;
+  } | null | undefined;
+};
+export type ArtworkListItemsListQuery = {
+  response: ArtworkListItemsListQuery$data;
+  variables: ArtworkListItemsListQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "saved-artwork"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v2 = {
+  "args": null,
+  "kind": "FragmentSpread",
+  "name": "ArtworkListItem_item"
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cursor",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "PageInfo",
+  "kind": "LinkedField",
+  "name": "pageInfo",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "endCursor",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "hasNextPage",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "default",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Literal",
+      "name": "onlyVisible",
+      "value": true
+    }
+  ],
+  "kind": "ScalarField",
+  "name": "artworksCount",
+  "storageKey": "artworksCount(onlyVisible:true)"
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "shareableWithPartners",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": [
+    {
+      "kind": "Literal",
+      "name": "first",
+      "value": 4
+    }
+  ],
+  "concreteType": "ArtworkConnection",
+  "kind": "LinkedField",
+  "name": "artworksConnection",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "ArtworkEdge",
+      "kind": "LinkedField",
+      "name": "edges",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Artwork",
+          "kind": "LinkedField",
+          "name": "node",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Image",
+              "kind": "LinkedField",
+              "name": "image",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": [
+                    {
+                      "kind": "Literal",
+                      "name": "version",
+                      "value": "square"
+                    }
+                  ],
+                  "kind": "ScalarField",
+                  "name": "url",
+                  "storageKey": "url(version:\"square\")"
+                }
+              ],
+              "storageKey": null
+            },
+            (v10/*: any*/)
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": "artworksConnection(first:4)"
+},
+v12 = [
+  {
+    "kind": "Literal",
+    "name": "default",
+    "value": false
+  },
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 30
+  },
+  {
+    "kind": "Literal",
+    "name": "saves",
+    "value": true
+  },
+  {
+    "kind": "Literal",
+    "name": "sort",
+    "value": "CREATED_AT_DESC"
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ArtworkListItemsListQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": "savedArtworksArtworkList",
+            "args": (v0/*: any*/),
+            "concreteType": "Collection",
+            "kind": "LinkedField",
+            "name": "collection",
+            "plural": false,
+            "selections": [
+              (v1/*: any*/),
+              (v2/*: any*/)
+            ],
+            "storageKey": "collection(id:\"saved-artwork\")"
+          },
+          {
+            "alias": "customArtworkLists",
+            "args": null,
+            "concreteType": "CollectionsConnection",
+            "kind": "LinkedField",
+            "name": "__CollectorProfileSavesRoute_customArtworkLists_connection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "CollectionsEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Collection",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v1/*: any*/),
+                      (v2/*: any*/),
+                      (v3/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  (v4/*: any*/)
+                ],
+                "storageKey": null
+              },
+              (v5/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "ArtworkListItemsListQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": "savedArtworksArtworkList",
+            "args": (v0/*: any*/),
+            "concreteType": "Collection",
+            "kind": "LinkedField",
+            "name": "collection",
+            "plural": false,
+            "selections": [
+              (v1/*: any*/),
+              (v6/*: any*/),
+              (v7/*: any*/),
+              (v8/*: any*/),
+              (v9/*: any*/),
+              (v11/*: any*/),
+              (v10/*: any*/)
+            ],
+            "storageKey": "collection(id:\"saved-artwork\")"
+          },
+          {
+            "alias": "customArtworkLists",
+            "args": (v12/*: any*/),
+            "concreteType": "CollectionsConnection",
+            "kind": "LinkedField",
+            "name": "collectionsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "CollectionsEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Collection",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v1/*: any*/),
+                      (v6/*: any*/),
+                      (v7/*: any*/),
+                      (v8/*: any*/),
+                      (v9/*: any*/),
+                      (v11/*: any*/),
+                      (v10/*: any*/),
+                      (v3/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  (v4/*: any*/)
+                ],
+                "storageKey": null
+              },
+              (v5/*: any*/)
+            ],
+            "storageKey": "collectionsConnection(default:false,first:30,saves:true,sort:\"CREATED_AT_DESC\")"
+          },
+          {
+            "alias": "customArtworkLists",
+            "args": (v12/*: any*/),
+            "filters": [],
+            "handle": "connection",
+            "key": "CollectorProfileSavesRoute_customArtworkLists",
+            "kind": "LinkedHandle",
+            "name": "collectionsConnection"
+          },
+          (v10/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "14d5f7eb655a8dadb1d4236864e13c76",
+    "id": null,
+    "metadata": {
+      "connection": [
+        {
+          "count": null,
+          "cursor": null,
+          "direction": "forward",
+          "path": [
+            "me",
+            "customArtworkLists"
+          ]
+        }
+      ]
+    },
+    "name": "ArtworkListItemsListQuery",
+    "operationKind": "query",
+    "text": "query ArtworkListItemsListQuery {\n  me {\n    savedArtworksArtworkList: collection(id: \"saved-artwork\") {\n      internalID\n      ...ArtworkListItem_item\n      id\n    }\n    customArtworkLists: collectionsConnection(first: 30, default: false, saves: true, sort: CREATED_AT_DESC) {\n      edges {\n        node {\n          internalID\n          ...ArtworkListItem_item\n          id\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n    id\n  }\n}\n\nfragment ArtworkListItem_item on Collection {\n  default\n  name\n  internalID\n  artworksCount(onlyVisible: true)\n  shareableWithPartners\n  artworksConnection(first: 4) {\n    edges {\n      node {\n        image {\n          url(version: \"square\")\n        }\n        id\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "54f086769e0be92699bc6f2b474c0c0c";
+
+export default node;


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

When user creates a saves list (from `/favorites/saves`) - page fails with 500 error. Honestly idk what happens exactly, but the error suggest to wrap the section in Suspense. For that I had to extract the whole saves lists rail into a query renderer component.

| Before | After |
|---|---|
| <video src="https://github.com/user-attachments/assets/c1b5b56b-0d2e-43bb-9dc8-8b4042d79a90" /> | <video src="https://github.com/user-attachments/assets/166aa1dd-b451-48ff-92fb-52c23380d102" /> |



