### PR TITLE
fix(feature): rendering of subheading

### DIFF
--- a/src/Apps/Feature/Components/FeatureHeader/FeatureHeaderFull.tsx
+++ b/src/Apps/Feature/Components/FeatureHeader/FeatureHeaderFull.tsx
@@ -39,12 +39,11 @@ export const FeatureHeaderFull: React.FC<FeatureHeaderFullProps> = ({
             </Text>
 
             {subheadline && (
-              <Text
+              <HTML
                 variant={["md", "lg-display"]}
                 color="rgba(255, 255, 255, 0.8)"
-              >
-                {subheadline}
-              </Text>
+                html={subheadline}
+              />
             )}
           </FullBleedHeaderOverlay>
         </FullBleedHeader>


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [PBRW-102]

### Description

Fixes a display issue related to the `Feature#subheadline` attribute

That field is meant to support markdown and does so correctly in the `FeatureHeaderDefault` component, but not in `FeatureHeaderFull`, which is what we fix in this PR.

This never surfaced before because the current Vanguard feature appears to be the first one with `layout: full` **and** a subheading with markdown formatting.

| Before | After |
|--------|--------|
| ![ht](https://github.com/user-attachments/assets/f6711a69-7d39-446e-b252-d4d250950691) | ![md](https://github.com/user-attachments/assets/482a74e3-3b47-423d-98a6-d35ed5332bf6) | 

(Example formatting^ in staging only)

[PBRW-102]: https://artsyproduct.atlassian.net/browse/PBRW-102?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ