### PR TITLE
fix(EMI-2123): dont redirect for displayState != submitted on payment failed route

### DIFF
--- a/src/Apps/Order/__tests__/OrderApp.jest.tsx
+++ b/src/Apps/Order/__tests__/OrderApp.jest.tsx
@@ -394,7 +394,7 @@ describe("OrderApp routing redirects", () => {
     expect(redirect.url).toBe("/orders/2939023/status")
   })
 
-  it("redirects to the new payment route if lastTransactionFailed failed on offer", async () => {
+  it("redirects to the new payment route if lastTransactionFailed failed on offer and state is submitted", async () => {
     const res = await render(
       "/orders/2939023/respond",
       mockResolver({

--- a/src/Apps/Order/redirects.tsx
+++ b/src/Apps/Order/redirects.tsx
@@ -118,12 +118,16 @@ const goToStatusIfOrderIsNotSubmitted = goToStatusIf(
 )
 
 const goToStatusIfNotLastTransactionFailed = goToStatusIf(
-  order => !order.lastTransactionFailed,
-  "Order's lastTransactionFailed must be true"
+  order => !(order.lastTransactionFailed && order.state === "SUBMITTED"),
+  "Order's lastTransactionFailed must be true + state submitted"
 )
 
 const goToNewPaymentIfOfferLastTransactionFailed = ({ order }) => {
-  if (order.mode === "OFFER" && order.lastTransactionFailed) {
+  if (
+    order.mode === "OFFER" &&
+    order.lastTransactionFailed &&
+    order.state === "SUBMITTED"
+  ) {
     return {
       path: `/orders/${order.internalID}/payment/new`,
       reason: "No payment has been successfully made",

--- a/src/Apps/Order/redirects.tsx
+++ b/src/Apps/Order/redirects.tsx
@@ -205,7 +205,6 @@ export const redirects: RedirectRecord<OrderQuery> = {
       path: "payment/new",
       rules: [
         goToStatusIfBuyNowCreditCardOrder,
-        goToStatusIfOrderIsNotSubmitted,
         goToStatusIfNotLastTransactionFailed,
       ],
     },


### PR DESCRIPTION
The type of this PR is: **fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2123]

### Description
We have a redirect rule which is incompatible with the new PAYMENT_FAILED display state. I don't think it is needed for this route but wouldn't mind a second set of eyes. Might need tests.

[EMI-2123]: https://artsyproduct.atlassian.net/browse/EMI-2123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ