### PR TITLE
feat(EMI-2113): add payment failed status and link to order history

### DIFF
--- a/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchasesRow.tsx
+++ b/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchasesRow.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  Button,
   Column,
   EntityHeader,
   Flex,
@@ -77,7 +78,7 @@ const getPaymentMethodText = (
 }
 
 const getOrderLink = order => {
-  const isOrderActive = order.state !== "CANCELED" && order.state !== "REFUNDED"
+  const isOrderActive = !["CANCELED", "REFUNDED"].includes(order.state)
   const isOrderPaymentFailed = order.displayState === "PAYMENT_FAILED"
 
   if (isOrderPaymentFailed) {
@@ -199,17 +200,37 @@ const SettingsPurchasesRow: FC<SettingsPurchasesRowProps> = ({ order }) => {
         </Column>
 
         <Column span={6}>
-          <EntityHeader
-            href={artwork?.partner?.href ?? ""}
-            image={{
-              ...(artwork?.partner?.profile?.icon?.cropped ?? {}),
-              alt: "",
-              lazyLoad: true,
-            }}
-            initials={artwork?.partner?.initials ?? ""}
-            meta={artwork?.shippingOrigin?.replace(/, US/g, "")}
-            name={artwork?.partner?.name ?? ""}
-          />
+          <Flex
+            justifyContent="space-between"
+            alignItems={"left"}
+            flexDirection={["column", "row"]}
+          >
+            <EntityHeader
+              href={artwork?.partner?.href ?? ""}
+              image={{
+                ...(artwork?.partner?.profile?.icon?.cropped ?? {}),
+                alt: "",
+                lazyLoad: true,
+              }}
+              initials={artwork?.partner?.initials ?? ""}
+              meta={artwork?.shippingOrigin?.replace(/, US/g, "")}
+              name={artwork?.partner?.name ?? ""}
+            />
+
+            {order.displayState === "PAYMENT_FAILED" && (
+              <Button
+                // @ts-ignore
+                as={RouterLink}
+                to={`/orders/${order.internalID}/payment/new`}
+                variant="primaryBlack"
+                size="large"
+                width="50%"
+                mt={[1, 0]}
+              >
+                Update Payment Method
+              </Button>
+            )}
+          </Flex>
         </Column>
 
         <Column span={12}>

--- a/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchasesRow.tsx
+++ b/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchasesRow.tsx
@@ -34,6 +34,7 @@ const ORDER_LABELS = {
   REFUNDED: "Refunded",
   SUBMITTED: "Pending",
   PROCESSING_APPROVAL: "Payment processing",
+  PAYMENT_FAILED: "Payment failed",
 } as const
 
 const ORDER_ICONS = {
@@ -45,6 +46,7 @@ const ORDER_ICONS = {
   REFUNDED: <CloseStrokeIcon fill="red100" />,
   SUBMITTED: <PendingIcon fill="black60" />,
   PROCESSING_APPROVAL: <PendingIcon fill="black60" />,
+  PAYMENT_FAILED: null,
 } as const
 
 const ORDER_COLORS = {
@@ -56,6 +58,7 @@ const ORDER_COLORS = {
   REFUNDED: "red100",
   SUBMITTED: "black60",
   PROCESSING_APPROVAL: "black60",
+  PAYMENT_FAILED: "red100",
 } as const
 
 const getPaymentMethodText = (
@@ -73,6 +76,29 @@ const getPaymentMethodText = (
   }
 }
 
+const getOrderLink = order => {
+  const isOrderActive = order.state !== "CANCELED" && order.state !== "REFUNDED"
+  const isOrderPaymentFailed = order.displayState === "PAYMENT_FAILED"
+
+  if (isOrderPaymentFailed) {
+    return (
+      <RouterLink inline to={`/orders/${order.internalID}/payment/new`}>
+        {order.code}
+      </RouterLink>
+    )
+  }
+
+  if (isOrderActive) {
+    return (
+      <RouterLink inline to={`/orders/${order.internalID}/status`}>
+        {order.code}
+      </RouterLink>
+    )
+  }
+
+  return <>{order.code}</>
+}
+
 interface SettingsPurchasesRowProps {
   order: SettingsPurchasesRow_order$data
 }
@@ -83,7 +109,6 @@ const SettingsPurchasesRow: FC<SettingsPurchasesRowProps> = ({ order }) => {
   const { requestedFulfillment } = order
 
   const orderCreatedAt = DateTime.fromISO(order.createdAt)
-  const isOrderActive = order.state !== "CANCELED" && order.state !== "REFUNDED"
   const trackingId = fulfillments?.edges?.[0]?.node?.trackingId
   const image = artworkVersion?.image?.cropped
 
@@ -148,7 +173,7 @@ const SettingsPurchasesRow: FC<SettingsPurchasesRowProps> = ({ order }) => {
           <Box ml={1}>
             <Text variant="sm-display">
               <RouterLink
-                to={artwork?.artists?.[0]?.href!}
+                to={artwork?.artists?.[0]?.href}
                 display="block"
                 textDecoration="none"
               >
@@ -161,7 +186,7 @@ const SettingsPurchasesRow: FC<SettingsPurchasesRowProps> = ({ order }) => {
                 artwork?.title
               ) : (
                 <RouterLink
-                  to={artwork?.href!}
+                  to={artwork?.href}
                   display="block"
                   color="black60"
                   textDecoration="none"
@@ -175,15 +200,15 @@ const SettingsPurchasesRow: FC<SettingsPurchasesRowProps> = ({ order }) => {
 
         <Column span={6}>
           <EntityHeader
-            href={artwork?.partner?.href!}
+            href={artwork?.partner?.href ?? ""}
             image={{
               ...(artwork?.partner?.profile?.icon?.cropped ?? {}),
               alt: "",
               lazyLoad: true,
             }}
-            initials={artwork?.partner?.initials!}
+            initials={artwork?.partner?.initials ?? ""}
             meta={artwork?.shippingOrigin?.replace(/, US/g, "")}
-            name={artwork?.partner?.name!}
+            name={artwork?.partner?.name ?? ""}
           />
         </Column>
 
@@ -195,13 +220,7 @@ const SettingsPurchasesRow: FC<SettingsPurchasesRowProps> = ({ order }) => {
           <Text variant="sm-display">Order No.</Text>
 
           <Text variant="sm-display" color="black60">
-            {isOrderActive ? (
-              <RouterLink inline to={`/orders/${order.internalID}/status`}>
-                {order.code}
-              </RouterLink>
-            ) : (
-              order.code
-            )}
+            {getOrderLink(order)}
           </Text>
         </Column>
 

--- a/src/Apps/Settings/Routes/Purchases/Components/__tests__/SettingsPurchases.jest.tsx
+++ b/src/Apps/Settings/Routes/Purchases/Components/__tests__/SettingsPurchases.jest.tsx
@@ -75,7 +75,7 @@ describe("SettingsPurchases", () => {
       expect(screen.getByText("Payment failed")).toBeInTheDocument()
     })
 
-    it("renders link to enter new payment", () => {
+    it("renders the order number with a link to enter new payment", () => {
       renderWithRelay({
         Me: () => ({
           orders: {
@@ -96,6 +96,31 @@ describe("SettingsPurchases", () => {
       const link = screen.getByRole("link", { name: /123/i })
       expect(link).toBeInTheDocument()
       expect(link).toHaveAttribute("href", "/orders/123/payment/new")
+    })
+
+    it("renders a button to update payment method", () => {
+      renderWithRelay({
+        Me: () => ({
+          orders: {
+            edges: [
+              {
+                node: {
+                  code: "123",
+                  internalID: "123",
+                  state: "SUBMITTED",
+                  displayState: "PAYMENT_FAILED",
+                },
+              },
+            ],
+          },
+        }),
+      })
+
+      const button = screen.getByRole("link", {
+        name: /Update Payment Method/i,
+      })
+      expect(button).toBeInTheDocument()
+      expect(button).toHaveAttribute("href", "/orders/123/payment/new")
     })
   })
 })

--- a/src/Apps/Settings/Routes/Purchases/Components/__tests__/SettingsPurchases.jest.tsx
+++ b/src/Apps/Settings/Routes/Purchases/Components/__tests__/SettingsPurchases.jest.tsx
@@ -53,4 +53,49 @@ describe("SettingsPurchases", () => {
       expect(screen.getByText("privatesales@artsy.net")).toBeInTheDocument()
     })
   })
+
+  describe("order payment failed", () => {
+    it("renders payment failed status", () => {
+      renderWithRelay({
+        Me: () => ({
+          orders: {
+            edges: [
+              {
+                node: {
+                  code: "123",
+                  state: "SUBMITTED",
+                  displayState: "PAYMENT_FAILED",
+                },
+              },
+            ],
+          },
+        }),
+      })
+
+      expect(screen.getByText("Payment failed")).toBeInTheDocument()
+    })
+
+    it("renders link to enter new payment", () => {
+      renderWithRelay({
+        Me: () => ({
+          orders: {
+            edges: [
+              {
+                node: {
+                  code: "123",
+                  internalID: "123",
+                  state: "SUBMITTED",
+                  displayState: "PAYMENT_FAILED",
+                },
+              },
+            ],
+          },
+        }),
+      })
+
+      const link = screen.getByRole("link", { name: /123/i })
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute("href", "/orders/123/payment/new")
+    })
+  })
 })


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2113]

### Description

This allows the order history page to display "Payment failed" and links to add a new payment to the order history page when `displayState` is `PAYMENT_FAILED`. 

<!-- Implementation description -->
<img width="1741" alt="Screenshot 2024-09-26 at 12 31 20 PM" src="https://github.com/user-attachments/assets/9811bc5c-161e-430e-9c69-71ea47a2af8d">


https://github.com/user-attachments/assets/68aeb9d3-41da-478a-a31e-b0f4e858b664




[EMI-2113]: https://artsyproduct.atlassian.net/browse/EMI-2113?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ