### PR TITLE
fix: Adds handling in case of `me` being null

### DIFF
--- a/src/Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp.tsx
@@ -61,7 +61,7 @@ export const SavedSearchAlertsApp: React.FC<SavedSearchAlertsAppProps> = ({
   const [showDeleteModal, setShowDeleteModal] = useState(false)
   const [sort, setSort] = useState("ENABLED_AT_DESC")
   const [loading, setLoading] = useState(false)
-  const alerts = extractNodes(me.alertsConnection)
+  const alerts = extractNodes(me?.alertsConnection)
 
   const xs = __internal__useMatchMedia(THEME.mediaQueries.xs)
   const sm = __internal__useMatchMedia(THEME.mediaQueries.sm)


### PR DESCRIPTION
The type of this PR is: Fix

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->


### Description

Noticed this bug on staging and production
If I am viewing my saved alerts and then go to log out from the menu bar, I receive a `Internal Server error 500`
Though, I am technically signed out, seeing the 500 seems to be a bit of a dead end as a user

Also to note, this only happens on desktop sized screens! Mobile correctly shows the sign in page

This is happening because I'm not logged out and `me` == null when trying to load in the alerts page


Example of the error in Sentry and Force:
- https://artsynet.sentry.io/issues/5900188608/?project=159064&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=14d&stream_index=1

<img width="1914" alt="Screenshot 2024-10-07 at 10 31 26 AM" src="https://github.com/user-attachments/assets/7fe9e31b-4cba-4b6d-930f-d56458e3310e">


---

I've adjusted the code to handle the case when `me` is `null` (aka logged out user), so they can see something like this and not a 500 exception

<img width="1916" alt="Screenshot 2024-10-07 at 10 44 51 AM" src="https://github.com/user-attachments/assets/b67dd597-dc73-4709-b740-32c1eedb9008">



---


⚠️ Pinging @artsy/onyx-devs for feedback if this is not the desired page experience!
