### PR TITLE
chore: update review app script

### DIFF
--- a/scripts/build_review_app.sh
+++ b/scripts/build_review_app.sh
@@ -38,7 +38,7 @@ review_app_file_path="hokusai/$NAME.yml"
 hokusai registry push --force --skip-latest --overwrite --verbose --tag "$NAME"
 
 # Edit the K8S YAML to reference the proper Docker image
-sed -i.bak "s/:staging/:$NAME/g" "$review_app_file_path" && rm "$review_app_file_path.bak"
+sed -i.bak "s/force:staging/force:$NAME/g" "$review_app_file_path" && rm "$review_app_file_path.bak"
 
 # Edit the K8S YAML Ingress resource to use the Review App's name as the host.
 sed -i.bak "s/host: staging.artsy.net/host: $NAME.artsy.net/g" "$review_app_file_path" && rm "$review_app_file_path.bak"


### PR DESCRIPTION
The type of this PR is: **Chore**

### Description

While creating a review app for [signals work](https://artsy.slack.com/archives/C02JHHHKP5K/p1729195691286149?thread_ts=1729195668.187189&cid=C02JHHHKP5K), the review app creation failed for the following reason. It looks the script might have incorrectly replaced [a wrong line](https://github.com/artsy/force/blob/25e34cd25ecbccb442f90b9f07da5cb907e3044c/hokusai/staging.yml#L35) that's for the new vault. This updates the script to be more specific.

![Screenshot 2024-10-17 at 10 43 48 AM](https://github.com/user-attachments/assets/7fd01712-5b47-4fd0-a671-651ac6fcdd76)

@artsy/emerald-devs 