### PR TITLE
fix(art-fairs): Fix UX

### DIFF
--- a/src/Apps/Fairs/Routes/FairsIndex.tsx
+++ b/src/Apps/Fairs/Routes/FairsIndex.tsx
@@ -250,10 +250,7 @@ export const FairsIndex: React.FC<FairsIndexProps> = ({
               <GridColumns my={2}>
                 {currentFairs.map(fair => {
                   return (
-                    <Column
-                      key={fair.internalID}
-                      span={fair.bannerSize === "x-large" ? 12 : 6}
-                    >
+                    <Column key={fair.internalID} span={6}>
                       <FairsFairBannerFragmentContainer fair={fair} />
                     </Column>
                   )


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

The /art-fairs page has been broken for a super long time and looks sloppy. 
- The first item takes up the whole screen
- Fair text isn't visible 
- User is required to scroll to see what fair it is 

So drop down to two columns. Priority position is still given to the first slot, but at least users can see whats going on at a glance.

Before:

<img width="1512" alt="Screenshot 2024-10-22 at 10 57 43 AM" src="https://github.com/user-attachments/assets/66033766-9afc-43a7-955d-8eaff6205d86">

After: 

<img width="1512" alt="Screenshot 2024-10-22 at 10 57 32 AM" src="https://github.com/user-attachments/assets/93ff16f0-21c0-4d91-8383-92aa678ad9b3">


