### PR TITLE
fix: Allow logged out users to exit Sell flow by clicking on Artsy logo

### DIFF
--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/ArtworkFormExitConfirmationDialog.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/ArtworkFormExitConfirmationDialog.tsx
@@ -1,11 +1,11 @@
 import { Button, ModalDialog, Text } from "@artsy/palette"
 
 interface ConfirmationModalProps {
-  isEditing: boolean
+  isEditing?: boolean
   onClose: () => void
   onLeave: () => void
 }
-export const ConfirmationModalBack: React.FC<ConfirmationModalProps> = ({
+export const ArtworkFormExitConfirmationDialog: React.FC<ConfirmationModalProps> = ({
   isEditing,
   onClose,
   onLeave,
@@ -31,11 +31,7 @@ export const ConfirmationModalBack: React.FC<ConfirmationModalProps> = ({
         </>
       }
     >
-      <Text>
-        {isEditing
-          ? "Changes you have made so far will not be saved."
-          : "Your artwork will not be added to My Collection."}
-      </Text>
+      <Text>Changes you have made so far will not be saved.</Text>
     </ModalDialog>
   )
 }

--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormHeader.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormHeader.tsx
@@ -1,3 +1,4 @@
+import ArtsyLogoIcon from "@artsy/icons/ArtsyLogoIcon"
 import { Flex, FullBleed, Separator, useTheme } from "@artsy/palette"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
@@ -5,7 +6,6 @@ import { BackLink } from "Components/Links/BackLink"
 import { Sticky } from "Components/Sticky"
 import { ReactNode } from "react"
 import { RouterLink } from "System/Components/RouterLink"
-import ArtsyLogoIcon from "@artsy/icons/ArtsyLogoIcon"
 
 interface MyCollectionArtworkFormHeaderProps {
   NextButton?: ReactNode

--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormMain.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormMain.tsx
@@ -9,7 +9,7 @@ import {
   useToasts,
 } from "@artsy/palette"
 import { AppContainer } from "Apps/Components/AppContainer"
-import { ConfirmationModalBack } from "Apps/MyCollection/Routes/EditArtwork/Components/ConfirmationModalBack"
+import { ArtworkFormExitConfirmationDialog } from "Apps/MyCollection/Routes/EditArtwork/Components/ArtworkFormExitConfirmationDialog"
 import { ConfirmationModalDelete } from "Apps/MyCollection/Routes/EditArtwork/Components/ConfirmationModalDelete"
 import { useMyCollectionArtworkFormContext } from "Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormContext"
 import { MyCollectionArtworkFormDetails } from "Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormDetails"
@@ -131,7 +131,7 @@ export const MyCollectionArtworkFormMain: React.FC<MyCollectionArtworkFormMainPr
       <AppContainer>
         <Form>
           {showLeaveWithoutSavingModal && (
-            <ConfirmationModalBack
+            <ArtworkFormExitConfirmationDialog
               onClose={() => setShowLeaveWithoutSavingModal(false)}
               isEditing={isEditing}
               onLeave={handleBack}

--- a/src/Apps/Sell/Components/SubmissionHeader.tsx
+++ b/src/Apps/Sell/Components/SubmissionHeader.tsx
@@ -2,17 +2,10 @@ import { AuthIntent, ContextModule } from "@artsy/cohesion"
 import ArtsyLogoIcon from "@artsy/icons/ArtsyLogoIcon"
 import ArtsyMarkIcon from "@artsy/icons/ArtsyMarkIcon"
 import CloseIcon from "@artsy/icons/CloseIcon"
-import {
-  Box,
-  Button,
-  Clickable,
-  Flex,
-  FullBleed,
-  ModalDialog,
-  Text,
-} from "@artsy/palette"
+import { Box, Button, Clickable, Flex, FullBleed } from "@artsy/palette"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
+import { ArtworkFormExitConfirmationDialog } from "Apps/MyCollection/Routes/EditArtwork/Components/ArtworkFormExitConfirmationDialog"
 import { useSubmissionTracking } from "Apps/Sell/Hooks/useSubmissionTracking"
 import { useAssociateSubmission } from "Apps/Sell/Mutations/useAssociateSubmission"
 import { useSellFlowContext } from "Apps/Sell/SellFlowContext"
@@ -253,46 +246,11 @@ const HeaderArtsyLogo: React.FC<{ withExitConfirmation }> = ({
       </Clickable>
 
       {showExitConfirmationModal && (
-        <ExitConfirmationModal
+        <ArtworkFormExitConfirmationDialog
           onClose={() => setShowExitConfirmationModal(false)}
           onLeave={() => router.push("/sell")}
         />
       )}
     </>
-  )
-}
-
-interface ExitConfirmationModalProps {
-  onClose: () => void
-  onLeave: () => void
-}
-
-export const ExitConfirmationModal: React.FC<ExitConfirmationModalProps> = ({
-  onClose,
-  onLeave,
-}) => {
-  return (
-    <ModalDialog
-      title="Leave without saving?"
-      onClose={onClose}
-      width={["100%", 600]}
-      footer={
-        <>
-          <Button onClick={onLeave} width="100%" data-testid="leave-button">
-            Leave Without Saving
-          </Button>
-          <Button
-            onClick={onClose}
-            variant="secondaryNeutral"
-            mt={2}
-            width="100%"
-          >
-            Continue Uploading Artwork
-          </Button>
-        </>
-      }
-    >
-      <Text>Changes you have made so far will not be saved.</Text>
-    </ModalDialog>
   )
 }


### PR DESCRIPTION
Addresses [ONYX-1266]

## Description

With this change, we will allow logged-out users to exit the Sell flow by clicking on the Artsy logo in the header. 

The current problem is that clicking on "Save & Exit" opens the "Sign up" modal for logged-out users and does not allow to (simply) exit the Sell flow.

Clicking on the Artsy logo in the header will now open a dialog to exit the flow without signing up and navigate the user to the "/sell" page.

<img width="1022" alt="Screenshot 2024-10-22 at 15 37 51" src="https://github.com/user-attachments/assets/d8a13976-3aca-4345-a1ce-17cac39c7d2c">


[ONYX-1266]: https://artsyproduct.atlassian.net/browse/ONYX-1266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ