### PR TITLE
fix: en dash in date range for collector signals

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCollectorSignal.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCollectorSignal.tsx
@@ -83,7 +83,7 @@ export const ArtworkSidebarCollectorSignal: React.FC<ArtworkSidebarCollectorSign
         <FairIcon mr={1} mt={0.5} />
         <Stack gap={0}>
           <Text variant="sm" color="black100">
-            Showing now • {startAt}-{endAt}
+            Showing now • {startAt}–{endAt}
           </Text>
           <RouterLink to={data.collectorSignals?.runningShow?.href}>
             <Text variant="sm">{data.collectorSignals?.runningShow?.name}</Text>

--- a/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarDetails.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebarDetails.jest.tsx
@@ -238,7 +238,7 @@ describe("ArtworkSidebarDetails", () => {
       })
 
       expect(screen.queryByText(/Showing now/)).toBeInTheDocument()
-      expect(screen.queryByText(/Jun 17-Jun 20/)).toBeInTheDocument()
+      expect(screen.queryByText(/Jun 17–Jun 20/)).toBeInTheDocument()
       expect(screen.queryByText(/Art Basel/)).toBeInTheDocument()
     })
 


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2134]

### Description

Numeric and date ranges should always be punctuated with an en dash. 


(See [our guidelines](https://docs.google.com/document/d/1NoBSYM-EBA4b6rdux-8CQJWneXcglISHzZNvSkKFDh0/edit#bookmark=id.yw4t3wp6qe04) or [this reference](https://www.thepunctuationguide.com/en-dash.html))

| Before | After |
|--------|--------|
| ![before](https://github.com/user-attachments/assets/176e4272-2ac8-470e-93a0-9d98b3cc3414) | ![after](https://github.com/user-attachments/assets/4ea52502-26f3-47ac-b5e5-5e4c1904c22c) |




[EMI-2134]: https://artsyproduct.atlassian.net/browse/EMI-2134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ