### PR TITLE
feat: pods to load vars from vault [Do-Not-Merge]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ COPY --chown=deploy:deploy --from=builder-base /app/src ./src
 COPY --chown=deploy:deploy --from=builder-base /app/server.dist.js .
 COPY --chown=deploy:deploy --from=builder-base /app/server.dist.js.map .
 
-ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+ENTRYPOINT ["/usr/bin/dumb-init", "./load_secrets_and_run.sh"]
 
 # TODO: Reduce production memory, this is not a concern
 CMD ["node", "--max_old_space_size=2048", "--heapsnapshot-signal=SIGUSR2", "--no-experimental-fetch", "./server.dist.js"]

--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -30,6 +30,21 @@ spec:
       name: force-web
       namespace: default
     spec:
+      initContainers:
+      - name: setenv
+        image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:production
+        imagePullPolicy: Always
+        command:
+        - python
+        - src/load_secrets_from_vault/load.py
+        - production
+        - force
+        envFrom:
+        - configMapRef:
+            name: secrets-config
+        volumeMounts:
+        - name: secrets
+          mountPath: /secrets
       containers:
       - name: force-web
         env:
@@ -46,6 +61,10 @@ spec:
         envFrom:
         - configMapRef:
             name: force-environment
+        volumeMounts:
+        - name: secrets
+          mountPath: /secrets
+          readOnly: true
         image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/force:production
         imagePullPolicy: Always
         ports:
@@ -79,6 +98,7 @@ spec:
         options:
         - name: ndots
           value: '1'
+      serviceAccountName: force
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -88,6 +108,10 @@ spec:
                 operator: In
                 values:
                 - foreground
+      volumes:
+      - name: secrets
+        emptyDir: {}
+
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -119,6 +143,21 @@ spec:
       name: force-web-spotty
       namespace: default
     spec:
+      initContainers:
+      - name: setenv
+        image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:production
+        imagePullPolicy: Always
+        command:
+        - python
+        - src/load_secrets_from_vault/load.py
+        - production
+        - force
+        envFrom:
+        - configMapRef:
+            name: secrets-config
+        volumeMounts:
+        - name: secrets
+          mountPath: /secrets
       containers:
       - name: force-web-spotty
         env:
@@ -135,6 +174,10 @@ spec:
         envFrom:
         - configMapRef:
             name: force-environment
+        volumeMounts:
+        - name: secrets
+          mountPath: /secrets
+          readOnly: true
         image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/force:production
         imagePullPolicy: Always
         ports:
@@ -173,6 +216,7 @@ spec:
           operator: Equal
           value: spot
           effect: NoSchedule
+      serviceAccountName: force
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -191,6 +235,10 @@ spec:
                 operator: In
                 values:
                 - foreground-spot
+      volumes:
+      - name: secrets
+        emptyDir: {}
+
 ---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
@@ -214,6 +262,7 @@ spec:
         averageUtilization: 70
         type: Utilization
     type: Resource
+
 ---
 apiVersion: v1
 kind: Service
@@ -235,6 +284,7 @@ spec:
     layer: application
     component: web
   type: ClusterIP
+
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -30,6 +30,21 @@ spec:
       name: force-web
       namespace: default
     spec:
+      initContainers:
+      - name: setenv
+        image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:staging
+        imagePullPolicy: Always
+        command:
+        - python
+        - src/load_secrets_from_vault/load.py
+        - staging
+        - force
+        envFrom:
+        - configMapRef:
+            name: secrets-config
+        volumeMounts:
+        - name: secrets
+          mountPath: /secrets
       containers:
       - name: force-web
         env:
@@ -50,6 +65,10 @@ spec:
         envFrom:
         - configMapRef:
             name: force-environment
+        volumeMounts:
+        - name: secrets
+          mountPath: /secrets
+          readOnly: true
         image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/force:staging
         imagePullPolicy: Always
         ports:
@@ -82,6 +101,7 @@ spec:
         options:
         - name: ndots
           value: '1'
+      serviceAccountName: force
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -91,6 +111,10 @@ spec:
                 operator: In
                 values:
                 - foreground
+      volumes:
+      - name: secrets
+        emptyDir: {}
+
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -122,6 +146,21 @@ spec:
       name: force-web-spotty
       namespace: default
     spec:
+      initContainers:
+      - name: setenv
+        image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/opstools:staging
+        imagePullPolicy: Always
+        command:
+        - python
+        - src/load_secrets_from_vault/load.py
+        - staging
+        - force
+        envFrom:
+        - configMapRef:
+            name: secrets-config
+        volumeMounts:
+        - name: secrets
+          mountPath: /secrets
       containers:
       - name: force-web-spotty
         env:
@@ -142,6 +181,10 @@ spec:
         envFrom:
         - configMapRef:
             name: force-environment
+        volumeMounts:
+        - name: secrets
+          mountPath: /secrets
+          readOnly: true
         image: 585031190124.dkr.ecr.us-east-1.amazonaws.com/force:staging
         imagePullPolicy: Always
         ports:
@@ -179,6 +222,7 @@ spec:
           operator: Equal
           value: spot
           effect: NoSchedule
+      serviceAccountName: force
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -197,6 +241,10 @@ spec:
                 operator: In
                 values:
                 - foreground-spot
+      volumes:
+      - name: secrets
+        emptyDir: {}
+
 ---
 apiVersion: autoscaling/v2beta2
 kind: HorizontalPodAutoscaler
@@ -220,6 +268,7 @@ spec:
         averageUtilization: 70
         type: Utilization
     type: Resource
+
 ---
 apiVersion: v1
 kind: Service
@@ -241,6 +290,7 @@ spec:
     layer: application
     component: web
   type: ClusterIP
+
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/scripts/load_secrets_and_run.sh
+++ b/scripts/load_secrets_and_run.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+CMD="$@"
+
+if [ ! -z "$SECRETS_FILE" ]
+then
+  echo "SECRETS_FILE env var is defined. Sourcing secrets file..."
+  source "$SECRETS_FILE"
+fi
+
+echo "Running command: $CMD"
+$CMD


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [PHIRE-1095]

### Description

This PR introduces:

- Kubernetes initContainer which takes care of fetching vars from [Vault](https://www.notion.so/artsy/Hashicorp-Vault-developer-instructions-77d94af51f714d51bb44049f4f2027bc) and writing them to a file.
- Kubernetes serviceAccount which the initContainer uses to authenticate to Vault.
- A script that loads the vars from file into container ENV.

This is a big change. Please create a deploy block, and QA.

Before merging:
- [x] Set SECRETS_FILE var in configmap. Use [hokusai-sandbox](https://github.com/artsy/hokusai-sandbox)'s for reference (`hokusai staging/production env get SECRETS_FILE`).
- [x] Create deploy block

After merging:
- [ ] QA
- [ ] [Migrate](https://www.notion.so/artsy/Migration-of-Artsy-Projects-Secrets-07e5ce9e1ed044dba8d4b7c3f0ae1ccf) Force' secrets from configmap to Vault.


[PHIRE-1095]: https://artsyproduct.atlassian.net/browse/PHIRE-1095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ