### PR TITLE
fix(router link): allow onclick prop explicitly

### DIFF
--- a/src/System/Components/RouterLink.tsx
+++ b/src/System/Components/RouterLink.tsx
@@ -121,6 +121,7 @@ const VALID_ROUTER_LINK_PROPS = [
   "data-test",
   "data-testid",
   "exact",
+  "onClick",
   "style",
   "target",
   "to",


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Apparently more fallout from the [Styled Components upgrade](https://github.com/artsy/force/pull/14678), and the need to explicitly allowlist some [more](https://github.com/artsy/force/pull/14686) props

(Surfaced by some [failing specs](https://artsy.slack.com/archives/C05EQL4R5N0/p1729619815219029) for logged-out MyC users in Integrity)