### PR TITLE
chore: Redirects user to home if log out from alerts page

### DIFF
--- a/src/Apps/Favorites/favoritesRoutes.tsx
+++ b/src/Apps/Favorites/favoritesRoutes.tsx
@@ -34,6 +34,13 @@ const Alerts = loadable(
   }
 )
 
+// Redirect home if the user is not logged in
+const handleServerSideRender = ({ req, res }) => {
+  if (!req.user) {
+    res.redirect("/")
+  }
+}
+
 export const favoritesRoutes: RouteProps[] = [
   {
     path: "/favorites",
@@ -87,6 +94,7 @@ export const favoritesRoutes: RouteProps[] = [
         onClientSideRender: () => {
           Alerts.preload()
         },
+        onServerSideRender: handleServerSideRender,
         query: graphql`
           query favoritesRoutesAlertsAppEditQuery {
             me {


### PR DESCRIPTION
The type of this PR is: Chore

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->



### Description

Fast follow from this [PR](https://github.com/artsy/force/pull/14622)

Treats the `/favorites/alerts/id` page to behavior similarly used in [settings Routes](https://github.com/artsy/force/blob/main/src/Apps/Settings/settingsRoutes.tsx#L172), If no user, redirect to HOME

There's slightly different behavior going on here for the `favorites/children` vs `settings/children` and this change pulls it more in [this direction](https://github.com/artsy/force/blob/main/src/Apps/Settings/settingsRoutes.tsx#L172)

https://github.com/user-attachments/assets/01aaea71-da31-4b99-89d8-d66f67fb924c



