### PR TITLE
fix(feature): double artwork sizes

### DIFF
--- a/src/Apps/Feature/Components/FeatureFeaturedLink.tsx
+++ b/src/Apps/Feature/Components/FeatureFeaturedLink.tsx
@@ -96,29 +96,28 @@ export const FeatureFeaturedLinkFragmentContainer = createFragmentContainer(
         subtitle(format: PLAIN)
         description(format: HTML)
         image {
-          # 9:16
-          small: cropped(width: 335, height: 240, version: ["main", "wide"]) {
+          small: cropped(width: 670, height: 480, version: ["main", "wide"]) {
             src
             srcSet
             width
             height
           }
           # 4:5
-          medium: cropped(width: 452, height: 324, version: ["main", "wide"]) {
+          medium: cropped(width: 904, height: 648, version: ["main", "wide"]) {
             src
             srcSet
             width
             height
           }
           # 16:9
-          large: cropped(width: 904, height: 648, version: ["main", "wide"]) {
+          large: cropped(width: 1808, height: 1296, version: ["main", "wide"]) {
             src
             srcSet
             width
             height
           }
           # ?:?
-          full: resized(width: 1085, height: 777, version: ["main", "wide"]) {
+          full: resized(width: 2170, height: 1554, version: ["main", "wide"]) {
             src
             srcSet
             width

--- a/src/__generated__/FeatureApp_Test_Query.graphql.ts
+++ b/src/__generated__/FeatureApp_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6c686bdaedfb20bfaa965687b8d0e5dc>>
+ * @generated SignedSource<<953f805a7b354f351fb18c4ec5d6d1e2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -954,13 +954,13 @@ return {
                                               {
                                                 "kind": "Literal",
                                                 "name": "height",
-                                                "value": 240
+                                                "value": 480
                                               },
                                               (v18/*: any*/),
                                               {
                                                 "kind": "Literal",
                                                 "name": "width",
-                                                "value": 335
+                                                "value": 670
                                               }
                                             ],
                                             "concreteType": "CroppedImageUrl",
@@ -968,32 +968,10 @@ return {
                                             "name": "cropped",
                                             "plural": false,
                                             "selections": (v19/*: any*/),
-                                            "storageKey": "cropped(height:240,version:[\"main\",\"wide\"],width:335)"
+                                            "storageKey": "cropped(height:480,version:[\"main\",\"wide\"],width:670)"
                                           },
                                           {
                                             "alias": "medium",
-                                            "args": [
-                                              {
-                                                "kind": "Literal",
-                                                "name": "height",
-                                                "value": 324
-                                              },
-                                              (v18/*: any*/),
-                                              {
-                                                "kind": "Literal",
-                                                "name": "width",
-                                                "value": 452
-                                              }
-                                            ],
-                                            "concreteType": "CroppedImageUrl",
-                                            "kind": "LinkedField",
-                                            "name": "cropped",
-                                            "plural": false,
-                                            "selections": (v19/*: any*/),
-                                            "storageKey": "cropped(height:324,version:[\"main\",\"wide\"],width:452)"
-                                          },
-                                          {
-                                            "alias": "large",
                                             "args": [
                                               {
                                                 "kind": "Literal",
@@ -1015,18 +993,40 @@ return {
                                             "storageKey": "cropped(height:648,version:[\"main\",\"wide\"],width:904)"
                                           },
                                           {
-                                            "alias": "full",
+                                            "alias": "large",
                                             "args": [
                                               {
                                                 "kind": "Literal",
                                                 "name": "height",
-                                                "value": 777
+                                                "value": 1296
                                               },
                                               (v18/*: any*/),
                                               {
                                                 "kind": "Literal",
                                                 "name": "width",
-                                                "value": 1085
+                                                "value": 1808
+                                              }
+                                            ],
+                                            "concreteType": "CroppedImageUrl",
+                                            "kind": "LinkedField",
+                                            "name": "cropped",
+                                            "plural": false,
+                                            "selections": (v19/*: any*/),
+                                            "storageKey": "cropped(height:1296,version:[\"main\",\"wide\"],width:1808)"
+                                          },
+                                          {
+                                            "alias": "full",
+                                            "args": [
+                                              {
+                                                "kind": "Literal",
+                                                "name": "height",
+                                                "value": 1554
+                                              },
+                                              (v18/*: any*/),
+                                              {
+                                                "kind": "Literal",
+                                                "name": "width",
+                                                "value": 2170
                                               }
                                             ],
                                             "concreteType": "ResizedImageUrl",
@@ -1034,7 +1034,7 @@ return {
                                             "name": "resized",
                                             "plural": false,
                                             "selections": (v19/*: any*/),
-                                            "storageKey": "resized(height:777,version:[\"main\",\"wide\"],width:1085)"
+                                            "storageKey": "resized(height:1554,version:[\"main\",\"wide\"],width:2170)"
                                           }
                                         ],
                                         "storageKey": null
@@ -1084,7 +1084,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "44989e94f48ca008ed7b5654ae0ceb3d",
+    "cacheID": "bf52b0e7a8e82a203588170d1ff27391",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -1388,7 +1388,7 @@ return {
     },
     "name": "FeatureApp_Test_Query",
     "operationKind": "query",
-    "text": "query FeatureApp_Test_Query {\n  feature(id: \"example\") {\n    ...FeatureApp_feature\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FeatureApp_feature on Feature {\n  ...FeatureMeta_feature\n  ...FeatureHeader_feature\n  description(format: HTML)\n  callout(format: HTML)\n  sets: setsConnection(first: 20) {\n    edges {\n      node {\n        id\n        ...FeatureSet_set\n      }\n    }\n  }\n}\n\nfragment FeatureFeaturedLink_featuredLink on FeaturedLink {\n  href\n  title\n  subtitle(format: PLAIN)\n  description(format: HTML)\n  image {\n    small: cropped(width: 335, height: 240, version: [\"main\", \"wide\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    medium: cropped(width: 452, height: 324, version: [\"main\", \"wide\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    large: cropped(width: 904, height: 648, version: [\"main\", \"wide\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    full: resized(width: 1085, height: 777, version: [\"main\", \"wide\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment FeatureHeaderDefault_feature on Feature {\n  name\n  subheadline(format: HTML)\n  defaultImage: image {\n    resized(width: 900, version: [\"main\", \"source\", \"wide\"]) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FeatureHeaderFull_feature on Feature {\n  name\n  subheadline(format: HTML)\n  fullImage: image {\n    url(version: [\"main\", \"source\", \"wide\"])\n  }\n}\n\nfragment FeatureHeader_feature on Feature {\n  ...FeatureHeaderDefault_feature\n  ...FeatureHeaderFull_feature\n  layout\n}\n\nfragment FeatureMeta_feature on Feature {\n  slug\n  meta {\n    name\n    description\n    image\n  }\n}\n\nfragment FeatureSetContainer_set on OrderedSet {\n  id\n  layout\n  itemType\n  orderedItems: orderedItemsConnection(first: 99) {\n    edges {\n      __typename\n    }\n  }\n}\n\nfragment FeatureSetItem_setItem on OrderedSetItem {\n  __isOrderedSetItem: __typename\n  __typename\n  ... on FeaturedLink {\n    id\n  }\n  ... on Artwork {\n    id\n  }\n  ...GridItem_artwork\n  ...FeatureFeaturedLink_featuredLink\n}\n\nfragment FeatureSetMeta_set on OrderedSet {\n  name\n  description(format: HTML)\n}\n\nfragment FeatureSet_set on OrderedSet {\n  id\n  layout\n  name\n  description(format: HTML)\n  itemType\n  orderedItems: orderedItemsConnection(first: 99) {\n    edges {\n      __typename\n      node {\n        __typename\n        ... on Artwork {\n          id\n        }\n        ... on FeaturedLink {\n          id\n        }\n        ...FeatureSetItem_setItem\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n        ... on Profile {\n          id\n        }\n      }\n    }\n  }\n  ...FeatureSetMeta_set\n  ...FeatureSetContainer_set\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
+    "text": "query FeatureApp_Test_Query {\n  feature(id: \"example\") {\n    ...FeatureApp_feature\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FeatureApp_feature on Feature {\n  ...FeatureMeta_feature\n  ...FeatureHeader_feature\n  description(format: HTML)\n  callout(format: HTML)\n  sets: setsConnection(first: 20) {\n    edges {\n      node {\n        id\n        ...FeatureSet_set\n      }\n    }\n  }\n}\n\nfragment FeatureFeaturedLink_featuredLink on FeaturedLink {\n  href\n  title\n  subtitle(format: PLAIN)\n  description(format: HTML)\n  image {\n    small: cropped(width: 670, height: 480, version: [\"main\", \"wide\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    medium: cropped(width: 904, height: 648, version: [\"main\", \"wide\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    large: cropped(width: 1808, height: 1296, version: [\"main\", \"wide\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    full: resized(width: 2170, height: 1554, version: [\"main\", \"wide\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment FeatureHeaderDefault_feature on Feature {\n  name\n  subheadline(format: HTML)\n  defaultImage: image {\n    resized(width: 900, version: [\"main\", \"source\", \"wide\"]) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FeatureHeaderFull_feature on Feature {\n  name\n  subheadline(format: HTML)\n  fullImage: image {\n    url(version: [\"main\", \"source\", \"wide\"])\n  }\n}\n\nfragment FeatureHeader_feature on Feature {\n  ...FeatureHeaderDefault_feature\n  ...FeatureHeaderFull_feature\n  layout\n}\n\nfragment FeatureMeta_feature on Feature {\n  slug\n  meta {\n    name\n    description\n    image\n  }\n}\n\nfragment FeatureSetContainer_set on OrderedSet {\n  id\n  layout\n  itemType\n  orderedItems: orderedItemsConnection(first: 99) {\n    edges {\n      __typename\n    }\n  }\n}\n\nfragment FeatureSetItem_setItem on OrderedSetItem {\n  __isOrderedSetItem: __typename\n  __typename\n  ... on FeaturedLink {\n    id\n  }\n  ... on Artwork {\n    id\n  }\n  ...GridItem_artwork\n  ...FeatureFeaturedLink_featuredLink\n}\n\nfragment FeatureSetMeta_set on OrderedSet {\n  name\n  description(format: HTML)\n}\n\nfragment FeatureSet_set on OrderedSet {\n  id\n  layout\n  name\n  description(format: HTML)\n  itemType\n  orderedItems: orderedItemsConnection(first: 99) {\n    edges {\n      __typename\n      node {\n        __typename\n        ... on Artwork {\n          id\n        }\n        ... on FeaturedLink {\n          id\n        }\n        ...FeatureSetItem_setItem\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n        ... on Profile {\n          id\n        }\n      }\n    }\n  }\n  ...FeatureSetMeta_set\n  ...FeatureSetContainer_set\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/FeatureFeaturedLink_featuredLink.graphql.ts
+++ b/src/__generated__/FeatureFeaturedLink_featuredLink.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<00e97eaa70ddaed74de84ca67174e517>>
+ * @generated SignedSource<<12163f59bc3ffdf4f18c4f049d2fde3c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -147,13 +147,13 @@ return {
             {
               "kind": "Literal",
               "name": "height",
-              "value": 240
+              "value": 480
             },
             (v0/*: any*/),
             {
               "kind": "Literal",
               "name": "width",
-              "value": 335
+              "value": 670
             }
           ],
           "concreteType": "CroppedImageUrl",
@@ -161,32 +161,10 @@ return {
           "name": "cropped",
           "plural": false,
           "selections": (v1/*: any*/),
-          "storageKey": "cropped(height:240,version:[\"main\",\"wide\"],width:335)"
+          "storageKey": "cropped(height:480,version:[\"main\",\"wide\"],width:670)"
         },
         {
           "alias": "medium",
-          "args": [
-            {
-              "kind": "Literal",
-              "name": "height",
-              "value": 324
-            },
-            (v0/*: any*/),
-            {
-              "kind": "Literal",
-              "name": "width",
-              "value": 452
-            }
-          ],
-          "concreteType": "CroppedImageUrl",
-          "kind": "LinkedField",
-          "name": "cropped",
-          "plural": false,
-          "selections": (v1/*: any*/),
-          "storageKey": "cropped(height:324,version:[\"main\",\"wide\"],width:452)"
-        },
-        {
-          "alias": "large",
           "args": [
             {
               "kind": "Literal",
@@ -208,18 +186,40 @@ return {
           "storageKey": "cropped(height:648,version:[\"main\",\"wide\"],width:904)"
         },
         {
-          "alias": "full",
+          "alias": "large",
           "args": [
             {
               "kind": "Literal",
               "name": "height",
-              "value": 777
+              "value": 1296
             },
             (v0/*: any*/),
             {
               "kind": "Literal",
               "name": "width",
-              "value": 1085
+              "value": 1808
+            }
+          ],
+          "concreteType": "CroppedImageUrl",
+          "kind": "LinkedField",
+          "name": "cropped",
+          "plural": false,
+          "selections": (v1/*: any*/),
+          "storageKey": "cropped(height:1296,version:[\"main\",\"wide\"],width:1808)"
+        },
+        {
+          "alias": "full",
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "height",
+              "value": 1554
+            },
+            (v0/*: any*/),
+            {
+              "kind": "Literal",
+              "name": "width",
+              "value": 2170
             }
           ],
           "concreteType": "ResizedImageUrl",
@@ -227,7 +227,7 @@ return {
           "name": "resized",
           "plural": false,
           "selections": (v1/*: any*/),
-          "storageKey": "resized(height:777,version:[\"main\",\"wide\"],width:1085)"
+          "storageKey": "resized(height:1554,version:[\"main\",\"wide\"],width:2170)"
         }
       ],
       "storageKey": null
@@ -238,6 +238,6 @@ return {
 };
 })();
 
-(node as any).hash = "80c4cca0a36a443e6ac6394d2cfd9be9";
+(node as any).hash = "dc8251bf0c9af03ee0eef2b21aa1221b";
 
 export default node;

--- a/src/__generated__/featureRoutes_FeatureQuery.graphql.ts
+++ b/src/__generated__/featureRoutes_FeatureQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<96b0236007d3b9f68dd970731cf07e7f>>
+ * @generated SignedSource<<4c3e91137d98be429609708b8b84b03f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -893,13 +893,13 @@ return {
                                               {
                                                 "kind": "Literal",
                                                 "name": "height",
-                                                "value": 240
+                                                "value": 480
                                               },
                                               (v19/*: any*/),
                                               {
                                                 "kind": "Literal",
                                                 "name": "width",
-                                                "value": 335
+                                                "value": 670
                                               }
                                             ],
                                             "concreteType": "CroppedImageUrl",
@@ -907,32 +907,10 @@ return {
                                             "name": "cropped",
                                             "plural": false,
                                             "selections": (v20/*: any*/),
-                                            "storageKey": "cropped(height:240,version:[\"main\",\"wide\"],width:335)"
+                                            "storageKey": "cropped(height:480,version:[\"main\",\"wide\"],width:670)"
                                           },
                                           {
                                             "alias": "medium",
-                                            "args": [
-                                              {
-                                                "kind": "Literal",
-                                                "name": "height",
-                                                "value": 324
-                                              },
-                                              (v19/*: any*/),
-                                              {
-                                                "kind": "Literal",
-                                                "name": "width",
-                                                "value": 452
-                                              }
-                                            ],
-                                            "concreteType": "CroppedImageUrl",
-                                            "kind": "LinkedField",
-                                            "name": "cropped",
-                                            "plural": false,
-                                            "selections": (v20/*: any*/),
-                                            "storageKey": "cropped(height:324,version:[\"main\",\"wide\"],width:452)"
-                                          },
-                                          {
-                                            "alias": "large",
                                             "args": [
                                               {
                                                 "kind": "Literal",
@@ -954,18 +932,40 @@ return {
                                             "storageKey": "cropped(height:648,version:[\"main\",\"wide\"],width:904)"
                                           },
                                           {
-                                            "alias": "full",
+                                            "alias": "large",
                                             "args": [
                                               {
                                                 "kind": "Literal",
                                                 "name": "height",
-                                                "value": 777
+                                                "value": 1296
                                               },
                                               (v19/*: any*/),
                                               {
                                                 "kind": "Literal",
                                                 "name": "width",
-                                                "value": 1085
+                                                "value": 1808
+                                              }
+                                            ],
+                                            "concreteType": "CroppedImageUrl",
+                                            "kind": "LinkedField",
+                                            "name": "cropped",
+                                            "plural": false,
+                                            "selections": (v20/*: any*/),
+                                            "storageKey": "cropped(height:1296,version:[\"main\",\"wide\"],width:1808)"
+                                          },
+                                          {
+                                            "alias": "full",
+                                            "args": [
+                                              {
+                                                "kind": "Literal",
+                                                "name": "height",
+                                                "value": 1554
+                                              },
+                                              (v19/*: any*/),
+                                              {
+                                                "kind": "Literal",
+                                                "name": "width",
+                                                "value": 2170
                                               }
                                             ],
                                             "concreteType": "ResizedImageUrl",
@@ -973,7 +973,7 @@ return {
                                             "name": "resized",
                                             "plural": false,
                                             "selections": (v20/*: any*/),
-                                            "storageKey": "resized(height:777,version:[\"main\",\"wide\"],width:1085)"
+                                            "storageKey": "resized(height:1554,version:[\"main\",\"wide\"],width:2170)"
                                           }
                                         ],
                                         "storageKey": null
@@ -1023,12 +1023,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d7b720cfad7edf4fee84ebb6ac51a3bc",
+    "cacheID": "51bfee998438d2529d13aad862ae0d85",
     "id": null,
     "metadata": {},
     "name": "featureRoutes_FeatureQuery",
     "operationKind": "query",
-    "text": "query featureRoutes_FeatureQuery(\n  $slug: ID!\n) @cacheable {\n  feature(id: $slug) @principalField {\n    ...FeatureApp_feature\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FeatureApp_feature on Feature {\n  ...FeatureMeta_feature\n  ...FeatureHeader_feature\n  description(format: HTML)\n  callout(format: HTML)\n  sets: setsConnection(first: 20) {\n    edges {\n      node {\n        id\n        ...FeatureSet_set\n      }\n    }\n  }\n}\n\nfragment FeatureFeaturedLink_featuredLink on FeaturedLink {\n  href\n  title\n  subtitle(format: PLAIN)\n  description(format: HTML)\n  image {\n    small: cropped(width: 335, height: 240, version: [\"main\", \"wide\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    medium: cropped(width: 452, height: 324, version: [\"main\", \"wide\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    large: cropped(width: 904, height: 648, version: [\"main\", \"wide\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    full: resized(width: 1085, height: 777, version: [\"main\", \"wide\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment FeatureHeaderDefault_feature on Feature {\n  name\n  subheadline(format: HTML)\n  defaultImage: image {\n    resized(width: 900, version: [\"main\", \"source\", \"wide\"]) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FeatureHeaderFull_feature on Feature {\n  name\n  subheadline(format: HTML)\n  fullImage: image {\n    url(version: [\"main\", \"source\", \"wide\"])\n  }\n}\n\nfragment FeatureHeader_feature on Feature {\n  ...FeatureHeaderDefault_feature\n  ...FeatureHeaderFull_feature\n  layout\n}\n\nfragment FeatureMeta_feature on Feature {\n  slug\n  meta {\n    name\n    description\n    image\n  }\n}\n\nfragment FeatureSetContainer_set on OrderedSet {\n  id\n  layout\n  itemType\n  orderedItems: orderedItemsConnection(first: 99) {\n    edges {\n      __typename\n    }\n  }\n}\n\nfragment FeatureSetItem_setItem on OrderedSetItem {\n  __isOrderedSetItem: __typename\n  __typename\n  ... on FeaturedLink {\n    id\n  }\n  ... on Artwork {\n    id\n  }\n  ...GridItem_artwork\n  ...FeatureFeaturedLink_featuredLink\n}\n\nfragment FeatureSetMeta_set on OrderedSet {\n  name\n  description(format: HTML)\n}\n\nfragment FeatureSet_set on OrderedSet {\n  id\n  layout\n  name\n  description(format: HTML)\n  itemType\n  orderedItems: orderedItemsConnection(first: 99) {\n    edges {\n      __typename\n      node {\n        __typename\n        ... on Artwork {\n          id\n        }\n        ... on FeaturedLink {\n          id\n        }\n        ...FeatureSetItem_setItem\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n        ... on Profile {\n          id\n        }\n      }\n    }\n  }\n  ...FeatureSetMeta_set\n  ...FeatureSetContainer_set\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
+    "text": "query featureRoutes_FeatureQuery(\n  $slug: ID!\n) @cacheable {\n  feature(id: $slug) @principalField {\n    ...FeatureApp_feature\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FeatureApp_feature on Feature {\n  ...FeatureMeta_feature\n  ...FeatureHeader_feature\n  description(format: HTML)\n  callout(format: HTML)\n  sets: setsConnection(first: 20) {\n    edges {\n      node {\n        id\n        ...FeatureSet_set\n      }\n    }\n  }\n}\n\nfragment FeatureFeaturedLink_featuredLink on FeaturedLink {\n  href\n  title\n  subtitle(format: PLAIN)\n  description(format: HTML)\n  image {\n    small: cropped(width: 670, height: 480, version: [\"main\", \"wide\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    medium: cropped(width: 904, height: 648, version: [\"main\", \"wide\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    large: cropped(width: 1808, height: 1296, version: [\"main\", \"wide\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    full: resized(width: 2170, height: 1554, version: [\"main\", \"wide\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment FeatureHeaderDefault_feature on Feature {\n  name\n  subheadline(format: HTML)\n  defaultImage: image {\n    resized(width: 900, version: [\"main\", \"source\", \"wide\"]) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FeatureHeaderFull_feature on Feature {\n  name\n  subheadline(format: HTML)\n  fullImage: image {\n    url(version: [\"main\", \"source\", \"wide\"])\n  }\n}\n\nfragment FeatureHeader_feature on Feature {\n  ...FeatureHeaderDefault_feature\n  ...FeatureHeaderFull_feature\n  layout\n}\n\nfragment FeatureMeta_feature on Feature {\n  slug\n  meta {\n    name\n    description\n    image\n  }\n}\n\nfragment FeatureSetContainer_set on OrderedSet {\n  id\n  layout\n  itemType\n  orderedItems: orderedItemsConnection(first: 99) {\n    edges {\n      __typename\n    }\n  }\n}\n\nfragment FeatureSetItem_setItem on OrderedSetItem {\n  __isOrderedSetItem: __typename\n  __typename\n  ... on FeaturedLink {\n    id\n  }\n  ... on Artwork {\n    id\n  }\n  ...GridItem_artwork\n  ...FeatureFeaturedLink_featuredLink\n}\n\nfragment FeatureSetMeta_set on OrderedSet {\n  name\n  description(format: HTML)\n}\n\nfragment FeatureSet_set on OrderedSet {\n  id\n  layout\n  name\n  description(format: HTML)\n  itemType\n  orderedItems: orderedItemsConnection(first: 99) {\n    edges {\n      __typename\n      node {\n        __typename\n        ... on Artwork {\n          id\n        }\n        ... on FeaturedLink {\n          id\n        }\n        ...FeatureSetItem_setItem\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n        ... on Profile {\n          id\n        }\n      }\n    }\n  }\n  ...FeatureSetMeta_set\n  ...FeatureSetContainer_set\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

This doubles the resized images in the graphql calls on a feature in an attempt to improve rendered image quality. 

<img width="1504" alt="Screenshot 2024-10-21 at 10 29 05 AM" src="https://github.com/user-attachments/assets/7f1a5932-e31e-4e4e-a4a4-f4146cb55916">

cc @artsy/diamond-devs 