### PR TITLE
chore(EMI-2132): remove secondary button from payment failed dialog

### DIFF
--- a/src/Apps/Order/Dialogs.tsx
+++ b/src/Apps/Order/Dialogs.tsx
@@ -81,7 +81,7 @@ export class DialogContainer extends Container<DialogState> {
     title,
     message,
     confirmButtonText = "Continue",
-    cancelButtonText = "Cancel",
+    cancelButtonText,
   }: {
     title: string
     message: React.ReactNode
@@ -107,10 +107,12 @@ export class DialogContainer extends Container<DialogState> {
             text: confirmButtonText,
             action: accept,
           },
-          secondaryCta: {
-            text: cancelButtonText,
-            action: reject,
-          },
+          secondaryCta: !!cancelButtonText
+            ? {
+                text: cancelButtonText,
+                action: reject,
+              }
+            : undefined,
           onClose: reject,
         },
         onForceClose: reject,

--- a/src/Apps/Order/Routes/Accept/index.tsx
+++ b/src/Apps/Order/Routes/Accept/index.tsx
@@ -194,7 +194,6 @@ export const Accept: FC<AcceptProps & StripeProps> = props => {
   }) => {
     const { confirmed } = await dialog.showConfirmDialog({
       ...props,
-      cancelButtonText: "OK",
       confirmButtonText: "Use new card",
     })
     if (confirmed) {


### PR DESCRIPTION
We noticed that in the 'update payment' flow if the new payment is failing as well we are displaying really confusing CTA. The easy solution was to at least remove extra CTA button that does not seem to add anything.

Before:
<img width="1393" alt="Screenshot 2024-10-01 at 11 25 11 AM" src="https://github.com/user-attachments/assets/d172218c-005b-45d1-a7a7-0fedadd673d1">

After:
<img width="616" alt="Screenshot 2024-10-02 at 1 10 25 PM" src="https://github.com/user-attachments/assets/4045245a-8c93-45c0-b9e7-05945a6baf2a">



