### PR TITLE
fix: Make artist name clickable on Private artworks pages

### DIFF
--- a/src/Apps/Artwork/Components/PrivateArtwork/PrivateArtworkAboutArtist.tsx
+++ b/src/Apps/Artwork/Components/PrivateArtwork/PrivateArtworkAboutArtist.tsx
@@ -16,6 +16,7 @@ import { useTracking } from "react-tracking"
 import { ActionType, ClickedOnReadMore } from "@artsy/cohesion"
 import styled from "styled-components"
 import { themeGet } from "@styled-system/theme-get"
+import { RouterLink } from "System/Components/RouterLink"
 
 interface PrivateArtworkAboutArtistProps {
   artwork: PrivateArtworkAboutArtist_artwork$key
@@ -97,9 +98,15 @@ export const PrivateArtworkAboutArtist: React.FC<PrivateArtworkAboutArtistProps>
                 </Box>
 
                 <Box>
-                  <Text variant="lg-display" color="white100" fontWeight="bold">
-                    {artist.name}
-                  </Text>
+                  <RouterLink to={artist.href} display="block">
+                    <Text
+                      variant="lg-display"
+                      color="white100"
+                      fontWeight="bold"
+                    >
+                      {artist.name}
+                    </Text>
+                  </RouterLink>
 
                   {artist.formattedNationalityAndBirthday && (
                     <Text variant="xs" color="white100">


### PR DESCRIPTION
The type of this PR is: Fix or small user experience improvement

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PBRW-86](https://artsyproduct.atlassian.net/browse/PBRW-86)

### Description

Got a report in #product-bugs about a gallery not being able to click artist name on the Private Artworks Exclusive access page and see more artist details. This is a small change that mimics the behavior of our publicly published artwork pages

Seems pretty low risk, eh?



[PBRW-86]: https://artsyproduct.atlassian.net/browse/PBRW-86?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ