### PR TITLE
feat(router-link): Add enablePrefetch flag to link

### DIFF
--- a/src/Apps/Conversations/components/ConversationHeader.tsx
+++ b/src/Apps/Conversations/components/ConversationHeader.tsx
@@ -91,7 +91,7 @@ export const ConversationHeader: React.FC<ConversationHeaderProps> = ({
   return (
     <>
       {/* Desktop view */}
-      <Media greaterThan="sm">
+      <Media greaterThan="xs">
         <Box
           p={2}
           borderBottom="1px solid"
@@ -146,7 +146,7 @@ export const ConversationHeader: React.FC<ConversationHeaderProps> = ({
       </Media>
 
       {/* Mobile view */}
-      <Media lessThan="md">
+      <Media lessThan="sm">
         <Box
           px={2}
           py={1}

--- a/src/Apps/Conversations/components/Details/OrderInformation/ReviewOrderButton.tsx
+++ b/src/Apps/Conversations/components/Details/OrderInformation/ReviewOrderButton.tsx
@@ -84,6 +84,7 @@ export const ReviewOrderButton: React.FC<ReviewOrderButtonProps> = ({
   return (
     <RouterLink
       to={`/orders/${data.id}/status?backToConversationId=${match.params.conversationId}`}
+      enablePrefetch={false}
       onClick={() =>
         trackEvent({
           action: "Click",

--- a/src/Apps/Conversations/components/Sidebar/ConversationsSidebarItem.tsx
+++ b/src/Apps/Conversations/components/Sidebar/ConversationsSidebarItem.tsx
@@ -67,6 +67,7 @@ export const ConversationsSidebarItem: React.FC<ConversationsSidebarItemProps> =
             ? `sidebarTotal=${getSidebarTotal()}`
             : ""
         }`}
+        enablePrefetch={false}
         display="block"
         p={2}
         textDecoration="none"

--- a/src/Apps/Conversations/components/__tests__/ConversationHeader.jest.tsx
+++ b/src/Apps/Conversations/components/__tests__/ConversationHeader.jest.tsx
@@ -33,7 +33,7 @@ jest.mock("System/Hooks/useRouter", () => ({
 }))
 
 describe("ConversationDetails", () => {
-  let breakpoint: "md" | "sm"
+  let breakpoint: "md" | "sm" | "xs"
   const mockUseMobileLayoutActions = useMobileLayoutActions as jest.Mock
   const onGoToDetails = jest.fn()
   const mockTracking = useTracking as jest.Mock
@@ -120,7 +120,7 @@ describe("ConversationDetails", () => {
 
   describe("sm breakpoint", () => {
     beforeEach(() => {
-      breakpoint = "sm"
+      breakpoint = "xs"
     })
 
     it("clicking collector's name goes to the conversations list", () => {

--- a/src/Components/NavBar/Menus/NavBarUserMenu.tsx
+++ b/src/Components/NavBar/Menus/NavBarUserMenu.tsx
@@ -66,6 +66,7 @@ export const NavBarUserMenu: React.FC<NavBarUserMenuProps> = props => {
           aria-label="View your collected artworks"
           to="/collector-profile/my-collection"
           onClick={trackClick}
+          enablePrefetch={false}
           gap={1}
         >
           <Suspense fallback={<NavBarUserMenuAvatarSkeleton />}>
@@ -94,6 +95,7 @@ export const NavBarUserMenu: React.FC<NavBarUserMenuProps> = props => {
         aria-label="View your collected artworks"
         to="/collector-profile/my-collection"
         onClick={trackClick}
+        enablePrefetch={false}
       >
         <ArtworkIcon mr={1} aria-hidden="true" /> Artworks
       </NavBarMenuItemLink>
@@ -102,6 +104,7 @@ export const NavBarUserMenu: React.FC<NavBarUserMenuProps> = props => {
         aria-label="View your collected artists"
         to="/collector-profile/artists"
         onClick={trackClick}
+        enablePrefetch={false}
       >
         <GroupIcon mr={1} aria-hidden="true" /> Artists
       </NavBarMenuItemLink>
@@ -110,6 +113,7 @@ export const NavBarUserMenu: React.FC<NavBarUserMenuProps> = props => {
         aria-label="View your collection's insights"
         to="/collector-profile/insights"
         onClick={trackClick}
+        enablePrefetch={false}
       >
         <GraphIcon mr={1} aria-hidden="true" /> Insights
       </NavBarMenuItemLink>
@@ -127,6 +131,7 @@ export const NavBarUserMenu: React.FC<NavBarUserMenuProps> = props => {
           aria-label="View your Saves"
           to={BASE_SAVES_PATH}
           onClick={trackClick}
+          enablePrefetch={false}
         >
           <HeartStrokeIcon mr={1} aria-hidden="true" /> Saves
         </NavBarMenuItemLink>
@@ -139,6 +144,7 @@ export const NavBarUserMenu: React.FC<NavBarUserMenuProps> = props => {
           aria-label="View your Follows"
           to="/favorites/follows"
           onClick={trackClick}
+          enablePrefetch={false}
         >
           <CheckmarkStrokeIcon mr={1} aria-hidden="true" /> Follows
         </NavBarMenuItemLink>
@@ -151,6 +157,7 @@ export const NavBarUserMenu: React.FC<NavBarUserMenuProps> = props => {
           aria-label="View your alerts"
           to="/favorites/alerts"
           onClick={trackClick}
+          enablePrefetch={false}
         >
           <BellStrokeIcon mr={1} aria-hidden="true" /> Alerts
         </NavBarMenuItemLink>
@@ -159,14 +166,22 @@ export const NavBarUserMenu: React.FC<NavBarUserMenuProps> = props => {
       <Separator my={1} />
 
       {isAdmin && (
-        <NavBarMenuItemLink to={getENV("ADMIN_URL")} onClick={trackClick}>
+        <NavBarMenuItemLink
+          to={getENV("ADMIN_URL")}
+          onClick={trackClick}
+          enablePrefetch={false}
+        >
           <LockIcon mr={1} aria-hidden="true" />
           Admin
         </NavBarMenuItemLink>
       )}
 
       {(isAdmin || hasPartnerAccess) && (
-        <NavBarMenuItemLink to={getENV("CMS_URL")} onClick={trackClick}>
+        <NavBarMenuItemLink
+          to={getENV("CMS_URL")}
+          onClick={trackClick}
+          enablePrefetch={false}
+        >
           <LockIcon mr={1} aria-hidden="true" />
           CMS
         </NavBarMenuItemLink>
@@ -176,6 +191,7 @@ export const NavBarUserMenu: React.FC<NavBarUserMenuProps> = props => {
         aria-label="Edit your settings"
         to="/settings/edit-profile"
         onClick={trackClick}
+        enablePrefetch={false}
       >
         <SettingsIcon mr={1} aria-hidden="true" /> Settings
       </NavBarMenuItemLink>
@@ -184,6 +200,7 @@ export const NavBarUserMenu: React.FC<NavBarUserMenuProps> = props => {
         aria-label="View your purchases"
         to="/settings/purchases"
         onClick={trackClick}
+        enablePrefetch={false}
       >
         <BagIcon mr={1} aria-hidden="true" />
         Order History

--- a/src/System/Components/RouterLink.tsx
+++ b/src/System/Components/RouterLink.tsx
@@ -27,17 +27,20 @@ export type RouterLinkProps = Omit<
     to: string | null | undefined
     textDecoration?: ResponsiveValue<string>
     inline?: boolean
+    enablePrefetch?: boolean
   }
 
 export const RouterLink: React.FC<RouterLinkProps> = React.forwardRef(
-  ({ inline, to, ...rest }, _ref) => {
+  ({ inline, to, enablePrefetch = true, ...rest }, _ref) => {
     const systemContext = useSystemContext()
     const { router } = useRouter()
 
     // Right now, prefetching on viewport enter is only enabled for logged-in users
     // TODO: Remove feature flag
     const isPrefetchOnEnterEnabled =
-      useFeatureFlag("diamond_prefetch-on-enter") && !!systemContext?.user
+      useFeatureFlag("diamond_prefetch-on-enter") &&
+      enablePrefetch &&
+      !!systemContext?.user
 
     const { prefetch } = usePrefetchRoute(to as string)
 
@@ -66,7 +69,9 @@ export const RouterLink: React.FC<RouterLinkProps> = React.forwardRef(
     })
 
     const handleMouseOver = () => {
-      prefetch()
+      if (enablePrefetch) {
+        prefetch()
+      }
     }
 
     if (isRouterAware) {


### PR DESCRIPTION
The type of this PR is: **Feat**

### Description

Adds the ability to toggle off link prefetching via `prefetchEnabled` prop on RouterLink, and disables for admin items. Also guards against erronious queries to the user menu. Not sure if that fixes anything related to [this reported issue](https://artsy.slack.com/archives/C03N12SR0RK/p1727365743754609) as I cannot reproduce, but lets just be safe. 
