### PR TITLE
feat: update review app scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Force
 
-[Force](https://github.com/artsy/force) is the Artsy website, [www.artsy.net](https://www.artsy.net)..
+[Force](https://github.com/artsy/force) is the Artsy website, [www.artsy.net](https://www.artsy.net).
 
 Are you an Engineer? Don't know what Artsy is? Check out [this overview](https://github.com/artsy/README/blob/main/culture/what-is-artsy.md#readme) and [more](https://github.com/artsy/README/).
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Force
 
-[Force](https://github.com/artsy/force) is the Artsy website, [www.artsy.net](https://www.artsy.net).
+[Force](https://github.com/artsy/force) is the Artsy website, [www.artsy.net](https://www.artsy.net)..
 
 Are you an Engineer? Don't know what Artsy is? Check out [this overview](https://github.com/artsy/README/blob/main/culture/what-is-artsy.md#readme) and [more](https://github.com/artsy/README/).
 

--- a/scripts/build_review_app.sh
+++ b/scripts/build_review_app.sh
@@ -46,9 +46,6 @@ sed -i.bak "s/host: staging.artsy.net/host: $NAME.artsy.net/g" "$review_app_file
 # Provision the review app
 hokusai review_app create "$NAME" --verbose
 
-# Copy Force staging's ConfigMap to your review app
-hokusai review_app env copy "$NAME" --verbose
-
 # To enable authentication via Force's server, we need to allow XHR requests
 # from Force's client to server. As such, Force's server needs to have the
 # proper name of the domain that the requests are coming from. Otherwise,

--- a/scripts/update_review_app.sh
+++ b/scripts/update_review_app.sh
@@ -12,5 +12,5 @@ if test -z "$NAME"; then
 fi
 
 hokusai registry push --force --skip-latest --overwrite --verbose --tag "$NAME"
-hokusai review_app setup "$NAME"
+hokusai review_app create-yaml "$NAME"
 hokusai review_app deploy "$NAME" "$NAME"


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [PHIIRE-1236]

### Description

`scripts/update_review_app.sh` calls `hokusai review_app setup` only to create Yaml. Now there's a [hokusai review_app create-yaml](https://github.com/artsy/hokusai/pull/428) command. Let's switch to that.

`hokusai review_app env copy` command is [deprecated](https://github.com/artsy/hokusai/pull/426). Remove.
