### PR TITLE
chore: bump up @artsy/icons version

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@artsy/eigen-web-association": "^1.6.0",
     "@artsy/express-reloadable": "^1.7.0",
     "@artsy/fresnel": "3.5.0",
-    "@artsy/icons": "3.20.0",
+    "@artsy/icons": "3.21.0",
     "@artsy/img": "1.0.3",
     "@artsy/multienv": "^1.2.0",
     "@artsy/palette": "38.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,10 +60,10 @@
   resolved "https://registry.yarnpkg.com/@artsy/fresnel/-/fresnel-3.5.0.tgz#a87ca1caca1f56d1c6d5b720581b9b6e3af1611b"
   integrity sha512-pqdQj4sbrgELlEKk+vR8vpmjgmSxk96PW7M+pWUT/UpHKD43YKCVTfe72z2WOqQru3ohobFvsnybQg/UbeSVtA==
 
-"@artsy/icons@3.20.0":
-  version "3.20.0"
-  resolved "https://registry.yarnpkg.com/@artsy/icons/-/icons-3.20.0.tgz#d8987aed2a2f6dcfd73fbe38a8a13e3cf061a9de"
-  integrity sha512-4SGgI3qpvb4q0rCYGk2ADn4ray1CQ8zcHfTK7TDiXBzxpjpWOLTItLnZ2Mmjf3F42E6uQQgiZjMs74BbAhsUzw==
+"@artsy/icons@3.21.0":
+  version "3.21.0"
+  resolved "https://registry.yarnpkg.com/@artsy/icons/-/icons-3.21.0.tgz#a2a91a47d6212aac54fed9ead305199642b24adf"
+  integrity sha512-oKywulfarvLRyo7N9KULNARBislSDQE7SHUACEF6Ee2u7fpf7pC7QSp44PxIkCw3Ew2QPwqbrajKNmod+KxcBg==
 
 "@artsy/icons@^3.2.2":
   version "3.8.1"


### PR DESCRIPTION
The type of this PR is: **Chore**

This PR solves [EMI-2063]

### Description

Bump up @artsy/icons version to 3.21.0.


[EMI-2063]: https://artsyproduct.atlassian.net/browse/EMI-2063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ