### PR TITLE
feat: display new credit card brand icons

### DIFF
--- a/src/Apps/Order/Components/CreditCardDetails.tsx
+++ b/src/Apps/Order/Components/CreditCardDetails.tsx
@@ -20,7 +20,12 @@ export const CreditCardDetails = (props: Props) => {
 
   return (
     <Flex alignItems="center">
-      <BrandCreditCardIcon mr={1} type={brand as Brand} width="25px" />
+      <BrandCreditCardIcon
+        mr={1}
+        type={brand as Brand}
+        width="24px"
+        height="24px"
+      />
       <Text
         variant="sm-display"
         color={textColor}

--- a/src/Components/BrandCreditCardIcon.tsx
+++ b/src/Components/BrandCreditCardIcon.tsx
@@ -4,6 +4,10 @@ import MastercardIcon from "@artsy/icons/MastercardIcon"
 import UnknownCardIcon from "@artsy/icons/UnknownCardIcon"
 import AmexIcon from "@artsy/icons/AmexIcon"
 import DiscoverIcon from "@artsy/icons/DiscoverIcon"
+import CartesBancairesIcon from "@artsy/icons/CartesBancairesIcon"
+import DinersClubIcon from "@artsy/icons/DinersClubIcon"
+import JcbIcon from "@artsy/icons/JcbIcon"
+import UnionPayIcon from "@artsy/icons/UnionPayIcon"
 import { BoxProps } from "@artsy/palette"
 
 export type Brand =
@@ -11,6 +15,10 @@ export type Brand =
   | "MasterCard"
   | "American Express"
   | "Discover"
+  | "Cartes Bancaires"
+  | "Diners Club"
+  | "JCB"
+  | "UnionPay"
   | "Unknown"
 
 export interface BrandCreditCardIconProps extends BoxProps {
@@ -30,6 +38,14 @@ export const BrandCreditCardIcon: FC<BrandCreditCardIconProps> = ({
       return <AmexIcon {...rest} />
     case "Discover":
       return <DiscoverIcon {...rest} />
+    case "Cartes Bancaires":
+      return <CartesBancairesIcon {...rest} />
+    case "Diners Club":
+      return <DinersClubIcon {...rest} />
+    case "JCB":
+      return <JcbIcon {...rest} />
+    case "UnionPay":
+      return <UnionPayIcon {...rest} />
     default:
       return <UnknownCardIcon color="black30" {...rest} />
   }


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [EMI-2063](https://artsyproduct.atlassian.net/browse/EMI-2063)

### Description

Now that we've updated the credit card icons and added a few more, including CB card that's required in the compliance project, in artsy/icons, let's display them.

![Screenshot 2024-10-22 at 9 25 39 PM](https://github.com/user-attachments/assets/6dfae32a-3f4d-448d-81aa-6a2494e1505d)


[EMI-2063]: https://artsyproduct.atlassian.net/browse/EMI-2063?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ