### PR TITLE
chore: add icon to failed payment display on order history

### DIFF
--- a/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchasesRow.tsx
+++ b/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchasesRow.tsx
@@ -25,6 +25,7 @@ import CloseStrokeIcon from "@artsy/icons/CloseStrokeIcon"
 import HelpIcon from "@artsy/icons/HelpIcon"
 import CheckmarkFillIcon from "@artsy/icons/CheckmarkFillIcon"
 import PendingIcon from "@artsy/icons/PendingIcon"
+import AlertStrokeIcon from "@artsy/icons/AlertStrokeIcon"
 
 const ORDER_LABELS = {
   APPROVED: "Confirmed",
@@ -47,7 +48,7 @@ const ORDER_ICONS = {
   REFUNDED: <CloseStrokeIcon fill="red100" />,
   SUBMITTED: <PendingIcon fill="black60" />,
   PROCESSING_APPROVAL: <PendingIcon fill="black60" />,
-  PAYMENT_FAILED: null,
+  PAYMENT_FAILED: <AlertStrokeIcon fill="red100" />,
 } as const
 
 const ORDER_COLORS = {


### PR DESCRIPTION
Minor follow up for this one: https://artsyproduct.atlassian.net/browse/EMI-2113

Here how it looks with the icon:
<img width="1432" alt="Screenshot 2024-09-27 at 11 55 15 AM" src="https://github.com/user-attachments/assets/64b2fcaf-6528-4c01-806d-e2bd65855784">
