### PR TITLE
Revert "fix(EMI-2133): fix collections signals tracking (#14661)"

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -276,252 +276,252 @@
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "145bdc9483588e8243c544e00dab4fd93040ff68",
         "is_verified": false,
-        "line_number": 97
+        "line_number": 94
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "de8d20175b765cac693a529d51145d55d3912082",
         "is_verified": false,
-        "line_number": 145
+        "line_number": 139
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "ebdf5259929f473604297bbbccd696fcd037c6f9",
         "is_verified": false,
-        "line_number": 186
+        "line_number": 177
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "2dcb5df59b78708ed33c9be2f53cf2e713cc136c",
         "is_verified": false,
-        "line_number": 194
+        "line_number": 185
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "36b5f9cd656a82144f10643146f5278fa4e1f9be",
         "is_verified": false,
-        "line_number": 238
+        "line_number": 226
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "b55958b35c43c441f87ff29bfee3fe29d778b9b5",
         "is_verified": false,
-        "line_number": 245
+        "line_number": 233
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "d56b9e588e1770b8ddf404a22b46d570e2bce004",
         "is_verified": false,
-        "line_number": 293
+        "line_number": 278
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "b0f93ef51b0daf64e471655e9f77cc90f230903d",
         "is_verified": false,
-        "line_number": 341
+        "line_number": 323
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "0483a680292f6e280adc41f57031fd77673088b8",
         "is_verified": false,
-        "line_number": 389
+        "line_number": 368
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "f4a65a11c81626ba80381ac4c60fb13531289963",
         "is_verified": false,
-        "line_number": 430
+        "line_number": 406
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "03b840a21f4dae9999524027fa91483b420138b0",
         "is_verified": false,
-        "line_number": 437
+        "line_number": 413
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "98612cabb08050b711614f3e0a250f7c5836678a",
         "is_verified": false,
-        "line_number": 485
+        "line_number": 458
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "c1c070cf96af376813ed8c4db59a2ff2d15f28ee",
         "is_verified": false,
-        "line_number": 526
+        "line_number": 496
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "b555e4b87dacaf097fb6c424a00f59569d7128ba",
         "is_verified": false,
-        "line_number": 534
+        "line_number": 504
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "dda3791c5e2432b1d0ddb2c3c8dccd4f86859115",
         "is_verified": false,
-        "line_number": 584
+        "line_number": 551
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "dff527ac716e7cc58833dc2ec113d77781001905",
         "is_verified": false,
-        "line_number": 635
+        "line_number": 599
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "7ebe78cb261e999ee2b9e7c1aae5c1f343870ced",
         "is_verified": false,
-        "line_number": 687
+        "line_number": 648
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "adacb996fb2315f6c435cf0bd98e7c117152a80e",
         "is_verified": false,
-        "line_number": 731
+        "line_number": 689
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "0f1163ee647469ef875eb67211d730376f28d6cf",
         "is_verified": false,
-        "line_number": 739
+        "line_number": 697
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "ec6c8d32d50c6f05c046e52629a2e1a464ac33d2",
         "is_verified": false,
-        "line_number": 790
+        "line_number": 745
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "aec29cbcda0c20fb980b12c463ed12fb16eb4d07",
         "is_verified": false,
-        "line_number": 831
+        "line_number": 783
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "e4dec77ed41da21f2db9ec8d14e6b64d5f5807cf",
         "is_verified": false,
-        "line_number": 838
+        "line_number": 790
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "1de1e75512b60c7a905448217786ec745b387142",
         "is_verified": false,
-        "line_number": 886
+        "line_number": 835
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "7aed2cddeb110852a1012df39f2bba85aa103776",
         "is_verified": false,
-        "line_number": 934
+        "line_number": 880
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "84de9414f2b51b7ab44280bc40daa8deaa32235c",
         "is_verified": false,
-        "line_number": 975
+        "line_number": 918
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "9d63f6c576077d795aa02894fe1cf5b164a7d7d5",
         "is_verified": false,
-        "line_number": 983
+        "line_number": 926
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "2e23f7aad94f835937ab440f6a92d37d8eb7efdc",
         "is_verified": false,
-        "line_number": 1033
+        "line_number": 973
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "58cae497261e0b72dfce1338c9288d3421e699e4",
         "is_verified": false,
-        "line_number": 1082
+        "line_number": 1019
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "9a2ed348bb3b66bde3e1dbe6b1e6b6ee83c79975",
         "is_verified": false,
-        "line_number": 1131
+        "line_number": 1065
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "2203e03a62a0efc06caeefbdf793a766dd831366",
         "is_verified": false,
-        "line_number": 1228
+        "line_number": 1156
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "1f9d91c9924d7d173ea08d54ddea2d223de6a7fb",
         "is_verified": false,
-        "line_number": 1277
+        "line_number": 1202
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "3d59c4db2a714d8af140b7a2d5624753e2bf5060",
         "is_verified": false,
-        "line_number": 1326
+        "line_number": 1248
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "10ebf82a6eae9289bee2554bf77f6099484f3bf6",
         "is_verified": false,
-        "line_number": 1367
+        "line_number": 1286
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "7e19d2e69f6f62b49510c83d28e1a5694feaff7b",
         "is_verified": false,
-        "line_number": 1374
+        "line_number": 1293
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "e1e8b627d3d71d392eb8b237c1514ccc6bfff594",
         "is_verified": false,
-        "line_number": 1422
+        "line_number": 1338
       },
       {
         "type": "Base64 High Entropy String",
         "filename": "src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx",
         "hashed_secret": "fd7df1a90d15d76b63d73bbf5873f23aadcceda8",
         "is_verified": false,
-        "line_number": 1471
+        "line_number": 1384
       }
     ],
     "src/Components/ArtworkGrid/__tests__/ArtworkGridFixture.ts": [
@@ -562,5 +562,5 @@
       }
     ]
   },
-  "generated_at": "2024-10-18T00:02:26Z"
+  "generated_at": "2024-10-09T13:30:14Z"
 }

--- a/src/Apps/Artwork/Components/ArtworkArtistSeries/ArtistSeriesArtworkRail.tsx
+++ b/src/Apps/Artwork/Components/ArtworkArtistSeries/ArtistSeriesArtworkRail.tsx
@@ -71,9 +71,9 @@ export const ArtistSeriesArtworkRail: React.FC<Props> = ({ artwork }) => {
                   destination_page_owner_slug: artwork.slug,
                   horizontal_slide_position: index,
                   type: "thumbnail",
-                  signal_label: getSignalLabel({
-                    collectorSignals: artwork.collectorSignals ?? {},
-                  }),
+                  signal_label: artwork.collectorSignals
+                    ? getSignalLabel(artwork.collectorSignals)
+                    : "",
                   signal_bid_count:
                     artwork.collectorSignals?.auction?.bidCount ?? undefined,
                   signal_lot_watcher_count:

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
@@ -124,9 +124,9 @@ export const ArtworkSidebarCommercialButtons: React.FC<ArtworkSidebarCommercialB
       context_owner_type: OwnerType.artwork,
       context_owner_slug: artwork.slug,
       context_owner_id: artwork.internalID,
-      signal_label: getSignalLabel({
-        collectorSignals: artwork.collectorSignals ?? {},
-      }),
+      signal_label: artwork.collectorSignals
+        ? getSignalLabel(artwork.collectorSignals)
+        : "",
     }
     trackEvent(event)
 
@@ -140,9 +140,9 @@ export const ArtworkSidebarCommercialButtons: React.FC<ArtworkSidebarCommercialB
       context_owner_id: artwork.internalID,
       context_owner_slug: artwork.slug,
       flow: "Partner offer",
-      signal_label: getSignalLabel({
-        collectorSignals: artwork.collectorSignals ?? {},
-      }),
+      signal_label: artwork.collectorSignals
+        ? getSignalLabel(artwork.collectorSignals)
+        : "",
     }
 
     trackEvent(event)
@@ -198,9 +198,9 @@ export const ArtworkSidebarCommercialButtons: React.FC<ArtworkSidebarCommercialB
       context_owner_id: artwork.internalID,
       context_owner_slug: artwork.slug,
       flow: "Buy now",
-      signal_label: getSignalLabel({
-        collectorSignals: artwork.collectorSignals ?? {},
-      }),
+      signal_label: artwork.collectorSignals
+        ? getSignalLabel(artwork.collectorSignals)
+        : "",
     }
 
     trackEvent(event)

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarPartnerInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarPartnerInfo.tsx
@@ -61,9 +61,7 @@ const ArtworkSidebarPartnerInfo: React.FC<ArtworkSidebarPartnerInfoProps> = ({
       context_owner_type: OwnerType.artwork,
       context_owner_slug: slug,
       context_owner_id: internalID,
-      signal_label: getSignalLabel({
-        collectorSignals: collectorSignals ?? {},
-      }),
+      signal_label: collectorSignals ? getSignalLabel(collectorSignals) : "",
     }
 
     trackEvent(event)

--- a/src/Apps/Fair/Routes/__tests__/FairArtworks.jest.tsx
+++ b/src/Apps/Fair/Routes/__tests__/FairArtworks.jest.tsx
@@ -110,9 +110,6 @@ const FAIR_ARTWORKS_FIXTURE: FairArtworks_Query$rawResponse = {
       edges: [
         {
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id: "ggg123",
             slug: "yayoi-kusama-pumpkin-2222222222222222",
             href: "/artwork/yayoi-kusama-pumpkin-2222222222222222",
@@ -191,9 +188,6 @@ const FAIR_ARTWORKS_FIXTURE: FairArtworks_Query$rawResponse = {
         },
         {
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id: "abc123",
             slug: "yayoi-kusama-pumpkin-33333333333333333",
             href: "/artwork/yayoi-kusama-pumpkin-33333333333333333",

--- a/src/Apps/Home/Components/HomeEmergingPicksArtworksRail.tsx
+++ b/src/Apps/Home/Components/HomeEmergingPicksArtworksRail.tsx
@@ -35,9 +35,7 @@ export const HomeEmergingPicksArtworksRail: React.FC<HomeEmergingPicksArtworksRa
   }
 
   return (
-    <ArtworkGridContextProvider
-      hideSignals={["CURATORS_PICK", "INCREASED_INTEREST"]}
-    >
+    <ArtworkGridContextProvider hideSignals>
       <Rail
         title="Curators’ Picks: Emerging"
         subTitle="The best works by rising talents on Artsy, all available now."
@@ -73,10 +71,9 @@ export const HomeEmergingPicksArtworksRail: React.FC<HomeEmergingPicksArtworksRa
                   destination_page_owner_id: artwork.internalID,
                   destination_page_owner_slug: artwork.slug,
                   type: "thumbnail",
-                  signal_label: getSignalLabel({
-                    collectorSignals: artwork.collectorSignals ?? {},
-                    hideSignals: ["CURATORS_PICK", "INCREASED_INTEREST"],
-                  }),
+                  signal_label: artwork.collectorSignals
+                    ? getSignalLabel(artwork.collectorSignals)
+                    : "",
                   signal_bid_count:
                     artwork.collectorSignals?.auction?.bidCount ?? undefined,
                   signal_lot_watcher_count:

--- a/src/Apps/Home/Components/HomeNewWorksForYouRail.tsx
+++ b/src/Apps/Home/Components/HomeNewWorksForYouRail.tsx
@@ -55,9 +55,9 @@ const HomeNewWorksForYouRail: React.FC<HomeNewWorksForYouRailProps> = ({
                 destination_page_owner_slug: artwork.slug,
                 destination_page_owner_type: OwnerType.artwork,
                 type: "thumbnail",
-                signal_label: getSignalLabel({
-                  collectorSignals: artwork.collectorSignals ?? {},
-                }),
+                signal_label: artwork.collectorSignals
+                  ? getSignalLabel(artwork.collectorSignals)
+                  : "",
                 signal_bid_count:
                   artwork.collectorSignals?.auction?.bidCount ?? undefined,
                 signal_lot_watcher_count:

--- a/src/Apps/Home/Components/HomeNewWorksFromGalleriesYouFollowRail.tsx
+++ b/src/Apps/Home/Components/HomeNewWorksFromGalleriesYouFollowRail.tsx
@@ -75,9 +75,9 @@ const HomeNewWorksFromGalleriesYouFollowRail: React.FC<HomeNewWorksFromGalleries
                 destination_page_owner_id: artwork.internalID,
                 destination_page_owner_slug: artwork.slug,
                 type: "thumbnail",
-                signal_label: getSignalLabel({
-                  collectorSignals: artwork.collectorSignals ?? {},
-                }),
+                signal_label: artwork.collectorSignals
+                  ? getSignalLabel(artwork.collectorSignals)
+                  : "",
                 signal_bid_count:
                   artwork.collectorSignals?.auction?.bidCount ?? undefined,
                 signal_lot_watcher_count:

--- a/src/Apps/Home/Components/HomeRecentlyViewedRail.tsx
+++ b/src/Apps/Home/Components/HomeRecentlyViewedRail.tsx
@@ -54,9 +54,9 @@ const HomeRecentlyViewedRail: React.FC<HomeRecentlyViewedRailProps> = ({
                 destination_page_owner_slug: artwork.slug,
                 destination_page_owner_type: OwnerType.artwork,
                 type: "thumbnail",
-                signal_label: getSignalLabel({
-                  collectorSignals: artwork.collectorSignals ?? {},
-                }),
+                signal_label: artwork.collectorSignals
+                  ? getSignalLabel(artwork.collectorSignals)
+                  : "",
                 signal_bid_count:
                   artwork.collectorSignals?.auction?.bidCount ?? undefined,
                 signal_lot_watcher_count:

--- a/src/Apps/Home/Components/HomeWorksByArtistsYouFollowRail.tsx
+++ b/src/Apps/Home/Components/HomeWorksByArtistsYouFollowRail.tsx
@@ -54,9 +54,9 @@ const HomeWorksByArtistsYouFollowRail: React.FC<HomeWorksByArtistsYouFollowRailP
                 destination_page_owner_slug: artwork.slug,
                 destination_page_owner_type: OwnerType.artwork,
                 type: "thumbnail",
-                signal_label: getSignalLabel({
-                  collectorSignals: artwork.collectorSignals ?? {},
-                }),
+                signal_label: artwork.collectorSignals
+                  ? getSignalLabel(artwork.collectorSignals)
+                  : "",
                 signal_bid_count:
                   artwork.collectorSignals?.auction?.bidCount ?? undefined,
                 signal_lot_watcher_count:

--- a/src/Components/Artwork/Details/PrimaryLabelLine.tsx
+++ b/src/Components/Artwork/Details/PrimaryLabelLine.tsx
@@ -34,10 +34,7 @@ export const PrimaryLabelLine: React.FC<PrimaryLabelLineProps> = ({
     )
   }
 
-  if (
-    primaryLabel === "INCREASED_INTEREST" &&
-    !hideSignals?.includes(primaryLabel)
-  ) {
+  if (primaryLabel === "INCREASED_INTEREST" && !hideSignals) {
     return (
       <Text
         variant="xs"
@@ -55,10 +52,7 @@ export const PrimaryLabelLine: React.FC<PrimaryLabelLineProps> = ({
     )
   }
 
-  if (
-    primaryLabel === "CURATORS_PICK" &&
-    !hideSignals?.includes(primaryLabel)
-  ) {
+  if (primaryLabel === "CURATORS_PICK" && !hideSignals) {
     return (
       <Text
         variant="xs"

--- a/src/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
@@ -14,9 +14,6 @@ import {
 } from "@artsy/cohesion"
 import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
 import { LoadingArea } from "Components/LoadingArea"
-import { extractNodes } from "Utils/extractNodes"
-import { getSignalLabel } from "Utils/getSignalLabel"
-import { useArtworkGridContext } from "Components/ArtworkGrid/ArtworkGridContext"
 
 interface ArtworkFilterArtworkGridProps {
   columnCount: number[]
@@ -34,9 +31,7 @@ const ArtworkFilterArtworkGrid: React.FC<ArtworkFilterArtworkGridProps> = props 
     contextPageOwnerSlug,
     contextPageOwnerId,
   } = useAnalyticsContext()
-  const { hideSignals } = useArtworkGridContext()
   const context = useArtworkFilterContext()
-  const filteredArtworks = extractNodes(props.filtered_artworks)
 
   const {
     columnCount,
@@ -75,9 +70,6 @@ const ArtworkFilterArtworkGrid: React.FC<ArtworkFilterArtworkGridProps> = props 
           onClearFilters={context.resetFilters}
           emptyStateComponent={context.ZeroState && <context.ZeroState />}
           onBrickClick={(artwork, artworkIndex) => {
-            const collectorSignals =
-              filteredArtworks?.[artworkIndex].collectorSignals ?? {}
-
             const event: ClickedMainArtworkGrid = {
               action: ActionType.clickedMainArtworkGrid,
               context_module: ContextModule.artworkGrid,
@@ -90,10 +82,6 @@ const ArtworkFilterArtworkGrid: React.FC<ArtworkFilterArtworkGridProps> = props 
               position: artworkIndex,
               sort: context?.filters?.sort,
               type: "thumbnail",
-              signal_label: getSignalLabel({
-                collectorSignals,
-                hideSignals,
-              }),
             }
             trackEvent(event)
           }}
@@ -130,9 +118,6 @@ export const ArtworkFilterArtworkGridRefetchContainer = createFragmentContainer(
         }
         edges {
           node {
-            collectorSignals {
-              primaryLabel
-            }
             id
           }
         }

--- a/src/Components/ArtworkFilter/__tests__/ArtworkFilter.jest.tsx
+++ b/src/Components/ArtworkFilter/__tests__/ArtworkFilter.jest.tsx
@@ -28,14 +28,6 @@ jest.mock("System/Hooks/useRouter", () => ({
   }),
 }))
 
-jest.mock("System/Hooks/useAnalyticsContext", () => ({
-  useAnalyticsContext: jest.fn(() => ({
-    contextPageOwnerId: "contextPageOwnerID",
-    contextPageOwnerSlug: "contextPageOwnerSlug",
-    contextPageOwnerType: "contextPageOwnerType",
-  })),
-}))
-
 describe("ArtworkFilter", () => {
   const onFilterClick = jest.fn()
   const onChange = jest.fn()
@@ -218,14 +210,10 @@ describe("ArtworkFilter", () => {
       expect(trackEvent).toHaveBeenCalledWith({
         action: "clickedMainArtworkGrid",
         context_module: "artworkGrid",
-        context_page_owner_id: "contextPageOwnerID",
-        context_page_owner_slug: "contextPageOwnerSlug",
-        context_page_owner_type: "contextPageOwnerType",
         destination_page_owner_id: "5d041931e607c200127ef3c1",
         destination_page_owner_slug: "andy-warhol-kenny-burrell",
         destination_page_owner_type: "artwork",
         position: 0,
-        signal_label: "",
         sort: "-decayed_merch",
         type: "thumbnail",
       })

--- a/src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx
+++ b/src/Components/ArtworkFilter/__tests__/fixtures/ArtworkFilter.fixture.tsx
@@ -48,9 +48,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
         {
           id: "QXJ0d29yazphbmR5LXdhcmhvbC1rZW5ueS1idXJyZWxs",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id: "QXJ0d29yazphbmR5LXdhcmhvbC1rZW5ueS1idXJyZWxs",
             slug: "andy-warhol-kenny-burrell",
             href: "/artwork/andy-warhol-kenny-burrell",
@@ -96,9 +93,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
         {
           id: "QXJ0d29yazphbmR5LXdhcmhvbC1kb2xsYXJzLTEtZnMtaWktZG90LTI3NA==",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id: "QXJ0d29yazphbmR5LXdhcmhvbC1kb2xsYXJzLTEtZnMtaWktZG90LTI3NA==",
             slug: "andy-warhol-dollars-1-fs-ii-dot-274",
             href: "/artwork/andy-warhol-dollars-1-fs-ii-dot-274",
@@ -144,9 +138,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
         {
           id: "QXJ0d29yazphbmR5LXdhcmhvbC1wZWFjaGVz",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id: "QXJ0d29yazphbmR5LXdhcmhvbC1wZWFjaGVz",
             slug: "andy-warhol-peaches",
             href: "/artwork/andy-warhol-peaches",
@@ -193,9 +184,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
           id:
             "QXJ0d29yazphbmR5LXdhcmhvbC1hY3RyZXNzLXNob3RzLWFuZHktd2FyaG9sLW55LWRhaWx5LW5ld3MtMTk2OA==",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id:
               "QXJ0d29yazphbmR5LXdhcmhvbC1hY3RyZXNzLXNob3RzLWFuZHktd2FyaG9sLW55LWRhaWx5LW5ld3MtMTk2OA==",
             slug: "andy-warhol-actress-shots-andy-warhol-ny-daily-news-1968",
@@ -244,9 +232,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
         {
           id: "QXJ0d29yazphbmR5LXdhcmhvbC1jb3Ntb3M=",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id: "QXJ0d29yazphbmR5LXdhcmhvbC1jb3Ntb3M=",
             slug: "andy-warhol-cosmos",
             href: "/artwork/andy-warhol-cosmos",
@@ -292,9 +277,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
         {
           id: "QXJ0d29yazphbmR5LXdhcmhvbC1sZWUtaWFjb2NjYS0y",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id: "QXJ0d29yazphbmR5LXdhcmhvbC1sZWUtaWFjb2NjYS0y",
             slug: "andy-warhol-lee-iacocca-2",
             href: "/artwork/andy-warhol-lee-iacocca-2",
@@ -340,9 +322,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
         {
           id: "QXJ0d29yazphbmR5LXdhcmhvbC1zaG9lLTE4",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id: "QXJ0d29yazphbmR5LXdhcmhvbC1zaG9lLTE4",
             slug: "andy-warhol-shoe-18",
             href: "/artwork/andy-warhol-shoe-18",
@@ -388,9 +367,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
         {
           id: "QXJ0d29yazphbmR5LXdhcmhvbC1zZXdpbmctbWFjaGluZQ==",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id: "QXJ0d29yazphbmR5LXdhcmhvbC1zZXdpbmctbWFjaGluZQ==",
             slug: "andy-warhol-sewing-machine",
             href: "/artwork/andy-warhol-sewing-machine",
@@ -436,9 +412,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
         {
           id: "QXJ0d29yazphbmR5LXdhcmhvbC1zdXBlcm1hbi1mLWFuZC1zLWlpLTI2MC0z",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id: "QXJ0d29yazphbmR5LXdhcmhvbC1zdXBlcm1hbi1mLWFuZC1zLWlpLTI2MC0z",
             slug: "andy-warhol-superman-f-and-s-ii-260-3",
             href: "/artwork/andy-warhol-superman-f-and-s-ii-260-3",
@@ -484,9 +457,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
         {
           id: "QXJ0d29yazphbmR5LXdhcmhvbC1iaXJtaW5naGFtLXJhY2UtcmlvdC0xMA==",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id: "QXJ0d29yazphbmR5LXdhcmhvbC1iaXJtaW5naGFtLXJhY2UtcmlvdC0xMA==",
             slug: "andy-warhol-birmingham-race-riot-10",
             href: "/artwork/andy-warhol-birmingham-race-riot-10",
@@ -533,9 +503,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
           id:
             "QXJ0d29yazphbmR5LXdhcmhvbC1ub3J0aHdlc3QtY29hc3QtbWFzay1mcy1paS1kb3QtMzgwLTI=",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id:
               "QXJ0d29yazphbmR5LXdhcmhvbC1ub3J0aHdlc3QtY29hc3QtbWFzay1mcy1paS1kb3QtMzgwLTI=",
             slug: "andy-warhol-northwest-coast-mask-fs-ii-dot-380-2",
@@ -583,9 +550,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
           id:
             "QXJ0d29yazphbmR5LXdhcmhvbC1yYXJlLW9yaWdpbmFsLWFuZHktd2FyaG9sLXJlY29yZC1hcnQ=",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id:
               "QXJ0d29yazphbmR5LXdhcmhvbC1yYXJlLW9yaWdpbmFsLWFuZHktd2FyaG9sLXJlY29yZC1hcnQ=",
             slug: "andy-warhol-rare-original-andy-warhol-record-art",
@@ -634,9 +598,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
           id:
             "QXJ0d29yazphbmR5LXdhcmhvbC1hbmR5LXdhcmhvbC1waGlsaXAtZmFnYW4tYW5kLWdlcmFyZC1tYWxhbmdh",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id:
               "QXJ0d29yazphbmR5LXdhcmhvbC1hbmR5LXdhcmhvbC1waGlsaXAtZmFnYW4tYW5kLWdlcmFyZC1tYWxhbmdh",
             slug: "andy-warhol-andy-warhol-philip-fagan-and-gerard-malanga",
@@ -686,9 +647,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
           id:
             "QXJ0d29yazphbmR5LXdhcmhvbC1hbmR5LXdhcmhvbC1waG90b2dyYXBoLW9mLWNvcm5lbGlhLWd1ZXN0LTE5ODU=",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id:
               "QXJ0d29yazphbmR5LXdhcmhvbC1hbmR5LXdhcmhvbC1waG90b2dyYXBoLW9mLWNvcm5lbGlhLWd1ZXN0LTE5ODU=",
             slug: "andy-warhol-andy-warhol-photograph-of-cornelia-guest-1985",
@@ -738,9 +696,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
           id:
             "QXJ0d29yazphbmR5LXdhcmhvbC1hbmR5LXdhcmhvbC1waG90b2dyYXBoLW9mLXRpbW90aHktaHV0dG9uLTE5ODA=",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id:
               "QXJ0d29yazphbmR5LXdhcmhvbC1hbmR5LXdhcmhvbC1waG90b2dyYXBoLW9mLXRpbW90aHktaHV0dG9uLTE5ODA=",
             slug: "andy-warhol-andy-warhol-photograph-of-timothy-hutton-1980",
@@ -789,9 +744,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
         {
           id: "QXJ0d29yazphbmR5LXdhcmhvbC1tdWhhbW1lZC1hbGktMQ==",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id: "QXJ0d29yazphbmR5LXdhcmhvbC1tdWhhbW1lZC1hbGktMQ==",
             slug: "andy-warhol-muhammed-ali-1",
             href: "/artwork/andy-warhol-muhammed-ali-1",
@@ -837,9 +789,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
         {
           id: "QXJ0d29yazphbmR5LXdhcmhvbC11bnRpdGxlZC1qb24tZ291bGQtMQ==",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id: "QXJ0d29yazphbmR5LXdhcmhvbC11bnRpdGxlZC1qb24tZ291bGQtMQ==",
             slug: "andy-warhol-untitled-jon-gould-1",
             href: "/artwork/andy-warhol-untitled-jon-gould-1",
@@ -885,9 +834,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
         {
           id: "QXJ0d29yazphbmR5LXdhcmhvbC1nZXJvbmltby1mcy1paS1kb3QtMzg0LTEy",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id: "QXJ0d29yazphbmR5LXdhcmhvbC1nZXJvbmltby1mcy1paS1kb3QtMzg0LTEy",
             slug: "andy-warhol-geronimo-fs-ii-dot-384-12",
             href: "/artwork/andy-warhol-geronimo-fs-ii-dot-384-12",
@@ -933,9 +879,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
         {
           id: "QXJ0d29yazphbmR5LXdhcmhvbC1qYXNvbi1tY2NveQ==",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id: "QXJ0d29yazphbmR5LXdhcmhvbC1qYXNvbi1tY2NveQ==",
             slug: "andy-warhol-jason-mccoy",
             href: "/artwork/andy-warhol-jason-mccoy",
@@ -982,9 +925,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
           id:
             "QXJ0d29yazphbmR5LXdhcmhvbC1kb2xsYXJzLXF1YWRyYW50LWZzLWlpLWRvdC0yODQtMQ==",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id:
               "QXJ0d29yazphbmR5LXdhcmhvbC1kb2xsYXJzLXF1YWRyYW50LWZzLWlpLWRvdC0yODQtMQ==",
             slug: "andy-warhol-dollars-quadrant-fs-ii-dot-284-1",
@@ -1032,9 +972,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
           id:
             "QXJ0d29yazphbmR5LXdhcmhvbC1sYWRpZXMtYW5kLWdlbnRsZW1lbi1mcy1paS1kb3QtMTMwLTE=",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id:
               "QXJ0d29yazphbmR5LXdhcmhvbC1sYWRpZXMtYW5kLWdlbnRsZW1lbi1mcy1paS1kb3QtMTMwLTE=",
             slug: "andy-warhol-ladies-and-gentlemen-fs-ii-dot-130-1",
@@ -1081,9 +1018,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
         {
           id: "QXJ0d29yazphbmR5LXdhcmhvbC1tYW8tZi1kb3Qtcy1paS1kb3QtOTU=",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id: "QXJ0d29yazphbmR5LXdhcmhvbC1tYW8tZi1kb3Qtcy1paS1kb3QtOTU=",
             slug: "andy-warhol-mao-f-dot-s-ii-dot-95",
             href: "/artwork/andy-warhol-mao-f-dot-s-ii-dot-95",
@@ -1130,9 +1064,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
           id:
             "QXJ0d29yazphbmR5LXdhcmhvbC1sYWRpZXMtYW5kLWdlbnRsZW1lbi1mcy1paS1kb3QtMTI3LTE=",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id:
               "QXJ0d29yazphbmR5LXdhcmhvbC1sYWRpZXMtYW5kLWdlbnRsZW1lbi1mcy1paS1kb3QtMTI3LTE=",
             slug: "andy-warhol-ladies-and-gentlemen-fs-ii-dot-127-1",
@@ -1179,9 +1110,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
         {
           id: "QXJ0d29yazphbmR5LXdhcmhvbC10cnVjay05",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id: "QXJ0d29yazphbmR5LXdhcmhvbC10cnVjay05",
             slug: "andy-warhol-truck-9",
             href: "/artwork/andy-warhol-truck-9",
@@ -1227,9 +1155,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
         {
           id: "QXJ0d29yazphbmR5LXdhcmhvbC1icmlsbG8tMQ==",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id: "QXJ0d29yazphbmR5LXdhcmhvbC1icmlsbG8tMQ==",
             slug: "andy-warhol-brillo-1",
             href: "/artwork/andy-warhol-brillo-1",
@@ -1276,9 +1201,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
           id:
             "QXJ0d29yazphbmR5LXdhcmhvbC1wbGFpbnMtaW5kaWFuLXNoaWVsZC1mcy1paS1kb3QtMzgyLTM=",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id:
               "QXJ0d29yazphbmR5LXdhcmhvbC1wbGFpbnMtaW5kaWFuLXNoaWVsZC1mcy1paS1kb3QtMzgyLTM=",
             slug: "andy-warhol-plains-indian-shield-fs-ii-dot-382-3",
@@ -1325,9 +1247,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
         {
           id: "QXJ0d29yazphbmR5LXdhcmhvbC1tYXJ0aGEtZ3JhaGFtLTE1",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id: "QXJ0d29yazphbmR5LXdhcmhvbC1tYXJ0aGEtZ3JhaGFtLTE1",
             slug: "andy-warhol-martha-graham-15",
             href: "/artwork/andy-warhol-martha-graham-15",
@@ -1373,9 +1292,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
         {
           id: "QXJ0d29yazphbmR5LXdhcmhvbC1maXNoLWZzLWlpaWEtZG90LTM5LTE=",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id: "QXJ0d29yazphbmR5LXdhcmhvbC1maXNoLWZzLWlpaWEtZG90LTM5LTE=",
             slug: "andy-warhol-fish-fs-iiia-dot-39-1",
             href: "/artwork/andy-warhol-fish-fs-iiia-dot-39-1",
@@ -1421,9 +1337,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
         {
           id: "QXJ0d29yazphbmR5LXdhcmhvbC11bnRpdGxlZC1mZW1hbGUtZmlndXJl",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id: "QXJ0d29yazphbmR5LXdhcmhvbC11bnRpdGxlZC1mZW1hbGUtZmlndXJl",
             slug: "andy-warhol-untitled-female-figure",
             href: "/artwork/andy-warhol-untitled-female-figure",
@@ -1470,9 +1383,6 @@ export const ArtworkFilterFixture: ArtworkQueryFilterQuery$rawResponse = {
           id:
             "QXJ0d29yazphbmR5LXdhcmhvbC1sYWRpZXMtYW5kLWdlbnRsZW1lbi1mcy1paS1kb3QtMTI4LTI=",
           node: {
-            collectorSignals: {
-              primaryLabel: null,
-            },
             id:
               "QXJ0d29yazphbmR5LXdhcmhvbC1sYWRpZXMtYW5kLWdlbnRsZW1lbi1mcy1paS1kb3QtMTI4LTI=",
             slug: "andy-warhol-ladies-and-gentlemen-fs-ii-dot-128-2",

--- a/src/Components/ArtworkFilter/index.tsx
+++ b/src/Components/ArtworkFilter/index.tsx
@@ -21,10 +21,7 @@ import {
 import { ArtworkFilterCreateAlert } from "Components/ArtworkFilter/ArtworkFilterCreateAlert"
 import { ArtworkFilterDrawer } from "Components/ArtworkFilter/ArtworkFilterDrawer"
 import { ArtworkFilterExpandableSort } from "Components/ArtworkFilter/ArtworkFilters/ArtworkFilterExpandableSort"
-import {
-  ArtworkGridContextProvider,
-  useArtworkGridContext,
-} from "Components/ArtworkGrid/ArtworkGridContext"
+import { useArtworkGridContext } from "Components/ArtworkGrid/ArtworkGridContext"
 import { Sticky } from "Components/Sticky"
 import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
 import { useSystemContext } from "System/Hooks/useSystemContext"
@@ -424,16 +421,12 @@ export const BaseArtworkFilter: React.FC<
         <Spacer y={2} />
 
         {children || (
-          <ArtworkGridContextProvider
-            hideSignals={hideSignalsBySlug(viewer.slug)}
-          >
-            <ArtworkFilterArtworkGrid
-              filtered_artworks={viewer.filtered_artworks}
-              isLoading={isLoading}
-              offset={offset}
-              columnCount={[2, 3, 4]}
-            />
-          </ArtworkGridContextProvider>
+          <ArtworkFilterArtworkGrid
+            filtered_artworks={viewer.filtered_artworks}
+            isLoading={isLoading}
+            offset={offset}
+            columnCount={[2, 3, 4]}
+          />
         )}
       </Media>
     </Box>
@@ -472,18 +465,4 @@ export const getTotalCountLabel = ({
   }`
 
   return totalCountLabel
-}
-
-const hideSignalsBySlug = (slug: string) => {
-  const HIDE_SIGNAL_SLUGS = [
-    "trending-now",
-    "curators-picks-emerging-artists",
-    "curators-picks-blue-chip-artists",
-  ]
-
-  if (HIDE_SIGNAL_SLUGS.includes(slug)) {
-    return ["CURATORS_PICK", "INCREASED_INTEREST"]
-  }
-
-  return []
 }

--- a/src/Components/ArtworkGrid/ArtworkGridContext.tsx
+++ b/src/Components/ArtworkGrid/ArtworkGridContext.tsx
@@ -14,14 +14,14 @@ interface ArtworkGridContextProps {
 
   saveOnlyToDefaultList?: boolean
 
-  hideSignals?: string[]
+  hideSignals?: boolean
 }
 
 const ArtworkGridContext = createContext<ArtworkGridContextProps>({
   isAuctionArtwork: false,
   hideLotLabel: false,
   saveOnlyToDefaultList: false,
-  hideSignals: [],
+  hideSignals: false,
 })
 
 export const ArtworkGridContextProvider: React.FC<ArtworkGridContextProps> = ({

--- a/src/Components/Notifications/Hooks/useNotificationsTracking.ts
+++ b/src/Components/Notifications/Hooks/useNotificationsTracking.ts
@@ -53,9 +53,7 @@ export const useNotificationsTracking = () => {
         context_owner_id: artworkID,
         context_owner_slug: artworkSlug,
         flow: "Partner Offer",
-        signal_label: getSignalLabel({
-          collectorSignals: collectorSignals ?? {},
-        }),
+        signal_label: collectorSignals ? getSignalLabel(collectorSignals) : "",
       }
 
       trackEvent(event)

--- a/src/Utils/getSignalLabel.ts
+++ b/src/Utils/getSignalLabel.ts
@@ -2,20 +2,8 @@ export interface CollectorSignals {
   primaryLabel?: string | null | undefined
 }
 
-interface SignalLabelProps {
-  collectorSignals: CollectorSignals
-  hideSignals?: string[]
-}
-
-export const getSignalLabel = ({
-  collectorSignals,
-  hideSignals,
-}: SignalLabelProps) => {
+export const getSignalLabel = (collectorSignals: CollectorSignals) => {
   const { primaryLabel } = collectorSignals
-
-  if (primaryLabel && hideSignals?.includes(primaryLabel)) {
-    return ""
-  }
 
   switch (primaryLabel) {
     case "PARTNER_OFFER":

--- a/src/__generated__/ArtistArtworkFilterQuery.graphql.ts
+++ b/src/__generated__/ArtistArtworkFilterQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e7ec65a6024219bce50135f8c5cec6ec>>
+ * @generated SignedSource<<c7d79095c46a775de61048e140db5edc>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -141,28 +141,31 @@ v7 = [
     "storageKey": null
   }
 ],
-v8 = {
+v8 = [
+  (v4/*: any*/)
+],
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v11 = {
+v12 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -170,14 +173,14 @@ v11 = {
     "large"
   ]
 },
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v13 = [
+v14 = [
   {
     "alias": null,
     "args": null,
@@ -186,28 +189,28 @@ v13 = [
     "storageKey": null
   }
 ],
-v14 = [
+v15 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v17 = [
+v18 = [
   (v3/*: any*/),
   (v4/*: any*/)
 ];
@@ -442,27 +445,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v4/*: any*/)
-                    ],
+                    "selections": (v8/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -494,9 +477,9 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v8/*: any*/),
                           (v9/*: any*/),
                           (v10/*: any*/),
+                          (v11/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -518,7 +501,7 @@ return {
                                 "name": "aspectRatio",
                                 "storageKey": null
                               },
-                              (v10/*: any*/),
+                              (v11/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -529,7 +512,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v11/*: any*/)
+                                  (v12/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -552,7 +535,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v11/*: any*/),
+                                  (v12/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -637,6 +620,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -688,7 +678,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v12/*: any*/),
+                                  (v13/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -696,7 +686,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v13/*: any*/),
+                                    "selections": (v14/*: any*/),
                                     "storageKey": null
                                   },
                                   (v4/*: any*/)
@@ -722,7 +712,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v14/*: any*/),
+                            "args": (v15/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -770,14 +760,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v14/*: any*/),
+                            "args": (v15/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v4/*: any*/),
-                              (v9/*: any*/),
+                              (v10/*: any*/),
                               (v3/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -791,14 +781,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v14/*: any*/),
+                            "args": (v15/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v3/*: any*/),
-                              (v9/*: any*/),
+                              (v10/*: any*/),
                               (v4/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -811,7 +801,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v12/*: any*/),
+                              (v13/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -873,7 +863,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v15/*: any*/),
+                              (v16/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -881,8 +871,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v12/*: any*/),
-                              (v16/*: any*/),
+                              (v13/*: any*/),
+                              (v17/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -915,7 +905,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v13/*: any*/),
+                                "selections": (v14/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -925,7 +915,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v13/*: any*/),
+                                "selections": (v14/*: any*/),
                                 "storageKey": null
                               },
                               (v4/*: any*/)
@@ -940,10 +930,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v15/*: any*/),
+                              (v16/*: any*/),
                               (v4/*: any*/),
-                              (v12/*: any*/),
-                              (v16/*: any*/)
+                              (v13/*: any*/),
+                              (v17/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -954,7 +944,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v17/*: any*/),
+                            "selections": (v18/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -972,7 +962,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v17/*: any*/),
+                                "selections": (v18/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -997,9 +987,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v4/*: any*/)
-                        ],
+                        "selections": (v8/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1013,8 +1001,8 @@ return {
             ],
             "storageKey": null
           },
-          (v10/*: any*/),
-          (v8/*: any*/),
+          (v11/*: any*/),
+          (v9/*: any*/),
           (v4/*: any*/)
         ],
         "storageKey": null
@@ -1022,12 +1010,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d009b39fd3d1b508ea829c0561e18ffd",
+    "cacheID": "4358427890f5d80cd0d9b36d337f0c46",
     "id": null,
     "metadata": {},
     "name": "ArtistArtworkFilterQuery",
     "operationKind": "query",
-    "text": "query ArtistArtworkFilterQuery(\n  $artistID: String!\n  $input: FilterArtworksInput\n) {\n  artist(id: $artistID) {\n    ...ArtistArtworkFilter_artist_2VV6jB\n    id\n  }\n}\n\nfragment ArtistArtworkFilter_artist_2VV6jB on Artist {\n  name\n  counts {\n    partner_shows: partnerShows\n    for_sale_artworks: forSaleArtworks\n    ecommerce_artworks: ecommerceArtworks\n    auction_artworks: auctionArtworks\n    artworks\n    has_make_offer_artworks: hasMakeOfferArtworks\n  }\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n  internalID\n  slug\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
+    "text": "query ArtistArtworkFilterQuery(\n  $artistID: String!\n  $input: FilterArtworksInput\n) {\n  artist(id: $artistID) {\n    ...ArtistArtworkFilter_artist_2VV6jB\n    id\n  }\n}\n\nfragment ArtistArtworkFilter_artist_2VV6jB on Artist {\n  name\n  counts {\n    partner_shows: partnerShows\n    for_sale_artworks: forSaleArtworks\n    ecommerce_artworks: ecommerceArtworks\n    auction_artworks: auctionArtworks\n    artworks\n    has_make_offer_artworks: hasMakeOfferArtworks\n  }\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n  internalID\n  slug\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistArtworkFilterTestQuery.graphql.ts
+++ b/src/__generated__/ArtistArtworkFilterTestQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9230e04e6b0b4adeac578590fcb84671>>
+ * @generated SignedSource<<3e551eeb4ce56fd51f489478f2bf911d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -68,28 +68,31 @@ v5 = [
     "storageKey": null
   }
 ],
-v6 = {
+v6 = [
+  (v2/*: any*/)
+],
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -97,14 +100,14 @@ v9 = {
     "large"
   ]
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v11 = [
+v12 = [
   {
     "alias": null,
     "args": null,
@@ -113,92 +116,92 @@ v11 = [
     "storageKey": null
   }
 ],
-v12 = [
+v13 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v15 = [
+v16 = [
   (v1/*: any*/),
   (v2/*: any*/)
 ],
-v16 = {
+v17 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Artist"
 },
-v17 = {
+v18 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FormattedNumber"
 },
-v18 = {
+v19 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Boolean"
-},
-v19 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "String"
 },
 v20 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
-  "type": "ID"
+  "type": "String"
 },
 v21 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v22 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v22 = {
+v23 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Int"
 },
-v23 = {
+v24 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Boolean"
 },
-v24 = {
+v25 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v25 = {
+v26 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "SaleArtwork"
 },
-v26 = {
+v27 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -432,27 +435,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v2/*: any*/)
-                    ],
+                    "selections": (v6/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -484,9 +467,9 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v6/*: any*/),
                           (v7/*: any*/),
                           (v8/*: any*/),
+                          (v9/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -508,7 +491,7 @@ return {
                                 "name": "aspectRatio",
                                 "storageKey": null
                               },
-                              (v8/*: any*/),
+                              (v9/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -519,7 +502,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v9/*: any*/)
+                                  (v10/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -542,7 +525,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v9/*: any*/),
+                                  (v10/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -627,6 +610,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -678,7 +668,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v10/*: any*/),
+                                  (v11/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -686,7 +676,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v11/*: any*/),
+                                    "selections": (v12/*: any*/),
                                     "storageKey": null
                                   },
                                   (v2/*: any*/)
@@ -712,7 +702,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v12/*: any*/),
+                            "args": (v13/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -760,14 +750,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v12/*: any*/),
+                            "args": (v13/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v2/*: any*/),
-                              (v7/*: any*/),
+                              (v8/*: any*/),
                               (v1/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -781,14 +771,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v12/*: any*/),
+                            "args": (v13/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v1/*: any*/),
-                              (v7/*: any*/),
+                              (v8/*: any*/),
                               (v2/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -801,7 +791,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v10/*: any*/),
+                              (v11/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -863,7 +853,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v13/*: any*/),
+                              (v14/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -871,8 +861,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v10/*: any*/),
-                              (v14/*: any*/),
+                              (v11/*: any*/),
+                              (v15/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -905,7 +895,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v11/*: any*/),
+                                "selections": (v12/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -915,7 +905,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v11/*: any*/),
+                                "selections": (v12/*: any*/),
                                 "storageKey": null
                               },
                               (v2/*: any*/)
@@ -930,10 +920,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v13/*: any*/),
+                              (v14/*: any*/),
                               (v2/*: any*/),
-                              (v10/*: any*/),
-                              (v14/*: any*/)
+                              (v11/*: any*/),
+                              (v15/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -944,7 +934,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v15/*: any*/),
+                            "selections": (v16/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -962,7 +952,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v15/*: any*/),
+                                "selections": (v16/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -987,9 +977,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v2/*: any*/)
-                        ],
+                        "selections": (v6/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1003,8 +991,8 @@ return {
             ],
             "storageKey": "filterArtworksConnection(first:30)"
           },
-          (v8/*: any*/),
-          (v6/*: any*/),
+          (v9/*: any*/),
+          (v7/*: any*/),
           (v2/*: any*/)
         ],
         "storageKey": "artist(id:\"example\")"
@@ -1012,80 +1000,80 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1ca7e3df91f6ee3d4c47769f75b778d5",
+    "cacheID": "ceccf6e5ab984984df76ae01d475a8f5",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
-        "artist": (v16/*: any*/),
+        "artist": (v17/*: any*/),
         "artist.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtistCounts"
         },
-        "artist.counts.artworks": (v17/*: any*/),
-        "artist.counts.auction_artworks": (v17/*: any*/),
-        "artist.counts.ecommerce_artworks": (v17/*: any*/),
-        "artist.counts.for_sale_artworks": (v17/*: any*/),
-        "artist.counts.has_make_offer_artworks": (v18/*: any*/),
-        "artist.counts.partner_shows": (v17/*: any*/),
+        "artist.counts.artworks": (v18/*: any*/),
+        "artist.counts.auction_artworks": (v18/*: any*/),
+        "artist.counts.ecommerce_artworks": (v18/*: any*/),
+        "artist.counts.for_sale_artworks": (v18/*: any*/),
+        "artist.counts.has_make_offer_artworks": (v19/*: any*/),
+        "artist.counts.partner_shows": (v18/*: any*/),
         "artist.filtered_artworks": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "FilterArtworksConnection"
         },
-        "artist.filtered_artworks.__isArtworkConnectionInterface": (v19/*: any*/),
+        "artist.filtered_artworks.__isArtworkConnectionInterface": (v20/*: any*/),
         "artist.filtered_artworks.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "FilterArtworksCounts"
         },
-        "artist.filtered_artworks.counts.total": (v17/*: any*/),
+        "artist.filtered_artworks.counts.total": (v18/*: any*/),
         "artist.filtered_artworks.edges": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "ArtworkEdgeInterface"
         },
-        "artist.filtered_artworks.edges.__isNode": (v19/*: any*/),
-        "artist.filtered_artworks.edges.__typename": (v19/*: any*/),
-        "artist.filtered_artworks.edges.id": (v20/*: any*/),
+        "artist.filtered_artworks.edges.__isNode": (v20/*: any*/),
+        "artist.filtered_artworks.edges.__typename": (v20/*: any*/),
+        "artist.filtered_artworks.edges.id": (v21/*: any*/),
         "artist.filtered_artworks.edges.node": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Artwork"
         },
-        "artist.filtered_artworks.edges.node.artist": (v16/*: any*/),
-        "artist.filtered_artworks.edges.node.artist.id": (v20/*: any*/),
+        "artist.filtered_artworks.edges.node.artist": (v17/*: any*/),
+        "artist.filtered_artworks.edges.node.artist.id": (v21/*: any*/),
         "artist.filtered_artworks.edges.node.artist.targetSupply": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "ArtistTargetSupply"
         },
-        "artist.filtered_artworks.edges.node.artist.targetSupply.isP1": (v18/*: any*/),
-        "artist.filtered_artworks.edges.node.artistNames": (v21/*: any*/),
+        "artist.filtered_artworks.edges.node.artist.targetSupply.isP1": (v19/*: any*/),
+        "artist.filtered_artworks.edges.node.artistNames": (v22/*: any*/),
         "artist.filtered_artworks.edges.node.artists": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Artist"
         },
-        "artist.filtered_artworks.edges.node.artists.href": (v21/*: any*/),
-        "artist.filtered_artworks.edges.node.artists.id": (v20/*: any*/),
-        "artist.filtered_artworks.edges.node.artists.name": (v21/*: any*/),
+        "artist.filtered_artworks.edges.node.artists.href": (v22/*: any*/),
+        "artist.filtered_artworks.edges.node.artists.id": (v21/*: any*/),
+        "artist.filtered_artworks.edges.node.artists.name": (v22/*: any*/),
         "artist.filtered_artworks.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "artist.filtered_artworks.edges.node.attributionClass.id": (v20/*: any*/),
-        "artist.filtered_artworks.edges.node.attributionClass.name": (v21/*: any*/),
-        "artist.filtered_artworks.edges.node.collecting_institution": (v21/*: any*/),
+        "artist.filtered_artworks.edges.node.attributionClass.id": (v21/*: any*/),
+        "artist.filtered_artworks.edges.node.attributionClass.name": (v22/*: any*/),
+        "artist.filtered_artworks.edges.node.collecting_institution": (v22/*: any*/),
         "artist.filtered_artworks.edges.node.collectorSignals": {
           "enumValues": null,
           "nullable": true,
@@ -1098,26 +1086,26 @@ return {
           "plural": false,
           "type": "AuctionCollectorSignals"
         },
-        "artist.filtered_artworks.edges.node.collectorSignals.auction.bidCount": (v22/*: any*/),
-        "artist.filtered_artworks.edges.node.collectorSignals.auction.liveBiddingStarted": (v23/*: any*/),
-        "artist.filtered_artworks.edges.node.collectorSignals.auction.lotClosesAt": (v21/*: any*/),
-        "artist.filtered_artworks.edges.node.collectorSignals.auction.onlineBiddingExtended": (v23/*: any*/),
-        "artist.filtered_artworks.edges.node.collectorSignals.auction.registrationEndsAt": (v21/*: any*/),
+        "artist.filtered_artworks.edges.node.collectorSignals.auction.bidCount": (v23/*: any*/),
+        "artist.filtered_artworks.edges.node.collectorSignals.auction.liveBiddingStarted": (v24/*: any*/),
+        "artist.filtered_artworks.edges.node.collectorSignals.auction.lotClosesAt": (v22/*: any*/),
+        "artist.filtered_artworks.edges.node.collectorSignals.auction.onlineBiddingExtended": (v24/*: any*/),
+        "artist.filtered_artworks.edges.node.collectorSignals.auction.registrationEndsAt": (v22/*: any*/),
         "artist.filtered_artworks.edges.node.collectorSignals.partnerOffer": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "PartnerOfferToCollector"
         },
-        "artist.filtered_artworks.edges.node.collectorSignals.partnerOffer.endAt": (v21/*: any*/),
-        "artist.filtered_artworks.edges.node.collectorSignals.partnerOffer.id": (v20/*: any*/),
+        "artist.filtered_artworks.edges.node.collectorSignals.partnerOffer.endAt": (v22/*: any*/),
+        "artist.filtered_artworks.edges.node.collectorSignals.partnerOffer.id": (v21/*: any*/),
         "artist.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Money"
         },
-        "artist.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v21/*: any*/),
+        "artist.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v22/*: any*/),
         "artist.filtered_artworks.edges.node.collectorSignals.primaryLabel": {
           "enumValues": [
             "CURATORS_PICK",
@@ -1128,10 +1116,10 @@ return {
           "plural": false,
           "type": "LabelSignalEnum"
         },
-        "artist.filtered_artworks.edges.node.cultural_maker": (v21/*: any*/),
-        "artist.filtered_artworks.edges.node.date": (v21/*: any*/),
-        "artist.filtered_artworks.edges.node.href": (v21/*: any*/),
-        "artist.filtered_artworks.edges.node.id": (v20/*: any*/),
+        "artist.filtered_artworks.edges.node.cultural_maker": (v22/*: any*/),
+        "artist.filtered_artworks.edges.node.date": (v22/*: any*/),
+        "artist.filtered_artworks.edges.node.href": (v22/*: any*/),
+        "artist.filtered_artworks.edges.node.id": (v21/*: any*/),
         "artist.filtered_artworks.edges.node.image": {
           "enumValues": null,
           "nullable": true,
@@ -1144,35 +1132,35 @@ return {
           "plural": false,
           "type": "Float"
         },
-        "artist.filtered_artworks.edges.node.image.blurhashDataURL": (v21/*: any*/),
+        "artist.filtered_artworks.edges.node.image.blurhashDataURL": (v22/*: any*/),
         "artist.filtered_artworks.edges.node.image.internalID": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ID"
         },
-        "artist.filtered_artworks.edges.node.image.placeholder": (v21/*: any*/),
+        "artist.filtered_artworks.edges.node.image.placeholder": (v22/*: any*/),
         "artist.filtered_artworks.edges.node.image.resized": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ResizedImageUrl"
         },
-        "artist.filtered_artworks.edges.node.image.resized.height": (v24/*: any*/),
-        "artist.filtered_artworks.edges.node.image.resized.src": (v19/*: any*/),
-        "artist.filtered_artworks.edges.node.image.resized.srcSet": (v19/*: any*/),
-        "artist.filtered_artworks.edges.node.image.resized.width": (v24/*: any*/),
-        "artist.filtered_artworks.edges.node.image.url": (v21/*: any*/),
+        "artist.filtered_artworks.edges.node.image.resized.height": (v25/*: any*/),
+        "artist.filtered_artworks.edges.node.image.resized.src": (v20/*: any*/),
+        "artist.filtered_artworks.edges.node.image.resized.srcSet": (v20/*: any*/),
+        "artist.filtered_artworks.edges.node.image.resized.width": (v25/*: any*/),
+        "artist.filtered_artworks.edges.node.image.url": (v22/*: any*/),
         "artist.filtered_artworks.edges.node.image.versions": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "String"
         },
-        "artist.filtered_artworks.edges.node.imageTitle": (v21/*: any*/),
-        "artist.filtered_artworks.edges.node.image_title": (v21/*: any*/),
-        "artist.filtered_artworks.edges.node.internalID": (v20/*: any*/),
-        "artist.filtered_artworks.edges.node.isUnlisted": (v23/*: any*/),
+        "artist.filtered_artworks.edges.node.imageTitle": (v22/*: any*/),
+        "artist.filtered_artworks.edges.node.image_title": (v22/*: any*/),
+        "artist.filtered_artworks.edges.node.internalID": (v21/*: any*/),
+        "artist.filtered_artworks.edges.node.isUnlisted": (v24/*: any*/),
         "artist.filtered_artworks.edges.node.marketPriceInsights": {
           "enumValues": null,
           "nullable": true,
@@ -1197,69 +1185,69 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "artist.filtered_artworks.edges.node.mediumType.filterGene.id": (v20/*: any*/),
-        "artist.filtered_artworks.edges.node.mediumType.filterGene.name": (v21/*: any*/),
+        "artist.filtered_artworks.edges.node.mediumType.filterGene.id": (v21/*: any*/),
+        "artist.filtered_artworks.edges.node.mediumType.filterGene.name": (v22/*: any*/),
         "artist.filtered_artworks.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "artist.filtered_artworks.edges.node.partner.href": (v21/*: any*/),
-        "artist.filtered_artworks.edges.node.partner.id": (v20/*: any*/),
-        "artist.filtered_artworks.edges.node.partner.name": (v21/*: any*/),
+        "artist.filtered_artworks.edges.node.partner.href": (v22/*: any*/),
+        "artist.filtered_artworks.edges.node.partner.id": (v21/*: any*/),
+        "artist.filtered_artworks.edges.node.partner.name": (v22/*: any*/),
         "artist.filtered_artworks.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "artist.filtered_artworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v24/*: any*/),
-        "artist.filtered_artworks.edges.node.sale.endAt": (v21/*: any*/),
-        "artist.filtered_artworks.edges.node.sale.extendedBiddingIntervalMinutes": (v24/*: any*/),
-        "artist.filtered_artworks.edges.node.sale.extendedBiddingPeriodMinutes": (v24/*: any*/),
-        "artist.filtered_artworks.edges.node.sale.id": (v20/*: any*/),
-        "artist.filtered_artworks.edges.node.sale.isOpen": (v18/*: any*/),
-        "artist.filtered_artworks.edges.node.sale.is_auction": (v18/*: any*/),
-        "artist.filtered_artworks.edges.node.sale.is_closed": (v18/*: any*/),
-        "artist.filtered_artworks.edges.node.sale.startAt": (v21/*: any*/),
-        "artist.filtered_artworks.edges.node.saleArtwork": (v25/*: any*/),
-        "artist.filtered_artworks.edges.node.saleArtwork.endAt": (v21/*: any*/),
-        "artist.filtered_artworks.edges.node.saleArtwork.extendedBiddingEndAt": (v21/*: any*/),
-        "artist.filtered_artworks.edges.node.saleArtwork.id": (v20/*: any*/),
-        "artist.filtered_artworks.edges.node.saleArtwork.lotID": (v21/*: any*/),
-        "artist.filtered_artworks.edges.node.sale_artwork": (v25/*: any*/),
+        "artist.filtered_artworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v25/*: any*/),
+        "artist.filtered_artworks.edges.node.sale.endAt": (v22/*: any*/),
+        "artist.filtered_artworks.edges.node.sale.extendedBiddingIntervalMinutes": (v25/*: any*/),
+        "artist.filtered_artworks.edges.node.sale.extendedBiddingPeriodMinutes": (v25/*: any*/),
+        "artist.filtered_artworks.edges.node.sale.id": (v21/*: any*/),
+        "artist.filtered_artworks.edges.node.sale.isOpen": (v19/*: any*/),
+        "artist.filtered_artworks.edges.node.sale.is_auction": (v19/*: any*/),
+        "artist.filtered_artworks.edges.node.sale.is_closed": (v19/*: any*/),
+        "artist.filtered_artworks.edges.node.sale.startAt": (v22/*: any*/),
+        "artist.filtered_artworks.edges.node.saleArtwork": (v26/*: any*/),
+        "artist.filtered_artworks.edges.node.saleArtwork.endAt": (v22/*: any*/),
+        "artist.filtered_artworks.edges.node.saleArtwork.extendedBiddingEndAt": (v22/*: any*/),
+        "artist.filtered_artworks.edges.node.saleArtwork.id": (v21/*: any*/),
+        "artist.filtered_artworks.edges.node.saleArtwork.lotID": (v22/*: any*/),
+        "artist.filtered_artworks.edges.node.sale_artwork": (v26/*: any*/),
         "artist.filtered_artworks.edges.node.sale_artwork.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkCounts"
         },
-        "artist.filtered_artworks.edges.node.sale_artwork.counts.bidder_positions": (v17/*: any*/),
-        "artist.filtered_artworks.edges.node.sale_artwork.endAt": (v21/*: any*/),
-        "artist.filtered_artworks.edges.node.sale_artwork.extendedBiddingEndAt": (v21/*: any*/),
-        "artist.filtered_artworks.edges.node.sale_artwork.formattedEndDateTime": (v21/*: any*/),
+        "artist.filtered_artworks.edges.node.sale_artwork.counts.bidder_positions": (v18/*: any*/),
+        "artist.filtered_artworks.edges.node.sale_artwork.endAt": (v22/*: any*/),
+        "artist.filtered_artworks.edges.node.sale_artwork.extendedBiddingEndAt": (v22/*: any*/),
+        "artist.filtered_artworks.edges.node.sale_artwork.formattedEndDateTime": (v22/*: any*/),
         "artist.filtered_artworks.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "artist.filtered_artworks.edges.node.sale_artwork.highest_bid.display": (v21/*: any*/),
-        "artist.filtered_artworks.edges.node.sale_artwork.id": (v20/*: any*/),
-        "artist.filtered_artworks.edges.node.sale_artwork.lotID": (v21/*: any*/),
-        "artist.filtered_artworks.edges.node.sale_artwork.lotLabel": (v21/*: any*/),
+        "artist.filtered_artworks.edges.node.sale_artwork.highest_bid.display": (v22/*: any*/),
+        "artist.filtered_artworks.edges.node.sale_artwork.id": (v21/*: any*/),
+        "artist.filtered_artworks.edges.node.sale_artwork.lotID": (v22/*: any*/),
+        "artist.filtered_artworks.edges.node.sale_artwork.lotLabel": (v22/*: any*/),
         "artist.filtered_artworks.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "artist.filtered_artworks.edges.node.sale_artwork.opening_bid.display": (v21/*: any*/),
-        "artist.filtered_artworks.edges.node.sale_message": (v21/*: any*/),
-        "artist.filtered_artworks.edges.node.slug": (v20/*: any*/),
-        "artist.filtered_artworks.edges.node.title": (v21/*: any*/),
-        "artist.filtered_artworks.id": (v20/*: any*/),
+        "artist.filtered_artworks.edges.node.sale_artwork.opening_bid.display": (v22/*: any*/),
+        "artist.filtered_artworks.edges.node.sale_message": (v22/*: any*/),
+        "artist.filtered_artworks.edges.node.slug": (v21/*: any*/),
+        "artist.filtered_artworks.edges.node.title": (v22/*: any*/),
+        "artist.filtered_artworks.id": (v21/*: any*/),
         "artist.filtered_artworks.pageCursors": {
           "enumValues": null,
           "nullable": false,
@@ -1272,37 +1260,37 @@ return {
           "plural": true,
           "type": "PageCursor"
         },
-        "artist.filtered_artworks.pageCursors.around.cursor": (v19/*: any*/),
-        "artist.filtered_artworks.pageCursors.around.isCurrent": (v23/*: any*/),
-        "artist.filtered_artworks.pageCursors.around.page": (v22/*: any*/),
-        "artist.filtered_artworks.pageCursors.first": (v26/*: any*/),
-        "artist.filtered_artworks.pageCursors.first.cursor": (v19/*: any*/),
-        "artist.filtered_artworks.pageCursors.first.isCurrent": (v23/*: any*/),
-        "artist.filtered_artworks.pageCursors.first.page": (v22/*: any*/),
-        "artist.filtered_artworks.pageCursors.last": (v26/*: any*/),
-        "artist.filtered_artworks.pageCursors.last.cursor": (v19/*: any*/),
-        "artist.filtered_artworks.pageCursors.last.isCurrent": (v23/*: any*/),
-        "artist.filtered_artworks.pageCursors.last.page": (v22/*: any*/),
-        "artist.filtered_artworks.pageCursors.previous": (v26/*: any*/),
-        "artist.filtered_artworks.pageCursors.previous.cursor": (v19/*: any*/),
-        "artist.filtered_artworks.pageCursors.previous.page": (v22/*: any*/),
+        "artist.filtered_artworks.pageCursors.around.cursor": (v20/*: any*/),
+        "artist.filtered_artworks.pageCursors.around.isCurrent": (v24/*: any*/),
+        "artist.filtered_artworks.pageCursors.around.page": (v23/*: any*/),
+        "artist.filtered_artworks.pageCursors.first": (v27/*: any*/),
+        "artist.filtered_artworks.pageCursors.first.cursor": (v20/*: any*/),
+        "artist.filtered_artworks.pageCursors.first.isCurrent": (v24/*: any*/),
+        "artist.filtered_artworks.pageCursors.first.page": (v23/*: any*/),
+        "artist.filtered_artworks.pageCursors.last": (v27/*: any*/),
+        "artist.filtered_artworks.pageCursors.last.cursor": (v20/*: any*/),
+        "artist.filtered_artworks.pageCursors.last.isCurrent": (v24/*: any*/),
+        "artist.filtered_artworks.pageCursors.last.page": (v23/*: any*/),
+        "artist.filtered_artworks.pageCursors.previous": (v27/*: any*/),
+        "artist.filtered_artworks.pageCursors.previous.cursor": (v20/*: any*/),
+        "artist.filtered_artworks.pageCursors.previous.page": (v23/*: any*/),
         "artist.filtered_artworks.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "artist.filtered_artworks.pageInfo.endCursor": (v21/*: any*/),
-        "artist.filtered_artworks.pageInfo.hasNextPage": (v23/*: any*/),
-        "artist.id": (v20/*: any*/),
-        "artist.internalID": (v20/*: any*/),
-        "artist.name": (v21/*: any*/),
-        "artist.slug": (v20/*: any*/)
+        "artist.filtered_artworks.pageInfo.endCursor": (v22/*: any*/),
+        "artist.filtered_artworks.pageInfo.hasNextPage": (v24/*: any*/),
+        "artist.id": (v21/*: any*/),
+        "artist.internalID": (v21/*: any*/),
+        "artist.name": (v22/*: any*/),
+        "artist.slug": (v21/*: any*/)
       }
     },
     "name": "ArtistArtworkFilterTestQuery",
     "operationKind": "query",
-    "text": "query ArtistArtworkFilterTestQuery {\n  artist(id: \"example\") {\n    ...ArtistArtworkFilter_artist\n    id\n  }\n}\n\nfragment ArtistArtworkFilter_artist on Artist {\n  name\n  counts {\n    partner_shows: partnerShows\n    for_sale_artworks: forSaleArtworks\n    ecommerce_artworks: ecommerceArtworks\n    auction_artworks: auctionArtworks\n    artworks\n    has_make_offer_artworks: hasMakeOfferArtworks\n  }\n  filtered_artworks: filterArtworksConnection(first: 30) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n  internalID\n  slug\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
+    "text": "query ArtistArtworkFilterTestQuery {\n  artist(id: \"example\") {\n    ...ArtistArtworkFilter_artist\n    id\n  }\n}\n\nfragment ArtistArtworkFilter_artist on Artist {\n  name\n  counts {\n    partner_shows: partnerShows\n    for_sale_artworks: forSaleArtworks\n    ecommerce_artworks: ecommerceArtworks\n    auction_artworks: auctionArtworks\n    artworks\n    has_make_offer_artworks: hasMakeOfferArtworks\n  }\n  filtered_artworks: filterArtworksConnection(first: 30) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n  internalID\n  slug\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistSeriesArtworksFilterQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesArtworksFilterQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<da56994bad85aad1e7199822e1ab4e0e>>
+ * @generated SignedSource<<79eb7c8b10463389d0c08d978809b382>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -150,21 +150,24 @@ v10 = [
     "storageKey": null
   }
 ],
-v11 = {
+v11 = [
+  (v7/*: any*/)
+],
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v13 = {
+v14 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -172,14 +175,14 @@ v13 = {
     "large"
   ]
 },
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v15 = [
+v16 = [
   {
     "alias": null,
     "args": null,
@@ -188,28 +191,28 @@ v15 = [
     "storageKey": null
   }
 ],
-v16 = [
+v17 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v18 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v19 = [
+v20 = [
   (v6/*: any*/),
   (v7/*: any*/)
 ];
@@ -457,27 +460,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v7/*: any*/)
-                    ],
+                    "selections": (v11/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -516,8 +499,8 @@ return {
                             "name": "slug",
                             "storageKey": null
                           },
-                          (v11/*: any*/),
                           (v12/*: any*/),
+                          (v13/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -539,7 +522,7 @@ return {
                                 "name": "aspectRatio",
                                 "storageKey": null
                               },
-                              (v12/*: any*/),
+                              (v13/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -550,7 +533,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v13/*: any*/)
+                                  (v14/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -573,7 +556,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v13/*: any*/),
+                                  (v14/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -658,6 +641,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -709,7 +699,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v14/*: any*/),
+                                  (v15/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -717,7 +707,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v15/*: any*/),
+                                    "selections": (v16/*: any*/),
                                     "storageKey": null
                                   },
                                   (v7/*: any*/)
@@ -743,7 +733,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v16/*: any*/),
+                            "args": (v17/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -791,14 +781,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v16/*: any*/),
+                            "args": (v17/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v7/*: any*/),
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               (v6/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -812,14 +802,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v16/*: any*/),
+                            "args": (v17/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v6/*: any*/),
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               (v7/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -832,7 +822,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v14/*: any*/),
+                              (v15/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -894,7 +884,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v17/*: any*/),
+                              (v18/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -902,8 +892,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v14/*: any*/),
-                              (v18/*: any*/),
+                              (v15/*: any*/),
+                              (v19/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -936,7 +926,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v15/*: any*/),
+                                "selections": (v16/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -946,7 +936,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v15/*: any*/),
+                                "selections": (v16/*: any*/),
                                 "storageKey": null
                               },
                               (v7/*: any*/)
@@ -961,10 +951,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v17/*: any*/),
+                              (v18/*: any*/),
                               (v7/*: any*/),
-                              (v14/*: any*/),
-                              (v18/*: any*/)
+                              (v15/*: any*/),
+                              (v19/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -975,7 +965,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v19/*: any*/),
+                            "selections": (v20/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -993,7 +983,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v19/*: any*/),
+                                "selections": (v20/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -1018,9 +1008,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v7/*: any*/)
-                        ],
+                        "selections": (v11/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1041,12 +1029,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "72b1cfd3629e85bc4ec9416ca10afa3a",
+    "cacheID": "1952b345b4db0ca6c5f67a769f3378bb",
     "id": null,
     "metadata": {},
     "name": "ArtistSeriesArtworksFilterQuery",
     "operationKind": "query",
-    "text": "query ArtistSeriesArtworksFilterQuery(\n  $slug: ID!\n  $input: FilterArtworksInput\n  $aggregations: [ArtworkAggregation]\n) {\n  artistSeries(id: $slug) {\n    ...ArtistSeriesArtworksFilter_artistSeries_2p2tYs\n    id\n  }\n}\n\nfragment ArtistSeriesArtworksFilter_artistSeries_2p2tYs on ArtistSeries {\n  sidebar: filterArtworksConnection(aggregations: $aggregations, first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
+    "text": "query ArtistSeriesArtworksFilterQuery(\n  $slug: ID!\n  $input: FilterArtworksInput\n  $aggregations: [ArtworkAggregation]\n) {\n  artistSeries(id: $slug) {\n    ...ArtistSeriesArtworksFilter_artistSeries_2p2tYs\n    id\n  }\n}\n\nfragment ArtistSeriesArtworksFilter_artistSeries_2p2tYs on ArtistSeries {\n  sidebar: filterArtworksConnection(aggregations: $aggregations, first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistSeriesArtworksFilterRefetchQuery.graphql.ts
+++ b/src/__generated__/ArtistSeriesArtworksFilterRefetchQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8e2f902eb4c3f53a4b37a1921c4f0461>>
+ * @generated SignedSource<<4811436f36e53edea371b3aacae47d24>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -143,21 +143,24 @@ v7 = [
     "storageKey": null
   }
 ],
-v8 = {
+v8 = [
+  (v4/*: any*/)
+],
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -165,14 +168,14 @@ v10 = {
     "large"
   ]
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v12 = [
+v13 = [
   {
     "alias": null,
     "args": null,
@@ -181,28 +184,28 @@ v12 = [
     "storageKey": null
   }
 ],
-v13 = [
+v14 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v16 = [
+v17 = [
   (v3/*: any*/),
   (v4/*: any*/)
 ];
@@ -436,27 +439,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v4/*: any*/)
-                    ],
+                    "selections": (v8/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -495,8 +478,8 @@ return {
                             "name": "slug",
                             "storageKey": null
                           },
-                          (v8/*: any*/),
                           (v9/*: any*/),
+                          (v10/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -518,7 +501,7 @@ return {
                                 "name": "aspectRatio",
                                 "storageKey": null
                               },
-                              (v9/*: any*/),
+                              (v10/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -529,7 +512,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v10/*: any*/)
+                                  (v11/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -552,7 +535,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v10/*: any*/),
+                                  (v11/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -637,6 +620,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -688,7 +678,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v11/*: any*/),
+                                  (v12/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -696,7 +686,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v12/*: any*/),
+                                    "selections": (v13/*: any*/),
                                     "storageKey": null
                                   },
                                   (v4/*: any*/)
@@ -722,7 +712,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -770,14 +760,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v4/*: any*/),
-                              (v8/*: any*/),
+                              (v9/*: any*/),
                               (v3/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -791,14 +781,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v3/*: any*/),
-                              (v8/*: any*/),
+                              (v9/*: any*/),
                               (v4/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -811,7 +801,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -873,7 +863,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v14/*: any*/),
+                              (v15/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -881,8 +871,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v11/*: any*/),
-                              (v15/*: any*/),
+                              (v12/*: any*/),
+                              (v16/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -915,7 +905,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v12/*: any*/),
+                                "selections": (v13/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -925,7 +915,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v12/*: any*/),
+                                "selections": (v13/*: any*/),
                                 "storageKey": null
                               },
                               (v4/*: any*/)
@@ -940,10 +930,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v14/*: any*/),
+                              (v15/*: any*/),
                               (v4/*: any*/),
-                              (v11/*: any*/),
-                              (v15/*: any*/)
+                              (v12/*: any*/),
+                              (v16/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -954,7 +944,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v16/*: any*/),
+                            "selections": (v17/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -972,7 +962,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v16/*: any*/),
+                                "selections": (v17/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -997,9 +987,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v4/*: any*/)
-                        ],
+                        "selections": (v8/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1020,12 +1008,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1c06638c690e99c8c8c8d3c1494a2397",
+    "cacheID": "0d5730de14c48e07ce7e23300b8be013",
     "id": null,
     "metadata": {},
     "name": "ArtistSeriesArtworksFilterRefetchQuery",
     "operationKind": "query",
-    "text": "query ArtistSeriesArtworksFilterRefetchQuery(\n  $input: FilterArtworksInput\n  $slug: ID!\n) {\n  artistSeries(id: $slug) {\n    ...ArtistSeriesArtworksFilter_artistSeries_2VV6jB\n    id\n  }\n}\n\nfragment ArtistSeriesArtworksFilter_artistSeries_2VV6jB on ArtistSeries {\n  sidebar: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
+    "text": "query ArtistSeriesArtworksFilterRefetchQuery(\n  $input: FilterArtworksInput\n  $slug: ID!\n) {\n  artistSeries(id: $slug) {\n    ...ArtistSeriesArtworksFilter_artistSeries_2VV6jB\n    id\n  }\n}\n\nfragment ArtistSeriesArtworksFilter_artistSeries_2VV6jB on ArtistSeries {\n  sidebar: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistSeriesArtworksFilter_Query.graphql.ts
+++ b/src/__generated__/ArtistSeriesArtworksFilter_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e6cb54ab70fc049c8db4b10bb785999d>>
+ * @generated SignedSource<<4ee6f8adb02a068b4708e0b087f851bd>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -77,21 +77,24 @@ v6 = [
     "storageKey": null
   }
 ],
-v7 = {
+v7 = [
+  (v3/*: any*/)
+],
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -99,14 +102,14 @@ v9 = {
     "large"
   ]
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v11 = [
+v12 = [
   {
     "alias": null,
     "args": null,
@@ -115,92 +118,92 @@ v11 = [
     "storageKey": null
   }
 ],
-v12 = [
+v13 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v15 = [
+v16 = [
   (v2/*: any*/),
   (v3/*: any*/)
 ],
-v16 = {
+v17 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FilterArtworksConnection"
 },
-v17 = {
+v18 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v18 = {
+v19 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FormattedNumber"
 },
-v19 = {
+v20 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v20 = {
+v21 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Boolean"
 },
-v21 = {
+v22 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v22 = {
+v23 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Int"
 },
-v23 = {
+v24 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Boolean"
 },
-v24 = {
+v25 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v25 = {
+v26 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "SaleArtwork"
 },
-v26 = {
+v27 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -436,27 +439,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v3/*: any*/)
-                    ],
+                    "selections": (v7/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -495,8 +478,8 @@ return {
                             "name": "slug",
                             "storageKey": null
                           },
-                          (v7/*: any*/),
                           (v8/*: any*/),
+                          (v9/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -518,7 +501,7 @@ return {
                                 "name": "aspectRatio",
                                 "storageKey": null
                               },
-                              (v8/*: any*/),
+                              (v9/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -529,7 +512,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v9/*: any*/)
+                                  (v10/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -552,7 +535,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v9/*: any*/),
+                                  (v10/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -637,6 +620,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -688,7 +678,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v10/*: any*/),
+                                  (v11/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -696,7 +686,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v11/*: any*/),
+                                    "selections": (v12/*: any*/),
                                     "storageKey": null
                                   },
                                   (v3/*: any*/)
@@ -722,7 +712,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v12/*: any*/),
+                            "args": (v13/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -770,14 +760,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v12/*: any*/),
+                            "args": (v13/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v3/*: any*/),
-                              (v7/*: any*/),
+                              (v8/*: any*/),
                               (v2/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -791,14 +781,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v12/*: any*/),
+                            "args": (v13/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v2/*: any*/),
-                              (v7/*: any*/),
+                              (v8/*: any*/),
                               (v3/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -811,7 +801,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v10/*: any*/),
+                              (v11/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -873,7 +863,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v13/*: any*/),
+                              (v14/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -881,8 +871,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v10/*: any*/),
-                              (v14/*: any*/),
+                              (v11/*: any*/),
+                              (v15/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -915,7 +905,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v11/*: any*/),
+                                "selections": (v12/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -925,7 +915,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v11/*: any*/),
+                                "selections": (v12/*: any*/),
                                 "storageKey": null
                               },
                               (v3/*: any*/)
@@ -940,10 +930,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v13/*: any*/),
+                              (v14/*: any*/),
                               (v3/*: any*/),
-                              (v10/*: any*/),
-                              (v14/*: any*/)
+                              (v11/*: any*/),
+                              (v15/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -954,7 +944,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v15/*: any*/),
+                            "selections": (v16/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -972,7 +962,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v15/*: any*/),
+                                "selections": (v16/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -997,9 +987,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v3/*: any*/)
-                        ],
+                        "selections": (v7/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1020,7 +1008,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "0c24bdf5cb1a0785d2942fac5d84b3e9",
+    "cacheID": "a3cf3a15829649ff3df08a7c90285dbb",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -1030,24 +1018,24 @@ return {
           "plural": false,
           "type": "ArtistSeries"
         },
-        "artistSeries.filtered_artworks": (v16/*: any*/),
-        "artistSeries.filtered_artworks.__isArtworkConnectionInterface": (v17/*: any*/),
+        "artistSeries.filtered_artworks": (v17/*: any*/),
+        "artistSeries.filtered_artworks.__isArtworkConnectionInterface": (v18/*: any*/),
         "artistSeries.filtered_artworks.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "FilterArtworksCounts"
         },
-        "artistSeries.filtered_artworks.counts.total": (v18/*: any*/),
+        "artistSeries.filtered_artworks.counts.total": (v19/*: any*/),
         "artistSeries.filtered_artworks.edges": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "ArtworkEdgeInterface"
         },
-        "artistSeries.filtered_artworks.edges.__isNode": (v17/*: any*/),
-        "artistSeries.filtered_artworks.edges.__typename": (v17/*: any*/),
-        "artistSeries.filtered_artworks.edges.id": (v19/*: any*/),
+        "artistSeries.filtered_artworks.edges.__isNode": (v18/*: any*/),
+        "artistSeries.filtered_artworks.edges.__typename": (v18/*: any*/),
+        "artistSeries.filtered_artworks.edges.id": (v20/*: any*/),
         "artistSeries.filtered_artworks.edges.node": {
           "enumValues": null,
           "nullable": true,
@@ -1060,33 +1048,33 @@ return {
           "plural": false,
           "type": "Artist"
         },
-        "artistSeries.filtered_artworks.edges.node.artist.id": (v19/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.artist.id": (v20/*: any*/),
         "artistSeries.filtered_artworks.edges.node.artist.targetSupply": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "ArtistTargetSupply"
         },
-        "artistSeries.filtered_artworks.edges.node.artist.targetSupply.isP1": (v20/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.artistNames": (v21/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.artist.targetSupply.isP1": (v21/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.artistNames": (v22/*: any*/),
         "artistSeries.filtered_artworks.edges.node.artists": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Artist"
         },
-        "artistSeries.filtered_artworks.edges.node.artists.href": (v21/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.artists.id": (v19/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.artists.name": (v21/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.artists.href": (v22/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.artists.id": (v20/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.artists.name": (v22/*: any*/),
         "artistSeries.filtered_artworks.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "artistSeries.filtered_artworks.edges.node.attributionClass.id": (v19/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.attributionClass.name": (v21/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.collecting_institution": (v21/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.attributionClass.id": (v20/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.attributionClass.name": (v22/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.collecting_institution": (v22/*: any*/),
         "artistSeries.filtered_artworks.edges.node.collectorSignals": {
           "enumValues": null,
           "nullable": true,
@@ -1099,26 +1087,26 @@ return {
           "plural": false,
           "type": "AuctionCollectorSignals"
         },
-        "artistSeries.filtered_artworks.edges.node.collectorSignals.auction.bidCount": (v22/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.collectorSignals.auction.liveBiddingStarted": (v23/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.collectorSignals.auction.lotClosesAt": (v21/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.collectorSignals.auction.onlineBiddingExtended": (v23/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.collectorSignals.auction.registrationEndsAt": (v21/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.collectorSignals.auction.bidCount": (v23/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.collectorSignals.auction.liveBiddingStarted": (v24/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.collectorSignals.auction.lotClosesAt": (v22/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.collectorSignals.auction.onlineBiddingExtended": (v24/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.collectorSignals.auction.registrationEndsAt": (v22/*: any*/),
         "artistSeries.filtered_artworks.edges.node.collectorSignals.partnerOffer": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "PartnerOfferToCollector"
         },
-        "artistSeries.filtered_artworks.edges.node.collectorSignals.partnerOffer.endAt": (v21/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.collectorSignals.partnerOffer.id": (v19/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.collectorSignals.partnerOffer.endAt": (v22/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.collectorSignals.partnerOffer.id": (v20/*: any*/),
         "artistSeries.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Money"
         },
-        "artistSeries.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v21/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v22/*: any*/),
         "artistSeries.filtered_artworks.edges.node.collectorSignals.primaryLabel": {
           "enumValues": [
             "CURATORS_PICK",
@@ -1129,10 +1117,10 @@ return {
           "plural": false,
           "type": "LabelSignalEnum"
         },
-        "artistSeries.filtered_artworks.edges.node.cultural_maker": (v21/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.date": (v21/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.href": (v21/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.id": (v19/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.cultural_maker": (v22/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.date": (v22/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.href": (v22/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.id": (v20/*: any*/),
         "artistSeries.filtered_artworks.edges.node.image": {
           "enumValues": null,
           "nullable": true,
@@ -1145,35 +1133,35 @@ return {
           "plural": false,
           "type": "Float"
         },
-        "artistSeries.filtered_artworks.edges.node.image.blurhashDataURL": (v21/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.image.blurhashDataURL": (v22/*: any*/),
         "artistSeries.filtered_artworks.edges.node.image.internalID": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ID"
         },
-        "artistSeries.filtered_artworks.edges.node.image.placeholder": (v21/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.image.placeholder": (v22/*: any*/),
         "artistSeries.filtered_artworks.edges.node.image.resized": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ResizedImageUrl"
         },
-        "artistSeries.filtered_artworks.edges.node.image.resized.height": (v24/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.image.resized.src": (v17/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.image.resized.srcSet": (v17/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.image.resized.width": (v24/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.image.url": (v21/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.image.resized.height": (v25/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.image.resized.src": (v18/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.image.resized.srcSet": (v18/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.image.resized.width": (v25/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.image.url": (v22/*: any*/),
         "artistSeries.filtered_artworks.edges.node.image.versions": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "String"
         },
-        "artistSeries.filtered_artworks.edges.node.imageTitle": (v21/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.image_title": (v21/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.internalID": (v19/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.isUnlisted": (v23/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.imageTitle": (v22/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.image_title": (v22/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.internalID": (v20/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.isUnlisted": (v24/*: any*/),
         "artistSeries.filtered_artworks.edges.node.marketPriceInsights": {
           "enumValues": null,
           "nullable": true,
@@ -1198,69 +1186,69 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "artistSeries.filtered_artworks.edges.node.mediumType.filterGene.id": (v19/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.mediumType.filterGene.name": (v21/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.mediumType.filterGene.id": (v20/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.mediumType.filterGene.name": (v22/*: any*/),
         "artistSeries.filtered_artworks.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "artistSeries.filtered_artworks.edges.node.partner.href": (v21/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.partner.id": (v19/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.partner.name": (v21/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.partner.href": (v22/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.partner.id": (v20/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.partner.name": (v22/*: any*/),
         "artistSeries.filtered_artworks.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "artistSeries.filtered_artworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v24/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.sale.endAt": (v21/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.sale.extendedBiddingIntervalMinutes": (v24/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.sale.extendedBiddingPeriodMinutes": (v24/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.sale.id": (v19/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.sale.isOpen": (v20/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.sale.is_auction": (v20/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.sale.is_closed": (v20/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.sale.startAt": (v21/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.saleArtwork": (v25/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.saleArtwork.endAt": (v21/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.saleArtwork.extendedBiddingEndAt": (v21/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.saleArtwork.id": (v19/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.saleArtwork.lotID": (v21/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.sale_artwork": (v25/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v25/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.sale.endAt": (v22/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.sale.extendedBiddingIntervalMinutes": (v25/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.sale.extendedBiddingPeriodMinutes": (v25/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.sale.id": (v20/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.sale.isOpen": (v21/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.sale.is_auction": (v21/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.sale.is_closed": (v21/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.sale.startAt": (v22/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.saleArtwork": (v26/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.saleArtwork.endAt": (v22/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.saleArtwork.extendedBiddingEndAt": (v22/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.saleArtwork.id": (v20/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.saleArtwork.lotID": (v22/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.sale_artwork": (v26/*: any*/),
         "artistSeries.filtered_artworks.edges.node.sale_artwork.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkCounts"
         },
-        "artistSeries.filtered_artworks.edges.node.sale_artwork.counts.bidder_positions": (v18/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.sale_artwork.endAt": (v21/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.sale_artwork.extendedBiddingEndAt": (v21/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.sale_artwork.formattedEndDateTime": (v21/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.sale_artwork.counts.bidder_positions": (v19/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.sale_artwork.endAt": (v22/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.sale_artwork.extendedBiddingEndAt": (v22/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.sale_artwork.formattedEndDateTime": (v22/*: any*/),
         "artistSeries.filtered_artworks.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "artistSeries.filtered_artworks.edges.node.sale_artwork.highest_bid.display": (v21/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.sale_artwork.id": (v19/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.sale_artwork.lotID": (v21/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.sale_artwork.lotLabel": (v21/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.sale_artwork.highest_bid.display": (v22/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.sale_artwork.id": (v20/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.sale_artwork.lotID": (v22/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.sale_artwork.lotLabel": (v22/*: any*/),
         "artistSeries.filtered_artworks.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "artistSeries.filtered_artworks.edges.node.sale_artwork.opening_bid.display": (v21/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.sale_message": (v21/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.slug": (v19/*: any*/),
-        "artistSeries.filtered_artworks.edges.node.title": (v21/*: any*/),
-        "artistSeries.filtered_artworks.id": (v19/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.sale_artwork.opening_bid.display": (v22/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.sale_message": (v22/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.slug": (v20/*: any*/),
+        "artistSeries.filtered_artworks.edges.node.title": (v22/*: any*/),
+        "artistSeries.filtered_artworks.id": (v20/*: any*/),
         "artistSeries.filtered_artworks.pageCursors": {
           "enumValues": null,
           "nullable": false,
@@ -1273,30 +1261,30 @@ return {
           "plural": true,
           "type": "PageCursor"
         },
-        "artistSeries.filtered_artworks.pageCursors.around.cursor": (v17/*: any*/),
-        "artistSeries.filtered_artworks.pageCursors.around.isCurrent": (v23/*: any*/),
-        "artistSeries.filtered_artworks.pageCursors.around.page": (v22/*: any*/),
-        "artistSeries.filtered_artworks.pageCursors.first": (v26/*: any*/),
-        "artistSeries.filtered_artworks.pageCursors.first.cursor": (v17/*: any*/),
-        "artistSeries.filtered_artworks.pageCursors.first.isCurrent": (v23/*: any*/),
-        "artistSeries.filtered_artworks.pageCursors.first.page": (v22/*: any*/),
-        "artistSeries.filtered_artworks.pageCursors.last": (v26/*: any*/),
-        "artistSeries.filtered_artworks.pageCursors.last.cursor": (v17/*: any*/),
-        "artistSeries.filtered_artworks.pageCursors.last.isCurrent": (v23/*: any*/),
-        "artistSeries.filtered_artworks.pageCursors.last.page": (v22/*: any*/),
-        "artistSeries.filtered_artworks.pageCursors.previous": (v26/*: any*/),
-        "artistSeries.filtered_artworks.pageCursors.previous.cursor": (v17/*: any*/),
-        "artistSeries.filtered_artworks.pageCursors.previous.page": (v22/*: any*/),
+        "artistSeries.filtered_artworks.pageCursors.around.cursor": (v18/*: any*/),
+        "artistSeries.filtered_artworks.pageCursors.around.isCurrent": (v24/*: any*/),
+        "artistSeries.filtered_artworks.pageCursors.around.page": (v23/*: any*/),
+        "artistSeries.filtered_artworks.pageCursors.first": (v27/*: any*/),
+        "artistSeries.filtered_artworks.pageCursors.first.cursor": (v18/*: any*/),
+        "artistSeries.filtered_artworks.pageCursors.first.isCurrent": (v24/*: any*/),
+        "artistSeries.filtered_artworks.pageCursors.first.page": (v23/*: any*/),
+        "artistSeries.filtered_artworks.pageCursors.last": (v27/*: any*/),
+        "artistSeries.filtered_artworks.pageCursors.last.cursor": (v18/*: any*/),
+        "artistSeries.filtered_artworks.pageCursors.last.isCurrent": (v24/*: any*/),
+        "artistSeries.filtered_artworks.pageCursors.last.page": (v23/*: any*/),
+        "artistSeries.filtered_artworks.pageCursors.previous": (v27/*: any*/),
+        "artistSeries.filtered_artworks.pageCursors.previous.cursor": (v18/*: any*/),
+        "artistSeries.filtered_artworks.pageCursors.previous.page": (v23/*: any*/),
         "artistSeries.filtered_artworks.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "artistSeries.filtered_artworks.pageInfo.endCursor": (v21/*: any*/),
-        "artistSeries.filtered_artworks.pageInfo.hasNextPage": (v23/*: any*/),
-        "artistSeries.id": (v19/*: any*/),
-        "artistSeries.sidebar": (v16/*: any*/),
+        "artistSeries.filtered_artworks.pageInfo.endCursor": (v22/*: any*/),
+        "artistSeries.filtered_artworks.pageInfo.hasNextPage": (v24/*: any*/),
+        "artistSeries.id": (v20/*: any*/),
+        "artistSeries.sidebar": (v17/*: any*/),
         "artistSeries.sidebar.aggregations": {
           "enumValues": null,
           "nullable": true,
@@ -1309,9 +1297,9 @@ return {
           "plural": true,
           "type": "AggregationCount"
         },
-        "artistSeries.sidebar.aggregations.counts.count": (v22/*: any*/),
-        "artistSeries.sidebar.aggregations.counts.name": (v17/*: any*/),
-        "artistSeries.sidebar.aggregations.counts.value": (v17/*: any*/),
+        "artistSeries.sidebar.aggregations.counts.count": (v23/*: any*/),
+        "artistSeries.sidebar.aggregations.counts.name": (v18/*: any*/),
+        "artistSeries.sidebar.aggregations.counts.value": (v18/*: any*/),
         "artistSeries.sidebar.aggregations.slice": {
           "enumValues": [
             "ARTIST",
@@ -1339,12 +1327,12 @@ return {
           "plural": false,
           "type": "ArtworkAggregation"
         },
-        "artistSeries.sidebar.id": (v19/*: any*/)
+        "artistSeries.sidebar.id": (v20/*: any*/)
       }
     },
     "name": "ArtistSeriesArtworksFilter_Query",
     "operationKind": "query",
-    "text": "query ArtistSeriesArtworksFilter_Query(\n  $slug: ID!\n) {\n  artistSeries(id: $slug) {\n    ...ArtistSeriesArtworksFilter_artistSeries\n    id\n  }\n}\n\nfragment ArtistSeriesArtworksFilter_artistSeries on ArtistSeries {\n  sidebar: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
+    "text": "query ArtistSeriesArtworksFilter_Query(\n  $slug: ID!\n) {\n  artistSeries(id: $slug) {\n    ...ArtistSeriesArtworksFilter_artistSeries\n    id\n  }\n}\n\nfragment ArtistSeriesArtworksFilter_artistSeries on ArtistSeries {\n  sidebar: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistWorksForSaleRouteArtworksQuery.graphql.ts
+++ b/src/__generated__/ArtistWorksForSaleRouteArtworksQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<406bee55199b4f0861a18785d3316537>>
+ * @generated SignedSource<<bbea72d4a131e4f46fd036f1174e1314>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -232,28 +232,31 @@ v12 = [
     "storageKey": null
   }
 ],
-v13 = {
+v13 = [
+  (v9/*: any*/)
+],
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v16 = {
+v17 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -261,14 +264,14 @@ v16 = {
     "large"
   ]
 },
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v18 = [
+v19 = [
   {
     "alias": null,
     "args": null,
@@ -277,28 +280,28 @@ v18 = [
     "storageKey": null
   }
 ],
-v19 = [
+v20 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v20 = {
+v21 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v21 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v22 = [
+v23 = [
   (v7/*: any*/),
   (v9/*: any*/)
 ];
@@ -554,27 +557,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v9/*: any*/)
-                    ],
+                    "selections": (v13/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -606,9 +589,9 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v13/*: any*/),
                           (v14/*: any*/),
                           (v15/*: any*/),
+                          (v16/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -630,7 +613,7 @@ return {
                                 "name": "aspectRatio",
                                 "storageKey": null
                               },
-                              (v15/*: any*/),
+                              (v16/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -641,7 +624,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v16/*: any*/)
+                                  (v17/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -664,7 +647,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v16/*: any*/),
+                                  (v17/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -749,6 +732,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -800,7 +790,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v17/*: any*/),
+                                  (v18/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -808,7 +798,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v18/*: any*/),
+                                    "selections": (v19/*: any*/),
                                     "storageKey": null
                                   },
                                   (v9/*: any*/)
@@ -834,7 +824,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v19/*: any*/),
+                            "args": (v20/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -882,14 +872,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v19/*: any*/),
+                            "args": (v20/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v9/*: any*/),
-                              (v14/*: any*/),
+                              (v15/*: any*/),
                               (v7/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -903,14 +893,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v19/*: any*/),
+                            "args": (v20/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v7/*: any*/),
-                              (v14/*: any*/),
+                              (v15/*: any*/),
                               (v9/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -923,7 +913,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v17/*: any*/),
+                              (v18/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -985,7 +975,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v20/*: any*/),
+                              (v21/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -993,8 +983,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v17/*: any*/),
-                              (v21/*: any*/),
+                              (v18/*: any*/),
+                              (v22/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1027,7 +1017,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v18/*: any*/),
+                                "selections": (v19/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -1037,7 +1027,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v18/*: any*/),
+                                "selections": (v19/*: any*/),
                                 "storageKey": null
                               },
                               (v9/*: any*/)
@@ -1052,10 +1042,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v20/*: any*/),
+                              (v21/*: any*/),
                               (v9/*: any*/),
-                              (v17/*: any*/),
-                              (v21/*: any*/)
+                              (v18/*: any*/),
+                              (v22/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -1066,7 +1056,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v22/*: any*/),
+                            "selections": (v23/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1084,7 +1074,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v22/*: any*/),
+                                "selections": (v23/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -1109,9 +1099,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v9/*: any*/)
-                        ],
+                        "selections": (v13/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1125,8 +1113,8 @@ return {
             ],
             "storageKey": null
           },
-          (v15/*: any*/),
-          (v13/*: any*/),
+          (v16/*: any*/),
+          (v14/*: any*/),
           {
             "alias": "sidebarAggregations",
             "args": (v5/*: any*/),
@@ -1148,12 +1136,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "5bee59a67d4db5c591f67acc9bfe01ed",
+    "cacheID": "23eb097b11eb189e1c6c05b206abe28a",
     "id": null,
     "metadata": {},
     "name": "ArtistWorksForSaleRouteArtworksQuery",
     "operationKind": "query",
-    "text": "query ArtistWorksForSaleRouteArtworksQuery(\n  $artistID: String!\n  $aggregations: [ArtworkAggregation]\n  $input: FilterArtworksInput!\n) {\n  artist(id: $artistID) {\n    ...ArtistArtworkFilter_artist_2VV6jB\n    sidebarAggregations: filterArtworksConnection(aggregations: $aggregations, first: 1) {\n      counts {\n        total\n      }\n      aggregations {\n        slice\n        counts {\n          name\n          value\n          count\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment ArtistArtworkFilter_artist_2VV6jB on Artist {\n  name\n  counts {\n    partner_shows: partnerShows\n    for_sale_artworks: forSaleArtworks\n    ecommerce_artworks: ecommerceArtworks\n    auction_artworks: auctionArtworks\n    artworks\n    has_make_offer_artworks: hasMakeOfferArtworks\n  }\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n  internalID\n  slug\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
+    "text": "query ArtistWorksForSaleRouteArtworksQuery(\n  $artistID: String!\n  $aggregations: [ArtworkAggregation]\n  $input: FilterArtworksInput!\n) {\n  artist(id: $artistID) {\n    ...ArtistArtworkFilter_artist_2VV6jB\n    sidebarAggregations: filterArtworksConnection(aggregations: $aggregations, first: 1) {\n      counts {\n        total\n      }\n      aggregations {\n        slice\n        counts {\n          name\n          value\n          count\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment ArtistArtworkFilter_artist_2VV6jB on Artist {\n  name\n  counts {\n    partner_shows: partnerShows\n    for_sale_artworks: forSaleArtworks\n    ecommerce_artworks: ecommerceArtworks\n    auction_artworks: auctionArtworks\n    artworks\n    has_make_offer_artworks: hasMakeOfferArtworks\n  }\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n  internalID\n  slug\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtworkFilterArtworkGrid_filtered_artworks.graphql.ts
+++ b/src/__generated__/ArtworkFilterArtworkGrid_filtered_artworks.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4022fe5ac4d4f215c1af78aca56156c6>>
+ * @generated SignedSource<<10b84819e7571de7f7a08cf5fc0923ba>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,14 +9,10 @@
 // @ts-nocheck
 
 import { Fragment, ReaderFragment } from 'relay-runtime';
-export type LabelSignalEnum = "CURATORS_PICK" | "INCREASED_INTEREST" | "PARTNER_OFFER" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type ArtworkFilterArtworkGrid_filtered_artworks$data = {
   readonly edges: ReadonlyArray<{
     readonly node: {
-      readonly collectorSignals: {
-        readonly primaryLabel: LabelSignalEnum | null | undefined;
-      } | null | undefined;
       readonly id: string;
     } | null | undefined;
   } | null | undefined> | null | undefined;
@@ -114,24 +110,6 @@ return {
           "name": "node",
           "plural": false,
           "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "concreteType": "CollectorSignals",
-              "kind": "LinkedField",
-              "name": "collectorSignals",
-              "plural": false,
-              "selections": [
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "primaryLabel",
-                  "storageKey": null
-                }
-              ],
-              "storageKey": null
-            },
             (v0/*: any*/)
           ],
           "storageKey": null
@@ -156,6 +134,6 @@ return {
 };
 })();
 
-(node as any).hash = "dbf8b5e1a2f079b0a2d145a197d0cfc8";
+(node as any).hash = "e6296fabcc752b9bb5de3add8435132d";
 
 export default node;

--- a/src/__generated__/ArtworkQueryFilterQuery.graphql.ts
+++ b/src/__generated__/ArtworkQueryFilterQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<704307fcea28fd38458b679c22c6244d>>
+ * @generated SignedSource<<a7586223e0c98a34161b2b52b96827be>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -101,15 +101,15 @@ export type ArtworkQueryFilterQuery$rawResponse = {
             readonly name: string | null | undefined;
           } | null | undefined;
           readonly collecting_institution?: string | null | undefined;
-          readonly collectorSignals: {
-            readonly auction?: {
+          readonly collectorSignals?: {
+            readonly auction: {
               readonly bidCount: number;
               readonly liveBiddingStarted: boolean;
               readonly lotClosesAt: string | null | undefined;
               readonly onlineBiddingExtended: boolean;
               readonly registrationEndsAt: string | null | undefined;
             } | null | undefined;
-            readonly partnerOffer?: {
+            readonly partnerOffer: {
               readonly endAt: string | null | undefined;
               readonly id: string;
               readonly priceWithDiscount: {
@@ -275,21 +275,24 @@ v5 = [
     "storageKey": null
   }
 ],
-v6 = {
+v6 = [
+  (v2/*: any*/)
+],
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v8 = {
+v9 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -297,14 +300,14 @@ v8 = {
     "large"
   ]
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v10 = [
+v11 = [
   {
     "alias": null,
     "args": null,
@@ -313,36 +316,36 @@ v10 = [
     "storageKey": null
   }
 ],
-v11 = [
+v12 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v15 = [
-  (v12/*: any*/),
+v16 = [
+  (v13/*: any*/),
   (v2/*: any*/)
 ];
 return {
@@ -489,27 +492,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v2/*: any*/)
-                    ],
+                    "selections": (v6/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -572,8 +555,8 @@ return {
                             "name": "slug",
                             "storageKey": null
                           },
-                          (v6/*: any*/),
                           (v7/*: any*/),
+                          (v8/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -595,7 +578,7 @@ return {
                                 "name": "aspectRatio",
                                 "storageKey": null
                               },
-                              (v7/*: any*/),
+                              (v8/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -606,7 +589,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v8/*: any*/)
+                                  (v9/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -629,7 +612,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v8/*: any*/),
+                                  (v9/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -714,6 +697,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -765,7 +755,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v9/*: any*/),
+                                  (v10/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -773,7 +763,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v10/*: any*/),
+                                    "selections": (v11/*: any*/),
                                     "storageKey": null
                                   },
                                   (v2/*: any*/)
@@ -799,7 +789,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v11/*: any*/),
+                            "args": (v12/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -847,15 +837,15 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v11/*: any*/),
+                            "args": (v12/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v2/*: any*/),
-                              (v6/*: any*/),
-                              (v12/*: any*/)
+                              (v7/*: any*/),
+                              (v13/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
                           },
@@ -868,14 +858,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v11/*: any*/),
+                            "args": (v12/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v12/*: any*/),
-                              (v6/*: any*/),
+                              (v13/*: any*/),
+                              (v7/*: any*/),
                               (v2/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -888,7 +878,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v9/*: any*/),
+                              (v10/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -950,7 +940,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v13/*: any*/),
+                              (v14/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -958,8 +948,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v9/*: any*/),
-                              (v14/*: any*/),
+                              (v10/*: any*/),
+                              (v15/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -992,7 +982,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v10/*: any*/),
+                                "selections": (v11/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -1002,7 +992,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v10/*: any*/),
+                                "selections": (v11/*: any*/),
                                 "storageKey": null
                               },
                               (v2/*: any*/)
@@ -1017,10 +1007,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v13/*: any*/),
+                              (v14/*: any*/),
                               (v2/*: any*/),
-                              (v9/*: any*/),
-                              (v14/*: any*/)
+                              (v10/*: any*/),
+                              (v15/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -1031,7 +1021,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v15/*: any*/),
+                            "selections": (v16/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1049,7 +1039,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v15/*: any*/),
+                                "selections": (v16/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -1074,9 +1064,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v2/*: any*/)
-                        ],
+                        "selections": (v6/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1096,12 +1084,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d12fbbbf95e6c5820ec8fb9d41525d56",
+    "cacheID": "67067376e6bb8c1e916dc55926161e6e",
     "id": null,
     "metadata": {},
     "name": "ArtworkQueryFilterQuery",
     "operationKind": "query",
-    "text": "query ArtworkQueryFilterQuery(\n  $input: FilterArtworksInput\n) {\n  viewer {\n    ...ArtworkFilter_viewer_2VV6jB\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkFilter_viewer_2VV6jB on Viewer {\n  filtered_artworks: artworksConnection(input: $input) {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    counts {\n      total(format: \"0,0\")\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
+    "text": "query ArtworkQueryFilterQuery(\n  $input: FilterArtworksInput\n) {\n  viewer {\n    ...ArtworkFilter_viewer_2VV6jB\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkFilter_viewer_2VV6jB on Viewer {\n  filtered_artworks: artworksConnection(input: $input) {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    counts {\n      total(format: \"0,0\")\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/AuctionArtworkFilterQuery.graphql.ts
+++ b/src/__generated__/AuctionArtworkFilterQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9c260479df64514a4e958f501f92d3e6>>
+ * @generated SignedSource<<39f2dff84de1dd97fa977fa095c5f57c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -131,21 +131,24 @@ v7 = [
     "storageKey": null
   }
 ],
-v8 = {
+v8 = [
+  (v4/*: any*/)
+],
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -153,14 +156,14 @@ v10 = {
     "large"
   ]
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v12 = [
+v13 = [
   {
     "alias": null,
     "args": null,
@@ -169,36 +172,36 @@ v12 = [
     "storageKey": null
   }
 ],
-v13 = [
+v14 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v17 = [
-  (v14/*: any*/),
+v18 = [
+  (v15/*: any*/),
   (v4/*: any*/)
 ];
 return {
@@ -367,27 +370,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v4/*: any*/)
-                    ],
+                    "selections": (v8/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -450,8 +433,8 @@ return {
                             "name": "slug",
                             "storageKey": null
                           },
-                          (v8/*: any*/),
                           (v9/*: any*/),
+                          (v10/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -473,7 +456,7 @@ return {
                                 "name": "aspectRatio",
                                 "storageKey": null
                               },
-                              (v9/*: any*/),
+                              (v10/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -484,7 +467,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v10/*: any*/)
+                                  (v11/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -507,7 +490,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v10/*: any*/),
+                                  (v11/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -592,6 +575,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -643,7 +633,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v11/*: any*/),
+                                  (v12/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -651,7 +641,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v12/*: any*/),
+                                    "selections": (v13/*: any*/),
                                     "storageKey": null
                                   },
                                   (v4/*: any*/)
@@ -677,7 +667,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -725,15 +715,15 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v4/*: any*/),
-                              (v8/*: any*/),
-                              (v14/*: any*/)
+                              (v9/*: any*/),
+                              (v15/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
                           },
@@ -746,14 +736,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v14/*: any*/),
-                              (v8/*: any*/),
+                              (v15/*: any*/),
+                              (v9/*: any*/),
                               (v4/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -766,7 +756,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -828,7 +818,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v15/*: any*/),
+                              (v16/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -836,8 +826,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v11/*: any*/),
-                              (v16/*: any*/),
+                              (v12/*: any*/),
+                              (v17/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -870,7 +860,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v12/*: any*/),
+                                "selections": (v13/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -880,7 +870,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v12/*: any*/),
+                                "selections": (v13/*: any*/),
                                 "storageKey": null
                               },
                               (v4/*: any*/)
@@ -895,10 +885,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v15/*: any*/),
+                              (v16/*: any*/),
                               (v4/*: any*/),
-                              (v11/*: any*/),
-                              (v16/*: any*/)
+                              (v12/*: any*/),
+                              (v17/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -909,7 +899,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v17/*: any*/),
+                            "selections": (v18/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -927,7 +917,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v17/*: any*/),
+                                "selections": (v18/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -952,9 +942,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v4/*: any*/)
-                        ],
+                        "selections": (v8/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1056,7 +1044,7 @@ return {
                     "name": "counts",
                     "plural": true,
                     "selections": [
-                      (v14/*: any*/),
+                      (v15/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1087,12 +1075,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "45a8dc08f52edf17097e3a0e82200d2a",
+    "cacheID": "47f761dffbbfe95c279a55523e1ee3aa",
     "id": null,
     "metadata": {},
     "name": "AuctionArtworkFilterQuery",
     "operationKind": "query",
-    "text": "query AuctionArtworkFilterQuery(\n  $saleID: String!\n  $input: FilterArtworksInput\n  $isLoggedIn: Boolean!\n) {\n  viewer {\n    ...AuctionArtworkFilter_viewer_1rdGPv\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkFilter_viewer_2VV6jB on Viewer {\n  filtered_artworks: artworksConnection(input: $input) {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    counts {\n      total(format: \"0,0\")\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment AuctionArtworkFilter_viewer_1rdGPv on Viewer {\n  ...ArtworkFilter_viewer_2VV6jB\n  sale(id: $saleID) {\n    featuredKeywords\n    id\n  }\n  sidebarAggregations: artworksConnection(input: $input, first: 1) {\n    counts @include(if: $isLoggedIn) {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
+    "text": "query AuctionArtworkFilterQuery(\n  $saleID: String!\n  $input: FilterArtworksInput\n  $isLoggedIn: Boolean!\n) {\n  viewer {\n    ...AuctionArtworkFilter_viewer_1rdGPv\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkFilter_viewer_2VV6jB on Viewer {\n  filtered_artworks: artworksConnection(input: $input) {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    counts {\n      total(format: \"0,0\")\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment AuctionArtworkFilter_viewer_1rdGPv on Viewer {\n  ...ArtworkFilter_viewer_2VV6jB\n  sale(id: $saleID) {\n    featuredKeywords\n    id\n  }\n  sidebarAggregations: artworksConnection(input: $input, first: 1) {\n    counts @include(if: $isLoggedIn) {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/AuctionArtworkFilterRefetchQuery.graphql.ts
+++ b/src/__generated__/AuctionArtworkFilterRefetchQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<99edcaaf846edc29c907e238c9155b6f>>
+ * @generated SignedSource<<2e6eefe3efa618280b2ad43b779160e1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -131,21 +131,24 @@ v7 = [
     "storageKey": null
   }
 ],
-v8 = {
+v8 = [
+  (v4/*: any*/)
+],
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -153,14 +156,14 @@ v10 = {
     "large"
   ]
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v12 = [
+v13 = [
   {
     "alias": null,
     "args": null,
@@ -169,36 +172,36 @@ v12 = [
     "storageKey": null
   }
 ],
-v13 = [
+v14 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v17 = [
-  (v14/*: any*/),
+v18 = [
+  (v15/*: any*/),
   (v4/*: any*/)
 ];
 return {
@@ -367,27 +370,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v4/*: any*/)
-                    ],
+                    "selections": (v8/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -450,8 +433,8 @@ return {
                             "name": "slug",
                             "storageKey": null
                           },
-                          (v8/*: any*/),
                           (v9/*: any*/),
+                          (v10/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -473,7 +456,7 @@ return {
                                 "name": "aspectRatio",
                                 "storageKey": null
                               },
-                              (v9/*: any*/),
+                              (v10/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -484,7 +467,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v10/*: any*/)
+                                  (v11/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -507,7 +490,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v10/*: any*/),
+                                  (v11/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -592,6 +575,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -643,7 +633,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v11/*: any*/),
+                                  (v12/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -651,7 +641,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v12/*: any*/),
+                                    "selections": (v13/*: any*/),
                                     "storageKey": null
                                   },
                                   (v4/*: any*/)
@@ -677,7 +667,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -725,15 +715,15 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v4/*: any*/),
-                              (v8/*: any*/),
-                              (v14/*: any*/)
+                              (v9/*: any*/),
+                              (v15/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
                           },
@@ -746,14 +736,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v14/*: any*/),
-                              (v8/*: any*/),
+                              (v15/*: any*/),
+                              (v9/*: any*/),
                               (v4/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -766,7 +756,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -828,7 +818,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v15/*: any*/),
+                              (v16/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -836,8 +826,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v11/*: any*/),
-                              (v16/*: any*/),
+                              (v12/*: any*/),
+                              (v17/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -870,7 +860,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v12/*: any*/),
+                                "selections": (v13/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -880,7 +870,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v12/*: any*/),
+                                "selections": (v13/*: any*/),
                                 "storageKey": null
                               },
                               (v4/*: any*/)
@@ -895,10 +885,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v15/*: any*/),
+                              (v16/*: any*/),
                               (v4/*: any*/),
-                              (v11/*: any*/),
-                              (v16/*: any*/)
+                              (v12/*: any*/),
+                              (v17/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -909,7 +899,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v17/*: any*/),
+                            "selections": (v18/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -927,7 +917,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v17/*: any*/),
+                                "selections": (v18/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -952,9 +942,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v4/*: any*/)
-                        ],
+                        "selections": (v8/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1056,7 +1044,7 @@ return {
                     "name": "counts",
                     "plural": true,
                     "selections": [
-                      (v14/*: any*/),
+                      (v15/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1087,12 +1075,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f914e70ac76db25dee8e8282e71c2b37",
+    "cacheID": "e4643cb55c1c5b4064ab70423e750e36",
     "id": null,
     "metadata": {},
     "name": "AuctionArtworkFilterRefetchQuery",
     "operationKind": "query",
-    "text": "query AuctionArtworkFilterRefetchQuery(\n  $input: FilterArtworksInput\n  $saleID: String!\n  $isLoggedIn: Boolean!\n) {\n  viewer {\n    ...AuctionArtworkFilter_viewer_1rdGPv\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkFilter_viewer_2VV6jB on Viewer {\n  filtered_artworks: artworksConnection(input: $input) {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    counts {\n      total(format: \"0,0\")\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment AuctionArtworkFilter_viewer_1rdGPv on Viewer {\n  ...ArtworkFilter_viewer_2VV6jB\n  sale(id: $saleID) {\n    featuredKeywords\n    id\n  }\n  sidebarAggregations: artworksConnection(input: $input, first: 1) {\n    counts @include(if: $isLoggedIn) {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
+    "text": "query AuctionArtworkFilterRefetchQuery(\n  $input: FilterArtworksInput\n  $saleID: String!\n  $isLoggedIn: Boolean!\n) {\n  viewer {\n    ...AuctionArtworkFilter_viewer_1rdGPv\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkFilter_viewer_2VV6jB on Viewer {\n  filtered_artworks: artworksConnection(input: $input) {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    counts {\n      total(format: \"0,0\")\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment AuctionArtworkFilter_viewer_1rdGPv on Viewer {\n  ...ArtworkFilter_viewer_2VV6jB\n  sale(id: $saleID) {\n    featuredKeywords\n    id\n  }\n  sidebarAggregations: artworksConnection(input: $input, first: 1) {\n    counts @include(if: $isLoggedIn) {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/AuctionArtworkFilterTestQuery.graphql.ts
+++ b/src/__generated__/AuctionArtworkFilterTestQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<561ccdc3f6e081df0a1154d3a025ec17>>
+ * @generated SignedSource<<b873e140ee0351cc169b84990a3fd332>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -54,21 +54,24 @@ v3 = [
     "storageKey": null
   }
 ],
-v4 = {
+v4 = [
+  (v0/*: any*/)
+],
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v6 = {
+v7 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -76,14 +79,14 @@ v6 = {
     "large"
   ]
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v8 = [
+v9 = [
   {
     "alias": null,
     "args": null,
@@ -92,36 +95,36 @@ v8 = [
     "storageKey": null
   }
 ],
-v9 = [
+v10 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v13 = [
-  (v10/*: any*/),
+v14 = [
+  (v11/*: any*/),
   (v0/*: any*/)
 ];
 return {
@@ -279,27 +282,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v0/*: any*/)
-                    ],
+                    "selections": (v4/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -362,8 +345,8 @@ return {
                             "name": "slug",
                             "storageKey": null
                           },
-                          (v4/*: any*/),
                           (v5/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -385,7 +368,7 @@ return {
                                 "name": "aspectRatio",
                                 "storageKey": null
                               },
-                              (v5/*: any*/),
+                              (v6/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -396,7 +379,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v6/*: any*/)
+                                  (v7/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -419,7 +402,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v6/*: any*/),
+                                  (v7/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -504,6 +487,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -555,7 +545,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v7/*: any*/),
+                                  (v8/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -563,7 +553,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v9/*: any*/),
                                     "storageKey": null
                                   },
                                   (v0/*: any*/)
@@ -589,7 +579,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v9/*: any*/),
+                            "args": (v10/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -637,15 +627,15 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v9/*: any*/),
+                            "args": (v10/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v0/*: any*/),
-                              (v4/*: any*/),
-                              (v10/*: any*/)
+                              (v5/*: any*/),
+                              (v11/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
                           },
@@ -658,14 +648,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v9/*: any*/),
+                            "args": (v10/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v10/*: any*/),
-                              (v4/*: any*/),
+                              (v11/*: any*/),
+                              (v5/*: any*/),
                               (v0/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -678,7 +668,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v7/*: any*/),
+                              (v8/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -740,7 +730,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -748,8 +738,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v7/*: any*/),
-                              (v12/*: any*/),
+                              (v8/*: any*/),
+                              (v13/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -782,7 +772,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v8/*: any*/),
+                                "selections": (v9/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -792,7 +782,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v8/*: any*/),
+                                "selections": (v9/*: any*/),
                                 "storageKey": null
                               },
                               (v0/*: any*/)
@@ -807,10 +797,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               (v0/*: any*/),
-                              (v7/*: any*/),
-                              (v12/*: any*/)
+                              (v8/*: any*/),
+                              (v13/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -821,7 +811,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v13/*: any*/),
+                            "selections": (v14/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -839,7 +829,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v13/*: any*/),
+                                "selections": (v14/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -864,9 +854,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v0/*: any*/)
-                        ],
+                        "selections": (v4/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -942,7 +930,7 @@ return {
                     "name": "counts",
                     "plural": true,
                     "selections": [
-                      (v10/*: any*/),
+                      (v11/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -973,12 +961,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1ff2df299ba14a8766c076c6abd2043d",
+    "cacheID": "99c1a1f0ef0a89c9275f503429723988",
     "id": null,
     "metadata": {},
     "name": "AuctionArtworkFilterTestQuery",
     "operationKind": "query",
-    "text": "query AuctionArtworkFilterTestQuery {\n  viewer {\n    ...AuctionArtworkFilter_viewer_2nJEft\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkFilter_viewer_4g78v5 on Viewer {\n  filtered_artworks: artworksConnection {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    counts {\n      total(format: \"0,0\")\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment AuctionArtworkFilter_viewer_2nJEft on Viewer {\n  ...ArtworkFilter_viewer_4g78v5\n  sale(id: \"test-sale\") {\n    featuredKeywords\n    id\n  }\n  sidebarAggregations: artworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
+    "text": "query AuctionArtworkFilterTestQuery {\n  viewer {\n    ...AuctionArtworkFilter_viewer_2nJEft\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkFilter_viewer_4g78v5 on Viewer {\n  filtered_artworks: artworksConnection {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    counts {\n      total(format: \"0,0\")\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment AuctionArtworkFilter_viewer_2nJEft on Viewer {\n  ...ArtworkFilter_viewer_4g78v5\n  sale(id: \"test-sale\") {\n    featuredKeywords\n    id\n  }\n  sidebarAggregations: artworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/CollectArtworkFilterQuery.graphql.ts
+++ b/src/__generated__/CollectArtworkFilterQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<55baadadc8ee7c0d4a7d637d9d0cff3e>>
+ * @generated SignedSource<<828aafc4cc5edb03e52c7f7b1cf2c188>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -231,21 +231,24 @@ v12 = [
     "storageKey": null
   }
 ],
-v13 = {
+v13 = [
+  (v9/*: any*/)
+],
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -253,14 +256,14 @@ v15 = {
     "large"
   ]
 },
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v17 = [
+v18 = [
   {
     "alias": null,
     "args": null,
@@ -269,28 +272,28 @@ v17 = [
     "storageKey": null
   }
 ],
-v18 = [
+v19 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v19 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v20 = {
+v21 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v21 = [
+v22 = [
   (v7/*: any*/),
   (v9/*: any*/)
 ];
@@ -459,27 +462,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v9/*: any*/)
-                    ],
+                    "selections": (v13/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -542,8 +525,8 @@ return {
                             "name": "slug",
                             "storageKey": null
                           },
-                          (v13/*: any*/),
                           (v14/*: any*/),
+                          (v15/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -565,7 +548,7 @@ return {
                                 "name": "aspectRatio",
                                 "storageKey": null
                               },
-                              (v14/*: any*/),
+                              (v15/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -576,7 +559,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v15/*: any*/)
+                                  (v16/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -599,7 +582,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v15/*: any*/),
+                                  (v16/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -684,6 +667,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -735,7 +725,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v16/*: any*/),
+                                  (v17/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -743,7 +733,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v17/*: any*/),
+                                    "selections": (v18/*: any*/),
                                     "storageKey": null
                                   },
                                   (v9/*: any*/)
@@ -769,7 +759,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v18/*: any*/),
+                            "args": (v19/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -817,14 +807,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v18/*: any*/),
+                            "args": (v19/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v9/*: any*/),
-                              (v13/*: any*/),
+                              (v14/*: any*/),
                               (v7/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -838,14 +828,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v18/*: any*/),
+                            "args": (v19/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v7/*: any*/),
-                              (v13/*: any*/),
+                              (v14/*: any*/),
                               (v9/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -858,7 +848,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v16/*: any*/),
+                              (v17/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -920,7 +910,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v19/*: any*/),
+                              (v20/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -928,8 +918,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v16/*: any*/),
-                              (v20/*: any*/),
+                              (v17/*: any*/),
+                              (v21/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -962,7 +952,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v17/*: any*/),
+                                "selections": (v18/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -972,7 +962,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v17/*: any*/),
+                                "selections": (v18/*: any*/),
                                 "storageKey": null
                               },
                               (v9/*: any*/)
@@ -987,10 +977,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v19/*: any*/),
+                              (v20/*: any*/),
                               (v9/*: any*/),
-                              (v16/*: any*/),
-                              (v20/*: any*/)
+                              (v17/*: any*/),
+                              (v21/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -1001,7 +991,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v21/*: any*/),
+                            "selections": (v22/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1019,7 +1009,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v21/*: any*/),
+                                "selections": (v22/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -1044,9 +1034,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v9/*: any*/)
-                        ],
+                        "selections": (v13/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1080,12 +1068,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "aba78ba227601ae53f0433d600f32eae",
+    "cacheID": "f2d291c3359b8ce9841c1e57f9e1cde2",
     "id": null,
     "metadata": {},
     "name": "CollectArtworkFilterQuery",
     "operationKind": "query",
-    "text": "query CollectArtworkFilterQuery(\n  $input: FilterArtworksInput\n  $aggregations: [ArtworkAggregation]\n  $shouldFetchCounts: Boolean!\n) {\n  viewer {\n    ...ArtworkFilter_viewer_2VV6jB\n    artworksConnection(aggregations: $aggregations, input: $input) {\n      counts @include(if: $shouldFetchCounts) {\n        followedArtists\n      }\n      aggregations {\n        slice\n        counts {\n          value\n          name\n          count\n        }\n      }\n      id\n    }\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkFilter_viewer_2VV6jB on Viewer {\n  filtered_artworks: artworksConnection(input: $input) {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    counts {\n      total(format: \"0,0\")\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
+    "text": "query CollectArtworkFilterQuery(\n  $input: FilterArtworksInput\n  $aggregations: [ArtworkAggregation]\n  $shouldFetchCounts: Boolean!\n) {\n  viewer {\n    ...ArtworkFilter_viewer_2VV6jB\n    artworksConnection(aggregations: $aggregations, input: $input) {\n      counts @include(if: $shouldFetchCounts) {\n        followedArtists\n      }\n      aggregations {\n        slice\n        counts {\n          value\n          name\n          count\n        }\n      }\n      id\n    }\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkFilter_viewer_2VV6jB on Viewer {\n  filtered_artworks: artworksConnection(input: $input) {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    counts {\n      total(format: \"0,0\")\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/CollectionArtworksFilterQuery.graphql.ts
+++ b/src/__generated__/CollectionArtworksFilterQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<39328ab5291125d524e393b65aa91d85>>
+ * @generated SignedSource<<e22713fd2f18ae0e7a5a7b1703dab05a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -143,21 +143,24 @@ v7 = [
     "storageKey": null
   }
 ],
-v8 = {
+v8 = [
+  (v4/*: any*/)
+],
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -165,14 +168,14 @@ v10 = {
     "large"
   ]
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v12 = [
+v13 = [
   {
     "alias": null,
     "args": null,
@@ -181,36 +184,36 @@ v12 = [
     "storageKey": null
   }
 ],
-v13 = [
+v14 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v17 = [
-  (v14/*: any*/),
+v18 = [
+  (v15/*: any*/),
   (v4/*: any*/)
 ];
 return {
@@ -400,27 +403,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v4/*: any*/)
-                    ],
+                    "selections": (v8/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -453,8 +436,8 @@ return {
                         "plural": false,
                         "selections": [
                           (v3/*: any*/),
-                          (v8/*: any*/),
                           (v9/*: any*/),
+                          (v10/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -476,7 +459,7 @@ return {
                                 "name": "aspectRatio",
                                 "storageKey": null
                               },
-                              (v9/*: any*/),
+                              (v10/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -487,7 +470,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v10/*: any*/)
+                                  (v11/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -510,7 +493,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v10/*: any*/),
+                                  (v11/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -595,6 +578,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -646,7 +636,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v11/*: any*/),
+                                  (v12/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -654,7 +644,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v12/*: any*/),
+                                    "selections": (v13/*: any*/),
                                     "storageKey": null
                                   },
                                   (v4/*: any*/)
@@ -680,7 +670,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -728,15 +718,15 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v4/*: any*/),
-                              (v8/*: any*/),
-                              (v14/*: any*/)
+                              (v9/*: any*/),
+                              (v15/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
                           },
@@ -749,14 +739,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v14/*: any*/),
-                              (v8/*: any*/),
+                              (v15/*: any*/),
+                              (v9/*: any*/),
                               (v4/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -769,7 +759,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -831,7 +821,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v15/*: any*/),
+                              (v16/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -839,8 +829,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v11/*: any*/),
-                              (v16/*: any*/),
+                              (v12/*: any*/),
+                              (v17/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -873,7 +863,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v12/*: any*/),
+                                "selections": (v13/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -883,7 +873,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v12/*: any*/),
+                                "selections": (v13/*: any*/),
                                 "storageKey": null
                               },
                               (v4/*: any*/)
@@ -898,10 +888,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v15/*: any*/),
+                              (v16/*: any*/),
                               (v4/*: any*/),
-                              (v11/*: any*/),
-                              (v16/*: any*/)
+                              (v12/*: any*/),
+                              (v17/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -912,7 +902,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v17/*: any*/),
+                            "selections": (v18/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -930,7 +920,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v17/*: any*/),
+                                "selections": (v18/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -955,9 +945,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v4/*: any*/)
-                        ],
+                        "selections": (v8/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -978,12 +966,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "fef177ba04866886860ce90efbaeb491",
+    "cacheID": "f671d7980666ccb0d284afec7e8dc26b",
     "id": null,
     "metadata": {},
     "name": "CollectionArtworksFilterQuery",
     "operationKind": "query",
-    "text": "query CollectionArtworksFilterQuery(\n  $input: FilterArtworksInput\n  $slug: String!\n) {\n  collection: marketingCollection(slug: $slug) {\n    ...CollectionArtworksFilter_collection_2VV6jB\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment CollectionArtworksFilter_collection_2VV6jB on MarketingCollection {\n  slug\n  query {\n    artistIDs\n  }\n  filtered_artworks: artworksConnection(input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
+    "text": "query CollectionArtworksFilterQuery(\n  $input: FilterArtworksInput\n  $slug: String!\n) {\n  collection: marketingCollection(slug: $slug) {\n    ...CollectionArtworksFilter_collection_2VV6jB\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment CollectionArtworksFilter_collection_2VV6jB on MarketingCollection {\n  slug\n  query {\n    artistIDs\n  }\n  filtered_artworks: artworksConnection(input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/CollectionArtworksFilter_Query.graphql.ts
+++ b/src/__generated__/CollectionArtworksFilter_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c7837b8772cf5a0110ec5d536ab6e95e>>
+ * @generated SignedSource<<4dfe2d620aae9c9ad8010a26cddb4004>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -143,21 +143,24 @@ v7 = [
     "storageKey": null
   }
 ],
-v8 = {
+v8 = [
+  (v4/*: any*/)
+],
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -165,14 +168,14 @@ v10 = {
     "large"
   ]
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v12 = [
+v13 = [
   {
     "alias": null,
     "args": null,
@@ -181,99 +184,99 @@ v12 = [
     "storageKey": null
   }
 ],
-v13 = [
+v14 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v17 = [
-  (v14/*: any*/),
+v18 = [
+  (v15/*: any*/),
   (v4/*: any*/)
 ],
-v18 = {
+v19 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v19 = {
+v20 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FormattedNumber"
 },
-v20 = {
+v21 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v21 = {
+v22 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Boolean"
 },
-v22 = {
+v23 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
-},
-v23 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "Int"
 },
 v24 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
-  "type": "Boolean"
+  "type": "Int"
 },
 v25 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "Boolean"
+},
+v26 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v26 = {
+v27 = {
   "enumValues": null,
   "nullable": true,
   "plural": true,
   "type": "String"
 },
-v27 = {
+v28 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "SaleArtwork"
 },
-v28 = {
+v29 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -466,27 +469,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v4/*: any*/)
-                    ],
+                    "selections": (v8/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -519,8 +502,8 @@ return {
                         "plural": false,
                         "selections": [
                           (v3/*: any*/),
-                          (v8/*: any*/),
                           (v9/*: any*/),
+                          (v10/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -542,7 +525,7 @@ return {
                                 "name": "aspectRatio",
                                 "storageKey": null
                               },
-                              (v9/*: any*/),
+                              (v10/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -553,7 +536,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v10/*: any*/)
+                                  (v11/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -576,7 +559,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v10/*: any*/),
+                                  (v11/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -661,6 +644,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -712,7 +702,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v11/*: any*/),
+                                  (v12/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -720,7 +710,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v12/*: any*/),
+                                    "selections": (v13/*: any*/),
                                     "storageKey": null
                                   },
                                   (v4/*: any*/)
@@ -746,7 +736,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -794,15 +784,15 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v4/*: any*/),
-                              (v8/*: any*/),
-                              (v14/*: any*/)
+                              (v9/*: any*/),
+                              (v15/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
                           },
@@ -815,14 +805,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v14/*: any*/),
-                              (v8/*: any*/),
+                              (v15/*: any*/),
+                              (v9/*: any*/),
                               (v4/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -835,7 +825,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -897,7 +887,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v15/*: any*/),
+                              (v16/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -905,8 +895,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v11/*: any*/),
-                              (v16/*: any*/),
+                              (v12/*: any*/),
+                              (v17/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -939,7 +929,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v12/*: any*/),
+                                "selections": (v13/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -949,7 +939,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v12/*: any*/),
+                                "selections": (v13/*: any*/),
                                 "storageKey": null
                               },
                               (v4/*: any*/)
@@ -964,10 +954,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v15/*: any*/),
+                              (v16/*: any*/),
                               (v4/*: any*/),
-                              (v11/*: any*/),
-                              (v16/*: any*/)
+                              (v12/*: any*/),
+                              (v17/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -978,7 +968,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v17/*: any*/),
+                            "selections": (v18/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -996,7 +986,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v17/*: any*/),
+                                "selections": (v18/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -1021,9 +1011,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v4/*: any*/)
-                        ],
+                        "selections": (v8/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1044,7 +1032,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "6e8dde34ffc0b674e87f3c3316d827ba",
+    "cacheID": "d66fdfbaaa69d84ad61e74162d853f77",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -1060,23 +1048,23 @@ return {
           "plural": false,
           "type": "FilterArtworksConnection"
         },
-        "collection.filtered_artworks.__isArtworkConnectionInterface": (v18/*: any*/),
+        "collection.filtered_artworks.__isArtworkConnectionInterface": (v19/*: any*/),
         "collection.filtered_artworks.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "FilterArtworksCounts"
         },
-        "collection.filtered_artworks.counts.total": (v19/*: any*/),
+        "collection.filtered_artworks.counts.total": (v20/*: any*/),
         "collection.filtered_artworks.edges": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "ArtworkEdgeInterface"
         },
-        "collection.filtered_artworks.edges.__isNode": (v18/*: any*/),
-        "collection.filtered_artworks.edges.__typename": (v18/*: any*/),
-        "collection.filtered_artworks.edges.id": (v20/*: any*/),
+        "collection.filtered_artworks.edges.__isNode": (v19/*: any*/),
+        "collection.filtered_artworks.edges.__typename": (v19/*: any*/),
+        "collection.filtered_artworks.edges.id": (v21/*: any*/),
         "collection.filtered_artworks.edges.node": {
           "enumValues": null,
           "nullable": true,
@@ -1089,33 +1077,33 @@ return {
           "plural": false,
           "type": "Artist"
         },
-        "collection.filtered_artworks.edges.node.artist.id": (v20/*: any*/),
+        "collection.filtered_artworks.edges.node.artist.id": (v21/*: any*/),
         "collection.filtered_artworks.edges.node.artist.targetSupply": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "ArtistTargetSupply"
         },
-        "collection.filtered_artworks.edges.node.artist.targetSupply.isP1": (v21/*: any*/),
-        "collection.filtered_artworks.edges.node.artistNames": (v22/*: any*/),
+        "collection.filtered_artworks.edges.node.artist.targetSupply.isP1": (v22/*: any*/),
+        "collection.filtered_artworks.edges.node.artistNames": (v23/*: any*/),
         "collection.filtered_artworks.edges.node.artists": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Artist"
         },
-        "collection.filtered_artworks.edges.node.artists.href": (v22/*: any*/),
-        "collection.filtered_artworks.edges.node.artists.id": (v20/*: any*/),
-        "collection.filtered_artworks.edges.node.artists.name": (v22/*: any*/),
+        "collection.filtered_artworks.edges.node.artists.href": (v23/*: any*/),
+        "collection.filtered_artworks.edges.node.artists.id": (v21/*: any*/),
+        "collection.filtered_artworks.edges.node.artists.name": (v23/*: any*/),
         "collection.filtered_artworks.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "collection.filtered_artworks.edges.node.attributionClass.id": (v20/*: any*/),
-        "collection.filtered_artworks.edges.node.attributionClass.name": (v22/*: any*/),
-        "collection.filtered_artworks.edges.node.collecting_institution": (v22/*: any*/),
+        "collection.filtered_artworks.edges.node.attributionClass.id": (v21/*: any*/),
+        "collection.filtered_artworks.edges.node.attributionClass.name": (v23/*: any*/),
+        "collection.filtered_artworks.edges.node.collecting_institution": (v23/*: any*/),
         "collection.filtered_artworks.edges.node.collectorSignals": {
           "enumValues": null,
           "nullable": true,
@@ -1128,26 +1116,26 @@ return {
           "plural": false,
           "type": "AuctionCollectorSignals"
         },
-        "collection.filtered_artworks.edges.node.collectorSignals.auction.bidCount": (v23/*: any*/),
-        "collection.filtered_artworks.edges.node.collectorSignals.auction.liveBiddingStarted": (v24/*: any*/),
-        "collection.filtered_artworks.edges.node.collectorSignals.auction.lotClosesAt": (v22/*: any*/),
-        "collection.filtered_artworks.edges.node.collectorSignals.auction.onlineBiddingExtended": (v24/*: any*/),
-        "collection.filtered_artworks.edges.node.collectorSignals.auction.registrationEndsAt": (v22/*: any*/),
+        "collection.filtered_artworks.edges.node.collectorSignals.auction.bidCount": (v24/*: any*/),
+        "collection.filtered_artworks.edges.node.collectorSignals.auction.liveBiddingStarted": (v25/*: any*/),
+        "collection.filtered_artworks.edges.node.collectorSignals.auction.lotClosesAt": (v23/*: any*/),
+        "collection.filtered_artworks.edges.node.collectorSignals.auction.onlineBiddingExtended": (v25/*: any*/),
+        "collection.filtered_artworks.edges.node.collectorSignals.auction.registrationEndsAt": (v23/*: any*/),
         "collection.filtered_artworks.edges.node.collectorSignals.partnerOffer": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "PartnerOfferToCollector"
         },
-        "collection.filtered_artworks.edges.node.collectorSignals.partnerOffer.endAt": (v22/*: any*/),
-        "collection.filtered_artworks.edges.node.collectorSignals.partnerOffer.id": (v20/*: any*/),
+        "collection.filtered_artworks.edges.node.collectorSignals.partnerOffer.endAt": (v23/*: any*/),
+        "collection.filtered_artworks.edges.node.collectorSignals.partnerOffer.id": (v21/*: any*/),
         "collection.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Money"
         },
-        "collection.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v22/*: any*/),
+        "collection.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v23/*: any*/),
         "collection.filtered_artworks.edges.node.collectorSignals.primaryLabel": {
           "enumValues": [
             "CURATORS_PICK",
@@ -1158,10 +1146,10 @@ return {
           "plural": false,
           "type": "LabelSignalEnum"
         },
-        "collection.filtered_artworks.edges.node.cultural_maker": (v22/*: any*/),
-        "collection.filtered_artworks.edges.node.date": (v22/*: any*/),
-        "collection.filtered_artworks.edges.node.href": (v22/*: any*/),
-        "collection.filtered_artworks.edges.node.id": (v20/*: any*/),
+        "collection.filtered_artworks.edges.node.cultural_maker": (v23/*: any*/),
+        "collection.filtered_artworks.edges.node.date": (v23/*: any*/),
+        "collection.filtered_artworks.edges.node.href": (v23/*: any*/),
+        "collection.filtered_artworks.edges.node.id": (v21/*: any*/),
         "collection.filtered_artworks.edges.node.image": {
           "enumValues": null,
           "nullable": true,
@@ -1174,30 +1162,30 @@ return {
           "plural": false,
           "type": "Float"
         },
-        "collection.filtered_artworks.edges.node.image.blurhashDataURL": (v22/*: any*/),
+        "collection.filtered_artworks.edges.node.image.blurhashDataURL": (v23/*: any*/),
         "collection.filtered_artworks.edges.node.image.internalID": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ID"
         },
-        "collection.filtered_artworks.edges.node.image.placeholder": (v22/*: any*/),
+        "collection.filtered_artworks.edges.node.image.placeholder": (v23/*: any*/),
         "collection.filtered_artworks.edges.node.image.resized": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ResizedImageUrl"
         },
-        "collection.filtered_artworks.edges.node.image.resized.height": (v25/*: any*/),
-        "collection.filtered_artworks.edges.node.image.resized.src": (v18/*: any*/),
-        "collection.filtered_artworks.edges.node.image.resized.srcSet": (v18/*: any*/),
-        "collection.filtered_artworks.edges.node.image.resized.width": (v25/*: any*/),
-        "collection.filtered_artworks.edges.node.image.url": (v22/*: any*/),
-        "collection.filtered_artworks.edges.node.image.versions": (v26/*: any*/),
-        "collection.filtered_artworks.edges.node.imageTitle": (v22/*: any*/),
-        "collection.filtered_artworks.edges.node.image_title": (v22/*: any*/),
-        "collection.filtered_artworks.edges.node.internalID": (v20/*: any*/),
-        "collection.filtered_artworks.edges.node.isUnlisted": (v24/*: any*/),
+        "collection.filtered_artworks.edges.node.image.resized.height": (v26/*: any*/),
+        "collection.filtered_artworks.edges.node.image.resized.src": (v19/*: any*/),
+        "collection.filtered_artworks.edges.node.image.resized.srcSet": (v19/*: any*/),
+        "collection.filtered_artworks.edges.node.image.resized.width": (v26/*: any*/),
+        "collection.filtered_artworks.edges.node.image.url": (v23/*: any*/),
+        "collection.filtered_artworks.edges.node.image.versions": (v27/*: any*/),
+        "collection.filtered_artworks.edges.node.imageTitle": (v23/*: any*/),
+        "collection.filtered_artworks.edges.node.image_title": (v23/*: any*/),
+        "collection.filtered_artworks.edges.node.internalID": (v21/*: any*/),
+        "collection.filtered_artworks.edges.node.isUnlisted": (v25/*: any*/),
         "collection.filtered_artworks.edges.node.marketPriceInsights": {
           "enumValues": null,
           "nullable": true,
@@ -1222,69 +1210,69 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "collection.filtered_artworks.edges.node.mediumType.filterGene.id": (v20/*: any*/),
-        "collection.filtered_artworks.edges.node.mediumType.filterGene.name": (v22/*: any*/),
+        "collection.filtered_artworks.edges.node.mediumType.filterGene.id": (v21/*: any*/),
+        "collection.filtered_artworks.edges.node.mediumType.filterGene.name": (v23/*: any*/),
         "collection.filtered_artworks.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "collection.filtered_artworks.edges.node.partner.href": (v22/*: any*/),
-        "collection.filtered_artworks.edges.node.partner.id": (v20/*: any*/),
-        "collection.filtered_artworks.edges.node.partner.name": (v22/*: any*/),
+        "collection.filtered_artworks.edges.node.partner.href": (v23/*: any*/),
+        "collection.filtered_artworks.edges.node.partner.id": (v21/*: any*/),
+        "collection.filtered_artworks.edges.node.partner.name": (v23/*: any*/),
         "collection.filtered_artworks.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "collection.filtered_artworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v25/*: any*/),
-        "collection.filtered_artworks.edges.node.sale.endAt": (v22/*: any*/),
-        "collection.filtered_artworks.edges.node.sale.extendedBiddingIntervalMinutes": (v25/*: any*/),
-        "collection.filtered_artworks.edges.node.sale.extendedBiddingPeriodMinutes": (v25/*: any*/),
-        "collection.filtered_artworks.edges.node.sale.id": (v20/*: any*/),
-        "collection.filtered_artworks.edges.node.sale.isOpen": (v21/*: any*/),
-        "collection.filtered_artworks.edges.node.sale.is_auction": (v21/*: any*/),
-        "collection.filtered_artworks.edges.node.sale.is_closed": (v21/*: any*/),
-        "collection.filtered_artworks.edges.node.sale.startAt": (v22/*: any*/),
-        "collection.filtered_artworks.edges.node.saleArtwork": (v27/*: any*/),
-        "collection.filtered_artworks.edges.node.saleArtwork.endAt": (v22/*: any*/),
-        "collection.filtered_artworks.edges.node.saleArtwork.extendedBiddingEndAt": (v22/*: any*/),
-        "collection.filtered_artworks.edges.node.saleArtwork.id": (v20/*: any*/),
-        "collection.filtered_artworks.edges.node.saleArtwork.lotID": (v22/*: any*/),
-        "collection.filtered_artworks.edges.node.sale_artwork": (v27/*: any*/),
+        "collection.filtered_artworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v26/*: any*/),
+        "collection.filtered_artworks.edges.node.sale.endAt": (v23/*: any*/),
+        "collection.filtered_artworks.edges.node.sale.extendedBiddingIntervalMinutes": (v26/*: any*/),
+        "collection.filtered_artworks.edges.node.sale.extendedBiddingPeriodMinutes": (v26/*: any*/),
+        "collection.filtered_artworks.edges.node.sale.id": (v21/*: any*/),
+        "collection.filtered_artworks.edges.node.sale.isOpen": (v22/*: any*/),
+        "collection.filtered_artworks.edges.node.sale.is_auction": (v22/*: any*/),
+        "collection.filtered_artworks.edges.node.sale.is_closed": (v22/*: any*/),
+        "collection.filtered_artworks.edges.node.sale.startAt": (v23/*: any*/),
+        "collection.filtered_artworks.edges.node.saleArtwork": (v28/*: any*/),
+        "collection.filtered_artworks.edges.node.saleArtwork.endAt": (v23/*: any*/),
+        "collection.filtered_artworks.edges.node.saleArtwork.extendedBiddingEndAt": (v23/*: any*/),
+        "collection.filtered_artworks.edges.node.saleArtwork.id": (v21/*: any*/),
+        "collection.filtered_artworks.edges.node.saleArtwork.lotID": (v23/*: any*/),
+        "collection.filtered_artworks.edges.node.sale_artwork": (v28/*: any*/),
         "collection.filtered_artworks.edges.node.sale_artwork.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkCounts"
         },
-        "collection.filtered_artworks.edges.node.sale_artwork.counts.bidder_positions": (v19/*: any*/),
-        "collection.filtered_artworks.edges.node.sale_artwork.endAt": (v22/*: any*/),
-        "collection.filtered_artworks.edges.node.sale_artwork.extendedBiddingEndAt": (v22/*: any*/),
-        "collection.filtered_artworks.edges.node.sale_artwork.formattedEndDateTime": (v22/*: any*/),
+        "collection.filtered_artworks.edges.node.sale_artwork.counts.bidder_positions": (v20/*: any*/),
+        "collection.filtered_artworks.edges.node.sale_artwork.endAt": (v23/*: any*/),
+        "collection.filtered_artworks.edges.node.sale_artwork.extendedBiddingEndAt": (v23/*: any*/),
+        "collection.filtered_artworks.edges.node.sale_artwork.formattedEndDateTime": (v23/*: any*/),
         "collection.filtered_artworks.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "collection.filtered_artworks.edges.node.sale_artwork.highest_bid.display": (v22/*: any*/),
-        "collection.filtered_artworks.edges.node.sale_artwork.id": (v20/*: any*/),
-        "collection.filtered_artworks.edges.node.sale_artwork.lotID": (v22/*: any*/),
-        "collection.filtered_artworks.edges.node.sale_artwork.lotLabel": (v22/*: any*/),
+        "collection.filtered_artworks.edges.node.sale_artwork.highest_bid.display": (v23/*: any*/),
+        "collection.filtered_artworks.edges.node.sale_artwork.id": (v21/*: any*/),
+        "collection.filtered_artworks.edges.node.sale_artwork.lotID": (v23/*: any*/),
+        "collection.filtered_artworks.edges.node.sale_artwork.lotLabel": (v23/*: any*/),
         "collection.filtered_artworks.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "collection.filtered_artworks.edges.node.sale_artwork.opening_bid.display": (v22/*: any*/),
-        "collection.filtered_artworks.edges.node.sale_message": (v22/*: any*/),
-        "collection.filtered_artworks.edges.node.slug": (v20/*: any*/),
-        "collection.filtered_artworks.edges.node.title": (v22/*: any*/),
-        "collection.filtered_artworks.id": (v20/*: any*/),
+        "collection.filtered_artworks.edges.node.sale_artwork.opening_bid.display": (v23/*: any*/),
+        "collection.filtered_artworks.edges.node.sale_message": (v23/*: any*/),
+        "collection.filtered_artworks.edges.node.slug": (v21/*: any*/),
+        "collection.filtered_artworks.edges.node.title": (v23/*: any*/),
+        "collection.filtered_artworks.id": (v21/*: any*/),
         "collection.filtered_artworks.pageCursors": {
           "enumValues": null,
           "nullable": false,
@@ -1297,42 +1285,42 @@ return {
           "plural": true,
           "type": "PageCursor"
         },
-        "collection.filtered_artworks.pageCursors.around.cursor": (v18/*: any*/),
-        "collection.filtered_artworks.pageCursors.around.isCurrent": (v24/*: any*/),
-        "collection.filtered_artworks.pageCursors.around.page": (v23/*: any*/),
-        "collection.filtered_artworks.pageCursors.first": (v28/*: any*/),
-        "collection.filtered_artworks.pageCursors.first.cursor": (v18/*: any*/),
-        "collection.filtered_artworks.pageCursors.first.isCurrent": (v24/*: any*/),
-        "collection.filtered_artworks.pageCursors.first.page": (v23/*: any*/),
-        "collection.filtered_artworks.pageCursors.last": (v28/*: any*/),
-        "collection.filtered_artworks.pageCursors.last.cursor": (v18/*: any*/),
-        "collection.filtered_artworks.pageCursors.last.isCurrent": (v24/*: any*/),
-        "collection.filtered_artworks.pageCursors.last.page": (v23/*: any*/),
-        "collection.filtered_artworks.pageCursors.previous": (v28/*: any*/),
-        "collection.filtered_artworks.pageCursors.previous.cursor": (v18/*: any*/),
-        "collection.filtered_artworks.pageCursors.previous.page": (v23/*: any*/),
+        "collection.filtered_artworks.pageCursors.around.cursor": (v19/*: any*/),
+        "collection.filtered_artworks.pageCursors.around.isCurrent": (v25/*: any*/),
+        "collection.filtered_artworks.pageCursors.around.page": (v24/*: any*/),
+        "collection.filtered_artworks.pageCursors.first": (v29/*: any*/),
+        "collection.filtered_artworks.pageCursors.first.cursor": (v19/*: any*/),
+        "collection.filtered_artworks.pageCursors.first.isCurrent": (v25/*: any*/),
+        "collection.filtered_artworks.pageCursors.first.page": (v24/*: any*/),
+        "collection.filtered_artworks.pageCursors.last": (v29/*: any*/),
+        "collection.filtered_artworks.pageCursors.last.cursor": (v19/*: any*/),
+        "collection.filtered_artworks.pageCursors.last.isCurrent": (v25/*: any*/),
+        "collection.filtered_artworks.pageCursors.last.page": (v24/*: any*/),
+        "collection.filtered_artworks.pageCursors.previous": (v29/*: any*/),
+        "collection.filtered_artworks.pageCursors.previous.cursor": (v19/*: any*/),
+        "collection.filtered_artworks.pageCursors.previous.page": (v24/*: any*/),
         "collection.filtered_artworks.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "collection.filtered_artworks.pageInfo.endCursor": (v22/*: any*/),
-        "collection.filtered_artworks.pageInfo.hasNextPage": (v24/*: any*/),
-        "collection.id": (v20/*: any*/),
+        "collection.filtered_artworks.pageInfo.endCursor": (v23/*: any*/),
+        "collection.filtered_artworks.pageInfo.hasNextPage": (v25/*: any*/),
+        "collection.id": (v21/*: any*/),
         "collection.query": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "MarketingCollectionQuery"
         },
-        "collection.query.artistIDs": (v26/*: any*/),
-        "collection.slug": (v18/*: any*/)
+        "collection.query.artistIDs": (v27/*: any*/),
+        "collection.slug": (v19/*: any*/)
       }
     },
     "name": "CollectionArtworksFilter_Query",
     "operationKind": "query",
-    "text": "query CollectionArtworksFilter_Query(\n  $input: FilterArtworksInput\n  $slug: String!\n) {\n  collection: marketingCollection(slug: $slug) {\n    ...CollectionArtworksFilter_collection_2VV6jB\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment CollectionArtworksFilter_collection_2VV6jB on MarketingCollection {\n  slug\n  query {\n    artistIDs\n  }\n  filtered_artworks: artworksConnection(input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
+    "text": "query CollectionArtworksFilter_Query(\n  $input: FilterArtworksInput\n  $slug: String!\n) {\n  collection: marketingCollection(slug: $slug) {\n    ...CollectionArtworksFilter_collection_2VV6jB\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment CollectionArtworksFilter_collection_2VV6jB on MarketingCollection {\n  slug\n  query {\n    artistIDs\n  }\n  filtered_artworks: artworksConnection(input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/CollectionArtworksQuery.graphql.ts
+++ b/src/__generated__/CollectionArtworksQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0540ff403a419b4908763e27b429a69c>>
+ * @generated SignedSource<<04610dc29dc4c50aee4c68f8501754d0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -264,21 +264,24 @@ v14 = [
     "storageKey": null
   }
 ],
-v15 = {
+v15 = [
+  (v11/*: any*/)
+],
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v17 = {
+v18 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -286,14 +289,14 @@ v17 = {
     "large"
   ]
 },
-v18 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v19 = [
+v20 = [
   {
     "alias": null,
     "args": null,
@@ -302,28 +305,28 @@ v19 = [
     "storageKey": null
   }
 ],
-v20 = [
+v21 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v21 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v22 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v23 = [
+v24 = [
   (v8/*: any*/),
   (v11/*: any*/)
 ];
@@ -537,27 +540,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v11/*: any*/)
-                    ],
+                    "selections": (v15/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -590,8 +573,8 @@ return {
                         "plural": false,
                         "selections": [
                           (v10/*: any*/),
-                          (v15/*: any*/),
                           (v16/*: any*/),
+                          (v17/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -613,7 +596,7 @@ return {
                                 "name": "aspectRatio",
                                 "storageKey": null
                               },
-                              (v16/*: any*/),
+                              (v17/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -624,7 +607,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v17/*: any*/)
+                                  (v18/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -647,7 +630,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v17/*: any*/),
+                                  (v18/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -732,6 +715,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -783,7 +773,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v18/*: any*/),
+                                  (v19/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -791,7 +781,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v19/*: any*/),
+                                    "selections": (v20/*: any*/),
                                     "storageKey": null
                                   },
                                   (v11/*: any*/)
@@ -817,7 +807,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v20/*: any*/),
+                            "args": (v21/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -865,14 +855,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v20/*: any*/),
+                            "args": (v21/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v11/*: any*/),
-                              (v15/*: any*/),
+                              (v16/*: any*/),
                               (v8/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -886,14 +876,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v20/*: any*/),
+                            "args": (v21/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v8/*: any*/),
-                              (v15/*: any*/),
+                              (v16/*: any*/),
                               (v11/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -906,7 +896,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v18/*: any*/),
+                              (v19/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -968,7 +958,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v21/*: any*/),
+                              (v22/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -976,8 +966,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v18/*: any*/),
-                              (v22/*: any*/),
+                              (v19/*: any*/),
+                              (v23/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1010,7 +1000,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v19/*: any*/),
+                                "selections": (v20/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -1020,7 +1010,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v19/*: any*/),
+                                "selections": (v20/*: any*/),
                                 "storageKey": null
                               },
                               (v11/*: any*/)
@@ -1035,10 +1025,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v21/*: any*/),
+                              (v22/*: any*/),
                               (v11/*: any*/),
-                              (v18/*: any*/),
-                              (v22/*: any*/)
+                              (v19/*: any*/),
+                              (v23/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -1049,7 +1039,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v23/*: any*/),
+                            "selections": (v24/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1067,7 +1057,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v23/*: any*/),
+                                "selections": (v24/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -1092,9 +1082,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v11/*: any*/)
-                        ],
+                        "selections": (v15/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1129,12 +1117,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f2737aa78baba43e01abdaa260bc530e",
+    "cacheID": "1c4befbe858bf7d3f3f3471ba337d6a8",
     "id": null,
     "metadata": {},
     "name": "CollectionArtworksQuery",
     "operationKind": "query",
-    "text": "query CollectionArtworksQuery(\n  $slug: String!\n  $aggregations: [ArtworkAggregation]\n  $input: FilterArtworksInput!\n  $shouldFetchCounts: Boolean!\n) {\n  marketingCollection(slug: $slug) {\n    ...CollectionArtworksFilter_collection_2VV6jB\n    artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, first: 20, sort: \"-decayed_merch\") {\n      counts @include(if: $shouldFetchCounts) {\n        followedArtists\n      }\n      aggregations {\n        slice\n        counts {\n          value\n          name\n          count\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment CollectionArtworksFilter_collection_2VV6jB on MarketingCollection {\n  slug\n  query {\n    artistIDs\n  }\n  filtered_artworks: artworksConnection(input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
+    "text": "query CollectionArtworksQuery(\n  $slug: String!\n  $aggregations: [ArtworkAggregation]\n  $input: FilterArtworksInput!\n  $shouldFetchCounts: Boolean!\n) {\n  marketingCollection(slug: $slug) {\n    ...CollectionArtworksFilter_collection_2VV6jB\n    artworksConnection(aggregations: $aggregations, includeMediumFilterInAggregation: true, first: 20, sort: \"-decayed_merch\") {\n      counts @include(if: $shouldFetchCounts) {\n        followedArtists\n      }\n      aggregations {\n        slice\n        counts {\n          value\n          name\n          count\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment CollectionArtworksFilter_collection_2VV6jB on MarketingCollection {\n  slug\n  query {\n    artistIDs\n  }\n  filtered_artworks: artworksConnection(input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/FairArtworksQuery.graphql.ts
+++ b/src/__generated__/FairArtworksQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4b654badbcee3ea6fb1b520b94fbdb4e>>
+ * @generated SignedSource<<252f1d9b187fd45ef6fb3ba3306e9f41>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -153,14 +153,17 @@ v10 = [
     "storageKey": null
   }
 ],
-v11 = {
+v11 = [
+  (v7/*: any*/)
+],
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v12 = {
+v13 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -168,14 +171,14 @@ v12 = {
     "large"
   ]
 },
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v14 = [
+v15 = [
   {
     "alias": null,
     "args": null,
@@ -184,28 +187,28 @@ v14 = [
     "storageKey": null
   }
 ],
-v15 = [
+v16 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v18 = [
+v19 = [
   (v6/*: any*/),
   (v7/*: any*/)
 ];
@@ -470,27 +473,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v7/*: any*/)
-                    ],
+                    "selections": (v11/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -523,7 +506,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v4/*: any*/),
-                          (v11/*: any*/),
+                          (v12/*: any*/),
                           (v5/*: any*/),
                           {
                             "alias": null,
@@ -557,7 +540,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v12/*: any*/)
+                                  (v13/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -580,7 +563,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v12/*: any*/),
+                                  (v13/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -665,6 +648,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -716,7 +706,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v13/*: any*/),
+                                  (v14/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -724,7 +714,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v14/*: any*/),
+                                    "selections": (v15/*: any*/),
                                     "storageKey": null
                                   },
                                   (v7/*: any*/)
@@ -750,7 +740,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v15/*: any*/),
+                            "args": (v16/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -798,14 +788,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v15/*: any*/),
+                            "args": (v16/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v7/*: any*/),
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               (v6/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -819,14 +809,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v15/*: any*/),
+                            "args": (v16/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v6/*: any*/),
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               (v7/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -839,7 +829,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v13/*: any*/),
+                              (v14/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -901,7 +891,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v16/*: any*/),
+                              (v17/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -909,8 +899,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v13/*: any*/),
-                              (v17/*: any*/),
+                              (v14/*: any*/),
+                              (v18/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -943,7 +933,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v14/*: any*/),
+                                "selections": (v15/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -953,7 +943,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v14/*: any*/),
+                                "selections": (v15/*: any*/),
                                 "storageKey": null
                               },
                               (v7/*: any*/)
@@ -968,10 +958,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v16/*: any*/),
+                              (v17/*: any*/),
                               (v7/*: any*/),
-                              (v13/*: any*/),
-                              (v17/*: any*/)
+                              (v14/*: any*/),
+                              (v18/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -982,7 +972,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v18/*: any*/),
+                            "selections": (v19/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1000,7 +990,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v18/*: any*/),
+                                "selections": (v19/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -1025,9 +1015,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v7/*: any*/)
-                        ],
+                        "selections": (v11/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1048,12 +1036,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "70beda745de9b2aedcd87769fa368d24",
+    "cacheID": "53f2708d0d1e1f8c8291e6546f30e238",
     "id": null,
     "metadata": {},
     "name": "FairArtworksQuery",
     "operationKind": "query",
-    "text": "query FairArtworksQuery(\n  $slug: String!\n  $input: FilterArtworksInput\n) {\n  fair(id: $slug) {\n    ...FairArtworks_fair_2VV6jB\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FairArtworks_fair_2VV6jB on Fair {\n  slug\n  internalID\n  featuredKeywords\n  sidebarAggregations: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    counts {\n      followedArtists\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
+    "text": "query FairArtworksQuery(\n  $slug: String!\n  $input: FilterArtworksInput\n) {\n  fair(id: $slug) {\n    ...FairArtworks_fair_2VV6jB\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FairArtworks_fair_2VV6jB on Fair {\n  slug\n  internalID\n  featuredKeywords\n  sidebarAggregations: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    counts {\n      followedArtists\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/FairArtworks_Query.graphql.ts
+++ b/src/__generated__/FairArtworks_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d307c5a273cabbe0f89a846b08e3cb28>>
+ * @generated SignedSource<<b708125d35b3e3fe6ee33a9be4e9ebaa>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -51,15 +51,15 @@ export type FairArtworks_Query$rawResponse = {
             readonly name: string | null | undefined;
           } | null | undefined;
           readonly collecting_institution?: string | null | undefined;
-          readonly collectorSignals: {
-            readonly auction?: {
+          readonly collectorSignals?: {
+            readonly auction: {
               readonly bidCount: number;
               readonly liveBiddingStarted: boolean;
               readonly lotClosesAt: string | null | undefined;
               readonly onlineBiddingExtended: boolean;
               readonly registrationEndsAt: string | null | undefined;
             } | null | undefined;
-            readonly partnerOffer?: {
+            readonly partnerOffer: {
               readonly endAt: string | null | undefined;
               readonly id: string;
               readonly priceWithDiscount: {
@@ -260,14 +260,17 @@ v8 = [
     "storageKey": null
   }
 ],
-v9 = {
+v9 = [
+  (v5/*: any*/)
+],
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -275,14 +278,14 @@ v10 = {
     "large"
   ]
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v12 = [
+v13 = [
   {
     "alias": null,
     "args": null,
@@ -291,92 +294,92 @@ v12 = [
     "storageKey": null
   }
 ],
-v13 = [
+v14 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v16 = [
+v17 = [
   (v4/*: any*/),
   (v5/*: any*/)
 ],
-v17 = {
+v18 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FilterArtworksConnection"
 },
-v18 = {
+v19 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v19 = {
+v20 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FormattedNumber"
 },
-v20 = {
+v21 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v21 = {
+v22 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Boolean"
 },
-v22 = {
+v23 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v23 = {
+v24 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Int"
 },
-v24 = {
+v25 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Boolean"
 },
-v25 = {
+v26 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v26 = {
+v27 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "SaleArtwork"
 },
-v27 = {
+v28 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -634,27 +637,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v5/*: any*/)
-                    ],
+                    "selections": (v9/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -687,7 +670,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v2/*: any*/),
-                          (v9/*: any*/),
+                          (v10/*: any*/),
                           (v3/*: any*/),
                           {
                             "alias": null,
@@ -721,7 +704,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v10/*: any*/)
+                                  (v11/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -744,7 +727,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v10/*: any*/),
+                                  (v11/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -829,6 +812,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -880,7 +870,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v11/*: any*/),
+                                  (v12/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -888,7 +878,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v12/*: any*/),
+                                    "selections": (v13/*: any*/),
                                     "storageKey": null
                                   },
                                   (v5/*: any*/)
@@ -914,7 +904,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -962,14 +952,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v5/*: any*/),
-                              (v9/*: any*/),
+                              (v10/*: any*/),
                               (v4/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -983,14 +973,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v4/*: any*/),
-                              (v9/*: any*/),
+                              (v10/*: any*/),
                               (v5/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -1003,7 +993,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1065,7 +1055,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v14/*: any*/),
+                              (v15/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1073,8 +1063,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v11/*: any*/),
-                              (v15/*: any*/),
+                              (v12/*: any*/),
+                              (v16/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1107,7 +1097,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v12/*: any*/),
+                                "selections": (v13/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -1117,7 +1107,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v12/*: any*/),
+                                "selections": (v13/*: any*/),
                                 "storageKey": null
                               },
                               (v5/*: any*/)
@@ -1132,10 +1122,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v14/*: any*/),
+                              (v15/*: any*/),
                               (v5/*: any*/),
-                              (v11/*: any*/),
-                              (v15/*: any*/)
+                              (v12/*: any*/),
+                              (v16/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -1146,7 +1136,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v16/*: any*/),
+                            "selections": (v17/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1164,7 +1154,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v16/*: any*/),
+                                "selections": (v17/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -1189,9 +1179,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v5/*: any*/)
-                        ],
+                        "selections": (v9/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1212,7 +1200,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "38400c0cd285e7a3f6b2298005af006b",
+    "cacheID": "3032f071cc2064ba80341c57869e1356",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -1228,25 +1216,25 @@ return {
           "plural": true,
           "type": "String"
         },
-        "fair.filtered_artworks": (v17/*: any*/),
-        "fair.filtered_artworks.__isArtworkConnectionInterface": (v18/*: any*/),
+        "fair.filtered_artworks": (v18/*: any*/),
+        "fair.filtered_artworks.__isArtworkConnectionInterface": (v19/*: any*/),
         "fair.filtered_artworks.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "FilterArtworksCounts"
         },
-        "fair.filtered_artworks.counts.followedArtists": (v19/*: any*/),
-        "fair.filtered_artworks.counts.total": (v19/*: any*/),
+        "fair.filtered_artworks.counts.followedArtists": (v20/*: any*/),
+        "fair.filtered_artworks.counts.total": (v20/*: any*/),
         "fair.filtered_artworks.edges": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "ArtworkEdgeInterface"
         },
-        "fair.filtered_artworks.edges.__isNode": (v18/*: any*/),
-        "fair.filtered_artworks.edges.__typename": (v18/*: any*/),
-        "fair.filtered_artworks.edges.id": (v20/*: any*/),
+        "fair.filtered_artworks.edges.__isNode": (v19/*: any*/),
+        "fair.filtered_artworks.edges.__typename": (v19/*: any*/),
+        "fair.filtered_artworks.edges.id": (v21/*: any*/),
         "fair.filtered_artworks.edges.node": {
           "enumValues": null,
           "nullable": true,
@@ -1259,33 +1247,33 @@ return {
           "plural": false,
           "type": "Artist"
         },
-        "fair.filtered_artworks.edges.node.artist.id": (v20/*: any*/),
+        "fair.filtered_artworks.edges.node.artist.id": (v21/*: any*/),
         "fair.filtered_artworks.edges.node.artist.targetSupply": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "ArtistTargetSupply"
         },
-        "fair.filtered_artworks.edges.node.artist.targetSupply.isP1": (v21/*: any*/),
-        "fair.filtered_artworks.edges.node.artistNames": (v22/*: any*/),
+        "fair.filtered_artworks.edges.node.artist.targetSupply.isP1": (v22/*: any*/),
+        "fair.filtered_artworks.edges.node.artistNames": (v23/*: any*/),
         "fair.filtered_artworks.edges.node.artists": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Artist"
         },
-        "fair.filtered_artworks.edges.node.artists.href": (v22/*: any*/),
-        "fair.filtered_artworks.edges.node.artists.id": (v20/*: any*/),
-        "fair.filtered_artworks.edges.node.artists.name": (v22/*: any*/),
+        "fair.filtered_artworks.edges.node.artists.href": (v23/*: any*/),
+        "fair.filtered_artworks.edges.node.artists.id": (v21/*: any*/),
+        "fair.filtered_artworks.edges.node.artists.name": (v23/*: any*/),
         "fair.filtered_artworks.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "fair.filtered_artworks.edges.node.attributionClass.id": (v20/*: any*/),
-        "fair.filtered_artworks.edges.node.attributionClass.name": (v22/*: any*/),
-        "fair.filtered_artworks.edges.node.collecting_institution": (v22/*: any*/),
+        "fair.filtered_artworks.edges.node.attributionClass.id": (v21/*: any*/),
+        "fair.filtered_artworks.edges.node.attributionClass.name": (v23/*: any*/),
+        "fair.filtered_artworks.edges.node.collecting_institution": (v23/*: any*/),
         "fair.filtered_artworks.edges.node.collectorSignals": {
           "enumValues": null,
           "nullable": true,
@@ -1298,26 +1286,26 @@ return {
           "plural": false,
           "type": "AuctionCollectorSignals"
         },
-        "fair.filtered_artworks.edges.node.collectorSignals.auction.bidCount": (v23/*: any*/),
-        "fair.filtered_artworks.edges.node.collectorSignals.auction.liveBiddingStarted": (v24/*: any*/),
-        "fair.filtered_artworks.edges.node.collectorSignals.auction.lotClosesAt": (v22/*: any*/),
-        "fair.filtered_artworks.edges.node.collectorSignals.auction.onlineBiddingExtended": (v24/*: any*/),
-        "fair.filtered_artworks.edges.node.collectorSignals.auction.registrationEndsAt": (v22/*: any*/),
+        "fair.filtered_artworks.edges.node.collectorSignals.auction.bidCount": (v24/*: any*/),
+        "fair.filtered_artworks.edges.node.collectorSignals.auction.liveBiddingStarted": (v25/*: any*/),
+        "fair.filtered_artworks.edges.node.collectorSignals.auction.lotClosesAt": (v23/*: any*/),
+        "fair.filtered_artworks.edges.node.collectorSignals.auction.onlineBiddingExtended": (v25/*: any*/),
+        "fair.filtered_artworks.edges.node.collectorSignals.auction.registrationEndsAt": (v23/*: any*/),
         "fair.filtered_artworks.edges.node.collectorSignals.partnerOffer": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "PartnerOfferToCollector"
         },
-        "fair.filtered_artworks.edges.node.collectorSignals.partnerOffer.endAt": (v22/*: any*/),
-        "fair.filtered_artworks.edges.node.collectorSignals.partnerOffer.id": (v20/*: any*/),
+        "fair.filtered_artworks.edges.node.collectorSignals.partnerOffer.endAt": (v23/*: any*/),
+        "fair.filtered_artworks.edges.node.collectorSignals.partnerOffer.id": (v21/*: any*/),
         "fair.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Money"
         },
-        "fair.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v22/*: any*/),
+        "fair.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v23/*: any*/),
         "fair.filtered_artworks.edges.node.collectorSignals.primaryLabel": {
           "enumValues": [
             "CURATORS_PICK",
@@ -1328,10 +1316,10 @@ return {
           "plural": false,
           "type": "LabelSignalEnum"
         },
-        "fair.filtered_artworks.edges.node.cultural_maker": (v22/*: any*/),
-        "fair.filtered_artworks.edges.node.date": (v22/*: any*/),
-        "fair.filtered_artworks.edges.node.href": (v22/*: any*/),
-        "fair.filtered_artworks.edges.node.id": (v20/*: any*/),
+        "fair.filtered_artworks.edges.node.cultural_maker": (v23/*: any*/),
+        "fair.filtered_artworks.edges.node.date": (v23/*: any*/),
+        "fair.filtered_artworks.edges.node.href": (v23/*: any*/),
+        "fair.filtered_artworks.edges.node.id": (v21/*: any*/),
         "fair.filtered_artworks.edges.node.image": {
           "enumValues": null,
           "nullable": true,
@@ -1344,35 +1332,35 @@ return {
           "plural": false,
           "type": "Float"
         },
-        "fair.filtered_artworks.edges.node.image.blurhashDataURL": (v22/*: any*/),
+        "fair.filtered_artworks.edges.node.image.blurhashDataURL": (v23/*: any*/),
         "fair.filtered_artworks.edges.node.image.internalID": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ID"
         },
-        "fair.filtered_artworks.edges.node.image.placeholder": (v22/*: any*/),
+        "fair.filtered_artworks.edges.node.image.placeholder": (v23/*: any*/),
         "fair.filtered_artworks.edges.node.image.resized": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ResizedImageUrl"
         },
-        "fair.filtered_artworks.edges.node.image.resized.height": (v25/*: any*/),
-        "fair.filtered_artworks.edges.node.image.resized.src": (v18/*: any*/),
-        "fair.filtered_artworks.edges.node.image.resized.srcSet": (v18/*: any*/),
-        "fair.filtered_artworks.edges.node.image.resized.width": (v25/*: any*/),
-        "fair.filtered_artworks.edges.node.image.url": (v22/*: any*/),
+        "fair.filtered_artworks.edges.node.image.resized.height": (v26/*: any*/),
+        "fair.filtered_artworks.edges.node.image.resized.src": (v19/*: any*/),
+        "fair.filtered_artworks.edges.node.image.resized.srcSet": (v19/*: any*/),
+        "fair.filtered_artworks.edges.node.image.resized.width": (v26/*: any*/),
+        "fair.filtered_artworks.edges.node.image.url": (v23/*: any*/),
         "fair.filtered_artworks.edges.node.image.versions": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "String"
         },
-        "fair.filtered_artworks.edges.node.imageTitle": (v22/*: any*/),
-        "fair.filtered_artworks.edges.node.image_title": (v22/*: any*/),
-        "fair.filtered_artworks.edges.node.internalID": (v20/*: any*/),
-        "fair.filtered_artworks.edges.node.isUnlisted": (v24/*: any*/),
+        "fair.filtered_artworks.edges.node.imageTitle": (v23/*: any*/),
+        "fair.filtered_artworks.edges.node.image_title": (v23/*: any*/),
+        "fair.filtered_artworks.edges.node.internalID": (v21/*: any*/),
+        "fair.filtered_artworks.edges.node.isUnlisted": (v25/*: any*/),
         "fair.filtered_artworks.edges.node.marketPriceInsights": {
           "enumValues": null,
           "nullable": true,
@@ -1397,69 +1385,69 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "fair.filtered_artworks.edges.node.mediumType.filterGene.id": (v20/*: any*/),
-        "fair.filtered_artworks.edges.node.mediumType.filterGene.name": (v22/*: any*/),
+        "fair.filtered_artworks.edges.node.mediumType.filterGene.id": (v21/*: any*/),
+        "fair.filtered_artworks.edges.node.mediumType.filterGene.name": (v23/*: any*/),
         "fair.filtered_artworks.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "fair.filtered_artworks.edges.node.partner.href": (v22/*: any*/),
-        "fair.filtered_artworks.edges.node.partner.id": (v20/*: any*/),
-        "fair.filtered_artworks.edges.node.partner.name": (v22/*: any*/),
+        "fair.filtered_artworks.edges.node.partner.href": (v23/*: any*/),
+        "fair.filtered_artworks.edges.node.partner.id": (v21/*: any*/),
+        "fair.filtered_artworks.edges.node.partner.name": (v23/*: any*/),
         "fair.filtered_artworks.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "fair.filtered_artworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v25/*: any*/),
-        "fair.filtered_artworks.edges.node.sale.endAt": (v22/*: any*/),
-        "fair.filtered_artworks.edges.node.sale.extendedBiddingIntervalMinutes": (v25/*: any*/),
-        "fair.filtered_artworks.edges.node.sale.extendedBiddingPeriodMinutes": (v25/*: any*/),
-        "fair.filtered_artworks.edges.node.sale.id": (v20/*: any*/),
-        "fair.filtered_artworks.edges.node.sale.isOpen": (v21/*: any*/),
-        "fair.filtered_artworks.edges.node.sale.is_auction": (v21/*: any*/),
-        "fair.filtered_artworks.edges.node.sale.is_closed": (v21/*: any*/),
-        "fair.filtered_artworks.edges.node.sale.startAt": (v22/*: any*/),
-        "fair.filtered_artworks.edges.node.saleArtwork": (v26/*: any*/),
-        "fair.filtered_artworks.edges.node.saleArtwork.endAt": (v22/*: any*/),
-        "fair.filtered_artworks.edges.node.saleArtwork.extendedBiddingEndAt": (v22/*: any*/),
-        "fair.filtered_artworks.edges.node.saleArtwork.id": (v20/*: any*/),
-        "fair.filtered_artworks.edges.node.saleArtwork.lotID": (v22/*: any*/),
-        "fair.filtered_artworks.edges.node.sale_artwork": (v26/*: any*/),
+        "fair.filtered_artworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v26/*: any*/),
+        "fair.filtered_artworks.edges.node.sale.endAt": (v23/*: any*/),
+        "fair.filtered_artworks.edges.node.sale.extendedBiddingIntervalMinutes": (v26/*: any*/),
+        "fair.filtered_artworks.edges.node.sale.extendedBiddingPeriodMinutes": (v26/*: any*/),
+        "fair.filtered_artworks.edges.node.sale.id": (v21/*: any*/),
+        "fair.filtered_artworks.edges.node.sale.isOpen": (v22/*: any*/),
+        "fair.filtered_artworks.edges.node.sale.is_auction": (v22/*: any*/),
+        "fair.filtered_artworks.edges.node.sale.is_closed": (v22/*: any*/),
+        "fair.filtered_artworks.edges.node.sale.startAt": (v23/*: any*/),
+        "fair.filtered_artworks.edges.node.saleArtwork": (v27/*: any*/),
+        "fair.filtered_artworks.edges.node.saleArtwork.endAt": (v23/*: any*/),
+        "fair.filtered_artworks.edges.node.saleArtwork.extendedBiddingEndAt": (v23/*: any*/),
+        "fair.filtered_artworks.edges.node.saleArtwork.id": (v21/*: any*/),
+        "fair.filtered_artworks.edges.node.saleArtwork.lotID": (v23/*: any*/),
+        "fair.filtered_artworks.edges.node.sale_artwork": (v27/*: any*/),
         "fair.filtered_artworks.edges.node.sale_artwork.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkCounts"
         },
-        "fair.filtered_artworks.edges.node.sale_artwork.counts.bidder_positions": (v19/*: any*/),
-        "fair.filtered_artworks.edges.node.sale_artwork.endAt": (v22/*: any*/),
-        "fair.filtered_artworks.edges.node.sale_artwork.extendedBiddingEndAt": (v22/*: any*/),
-        "fair.filtered_artworks.edges.node.sale_artwork.formattedEndDateTime": (v22/*: any*/),
+        "fair.filtered_artworks.edges.node.sale_artwork.counts.bidder_positions": (v20/*: any*/),
+        "fair.filtered_artworks.edges.node.sale_artwork.endAt": (v23/*: any*/),
+        "fair.filtered_artworks.edges.node.sale_artwork.extendedBiddingEndAt": (v23/*: any*/),
+        "fair.filtered_artworks.edges.node.sale_artwork.formattedEndDateTime": (v23/*: any*/),
         "fair.filtered_artworks.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "fair.filtered_artworks.edges.node.sale_artwork.highest_bid.display": (v22/*: any*/),
-        "fair.filtered_artworks.edges.node.sale_artwork.id": (v20/*: any*/),
-        "fair.filtered_artworks.edges.node.sale_artwork.lotID": (v22/*: any*/),
-        "fair.filtered_artworks.edges.node.sale_artwork.lotLabel": (v22/*: any*/),
+        "fair.filtered_artworks.edges.node.sale_artwork.highest_bid.display": (v23/*: any*/),
+        "fair.filtered_artworks.edges.node.sale_artwork.id": (v21/*: any*/),
+        "fair.filtered_artworks.edges.node.sale_artwork.lotID": (v23/*: any*/),
+        "fair.filtered_artworks.edges.node.sale_artwork.lotLabel": (v23/*: any*/),
         "fair.filtered_artworks.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "fair.filtered_artworks.edges.node.sale_artwork.opening_bid.display": (v22/*: any*/),
-        "fair.filtered_artworks.edges.node.sale_message": (v22/*: any*/),
-        "fair.filtered_artworks.edges.node.slug": (v20/*: any*/),
-        "fair.filtered_artworks.edges.node.title": (v22/*: any*/),
-        "fair.filtered_artworks.id": (v20/*: any*/),
+        "fair.filtered_artworks.edges.node.sale_artwork.opening_bid.display": (v23/*: any*/),
+        "fair.filtered_artworks.edges.node.sale_message": (v23/*: any*/),
+        "fair.filtered_artworks.edges.node.slug": (v21/*: any*/),
+        "fair.filtered_artworks.edges.node.title": (v23/*: any*/),
+        "fair.filtered_artworks.id": (v21/*: any*/),
         "fair.filtered_artworks.pageCursors": {
           "enumValues": null,
           "nullable": false,
@@ -1472,31 +1460,31 @@ return {
           "plural": true,
           "type": "PageCursor"
         },
-        "fair.filtered_artworks.pageCursors.around.cursor": (v18/*: any*/),
-        "fair.filtered_artworks.pageCursors.around.isCurrent": (v24/*: any*/),
-        "fair.filtered_artworks.pageCursors.around.page": (v23/*: any*/),
-        "fair.filtered_artworks.pageCursors.first": (v27/*: any*/),
-        "fair.filtered_artworks.pageCursors.first.cursor": (v18/*: any*/),
-        "fair.filtered_artworks.pageCursors.first.isCurrent": (v24/*: any*/),
-        "fair.filtered_artworks.pageCursors.first.page": (v23/*: any*/),
-        "fair.filtered_artworks.pageCursors.last": (v27/*: any*/),
-        "fair.filtered_artworks.pageCursors.last.cursor": (v18/*: any*/),
-        "fair.filtered_artworks.pageCursors.last.isCurrent": (v24/*: any*/),
-        "fair.filtered_artworks.pageCursors.last.page": (v23/*: any*/),
-        "fair.filtered_artworks.pageCursors.previous": (v27/*: any*/),
-        "fair.filtered_artworks.pageCursors.previous.cursor": (v18/*: any*/),
-        "fair.filtered_artworks.pageCursors.previous.page": (v23/*: any*/),
+        "fair.filtered_artworks.pageCursors.around.cursor": (v19/*: any*/),
+        "fair.filtered_artworks.pageCursors.around.isCurrent": (v25/*: any*/),
+        "fair.filtered_artworks.pageCursors.around.page": (v24/*: any*/),
+        "fair.filtered_artworks.pageCursors.first": (v28/*: any*/),
+        "fair.filtered_artworks.pageCursors.first.cursor": (v19/*: any*/),
+        "fair.filtered_artworks.pageCursors.first.isCurrent": (v25/*: any*/),
+        "fair.filtered_artworks.pageCursors.first.page": (v24/*: any*/),
+        "fair.filtered_artworks.pageCursors.last": (v28/*: any*/),
+        "fair.filtered_artworks.pageCursors.last.cursor": (v19/*: any*/),
+        "fair.filtered_artworks.pageCursors.last.isCurrent": (v25/*: any*/),
+        "fair.filtered_artworks.pageCursors.last.page": (v24/*: any*/),
+        "fair.filtered_artworks.pageCursors.previous": (v28/*: any*/),
+        "fair.filtered_artworks.pageCursors.previous.cursor": (v19/*: any*/),
+        "fair.filtered_artworks.pageCursors.previous.page": (v24/*: any*/),
         "fair.filtered_artworks.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "fair.filtered_artworks.pageInfo.endCursor": (v22/*: any*/),
-        "fair.filtered_artworks.pageInfo.hasNextPage": (v24/*: any*/),
-        "fair.id": (v20/*: any*/),
-        "fair.internalID": (v20/*: any*/),
-        "fair.sidebarAggregations": (v17/*: any*/),
+        "fair.filtered_artworks.pageInfo.endCursor": (v23/*: any*/),
+        "fair.filtered_artworks.pageInfo.hasNextPage": (v25/*: any*/),
+        "fair.id": (v21/*: any*/),
+        "fair.internalID": (v21/*: any*/),
+        "fair.sidebarAggregations": (v18/*: any*/),
         "fair.sidebarAggregations.aggregations": {
           "enumValues": null,
           "nullable": true,
@@ -1509,9 +1497,9 @@ return {
           "plural": true,
           "type": "AggregationCount"
         },
-        "fair.sidebarAggregations.aggregations.counts.count": (v23/*: any*/),
-        "fair.sidebarAggregations.aggregations.counts.name": (v18/*: any*/),
-        "fair.sidebarAggregations.aggregations.counts.value": (v18/*: any*/),
+        "fair.sidebarAggregations.aggregations.counts.count": (v24/*: any*/),
+        "fair.sidebarAggregations.aggregations.counts.name": (v19/*: any*/),
+        "fair.sidebarAggregations.aggregations.counts.value": (v19/*: any*/),
         "fair.sidebarAggregations.aggregations.slice": {
           "enumValues": [
             "ARTIST",
@@ -1539,13 +1527,13 @@ return {
           "plural": false,
           "type": "ArtworkAggregation"
         },
-        "fair.sidebarAggregations.id": (v20/*: any*/),
-        "fair.slug": (v20/*: any*/)
+        "fair.sidebarAggregations.id": (v21/*: any*/),
+        "fair.slug": (v21/*: any*/)
       }
     },
     "name": "FairArtworks_Query",
     "operationKind": "query",
-    "text": "query FairArtworks_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairArtworks_fair\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FairArtworks_fair on Fair {\n  slug\n  internalID\n  featuredKeywords\n  sidebarAggregations: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30) {\n    id\n    counts {\n      followedArtists\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
+    "text": "query FairArtworks_Query(\n  $slug: String!\n) {\n  fair(id: $slug) {\n    ...FairArtworks_fair\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FairArtworks_fair on Fair {\n  slug\n  internalID\n  featuredKeywords\n  sidebarAggregations: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30) {\n    id\n    counts {\n      followedArtists\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/GeneArtworkFilterQuery.graphql.ts
+++ b/src/__generated__/GeneArtworkFilterQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<cdcae4dd7e6e06c23d48f5a4c7ecee5a>>
+ * @generated SignedSource<<9a02e36c2a2f55ed2b115268c13fe5e0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -170,14 +170,17 @@ v13 = [
     "storageKey": null
   }
 ],
-v14 = {
+v14 = [
+  (v10/*: any*/)
+],
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -185,14 +188,14 @@ v15 = {
     "large"
   ]
 },
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v17 = [
+v18 = [
   {
     "alias": null,
     "args": null,
@@ -201,28 +204,28 @@ v17 = [
     "storageKey": null
   }
 ],
-v18 = [
+v19 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v19 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v20 = {
+v21 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v21 = [
+v22 = [
   (v9/*: any*/),
   (v10/*: any*/)
 ];
@@ -509,27 +512,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v10/*: any*/)
-                    ],
+                    "selections": (v14/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -562,7 +545,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v7/*: any*/),
-                          (v14/*: any*/),
+                          (v15/*: any*/),
                           (v8/*: any*/),
                           {
                             "alias": null,
@@ -596,7 +579,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v15/*: any*/)
+                                  (v16/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -619,7 +602,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v15/*: any*/),
+                                  (v16/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -704,6 +687,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -755,7 +745,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v16/*: any*/),
+                                  (v17/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -763,7 +753,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v17/*: any*/),
+                                    "selections": (v18/*: any*/),
                                     "storageKey": null
                                   },
                                   (v10/*: any*/)
@@ -789,7 +779,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v18/*: any*/),
+                            "args": (v19/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -837,14 +827,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v18/*: any*/),
+                            "args": (v19/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v10/*: any*/),
-                              (v14/*: any*/),
+                              (v15/*: any*/),
                               (v9/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -858,14 +848,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v18/*: any*/),
+                            "args": (v19/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v9/*: any*/),
-                              (v14/*: any*/),
+                              (v15/*: any*/),
                               (v10/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -878,7 +868,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v16/*: any*/),
+                              (v17/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -940,7 +930,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v19/*: any*/),
+                              (v20/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -948,8 +938,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v16/*: any*/),
-                              (v20/*: any*/),
+                              (v17/*: any*/),
+                              (v21/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -982,7 +972,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v17/*: any*/),
+                                "selections": (v18/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -992,7 +982,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v17/*: any*/),
+                                "selections": (v18/*: any*/),
                                 "storageKey": null
                               },
                               (v10/*: any*/)
@@ -1007,10 +997,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v19/*: any*/),
+                              (v20/*: any*/),
                               (v10/*: any*/),
-                              (v16/*: any*/),
-                              (v20/*: any*/)
+                              (v17/*: any*/),
+                              (v21/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -1021,7 +1011,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v21/*: any*/),
+                            "selections": (v22/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1039,7 +1029,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v21/*: any*/),
+                                "selections": (v22/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -1064,9 +1054,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v10/*: any*/)
-                        ],
+                        "selections": (v14/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1087,12 +1075,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b63ec0e8a28d3340b54a55b7fa817ca2",
+    "cacheID": "607923e87905ab117e7da28944ccd735",
     "id": null,
     "metadata": {},
     "name": "GeneArtworkFilterQuery",
     "operationKind": "query",
-    "text": "query GeneArtworkFilterQuery(\n  $slug: String!\n  $input: FilterArtworksInput\n  $aggregations: [ArtworkAggregation]\n  $shouldFetchCounts: Boolean!\n) {\n  gene(id: $slug) {\n    ...GeneArtworkFilter_gene_3TMxyn\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GeneArtworkFilter_gene_3TMxyn on Gene {\n  slug\n  internalID\n  sidebar: filterArtworksConnection(aggregations: $aggregations, first: 1) {\n    counts @include(if: $shouldFetchCounts) {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
+    "text": "query GeneArtworkFilterQuery(\n  $slug: String!\n  $input: FilterArtworksInput\n  $aggregations: [ArtworkAggregation]\n  $shouldFetchCounts: Boolean!\n) {\n  gene(id: $slug) {\n    ...GeneArtworkFilter_gene_3TMxyn\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GeneArtworkFilter_gene_3TMxyn on Gene {\n  slug\n  internalID\n  sidebar: filterArtworksConnection(aggregations: $aggregations, first: 1) {\n    counts @include(if: $shouldFetchCounts) {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/GeneArtworkFilterRefetchQuery.graphql.ts
+++ b/src/__generated__/GeneArtworkFilterRefetchQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<974c5a1e467470a5ae3c2f477681c3bc>>
+ * @generated SignedSource<<7d989bbfd8b4b3ffc9b4ce8a6835f052>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -153,14 +153,17 @@ v10 = [
     "storageKey": null
   }
 ],
-v11 = {
+v11 = [
+  (v7/*: any*/)
+],
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v12 = {
+v13 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -168,14 +171,14 @@ v12 = {
     "large"
   ]
 },
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v14 = [
+v15 = [
   {
     "alias": null,
     "args": null,
@@ -184,28 +187,28 @@ v14 = [
     "storageKey": null
   }
 ],
-v15 = [
+v16 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v18 = [
+v19 = [
   (v6/*: any*/),
   (v7/*: any*/)
 ];
@@ -456,27 +459,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v7/*: any*/)
-                    ],
+                    "selections": (v11/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -509,7 +492,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v4/*: any*/),
-                          (v11/*: any*/),
+                          (v12/*: any*/),
                           (v5/*: any*/),
                           {
                             "alias": null,
@@ -543,7 +526,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v12/*: any*/)
+                                  (v13/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -566,7 +549,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v12/*: any*/),
+                                  (v13/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -651,6 +634,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -702,7 +692,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v13/*: any*/),
+                                  (v14/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -710,7 +700,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v14/*: any*/),
+                                    "selections": (v15/*: any*/),
                                     "storageKey": null
                                   },
                                   (v7/*: any*/)
@@ -736,7 +726,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v15/*: any*/),
+                            "args": (v16/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -784,14 +774,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v15/*: any*/),
+                            "args": (v16/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v7/*: any*/),
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               (v6/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -805,14 +795,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v15/*: any*/),
+                            "args": (v16/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v6/*: any*/),
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               (v7/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -825,7 +815,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v13/*: any*/),
+                              (v14/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -887,7 +877,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v16/*: any*/),
+                              (v17/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -895,8 +885,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v13/*: any*/),
-                              (v17/*: any*/),
+                              (v14/*: any*/),
+                              (v18/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -929,7 +919,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v14/*: any*/),
+                                "selections": (v15/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -939,7 +929,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v14/*: any*/),
+                                "selections": (v15/*: any*/),
                                 "storageKey": null
                               },
                               (v7/*: any*/)
@@ -954,10 +944,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v16/*: any*/),
+                              (v17/*: any*/),
                               (v7/*: any*/),
-                              (v13/*: any*/),
-                              (v17/*: any*/)
+                              (v14/*: any*/),
+                              (v18/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -968,7 +958,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v18/*: any*/),
+                            "selections": (v19/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -986,7 +976,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v18/*: any*/),
+                                "selections": (v19/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -1011,9 +1001,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v7/*: any*/)
-                        ],
+                        "selections": (v11/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1034,12 +1022,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a914faec34c10e580ba615a383d7f571",
+    "cacheID": "deba0d4dbe2f9604ff2689338b1ba8e5",
     "id": null,
     "metadata": {},
     "name": "GeneArtworkFilterRefetchQuery",
     "operationKind": "query",
-    "text": "query GeneArtworkFilterRefetchQuery(\n  $slug: String!\n  $input: FilterArtworksInput\n) {\n  gene(id: $slug) {\n    ...GeneArtworkFilter_gene_2VV6jB\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GeneArtworkFilter_gene_2VV6jB on Gene {\n  slug\n  internalID\n  sidebar: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
+    "text": "query GeneArtworkFilterRefetchQuery(\n  $slug: String!\n  $input: FilterArtworksInput\n) {\n  gene(id: $slug) {\n    ...GeneArtworkFilter_gene_2VV6jB\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GeneArtworkFilter_gene_2VV6jB on Gene {\n  slug\n  internalID\n  sidebar: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/GeneArtworkFilter_Query.graphql.ts
+++ b/src/__generated__/GeneArtworkFilter_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<647bcc464b064974a829e86ef792d1b2>>
+ * @generated SignedSource<<31782472e3bb39c284c3061a5542425d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -91,14 +91,17 @@ v8 = [
     "storageKey": null
   }
 ],
-v9 = {
+v9 = [
+  (v5/*: any*/)
+],
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -106,14 +109,14 @@ v10 = {
     "large"
   ]
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v12 = [
+v13 = [
   {
     "alias": null,
     "args": null,
@@ -122,104 +125,104 @@ v12 = [
     "storageKey": null
   }
 ],
-v13 = [
+v14 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v16 = [
+v17 = [
   (v4/*: any*/),
   (v5/*: any*/)
 ],
-v17 = {
+v18 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Gene"
 },
-v18 = {
+v19 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FilterArtworksConnection"
 },
-v19 = {
+v20 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
-},
-v20 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "FilterArtworksCounts"
 },
 v21 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "FormattedNumber"
+  "type": "FilterArtworksCounts"
 },
 v22 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "FormattedNumber"
+},
+v23 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v23 = {
+v24 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Boolean"
 },
-v24 = {
+v25 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v25 = {
+v26 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Int"
 },
-v26 = {
+v27 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Boolean"
 },
-v27 = {
+v28 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v28 = {
+v29 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "SaleArtwork"
 },
-v29 = {
+v30 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -487,27 +490,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v5/*: any*/)
-                    ],
+                    "selections": (v9/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -540,7 +523,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v2/*: any*/),
-                          (v9/*: any*/),
+                          (v10/*: any*/),
                           (v3/*: any*/),
                           {
                             "alias": null,
@@ -574,7 +557,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v10/*: any*/)
+                                  (v11/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -597,7 +580,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v10/*: any*/),
+                                  (v11/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -682,6 +665,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -733,7 +723,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v11/*: any*/),
+                                  (v12/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -741,7 +731,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v12/*: any*/),
+                                    "selections": (v13/*: any*/),
                                     "storageKey": null
                                   },
                                   (v5/*: any*/)
@@ -767,7 +757,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -815,14 +805,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v5/*: any*/),
-                              (v9/*: any*/),
+                              (v10/*: any*/),
                               (v4/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -836,14 +826,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v4/*: any*/),
-                              (v9/*: any*/),
+                              (v10/*: any*/),
                               (v5/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -856,7 +846,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -918,7 +908,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v14/*: any*/),
+                              (v15/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -926,8 +916,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v11/*: any*/),
-                              (v15/*: any*/),
+                              (v12/*: any*/),
+                              (v16/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -960,7 +950,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v12/*: any*/),
+                                "selections": (v13/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -970,7 +960,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v12/*: any*/),
+                                "selections": (v13/*: any*/),
                                 "storageKey": null
                               },
                               (v5/*: any*/)
@@ -985,10 +975,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v14/*: any*/),
+                              (v15/*: any*/),
                               (v5/*: any*/),
-                              (v11/*: any*/),
-                              (v15/*: any*/)
+                              (v12/*: any*/),
+                              (v16/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -999,7 +989,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v16/*: any*/),
+                            "selections": (v17/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1017,7 +1007,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v16/*: any*/),
+                                "selections": (v17/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -1042,9 +1032,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v5/*: any*/)
-                        ],
+                        "selections": (v9/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1065,24 +1053,24 @@ return {
     ]
   },
   "params": {
-    "cacheID": "fef2e5bc8dfcc83a282be435883feedb",
+    "cacheID": "3a9ef4838e2dccfaa56dce2c5b6902c8",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
-        "gene": (v17/*: any*/),
-        "gene.filtered_artworks": (v18/*: any*/),
-        "gene.filtered_artworks.__isArtworkConnectionInterface": (v19/*: any*/),
-        "gene.filtered_artworks.counts": (v20/*: any*/),
-        "gene.filtered_artworks.counts.total": (v21/*: any*/),
+        "gene": (v18/*: any*/),
+        "gene.filtered_artworks": (v19/*: any*/),
+        "gene.filtered_artworks.__isArtworkConnectionInterface": (v20/*: any*/),
+        "gene.filtered_artworks.counts": (v21/*: any*/),
+        "gene.filtered_artworks.counts.total": (v22/*: any*/),
         "gene.filtered_artworks.edges": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "ArtworkEdgeInterface"
         },
-        "gene.filtered_artworks.edges.__isNode": (v19/*: any*/),
-        "gene.filtered_artworks.edges.__typename": (v19/*: any*/),
-        "gene.filtered_artworks.edges.id": (v22/*: any*/),
+        "gene.filtered_artworks.edges.__isNode": (v20/*: any*/),
+        "gene.filtered_artworks.edges.__typename": (v20/*: any*/),
+        "gene.filtered_artworks.edges.id": (v23/*: any*/),
         "gene.filtered_artworks.edges.node": {
           "enumValues": null,
           "nullable": true,
@@ -1095,33 +1083,33 @@ return {
           "plural": false,
           "type": "Artist"
         },
-        "gene.filtered_artworks.edges.node.artist.id": (v22/*: any*/),
+        "gene.filtered_artworks.edges.node.artist.id": (v23/*: any*/),
         "gene.filtered_artworks.edges.node.artist.targetSupply": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "ArtistTargetSupply"
         },
-        "gene.filtered_artworks.edges.node.artist.targetSupply.isP1": (v23/*: any*/),
-        "gene.filtered_artworks.edges.node.artistNames": (v24/*: any*/),
+        "gene.filtered_artworks.edges.node.artist.targetSupply.isP1": (v24/*: any*/),
+        "gene.filtered_artworks.edges.node.artistNames": (v25/*: any*/),
         "gene.filtered_artworks.edges.node.artists": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Artist"
         },
-        "gene.filtered_artworks.edges.node.artists.href": (v24/*: any*/),
-        "gene.filtered_artworks.edges.node.artists.id": (v22/*: any*/),
-        "gene.filtered_artworks.edges.node.artists.name": (v24/*: any*/),
+        "gene.filtered_artworks.edges.node.artists.href": (v25/*: any*/),
+        "gene.filtered_artworks.edges.node.artists.id": (v23/*: any*/),
+        "gene.filtered_artworks.edges.node.artists.name": (v25/*: any*/),
         "gene.filtered_artworks.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "gene.filtered_artworks.edges.node.attributionClass.id": (v22/*: any*/),
-        "gene.filtered_artworks.edges.node.attributionClass.name": (v24/*: any*/),
-        "gene.filtered_artworks.edges.node.collecting_institution": (v24/*: any*/),
+        "gene.filtered_artworks.edges.node.attributionClass.id": (v23/*: any*/),
+        "gene.filtered_artworks.edges.node.attributionClass.name": (v25/*: any*/),
+        "gene.filtered_artworks.edges.node.collecting_institution": (v25/*: any*/),
         "gene.filtered_artworks.edges.node.collectorSignals": {
           "enumValues": null,
           "nullable": true,
@@ -1134,26 +1122,26 @@ return {
           "plural": false,
           "type": "AuctionCollectorSignals"
         },
-        "gene.filtered_artworks.edges.node.collectorSignals.auction.bidCount": (v25/*: any*/),
-        "gene.filtered_artworks.edges.node.collectorSignals.auction.liveBiddingStarted": (v26/*: any*/),
-        "gene.filtered_artworks.edges.node.collectorSignals.auction.lotClosesAt": (v24/*: any*/),
-        "gene.filtered_artworks.edges.node.collectorSignals.auction.onlineBiddingExtended": (v26/*: any*/),
-        "gene.filtered_artworks.edges.node.collectorSignals.auction.registrationEndsAt": (v24/*: any*/),
+        "gene.filtered_artworks.edges.node.collectorSignals.auction.bidCount": (v26/*: any*/),
+        "gene.filtered_artworks.edges.node.collectorSignals.auction.liveBiddingStarted": (v27/*: any*/),
+        "gene.filtered_artworks.edges.node.collectorSignals.auction.lotClosesAt": (v25/*: any*/),
+        "gene.filtered_artworks.edges.node.collectorSignals.auction.onlineBiddingExtended": (v27/*: any*/),
+        "gene.filtered_artworks.edges.node.collectorSignals.auction.registrationEndsAt": (v25/*: any*/),
         "gene.filtered_artworks.edges.node.collectorSignals.partnerOffer": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "PartnerOfferToCollector"
         },
-        "gene.filtered_artworks.edges.node.collectorSignals.partnerOffer.endAt": (v24/*: any*/),
-        "gene.filtered_artworks.edges.node.collectorSignals.partnerOffer.id": (v22/*: any*/),
+        "gene.filtered_artworks.edges.node.collectorSignals.partnerOffer.endAt": (v25/*: any*/),
+        "gene.filtered_artworks.edges.node.collectorSignals.partnerOffer.id": (v23/*: any*/),
         "gene.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Money"
         },
-        "gene.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v24/*: any*/),
+        "gene.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v25/*: any*/),
         "gene.filtered_artworks.edges.node.collectorSignals.primaryLabel": {
           "enumValues": [
             "CURATORS_PICK",
@@ -1164,10 +1152,10 @@ return {
           "plural": false,
           "type": "LabelSignalEnum"
         },
-        "gene.filtered_artworks.edges.node.cultural_maker": (v24/*: any*/),
-        "gene.filtered_artworks.edges.node.date": (v24/*: any*/),
-        "gene.filtered_artworks.edges.node.href": (v24/*: any*/),
-        "gene.filtered_artworks.edges.node.id": (v22/*: any*/),
+        "gene.filtered_artworks.edges.node.cultural_maker": (v25/*: any*/),
+        "gene.filtered_artworks.edges.node.date": (v25/*: any*/),
+        "gene.filtered_artworks.edges.node.href": (v25/*: any*/),
+        "gene.filtered_artworks.edges.node.id": (v23/*: any*/),
         "gene.filtered_artworks.edges.node.image": {
           "enumValues": null,
           "nullable": true,
@@ -1180,35 +1168,35 @@ return {
           "plural": false,
           "type": "Float"
         },
-        "gene.filtered_artworks.edges.node.image.blurhashDataURL": (v24/*: any*/),
+        "gene.filtered_artworks.edges.node.image.blurhashDataURL": (v25/*: any*/),
         "gene.filtered_artworks.edges.node.image.internalID": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ID"
         },
-        "gene.filtered_artworks.edges.node.image.placeholder": (v24/*: any*/),
+        "gene.filtered_artworks.edges.node.image.placeholder": (v25/*: any*/),
         "gene.filtered_artworks.edges.node.image.resized": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ResizedImageUrl"
         },
-        "gene.filtered_artworks.edges.node.image.resized.height": (v27/*: any*/),
-        "gene.filtered_artworks.edges.node.image.resized.src": (v19/*: any*/),
-        "gene.filtered_artworks.edges.node.image.resized.srcSet": (v19/*: any*/),
-        "gene.filtered_artworks.edges.node.image.resized.width": (v27/*: any*/),
-        "gene.filtered_artworks.edges.node.image.url": (v24/*: any*/),
+        "gene.filtered_artworks.edges.node.image.resized.height": (v28/*: any*/),
+        "gene.filtered_artworks.edges.node.image.resized.src": (v20/*: any*/),
+        "gene.filtered_artworks.edges.node.image.resized.srcSet": (v20/*: any*/),
+        "gene.filtered_artworks.edges.node.image.resized.width": (v28/*: any*/),
+        "gene.filtered_artworks.edges.node.image.url": (v25/*: any*/),
         "gene.filtered_artworks.edges.node.image.versions": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "String"
         },
-        "gene.filtered_artworks.edges.node.imageTitle": (v24/*: any*/),
-        "gene.filtered_artworks.edges.node.image_title": (v24/*: any*/),
-        "gene.filtered_artworks.edges.node.internalID": (v22/*: any*/),
-        "gene.filtered_artworks.edges.node.isUnlisted": (v26/*: any*/),
+        "gene.filtered_artworks.edges.node.imageTitle": (v25/*: any*/),
+        "gene.filtered_artworks.edges.node.image_title": (v25/*: any*/),
+        "gene.filtered_artworks.edges.node.internalID": (v23/*: any*/),
+        "gene.filtered_artworks.edges.node.isUnlisted": (v27/*: any*/),
         "gene.filtered_artworks.edges.node.marketPriceInsights": {
           "enumValues": null,
           "nullable": true,
@@ -1227,70 +1215,70 @@ return {
           "plural": false,
           "type": "ArtworkMedium"
         },
-        "gene.filtered_artworks.edges.node.mediumType.filterGene": (v17/*: any*/),
-        "gene.filtered_artworks.edges.node.mediumType.filterGene.id": (v22/*: any*/),
-        "gene.filtered_artworks.edges.node.mediumType.filterGene.name": (v24/*: any*/),
+        "gene.filtered_artworks.edges.node.mediumType.filterGene": (v18/*: any*/),
+        "gene.filtered_artworks.edges.node.mediumType.filterGene.id": (v23/*: any*/),
+        "gene.filtered_artworks.edges.node.mediumType.filterGene.name": (v25/*: any*/),
         "gene.filtered_artworks.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "gene.filtered_artworks.edges.node.partner.href": (v24/*: any*/),
-        "gene.filtered_artworks.edges.node.partner.id": (v22/*: any*/),
-        "gene.filtered_artworks.edges.node.partner.name": (v24/*: any*/),
+        "gene.filtered_artworks.edges.node.partner.href": (v25/*: any*/),
+        "gene.filtered_artworks.edges.node.partner.id": (v23/*: any*/),
+        "gene.filtered_artworks.edges.node.partner.name": (v25/*: any*/),
         "gene.filtered_artworks.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "gene.filtered_artworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v27/*: any*/),
-        "gene.filtered_artworks.edges.node.sale.endAt": (v24/*: any*/),
-        "gene.filtered_artworks.edges.node.sale.extendedBiddingIntervalMinutes": (v27/*: any*/),
-        "gene.filtered_artworks.edges.node.sale.extendedBiddingPeriodMinutes": (v27/*: any*/),
-        "gene.filtered_artworks.edges.node.sale.id": (v22/*: any*/),
-        "gene.filtered_artworks.edges.node.sale.isOpen": (v23/*: any*/),
-        "gene.filtered_artworks.edges.node.sale.is_auction": (v23/*: any*/),
-        "gene.filtered_artworks.edges.node.sale.is_closed": (v23/*: any*/),
-        "gene.filtered_artworks.edges.node.sale.startAt": (v24/*: any*/),
-        "gene.filtered_artworks.edges.node.saleArtwork": (v28/*: any*/),
-        "gene.filtered_artworks.edges.node.saleArtwork.endAt": (v24/*: any*/),
-        "gene.filtered_artworks.edges.node.saleArtwork.extendedBiddingEndAt": (v24/*: any*/),
-        "gene.filtered_artworks.edges.node.saleArtwork.id": (v22/*: any*/),
-        "gene.filtered_artworks.edges.node.saleArtwork.lotID": (v24/*: any*/),
-        "gene.filtered_artworks.edges.node.sale_artwork": (v28/*: any*/),
+        "gene.filtered_artworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v28/*: any*/),
+        "gene.filtered_artworks.edges.node.sale.endAt": (v25/*: any*/),
+        "gene.filtered_artworks.edges.node.sale.extendedBiddingIntervalMinutes": (v28/*: any*/),
+        "gene.filtered_artworks.edges.node.sale.extendedBiddingPeriodMinutes": (v28/*: any*/),
+        "gene.filtered_artworks.edges.node.sale.id": (v23/*: any*/),
+        "gene.filtered_artworks.edges.node.sale.isOpen": (v24/*: any*/),
+        "gene.filtered_artworks.edges.node.sale.is_auction": (v24/*: any*/),
+        "gene.filtered_artworks.edges.node.sale.is_closed": (v24/*: any*/),
+        "gene.filtered_artworks.edges.node.sale.startAt": (v25/*: any*/),
+        "gene.filtered_artworks.edges.node.saleArtwork": (v29/*: any*/),
+        "gene.filtered_artworks.edges.node.saleArtwork.endAt": (v25/*: any*/),
+        "gene.filtered_artworks.edges.node.saleArtwork.extendedBiddingEndAt": (v25/*: any*/),
+        "gene.filtered_artworks.edges.node.saleArtwork.id": (v23/*: any*/),
+        "gene.filtered_artworks.edges.node.saleArtwork.lotID": (v25/*: any*/),
+        "gene.filtered_artworks.edges.node.sale_artwork": (v29/*: any*/),
         "gene.filtered_artworks.edges.node.sale_artwork.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkCounts"
         },
-        "gene.filtered_artworks.edges.node.sale_artwork.counts.bidder_positions": (v21/*: any*/),
-        "gene.filtered_artworks.edges.node.sale_artwork.endAt": (v24/*: any*/),
-        "gene.filtered_artworks.edges.node.sale_artwork.extendedBiddingEndAt": (v24/*: any*/),
-        "gene.filtered_artworks.edges.node.sale_artwork.formattedEndDateTime": (v24/*: any*/),
+        "gene.filtered_artworks.edges.node.sale_artwork.counts.bidder_positions": (v22/*: any*/),
+        "gene.filtered_artworks.edges.node.sale_artwork.endAt": (v25/*: any*/),
+        "gene.filtered_artworks.edges.node.sale_artwork.extendedBiddingEndAt": (v25/*: any*/),
+        "gene.filtered_artworks.edges.node.sale_artwork.formattedEndDateTime": (v25/*: any*/),
         "gene.filtered_artworks.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "gene.filtered_artworks.edges.node.sale_artwork.highest_bid.display": (v24/*: any*/),
-        "gene.filtered_artworks.edges.node.sale_artwork.id": (v22/*: any*/),
-        "gene.filtered_artworks.edges.node.sale_artwork.lotID": (v24/*: any*/),
-        "gene.filtered_artworks.edges.node.sale_artwork.lotLabel": (v24/*: any*/),
+        "gene.filtered_artworks.edges.node.sale_artwork.highest_bid.display": (v25/*: any*/),
+        "gene.filtered_artworks.edges.node.sale_artwork.id": (v23/*: any*/),
+        "gene.filtered_artworks.edges.node.sale_artwork.lotID": (v25/*: any*/),
+        "gene.filtered_artworks.edges.node.sale_artwork.lotLabel": (v25/*: any*/),
         "gene.filtered_artworks.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "gene.filtered_artworks.edges.node.sale_artwork.opening_bid.display": (v24/*: any*/),
-        "gene.filtered_artworks.edges.node.sale_message": (v24/*: any*/),
-        "gene.filtered_artworks.edges.node.slug": (v22/*: any*/),
-        "gene.filtered_artworks.edges.node.title": (v24/*: any*/),
-        "gene.filtered_artworks.id": (v22/*: any*/),
+        "gene.filtered_artworks.edges.node.sale_artwork.opening_bid.display": (v25/*: any*/),
+        "gene.filtered_artworks.edges.node.sale_message": (v25/*: any*/),
+        "gene.filtered_artworks.edges.node.slug": (v23/*: any*/),
+        "gene.filtered_artworks.edges.node.title": (v25/*: any*/),
+        "gene.filtered_artworks.id": (v23/*: any*/),
         "gene.filtered_artworks.pageCursors": {
           "enumValues": null,
           "nullable": false,
@@ -1303,31 +1291,31 @@ return {
           "plural": true,
           "type": "PageCursor"
         },
-        "gene.filtered_artworks.pageCursors.around.cursor": (v19/*: any*/),
-        "gene.filtered_artworks.pageCursors.around.isCurrent": (v26/*: any*/),
-        "gene.filtered_artworks.pageCursors.around.page": (v25/*: any*/),
-        "gene.filtered_artworks.pageCursors.first": (v29/*: any*/),
-        "gene.filtered_artworks.pageCursors.first.cursor": (v19/*: any*/),
-        "gene.filtered_artworks.pageCursors.first.isCurrent": (v26/*: any*/),
-        "gene.filtered_artworks.pageCursors.first.page": (v25/*: any*/),
-        "gene.filtered_artworks.pageCursors.last": (v29/*: any*/),
-        "gene.filtered_artworks.pageCursors.last.cursor": (v19/*: any*/),
-        "gene.filtered_artworks.pageCursors.last.isCurrent": (v26/*: any*/),
-        "gene.filtered_artworks.pageCursors.last.page": (v25/*: any*/),
-        "gene.filtered_artworks.pageCursors.previous": (v29/*: any*/),
-        "gene.filtered_artworks.pageCursors.previous.cursor": (v19/*: any*/),
-        "gene.filtered_artworks.pageCursors.previous.page": (v25/*: any*/),
+        "gene.filtered_artworks.pageCursors.around.cursor": (v20/*: any*/),
+        "gene.filtered_artworks.pageCursors.around.isCurrent": (v27/*: any*/),
+        "gene.filtered_artworks.pageCursors.around.page": (v26/*: any*/),
+        "gene.filtered_artworks.pageCursors.first": (v30/*: any*/),
+        "gene.filtered_artworks.pageCursors.first.cursor": (v20/*: any*/),
+        "gene.filtered_artworks.pageCursors.first.isCurrent": (v27/*: any*/),
+        "gene.filtered_artworks.pageCursors.first.page": (v26/*: any*/),
+        "gene.filtered_artworks.pageCursors.last": (v30/*: any*/),
+        "gene.filtered_artworks.pageCursors.last.cursor": (v20/*: any*/),
+        "gene.filtered_artworks.pageCursors.last.isCurrent": (v27/*: any*/),
+        "gene.filtered_artworks.pageCursors.last.page": (v26/*: any*/),
+        "gene.filtered_artworks.pageCursors.previous": (v30/*: any*/),
+        "gene.filtered_artworks.pageCursors.previous.cursor": (v20/*: any*/),
+        "gene.filtered_artworks.pageCursors.previous.page": (v26/*: any*/),
         "gene.filtered_artworks.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "gene.filtered_artworks.pageInfo.endCursor": (v24/*: any*/),
-        "gene.filtered_artworks.pageInfo.hasNextPage": (v26/*: any*/),
-        "gene.id": (v22/*: any*/),
-        "gene.internalID": (v22/*: any*/),
-        "gene.sidebar": (v18/*: any*/),
+        "gene.filtered_artworks.pageInfo.endCursor": (v25/*: any*/),
+        "gene.filtered_artworks.pageInfo.hasNextPage": (v27/*: any*/),
+        "gene.id": (v23/*: any*/),
+        "gene.internalID": (v23/*: any*/),
+        "gene.sidebar": (v19/*: any*/),
         "gene.sidebar.aggregations": {
           "enumValues": null,
           "nullable": true,
@@ -1340,9 +1328,9 @@ return {
           "plural": true,
           "type": "AggregationCount"
         },
-        "gene.sidebar.aggregations.counts.count": (v25/*: any*/),
-        "gene.sidebar.aggregations.counts.name": (v19/*: any*/),
-        "gene.sidebar.aggregations.counts.value": (v19/*: any*/),
+        "gene.sidebar.aggregations.counts.count": (v26/*: any*/),
+        "gene.sidebar.aggregations.counts.name": (v20/*: any*/),
+        "gene.sidebar.aggregations.counts.value": (v20/*: any*/),
         "gene.sidebar.aggregations.slice": {
           "enumValues": [
             "ARTIST",
@@ -1370,15 +1358,15 @@ return {
           "plural": false,
           "type": "ArtworkAggregation"
         },
-        "gene.sidebar.counts": (v20/*: any*/),
-        "gene.sidebar.counts.followedArtists": (v21/*: any*/),
-        "gene.sidebar.id": (v22/*: any*/),
-        "gene.slug": (v22/*: any*/)
+        "gene.sidebar.counts": (v21/*: any*/),
+        "gene.sidebar.counts.followedArtists": (v22/*: any*/),
+        "gene.sidebar.id": (v23/*: any*/),
+        "gene.slug": (v23/*: any*/)
       }
     },
     "name": "GeneArtworkFilter_Query",
     "operationKind": "query",
-    "text": "query GeneArtworkFilter_Query(\n  $slug: String!\n) {\n  gene(id: $slug) {\n    ...GeneArtworkFilter_gene_3Rrp9Z\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GeneArtworkFilter_gene_3Rrp9Z on Gene {\n  slug\n  internalID\n  sidebar: filterArtworksConnection(first: 1) {\n    counts {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
+    "text": "query GeneArtworkFilter_Query(\n  $slug: String!\n) {\n  gene(id: $slug) {\n    ...GeneArtworkFilter_gene_3Rrp9Z\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GeneArtworkFilter_gene_3Rrp9Z on Gene {\n  slug\n  internalID\n  sidebar: filterArtworksConnection(first: 1) {\n    counts {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SaleArtworksFilterQuery.graphql.ts
+++ b/src/__generated__/SaleArtworksFilterQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4f340687fbd62fa7062b1bad3539018d>>
+ * @generated SignedSource<<4170bd44777d7361037dd855271d2155>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -124,21 +124,24 @@ v6 = [
     "storageKey": null
   }
 ],
-v7 = {
+v7 = [
+  (v3/*: any*/)
+],
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -146,14 +149,14 @@ v9 = {
     "large"
   ]
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v11 = [
+v12 = [
   {
     "alias": null,
     "args": null,
@@ -162,36 +165,36 @@ v11 = [
     "storageKey": null
   }
 ],
-v12 = [
+v13 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v16 = [
-  (v13/*: any*/),
+v17 = [
+  (v14/*: any*/),
   (v3/*: any*/)
 ];
 return {
@@ -362,27 +365,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v3/*: any*/)
-                    ],
+                    "selections": (v7/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -421,8 +404,8 @@ return {
                             "name": "slug",
                             "storageKey": null
                           },
-                          (v7/*: any*/),
                           (v8/*: any*/),
+                          (v9/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -444,7 +427,7 @@ return {
                                 "name": "aspectRatio",
                                 "storageKey": null
                               },
-                              (v8/*: any*/),
+                              (v9/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -455,7 +438,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v9/*: any*/)
+                                  (v10/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -478,7 +461,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v9/*: any*/),
+                                  (v10/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -563,6 +546,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -614,7 +604,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v10/*: any*/),
+                                  (v11/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -622,7 +612,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v11/*: any*/),
+                                    "selections": (v12/*: any*/),
                                     "storageKey": null
                                   },
                                   (v3/*: any*/)
@@ -648,7 +638,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v12/*: any*/),
+                            "args": (v13/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -696,15 +686,15 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v12/*: any*/),
+                            "args": (v13/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v3/*: any*/),
-                              (v7/*: any*/),
-                              (v13/*: any*/)
+                              (v8/*: any*/),
+                              (v14/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
                           },
@@ -717,14 +707,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v12/*: any*/),
+                            "args": (v13/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v13/*: any*/),
-                              (v7/*: any*/),
+                              (v14/*: any*/),
+                              (v8/*: any*/),
                               (v3/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -737,7 +727,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v10/*: any*/),
+                              (v11/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -799,7 +789,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v14/*: any*/),
+                              (v15/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -807,8 +797,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v10/*: any*/),
-                              (v15/*: any*/),
+                              (v11/*: any*/),
+                              (v16/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -841,7 +831,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v11/*: any*/),
+                                "selections": (v12/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -851,7 +841,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v11/*: any*/),
+                                "selections": (v12/*: any*/),
                                 "storageKey": null
                               },
                               (v3/*: any*/)
@@ -866,10 +856,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v14/*: any*/),
+                              (v15/*: any*/),
                               (v3/*: any*/),
-                              (v10/*: any*/),
-                              (v15/*: any*/)
+                              (v11/*: any*/),
+                              (v16/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -880,7 +870,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v16/*: any*/),
+                            "selections": (v17/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -898,7 +888,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v16/*: any*/),
+                                "selections": (v17/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -923,9 +913,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v3/*: any*/)
-                        ],
+                        "selections": (v7/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -995,7 +983,7 @@ return {
                     "name": "counts",
                     "plural": true,
                     "selections": [
-                      (v13/*: any*/),
+                      (v14/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1026,12 +1014,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "582c3ccb79eb6ff68f6995c8a23531f5",
+    "cacheID": "5d6c4518317ea50397b4e2c19529cfc5",
     "id": null,
     "metadata": {},
     "name": "SaleArtworksFilterQuery",
     "operationKind": "query",
-    "text": "query SaleArtworksFilterQuery(\n  $input: FilterArtworksInput\n) {\n  viewer {\n    ...SaleArtworksFilter_viewer_2VV6jB\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment SaleArtworksFilter_viewer_2VV6jB on Viewer {\n  filtered_artworks: artworksConnection(input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n  sidebarAggregations: artworksConnection(input: $input, first: 1) {\n    counts {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query SaleArtworksFilterQuery(\n  $input: FilterArtworksInput\n) {\n  viewer {\n    ...SaleArtworksFilter_viewer_2VV6jB\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment SaleArtworksFilter_viewer_2VV6jB on Viewer {\n  filtered_artworks: artworksConnection(input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n  sidebarAggregations: artworksConnection(input: $input, first: 1) {\n    counts {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SaleArtworks_Test_Query.graphql.ts
+++ b/src/__generated__/SaleArtworks_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<611da6f92c9be0f11b92570c47922ddf>>
+ * @generated SignedSource<<6471e74c00323b0e62344fe1b84fd6d6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -54,21 +54,24 @@ v3 = [
     "storageKey": null
   }
 ],
-v4 = {
+v4 = [
+  (v0/*: any*/)
+],
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v6 = {
+v7 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -76,14 +79,14 @@ v6 = {
     "large"
   ]
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v8 = [
+v9 = [
   {
     "alias": null,
     "args": null,
@@ -92,105 +95,105 @@ v8 = [
     "storageKey": null
   }
 ],
-v9 = [
+v10 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v13 = [
-  (v10/*: any*/),
+v14 = [
+  (v11/*: any*/),
   (v0/*: any*/)
 ],
-v14 = {
+v15 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FilterArtworksConnection"
 },
-v15 = {
+v16 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
-},
-v16 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "FilterArtworksCounts"
 },
 v17 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "FormattedNumber"
+  "type": "FilterArtworksCounts"
 },
 v18 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "FormattedNumber"
+},
+v19 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v19 = {
+v20 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Boolean"
 },
-v20 = {
+v21 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v21 = {
+v22 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Int"
 },
-v22 = {
+v23 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Boolean"
 },
-v23 = {
+v24 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v24 = {
+v25 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "SaleArtwork"
 },
-v25 = {
+v26 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -364,27 +367,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v0/*: any*/)
-                    ],
+                    "selections": (v4/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -423,8 +406,8 @@ return {
                             "name": "slug",
                             "storageKey": null
                           },
-                          (v4/*: any*/),
                           (v5/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -446,7 +429,7 @@ return {
                                 "name": "aspectRatio",
                                 "storageKey": null
                               },
-                              (v5/*: any*/),
+                              (v6/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -457,7 +440,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v6/*: any*/)
+                                  (v7/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -480,7 +463,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v6/*: any*/),
+                                  (v7/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -565,6 +548,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -616,7 +606,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v7/*: any*/),
+                                  (v8/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -624,7 +614,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v8/*: any*/),
+                                    "selections": (v9/*: any*/),
                                     "storageKey": null
                                   },
                                   (v0/*: any*/)
@@ -650,7 +640,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v9/*: any*/),
+                            "args": (v10/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -698,15 +688,15 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v9/*: any*/),
+                            "args": (v10/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v0/*: any*/),
-                              (v4/*: any*/),
-                              (v10/*: any*/)
+                              (v5/*: any*/),
+                              (v11/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
                           },
@@ -719,14 +709,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v9/*: any*/),
+                            "args": (v10/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v10/*: any*/),
-                              (v4/*: any*/),
+                              (v11/*: any*/),
+                              (v5/*: any*/),
                               (v0/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -739,7 +729,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v7/*: any*/),
+                              (v8/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -801,7 +791,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -809,8 +799,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v7/*: any*/),
-                              (v12/*: any*/),
+                              (v8/*: any*/),
+                              (v13/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -843,7 +833,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v8/*: any*/),
+                                "selections": (v9/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -853,7 +843,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v8/*: any*/),
+                                "selections": (v9/*: any*/),
                                 "storageKey": null
                               },
                               (v0/*: any*/)
@@ -868,10 +858,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               (v0/*: any*/),
-                              (v7/*: any*/),
-                              (v12/*: any*/)
+                              (v8/*: any*/),
+                              (v13/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -882,7 +872,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v13/*: any*/),
+                            "selections": (v14/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -900,7 +890,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v13/*: any*/),
+                                "selections": (v14/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -925,9 +915,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v0/*: any*/)
-                        ],
+                        "selections": (v4/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -996,7 +984,7 @@ return {
                     "name": "counts",
                     "plural": true,
                     "selections": [
-                      (v10/*: any*/),
+                      (v11/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1027,7 +1015,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b5ae260febf38946c6051435ff458b14",
+    "cacheID": "2fd686a43f44ff592dd4bf4b107b9cc6",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -1037,19 +1025,19 @@ return {
           "plural": false,
           "type": "Viewer"
         },
-        "viewer.filtered_artworks": (v14/*: any*/),
-        "viewer.filtered_artworks.__isArtworkConnectionInterface": (v15/*: any*/),
-        "viewer.filtered_artworks.counts": (v16/*: any*/),
-        "viewer.filtered_artworks.counts.total": (v17/*: any*/),
+        "viewer.filtered_artworks": (v15/*: any*/),
+        "viewer.filtered_artworks.__isArtworkConnectionInterface": (v16/*: any*/),
+        "viewer.filtered_artworks.counts": (v17/*: any*/),
+        "viewer.filtered_artworks.counts.total": (v18/*: any*/),
         "viewer.filtered_artworks.edges": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "ArtworkEdgeInterface"
         },
-        "viewer.filtered_artworks.edges.__isNode": (v15/*: any*/),
-        "viewer.filtered_artworks.edges.__typename": (v15/*: any*/),
-        "viewer.filtered_artworks.edges.id": (v18/*: any*/),
+        "viewer.filtered_artworks.edges.__isNode": (v16/*: any*/),
+        "viewer.filtered_artworks.edges.__typename": (v16/*: any*/),
+        "viewer.filtered_artworks.edges.id": (v19/*: any*/),
         "viewer.filtered_artworks.edges.node": {
           "enumValues": null,
           "nullable": true,
@@ -1062,33 +1050,33 @@ return {
           "plural": false,
           "type": "Artist"
         },
-        "viewer.filtered_artworks.edges.node.artist.id": (v18/*: any*/),
+        "viewer.filtered_artworks.edges.node.artist.id": (v19/*: any*/),
         "viewer.filtered_artworks.edges.node.artist.targetSupply": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "ArtistTargetSupply"
         },
-        "viewer.filtered_artworks.edges.node.artist.targetSupply.isP1": (v19/*: any*/),
-        "viewer.filtered_artworks.edges.node.artistNames": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.artist.targetSupply.isP1": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.artistNames": (v21/*: any*/),
         "viewer.filtered_artworks.edges.node.artists": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Artist"
         },
-        "viewer.filtered_artworks.edges.node.artists.href": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.artists.id": (v18/*: any*/),
-        "viewer.filtered_artworks.edges.node.artists.name": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.artists.href": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.artists.id": (v19/*: any*/),
+        "viewer.filtered_artworks.edges.node.artists.name": (v21/*: any*/),
         "viewer.filtered_artworks.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "viewer.filtered_artworks.edges.node.attributionClass.id": (v18/*: any*/),
-        "viewer.filtered_artworks.edges.node.attributionClass.name": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.collecting_institution": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.attributionClass.id": (v19/*: any*/),
+        "viewer.filtered_artworks.edges.node.attributionClass.name": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.collecting_institution": (v21/*: any*/),
         "viewer.filtered_artworks.edges.node.collectorSignals": {
           "enumValues": null,
           "nullable": true,
@@ -1101,26 +1089,26 @@ return {
           "plural": false,
           "type": "AuctionCollectorSignals"
         },
-        "viewer.filtered_artworks.edges.node.collectorSignals.auction.bidCount": (v21/*: any*/),
-        "viewer.filtered_artworks.edges.node.collectorSignals.auction.liveBiddingStarted": (v22/*: any*/),
-        "viewer.filtered_artworks.edges.node.collectorSignals.auction.lotClosesAt": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.collectorSignals.auction.onlineBiddingExtended": (v22/*: any*/),
-        "viewer.filtered_artworks.edges.node.collectorSignals.auction.registrationEndsAt": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.collectorSignals.auction.bidCount": (v22/*: any*/),
+        "viewer.filtered_artworks.edges.node.collectorSignals.auction.liveBiddingStarted": (v23/*: any*/),
+        "viewer.filtered_artworks.edges.node.collectorSignals.auction.lotClosesAt": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.collectorSignals.auction.onlineBiddingExtended": (v23/*: any*/),
+        "viewer.filtered_artworks.edges.node.collectorSignals.auction.registrationEndsAt": (v21/*: any*/),
         "viewer.filtered_artworks.edges.node.collectorSignals.partnerOffer": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "PartnerOfferToCollector"
         },
-        "viewer.filtered_artworks.edges.node.collectorSignals.partnerOffer.endAt": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.collectorSignals.partnerOffer.id": (v18/*: any*/),
+        "viewer.filtered_artworks.edges.node.collectorSignals.partnerOffer.endAt": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.collectorSignals.partnerOffer.id": (v19/*: any*/),
         "viewer.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Money"
         },
-        "viewer.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v21/*: any*/),
         "viewer.filtered_artworks.edges.node.collectorSignals.primaryLabel": {
           "enumValues": [
             "CURATORS_PICK",
@@ -1131,10 +1119,10 @@ return {
           "plural": false,
           "type": "LabelSignalEnum"
         },
-        "viewer.filtered_artworks.edges.node.cultural_maker": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.date": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.href": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.id": (v18/*: any*/),
+        "viewer.filtered_artworks.edges.node.cultural_maker": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.date": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.href": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.id": (v19/*: any*/),
         "viewer.filtered_artworks.edges.node.image": {
           "enumValues": null,
           "nullable": true,
@@ -1147,35 +1135,35 @@ return {
           "plural": false,
           "type": "Float"
         },
-        "viewer.filtered_artworks.edges.node.image.blurhashDataURL": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.image.blurhashDataURL": (v21/*: any*/),
         "viewer.filtered_artworks.edges.node.image.internalID": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ID"
         },
-        "viewer.filtered_artworks.edges.node.image.placeholder": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.image.placeholder": (v21/*: any*/),
         "viewer.filtered_artworks.edges.node.image.resized": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ResizedImageUrl"
         },
-        "viewer.filtered_artworks.edges.node.image.resized.height": (v23/*: any*/),
-        "viewer.filtered_artworks.edges.node.image.resized.src": (v15/*: any*/),
-        "viewer.filtered_artworks.edges.node.image.resized.srcSet": (v15/*: any*/),
-        "viewer.filtered_artworks.edges.node.image.resized.width": (v23/*: any*/),
-        "viewer.filtered_artworks.edges.node.image.url": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.image.resized.height": (v24/*: any*/),
+        "viewer.filtered_artworks.edges.node.image.resized.src": (v16/*: any*/),
+        "viewer.filtered_artworks.edges.node.image.resized.srcSet": (v16/*: any*/),
+        "viewer.filtered_artworks.edges.node.image.resized.width": (v24/*: any*/),
+        "viewer.filtered_artworks.edges.node.image.url": (v21/*: any*/),
         "viewer.filtered_artworks.edges.node.image.versions": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "String"
         },
-        "viewer.filtered_artworks.edges.node.imageTitle": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.image_title": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.internalID": (v18/*: any*/),
-        "viewer.filtered_artworks.edges.node.isUnlisted": (v22/*: any*/),
+        "viewer.filtered_artworks.edges.node.imageTitle": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.image_title": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.internalID": (v19/*: any*/),
+        "viewer.filtered_artworks.edges.node.isUnlisted": (v23/*: any*/),
         "viewer.filtered_artworks.edges.node.marketPriceInsights": {
           "enumValues": null,
           "nullable": true,
@@ -1200,69 +1188,69 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "viewer.filtered_artworks.edges.node.mediumType.filterGene.id": (v18/*: any*/),
-        "viewer.filtered_artworks.edges.node.mediumType.filterGene.name": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.mediumType.filterGene.id": (v19/*: any*/),
+        "viewer.filtered_artworks.edges.node.mediumType.filterGene.name": (v21/*: any*/),
         "viewer.filtered_artworks.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "viewer.filtered_artworks.edges.node.partner.href": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.partner.id": (v18/*: any*/),
-        "viewer.filtered_artworks.edges.node.partner.name": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.partner.href": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.partner.id": (v19/*: any*/),
+        "viewer.filtered_artworks.edges.node.partner.name": (v21/*: any*/),
         "viewer.filtered_artworks.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "viewer.filtered_artworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v23/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale.endAt": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale.extendedBiddingIntervalMinutes": (v23/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale.extendedBiddingPeriodMinutes": (v23/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale.id": (v18/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale.isOpen": (v19/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale.is_auction": (v19/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale.is_closed": (v19/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale.startAt": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.saleArtwork": (v24/*: any*/),
-        "viewer.filtered_artworks.edges.node.saleArtwork.endAt": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.saleArtwork.extendedBiddingEndAt": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.saleArtwork.id": (v18/*: any*/),
-        "viewer.filtered_artworks.edges.node.saleArtwork.lotID": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale_artwork": (v24/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v24/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale.endAt": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale.extendedBiddingIntervalMinutes": (v24/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale.extendedBiddingPeriodMinutes": (v24/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale.id": (v19/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale.isOpen": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale.is_auction": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale.is_closed": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale.startAt": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.saleArtwork": (v25/*: any*/),
+        "viewer.filtered_artworks.edges.node.saleArtwork.endAt": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.saleArtwork.extendedBiddingEndAt": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.saleArtwork.id": (v19/*: any*/),
+        "viewer.filtered_artworks.edges.node.saleArtwork.lotID": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale_artwork": (v25/*: any*/),
         "viewer.filtered_artworks.edges.node.sale_artwork.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkCounts"
         },
-        "viewer.filtered_artworks.edges.node.sale_artwork.counts.bidder_positions": (v17/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale_artwork.endAt": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale_artwork.extendedBiddingEndAt": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale_artwork.formattedEndDateTime": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale_artwork.counts.bidder_positions": (v18/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale_artwork.endAt": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale_artwork.extendedBiddingEndAt": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale_artwork.formattedEndDateTime": (v21/*: any*/),
         "viewer.filtered_artworks.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "viewer.filtered_artworks.edges.node.sale_artwork.highest_bid.display": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale_artwork.id": (v18/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale_artwork.lotID": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale_artwork.lotLabel": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale_artwork.highest_bid.display": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale_artwork.id": (v19/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale_artwork.lotID": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale_artwork.lotLabel": (v21/*: any*/),
         "viewer.filtered_artworks.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "viewer.filtered_artworks.edges.node.sale_artwork.opening_bid.display": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale_message": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.slug": (v18/*: any*/),
-        "viewer.filtered_artworks.edges.node.title": (v20/*: any*/),
-        "viewer.filtered_artworks.id": (v18/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale_artwork.opening_bid.display": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale_message": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.slug": (v19/*: any*/),
+        "viewer.filtered_artworks.edges.node.title": (v21/*: any*/),
+        "viewer.filtered_artworks.id": (v19/*: any*/),
         "viewer.filtered_artworks.pageCursors": {
           "enumValues": null,
           "nullable": false,
@@ -1275,29 +1263,29 @@ return {
           "plural": true,
           "type": "PageCursor"
         },
-        "viewer.filtered_artworks.pageCursors.around.cursor": (v15/*: any*/),
-        "viewer.filtered_artworks.pageCursors.around.isCurrent": (v22/*: any*/),
-        "viewer.filtered_artworks.pageCursors.around.page": (v21/*: any*/),
-        "viewer.filtered_artworks.pageCursors.first": (v25/*: any*/),
-        "viewer.filtered_artworks.pageCursors.first.cursor": (v15/*: any*/),
-        "viewer.filtered_artworks.pageCursors.first.isCurrent": (v22/*: any*/),
-        "viewer.filtered_artworks.pageCursors.first.page": (v21/*: any*/),
-        "viewer.filtered_artworks.pageCursors.last": (v25/*: any*/),
-        "viewer.filtered_artworks.pageCursors.last.cursor": (v15/*: any*/),
-        "viewer.filtered_artworks.pageCursors.last.isCurrent": (v22/*: any*/),
-        "viewer.filtered_artworks.pageCursors.last.page": (v21/*: any*/),
-        "viewer.filtered_artworks.pageCursors.previous": (v25/*: any*/),
-        "viewer.filtered_artworks.pageCursors.previous.cursor": (v15/*: any*/),
-        "viewer.filtered_artworks.pageCursors.previous.page": (v21/*: any*/),
+        "viewer.filtered_artworks.pageCursors.around.cursor": (v16/*: any*/),
+        "viewer.filtered_artworks.pageCursors.around.isCurrent": (v23/*: any*/),
+        "viewer.filtered_artworks.pageCursors.around.page": (v22/*: any*/),
+        "viewer.filtered_artworks.pageCursors.first": (v26/*: any*/),
+        "viewer.filtered_artworks.pageCursors.first.cursor": (v16/*: any*/),
+        "viewer.filtered_artworks.pageCursors.first.isCurrent": (v23/*: any*/),
+        "viewer.filtered_artworks.pageCursors.first.page": (v22/*: any*/),
+        "viewer.filtered_artworks.pageCursors.last": (v26/*: any*/),
+        "viewer.filtered_artworks.pageCursors.last.cursor": (v16/*: any*/),
+        "viewer.filtered_artworks.pageCursors.last.isCurrent": (v23/*: any*/),
+        "viewer.filtered_artworks.pageCursors.last.page": (v22/*: any*/),
+        "viewer.filtered_artworks.pageCursors.previous": (v26/*: any*/),
+        "viewer.filtered_artworks.pageCursors.previous.cursor": (v16/*: any*/),
+        "viewer.filtered_artworks.pageCursors.previous.page": (v22/*: any*/),
         "viewer.filtered_artworks.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "viewer.filtered_artworks.pageInfo.endCursor": (v20/*: any*/),
-        "viewer.filtered_artworks.pageInfo.hasNextPage": (v22/*: any*/),
-        "viewer.sidebarAggregations": (v14/*: any*/),
+        "viewer.filtered_artworks.pageInfo.endCursor": (v21/*: any*/),
+        "viewer.filtered_artworks.pageInfo.hasNextPage": (v23/*: any*/),
+        "viewer.sidebarAggregations": (v15/*: any*/),
         "viewer.sidebarAggregations.aggregations": {
           "enumValues": null,
           "nullable": true,
@@ -1310,9 +1298,9 @@ return {
           "plural": true,
           "type": "AggregationCount"
         },
-        "viewer.sidebarAggregations.aggregations.counts.count": (v21/*: any*/),
-        "viewer.sidebarAggregations.aggregations.counts.name": (v15/*: any*/),
-        "viewer.sidebarAggregations.aggregations.counts.value": (v15/*: any*/),
+        "viewer.sidebarAggregations.aggregations.counts.count": (v22/*: any*/),
+        "viewer.sidebarAggregations.aggregations.counts.name": (v16/*: any*/),
+        "viewer.sidebarAggregations.aggregations.counts.value": (v16/*: any*/),
         "viewer.sidebarAggregations.aggregations.slice": {
           "enumValues": [
             "ARTIST",
@@ -1340,14 +1328,14 @@ return {
           "plural": false,
           "type": "ArtworkAggregation"
         },
-        "viewer.sidebarAggregations.counts": (v16/*: any*/),
-        "viewer.sidebarAggregations.counts.followedArtists": (v17/*: any*/),
-        "viewer.sidebarAggregations.id": (v18/*: any*/)
+        "viewer.sidebarAggregations.counts": (v17/*: any*/),
+        "viewer.sidebarAggregations.counts.followedArtists": (v18/*: any*/),
+        "viewer.sidebarAggregations.id": (v19/*: any*/)
       }
     },
     "name": "SaleArtworks_Test_Query",
     "operationKind": "query",
-    "text": "query SaleArtworks_Test_Query {\n  viewer {\n    ...SaleArtworksFilter_viewer\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment SaleArtworksFilter_viewer on Viewer {\n  filtered_artworks: artworksConnection {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n  sidebarAggregations: artworksConnection(first: 1) {\n    counts {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query SaleArtworks_Test_Query {\n  viewer {\n    ...SaleArtworksFilter_viewer\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment SaleArtworksFilter_viewer on Viewer {\n  filtered_artworks: artworksConnection {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n  sidebarAggregations: artworksConnection(first: 1) {\n    counts {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SearchResultsArtworks_Query.graphql.ts
+++ b/src/__generated__/SearchResultsArtworks_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8c4f8522e44fea801aee0af3ce801fa1>>
+ * @generated SignedSource<<83912d0ba85d2d2cea0c999dbfb411b7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -61,21 +61,24 @@ v4 = [
     "storageKey": null
   }
 ],
-v5 = {
+v5 = [
+  (v1/*: any*/)
+],
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v7 = {
+v8 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -83,14 +86,14 @@ v7 = {
     "large"
   ]
 },
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v9 = [
+v10 = [
   {
     "alias": null,
     "args": null,
@@ -99,98 +102,98 @@ v9 = [
     "storageKey": null
   }
 ],
-v10 = [
+v11 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v13 = [
+v14 = [
   (v0/*: any*/),
   (v1/*: any*/)
 ],
-v14 = {
+v15 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FilterArtworksConnection"
 },
-v15 = {
+v16 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
-},
-v16 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "FilterArtworksCounts"
 },
 v17 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "FormattedNumber"
+  "type": "FilterArtworksCounts"
 },
 v18 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "FormattedNumber"
+},
+v19 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v19 = {
+v20 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Boolean"
 },
-v20 = {
+v21 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v21 = {
+v22 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Int"
 },
-v22 = {
+v23 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Boolean"
 },
-v23 = {
+v24 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v24 = {
+v25 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "SaleArtwork"
 },
-v25 = {
+v26 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -426,27 +429,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v1/*: any*/)
-                    ],
+                    "selections": (v5/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -509,8 +492,8 @@ return {
                             "name": "slug",
                             "storageKey": null
                           },
-                          (v5/*: any*/),
                           (v6/*: any*/),
+                          (v7/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -532,7 +515,7 @@ return {
                                 "name": "aspectRatio",
                                 "storageKey": null
                               },
-                              (v6/*: any*/),
+                              (v7/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -543,7 +526,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v7/*: any*/)
+                                  (v8/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -566,7 +549,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v7/*: any*/),
+                                  (v8/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -651,6 +634,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -702,7 +692,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v8/*: any*/),
+                                  (v9/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -710,7 +700,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v9/*: any*/),
+                                    "selections": (v10/*: any*/),
                                     "storageKey": null
                                   },
                                   (v1/*: any*/)
@@ -736,7 +726,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v10/*: any*/),
+                            "args": (v11/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -784,14 +774,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v10/*: any*/),
+                            "args": (v11/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v1/*: any*/),
-                              (v5/*: any*/),
+                              (v6/*: any*/),
                               (v0/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -805,14 +795,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v10/*: any*/),
+                            "args": (v11/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v0/*: any*/),
-                              (v5/*: any*/),
+                              (v6/*: any*/),
                               (v1/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -825,7 +815,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v8/*: any*/),
+                              (v9/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -887,7 +877,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -895,8 +885,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v8/*: any*/),
-                              (v12/*: any*/),
+                              (v9/*: any*/),
+                              (v13/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -929,7 +919,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v9/*: any*/),
+                                "selections": (v10/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -939,7 +929,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v9/*: any*/),
+                                "selections": (v10/*: any*/),
                                 "storageKey": null
                               },
                               (v1/*: any*/)
@@ -954,10 +944,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               (v1/*: any*/),
-                              (v8/*: any*/),
-                              (v12/*: any*/)
+                              (v9/*: any*/),
+                              (v13/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -968,7 +958,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v13/*: any*/),
+                            "selections": (v14/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -986,7 +976,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v13/*: any*/),
+                                "selections": (v14/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -1011,9 +1001,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v1/*: any*/)
-                        ],
+                        "selections": (v5/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1033,7 +1021,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "7dd12d14ba3cbec9da92ce644d638c82",
+    "cacheID": "012d0f893e92545547bbd72c5fb0e6c2",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -1043,19 +1031,19 @@ return {
           "plural": false,
           "type": "Viewer"
         },
-        "viewer.filtered_artworks": (v14/*: any*/),
-        "viewer.filtered_artworks.__isArtworkConnectionInterface": (v15/*: any*/),
-        "viewer.filtered_artworks.counts": (v16/*: any*/),
-        "viewer.filtered_artworks.counts.total": (v17/*: any*/),
+        "viewer.filtered_artworks": (v15/*: any*/),
+        "viewer.filtered_artworks.__isArtworkConnectionInterface": (v16/*: any*/),
+        "viewer.filtered_artworks.counts": (v17/*: any*/),
+        "viewer.filtered_artworks.counts.total": (v18/*: any*/),
         "viewer.filtered_artworks.edges": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "ArtworkEdgeInterface"
         },
-        "viewer.filtered_artworks.edges.__isNode": (v15/*: any*/),
-        "viewer.filtered_artworks.edges.__typename": (v15/*: any*/),
-        "viewer.filtered_artworks.edges.id": (v18/*: any*/),
+        "viewer.filtered_artworks.edges.__isNode": (v16/*: any*/),
+        "viewer.filtered_artworks.edges.__typename": (v16/*: any*/),
+        "viewer.filtered_artworks.edges.id": (v19/*: any*/),
         "viewer.filtered_artworks.edges.node": {
           "enumValues": null,
           "nullable": true,
@@ -1068,33 +1056,33 @@ return {
           "plural": false,
           "type": "Artist"
         },
-        "viewer.filtered_artworks.edges.node.artist.id": (v18/*: any*/),
+        "viewer.filtered_artworks.edges.node.artist.id": (v19/*: any*/),
         "viewer.filtered_artworks.edges.node.artist.targetSupply": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "ArtistTargetSupply"
         },
-        "viewer.filtered_artworks.edges.node.artist.targetSupply.isP1": (v19/*: any*/),
-        "viewer.filtered_artworks.edges.node.artistNames": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.artist.targetSupply.isP1": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.artistNames": (v21/*: any*/),
         "viewer.filtered_artworks.edges.node.artists": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Artist"
         },
-        "viewer.filtered_artworks.edges.node.artists.href": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.artists.id": (v18/*: any*/),
-        "viewer.filtered_artworks.edges.node.artists.name": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.artists.href": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.artists.id": (v19/*: any*/),
+        "viewer.filtered_artworks.edges.node.artists.name": (v21/*: any*/),
         "viewer.filtered_artworks.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "viewer.filtered_artworks.edges.node.attributionClass.id": (v18/*: any*/),
-        "viewer.filtered_artworks.edges.node.attributionClass.name": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.collecting_institution": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.attributionClass.id": (v19/*: any*/),
+        "viewer.filtered_artworks.edges.node.attributionClass.name": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.collecting_institution": (v21/*: any*/),
         "viewer.filtered_artworks.edges.node.collectorSignals": {
           "enumValues": null,
           "nullable": true,
@@ -1107,26 +1095,26 @@ return {
           "plural": false,
           "type": "AuctionCollectorSignals"
         },
-        "viewer.filtered_artworks.edges.node.collectorSignals.auction.bidCount": (v21/*: any*/),
-        "viewer.filtered_artworks.edges.node.collectorSignals.auction.liveBiddingStarted": (v22/*: any*/),
-        "viewer.filtered_artworks.edges.node.collectorSignals.auction.lotClosesAt": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.collectorSignals.auction.onlineBiddingExtended": (v22/*: any*/),
-        "viewer.filtered_artworks.edges.node.collectorSignals.auction.registrationEndsAt": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.collectorSignals.auction.bidCount": (v22/*: any*/),
+        "viewer.filtered_artworks.edges.node.collectorSignals.auction.liveBiddingStarted": (v23/*: any*/),
+        "viewer.filtered_artworks.edges.node.collectorSignals.auction.lotClosesAt": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.collectorSignals.auction.onlineBiddingExtended": (v23/*: any*/),
+        "viewer.filtered_artworks.edges.node.collectorSignals.auction.registrationEndsAt": (v21/*: any*/),
         "viewer.filtered_artworks.edges.node.collectorSignals.partnerOffer": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "PartnerOfferToCollector"
         },
-        "viewer.filtered_artworks.edges.node.collectorSignals.partnerOffer.endAt": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.collectorSignals.partnerOffer.id": (v18/*: any*/),
+        "viewer.filtered_artworks.edges.node.collectorSignals.partnerOffer.endAt": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.collectorSignals.partnerOffer.id": (v19/*: any*/),
         "viewer.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Money"
         },
-        "viewer.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v21/*: any*/),
         "viewer.filtered_artworks.edges.node.collectorSignals.primaryLabel": {
           "enumValues": [
             "CURATORS_PICK",
@@ -1137,10 +1125,10 @@ return {
           "plural": false,
           "type": "LabelSignalEnum"
         },
-        "viewer.filtered_artworks.edges.node.cultural_maker": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.date": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.href": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.id": (v18/*: any*/),
+        "viewer.filtered_artworks.edges.node.cultural_maker": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.date": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.href": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.id": (v19/*: any*/),
         "viewer.filtered_artworks.edges.node.image": {
           "enumValues": null,
           "nullable": true,
@@ -1153,35 +1141,35 @@ return {
           "plural": false,
           "type": "Float"
         },
-        "viewer.filtered_artworks.edges.node.image.blurhashDataURL": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.image.blurhashDataURL": (v21/*: any*/),
         "viewer.filtered_artworks.edges.node.image.internalID": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ID"
         },
-        "viewer.filtered_artworks.edges.node.image.placeholder": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.image.placeholder": (v21/*: any*/),
         "viewer.filtered_artworks.edges.node.image.resized": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ResizedImageUrl"
         },
-        "viewer.filtered_artworks.edges.node.image.resized.height": (v23/*: any*/),
-        "viewer.filtered_artworks.edges.node.image.resized.src": (v15/*: any*/),
-        "viewer.filtered_artworks.edges.node.image.resized.srcSet": (v15/*: any*/),
-        "viewer.filtered_artworks.edges.node.image.resized.width": (v23/*: any*/),
-        "viewer.filtered_artworks.edges.node.image.url": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.image.resized.height": (v24/*: any*/),
+        "viewer.filtered_artworks.edges.node.image.resized.src": (v16/*: any*/),
+        "viewer.filtered_artworks.edges.node.image.resized.srcSet": (v16/*: any*/),
+        "viewer.filtered_artworks.edges.node.image.resized.width": (v24/*: any*/),
+        "viewer.filtered_artworks.edges.node.image.url": (v21/*: any*/),
         "viewer.filtered_artworks.edges.node.image.versions": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "String"
         },
-        "viewer.filtered_artworks.edges.node.imageTitle": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.image_title": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.internalID": (v18/*: any*/),
-        "viewer.filtered_artworks.edges.node.isUnlisted": (v22/*: any*/),
+        "viewer.filtered_artworks.edges.node.imageTitle": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.image_title": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.internalID": (v19/*: any*/),
+        "viewer.filtered_artworks.edges.node.isUnlisted": (v23/*: any*/),
         "viewer.filtered_artworks.edges.node.marketPriceInsights": {
           "enumValues": null,
           "nullable": true,
@@ -1206,69 +1194,69 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "viewer.filtered_artworks.edges.node.mediumType.filterGene.id": (v18/*: any*/),
-        "viewer.filtered_artworks.edges.node.mediumType.filterGene.name": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.mediumType.filterGene.id": (v19/*: any*/),
+        "viewer.filtered_artworks.edges.node.mediumType.filterGene.name": (v21/*: any*/),
         "viewer.filtered_artworks.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "viewer.filtered_artworks.edges.node.partner.href": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.partner.id": (v18/*: any*/),
-        "viewer.filtered_artworks.edges.node.partner.name": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.partner.href": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.partner.id": (v19/*: any*/),
+        "viewer.filtered_artworks.edges.node.partner.name": (v21/*: any*/),
         "viewer.filtered_artworks.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "viewer.filtered_artworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v23/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale.endAt": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale.extendedBiddingIntervalMinutes": (v23/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale.extendedBiddingPeriodMinutes": (v23/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale.id": (v18/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale.isOpen": (v19/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale.is_auction": (v19/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale.is_closed": (v19/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale.startAt": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.saleArtwork": (v24/*: any*/),
-        "viewer.filtered_artworks.edges.node.saleArtwork.endAt": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.saleArtwork.extendedBiddingEndAt": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.saleArtwork.id": (v18/*: any*/),
-        "viewer.filtered_artworks.edges.node.saleArtwork.lotID": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale_artwork": (v24/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v24/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale.endAt": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale.extendedBiddingIntervalMinutes": (v24/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale.extendedBiddingPeriodMinutes": (v24/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale.id": (v19/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale.isOpen": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale.is_auction": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale.is_closed": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale.startAt": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.saleArtwork": (v25/*: any*/),
+        "viewer.filtered_artworks.edges.node.saleArtwork.endAt": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.saleArtwork.extendedBiddingEndAt": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.saleArtwork.id": (v19/*: any*/),
+        "viewer.filtered_artworks.edges.node.saleArtwork.lotID": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale_artwork": (v25/*: any*/),
         "viewer.filtered_artworks.edges.node.sale_artwork.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkCounts"
         },
-        "viewer.filtered_artworks.edges.node.sale_artwork.counts.bidder_positions": (v17/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale_artwork.endAt": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale_artwork.extendedBiddingEndAt": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale_artwork.formattedEndDateTime": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale_artwork.counts.bidder_positions": (v18/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale_artwork.endAt": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale_artwork.extendedBiddingEndAt": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale_artwork.formattedEndDateTime": (v21/*: any*/),
         "viewer.filtered_artworks.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "viewer.filtered_artworks.edges.node.sale_artwork.highest_bid.display": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale_artwork.id": (v18/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale_artwork.lotID": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale_artwork.lotLabel": (v20/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale_artwork.highest_bid.display": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale_artwork.id": (v19/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale_artwork.lotID": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale_artwork.lotLabel": (v21/*: any*/),
         "viewer.filtered_artworks.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "viewer.filtered_artworks.edges.node.sale_artwork.opening_bid.display": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.sale_message": (v20/*: any*/),
-        "viewer.filtered_artworks.edges.node.slug": (v18/*: any*/),
-        "viewer.filtered_artworks.edges.node.title": (v20/*: any*/),
-        "viewer.filtered_artworks.id": (v18/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale_artwork.opening_bid.display": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.sale_message": (v21/*: any*/),
+        "viewer.filtered_artworks.edges.node.slug": (v19/*: any*/),
+        "viewer.filtered_artworks.edges.node.title": (v21/*: any*/),
+        "viewer.filtered_artworks.id": (v19/*: any*/),
         "viewer.filtered_artworks.pageCursors": {
           "enumValues": null,
           "nullable": false,
@@ -1281,29 +1269,29 @@ return {
           "plural": true,
           "type": "PageCursor"
         },
-        "viewer.filtered_artworks.pageCursors.around.cursor": (v15/*: any*/),
-        "viewer.filtered_artworks.pageCursors.around.isCurrent": (v22/*: any*/),
-        "viewer.filtered_artworks.pageCursors.around.page": (v21/*: any*/),
-        "viewer.filtered_artworks.pageCursors.first": (v25/*: any*/),
-        "viewer.filtered_artworks.pageCursors.first.cursor": (v15/*: any*/),
-        "viewer.filtered_artworks.pageCursors.first.isCurrent": (v22/*: any*/),
-        "viewer.filtered_artworks.pageCursors.first.page": (v21/*: any*/),
-        "viewer.filtered_artworks.pageCursors.last": (v25/*: any*/),
-        "viewer.filtered_artworks.pageCursors.last.cursor": (v15/*: any*/),
-        "viewer.filtered_artworks.pageCursors.last.isCurrent": (v22/*: any*/),
-        "viewer.filtered_artworks.pageCursors.last.page": (v21/*: any*/),
-        "viewer.filtered_artworks.pageCursors.previous": (v25/*: any*/),
-        "viewer.filtered_artworks.pageCursors.previous.cursor": (v15/*: any*/),
-        "viewer.filtered_artworks.pageCursors.previous.page": (v21/*: any*/),
+        "viewer.filtered_artworks.pageCursors.around.cursor": (v16/*: any*/),
+        "viewer.filtered_artworks.pageCursors.around.isCurrent": (v23/*: any*/),
+        "viewer.filtered_artworks.pageCursors.around.page": (v22/*: any*/),
+        "viewer.filtered_artworks.pageCursors.first": (v26/*: any*/),
+        "viewer.filtered_artworks.pageCursors.first.cursor": (v16/*: any*/),
+        "viewer.filtered_artworks.pageCursors.first.isCurrent": (v23/*: any*/),
+        "viewer.filtered_artworks.pageCursors.first.page": (v22/*: any*/),
+        "viewer.filtered_artworks.pageCursors.last": (v26/*: any*/),
+        "viewer.filtered_artworks.pageCursors.last.cursor": (v16/*: any*/),
+        "viewer.filtered_artworks.pageCursors.last.isCurrent": (v23/*: any*/),
+        "viewer.filtered_artworks.pageCursors.last.page": (v22/*: any*/),
+        "viewer.filtered_artworks.pageCursors.previous": (v26/*: any*/),
+        "viewer.filtered_artworks.pageCursors.previous.cursor": (v16/*: any*/),
+        "viewer.filtered_artworks.pageCursors.previous.page": (v22/*: any*/),
         "viewer.filtered_artworks.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "viewer.filtered_artworks.pageInfo.endCursor": (v20/*: any*/),
-        "viewer.filtered_artworks.pageInfo.hasNextPage": (v22/*: any*/),
-        "viewer.sidebar": (v14/*: any*/),
+        "viewer.filtered_artworks.pageInfo.endCursor": (v21/*: any*/),
+        "viewer.filtered_artworks.pageInfo.hasNextPage": (v23/*: any*/),
+        "viewer.sidebar": (v15/*: any*/),
         "viewer.sidebar.aggregations": {
           "enumValues": null,
           "nullable": true,
@@ -1316,9 +1304,9 @@ return {
           "plural": true,
           "type": "AggregationCount"
         },
-        "viewer.sidebar.aggregations.counts.count": (v21/*: any*/),
-        "viewer.sidebar.aggregations.counts.name": (v15/*: any*/),
-        "viewer.sidebar.aggregations.counts.value": (v15/*: any*/),
+        "viewer.sidebar.aggregations.counts.count": (v22/*: any*/),
+        "viewer.sidebar.aggregations.counts.name": (v16/*: any*/),
+        "viewer.sidebar.aggregations.counts.value": (v16/*: any*/),
         "viewer.sidebar.aggregations.slice": {
           "enumValues": [
             "ARTIST",
@@ -1346,14 +1334,14 @@ return {
           "plural": false,
           "type": "ArtworkAggregation"
         },
-        "viewer.sidebar.counts": (v16/*: any*/),
-        "viewer.sidebar.counts.followedArtists": (v17/*: any*/),
-        "viewer.sidebar.id": (v18/*: any*/)
+        "viewer.sidebar.counts": (v17/*: any*/),
+        "viewer.sidebar.counts.followedArtists": (v18/*: any*/),
+        "viewer.sidebar.id": (v19/*: any*/)
       }
     },
     "name": "SearchResultsArtworks_Query",
     "operationKind": "query",
-    "text": "query SearchResultsArtworks_Query {\n  viewer {\n    ...SearchResultsArtworks_viewer_3Rrp9Z\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkFilter_viewer_4g78v5 on Viewer {\n  filtered_artworks: artworksConnection {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    counts {\n      total(format: \"0,0\")\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment SearchResultsArtworks_viewer_3Rrp9Z on Viewer {\n  sidebar: artworksConnection(first: 1) {\n    counts {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  ...ArtworkFilter_viewer_4g78v5\n}\n"
+    "text": "query SearchResultsArtworks_Query {\n  viewer {\n    ...SearchResultsArtworks_viewer_3Rrp9Z\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkFilter_viewer_4g78v5 on Viewer {\n  filtered_artworks: artworksConnection {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    counts {\n      total(format: \"0,0\")\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment SearchResultsArtworks_viewer_3Rrp9Z on Viewer {\n  sidebar: artworksConnection(first: 1) {\n    counts {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  ...ArtworkFilter_viewer_4g78v5\n}\n"
   }
 };
 })();

--- a/src/__generated__/ShowArtworksFilterQuery.graphql.ts
+++ b/src/__generated__/ShowArtworksFilterQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9ed4175d25496f4b7e79e26c7f9dbc9f>>
+ * @generated SignedSource<<7e0b1835c6f37a106f9e277cf57db741>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -150,21 +150,24 @@ v10 = [
     "storageKey": null
   }
 ],
-v11 = {
+v11 = [
+  (v7/*: any*/)
+],
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v13 = {
+v14 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -172,14 +175,14 @@ v13 = {
     "large"
   ]
 },
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v15 = [
+v16 = [
   {
     "alias": null,
     "args": null,
@@ -188,28 +191,28 @@ v15 = [
     "storageKey": null
   }
 ],
-v16 = [
+v17 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v18 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v19 = [
+v20 = [
   (v6/*: any*/),
   (v7/*: any*/)
 ];
@@ -462,27 +465,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v7/*: any*/)
-                    ],
+                    "selections": (v11/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -521,8 +504,8 @@ return {
                             "name": "slug",
                             "storageKey": null
                           },
-                          (v11/*: any*/),
                           (v12/*: any*/),
+                          (v13/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -544,7 +527,7 @@ return {
                                 "name": "aspectRatio",
                                 "storageKey": null
                               },
-                              (v12/*: any*/),
+                              (v13/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -555,7 +538,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v13/*: any*/)
+                                  (v14/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -578,7 +561,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v13/*: any*/),
+                                  (v14/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -663,6 +646,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -714,7 +704,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v14/*: any*/),
+                                  (v15/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -722,7 +712,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v15/*: any*/),
+                                    "selections": (v16/*: any*/),
                                     "storageKey": null
                                   },
                                   (v7/*: any*/)
@@ -748,7 +738,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v16/*: any*/),
+                            "args": (v17/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -796,14 +786,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v16/*: any*/),
+                            "args": (v17/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v7/*: any*/),
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               (v6/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -817,14 +807,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v16/*: any*/),
+                            "args": (v17/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v6/*: any*/),
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               (v7/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -837,7 +827,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v14/*: any*/),
+                              (v15/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -899,7 +889,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v17/*: any*/),
+                              (v18/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -907,8 +897,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v14/*: any*/),
-                              (v18/*: any*/),
+                              (v15/*: any*/),
+                              (v19/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -941,7 +931,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v15/*: any*/),
+                                "selections": (v16/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -951,7 +941,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v15/*: any*/),
+                                "selections": (v16/*: any*/),
                                 "storageKey": null
                               },
                               (v7/*: any*/)
@@ -966,10 +956,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v17/*: any*/),
+                              (v18/*: any*/),
                               (v7/*: any*/),
-                              (v14/*: any*/),
-                              (v18/*: any*/)
+                              (v15/*: any*/),
+                              (v19/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -980,7 +970,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v19/*: any*/),
+                            "selections": (v20/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -998,7 +988,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v19/*: any*/),
+                                "selections": (v20/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -1023,9 +1013,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v7/*: any*/)
-                        ],
+                        "selections": (v11/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1046,12 +1034,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "88207e8efeb6b07a3c11a8cd43a34b9d",
+    "cacheID": "adbef358a359fc716e76f3df787fa12a",
     "id": null,
     "metadata": {},
     "name": "ShowArtworksFilterQuery",
     "operationKind": "query",
-    "text": "query ShowArtworksFilterQuery(\n  $slug: String!\n  $input: FilterArtworksInput\n  $aggregations: [ArtworkAggregation]\n) {\n  show(id: $slug) {\n    ...ShowArtworks_show_2p2tYs\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment ShowArtworks_show_2p2tYs on Show {\n  sidebar: filterArtworksConnection(aggregations: $aggregations, first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n"
+    "text": "query ShowArtworksFilterQuery(\n  $slug: String!\n  $input: FilterArtworksInput\n  $aggregations: [ArtworkAggregation]\n) {\n  show(id: $slug) {\n    ...ShowArtworks_show_2p2tYs\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment ShowArtworks_show_2p2tYs on Show {\n  sidebar: filterArtworksConnection(aggregations: $aggregations, first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ShowArtworksFilterRefetchQuery.graphql.ts
+++ b/src/__generated__/ShowArtworksFilterRefetchQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ddc301b5f37c88aa9b297f4f3cd88845>>
+ * @generated SignedSource<<b6e7176e32abde237eacb2d66cf5a942>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -139,21 +139,24 @@ v8 = [
     "storageKey": null
   }
 ],
-v9 = {
+v9 = [
+  (v5/*: any*/)
+],
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v11 = {
+v12 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -161,14 +164,14 @@ v11 = {
     "large"
   ]
 },
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v13 = [
+v14 = [
   {
     "alias": null,
     "args": null,
@@ -177,28 +180,28 @@ v13 = [
     "storageKey": null
   }
 ],
-v14 = [
+v15 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v17 = [
+v18 = [
   (v4/*: any*/),
   (v5/*: any*/)
 ];
@@ -447,27 +450,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v5/*: any*/)
-                    ],
+                    "selections": (v9/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -506,8 +489,8 @@ return {
                             "name": "slug",
                             "storageKey": null
                           },
-                          (v9/*: any*/),
                           (v10/*: any*/),
+                          (v11/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -529,7 +512,7 @@ return {
                                 "name": "aspectRatio",
                                 "storageKey": null
                               },
-                              (v10/*: any*/),
+                              (v11/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -540,7 +523,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v11/*: any*/)
+                                  (v12/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -563,7 +546,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v11/*: any*/),
+                                  (v12/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -648,6 +631,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -699,7 +689,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v12/*: any*/),
+                                  (v13/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -707,7 +697,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v13/*: any*/),
+                                    "selections": (v14/*: any*/),
                                     "storageKey": null
                                   },
                                   (v5/*: any*/)
@@ -733,7 +723,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v14/*: any*/),
+                            "args": (v15/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -781,14 +771,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v14/*: any*/),
+                            "args": (v15/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v5/*: any*/),
-                              (v9/*: any*/),
+                              (v10/*: any*/),
                               (v4/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -802,14 +792,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v14/*: any*/),
+                            "args": (v15/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v4/*: any*/),
-                              (v9/*: any*/),
+                              (v10/*: any*/),
                               (v5/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -822,7 +812,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v12/*: any*/),
+                              (v13/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -884,7 +874,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v15/*: any*/),
+                              (v16/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -892,8 +882,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v12/*: any*/),
-                              (v16/*: any*/),
+                              (v13/*: any*/),
+                              (v17/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -926,7 +916,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v13/*: any*/),
+                                "selections": (v14/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -936,7 +926,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v13/*: any*/),
+                                "selections": (v14/*: any*/),
                                 "storageKey": null
                               },
                               (v5/*: any*/)
@@ -951,10 +941,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v15/*: any*/),
+                              (v16/*: any*/),
                               (v5/*: any*/),
-                              (v12/*: any*/),
-                              (v16/*: any*/)
+                              (v13/*: any*/),
+                              (v17/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -965,7 +955,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v17/*: any*/),
+                            "selections": (v18/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -983,7 +973,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v17/*: any*/),
+                                "selections": (v18/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -1008,9 +998,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v5/*: any*/)
-                        ],
+                        "selections": (v9/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1031,12 +1019,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "aba48e79380efeaa47577241b1bb27a7",
+    "cacheID": "277e06a6d315f776a26d144cca2ba8a1",
     "id": null,
     "metadata": {},
     "name": "ShowArtworksFilterRefetchQuery",
     "operationKind": "query",
-    "text": "query ShowArtworksFilterRefetchQuery(\n  $slug: String!\n  $input: FilterArtworksInput\n) {\n  show(id: $slug) {\n    ...ShowArtworks_show_2VV6jB\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment ShowArtworks_show_2VV6jB on Show {\n  sidebar: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n"
+    "text": "query ShowArtworksFilterRefetchQuery(\n  $slug: String!\n  $input: FilterArtworksInput\n) {\n  show(id: $slug) {\n    ...ShowArtworks_show_2VV6jB\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment ShowArtworks_show_2VV6jB on Show {\n  sidebar: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ShowArtworks_Test_Query.graphql.ts
+++ b/src/__generated__/ShowArtworks_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b8c888168d8319c30f2e6992b9067bfb>>
+ * @generated SignedSource<<7a6ed88825e9bad3c8d8475df9017d34>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -68,21 +68,24 @@ v5 = [
     "storageKey": null
   }
 ],
-v6 = {
+v6 = [
+  (v2/*: any*/)
+],
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v8 = {
+v9 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -90,14 +93,14 @@ v8 = {
     "large"
   ]
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v10 = [
+v11 = [
   {
     "alias": null,
     "args": null,
@@ -106,92 +109,92 @@ v10 = [
     "storageKey": null
   }
 ],
-v11 = [
+v12 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v14 = [
+v15 = [
   (v1/*: any*/),
   (v2/*: any*/)
 ],
-v15 = {
+v16 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FilterArtworksConnection"
 },
-v16 = {
+v17 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v17 = {
+v18 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FormattedNumber"
 },
-v18 = {
+v19 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v19 = {
+v20 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Boolean"
 },
-v20 = {
+v21 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v21 = {
+v22 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Int"
 },
-v22 = {
+v23 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Boolean"
 },
-v23 = {
+v24 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v24 = {
+v25 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "SaleArtwork"
 },
-v25 = {
+v26 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -433,27 +436,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v2/*: any*/)
-                    ],
+                    "selections": (v6/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -492,8 +475,8 @@ return {
                             "name": "slug",
                             "storageKey": null
                           },
-                          (v6/*: any*/),
                           (v7/*: any*/),
+                          (v8/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -515,7 +498,7 @@ return {
                                 "name": "aspectRatio",
                                 "storageKey": null
                               },
-                              (v7/*: any*/),
+                              (v8/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -526,7 +509,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v8/*: any*/)
+                                  (v9/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -549,7 +532,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v8/*: any*/),
+                                  (v9/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -634,6 +617,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -685,7 +675,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v9/*: any*/),
+                                  (v10/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -693,7 +683,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v10/*: any*/),
+                                    "selections": (v11/*: any*/),
                                     "storageKey": null
                                   },
                                   (v2/*: any*/)
@@ -719,7 +709,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v11/*: any*/),
+                            "args": (v12/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -767,14 +757,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v11/*: any*/),
+                            "args": (v12/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v2/*: any*/),
-                              (v6/*: any*/),
+                              (v7/*: any*/),
                               (v1/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -788,14 +778,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v11/*: any*/),
+                            "args": (v12/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v1/*: any*/),
-                              (v6/*: any*/),
+                              (v7/*: any*/),
                               (v2/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -808,7 +798,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v9/*: any*/),
+                              (v10/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -870,7 +860,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v12/*: any*/),
+                              (v13/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -878,8 +868,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v9/*: any*/),
-                              (v13/*: any*/),
+                              (v10/*: any*/),
+                              (v14/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -912,7 +902,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v10/*: any*/),
+                                "selections": (v11/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -922,7 +912,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v10/*: any*/),
+                                "selections": (v11/*: any*/),
                                 "storageKey": null
                               },
                               (v2/*: any*/)
@@ -937,10 +927,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v12/*: any*/),
+                              (v13/*: any*/),
                               (v2/*: any*/),
-                              (v9/*: any*/),
-                              (v13/*: any*/)
+                              (v10/*: any*/),
+                              (v14/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -951,7 +941,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v14/*: any*/),
+                            "selections": (v15/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -969,7 +959,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v14/*: any*/),
+                                "selections": (v15/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -994,9 +984,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v2/*: any*/)
-                        ],
+                        "selections": (v6/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1017,7 +1005,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "0d1d0aa1b515a0905dd5905b4710a7ba",
+    "cacheID": "17c4ab7b9d55722c7744dc8cff8fb516",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -1027,24 +1015,24 @@ return {
           "plural": false,
           "type": "Show"
         },
-        "show.filtered_artworks": (v15/*: any*/),
-        "show.filtered_artworks.__isArtworkConnectionInterface": (v16/*: any*/),
+        "show.filtered_artworks": (v16/*: any*/),
+        "show.filtered_artworks.__isArtworkConnectionInterface": (v17/*: any*/),
         "show.filtered_artworks.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "FilterArtworksCounts"
         },
-        "show.filtered_artworks.counts.total": (v17/*: any*/),
+        "show.filtered_artworks.counts.total": (v18/*: any*/),
         "show.filtered_artworks.edges": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "ArtworkEdgeInterface"
         },
-        "show.filtered_artworks.edges.__isNode": (v16/*: any*/),
-        "show.filtered_artworks.edges.__typename": (v16/*: any*/),
-        "show.filtered_artworks.edges.id": (v18/*: any*/),
+        "show.filtered_artworks.edges.__isNode": (v17/*: any*/),
+        "show.filtered_artworks.edges.__typename": (v17/*: any*/),
+        "show.filtered_artworks.edges.id": (v19/*: any*/),
         "show.filtered_artworks.edges.node": {
           "enumValues": null,
           "nullable": true,
@@ -1057,33 +1045,33 @@ return {
           "plural": false,
           "type": "Artist"
         },
-        "show.filtered_artworks.edges.node.artist.id": (v18/*: any*/),
+        "show.filtered_artworks.edges.node.artist.id": (v19/*: any*/),
         "show.filtered_artworks.edges.node.artist.targetSupply": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "ArtistTargetSupply"
         },
-        "show.filtered_artworks.edges.node.artist.targetSupply.isP1": (v19/*: any*/),
-        "show.filtered_artworks.edges.node.artistNames": (v20/*: any*/),
+        "show.filtered_artworks.edges.node.artist.targetSupply.isP1": (v20/*: any*/),
+        "show.filtered_artworks.edges.node.artistNames": (v21/*: any*/),
         "show.filtered_artworks.edges.node.artists": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Artist"
         },
-        "show.filtered_artworks.edges.node.artists.href": (v20/*: any*/),
-        "show.filtered_artworks.edges.node.artists.id": (v18/*: any*/),
-        "show.filtered_artworks.edges.node.artists.name": (v20/*: any*/),
+        "show.filtered_artworks.edges.node.artists.href": (v21/*: any*/),
+        "show.filtered_artworks.edges.node.artists.id": (v19/*: any*/),
+        "show.filtered_artworks.edges.node.artists.name": (v21/*: any*/),
         "show.filtered_artworks.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "show.filtered_artworks.edges.node.attributionClass.id": (v18/*: any*/),
-        "show.filtered_artworks.edges.node.attributionClass.name": (v20/*: any*/),
-        "show.filtered_artworks.edges.node.collecting_institution": (v20/*: any*/),
+        "show.filtered_artworks.edges.node.attributionClass.id": (v19/*: any*/),
+        "show.filtered_artworks.edges.node.attributionClass.name": (v21/*: any*/),
+        "show.filtered_artworks.edges.node.collecting_institution": (v21/*: any*/),
         "show.filtered_artworks.edges.node.collectorSignals": {
           "enumValues": null,
           "nullable": true,
@@ -1096,26 +1084,26 @@ return {
           "plural": false,
           "type": "AuctionCollectorSignals"
         },
-        "show.filtered_artworks.edges.node.collectorSignals.auction.bidCount": (v21/*: any*/),
-        "show.filtered_artworks.edges.node.collectorSignals.auction.liveBiddingStarted": (v22/*: any*/),
-        "show.filtered_artworks.edges.node.collectorSignals.auction.lotClosesAt": (v20/*: any*/),
-        "show.filtered_artworks.edges.node.collectorSignals.auction.onlineBiddingExtended": (v22/*: any*/),
-        "show.filtered_artworks.edges.node.collectorSignals.auction.registrationEndsAt": (v20/*: any*/),
+        "show.filtered_artworks.edges.node.collectorSignals.auction.bidCount": (v22/*: any*/),
+        "show.filtered_artworks.edges.node.collectorSignals.auction.liveBiddingStarted": (v23/*: any*/),
+        "show.filtered_artworks.edges.node.collectorSignals.auction.lotClosesAt": (v21/*: any*/),
+        "show.filtered_artworks.edges.node.collectorSignals.auction.onlineBiddingExtended": (v23/*: any*/),
+        "show.filtered_artworks.edges.node.collectorSignals.auction.registrationEndsAt": (v21/*: any*/),
         "show.filtered_artworks.edges.node.collectorSignals.partnerOffer": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "PartnerOfferToCollector"
         },
-        "show.filtered_artworks.edges.node.collectorSignals.partnerOffer.endAt": (v20/*: any*/),
-        "show.filtered_artworks.edges.node.collectorSignals.partnerOffer.id": (v18/*: any*/),
+        "show.filtered_artworks.edges.node.collectorSignals.partnerOffer.endAt": (v21/*: any*/),
+        "show.filtered_artworks.edges.node.collectorSignals.partnerOffer.id": (v19/*: any*/),
         "show.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Money"
         },
-        "show.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v20/*: any*/),
+        "show.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v21/*: any*/),
         "show.filtered_artworks.edges.node.collectorSignals.primaryLabel": {
           "enumValues": [
             "CURATORS_PICK",
@@ -1126,10 +1114,10 @@ return {
           "plural": false,
           "type": "LabelSignalEnum"
         },
-        "show.filtered_artworks.edges.node.cultural_maker": (v20/*: any*/),
-        "show.filtered_artworks.edges.node.date": (v20/*: any*/),
-        "show.filtered_artworks.edges.node.href": (v20/*: any*/),
-        "show.filtered_artworks.edges.node.id": (v18/*: any*/),
+        "show.filtered_artworks.edges.node.cultural_maker": (v21/*: any*/),
+        "show.filtered_artworks.edges.node.date": (v21/*: any*/),
+        "show.filtered_artworks.edges.node.href": (v21/*: any*/),
+        "show.filtered_artworks.edges.node.id": (v19/*: any*/),
         "show.filtered_artworks.edges.node.image": {
           "enumValues": null,
           "nullable": true,
@@ -1142,35 +1130,35 @@ return {
           "plural": false,
           "type": "Float"
         },
-        "show.filtered_artworks.edges.node.image.blurhashDataURL": (v20/*: any*/),
+        "show.filtered_artworks.edges.node.image.blurhashDataURL": (v21/*: any*/),
         "show.filtered_artworks.edges.node.image.internalID": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ID"
         },
-        "show.filtered_artworks.edges.node.image.placeholder": (v20/*: any*/),
+        "show.filtered_artworks.edges.node.image.placeholder": (v21/*: any*/),
         "show.filtered_artworks.edges.node.image.resized": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ResizedImageUrl"
         },
-        "show.filtered_artworks.edges.node.image.resized.height": (v23/*: any*/),
-        "show.filtered_artworks.edges.node.image.resized.src": (v16/*: any*/),
-        "show.filtered_artworks.edges.node.image.resized.srcSet": (v16/*: any*/),
-        "show.filtered_artworks.edges.node.image.resized.width": (v23/*: any*/),
-        "show.filtered_artworks.edges.node.image.url": (v20/*: any*/),
+        "show.filtered_artworks.edges.node.image.resized.height": (v24/*: any*/),
+        "show.filtered_artworks.edges.node.image.resized.src": (v17/*: any*/),
+        "show.filtered_artworks.edges.node.image.resized.srcSet": (v17/*: any*/),
+        "show.filtered_artworks.edges.node.image.resized.width": (v24/*: any*/),
+        "show.filtered_artworks.edges.node.image.url": (v21/*: any*/),
         "show.filtered_artworks.edges.node.image.versions": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "String"
         },
-        "show.filtered_artworks.edges.node.imageTitle": (v20/*: any*/),
-        "show.filtered_artworks.edges.node.image_title": (v20/*: any*/),
-        "show.filtered_artworks.edges.node.internalID": (v18/*: any*/),
-        "show.filtered_artworks.edges.node.isUnlisted": (v22/*: any*/),
+        "show.filtered_artworks.edges.node.imageTitle": (v21/*: any*/),
+        "show.filtered_artworks.edges.node.image_title": (v21/*: any*/),
+        "show.filtered_artworks.edges.node.internalID": (v19/*: any*/),
+        "show.filtered_artworks.edges.node.isUnlisted": (v23/*: any*/),
         "show.filtered_artworks.edges.node.marketPriceInsights": {
           "enumValues": null,
           "nullable": true,
@@ -1195,69 +1183,69 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "show.filtered_artworks.edges.node.mediumType.filterGene.id": (v18/*: any*/),
-        "show.filtered_artworks.edges.node.mediumType.filterGene.name": (v20/*: any*/),
+        "show.filtered_artworks.edges.node.mediumType.filterGene.id": (v19/*: any*/),
+        "show.filtered_artworks.edges.node.mediumType.filterGene.name": (v21/*: any*/),
         "show.filtered_artworks.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "show.filtered_artworks.edges.node.partner.href": (v20/*: any*/),
-        "show.filtered_artworks.edges.node.partner.id": (v18/*: any*/),
-        "show.filtered_artworks.edges.node.partner.name": (v20/*: any*/),
+        "show.filtered_artworks.edges.node.partner.href": (v21/*: any*/),
+        "show.filtered_artworks.edges.node.partner.id": (v19/*: any*/),
+        "show.filtered_artworks.edges.node.partner.name": (v21/*: any*/),
         "show.filtered_artworks.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "show.filtered_artworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v23/*: any*/),
-        "show.filtered_artworks.edges.node.sale.endAt": (v20/*: any*/),
-        "show.filtered_artworks.edges.node.sale.extendedBiddingIntervalMinutes": (v23/*: any*/),
-        "show.filtered_artworks.edges.node.sale.extendedBiddingPeriodMinutes": (v23/*: any*/),
-        "show.filtered_artworks.edges.node.sale.id": (v18/*: any*/),
-        "show.filtered_artworks.edges.node.sale.isOpen": (v19/*: any*/),
-        "show.filtered_artworks.edges.node.sale.is_auction": (v19/*: any*/),
-        "show.filtered_artworks.edges.node.sale.is_closed": (v19/*: any*/),
-        "show.filtered_artworks.edges.node.sale.startAt": (v20/*: any*/),
-        "show.filtered_artworks.edges.node.saleArtwork": (v24/*: any*/),
-        "show.filtered_artworks.edges.node.saleArtwork.endAt": (v20/*: any*/),
-        "show.filtered_artworks.edges.node.saleArtwork.extendedBiddingEndAt": (v20/*: any*/),
-        "show.filtered_artworks.edges.node.saleArtwork.id": (v18/*: any*/),
-        "show.filtered_artworks.edges.node.saleArtwork.lotID": (v20/*: any*/),
-        "show.filtered_artworks.edges.node.sale_artwork": (v24/*: any*/),
+        "show.filtered_artworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v24/*: any*/),
+        "show.filtered_artworks.edges.node.sale.endAt": (v21/*: any*/),
+        "show.filtered_artworks.edges.node.sale.extendedBiddingIntervalMinutes": (v24/*: any*/),
+        "show.filtered_artworks.edges.node.sale.extendedBiddingPeriodMinutes": (v24/*: any*/),
+        "show.filtered_artworks.edges.node.sale.id": (v19/*: any*/),
+        "show.filtered_artworks.edges.node.sale.isOpen": (v20/*: any*/),
+        "show.filtered_artworks.edges.node.sale.is_auction": (v20/*: any*/),
+        "show.filtered_artworks.edges.node.sale.is_closed": (v20/*: any*/),
+        "show.filtered_artworks.edges.node.sale.startAt": (v21/*: any*/),
+        "show.filtered_artworks.edges.node.saleArtwork": (v25/*: any*/),
+        "show.filtered_artworks.edges.node.saleArtwork.endAt": (v21/*: any*/),
+        "show.filtered_artworks.edges.node.saleArtwork.extendedBiddingEndAt": (v21/*: any*/),
+        "show.filtered_artworks.edges.node.saleArtwork.id": (v19/*: any*/),
+        "show.filtered_artworks.edges.node.saleArtwork.lotID": (v21/*: any*/),
+        "show.filtered_artworks.edges.node.sale_artwork": (v25/*: any*/),
         "show.filtered_artworks.edges.node.sale_artwork.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkCounts"
         },
-        "show.filtered_artworks.edges.node.sale_artwork.counts.bidder_positions": (v17/*: any*/),
-        "show.filtered_artworks.edges.node.sale_artwork.endAt": (v20/*: any*/),
-        "show.filtered_artworks.edges.node.sale_artwork.extendedBiddingEndAt": (v20/*: any*/),
-        "show.filtered_artworks.edges.node.sale_artwork.formattedEndDateTime": (v20/*: any*/),
+        "show.filtered_artworks.edges.node.sale_artwork.counts.bidder_positions": (v18/*: any*/),
+        "show.filtered_artworks.edges.node.sale_artwork.endAt": (v21/*: any*/),
+        "show.filtered_artworks.edges.node.sale_artwork.extendedBiddingEndAt": (v21/*: any*/),
+        "show.filtered_artworks.edges.node.sale_artwork.formattedEndDateTime": (v21/*: any*/),
         "show.filtered_artworks.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "show.filtered_artworks.edges.node.sale_artwork.highest_bid.display": (v20/*: any*/),
-        "show.filtered_artworks.edges.node.sale_artwork.id": (v18/*: any*/),
-        "show.filtered_artworks.edges.node.sale_artwork.lotID": (v20/*: any*/),
-        "show.filtered_artworks.edges.node.sale_artwork.lotLabel": (v20/*: any*/),
+        "show.filtered_artworks.edges.node.sale_artwork.highest_bid.display": (v21/*: any*/),
+        "show.filtered_artworks.edges.node.sale_artwork.id": (v19/*: any*/),
+        "show.filtered_artworks.edges.node.sale_artwork.lotID": (v21/*: any*/),
+        "show.filtered_artworks.edges.node.sale_artwork.lotLabel": (v21/*: any*/),
         "show.filtered_artworks.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "show.filtered_artworks.edges.node.sale_artwork.opening_bid.display": (v20/*: any*/),
-        "show.filtered_artworks.edges.node.sale_message": (v20/*: any*/),
-        "show.filtered_artworks.edges.node.slug": (v18/*: any*/),
-        "show.filtered_artworks.edges.node.title": (v20/*: any*/),
-        "show.filtered_artworks.id": (v18/*: any*/),
+        "show.filtered_artworks.edges.node.sale_artwork.opening_bid.display": (v21/*: any*/),
+        "show.filtered_artworks.edges.node.sale_message": (v21/*: any*/),
+        "show.filtered_artworks.edges.node.slug": (v19/*: any*/),
+        "show.filtered_artworks.edges.node.title": (v21/*: any*/),
+        "show.filtered_artworks.id": (v19/*: any*/),
         "show.filtered_artworks.pageCursors": {
           "enumValues": null,
           "nullable": false,
@@ -1270,30 +1258,30 @@ return {
           "plural": true,
           "type": "PageCursor"
         },
-        "show.filtered_artworks.pageCursors.around.cursor": (v16/*: any*/),
-        "show.filtered_artworks.pageCursors.around.isCurrent": (v22/*: any*/),
-        "show.filtered_artworks.pageCursors.around.page": (v21/*: any*/),
-        "show.filtered_artworks.pageCursors.first": (v25/*: any*/),
-        "show.filtered_artworks.pageCursors.first.cursor": (v16/*: any*/),
-        "show.filtered_artworks.pageCursors.first.isCurrent": (v22/*: any*/),
-        "show.filtered_artworks.pageCursors.first.page": (v21/*: any*/),
-        "show.filtered_artworks.pageCursors.last": (v25/*: any*/),
-        "show.filtered_artworks.pageCursors.last.cursor": (v16/*: any*/),
-        "show.filtered_artworks.pageCursors.last.isCurrent": (v22/*: any*/),
-        "show.filtered_artworks.pageCursors.last.page": (v21/*: any*/),
-        "show.filtered_artworks.pageCursors.previous": (v25/*: any*/),
-        "show.filtered_artworks.pageCursors.previous.cursor": (v16/*: any*/),
-        "show.filtered_artworks.pageCursors.previous.page": (v21/*: any*/),
+        "show.filtered_artworks.pageCursors.around.cursor": (v17/*: any*/),
+        "show.filtered_artworks.pageCursors.around.isCurrent": (v23/*: any*/),
+        "show.filtered_artworks.pageCursors.around.page": (v22/*: any*/),
+        "show.filtered_artworks.pageCursors.first": (v26/*: any*/),
+        "show.filtered_artworks.pageCursors.first.cursor": (v17/*: any*/),
+        "show.filtered_artworks.pageCursors.first.isCurrent": (v23/*: any*/),
+        "show.filtered_artworks.pageCursors.first.page": (v22/*: any*/),
+        "show.filtered_artworks.pageCursors.last": (v26/*: any*/),
+        "show.filtered_artworks.pageCursors.last.cursor": (v17/*: any*/),
+        "show.filtered_artworks.pageCursors.last.isCurrent": (v23/*: any*/),
+        "show.filtered_artworks.pageCursors.last.page": (v22/*: any*/),
+        "show.filtered_artworks.pageCursors.previous": (v26/*: any*/),
+        "show.filtered_artworks.pageCursors.previous.cursor": (v17/*: any*/),
+        "show.filtered_artworks.pageCursors.previous.page": (v22/*: any*/),
         "show.filtered_artworks.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "show.filtered_artworks.pageInfo.endCursor": (v20/*: any*/),
-        "show.filtered_artworks.pageInfo.hasNextPage": (v22/*: any*/),
-        "show.id": (v18/*: any*/),
-        "show.sidebar": (v15/*: any*/),
+        "show.filtered_artworks.pageInfo.endCursor": (v21/*: any*/),
+        "show.filtered_artworks.pageInfo.hasNextPage": (v23/*: any*/),
+        "show.id": (v19/*: any*/),
+        "show.sidebar": (v16/*: any*/),
         "show.sidebar.aggregations": {
           "enumValues": null,
           "nullable": true,
@@ -1306,9 +1294,9 @@ return {
           "plural": true,
           "type": "AggregationCount"
         },
-        "show.sidebar.aggregations.counts.count": (v21/*: any*/),
-        "show.sidebar.aggregations.counts.name": (v16/*: any*/),
-        "show.sidebar.aggregations.counts.value": (v16/*: any*/),
+        "show.sidebar.aggregations.counts.count": (v22/*: any*/),
+        "show.sidebar.aggregations.counts.name": (v17/*: any*/),
+        "show.sidebar.aggregations.counts.value": (v17/*: any*/),
         "show.sidebar.aggregations.slice": {
           "enumValues": [
             "ARTIST",
@@ -1336,12 +1324,12 @@ return {
           "plural": false,
           "type": "ArtworkAggregation"
         },
-        "show.sidebar.id": (v18/*: any*/)
+        "show.sidebar.id": (v19/*: any*/)
       }
     },
     "name": "ShowArtworks_Test_Query",
     "operationKind": "query",
-    "text": "query ShowArtworks_Test_Query {\n  show(id: \"catty-show\") {\n    ...ShowArtworks_show\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment ShowArtworks_show on Show {\n  sidebar: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n"
+    "text": "query ShowArtworks_Test_Query {\n  show(id: \"catty-show\") {\n    ...ShowArtworks_show\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment ShowArtworks_show on Show {\n  sidebar: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/TagArtworkFilterQuery.graphql.ts
+++ b/src/__generated__/TagArtworkFilterQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7b968c20ee1319474a4d8c7146898e7d>>
+ * @generated SignedSource<<fcd8af02fd4a1e6e20d8857c351f9867>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -170,14 +170,17 @@ v13 = [
     "storageKey": null
   }
 ],
-v14 = {
+v14 = [
+  (v10/*: any*/)
+],
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -185,14 +188,14 @@ v15 = {
     "large"
   ]
 },
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v17 = [
+v18 = [
   {
     "alias": null,
     "args": null,
@@ -201,28 +204,28 @@ v17 = [
     "storageKey": null
   }
 ],
-v18 = [
+v19 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v19 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v20 = {
+v21 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v21 = [
+v22 = [
   (v9/*: any*/),
   (v10/*: any*/)
 ];
@@ -509,27 +512,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v10/*: any*/)
-                    ],
+                    "selections": (v14/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -562,7 +545,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v7/*: any*/),
-                          (v14/*: any*/),
+                          (v15/*: any*/),
                           (v8/*: any*/),
                           {
                             "alias": null,
@@ -596,7 +579,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v15/*: any*/)
+                                  (v16/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -619,7 +602,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v15/*: any*/),
+                                  (v16/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -704,6 +687,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -755,7 +745,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v16/*: any*/),
+                                  (v17/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -763,7 +753,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v17/*: any*/),
+                                    "selections": (v18/*: any*/),
                                     "storageKey": null
                                   },
                                   (v10/*: any*/)
@@ -789,7 +779,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v18/*: any*/),
+                            "args": (v19/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -837,14 +827,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v18/*: any*/),
+                            "args": (v19/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v10/*: any*/),
-                              (v14/*: any*/),
+                              (v15/*: any*/),
                               (v9/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -858,14 +848,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v18/*: any*/),
+                            "args": (v19/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v9/*: any*/),
-                              (v14/*: any*/),
+                              (v15/*: any*/),
                               (v10/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -878,7 +868,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v16/*: any*/),
+                              (v17/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -940,7 +930,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v19/*: any*/),
+                              (v20/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -948,8 +938,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v16/*: any*/),
-                              (v20/*: any*/),
+                              (v17/*: any*/),
+                              (v21/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -982,7 +972,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v17/*: any*/),
+                                "selections": (v18/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -992,7 +982,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v17/*: any*/),
+                                "selections": (v18/*: any*/),
                                 "storageKey": null
                               },
                               (v10/*: any*/)
@@ -1007,10 +997,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v19/*: any*/),
+                              (v20/*: any*/),
                               (v10/*: any*/),
-                              (v16/*: any*/),
-                              (v20/*: any*/)
+                              (v17/*: any*/),
+                              (v21/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -1021,7 +1011,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v21/*: any*/),
+                            "selections": (v22/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1039,7 +1029,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v21/*: any*/),
+                                "selections": (v22/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -1064,9 +1054,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v10/*: any*/)
-                        ],
+                        "selections": (v14/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1087,12 +1075,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f41f1bd119ad6bc8aea9fbb568186ac6",
+    "cacheID": "4190f912fdf12d9cd5e5a4995d6d4026",
     "id": null,
     "metadata": {},
     "name": "TagArtworkFilterQuery",
     "operationKind": "query",
-    "text": "query TagArtworkFilterQuery(\n  $slug: String!\n  $input: FilterArtworksInput\n  $aggregations: [ArtworkAggregation]\n  $shouldFetchCounts: Boolean!\n) {\n  tag(id: $slug) {\n    ...TagArtworkFilter_tag_3TMxyn\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment TagArtworkFilter_tag_3TMxyn on Tag {\n  slug\n  internalID\n  sidebar: filterArtworksConnection(aggregations: $aggregations, first: 1) {\n    counts @include(if: $shouldFetchCounts) {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n"
+    "text": "query TagArtworkFilterQuery(\n  $slug: String!\n  $input: FilterArtworksInput\n  $aggregations: [ArtworkAggregation]\n  $shouldFetchCounts: Boolean!\n) {\n  tag(id: $slug) {\n    ...TagArtworkFilter_tag_3TMxyn\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment TagArtworkFilter_tag_3TMxyn on Tag {\n  slug\n  internalID\n  sidebar: filterArtworksConnection(aggregations: $aggregations, first: 1) {\n    counts @include(if: $shouldFetchCounts) {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/TagArtworkFilterRefetchQuery.graphql.ts
+++ b/src/__generated__/TagArtworkFilterRefetchQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ee6087ae99f4c484147b14d97f3bb095>>
+ * @generated SignedSource<<4907de2f0e6088d675a8c6128cac63e1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -153,14 +153,17 @@ v10 = [
     "storageKey": null
   }
 ],
-v11 = {
+v11 = [
+  (v7/*: any*/)
+],
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v12 = {
+v13 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -168,14 +171,14 @@ v12 = {
     "large"
   ]
 },
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v14 = [
+v15 = [
   {
     "alias": null,
     "args": null,
@@ -184,28 +187,28 @@ v14 = [
     "storageKey": null
   }
 ],
-v15 = [
+v16 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v18 = [
+v19 = [
   (v6/*: any*/),
   (v7/*: any*/)
 ];
@@ -456,27 +459,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v7/*: any*/)
-                    ],
+                    "selections": (v11/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -509,7 +492,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v4/*: any*/),
-                          (v11/*: any*/),
+                          (v12/*: any*/),
                           (v5/*: any*/),
                           {
                             "alias": null,
@@ -543,7 +526,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v12/*: any*/)
+                                  (v13/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -566,7 +549,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v12/*: any*/),
+                                  (v13/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -651,6 +634,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -702,7 +692,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v13/*: any*/),
+                                  (v14/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -710,7 +700,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v14/*: any*/),
+                                    "selections": (v15/*: any*/),
                                     "storageKey": null
                                   },
                                   (v7/*: any*/)
@@ -736,7 +726,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v15/*: any*/),
+                            "args": (v16/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -784,14 +774,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v15/*: any*/),
+                            "args": (v16/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v7/*: any*/),
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               (v6/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -805,14 +795,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v15/*: any*/),
+                            "args": (v16/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v6/*: any*/),
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               (v7/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -825,7 +815,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v13/*: any*/),
+                              (v14/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -887,7 +877,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v16/*: any*/),
+                              (v17/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -895,8 +885,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v13/*: any*/),
-                              (v17/*: any*/),
+                              (v14/*: any*/),
+                              (v18/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -929,7 +919,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v14/*: any*/),
+                                "selections": (v15/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -939,7 +929,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v14/*: any*/),
+                                "selections": (v15/*: any*/),
                                 "storageKey": null
                               },
                               (v7/*: any*/)
@@ -954,10 +944,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v16/*: any*/),
+                              (v17/*: any*/),
                               (v7/*: any*/),
-                              (v13/*: any*/),
-                              (v17/*: any*/)
+                              (v14/*: any*/),
+                              (v18/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -968,7 +958,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v18/*: any*/),
+                            "selections": (v19/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -986,7 +976,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v18/*: any*/),
+                                "selections": (v19/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -1011,9 +1001,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v7/*: any*/)
-                        ],
+                        "selections": (v11/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1034,12 +1022,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4869526fd50223efe7918907cf52e284",
+    "cacheID": "aef1d54f77c5674f2a923d8a08203382",
     "id": null,
     "metadata": {},
     "name": "TagArtworkFilterRefetchQuery",
     "operationKind": "query",
-    "text": "query TagArtworkFilterRefetchQuery(\n  $slug: String!\n  $input: FilterArtworksInput\n) {\n  tag(id: $slug) {\n    ...TagArtworkFilter_tag_2VV6jB\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment TagArtworkFilter_tag_2VV6jB on Tag {\n  slug\n  internalID\n  sidebar: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n"
+    "text": "query TagArtworkFilterRefetchQuery(\n  $slug: String!\n  $input: FilterArtworksInput\n) {\n  tag(id: $slug) {\n    ...TagArtworkFilter_tag_2VV6jB\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment TagArtworkFilter_tag_2VV6jB on Tag {\n  slug\n  internalID\n  sidebar: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/TagArtworkFilter_Query.graphql.ts
+++ b/src/__generated__/TagArtworkFilter_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a4b13a2cd9e60e6e0b7d51d257e0b490>>
+ * @generated SignedSource<<7f8eb2c98492abef6ce828d30dd25e1e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -91,14 +91,17 @@ v8 = [
     "storageKey": null
   }
 ],
-v9 = {
+v9 = [
+  (v5/*: any*/)
+],
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -106,14 +109,14 @@ v10 = {
     "large"
   ]
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v12 = [
+v13 = [
   {
     "alias": null,
     "args": null,
@@ -122,98 +125,98 @@ v12 = [
     "storageKey": null
   }
 ],
-v13 = [
+v14 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v16 = [
+v17 = [
   (v4/*: any*/),
   (v5/*: any*/)
 ],
-v17 = {
+v18 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FilterArtworksConnection"
 },
-v18 = {
+v19 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
-},
-v19 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "FilterArtworksCounts"
 },
 v20 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "FormattedNumber"
+  "type": "FilterArtworksCounts"
 },
 v21 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "FormattedNumber"
+},
+v22 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v22 = {
+v23 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Boolean"
 },
-v23 = {
+v24 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v24 = {
+v25 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Int"
 },
-v25 = {
+v26 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Boolean"
 },
-v26 = {
+v27 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v27 = {
+v28 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "SaleArtwork"
 },
-v28 = {
+v29 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -481,27 +484,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v5/*: any*/)
-                    ],
+                    "selections": (v9/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -534,7 +517,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v2/*: any*/),
-                          (v9/*: any*/),
+                          (v10/*: any*/),
                           (v3/*: any*/),
                           {
                             "alias": null,
@@ -568,7 +551,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v10/*: any*/)
+                                  (v11/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -591,7 +574,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v10/*: any*/),
+                                  (v11/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -676,6 +659,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -727,7 +717,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v11/*: any*/),
+                                  (v12/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -735,7 +725,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v12/*: any*/),
+                                    "selections": (v13/*: any*/),
                                     "storageKey": null
                                   },
                                   (v5/*: any*/)
@@ -761,7 +751,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -809,14 +799,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v5/*: any*/),
-                              (v9/*: any*/),
+                              (v10/*: any*/),
                               (v4/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -830,14 +820,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v4/*: any*/),
-                              (v9/*: any*/),
+                              (v10/*: any*/),
                               (v5/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -850,7 +840,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -912,7 +902,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v14/*: any*/),
+                              (v15/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -920,8 +910,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v11/*: any*/),
-                              (v15/*: any*/),
+                              (v12/*: any*/),
+                              (v16/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -954,7 +944,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v12/*: any*/),
+                                "selections": (v13/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -964,7 +954,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v12/*: any*/),
+                                "selections": (v13/*: any*/),
                                 "storageKey": null
                               },
                               (v5/*: any*/)
@@ -979,10 +969,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v14/*: any*/),
+                              (v15/*: any*/),
                               (v5/*: any*/),
-                              (v11/*: any*/),
-                              (v15/*: any*/)
+                              (v12/*: any*/),
+                              (v16/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -993,7 +983,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v16/*: any*/),
+                            "selections": (v17/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1011,7 +1001,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v16/*: any*/),
+                                "selections": (v17/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -1036,9 +1026,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v5/*: any*/)
-                        ],
+                        "selections": (v9/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1059,7 +1047,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "fc6d0f1af1cc76a4a87520f2e470b75e",
+    "cacheID": "3ba618b01312dcb7287dd0b7f0d15cca",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -1069,19 +1057,19 @@ return {
           "plural": false,
           "type": "Tag"
         },
-        "tag.filtered_artworks": (v17/*: any*/),
-        "tag.filtered_artworks.__isArtworkConnectionInterface": (v18/*: any*/),
-        "tag.filtered_artworks.counts": (v19/*: any*/),
-        "tag.filtered_artworks.counts.total": (v20/*: any*/),
+        "tag.filtered_artworks": (v18/*: any*/),
+        "tag.filtered_artworks.__isArtworkConnectionInterface": (v19/*: any*/),
+        "tag.filtered_artworks.counts": (v20/*: any*/),
+        "tag.filtered_artworks.counts.total": (v21/*: any*/),
         "tag.filtered_artworks.edges": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "ArtworkEdgeInterface"
         },
-        "tag.filtered_artworks.edges.__isNode": (v18/*: any*/),
-        "tag.filtered_artworks.edges.__typename": (v18/*: any*/),
-        "tag.filtered_artworks.edges.id": (v21/*: any*/),
+        "tag.filtered_artworks.edges.__isNode": (v19/*: any*/),
+        "tag.filtered_artworks.edges.__typename": (v19/*: any*/),
+        "tag.filtered_artworks.edges.id": (v22/*: any*/),
         "tag.filtered_artworks.edges.node": {
           "enumValues": null,
           "nullable": true,
@@ -1094,33 +1082,33 @@ return {
           "plural": false,
           "type": "Artist"
         },
-        "tag.filtered_artworks.edges.node.artist.id": (v21/*: any*/),
+        "tag.filtered_artworks.edges.node.artist.id": (v22/*: any*/),
         "tag.filtered_artworks.edges.node.artist.targetSupply": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "ArtistTargetSupply"
         },
-        "tag.filtered_artworks.edges.node.artist.targetSupply.isP1": (v22/*: any*/),
-        "tag.filtered_artworks.edges.node.artistNames": (v23/*: any*/),
+        "tag.filtered_artworks.edges.node.artist.targetSupply.isP1": (v23/*: any*/),
+        "tag.filtered_artworks.edges.node.artistNames": (v24/*: any*/),
         "tag.filtered_artworks.edges.node.artists": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Artist"
         },
-        "tag.filtered_artworks.edges.node.artists.href": (v23/*: any*/),
-        "tag.filtered_artworks.edges.node.artists.id": (v21/*: any*/),
-        "tag.filtered_artworks.edges.node.artists.name": (v23/*: any*/),
+        "tag.filtered_artworks.edges.node.artists.href": (v24/*: any*/),
+        "tag.filtered_artworks.edges.node.artists.id": (v22/*: any*/),
+        "tag.filtered_artworks.edges.node.artists.name": (v24/*: any*/),
         "tag.filtered_artworks.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "tag.filtered_artworks.edges.node.attributionClass.id": (v21/*: any*/),
-        "tag.filtered_artworks.edges.node.attributionClass.name": (v23/*: any*/),
-        "tag.filtered_artworks.edges.node.collecting_institution": (v23/*: any*/),
+        "tag.filtered_artworks.edges.node.attributionClass.id": (v22/*: any*/),
+        "tag.filtered_artworks.edges.node.attributionClass.name": (v24/*: any*/),
+        "tag.filtered_artworks.edges.node.collecting_institution": (v24/*: any*/),
         "tag.filtered_artworks.edges.node.collectorSignals": {
           "enumValues": null,
           "nullable": true,
@@ -1133,26 +1121,26 @@ return {
           "plural": false,
           "type": "AuctionCollectorSignals"
         },
-        "tag.filtered_artworks.edges.node.collectorSignals.auction.bidCount": (v24/*: any*/),
-        "tag.filtered_artworks.edges.node.collectorSignals.auction.liveBiddingStarted": (v25/*: any*/),
-        "tag.filtered_artworks.edges.node.collectorSignals.auction.lotClosesAt": (v23/*: any*/),
-        "tag.filtered_artworks.edges.node.collectorSignals.auction.onlineBiddingExtended": (v25/*: any*/),
-        "tag.filtered_artworks.edges.node.collectorSignals.auction.registrationEndsAt": (v23/*: any*/),
+        "tag.filtered_artworks.edges.node.collectorSignals.auction.bidCount": (v25/*: any*/),
+        "tag.filtered_artworks.edges.node.collectorSignals.auction.liveBiddingStarted": (v26/*: any*/),
+        "tag.filtered_artworks.edges.node.collectorSignals.auction.lotClosesAt": (v24/*: any*/),
+        "tag.filtered_artworks.edges.node.collectorSignals.auction.onlineBiddingExtended": (v26/*: any*/),
+        "tag.filtered_artworks.edges.node.collectorSignals.auction.registrationEndsAt": (v24/*: any*/),
         "tag.filtered_artworks.edges.node.collectorSignals.partnerOffer": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "PartnerOfferToCollector"
         },
-        "tag.filtered_artworks.edges.node.collectorSignals.partnerOffer.endAt": (v23/*: any*/),
-        "tag.filtered_artworks.edges.node.collectorSignals.partnerOffer.id": (v21/*: any*/),
+        "tag.filtered_artworks.edges.node.collectorSignals.partnerOffer.endAt": (v24/*: any*/),
+        "tag.filtered_artworks.edges.node.collectorSignals.partnerOffer.id": (v22/*: any*/),
         "tag.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Money"
         },
-        "tag.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v23/*: any*/),
+        "tag.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v24/*: any*/),
         "tag.filtered_artworks.edges.node.collectorSignals.primaryLabel": {
           "enumValues": [
             "CURATORS_PICK",
@@ -1163,10 +1151,10 @@ return {
           "plural": false,
           "type": "LabelSignalEnum"
         },
-        "tag.filtered_artworks.edges.node.cultural_maker": (v23/*: any*/),
-        "tag.filtered_artworks.edges.node.date": (v23/*: any*/),
-        "tag.filtered_artworks.edges.node.href": (v23/*: any*/),
-        "tag.filtered_artworks.edges.node.id": (v21/*: any*/),
+        "tag.filtered_artworks.edges.node.cultural_maker": (v24/*: any*/),
+        "tag.filtered_artworks.edges.node.date": (v24/*: any*/),
+        "tag.filtered_artworks.edges.node.href": (v24/*: any*/),
+        "tag.filtered_artworks.edges.node.id": (v22/*: any*/),
         "tag.filtered_artworks.edges.node.image": {
           "enumValues": null,
           "nullable": true,
@@ -1179,35 +1167,35 @@ return {
           "plural": false,
           "type": "Float"
         },
-        "tag.filtered_artworks.edges.node.image.blurhashDataURL": (v23/*: any*/),
+        "tag.filtered_artworks.edges.node.image.blurhashDataURL": (v24/*: any*/),
         "tag.filtered_artworks.edges.node.image.internalID": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ID"
         },
-        "tag.filtered_artworks.edges.node.image.placeholder": (v23/*: any*/),
+        "tag.filtered_artworks.edges.node.image.placeholder": (v24/*: any*/),
         "tag.filtered_artworks.edges.node.image.resized": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ResizedImageUrl"
         },
-        "tag.filtered_artworks.edges.node.image.resized.height": (v26/*: any*/),
-        "tag.filtered_artworks.edges.node.image.resized.src": (v18/*: any*/),
-        "tag.filtered_artworks.edges.node.image.resized.srcSet": (v18/*: any*/),
-        "tag.filtered_artworks.edges.node.image.resized.width": (v26/*: any*/),
-        "tag.filtered_artworks.edges.node.image.url": (v23/*: any*/),
+        "tag.filtered_artworks.edges.node.image.resized.height": (v27/*: any*/),
+        "tag.filtered_artworks.edges.node.image.resized.src": (v19/*: any*/),
+        "tag.filtered_artworks.edges.node.image.resized.srcSet": (v19/*: any*/),
+        "tag.filtered_artworks.edges.node.image.resized.width": (v27/*: any*/),
+        "tag.filtered_artworks.edges.node.image.url": (v24/*: any*/),
         "tag.filtered_artworks.edges.node.image.versions": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "String"
         },
-        "tag.filtered_artworks.edges.node.imageTitle": (v23/*: any*/),
-        "tag.filtered_artworks.edges.node.image_title": (v23/*: any*/),
-        "tag.filtered_artworks.edges.node.internalID": (v21/*: any*/),
-        "tag.filtered_artworks.edges.node.isUnlisted": (v25/*: any*/),
+        "tag.filtered_artworks.edges.node.imageTitle": (v24/*: any*/),
+        "tag.filtered_artworks.edges.node.image_title": (v24/*: any*/),
+        "tag.filtered_artworks.edges.node.internalID": (v22/*: any*/),
+        "tag.filtered_artworks.edges.node.isUnlisted": (v26/*: any*/),
         "tag.filtered_artworks.edges.node.marketPriceInsights": {
           "enumValues": null,
           "nullable": true,
@@ -1232,69 +1220,69 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "tag.filtered_artworks.edges.node.mediumType.filterGene.id": (v21/*: any*/),
-        "tag.filtered_artworks.edges.node.mediumType.filterGene.name": (v23/*: any*/),
+        "tag.filtered_artworks.edges.node.mediumType.filterGene.id": (v22/*: any*/),
+        "tag.filtered_artworks.edges.node.mediumType.filterGene.name": (v24/*: any*/),
         "tag.filtered_artworks.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "tag.filtered_artworks.edges.node.partner.href": (v23/*: any*/),
-        "tag.filtered_artworks.edges.node.partner.id": (v21/*: any*/),
-        "tag.filtered_artworks.edges.node.partner.name": (v23/*: any*/),
+        "tag.filtered_artworks.edges.node.partner.href": (v24/*: any*/),
+        "tag.filtered_artworks.edges.node.partner.id": (v22/*: any*/),
+        "tag.filtered_artworks.edges.node.partner.name": (v24/*: any*/),
         "tag.filtered_artworks.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "tag.filtered_artworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v26/*: any*/),
-        "tag.filtered_artworks.edges.node.sale.endAt": (v23/*: any*/),
-        "tag.filtered_artworks.edges.node.sale.extendedBiddingIntervalMinutes": (v26/*: any*/),
-        "tag.filtered_artworks.edges.node.sale.extendedBiddingPeriodMinutes": (v26/*: any*/),
-        "tag.filtered_artworks.edges.node.sale.id": (v21/*: any*/),
-        "tag.filtered_artworks.edges.node.sale.isOpen": (v22/*: any*/),
-        "tag.filtered_artworks.edges.node.sale.is_auction": (v22/*: any*/),
-        "tag.filtered_artworks.edges.node.sale.is_closed": (v22/*: any*/),
-        "tag.filtered_artworks.edges.node.sale.startAt": (v23/*: any*/),
-        "tag.filtered_artworks.edges.node.saleArtwork": (v27/*: any*/),
-        "tag.filtered_artworks.edges.node.saleArtwork.endAt": (v23/*: any*/),
-        "tag.filtered_artworks.edges.node.saleArtwork.extendedBiddingEndAt": (v23/*: any*/),
-        "tag.filtered_artworks.edges.node.saleArtwork.id": (v21/*: any*/),
-        "tag.filtered_artworks.edges.node.saleArtwork.lotID": (v23/*: any*/),
-        "tag.filtered_artworks.edges.node.sale_artwork": (v27/*: any*/),
+        "tag.filtered_artworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v27/*: any*/),
+        "tag.filtered_artworks.edges.node.sale.endAt": (v24/*: any*/),
+        "tag.filtered_artworks.edges.node.sale.extendedBiddingIntervalMinutes": (v27/*: any*/),
+        "tag.filtered_artworks.edges.node.sale.extendedBiddingPeriodMinutes": (v27/*: any*/),
+        "tag.filtered_artworks.edges.node.sale.id": (v22/*: any*/),
+        "tag.filtered_artworks.edges.node.sale.isOpen": (v23/*: any*/),
+        "tag.filtered_artworks.edges.node.sale.is_auction": (v23/*: any*/),
+        "tag.filtered_artworks.edges.node.sale.is_closed": (v23/*: any*/),
+        "tag.filtered_artworks.edges.node.sale.startAt": (v24/*: any*/),
+        "tag.filtered_artworks.edges.node.saleArtwork": (v28/*: any*/),
+        "tag.filtered_artworks.edges.node.saleArtwork.endAt": (v24/*: any*/),
+        "tag.filtered_artworks.edges.node.saleArtwork.extendedBiddingEndAt": (v24/*: any*/),
+        "tag.filtered_artworks.edges.node.saleArtwork.id": (v22/*: any*/),
+        "tag.filtered_artworks.edges.node.saleArtwork.lotID": (v24/*: any*/),
+        "tag.filtered_artworks.edges.node.sale_artwork": (v28/*: any*/),
         "tag.filtered_artworks.edges.node.sale_artwork.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkCounts"
         },
-        "tag.filtered_artworks.edges.node.sale_artwork.counts.bidder_positions": (v20/*: any*/),
-        "tag.filtered_artworks.edges.node.sale_artwork.endAt": (v23/*: any*/),
-        "tag.filtered_artworks.edges.node.sale_artwork.extendedBiddingEndAt": (v23/*: any*/),
-        "tag.filtered_artworks.edges.node.sale_artwork.formattedEndDateTime": (v23/*: any*/),
+        "tag.filtered_artworks.edges.node.sale_artwork.counts.bidder_positions": (v21/*: any*/),
+        "tag.filtered_artworks.edges.node.sale_artwork.endAt": (v24/*: any*/),
+        "tag.filtered_artworks.edges.node.sale_artwork.extendedBiddingEndAt": (v24/*: any*/),
+        "tag.filtered_artworks.edges.node.sale_artwork.formattedEndDateTime": (v24/*: any*/),
         "tag.filtered_artworks.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "tag.filtered_artworks.edges.node.sale_artwork.highest_bid.display": (v23/*: any*/),
-        "tag.filtered_artworks.edges.node.sale_artwork.id": (v21/*: any*/),
-        "tag.filtered_artworks.edges.node.sale_artwork.lotID": (v23/*: any*/),
-        "tag.filtered_artworks.edges.node.sale_artwork.lotLabel": (v23/*: any*/),
+        "tag.filtered_artworks.edges.node.sale_artwork.highest_bid.display": (v24/*: any*/),
+        "tag.filtered_artworks.edges.node.sale_artwork.id": (v22/*: any*/),
+        "tag.filtered_artworks.edges.node.sale_artwork.lotID": (v24/*: any*/),
+        "tag.filtered_artworks.edges.node.sale_artwork.lotLabel": (v24/*: any*/),
         "tag.filtered_artworks.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "tag.filtered_artworks.edges.node.sale_artwork.opening_bid.display": (v23/*: any*/),
-        "tag.filtered_artworks.edges.node.sale_message": (v23/*: any*/),
-        "tag.filtered_artworks.edges.node.slug": (v21/*: any*/),
-        "tag.filtered_artworks.edges.node.title": (v23/*: any*/),
-        "tag.filtered_artworks.id": (v21/*: any*/),
+        "tag.filtered_artworks.edges.node.sale_artwork.opening_bid.display": (v24/*: any*/),
+        "tag.filtered_artworks.edges.node.sale_message": (v24/*: any*/),
+        "tag.filtered_artworks.edges.node.slug": (v22/*: any*/),
+        "tag.filtered_artworks.edges.node.title": (v24/*: any*/),
+        "tag.filtered_artworks.id": (v22/*: any*/),
         "tag.filtered_artworks.pageCursors": {
           "enumValues": null,
           "nullable": false,
@@ -1307,31 +1295,31 @@ return {
           "plural": true,
           "type": "PageCursor"
         },
-        "tag.filtered_artworks.pageCursors.around.cursor": (v18/*: any*/),
-        "tag.filtered_artworks.pageCursors.around.isCurrent": (v25/*: any*/),
-        "tag.filtered_artworks.pageCursors.around.page": (v24/*: any*/),
-        "tag.filtered_artworks.pageCursors.first": (v28/*: any*/),
-        "tag.filtered_artworks.pageCursors.first.cursor": (v18/*: any*/),
-        "tag.filtered_artworks.pageCursors.first.isCurrent": (v25/*: any*/),
-        "tag.filtered_artworks.pageCursors.first.page": (v24/*: any*/),
-        "tag.filtered_artworks.pageCursors.last": (v28/*: any*/),
-        "tag.filtered_artworks.pageCursors.last.cursor": (v18/*: any*/),
-        "tag.filtered_artworks.pageCursors.last.isCurrent": (v25/*: any*/),
-        "tag.filtered_artworks.pageCursors.last.page": (v24/*: any*/),
-        "tag.filtered_artworks.pageCursors.previous": (v28/*: any*/),
-        "tag.filtered_artworks.pageCursors.previous.cursor": (v18/*: any*/),
-        "tag.filtered_artworks.pageCursors.previous.page": (v24/*: any*/),
+        "tag.filtered_artworks.pageCursors.around.cursor": (v19/*: any*/),
+        "tag.filtered_artworks.pageCursors.around.isCurrent": (v26/*: any*/),
+        "tag.filtered_artworks.pageCursors.around.page": (v25/*: any*/),
+        "tag.filtered_artworks.pageCursors.first": (v29/*: any*/),
+        "tag.filtered_artworks.pageCursors.first.cursor": (v19/*: any*/),
+        "tag.filtered_artworks.pageCursors.first.isCurrent": (v26/*: any*/),
+        "tag.filtered_artworks.pageCursors.first.page": (v25/*: any*/),
+        "tag.filtered_artworks.pageCursors.last": (v29/*: any*/),
+        "tag.filtered_artworks.pageCursors.last.cursor": (v19/*: any*/),
+        "tag.filtered_artworks.pageCursors.last.isCurrent": (v26/*: any*/),
+        "tag.filtered_artworks.pageCursors.last.page": (v25/*: any*/),
+        "tag.filtered_artworks.pageCursors.previous": (v29/*: any*/),
+        "tag.filtered_artworks.pageCursors.previous.cursor": (v19/*: any*/),
+        "tag.filtered_artworks.pageCursors.previous.page": (v25/*: any*/),
         "tag.filtered_artworks.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "tag.filtered_artworks.pageInfo.endCursor": (v23/*: any*/),
-        "tag.filtered_artworks.pageInfo.hasNextPage": (v25/*: any*/),
-        "tag.id": (v21/*: any*/),
-        "tag.internalID": (v21/*: any*/),
-        "tag.sidebar": (v17/*: any*/),
+        "tag.filtered_artworks.pageInfo.endCursor": (v24/*: any*/),
+        "tag.filtered_artworks.pageInfo.hasNextPage": (v26/*: any*/),
+        "tag.id": (v22/*: any*/),
+        "tag.internalID": (v22/*: any*/),
+        "tag.sidebar": (v18/*: any*/),
         "tag.sidebar.aggregations": {
           "enumValues": null,
           "nullable": true,
@@ -1344,9 +1332,9 @@ return {
           "plural": true,
           "type": "AggregationCount"
         },
-        "tag.sidebar.aggregations.counts.count": (v24/*: any*/),
-        "tag.sidebar.aggregations.counts.name": (v18/*: any*/),
-        "tag.sidebar.aggregations.counts.value": (v18/*: any*/),
+        "tag.sidebar.aggregations.counts.count": (v25/*: any*/),
+        "tag.sidebar.aggregations.counts.name": (v19/*: any*/),
+        "tag.sidebar.aggregations.counts.value": (v19/*: any*/),
         "tag.sidebar.aggregations.slice": {
           "enumValues": [
             "ARTIST",
@@ -1374,15 +1362,15 @@ return {
           "plural": false,
           "type": "ArtworkAggregation"
         },
-        "tag.sidebar.counts": (v19/*: any*/),
-        "tag.sidebar.counts.followedArtists": (v20/*: any*/),
-        "tag.sidebar.id": (v21/*: any*/),
-        "tag.slug": (v21/*: any*/)
+        "tag.sidebar.counts": (v20/*: any*/),
+        "tag.sidebar.counts.followedArtists": (v21/*: any*/),
+        "tag.sidebar.id": (v22/*: any*/),
+        "tag.slug": (v22/*: any*/)
       }
     },
     "name": "TagArtworkFilter_Query",
     "operationKind": "query",
-    "text": "query TagArtworkFilter_Query(\n  $slug: String!\n) {\n  tag(id: $slug) {\n    ...TagArtworkFilter_tag_3Rrp9Z\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment TagArtworkFilter_tag_3Rrp9Z on Tag {\n  slug\n  internalID\n  sidebar: filterArtworksConnection(first: 1) {\n    counts {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n"
+    "text": "query TagArtworkFilter_Query(\n  $slug: String!\n) {\n  tag(id: $slug) {\n    ...TagArtworkFilter_tag_3Rrp9Z\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment TagArtworkFilter_tag_3Rrp9Z on Tag {\n  slug\n  internalID\n  sidebar: filterArtworksConnection(first: 1) {\n    counts {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/WorksQuery.graphql.ts
+++ b/src/__generated__/WorksQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4f0ec7e921f553bf909bdaa8763d1837>>
+ * @generated SignedSource<<66805741cfc10d3e6758df9d5ef99bc9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -153,14 +153,17 @@ v10 = [
     "storageKey": null
   }
 ],
-v11 = {
+v11 = [
+  (v7/*: any*/)
+],
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v12 = {
+v13 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -168,14 +171,14 @@ v12 = {
     "large"
   ]
 },
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v14 = [
+v15 = [
   {
     "alias": null,
     "args": null,
@@ -184,28 +187,28 @@ v14 = [
     "storageKey": null
   }
 ],
-v15 = [
+v16 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v18 = [
+v19 = [
   (v6/*: any*/),
   (v7/*: any*/)
 ];
@@ -463,27 +466,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v7/*: any*/)
-                    ],
+                    "selections": (v11/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -516,7 +499,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v4/*: any*/),
-                          (v11/*: any*/),
+                          (v12/*: any*/),
                           (v5/*: any*/),
                           {
                             "alias": null,
@@ -550,7 +533,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v12/*: any*/)
+                                  (v13/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -573,7 +556,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v12/*: any*/),
+                                  (v13/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -658,6 +641,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -709,7 +699,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v13/*: any*/),
+                                  (v14/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -717,7 +707,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v14/*: any*/),
+                                    "selections": (v15/*: any*/),
                                     "storageKey": null
                                   },
                                   (v7/*: any*/)
@@ -743,7 +733,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v15/*: any*/),
+                            "args": (v16/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -791,14 +781,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v15/*: any*/),
+                            "args": (v16/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v7/*: any*/),
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               (v6/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -812,14 +802,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v15/*: any*/),
+                            "args": (v16/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v6/*: any*/),
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               (v7/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -832,7 +822,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v13/*: any*/),
+                              (v14/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -894,7 +884,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v16/*: any*/),
+                              (v17/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -902,8 +892,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v13/*: any*/),
-                              (v17/*: any*/),
+                              (v14/*: any*/),
+                              (v18/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -936,7 +926,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v14/*: any*/),
+                                "selections": (v15/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -946,7 +936,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v14/*: any*/),
+                                "selections": (v15/*: any*/),
                                 "storageKey": null
                               },
                               (v7/*: any*/)
@@ -961,10 +951,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v16/*: any*/),
+                              (v17/*: any*/),
                               (v7/*: any*/),
-                              (v13/*: any*/),
-                              (v17/*: any*/)
+                              (v14/*: any*/),
+                              (v18/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -975,7 +965,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v18/*: any*/),
+                            "selections": (v19/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -993,7 +983,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v18/*: any*/),
+                                "selections": (v19/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -1018,9 +1008,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v7/*: any*/)
-                        ],
+                        "selections": (v11/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1041,12 +1029,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "5728a0b2820ab45b5948315d03e88c42",
+    "cacheID": "3ff701442fb755e4f943581f788150ab",
     "id": null,
     "metadata": {},
     "name": "WorksQuery",
     "operationKind": "query",
-    "text": "query WorksQuery(\n  $partnerId: String!\n  $input: FilterArtworksInput\n) {\n  partner(id: $partnerId) {\n    ...Works_partner_2VV6jB\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment Works_partner_2VV6jB on Partner {\n  slug\n  internalID\n  featuredKeywords\n  sidebar: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n"
+    "text": "query WorksQuery(\n  $partnerId: String!\n  $input: FilterArtworksInput\n) {\n  partner(id: $partnerId) {\n    ...Works_partner_2VV6jB\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment Works_partner_2VV6jB on Partner {\n  slug\n  internalID\n  featuredKeywords\n  sidebar: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/WorksTL_Query.graphql.ts
+++ b/src/__generated__/WorksTL_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0208abc27e92fc256a373f057b501ac9>>
+ * @generated SignedSource<<b89841fe966515b5d7f24d3e62afd1c9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -91,14 +91,17 @@ v8 = [
     "storageKey": null
   }
 ],
-v9 = {
+v9 = [
+  (v5/*: any*/)
+],
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -106,14 +109,14 @@ v10 = {
     "large"
   ]
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v12 = [
+v13 = [
   {
     "alias": null,
     "args": null,
@@ -122,98 +125,98 @@ v12 = [
     "storageKey": null
   }
 ],
-v13 = [
+v14 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v16 = [
+v17 = [
   (v4/*: any*/),
   (v5/*: any*/)
 ],
-v17 = {
+v18 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Partner"
 },
-v18 = {
+v19 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FilterArtworksConnection"
 },
-v19 = {
+v20 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v20 = {
+v21 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FormattedNumber"
 },
-v21 = {
+v22 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v22 = {
+v23 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Boolean"
 },
-v23 = {
+v24 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v24 = {
+v25 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Int"
 },
-v25 = {
+v26 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Boolean"
 },
-v26 = {
+v27 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v27 = {
+v28 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "SaleArtwork"
 },
-v28 = {
+v29 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -464,27 +467,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v5/*: any*/)
-                    ],
+                    "selections": (v9/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -517,7 +500,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v2/*: any*/),
-                          (v9/*: any*/),
+                          (v10/*: any*/),
                           (v3/*: any*/),
                           {
                             "alias": null,
@@ -551,7 +534,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v10/*: any*/)
+                                  (v11/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -574,7 +557,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v10/*: any*/),
+                                  (v11/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -659,6 +642,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -710,7 +700,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v11/*: any*/),
+                                  (v12/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -718,7 +708,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v12/*: any*/),
+                                    "selections": (v13/*: any*/),
                                     "storageKey": null
                                   },
                                   (v5/*: any*/)
@@ -744,7 +734,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -792,14 +782,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v5/*: any*/),
-                              (v9/*: any*/),
+                              (v10/*: any*/),
                               (v4/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -813,14 +803,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v4/*: any*/),
-                              (v9/*: any*/),
+                              (v10/*: any*/),
                               (v5/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -833,7 +823,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -895,7 +885,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v14/*: any*/),
+                              (v15/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -903,8 +893,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v11/*: any*/),
-                              (v15/*: any*/),
+                              (v12/*: any*/),
+                              (v16/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -937,7 +927,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v12/*: any*/),
+                                "selections": (v13/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -947,7 +937,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v12/*: any*/),
+                                "selections": (v13/*: any*/),
                                 "storageKey": null
                               },
                               (v5/*: any*/)
@@ -962,10 +952,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v14/*: any*/),
+                              (v15/*: any*/),
                               (v5/*: any*/),
-                              (v11/*: any*/),
-                              (v15/*: any*/)
+                              (v12/*: any*/),
+                              (v16/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -976,7 +966,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v16/*: any*/),
+                            "selections": (v17/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -994,7 +984,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v16/*: any*/),
+                                "selections": (v17/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -1019,9 +1009,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v5/*: any*/)
-                        ],
+                        "selections": (v9/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1042,35 +1030,35 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a62a8bec5dbf7478962f880c4031ac76",
+    "cacheID": "c16929b683db6d7a0eef92c8d7f0b838",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
-        "partner": (v17/*: any*/),
+        "partner": (v18/*: any*/),
         "partner.featuredKeywords": {
           "enumValues": null,
           "nullable": false,
           "plural": true,
           "type": "String"
         },
-        "partner.filtered_artworks": (v18/*: any*/),
-        "partner.filtered_artworks.__isArtworkConnectionInterface": (v19/*: any*/),
+        "partner.filtered_artworks": (v19/*: any*/),
+        "partner.filtered_artworks.__isArtworkConnectionInterface": (v20/*: any*/),
         "partner.filtered_artworks.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "FilterArtworksCounts"
         },
-        "partner.filtered_artworks.counts.total": (v20/*: any*/),
+        "partner.filtered_artworks.counts.total": (v21/*: any*/),
         "partner.filtered_artworks.edges": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "ArtworkEdgeInterface"
         },
-        "partner.filtered_artworks.edges.__isNode": (v19/*: any*/),
-        "partner.filtered_artworks.edges.__typename": (v19/*: any*/),
-        "partner.filtered_artworks.edges.id": (v21/*: any*/),
+        "partner.filtered_artworks.edges.__isNode": (v20/*: any*/),
+        "partner.filtered_artworks.edges.__typename": (v20/*: any*/),
+        "partner.filtered_artworks.edges.id": (v22/*: any*/),
         "partner.filtered_artworks.edges.node": {
           "enumValues": null,
           "nullable": true,
@@ -1083,33 +1071,33 @@ return {
           "plural": false,
           "type": "Artist"
         },
-        "partner.filtered_artworks.edges.node.artist.id": (v21/*: any*/),
+        "partner.filtered_artworks.edges.node.artist.id": (v22/*: any*/),
         "partner.filtered_artworks.edges.node.artist.targetSupply": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "ArtistTargetSupply"
         },
-        "partner.filtered_artworks.edges.node.artist.targetSupply.isP1": (v22/*: any*/),
-        "partner.filtered_artworks.edges.node.artistNames": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.artist.targetSupply.isP1": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.artistNames": (v24/*: any*/),
         "partner.filtered_artworks.edges.node.artists": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Artist"
         },
-        "partner.filtered_artworks.edges.node.artists.href": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.artists.id": (v21/*: any*/),
-        "partner.filtered_artworks.edges.node.artists.name": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.artists.href": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.artists.id": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.artists.name": (v24/*: any*/),
         "partner.filtered_artworks.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "partner.filtered_artworks.edges.node.attributionClass.id": (v21/*: any*/),
-        "partner.filtered_artworks.edges.node.attributionClass.name": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.collecting_institution": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.attributionClass.id": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.attributionClass.name": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.collecting_institution": (v24/*: any*/),
         "partner.filtered_artworks.edges.node.collectorSignals": {
           "enumValues": null,
           "nullable": true,
@@ -1122,26 +1110,26 @@ return {
           "plural": false,
           "type": "AuctionCollectorSignals"
         },
-        "partner.filtered_artworks.edges.node.collectorSignals.auction.bidCount": (v24/*: any*/),
-        "partner.filtered_artworks.edges.node.collectorSignals.auction.liveBiddingStarted": (v25/*: any*/),
-        "partner.filtered_artworks.edges.node.collectorSignals.auction.lotClosesAt": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.collectorSignals.auction.onlineBiddingExtended": (v25/*: any*/),
-        "partner.filtered_artworks.edges.node.collectorSignals.auction.registrationEndsAt": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.collectorSignals.auction.bidCount": (v25/*: any*/),
+        "partner.filtered_artworks.edges.node.collectorSignals.auction.liveBiddingStarted": (v26/*: any*/),
+        "partner.filtered_artworks.edges.node.collectorSignals.auction.lotClosesAt": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.collectorSignals.auction.onlineBiddingExtended": (v26/*: any*/),
+        "partner.filtered_artworks.edges.node.collectorSignals.auction.registrationEndsAt": (v24/*: any*/),
         "partner.filtered_artworks.edges.node.collectorSignals.partnerOffer": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "PartnerOfferToCollector"
         },
-        "partner.filtered_artworks.edges.node.collectorSignals.partnerOffer.endAt": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.collectorSignals.partnerOffer.id": (v21/*: any*/),
+        "partner.filtered_artworks.edges.node.collectorSignals.partnerOffer.endAt": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.collectorSignals.partnerOffer.id": (v22/*: any*/),
         "partner.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Money"
         },
-        "partner.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v24/*: any*/),
         "partner.filtered_artworks.edges.node.collectorSignals.primaryLabel": {
           "enumValues": [
             "CURATORS_PICK",
@@ -1152,10 +1140,10 @@ return {
           "plural": false,
           "type": "LabelSignalEnum"
         },
-        "partner.filtered_artworks.edges.node.cultural_maker": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.date": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.href": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.id": (v21/*: any*/),
+        "partner.filtered_artworks.edges.node.cultural_maker": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.date": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.href": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.id": (v22/*: any*/),
         "partner.filtered_artworks.edges.node.image": {
           "enumValues": null,
           "nullable": true,
@@ -1168,35 +1156,35 @@ return {
           "plural": false,
           "type": "Float"
         },
-        "partner.filtered_artworks.edges.node.image.blurhashDataURL": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.image.blurhashDataURL": (v24/*: any*/),
         "partner.filtered_artworks.edges.node.image.internalID": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ID"
         },
-        "partner.filtered_artworks.edges.node.image.placeholder": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.image.placeholder": (v24/*: any*/),
         "partner.filtered_artworks.edges.node.image.resized": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ResizedImageUrl"
         },
-        "partner.filtered_artworks.edges.node.image.resized.height": (v26/*: any*/),
-        "partner.filtered_artworks.edges.node.image.resized.src": (v19/*: any*/),
-        "partner.filtered_artworks.edges.node.image.resized.srcSet": (v19/*: any*/),
-        "partner.filtered_artworks.edges.node.image.resized.width": (v26/*: any*/),
-        "partner.filtered_artworks.edges.node.image.url": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.image.resized.height": (v27/*: any*/),
+        "partner.filtered_artworks.edges.node.image.resized.src": (v20/*: any*/),
+        "partner.filtered_artworks.edges.node.image.resized.srcSet": (v20/*: any*/),
+        "partner.filtered_artworks.edges.node.image.resized.width": (v27/*: any*/),
+        "partner.filtered_artworks.edges.node.image.url": (v24/*: any*/),
         "partner.filtered_artworks.edges.node.image.versions": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "String"
         },
-        "partner.filtered_artworks.edges.node.imageTitle": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.image_title": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.internalID": (v21/*: any*/),
-        "partner.filtered_artworks.edges.node.isUnlisted": (v25/*: any*/),
+        "partner.filtered_artworks.edges.node.imageTitle": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.image_title": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.internalID": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.isUnlisted": (v26/*: any*/),
         "partner.filtered_artworks.edges.node.marketPriceInsights": {
           "enumValues": null,
           "nullable": true,
@@ -1221,64 +1209,64 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "partner.filtered_artworks.edges.node.mediumType.filterGene.id": (v21/*: any*/),
-        "partner.filtered_artworks.edges.node.mediumType.filterGene.name": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.partner": (v17/*: any*/),
-        "partner.filtered_artworks.edges.node.partner.href": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.partner.id": (v21/*: any*/),
-        "partner.filtered_artworks.edges.node.partner.name": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.mediumType.filterGene.id": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.mediumType.filterGene.name": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.partner": (v18/*: any*/),
+        "partner.filtered_artworks.edges.node.partner.href": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.partner.id": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.partner.name": (v24/*: any*/),
         "partner.filtered_artworks.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "partner.filtered_artworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v26/*: any*/),
-        "partner.filtered_artworks.edges.node.sale.endAt": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.sale.extendedBiddingIntervalMinutes": (v26/*: any*/),
-        "partner.filtered_artworks.edges.node.sale.extendedBiddingPeriodMinutes": (v26/*: any*/),
-        "partner.filtered_artworks.edges.node.sale.id": (v21/*: any*/),
-        "partner.filtered_artworks.edges.node.sale.isOpen": (v22/*: any*/),
-        "partner.filtered_artworks.edges.node.sale.is_auction": (v22/*: any*/),
-        "partner.filtered_artworks.edges.node.sale.is_closed": (v22/*: any*/),
-        "partner.filtered_artworks.edges.node.sale.startAt": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.saleArtwork": (v27/*: any*/),
-        "partner.filtered_artworks.edges.node.saleArtwork.endAt": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.saleArtwork.extendedBiddingEndAt": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.saleArtwork.id": (v21/*: any*/),
-        "partner.filtered_artworks.edges.node.saleArtwork.lotID": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.sale_artwork": (v27/*: any*/),
+        "partner.filtered_artworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v27/*: any*/),
+        "partner.filtered_artworks.edges.node.sale.endAt": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.sale.extendedBiddingIntervalMinutes": (v27/*: any*/),
+        "partner.filtered_artworks.edges.node.sale.extendedBiddingPeriodMinutes": (v27/*: any*/),
+        "partner.filtered_artworks.edges.node.sale.id": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.sale.isOpen": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.sale.is_auction": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.sale.is_closed": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.sale.startAt": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.saleArtwork": (v28/*: any*/),
+        "partner.filtered_artworks.edges.node.saleArtwork.endAt": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.saleArtwork.extendedBiddingEndAt": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.saleArtwork.id": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.saleArtwork.lotID": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork": (v28/*: any*/),
         "partner.filtered_artworks.edges.node.sale_artwork.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkCounts"
         },
-        "partner.filtered_artworks.edges.node.sale_artwork.counts.bidder_positions": (v20/*: any*/),
-        "partner.filtered_artworks.edges.node.sale_artwork.endAt": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.sale_artwork.extendedBiddingEndAt": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.sale_artwork.formattedEndDateTime": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork.counts.bidder_positions": (v21/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork.endAt": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork.extendedBiddingEndAt": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork.formattedEndDateTime": (v24/*: any*/),
         "partner.filtered_artworks.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "partner.filtered_artworks.edges.node.sale_artwork.highest_bid.display": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.sale_artwork.id": (v21/*: any*/),
-        "partner.filtered_artworks.edges.node.sale_artwork.lotID": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.sale_artwork.lotLabel": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork.highest_bid.display": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork.id": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork.lotID": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork.lotLabel": (v24/*: any*/),
         "partner.filtered_artworks.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "partner.filtered_artworks.edges.node.sale_artwork.opening_bid.display": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.sale_message": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.slug": (v21/*: any*/),
-        "partner.filtered_artworks.edges.node.title": (v23/*: any*/),
-        "partner.filtered_artworks.id": (v21/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork.opening_bid.display": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_message": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.slug": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.title": (v24/*: any*/),
+        "partner.filtered_artworks.id": (v22/*: any*/),
         "partner.filtered_artworks.pageCursors": {
           "enumValues": null,
           "nullable": false,
@@ -1291,31 +1279,31 @@ return {
           "plural": true,
           "type": "PageCursor"
         },
-        "partner.filtered_artworks.pageCursors.around.cursor": (v19/*: any*/),
-        "partner.filtered_artworks.pageCursors.around.isCurrent": (v25/*: any*/),
-        "partner.filtered_artworks.pageCursors.around.page": (v24/*: any*/),
-        "partner.filtered_artworks.pageCursors.first": (v28/*: any*/),
-        "partner.filtered_artworks.pageCursors.first.cursor": (v19/*: any*/),
-        "partner.filtered_artworks.pageCursors.first.isCurrent": (v25/*: any*/),
-        "partner.filtered_artworks.pageCursors.first.page": (v24/*: any*/),
-        "partner.filtered_artworks.pageCursors.last": (v28/*: any*/),
-        "partner.filtered_artworks.pageCursors.last.cursor": (v19/*: any*/),
-        "partner.filtered_artworks.pageCursors.last.isCurrent": (v25/*: any*/),
-        "partner.filtered_artworks.pageCursors.last.page": (v24/*: any*/),
-        "partner.filtered_artworks.pageCursors.previous": (v28/*: any*/),
-        "partner.filtered_artworks.pageCursors.previous.cursor": (v19/*: any*/),
-        "partner.filtered_artworks.pageCursors.previous.page": (v24/*: any*/),
+        "partner.filtered_artworks.pageCursors.around.cursor": (v20/*: any*/),
+        "partner.filtered_artworks.pageCursors.around.isCurrent": (v26/*: any*/),
+        "partner.filtered_artworks.pageCursors.around.page": (v25/*: any*/),
+        "partner.filtered_artworks.pageCursors.first": (v29/*: any*/),
+        "partner.filtered_artworks.pageCursors.first.cursor": (v20/*: any*/),
+        "partner.filtered_artworks.pageCursors.first.isCurrent": (v26/*: any*/),
+        "partner.filtered_artworks.pageCursors.first.page": (v25/*: any*/),
+        "partner.filtered_artworks.pageCursors.last": (v29/*: any*/),
+        "partner.filtered_artworks.pageCursors.last.cursor": (v20/*: any*/),
+        "partner.filtered_artworks.pageCursors.last.isCurrent": (v26/*: any*/),
+        "partner.filtered_artworks.pageCursors.last.page": (v25/*: any*/),
+        "partner.filtered_artworks.pageCursors.previous": (v29/*: any*/),
+        "partner.filtered_artworks.pageCursors.previous.cursor": (v20/*: any*/),
+        "partner.filtered_artworks.pageCursors.previous.page": (v25/*: any*/),
         "partner.filtered_artworks.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "partner.filtered_artworks.pageInfo.endCursor": (v23/*: any*/),
-        "partner.filtered_artworks.pageInfo.hasNextPage": (v25/*: any*/),
-        "partner.id": (v21/*: any*/),
-        "partner.internalID": (v21/*: any*/),
-        "partner.sidebar": (v18/*: any*/),
+        "partner.filtered_artworks.pageInfo.endCursor": (v24/*: any*/),
+        "partner.filtered_artworks.pageInfo.hasNextPage": (v26/*: any*/),
+        "partner.id": (v22/*: any*/),
+        "partner.internalID": (v22/*: any*/),
+        "partner.sidebar": (v19/*: any*/),
         "partner.sidebar.aggregations": {
           "enumValues": null,
           "nullable": true,
@@ -1328,9 +1316,9 @@ return {
           "plural": true,
           "type": "AggregationCount"
         },
-        "partner.sidebar.aggregations.counts.count": (v24/*: any*/),
-        "partner.sidebar.aggregations.counts.name": (v19/*: any*/),
-        "partner.sidebar.aggregations.counts.value": (v19/*: any*/),
+        "partner.sidebar.aggregations.counts.count": (v25/*: any*/),
+        "partner.sidebar.aggregations.counts.name": (v20/*: any*/),
+        "partner.sidebar.aggregations.counts.value": (v20/*: any*/),
         "partner.sidebar.aggregations.slice": {
           "enumValues": [
             "ARTIST",
@@ -1358,13 +1346,13 @@ return {
           "plural": false,
           "type": "ArtworkAggregation"
         },
-        "partner.sidebar.id": (v21/*: any*/),
-        "partner.slug": (v21/*: any*/)
+        "partner.sidebar.id": (v22/*: any*/),
+        "partner.slug": (v22/*: any*/)
       }
     },
     "name": "WorksTL_Query",
     "operationKind": "query",
-    "text": "query WorksTL_Query(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) {\n    ...Works_partner\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment Works_partner on Partner {\n  slug\n  internalID\n  featuredKeywords\n  sidebar: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n"
+    "text": "query WorksTL_Query(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) {\n    ...Works_partner\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment Works_partner on Partner {\n  slug\n  internalID\n  featuredKeywords\n  sidebar: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/Works_Query.graphql.ts
+++ b/src/__generated__/Works_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<20939b6a5e21a4404f1d938d8f30df6e>>
+ * @generated SignedSource<<a6a4ead9d777e47e0fe35eda61eed3d8>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -91,14 +91,17 @@ v8 = [
     "storageKey": null
   }
 ],
-v9 = {
+v9 = [
+  (v5/*: any*/)
+],
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -106,14 +109,14 @@ v10 = {
     "large"
   ]
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v12 = [
+v13 = [
   {
     "alias": null,
     "args": null,
@@ -122,98 +125,98 @@ v12 = [
     "storageKey": null
   }
 ],
-v13 = [
+v14 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v16 = [
+v17 = [
   (v4/*: any*/),
   (v5/*: any*/)
 ],
-v17 = {
+v18 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Partner"
 },
-v18 = {
+v19 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FilterArtworksConnection"
 },
-v19 = {
+v20 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v20 = {
+v21 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "FormattedNumber"
 },
-v21 = {
+v22 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v22 = {
+v23 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Boolean"
 },
-v23 = {
+v24 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v24 = {
+v25 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Int"
 },
-v25 = {
+v26 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Boolean"
 },
-v26 = {
+v27 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v27 = {
+v28 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "SaleArtwork"
 },
-v28 = {
+v29 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -464,27 +467,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v5/*: any*/)
-                    ],
+                    "selections": (v9/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -517,7 +500,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v2/*: any*/),
-                          (v9/*: any*/),
+                          (v10/*: any*/),
                           (v3/*: any*/),
                           {
                             "alias": null,
@@ -551,7 +534,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v10/*: any*/)
+                                  (v11/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -574,7 +557,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v10/*: any*/),
+                                  (v11/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -659,6 +642,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -710,7 +700,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v11/*: any*/),
+                                  (v12/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -718,7 +708,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v12/*: any*/),
+                                    "selections": (v13/*: any*/),
                                     "storageKey": null
                                   },
                                   (v5/*: any*/)
@@ -744,7 +734,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -792,14 +782,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v5/*: any*/),
-                              (v9/*: any*/),
+                              (v10/*: any*/),
                               (v4/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -813,14 +803,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v13/*: any*/),
+                            "args": (v14/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v4/*: any*/),
-                              (v9/*: any*/),
+                              (v10/*: any*/),
                               (v5/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -833,7 +823,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v11/*: any*/),
+                              (v12/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -895,7 +885,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v14/*: any*/),
+                              (v15/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -903,8 +893,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v11/*: any*/),
-                              (v15/*: any*/),
+                              (v12/*: any*/),
+                              (v16/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -937,7 +927,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v12/*: any*/),
+                                "selections": (v13/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -947,7 +937,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v12/*: any*/),
+                                "selections": (v13/*: any*/),
                                 "storageKey": null
                               },
                               (v5/*: any*/)
@@ -962,10 +952,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v14/*: any*/),
+                              (v15/*: any*/),
                               (v5/*: any*/),
-                              (v11/*: any*/),
-                              (v15/*: any*/)
+                              (v12/*: any*/),
+                              (v16/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -976,7 +966,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v16/*: any*/),
+                            "selections": (v17/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -994,7 +984,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v16/*: any*/),
+                                "selections": (v17/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -1019,9 +1009,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v5/*: any*/)
-                        ],
+                        "selections": (v9/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1042,35 +1030,35 @@ return {
     ]
   },
   "params": {
-    "cacheID": "29e581bc7627e0c07e34f1469528ef9e",
+    "cacheID": "271fc67c4851d3ed020cfc5ce2438c44",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
-        "partner": (v17/*: any*/),
+        "partner": (v18/*: any*/),
         "partner.featuredKeywords": {
           "enumValues": null,
           "nullable": false,
           "plural": true,
           "type": "String"
         },
-        "partner.filtered_artworks": (v18/*: any*/),
-        "partner.filtered_artworks.__isArtworkConnectionInterface": (v19/*: any*/),
+        "partner.filtered_artworks": (v19/*: any*/),
+        "partner.filtered_artworks.__isArtworkConnectionInterface": (v20/*: any*/),
         "partner.filtered_artworks.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "FilterArtworksCounts"
         },
-        "partner.filtered_artworks.counts.total": (v20/*: any*/),
+        "partner.filtered_artworks.counts.total": (v21/*: any*/),
         "partner.filtered_artworks.edges": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "ArtworkEdgeInterface"
         },
-        "partner.filtered_artworks.edges.__isNode": (v19/*: any*/),
-        "partner.filtered_artworks.edges.__typename": (v19/*: any*/),
-        "partner.filtered_artworks.edges.id": (v21/*: any*/),
+        "partner.filtered_artworks.edges.__isNode": (v20/*: any*/),
+        "partner.filtered_artworks.edges.__typename": (v20/*: any*/),
+        "partner.filtered_artworks.edges.id": (v22/*: any*/),
         "partner.filtered_artworks.edges.node": {
           "enumValues": null,
           "nullable": true,
@@ -1083,33 +1071,33 @@ return {
           "plural": false,
           "type": "Artist"
         },
-        "partner.filtered_artworks.edges.node.artist.id": (v21/*: any*/),
+        "partner.filtered_artworks.edges.node.artist.id": (v22/*: any*/),
         "partner.filtered_artworks.edges.node.artist.targetSupply": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "ArtistTargetSupply"
         },
-        "partner.filtered_artworks.edges.node.artist.targetSupply.isP1": (v22/*: any*/),
-        "partner.filtered_artworks.edges.node.artistNames": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.artist.targetSupply.isP1": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.artistNames": (v24/*: any*/),
         "partner.filtered_artworks.edges.node.artists": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Artist"
         },
-        "partner.filtered_artworks.edges.node.artists.href": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.artists.id": (v21/*: any*/),
-        "partner.filtered_artworks.edges.node.artists.name": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.artists.href": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.artists.id": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.artists.name": (v24/*: any*/),
         "partner.filtered_artworks.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "partner.filtered_artworks.edges.node.attributionClass.id": (v21/*: any*/),
-        "partner.filtered_artworks.edges.node.attributionClass.name": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.collecting_institution": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.attributionClass.id": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.attributionClass.name": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.collecting_institution": (v24/*: any*/),
         "partner.filtered_artworks.edges.node.collectorSignals": {
           "enumValues": null,
           "nullable": true,
@@ -1122,26 +1110,26 @@ return {
           "plural": false,
           "type": "AuctionCollectorSignals"
         },
-        "partner.filtered_artworks.edges.node.collectorSignals.auction.bidCount": (v24/*: any*/),
-        "partner.filtered_artworks.edges.node.collectorSignals.auction.liveBiddingStarted": (v25/*: any*/),
-        "partner.filtered_artworks.edges.node.collectorSignals.auction.lotClosesAt": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.collectorSignals.auction.onlineBiddingExtended": (v25/*: any*/),
-        "partner.filtered_artworks.edges.node.collectorSignals.auction.registrationEndsAt": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.collectorSignals.auction.bidCount": (v25/*: any*/),
+        "partner.filtered_artworks.edges.node.collectorSignals.auction.liveBiddingStarted": (v26/*: any*/),
+        "partner.filtered_artworks.edges.node.collectorSignals.auction.lotClosesAt": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.collectorSignals.auction.onlineBiddingExtended": (v26/*: any*/),
+        "partner.filtered_artworks.edges.node.collectorSignals.auction.registrationEndsAt": (v24/*: any*/),
         "partner.filtered_artworks.edges.node.collectorSignals.partnerOffer": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "PartnerOfferToCollector"
         },
-        "partner.filtered_artworks.edges.node.collectorSignals.partnerOffer.endAt": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.collectorSignals.partnerOffer.id": (v21/*: any*/),
+        "partner.filtered_artworks.edges.node.collectorSignals.partnerOffer.endAt": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.collectorSignals.partnerOffer.id": (v22/*: any*/),
         "partner.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Money"
         },
-        "partner.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v24/*: any*/),
         "partner.filtered_artworks.edges.node.collectorSignals.primaryLabel": {
           "enumValues": [
             "CURATORS_PICK",
@@ -1152,10 +1140,10 @@ return {
           "plural": false,
           "type": "LabelSignalEnum"
         },
-        "partner.filtered_artworks.edges.node.cultural_maker": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.date": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.href": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.id": (v21/*: any*/),
+        "partner.filtered_artworks.edges.node.cultural_maker": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.date": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.href": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.id": (v22/*: any*/),
         "partner.filtered_artworks.edges.node.image": {
           "enumValues": null,
           "nullable": true,
@@ -1168,35 +1156,35 @@ return {
           "plural": false,
           "type": "Float"
         },
-        "partner.filtered_artworks.edges.node.image.blurhashDataURL": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.image.blurhashDataURL": (v24/*: any*/),
         "partner.filtered_artworks.edges.node.image.internalID": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ID"
         },
-        "partner.filtered_artworks.edges.node.image.placeholder": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.image.placeholder": (v24/*: any*/),
         "partner.filtered_artworks.edges.node.image.resized": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ResizedImageUrl"
         },
-        "partner.filtered_artworks.edges.node.image.resized.height": (v26/*: any*/),
-        "partner.filtered_artworks.edges.node.image.resized.src": (v19/*: any*/),
-        "partner.filtered_artworks.edges.node.image.resized.srcSet": (v19/*: any*/),
-        "partner.filtered_artworks.edges.node.image.resized.width": (v26/*: any*/),
-        "partner.filtered_artworks.edges.node.image.url": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.image.resized.height": (v27/*: any*/),
+        "partner.filtered_artworks.edges.node.image.resized.src": (v20/*: any*/),
+        "partner.filtered_artworks.edges.node.image.resized.srcSet": (v20/*: any*/),
+        "partner.filtered_artworks.edges.node.image.resized.width": (v27/*: any*/),
+        "partner.filtered_artworks.edges.node.image.url": (v24/*: any*/),
         "partner.filtered_artworks.edges.node.image.versions": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "String"
         },
-        "partner.filtered_artworks.edges.node.imageTitle": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.image_title": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.internalID": (v21/*: any*/),
-        "partner.filtered_artworks.edges.node.isUnlisted": (v25/*: any*/),
+        "partner.filtered_artworks.edges.node.imageTitle": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.image_title": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.internalID": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.isUnlisted": (v26/*: any*/),
         "partner.filtered_artworks.edges.node.marketPriceInsights": {
           "enumValues": null,
           "nullable": true,
@@ -1221,64 +1209,64 @@ return {
           "plural": false,
           "type": "Gene"
         },
-        "partner.filtered_artworks.edges.node.mediumType.filterGene.id": (v21/*: any*/),
-        "partner.filtered_artworks.edges.node.mediumType.filterGene.name": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.partner": (v17/*: any*/),
-        "partner.filtered_artworks.edges.node.partner.href": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.partner.id": (v21/*: any*/),
-        "partner.filtered_artworks.edges.node.partner.name": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.mediumType.filterGene.id": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.mediumType.filterGene.name": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.partner": (v18/*: any*/),
+        "partner.filtered_artworks.edges.node.partner.href": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.partner.id": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.partner.name": (v24/*: any*/),
         "partner.filtered_artworks.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "partner.filtered_artworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v26/*: any*/),
-        "partner.filtered_artworks.edges.node.sale.endAt": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.sale.extendedBiddingIntervalMinutes": (v26/*: any*/),
-        "partner.filtered_artworks.edges.node.sale.extendedBiddingPeriodMinutes": (v26/*: any*/),
-        "partner.filtered_artworks.edges.node.sale.id": (v21/*: any*/),
-        "partner.filtered_artworks.edges.node.sale.isOpen": (v22/*: any*/),
-        "partner.filtered_artworks.edges.node.sale.is_auction": (v22/*: any*/),
-        "partner.filtered_artworks.edges.node.sale.is_closed": (v22/*: any*/),
-        "partner.filtered_artworks.edges.node.sale.startAt": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.saleArtwork": (v27/*: any*/),
-        "partner.filtered_artworks.edges.node.saleArtwork.endAt": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.saleArtwork.extendedBiddingEndAt": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.saleArtwork.id": (v21/*: any*/),
-        "partner.filtered_artworks.edges.node.saleArtwork.lotID": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.sale_artwork": (v27/*: any*/),
+        "partner.filtered_artworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v27/*: any*/),
+        "partner.filtered_artworks.edges.node.sale.endAt": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.sale.extendedBiddingIntervalMinutes": (v27/*: any*/),
+        "partner.filtered_artworks.edges.node.sale.extendedBiddingPeriodMinutes": (v27/*: any*/),
+        "partner.filtered_artworks.edges.node.sale.id": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.sale.isOpen": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.sale.is_auction": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.sale.is_closed": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.sale.startAt": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.saleArtwork": (v28/*: any*/),
+        "partner.filtered_artworks.edges.node.saleArtwork.endAt": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.saleArtwork.extendedBiddingEndAt": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.saleArtwork.id": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.saleArtwork.lotID": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork": (v28/*: any*/),
         "partner.filtered_artworks.edges.node.sale_artwork.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkCounts"
         },
-        "partner.filtered_artworks.edges.node.sale_artwork.counts.bidder_positions": (v20/*: any*/),
-        "partner.filtered_artworks.edges.node.sale_artwork.endAt": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.sale_artwork.extendedBiddingEndAt": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.sale_artwork.formattedEndDateTime": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork.counts.bidder_positions": (v21/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork.endAt": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork.extendedBiddingEndAt": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork.formattedEndDateTime": (v24/*: any*/),
         "partner.filtered_artworks.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "partner.filtered_artworks.edges.node.sale_artwork.highest_bid.display": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.sale_artwork.id": (v21/*: any*/),
-        "partner.filtered_artworks.edges.node.sale_artwork.lotID": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.sale_artwork.lotLabel": (v23/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork.highest_bid.display": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork.id": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork.lotID": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork.lotLabel": (v24/*: any*/),
         "partner.filtered_artworks.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "partner.filtered_artworks.edges.node.sale_artwork.opening_bid.display": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.sale_message": (v23/*: any*/),
-        "partner.filtered_artworks.edges.node.slug": (v21/*: any*/),
-        "partner.filtered_artworks.edges.node.title": (v23/*: any*/),
-        "partner.filtered_artworks.id": (v21/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_artwork.opening_bid.display": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.sale_message": (v24/*: any*/),
+        "partner.filtered_artworks.edges.node.slug": (v22/*: any*/),
+        "partner.filtered_artworks.edges.node.title": (v24/*: any*/),
+        "partner.filtered_artworks.id": (v22/*: any*/),
         "partner.filtered_artworks.pageCursors": {
           "enumValues": null,
           "nullable": false,
@@ -1291,31 +1279,31 @@ return {
           "plural": true,
           "type": "PageCursor"
         },
-        "partner.filtered_artworks.pageCursors.around.cursor": (v19/*: any*/),
-        "partner.filtered_artworks.pageCursors.around.isCurrent": (v25/*: any*/),
-        "partner.filtered_artworks.pageCursors.around.page": (v24/*: any*/),
-        "partner.filtered_artworks.pageCursors.first": (v28/*: any*/),
-        "partner.filtered_artworks.pageCursors.first.cursor": (v19/*: any*/),
-        "partner.filtered_artworks.pageCursors.first.isCurrent": (v25/*: any*/),
-        "partner.filtered_artworks.pageCursors.first.page": (v24/*: any*/),
-        "partner.filtered_artworks.pageCursors.last": (v28/*: any*/),
-        "partner.filtered_artworks.pageCursors.last.cursor": (v19/*: any*/),
-        "partner.filtered_artworks.pageCursors.last.isCurrent": (v25/*: any*/),
-        "partner.filtered_artworks.pageCursors.last.page": (v24/*: any*/),
-        "partner.filtered_artworks.pageCursors.previous": (v28/*: any*/),
-        "partner.filtered_artworks.pageCursors.previous.cursor": (v19/*: any*/),
-        "partner.filtered_artworks.pageCursors.previous.page": (v24/*: any*/),
+        "partner.filtered_artworks.pageCursors.around.cursor": (v20/*: any*/),
+        "partner.filtered_artworks.pageCursors.around.isCurrent": (v26/*: any*/),
+        "partner.filtered_artworks.pageCursors.around.page": (v25/*: any*/),
+        "partner.filtered_artworks.pageCursors.first": (v29/*: any*/),
+        "partner.filtered_artworks.pageCursors.first.cursor": (v20/*: any*/),
+        "partner.filtered_artworks.pageCursors.first.isCurrent": (v26/*: any*/),
+        "partner.filtered_artworks.pageCursors.first.page": (v25/*: any*/),
+        "partner.filtered_artworks.pageCursors.last": (v29/*: any*/),
+        "partner.filtered_artworks.pageCursors.last.cursor": (v20/*: any*/),
+        "partner.filtered_artworks.pageCursors.last.isCurrent": (v26/*: any*/),
+        "partner.filtered_artworks.pageCursors.last.page": (v25/*: any*/),
+        "partner.filtered_artworks.pageCursors.previous": (v29/*: any*/),
+        "partner.filtered_artworks.pageCursors.previous.cursor": (v20/*: any*/),
+        "partner.filtered_artworks.pageCursors.previous.page": (v25/*: any*/),
         "partner.filtered_artworks.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "partner.filtered_artworks.pageInfo.endCursor": (v23/*: any*/),
-        "partner.filtered_artworks.pageInfo.hasNextPage": (v25/*: any*/),
-        "partner.id": (v21/*: any*/),
-        "partner.internalID": (v21/*: any*/),
-        "partner.sidebar": (v18/*: any*/),
+        "partner.filtered_artworks.pageInfo.endCursor": (v24/*: any*/),
+        "partner.filtered_artworks.pageInfo.hasNextPage": (v26/*: any*/),
+        "partner.id": (v22/*: any*/),
+        "partner.internalID": (v22/*: any*/),
+        "partner.sidebar": (v19/*: any*/),
         "partner.sidebar.aggregations": {
           "enumValues": null,
           "nullable": true,
@@ -1328,9 +1316,9 @@ return {
           "plural": true,
           "type": "AggregationCount"
         },
-        "partner.sidebar.aggregations.counts.count": (v24/*: any*/),
-        "partner.sidebar.aggregations.counts.name": (v19/*: any*/),
-        "partner.sidebar.aggregations.counts.value": (v19/*: any*/),
+        "partner.sidebar.aggregations.counts.count": (v25/*: any*/),
+        "partner.sidebar.aggregations.counts.name": (v20/*: any*/),
+        "partner.sidebar.aggregations.counts.value": (v20/*: any*/),
         "partner.sidebar.aggregations.slice": {
           "enumValues": [
             "ARTIST",
@@ -1358,13 +1346,13 @@ return {
           "plural": false,
           "type": "ArtworkAggregation"
         },
-        "partner.sidebar.id": (v21/*: any*/),
-        "partner.slug": (v21/*: any*/)
+        "partner.sidebar.id": (v22/*: any*/),
+        "partner.slug": (v22/*: any*/)
       }
     },
     "name": "Works_Query",
     "operationKind": "query",
-    "text": "query Works_Query(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) {\n    ...Works_partner\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment Works_partner on Partner {\n  slug\n  internalID\n  featuredKeywords\n  sidebar: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n"
+    "text": "query Works_Query(\n  $partnerId: String!\n) {\n  partner(id: $partnerId) {\n    ...Works_partner\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment Works_partner on Partner {\n  slug\n  internalID\n  featuredKeywords\n  sidebar: filterArtworksConnection(first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/exampleRoutes_ArtworkFilterQuery.graphql.ts
+++ b/src/__generated__/exampleRoutes_ArtworkFilterQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6287754fb7a339c614e126378a3cc7a9>>
+ * @generated SignedSource<<245a48794886390f5611331a29a49c06>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -123,21 +123,24 @@ v5 = [
     "storageKey": null
   }
 ],
-v6 = {
+v6 = [
+  (v2/*: any*/)
+],
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v8 = {
+v9 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -145,14 +148,14 @@ v8 = {
     "large"
   ]
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v10 = [
+v11 = [
   {
     "alias": null,
     "args": null,
@@ -161,36 +164,36 @@ v10 = [
     "storageKey": null
   }
 ],
-v11 = [
+v12 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v15 = [
-  (v12/*: any*/),
+v16 = [
+  (v13/*: any*/),
   (v2/*: any*/)
 ];
 return {
@@ -337,27 +340,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v2/*: any*/)
-                    ],
+                    "selections": (v6/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -420,8 +403,8 @@ return {
                             "name": "slug",
                             "storageKey": null
                           },
-                          (v6/*: any*/),
                           (v7/*: any*/),
+                          (v8/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -443,7 +426,7 @@ return {
                                 "name": "aspectRatio",
                                 "storageKey": null
                               },
-                              (v7/*: any*/),
+                              (v8/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -454,7 +437,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v8/*: any*/)
+                                  (v9/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -477,7 +460,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v8/*: any*/),
+                                  (v9/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -562,6 +545,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -613,7 +603,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v9/*: any*/),
+                                  (v10/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -621,7 +611,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v10/*: any*/),
+                                    "selections": (v11/*: any*/),
                                     "storageKey": null
                                   },
                                   (v2/*: any*/)
@@ -647,7 +637,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v11/*: any*/),
+                            "args": (v12/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -695,15 +685,15 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v11/*: any*/),
+                            "args": (v12/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v2/*: any*/),
-                              (v6/*: any*/),
-                              (v12/*: any*/)
+                              (v7/*: any*/),
+                              (v13/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
                           },
@@ -716,14 +706,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v11/*: any*/),
+                            "args": (v12/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v12/*: any*/),
-                              (v6/*: any*/),
+                              (v13/*: any*/),
+                              (v7/*: any*/),
                               (v2/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -736,7 +726,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v9/*: any*/),
+                              (v10/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -798,7 +788,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v13/*: any*/),
+                              (v14/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -806,8 +796,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v9/*: any*/),
-                              (v14/*: any*/),
+                              (v10/*: any*/),
+                              (v15/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -840,7 +830,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v10/*: any*/),
+                                "selections": (v11/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -850,7 +840,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v10/*: any*/),
+                                "selections": (v11/*: any*/),
                                 "storageKey": null
                               },
                               (v2/*: any*/)
@@ -865,10 +855,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v13/*: any*/),
+                              (v14/*: any*/),
                               (v2/*: any*/),
-                              (v9/*: any*/),
-                              (v14/*: any*/)
+                              (v10/*: any*/),
+                              (v15/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -879,7 +869,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v15/*: any*/),
+                            "selections": (v16/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -897,7 +887,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v15/*: any*/),
+                                "selections": (v16/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -922,9 +912,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v2/*: any*/)
-                        ],
+                        "selections": (v6/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -944,12 +932,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "2b7c24a8d8731f3f826def67d907a429",
+    "cacheID": "a5b0e75011a6c9c1aa5891cc4b2152be",
     "id": null,
     "metadata": {},
     "name": "exampleRoutes_ArtworkFilterQuery",
     "operationKind": "query",
-    "text": "query exampleRoutes_ArtworkFilterQuery(\n  $input: FilterArtworksInput\n) {\n  viewer {\n    ...ExampleArtworkFilterRoute_viewer_2VV6jB\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkFilter_viewer_2VV6jB on Viewer {\n  filtered_artworks: artworksConnection(input: $input) {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    counts {\n      total(format: \"0,0\")\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExampleArtworkFilterRoute_viewer_2VV6jB on Viewer {\n  ...ArtworkFilter_viewer_2VV6jB\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
+    "text": "query exampleRoutes_ArtworkFilterQuery(\n  $input: FilterArtworksInput\n) {\n  viewer {\n    ...ExampleArtworkFilterRoute_viewer_2VV6jB\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkFilter_viewer_2VV6jB on Viewer {\n  filtered_artworks: artworksConnection(input: $input) {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    counts {\n      total(format: \"0,0\")\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExampleArtworkFilterRoute_viewer_2VV6jB on Viewer {\n  ...ArtworkFilter_viewer_2VV6jB\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/fairRoutes_FairArtworksQuery.graphql.ts
+++ b/src/__generated__/fairRoutes_FairArtworksQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<63521ed73a2366f38d8df74c1f69b1ca>>
+ * @generated SignedSource<<fd0695d02c447413d3095c67b8cf457d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -164,14 +164,17 @@ v12 = [
     "storageKey": null
   }
 ],
-v13 = {
+v13 = [
+  (v9/*: any*/)
+],
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v14 = {
+v15 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -179,14 +182,14 @@ v14 = {
     "large"
   ]
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v16 = [
+v17 = [
   {
     "alias": null,
     "args": null,
@@ -195,28 +198,28 @@ v16 = [
     "storageKey": null
   }
 ],
-v17 = [
+v18 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v18 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v19 = {
+v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v20 = [
+v21 = [
   (v8/*: any*/),
   (v9/*: any*/)
 ];
@@ -485,27 +488,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v9/*: any*/)
-                    ],
+                    "selections": (v13/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -538,7 +521,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v6/*: any*/),
-                          (v13/*: any*/),
+                          (v14/*: any*/),
                           (v7/*: any*/),
                           {
                             "alias": null,
@@ -572,7 +555,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v14/*: any*/)
+                                  (v15/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -595,7 +578,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v14/*: any*/),
+                                  (v15/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -680,6 +663,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -731,7 +721,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v15/*: any*/),
+                                  (v16/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -739,7 +729,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v16/*: any*/),
+                                    "selections": (v17/*: any*/),
                                     "storageKey": null
                                   },
                                   (v9/*: any*/)
@@ -765,7 +755,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v17/*: any*/),
+                            "args": (v18/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -813,14 +803,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v17/*: any*/),
+                            "args": (v18/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v9/*: any*/),
-                              (v13/*: any*/),
+                              (v14/*: any*/),
                               (v8/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -834,14 +824,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v17/*: any*/),
+                            "args": (v18/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v8/*: any*/),
-                              (v13/*: any*/),
+                              (v14/*: any*/),
                               (v9/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -854,7 +844,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v15/*: any*/),
+                              (v16/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -916,7 +906,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v18/*: any*/),
+                              (v19/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -924,8 +914,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v15/*: any*/),
-                              (v19/*: any*/),
+                              (v16/*: any*/),
+                              (v20/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -958,7 +948,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v16/*: any*/),
+                                "selections": (v17/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -968,7 +958,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v16/*: any*/),
+                                "selections": (v17/*: any*/),
                                 "storageKey": null
                               },
                               (v9/*: any*/)
@@ -983,10 +973,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v18/*: any*/),
+                              (v19/*: any*/),
                               (v9/*: any*/),
-                              (v15/*: any*/),
-                              (v19/*: any*/)
+                              (v16/*: any*/),
+                              (v20/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -997,7 +987,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v20/*: any*/),
+                            "selections": (v21/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1015,7 +1005,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v20/*: any*/),
+                                "selections": (v21/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -1040,9 +1030,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v9/*: any*/)
-                        ],
+                        "selections": (v13/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1063,12 +1051,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "00b0234fe06f175509cadce92a90b81a",
+    "cacheID": "0eb45094803b633bb1077c295cec8942",
     "id": null,
     "metadata": {},
     "name": "fairRoutes_FairArtworksQuery",
     "operationKind": "query",
-    "text": "query fairRoutes_FairArtworksQuery(\n  $slug: String!\n  $input: FilterArtworksInput\n  $aggregations: [ArtworkAggregation]\n) {\n  fair(id: $slug) @principalField {\n    ...FairArtworks_fair_2p2tYs\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FairArtworks_fair_2p2tYs on Fair {\n  slug\n  internalID\n  featuredKeywords\n  sidebarAggregations: filterArtworksConnection(aggregations: $aggregations, first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    counts {\n      followedArtists\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
+    "text": "query fairRoutes_FairArtworksQuery(\n  $slug: String!\n  $input: FilterArtworksInput\n  $aggregations: [ArtworkAggregation]\n) {\n  fair(id: $slug) @principalField {\n    ...FairArtworks_fair_2p2tYs\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FairArtworks_fair_2p2tYs on Fair {\n  slug\n  internalID\n  featuredKeywords\n  sidebarAggregations: filterArtworksConnection(aggregations: $aggregations, first: 1) {\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    counts {\n      followedArtists\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/partnerRoutes_WorksQuery.graphql.ts
+++ b/src/__generated__/partnerRoutes_WorksQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<de5a2413ed49bb9d75296e04287505d4>>
+ * @generated SignedSource<<f98ef4b4f4875470faec16e071f3350b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -199,14 +199,17 @@ v15 = [
     "storageKey": null
   }
 ],
-v16 = {
+v16 = [
+  (v12/*: any*/)
+],
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v17 = {
+v18 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -214,14 +217,14 @@ v17 = {
     "large"
   ]
 },
-v18 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v19 = [
+v20 = [
   {
     "alias": null,
     "args": null,
@@ -230,28 +233,28 @@ v19 = [
     "storageKey": null
   }
 ],
-v20 = [
+v21 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v21 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v22 = {
+v23 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v23 = [
+v24 = [
   (v11/*: any*/),
   (v12/*: any*/)
 ];
@@ -547,27 +550,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v12/*: any*/)
-                    ],
+                    "selections": (v16/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -600,7 +583,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v9/*: any*/),
-                          (v16/*: any*/),
+                          (v17/*: any*/),
                           (v10/*: any*/),
                           {
                             "alias": null,
@@ -634,7 +617,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v17/*: any*/)
+                                  (v18/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -657,7 +640,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v17/*: any*/),
+                                  (v18/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -742,6 +725,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -793,7 +783,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v18/*: any*/),
+                                  (v19/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -801,7 +791,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v19/*: any*/),
+                                    "selections": (v20/*: any*/),
                                     "storageKey": null
                                   },
                                   (v12/*: any*/)
@@ -827,7 +817,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v20/*: any*/),
+                            "args": (v21/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -875,14 +865,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v20/*: any*/),
+                            "args": (v21/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v12/*: any*/),
-                              (v16/*: any*/),
+                              (v17/*: any*/),
                               (v11/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -896,14 +886,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v20/*: any*/),
+                            "args": (v21/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v11/*: any*/),
-                              (v16/*: any*/),
+                              (v17/*: any*/),
                               (v12/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -916,7 +906,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v18/*: any*/),
+                              (v19/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -978,7 +968,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v21/*: any*/),
+                              (v22/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -986,8 +976,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v18/*: any*/),
-                              (v22/*: any*/),
+                              (v19/*: any*/),
+                              (v23/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1020,7 +1010,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v19/*: any*/),
+                                "selections": (v20/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -1030,7 +1020,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v19/*: any*/),
+                                "selections": (v20/*: any*/),
                                 "storageKey": null
                               },
                               (v12/*: any*/)
@@ -1045,10 +1035,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v21/*: any*/),
+                              (v22/*: any*/),
                               (v12/*: any*/),
-                              (v18/*: any*/),
-                              (v22/*: any*/)
+                              (v19/*: any*/),
+                              (v23/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -1059,7 +1049,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v23/*: any*/),
+                            "selections": (v24/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1077,7 +1067,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v23/*: any*/),
+                                "selections": (v24/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -1102,9 +1092,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v12/*: any*/)
-                        ],
+                        "selections": (v16/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1127,12 +1115,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "9dc74fd8156bc45f925ef49c25df7172",
+    "cacheID": "3a1ac1ffb2aba5fbf2fea535f18c2924",
     "id": null,
     "metadata": {},
     "name": "partnerRoutes_WorksQuery",
     "operationKind": "query",
-    "text": "query partnerRoutes_WorksQuery(\n  $partnerId: String!\n  $input: FilterArtworksInput\n  $aggregations: [ArtworkAggregation]\n  $shouldFetchCounts: Boolean!\n) {\n  partner(id: $partnerId) @principalField {\n    ...Works_partner_3TMxyn\n    displayWorksSection\n    counts {\n      eligibleArtworks\n    }\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment Works_partner_3TMxyn on Partner {\n  slug\n  internalID\n  featuredKeywords\n  sidebar: filterArtworksConnection(first: 1, aggregations: $aggregations) {\n    counts @include(if: $shouldFetchCounts) {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n"
+    "text": "query partnerRoutes_WorksQuery(\n  $partnerId: String!\n  $input: FilterArtworksInput\n  $aggregations: [ArtworkAggregation]\n  $shouldFetchCounts: Boolean!\n) {\n  partner(id: $partnerId) @principalField {\n    ...Works_partner_3TMxyn\n    displayWorksSection\n    counts {\n      eligibleArtworks\n    }\n    id\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment Works_partner_3TMxyn on Partner {\n  slug\n  internalID\n  featuredKeywords\n  sidebar: filterArtworksConnection(first: 1, aggregations: $aggregations) {\n    counts @include(if: $shouldFetchCounts) {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/saleRoutes_SaleQuery.graphql.ts
+++ b/src/__generated__/saleRoutes_SaleQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4bd541029594958b9d85eead864cefa1>>
+ * @generated SignedSource<<ebbea7087a94f427da1f1cc74ef6cb1a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -169,14 +169,17 @@ v11 = [
     "storageKey": null
   }
 ],
-v12 = {
+v12 = [
+  (v8/*: any*/)
+],
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v13 = {
+v14 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -184,14 +187,14 @@ v13 = {
     "large"
   ]
 },
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v15 = [
+v16 = [
   {
     "alias": null,
     "args": null,
@@ -200,28 +203,28 @@ v15 = [
     "storageKey": null
   }
 ],
-v16 = [
+v17 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v18 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v19 = [
+v20 = [
   (v5/*: any*/),
   (v8/*: any*/)
 ];
@@ -481,27 +484,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v8/*: any*/)
-                    ],
+                    "selections": (v12/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -534,7 +517,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v6/*: any*/),
-                          (v12/*: any*/),
+                          (v13/*: any*/),
                           (v7/*: any*/),
                           {
                             "alias": null,
@@ -568,7 +551,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v13/*: any*/)
+                                  (v14/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -591,7 +574,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v13/*: any*/),
+                                  (v14/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -676,6 +659,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -727,7 +717,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v14/*: any*/),
+                                  (v15/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -735,7 +725,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v15/*: any*/),
+                                    "selections": (v16/*: any*/),
                                     "storageKey": null
                                   },
                                   (v8/*: any*/)
@@ -761,7 +751,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v16/*: any*/),
+                            "args": (v17/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -809,14 +799,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v16/*: any*/),
+                            "args": (v17/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v8/*: any*/),
-                              (v12/*: any*/),
+                              (v13/*: any*/),
                               (v5/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -830,14 +820,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v16/*: any*/),
+                            "args": (v17/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v5/*: any*/),
-                              (v12/*: any*/),
+                              (v13/*: any*/),
                               (v8/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -850,7 +840,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v14/*: any*/),
+                              (v15/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -912,7 +902,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v17/*: any*/),
+                              (v18/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -920,8 +910,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v14/*: any*/),
-                              (v18/*: any*/),
+                              (v15/*: any*/),
+                              (v19/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -954,7 +944,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v15/*: any*/),
+                                "selections": (v16/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -964,7 +954,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v15/*: any*/),
+                                "selections": (v16/*: any*/),
                                 "storageKey": null
                               },
                               (v8/*: any*/)
@@ -979,10 +969,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v17/*: any*/),
+                              (v18/*: any*/),
                               (v8/*: any*/),
-                              (v14/*: any*/),
-                              (v18/*: any*/)
+                              (v15/*: any*/),
+                              (v19/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -993,7 +983,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v19/*: any*/),
+                            "selections": (v20/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1011,7 +1001,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v19/*: any*/),
+                                "selections": (v20/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -1036,9 +1026,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v8/*: any*/)
-                        ],
+                        "selections": (v12/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1139,12 +1127,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4e2311c2cb9157764ebcbc714fc58a94",
+    "cacheID": "85ca5a0d1dd3385294ad9d966dcc8871",
     "id": null,
     "metadata": {},
     "name": "saleRoutes_SaleQuery",
     "operationKind": "query",
-    "text": "query saleRoutes_SaleQuery(\n  $input: FilterArtworksInput\n  $slug: String!\n) {\n  sale(id: $slug) @principalField {\n    ...SaleApp_sale\n    isAuction\n    id\n  }\n  viewer {\n    ...SaleApp_viewer_2VV6jB\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment SaleApp_sale on Sale {\n  ...SaleMeta_sale\n  coverImage {\n    url(version: [\"wide\", \"source\", \"large_rectangle\"])\n  }\n  description(format: HTML)\n  eligibleSaleArtworksCount\n  internalID\n  name\n  featuredKeywords\n}\n\nfragment SaleApp_viewer_2VV6jB on Viewer {\n  ...SaleArtworksFilter_viewer_2VV6jB\n}\n\nfragment SaleArtworksFilter_viewer_2VV6jB on Viewer {\n  filtered_artworks: artworksConnection(input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n  sidebarAggregations: artworksConnection(input: $input, first: 1) {\n    counts {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n}\n\nfragment SaleMeta_sale on Sale {\n  name\n  description(format: HTML)\n  slug\n  coverImage {\n    url(version: [\"wide\", \"source\", \"large_rectangle\"])\n  }\n}\n"
+    "text": "query saleRoutes_SaleQuery(\n  $input: FilterArtworksInput\n  $slug: String!\n) {\n  sale(id: $slug) @principalField {\n    ...SaleApp_sale\n    isAuction\n    id\n  }\n  viewer {\n    ...SaleApp_viewer_2VV6jB\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment SaleApp_sale on Sale {\n  ...SaleMeta_sale\n  coverImage {\n    url(version: [\"wide\", \"source\", \"large_rectangle\"])\n  }\n  description(format: HTML)\n  eligibleSaleArtworksCount\n  internalID\n  name\n  featuredKeywords\n}\n\nfragment SaleApp_viewer_2VV6jB on Viewer {\n  ...SaleArtworksFilter_viewer_2VV6jB\n}\n\nfragment SaleArtworksFilter_viewer_2VV6jB on Viewer {\n  filtered_artworks: artworksConnection(input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n  sidebarAggregations: artworksConnection(input: $input, first: 1) {\n    counts {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n}\n\nfragment SaleMeta_sale on Sale {\n  name\n  description(format: HTML)\n  slug\n  coverImage {\n    url(version: [\"wide\", \"source\", \"large_rectangle\"])\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/searchRoutes_ArtworksViewerQuery.graphql.ts
+++ b/src/__generated__/searchRoutes_ArtworksViewerQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<20cc76197891ac61de553815dac4f33d>>
+ * @generated SignedSource<<6bf03344efb84e01e0915fbdd3de3ae8>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -138,21 +138,24 @@ v8 = [
     "storageKey": null
   }
 ],
-v9 = {
+v9 = [
+  (v5/*: any*/)
+],
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v11 = {
+v12 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -160,14 +163,14 @@ v11 = {
     "large"
   ]
 },
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v13 = [
+v14 = [
   {
     "alias": null,
     "args": null,
@@ -176,28 +179,28 @@ v13 = [
     "storageKey": null
   }
 ],
-v14 = [
+v15 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v17 = [
+v18 = [
   (v4/*: any*/),
   (v5/*: any*/)
 ];
@@ -459,27 +462,7 @@ return {
                     "kind": "LinkedField",
                     "name": "node",
                     "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v5/*: any*/)
-                    ],
+                    "selections": (v9/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -542,8 +525,8 @@ return {
                             "name": "slug",
                             "storageKey": null
                           },
-                          (v9/*: any*/),
                           (v10/*: any*/),
+                          (v11/*: any*/),
                           {
                             "alias": null,
                             "args": [
@@ -565,7 +548,7 @@ return {
                                 "name": "aspectRatio",
                                 "storageKey": null
                               },
-                              (v10/*: any*/),
+                              (v11/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -576,7 +559,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v11/*: any*/)
+                                  (v12/*: any*/)
                                 ],
                                 "kind": "ScalarField",
                                 "name": "url",
@@ -599,7 +582,7 @@ return {
                               {
                                 "alias": null,
                                 "args": [
-                                  (v11/*: any*/),
+                                  (v12/*: any*/),
                                   {
                                     "kind": "Literal",
                                     "name": "width",
@@ -684,6 +667,13 @@ return {
                               {
                                 "alias": null,
                                 "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
                                 "concreteType": "AuctionCollectorSignals",
                                 "kind": "LinkedField",
                                 "name": "auction",
@@ -735,7 +725,7 @@ return {
                                 "name": "partnerOffer",
                                 "plural": false,
                                 "selections": [
-                                  (v12/*: any*/),
+                                  (v13/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -743,7 +733,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "priceWithDiscount",
                                     "plural": false,
-                                    "selections": (v13/*: any*/),
+                                    "selections": (v14/*: any*/),
                                     "storageKey": null
                                   },
                                   (v5/*: any*/)
@@ -769,7 +759,7 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v14/*: any*/),
+                            "args": (v15/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artist",
@@ -817,14 +807,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v14/*: any*/),
+                            "args": (v15/*: any*/),
                             "concreteType": "Artist",
                             "kind": "LinkedField",
                             "name": "artists",
                             "plural": true,
                             "selections": [
                               (v5/*: any*/),
-                              (v9/*: any*/),
+                              (v10/*: any*/),
                               (v4/*: any*/)
                             ],
                             "storageKey": "artists(shallow:true)"
@@ -838,14 +828,14 @@ return {
                           },
                           {
                             "alias": null,
-                            "args": (v14/*: any*/),
+                            "args": (v15/*: any*/),
                             "concreteType": "Partner",
                             "kind": "LinkedField",
                             "name": "partner",
                             "plural": false,
                             "selections": [
                               (v4/*: any*/),
-                              (v9/*: any*/),
+                              (v10/*: any*/),
                               (v5/*: any*/)
                             ],
                             "storageKey": "partner(shallow:true)"
@@ -858,7 +848,7 @@ return {
                             "name": "sale",
                             "plural": false,
                             "selections": [
-                              (v12/*: any*/),
+                              (v13/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -920,7 +910,7 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v15/*: any*/),
+                              (v16/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -928,8 +918,8 @@ return {
                                 "name": "lotLabel",
                                 "storageKey": null
                               },
-                              (v12/*: any*/),
-                              (v16/*: any*/),
+                              (v13/*: any*/),
+                              (v17/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -962,7 +952,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "highestBid",
                                 "plural": false,
-                                "selections": (v13/*: any*/),
+                                "selections": (v14/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -972,7 +962,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "openingBid",
                                 "plural": false,
-                                "selections": (v13/*: any*/),
+                                "selections": (v14/*: any*/),
                                 "storageKey": null
                               },
                               (v5/*: any*/)
@@ -987,10 +977,10 @@ return {
                             "name": "saleArtwork",
                             "plural": false,
                             "selections": [
-                              (v15/*: any*/),
+                              (v16/*: any*/),
                               (v5/*: any*/),
-                              (v12/*: any*/),
-                              (v16/*: any*/)
+                              (v13/*: any*/),
+                              (v17/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -1001,7 +991,7 @@ return {
                             "kind": "LinkedField",
                             "name": "attributionClass",
                             "plural": false,
-                            "selections": (v17/*: any*/),
+                            "selections": (v18/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -1019,7 +1009,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "filterGene",
                                 "plural": false,
-                                "selections": (v17/*: any*/),
+                                "selections": (v18/*: any*/),
                                 "storageKey": null
                               }
                             ],
@@ -1044,9 +1034,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": [
-                          (v5/*: any*/)
-                        ],
+                        "selections": (v9/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -1066,12 +1054,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e0a96092f1d588582029dc2266cac336",
+    "cacheID": "b20662ab59c1813b4203a1a84a1e1da4",
     "id": null,
     "metadata": {},
     "name": "searchRoutes_ArtworksViewerQuery",
     "operationKind": "query",
-    "text": "query searchRoutes_ArtworksViewerQuery(\n  $input: FilterArtworksInput\n  $sidebarInput: FilterArtworksInput\n  $shouldFetchCounts: Boolean!\n) {\n  viewer {\n    ...SearchResultsArtworks_viewer_1OkEZd\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      collectorSignals {\n        primaryLabel\n      }\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkFilter_viewer_2VV6jB on Viewer {\n  filtered_artworks: artworksConnection(input: $input) {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    counts {\n      total(format: \"0,0\")\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment SearchResultsArtworks_viewer_1OkEZd on Viewer {\n  sidebar: artworksConnection(first: 1, input: $sidebarInput) {\n    counts @include(if: $shouldFetchCounts) {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  ...ArtworkFilter_viewer_2VV6jB\n}\n"
+    "text": "query searchRoutes_ArtworksViewerQuery(\n  $input: FilterArtworksInput\n  $sidebarInput: FilterArtworksInput\n  $shouldFetchCounts: Boolean!\n) {\n  viewer {\n    ...SearchResultsArtworks_viewer_1OkEZd\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkFilter_viewer_2VV6jB on Viewer {\n  filtered_artworks: artworksConnection(input: $input) {\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n    counts {\n      total(format: \"0,0\")\n    }\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment SearchResultsArtworks_viewer_1OkEZd on Viewer {\n  sidebar: artworksConnection(first: 1, input: $sidebarInput) {\n    counts @include(if: $shouldFetchCounts) {\n      followedArtists\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  ...ArtworkFilter_viewer_2VV6jB\n}\n"
   }
 };
 })();


### PR DESCRIPTION
I think this might cleanly revert #14661 , but should be double-checked.

Something is off in the PR - the auction artwork grid isn't using the `isAuctionArtwork` context value properly, and as a result wasn't using the right grid - it was using a masonry layout and hiding the lot labels. Took me a little while to notice!

Brought up in Slack - https://artsy.slack.com/archives/C02JHHHKP5K/p1729737714932469