### PR TITLE
feat: downgrade @artsy/icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@artsy/eigen-web-association": "^1.6.0",
     "@artsy/express-reloadable": "^1.7.0",
     "@artsy/fresnel": "3.5.0",
-    "@artsy/icons": "3.21.0",
+    "@artsy/icons": "3.19.0",
     "@artsy/img": "1.0.3",
     "@artsy/multienv": "^1.2.0",
     "@artsy/palette": "38.14.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,10 +60,10 @@
   resolved "https://registry.yarnpkg.com/@artsy/fresnel/-/fresnel-3.5.0.tgz#a87ca1caca1f56d1c6d5b720581b9b6e3af1611b"
   integrity sha512-pqdQj4sbrgELlEKk+vR8vpmjgmSxk96PW7M+pWUT/UpHKD43YKCVTfe72z2WOqQru3ohobFvsnybQg/UbeSVtA==
 
-"@artsy/icons@3.21.0":
-  version "3.21.0"
-  resolved "https://registry.yarnpkg.com/@artsy/icons/-/icons-3.21.0.tgz#a2a91a47d6212aac54fed9ead305199642b24adf"
-  integrity sha512-oKywulfarvLRyo7N9KULNARBislSDQE7SHUACEF6Ee2u7fpf7pC7QSp44PxIkCw3Ew2QPwqbrajKNmod+KxcBg==
+"@artsy/icons@3.19.0":
+  version "3.19.0"
+  resolved "https://registry.yarnpkg.com/@artsy/icons/-/icons-3.19.0.tgz#d568843ececac94897785c85c20d24af0812e7ec"
+  integrity sha512-14k1iArqSS9NqyfwrBwU+wCoFQ4SQdDxaGl0XlAL1OiAfW+nZRpzsV4T15/LAmfzNDB2B/ZMJUq/yutwBB22jA==
 
 "@artsy/icons@^3.2.2":
   version "3.8.1"


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [EMI-2063]

### Description

Noticing the credit card icons are rendered black after the @artsy/icons version bump. Going to revert back for now and investigate further.

![Screenshot 2024-10-21 at 10 10 35 AM](https://github.com/user-attachments/assets/261993b3-364f-4dec-80f8-1c8e83f0ec6e)


[EMI-2063]: https://artsyproduct.atlassian.net/browse/EMI-2063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

cc @artsy/emerald-devs 