### PR TITLE
fix(dia-753): update meta descriptions to remove markdown syntax

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -12282,7 +12282,9 @@ type MarketingCollection implements Node {
   ): String
   credit: String
   description: String
+    @deprecated(reason: "Use `markdownDescription` field instead")
   descriptionMarkdown: String
+    @deprecated(reason: "Use `markdownDescription` field instead")
   featuredArtistExclusionIds: [String!]!
   geneIds: [String]
   headerImage: String
@@ -12298,6 +12300,7 @@ type MarketingCollection implements Node {
 
   # Linked Collections
   linkedCollections: [MarketingCollectionGroup!]!
+  markdownDescription(format: Format): String
   priceGuidance: Float
   query: MarketingCollectionQuery!
 

--- a/src/Apps/Collect/Routes/Collection/Components/Header/index.tsx
+++ b/src/Apps/Collect/Routes/Collection/Components/Header/index.tsx
@@ -59,7 +59,7 @@ export const CollectionHeaderFragmentContainer = createFragmentContainer(
     collection: graphql`
       fragment Header_collection on MarketingCollection {
         category
-        description
+        description: markdownDescription(format: HTML)
         id
         slug
         title

--- a/src/Apps/Collect/Routes/Collection/index.tsx
+++ b/src/Apps/Collect/Routes/Collection/index.tsx
@@ -38,13 +38,12 @@ export const CollectionApp: React.FC<CollectionAppProps> = props => {
 
   if (!collection) return <ErrorPage code={404} />
 
-  const { title, slug, headerImage, descriptionMarkdown } = collection
+  const { title, slug, headerImage, metaDescription } = collection
 
-  const metadataDescription = descriptionMarkdown
-    ? `Buy, bid, and inquire on ${title} on Artsy. ${truncate(
-        descriptionMarkdown,
-        { length: 158 }
-      )}`
+  const metadataDescription = metaDescription
+    ? `Buy, bid, and inquire on ${title} on Artsy. ${truncate(metaDescription, {
+        length: 158,
+      })}`
     : `Buy, bid, and inquire on ${title} on Artsy.`
 
   const socialImage = headerImage
@@ -166,7 +165,7 @@ export const CollectionFragmentContainer = createFragmentContainer(
     collection: graphql`
       fragment Collection_collection on MarketingCollection {
         ...Header_collection
-        descriptionMarkdown
+        metaDescription: markdownDescription(format: PLAIN)
         headerImage
         slug
         title

--- a/src/__generated__/Collection_collection.graphql.ts
+++ b/src/__generated__/Collection_collection.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<da402d0bd02e79b8cc21f065313ea9ec>>
+ * @generated SignedSource<<6883bc72872d0bbe893d14906c1a9467>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,8 +11,8 @@
 import { Fragment, ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type Collection_collection$data = {
-  readonly descriptionMarkdown: string | null | undefined;
   readonly headerImage: string | null | undefined;
+  readonly metaDescription: string | null | undefined;
   readonly showFeaturedArtists: boolean;
   readonly slug: string;
   readonly title: string;
@@ -36,11 +36,17 @@ const node: ReaderFragment = {
       "name": "Header_collection"
     },
     {
-      "alias": null,
-      "args": null,
+      "alias": "metaDescription",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "format",
+          "value": "PLAIN"
+        }
+      ],
       "kind": "ScalarField",
-      "name": "descriptionMarkdown",
-      "storageKey": null
+      "name": "markdownDescription",
+      "storageKey": "markdownDescription(format:\"PLAIN\")"
     },
     {
       "alias": null,
@@ -75,6 +81,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "0073995c658314c7475a9c2040915ab0";
+(node as any).hash = "905f79e256cd1be111ff963a159fa30d";
 
 export default node;

--- a/src/__generated__/Header_collection.graphql.ts
+++ b/src/__generated__/Header_collection.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8c989962d1ca18bb435e74202d1c9e62>>
+ * @generated SignedSource<<dae6245012dc29f8169b2d40819930d8>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -37,11 +37,17 @@ const node: ReaderFragment = {
       "storageKey": null
     },
     {
-      "alias": null,
-      "args": null,
+      "alias": "description",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "format",
+          "value": "HTML"
+        }
+      ],
       "kind": "ScalarField",
-      "name": "description",
-      "storageKey": null
+      "name": "markdownDescription",
+      "storageKey": "markdownDescription(format:\"HTML\")"
     },
     {
       "alias": null,
@@ -69,6 +75,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "c6b370ceb658f3c90555b3f2b2f9224d";
+(node as any).hash = "74cf06890d9a09b7ade06115aa46dde2";
 
 export default node;

--- a/src/__generated__/collectRoutes_CollectionQuery.graphql.ts
+++ b/src/__generated__/collectRoutes_CollectionQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<08efe62bde1356b2123f63db5ba4f3ca>>
+ * @generated SignedSource<<7decebe18a81246743eef915d83eeafc>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -87,11 +87,17 @@ return {
             "storageKey": null
           },
           {
-            "alias": null,
-            "args": null,
+            "alias": "description",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "format",
+                "value": "HTML"
+              }
+            ],
             "kind": "ScalarField",
-            "name": "description",
-            "storageKey": null
+            "name": "markdownDescription",
+            "storageKey": "markdownDescription(format:\"HTML\")"
           },
           {
             "alias": null,
@@ -115,11 +121,17 @@ return {
             "storageKey": null
           },
           {
-            "alias": null,
-            "args": null,
+            "alias": "metaDescription",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "format",
+                "value": "PLAIN"
+              }
+            ],
             "kind": "ScalarField",
-            "name": "descriptionMarkdown",
-            "storageKey": null
+            "name": "markdownDescription",
+            "storageKey": "markdownDescription(format:\"PLAIN\")"
           },
           {
             "alias": null,
@@ -141,12 +153,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4001b13ca012549b75086e23f183b73c",
+    "cacheID": "ba5f3b408393f1fe8869e50d1d1c3531",
     "id": null,
     "metadata": {},
     "name": "collectRoutes_CollectionQuery",
     "operationKind": "query",
-    "text": "query collectRoutes_CollectionQuery(\n  $slug: String!\n) {\n  collection: marketingCollection(slug: $slug) @principalField {\n    ...Collection_collection\n    id\n  }\n}\n\nfragment Collection_collection on MarketingCollection {\n  ...Header_collection\n  descriptionMarkdown\n  headerImage\n  slug\n  title\n  showFeaturedArtists\n}\n\nfragment Header_collection on MarketingCollection {\n  category\n  description\n  id\n  slug\n  title\n}\n"
+    "text": "query collectRoutes_CollectionQuery(\n  $slug: String!\n) {\n  collection: marketingCollection(slug: $slug) @principalField {\n    ...Collection_collection\n    id\n  }\n}\n\nfragment Collection_collection on MarketingCollection {\n  ...Header_collection\n  metaDescription: markdownDescription(format: PLAIN)\n  headerImage\n  slug\n  title\n  showFeaturedArtists\n}\n\nfragment Header_collection on MarketingCollection {\n  category\n  description: markdownDescription(format: HTML)\n  id\n  slug\n  title\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Closes [DIA-753](https://artsyproduct.atlassian.net/browse/DIA-753)

Depends on https://github.com/artsy/metaphysics/pull/6077

Once deployed we can circle back and make the change on the `description` field. The default format is just Markdown syntax not HTML.

[DIA-753]: https://artsyproduct.atlassian.net/browse/DIA-753?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ