### PR TITLE
fix: do not show # of bids after lot ends

### DIFF
--- a/src/Components/Artwork/Details/Details.tsx
+++ b/src/Components/Artwork/Details/Details.tsx
@@ -253,24 +253,17 @@ const BidInfo: React.FC<DetailsProps> = ({
     return null
   }
 
-  const bidderPositionCounts = sale_artwork?.counts?.bidder_positions ?? 0
-  const bidCount = collectorSignals?.auction?.bidCount ?? 0
+  const bidCount = signalsAuctionEnabled
+    ? collectorSignals?.auction?.bidCount ?? 0
+    : sale_artwork?.counts?.bidder_positions ?? 0
 
-  if (bidCount === 0 && bidderPositionCounts === 0) {
+  if (bidCount === 0) {
     return null
   }
 
   return (
     <>
-      {signalsAuctionEnabled ? (
-        <>
-          ({bidCount} bid{bidCount === 1 ? "" : "s"})
-        </>
-      ) : (
-        <>
-          ({bidderPositionCounts} bid{bidderPositionCounts === 1 ? "" : "s"})
-        </>
-      )}
+      ({bidCount} bid{bidCount === 1 ? "" : "s"})
     </>
   )
 }

--- a/src/Components/Artwork/Details/__tests__/Details.jest.tsx
+++ b/src/Components/Artwork/Details/__tests__/Details.jest.tsx
@@ -636,6 +636,28 @@ describe("Details", () => {
 
       expect(html).toContain("Increased Interest")
     })
+
+    it("does not show the number of bids when there are bids on the sale artwork but no auction signals", async () => {
+      const data: any = {
+        ...artworkInAuction,
+        collectorSignals: {
+          ...artworkInAuction?.collectorSignals,
+          auction: null,
+        },
+        sale_artwork: {
+          ...artworkInAuction?.sale_artwork,
+          counts: {
+            ...artworkInAuction?.sale_artwork?.counts,
+            bidder_positions: 2,
+          },
+        },
+      }
+
+      const wrapper = await getWrapper(data)
+      const html = wrapper.html()
+      expect(html).toContain("$2,600")
+      expect(html).not.toMatch(/\d+ bids?/)
+    })
   })
 })
 


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [EMI-2022]

### Description

See [Slack](https://artsy.slack.com/archives/C02JHHHKP5K/p1727989357076919?thread_ts=1727370726.687139&cid=C02JHHHKP5K) for context.

We show `(0 bids)` on lots with bids after the lot ends. It's because we only hide the # of bids when _both_ the lot count from auction signals and bidder position count from sale artwork are 0 or not available. We shouldn't be checking both of them at the same time, and the fix is to only check the desired one based on the feature flag.

![Screenshot 2024-10-03 at 5 01 37 PM](https://github.com/user-attachments/assets/9921de03-7557-425b-8dcf-428c66a2fc2d)
