### PR TITLE
feat: separate quick filter menus from featured keywords

### DIFF
--- a/src/Components/ArtworkFilter/ArtworkFiltersQuick/FeaturedKeywordsFilterQuick.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFiltersQuick/FeaturedKeywordsFilterQuick.tsx
@@ -1,6 +1,6 @@
 import { FC } from "react"
 import { useArtworkFilterContext } from "Components/ArtworkFilter/ArtworkFilterContext"
-import { Pill } from "@artsy/palette"
+import { Box, Pill, Spacer } from "@artsy/palette"
 
 export interface FeaturedKeywordsFilterQuickProps {
   featuredKeywords: readonly string[] | null | undefined
@@ -16,6 +16,10 @@ export const FeaturedKeywordsFilterQuick: FC<FeaturedKeywordsFilterQuickProps> =
   if (!props.featuredKeywords || !props.featuredKeywords.length) return null
   return (
     <>
+      <Spacer y={2} />
+      <Box width="1px" bg="black30" />
+      <Spacer y={2} />
+
       {props.featuredKeywords.map((keyword, idx) => (
         <Pill
           key={idx}


### PR DESCRIPTION
Chatting with Ryan today, we puzzled over how to visually distinguish featured keywords, which operate almost as toggles, from the quick filter menus that expand. He's refining a few alternatives, but in the meantime we thought they should _at least_ be separated somehow. In this PR, I borrow the separator used on artists' artwork grids:

<img width="843" alt="Screenshot 2024-09-26 at 5 02 51 PM" src="https://github.com/user-attachments/assets/75e4a2e2-4129-47c8-9312-2860cde3137c">


Looks like:

<img width="1416" alt="Screenshot 2024-09-26 at 4 59 13 PM" src="https://github.com/user-attachments/assets/2d45ed3f-5d61-4a96-96a0-e7c96f68014c">

Q: should this separator and its spacing be elevated to Palette?