### PR TITLE
feat: remove caching from article(s), opt-out of CDN

### DIFF
--- a/src/Apps/Article/articleRoutes.tsx
+++ b/src/Apps/Article/articleRoutes.tsx
@@ -1,4 +1,5 @@
 import loadable from "@loadable/component"
+import { serverCacheTTLs } from "Apps/serverCacheTTLs"
 import { RedirectException, RouteRenderArgs } from "found"
 import { graphql } from "react-relay"
 import { RouteProps } from "System/Router/Route"
@@ -26,12 +27,13 @@ export const articleRoutes: RouteProps[] = [
       ArticleApp.preload()
     },
     query: graphql`
-      query articleRoutes_ArticleQuery($id: String!) @cacheable {
+      query articleRoutes_ArticleQuery($id: String!) {
         article(id: $id) @principalField {
           ...ArticleApp_article
         }
       }
     `,
+    serverCacheTTL: serverCacheTTLs.article,
   },
   { path: "/news/:id", render: redirectToArticle },
   { path: "/video/:id", render: redirectToArticle },

--- a/src/Apps/Articles/articlesRoutes.tsx
+++ b/src/Apps/Articles/articlesRoutes.tsx
@@ -1,4 +1,5 @@
 import loadable from "@loadable/component"
+import { serverCacheTTLs } from "Apps/serverCacheTTLs"
 import { graphql } from "react-relay"
 import { RouteProps } from "System/Router/Route"
 
@@ -24,12 +25,13 @@ export const articlesRoutes: RouteProps[] = [
       ArticlesApp.preload()
     },
     query: graphql`
-      query articlesRoutes_ArticlesQuery @cacheable {
+      query articlesRoutes_ArticlesQuery {
         viewer {
           ...ArticlesApp_viewer
         }
       }
     `,
+    serverCacheTTL: serverCacheTTLs.articles,
   },
   {
     path: "/news",
@@ -38,12 +40,13 @@ export const articlesRoutes: RouteProps[] = [
       NewsApp.preload()
     },
     query: graphql`
-      query articlesRoutes_NewsQuery @cacheable {
+      query articlesRoutes_NewsQuery {
         viewer {
           ...NewsApp_viewer
         }
       }
     `,
+    serverCacheTTL: serverCacheTTLs.articles,
   },
   {
     path: "/channel/:id",
@@ -52,11 +55,12 @@ export const articlesRoutes: RouteProps[] = [
       ChannelApp.preload()
     },
     query: graphql`
-      query articlesRoutes_ChannelQuery($id: ID!) @cacheable {
+      query articlesRoutes_ChannelQuery($id: ID!) {
         channel(id: $id) @principalField {
           ...ChannelApp_channel
         }
       }
     `,
+    serverCacheTTL: serverCacheTTLs.articles,
   },
 ]

--- a/src/Apps/serverCacheTTLs.tsx
+++ b/src/Apps/serverCacheTTLs.tsx
@@ -8,6 +8,8 @@ const HOURS_24 = 86400 // In seconds
  */
 export const serverCacheTTLs = {
   artist: HOURS_24,
+  article: NO_CACHE,
+  articles: NO_CACHE,
   artists: HOURS_24,
   artistSeries: HOURS_24,
   auction: NO_CACHE,

--- a/src/Apps/serverCacheTTLs.tsx
+++ b/src/Apps/serverCacheTTLs.tsx
@@ -1,5 +1,6 @@
 const NO_CACHE = 0
 const HOURS_24 = 86400 // In seconds
+const MINUTES_5 = 300 // In seconds
 
 /**
  * This defines non-default cache TTLs for specific routes. Default is typically
@@ -8,8 +9,8 @@ const HOURS_24 = 86400 // In seconds
  */
 export const serverCacheTTLs = {
   artist: HOURS_24,
-  article: NO_CACHE,
-  articles: NO_CACHE,
+  article: MINUTES_5,
+  articles: MINUTES_5,
   artists: HOURS_24,
   artistSeries: HOURS_24,
   auction: NO_CACHE,


### PR DESCRIPTION
Reported by Casey - the 60 minute default TTL at the CDN was asked to be removed in order to keep articles timely as news is published. My sense is most of the time it would have been _fine_ to enforce the TTL, but article pages don't appear to have any glaring performance issues according to DataDog, so this is fine.

Also, this would have been the behavior prior to these more recent caching experiments.