### PR TITLE
fix: show seconds left to bid in auction signals

### DIFF
--- a/src/Components/Artwork/Details/BidTimerLine.tsx
+++ b/src/Components/Artwork/Details/BidTimerLine.tsx
@@ -17,7 +17,7 @@ export const BidTimerLine: React.FC<BidTimerLineProps> = ({ artwork }) => {
   const { lotClosesAt, registrationEndsAt, onlineBiddingExtended } =
     collectorSignals?.auction ?? {}
   const { time } = useTimer(lotClosesAt ?? "")
-  const { days, hours, minutes } = time
+  const { days, hours, minutes, seconds } = time
   const { isAuctionArtwork } = useArtworkGridContext()
   const biddingEnded = lotClosesAt && new Date(lotClosesAt) <= new Date()
   const registrationEnded =
@@ -26,6 +26,7 @@ export const BidTimerLine: React.FC<BidTimerLineProps> = ({ artwork }) => {
   const numDays = Number(days)
   const numHours = Number(hours)
   const numMinutes = Number(minutes)
+  const numSeconds = Number(seconds)
 
   if (registrationEndsAt && !registrationEnded && !isAuctionArtwork) {
     const date = DateTime.fromISO(registrationEndsAt)
@@ -51,7 +52,8 @@ export const BidTimerLine: React.FC<BidTimerLineProps> = ({ artwork }) => {
   const renderLotCloseTime = [
     numDays > 0 && `${numDays}d`,
     numHours > 0 && `${numHours}h`,
-    numDays === 0 && numHours === 0 && `${numMinutes}m`,
+    numDays === 0 && numHours === 0 && numMinutes > 0 && `${numMinutes}m`,
+    numDays === 0 && numHours === 0 && numMinutes === 0 && `${numSeconds}s`,
   ]
     .filter(Boolean)
     .join(" ")


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [EMI-2022]

### Description

See [Slack](https://artsy.slack.com/archives/C02JHHHKP5K/p1727989265612639?thread_ts=1727370726.687139&cid=C02JHHHKP5K) for context.

We currently don't show seconds in the time left to bid for auction artworks. When it's less than 1 minute, it displays "0m left to bid". This updates the logic to show seconds.

<details><summary>Before</summary>
<p>

![Screen Shot 2024-10-03 at 2 00 47 PM](https://github.com/user-attachments/assets/20ef33d0-1e38-4aa9-800a-805b14b99d94)

</p>
</details> 

<details><summary>After: not extended timer</summary>
<p>

![non-extended](https://github.com/user-attachments/assets/ba389271-03ed-4370-883a-19138192bdaa)

</p>
</details> 

<details><summary>After: extended timer</summary>
<p>

![extended](https://github.com/user-attachments/assets/9458ca32-5420-4e18-96a6-8b2fedb09e50)

</p>
</details> 

[EMI-2022]: https://artsyproduct.atlassian.net/browse/EMI-2022?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ