### PR TITLE
fix(auth): adjusts re-captcha fallback behavior

### DIFF
--- a/src/Components/AuthDialog/AuthDialogContext.tsx
+++ b/src/Components/AuthDialog/AuthDialogContext.tsx
@@ -121,7 +121,7 @@ export const reducer = (state: State, action: Action): State => {
     }
 
     case "FALLBACK": {
-      return { ...state, mode: "SignUp", isFallback: true }
+      return { ...state, mode: "Login", isFallback: true }
     }
 
     default: {


### PR DESCRIPTION
Apparently `fetchQuery` does not reject on GraphQL errors, only actual network errors. So:

* reCAPTCHA might fail; in which case it would reject/throw and you'd get the fallback
* If it does give you a token, _we_ might reject based on the score, in which case it would _not_ reject/throw, instead we'd assume that your account did not exist, not triggering the fallback.

There literally is no way to access the errors field when using `fetchQuery`, as far as I can tell. So we just have to assume that the absence of a response at all is failing.

I've also switched the fallback state to default to the login, since that seems to be what's desirable most of the time.

* `verifyUser: null` = failed reCAPTCHA, fallback to login
* `verifyUser: { exists: true }` = go to login
* `verifyUser: { exists: false }` = go to sign up