### PR TITLE
fix(artwork-grids): Ensure we dont rerender on route changes

### DIFF
--- a/src/Apps/Artist/Components/ArtistHeader/ArtistHeaderImage.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/ArtistHeaderImage.tsx
@@ -6,8 +6,6 @@ import { BREAKPOINTS, Media } from "Utils/Responsive"
 import { Link } from "react-head"
 import { getENV } from "Utils/getENV"
 
-const IS_GOOGLEBOT = getENV("IS_GOOGLEBOT")
-
 interface ArtistHeaderImageProps
   extends Omit<BoxProps, "maxHeight" | "maxWidth"> {
   image: ValidImage
@@ -17,6 +15,8 @@ export const ArtistHeaderImage: FC<ArtistHeaderImageProps> = ({
   image,
   ...rest
 }) => {
+  const lazyLoad = !(getENV("IS_GOOGLEBOT") || getENV("IS_MOBILE"))
+
   const max = maxDimensionsByArea({
     width: image.width,
     height: image.height,
@@ -62,7 +62,7 @@ export const ArtistHeaderImage: FC<ArtistHeaderImageProps> = ({
             width="100%"
             height="100%"
             style={{ objectFit: "cover" }}
-            lazyLoad={!IS_GOOGLEBOT}
+            lazyLoad={lazyLoad}
           />
         </ResponsiveBox>
       </Media>

--- a/src/Apps/ArtistSeries/ArtistSeriesApp.tsx
+++ b/src/Apps/ArtistSeries/ArtistSeriesApp.tsx
@@ -31,7 +31,7 @@ const ArtistSeriesApp: React.FC<ArtistSeriesAppProps> = ({ artistSeries }) => {
           <Spacer y={6} />
 
           <OtherArtistSeriesRail
-            artist={(railArtist ?? [])[0]!}
+            artist={(railArtist ?? [])[0]}
             title="Series by this artist"
             contextModule={ContextModule.moreSeriesByThisArtist}
           />

--- a/src/Apps/ArtistSeries/Components/ArtistSeriesArtworksFilter.tsx
+++ b/src/Apps/ArtistSeries/Components/ArtistSeriesArtworksFilter.tsx
@@ -14,6 +14,7 @@ import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { useRouter } from "System/Hooks/useRouter"
 import { ArtworkFilterPlaceholder } from "Components/ArtworkFilter/ArtworkFilterPlaceholder"
 import { ArtistSeriesArtworksFilterQuery } from "__generated__/ArtistSeriesArtworksFilterQuery.graphql"
+import { LazyArtworkGrid } from "Components/ArtworkGrid/LazyArtworkGrid"
 
 interface ArtistSeriesArtworksFilterProps {
   artistSeries: ArtistSeriesArtworksFilter_artistSeries$data
@@ -117,36 +118,38 @@ export const ArtistSeriesArtworkFilterQueryRenderer: React.FC<ArtistSeriesArtwor
   const { match } = useRouter()
 
   return (
-    <SystemQueryRenderer<ArtistSeriesArtworksFilterQuery>
-      environment={relayEnvironment}
-      query={graphql`
-        query ArtistSeriesArtworksFilterQuery(
-          $slug: ID!
-          $input: FilterArtworksInput
-          $aggregations: [ArtworkAggregation]
-        ) {
-          artistSeries(id: $slug) {
-            ...ArtistSeriesArtworksFilter_artistSeries
-              @arguments(input: $input, aggregations: $aggregations)
+    <LazyArtworkGrid>
+      <SystemQueryRenderer<ArtistSeriesArtworksFilterQuery>
+        environment={relayEnvironment}
+        query={graphql`
+          query ArtistSeriesArtworksFilterQuery(
+            $slug: ID!
+            $input: FilterArtworksInput
+            $aggregations: [ArtworkAggregation]
+          ) {
+            artistSeries(id: $slug) {
+              ...ArtistSeriesArtworksFilter_artistSeries
+                @arguments(input: $input, aggregations: $aggregations)
+            }
           }
-        }
-      `}
-      variables={initializeVariablesWithFilterState(match.params, match)}
-      fetchPolicy="store-and-network"
-      placeholder={<ArtworkFilterPlaceholder />}
-      render={({ error, props }) => {
-        if (error || !props?.artistSeries) {
-          return <ArtworkFilterPlaceholder />
-        }
+        `}
+        variables={initializeVariablesWithFilterState(match.params, match)}
+        fetchPolicy="store-and-network"
+        placeholder={<ArtworkFilterPlaceholder />}
+        render={({ error, props }) => {
+          if (error || !props?.artistSeries) {
+            return <ArtworkFilterPlaceholder />
+          }
 
-        return (
-          <ArtistSeriesArtworksFilterRefetchContainer
-            artistSeries={props.artistSeries}
-            {...rest}
-          />
-        )
-      }}
-    />
+          return (
+            <ArtistSeriesArtworksFilterRefetchContainer
+              artistSeries={props.artistSeries}
+              {...rest}
+            />
+          )
+        }}
+      />
+    </LazyArtworkGrid>
   )
 }
 

--- a/src/Apps/Artwork/Components/ArtworkLightbox.tsx
+++ b/src/Apps/Artwork/Components/ArtworkLightbox.tsx
@@ -51,7 +51,9 @@ const ArtworkLightbox: React.FC<ArtworkLightboxProps> = ({
 
   if (!image) return null
 
-  const shouldLazyLoad = Boolean(lazyLoad && !getENV("IS_GOOGLEBOT"))
+  const shouldLazyLoad = Boolean(
+    lazyLoad && !(getENV("IS_GOOGLEBOT") || getENV("IS_MOBILE"))
+  )
 
   return (
     <>

--- a/src/Apps/Auction/Components/AuctionArtworkFilter.tsx
+++ b/src/Apps/Auction/Components/AuctionArtworkFilter.tsx
@@ -22,6 +22,7 @@ import { getInitialFilterState } from "Components/ArtworkFilter/Utils/getInitial
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { ArtworkFilterPlaceholder } from "Components/ArtworkFilter/ArtworkFilterPlaceholder"
 import { AuctionArtworkFilterQuery } from "__generated__/AuctionArtworkFilterQuery.graphql"
+import { LazyArtworkGrid } from "Components/ArtworkGrid/LazyArtworkGrid"
 
 interface AuctionArtworkFilterProps {
   relay: RelayRefetchProp
@@ -126,40 +127,42 @@ export const AuctionArtworkFilterQueryRenderer: React.FC<AuctionArtworkFilterQue
   const { match } = useRouter()
 
   return (
-    <SystemQueryRenderer<AuctionArtworkFilterQuery>
-      environment={relayEnvironment}
-      query={graphql`
-        query AuctionArtworkFilterQuery(
-          $saleID: String!
-          $input: FilterArtworksInput
-          $isLoggedIn: Boolean!
-        ) {
-          viewer {
-            ...AuctionArtworkFilter_viewer
-              @arguments(
-                input: $input
-                saleID: $saleID
-                isLoggedIn: $isLoggedIn
-              )
+    <LazyArtworkGrid>
+      <SystemQueryRenderer<AuctionArtworkFilterQuery>
+        environment={relayEnvironment}
+        query={graphql`
+          query AuctionArtworkFilterQuery(
+            $saleID: String!
+            $input: FilterArtworksInput
+            $isLoggedIn: Boolean!
+          ) {
+            viewer {
+              ...AuctionArtworkFilter_viewer
+                @arguments(
+                  input: $input
+                  saleID: $saleID
+                  isLoggedIn: $isLoggedIn
+                )
+            }
           }
-        }
-      `}
-      variables={initializeVariablesWithFilterState(match.params, match)}
-      fetchPolicy="network-only"
-      placeholder={<ArtworkFilterPlaceholder />}
-      render={({ error, props }) => {
-        if (error || !props?.viewer) {
-          return <ArtworkFilterPlaceholder />
-        }
+        `}
+        variables={initializeVariablesWithFilterState(match.params, match)}
+        fetchPolicy="network-only"
+        placeholder={<ArtworkFilterPlaceholder />}
+        render={({ error, props }) => {
+          if (error || !props?.viewer) {
+            return <ArtworkFilterPlaceholder />
+          }
 
-        return (
-          <AuctionArtworkFilterRefetchContainer
-            viewer={props.viewer}
-            {...rest}
-          />
-        )
-      }}
-    />
+          return (
+            <AuctionArtworkFilterRefetchContainer
+              viewer={props.viewer}
+              {...rest}
+            />
+          )
+        }}
+      />
+    </LazyArtworkGrid>
   )
 }
 

--- a/src/Apps/Collect/Routes/Collect/index.tsx
+++ b/src/Apps/Collect/Routes/Collect/index.tsx
@@ -1,4 +1,3 @@
-import StaticContainer from "found/StaticContainer"
 import { Box, Separator, Spacer, Text, Flex } from "@artsy/palette"
 import { Match, Router } from "found"
 import * as React from "react"
@@ -21,6 +20,7 @@ import { MetaTags } from "Components/MetaTags"
 import { initializeVariablesWithFilterState } from "Apps/Collect/collectRoutes"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { ArtworkFilterPlaceholder } from "Components/ArtworkFilter/ArtworkFilterPlaceholder"
+import { LazyArtworkGrid } from "Components/ArtworkGrid/LazyArtworkGrid"
 
 export interface CollectAppProps {
   match: Match
@@ -84,9 +84,7 @@ export const CollectApp: React.FC<CollectAppProps> = ({
         </Box>
 
         <Box>
-          {/* Prevent layout jank when transitioning routes, because that
-              generates new params from `match` and causes rerenders */}
-          <StaticContainer shouldUpdate={!!match.elements}>
+          <LazyArtworkGrid>
             <SystemQueryRenderer<CollectArtworkFilterQuery>
               query={graphql`
                 query CollectArtworkFilterQuery(
@@ -155,7 +153,7 @@ export const CollectApp: React.FC<CollectAppProps> = ({
                 )
               }}
             />
-          </StaticContainer>
+          </LazyArtworkGrid>
         </Box>
       </FrameWithRecentlyViewed>
     </>

--- a/src/Apps/Collect/Routes/Collection/Components/Header/CollectionFeaturedArtists.tsx
+++ b/src/Apps/Collect/Routes/Collection/Components/Header/CollectionFeaturedArtists.tsx
@@ -1,4 +1,3 @@
-import StaticContainer from "found/StaticContainer"
 import { Column, GridColumns, Skeleton, Text } from "@artsy/palette"
 import { EntityHeaderArtistFragmentContainer } from "Components/EntityHeaders/EntityHeaderArtist"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -11,6 +10,7 @@ import { useRouter } from "System/Hooks/useRouter"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { initializeVariablesWithFilterState } from "Apps/Collect/collectRoutes"
 import { EntityHeaderPlaceholder } from "Components/EntityHeaders/EntityHeaderPlaceholder"
+import { LazyArtworkGrid } from "Components/ArtworkGrid/LazyArtworkGrid"
 
 interface CollectionFeaturedArtistsProps {
   collection: CollectionFeaturedArtists_collection$data
@@ -107,7 +107,7 @@ export const CollectionFeaturedArtistsQueryRenderer: React.FC<{
   )
 
   return (
-    <StaticContainer shouldUpdate={!!match.elements}>
+    <LazyArtworkGrid>
       <SystemQueryRenderer<CollectionFeaturedArtistsQuery>
         query={graphql`
           query CollectionFeaturedArtistsQuery(
@@ -158,7 +158,7 @@ export const CollectionFeaturedArtistsQueryRenderer: React.FC<{
           )
         }}
       />
-    </StaticContainer>
+    </LazyArtworkGrid>
   )
 }
 

--- a/src/Apps/Collect/Routes/Collection/index.tsx
+++ b/src/Apps/Collect/Routes/Collection/index.tsx
@@ -1,4 +1,3 @@
-import StaticContainer from "found/StaticContainer"
 import { Spacer } from "@artsy/palette"
 import { Collection_collection$data } from "__generated__/Collection_collection.graphql"
 import { CollectionArtworksQuery } from "__generated__/CollectionArtworksQuery.graphql"
@@ -23,6 +22,7 @@ import { useRouter } from "System/Hooks/useRouter"
 import { ArtworkFilterPlaceholder } from "Components/ArtworkFilter/ArtworkFilterPlaceholder"
 import { CollectionFeaturedArtistsQueryRenderer } from "Apps/Collect/Routes/Collection/Components/Header/CollectionFeaturedArtists"
 import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
+import { LazyArtworkGrid } from "Components/ArtworkGrid/LazyArtworkGrid"
 
 interface CollectionAppProps {
   collection: Collection_collection$data
@@ -48,7 +48,7 @@ export const CollectionApp: React.FC<CollectionAppProps> = props => {
   const socialImage = headerImage
 
   return (
-    <StaticContainer shouldUpdate={!!match.elements}>
+    <LazyArtworkGrid>
       <Analytics contextPageOwnerId={context.contextPageOwnerId as string}>
         <MetaTags
           description={metadataDescription}
@@ -144,7 +144,7 @@ export const CollectionApp: React.FC<CollectionAppProps> = props => {
           </FrameWithRecentlyViewed>
         </>
       </Analytics>
-    </StaticContainer>
+    </LazyArtworkGrid>
   )
 }
 

--- a/src/Apps/Gene/Components/GeneArtworkFilter.tsx
+++ b/src/Apps/Gene/Components/GeneArtworkFilter.tsx
@@ -16,6 +16,7 @@ import { ArtworkFilterPlaceholder } from "Components/ArtworkFilter/ArtworkFilter
 import { GeneArtworkFilterQuery } from "__generated__/GeneArtworkFilterQuery.graphql"
 import { paramsToCamelCase } from "Components/ArtworkFilter/Utils/paramsCasing"
 import { allowedFilters } from "Components/ArtworkFilter/Utils/allowedFilters"
+import { LazyArtworkGrid } from "Components/ArtworkGrid/LazyArtworkGrid"
 
 interface GeneArtworkFilterProps {
   gene: GeneArtworkFilter_gene$data
@@ -111,36 +112,40 @@ export const GeneArtworkFilterQueryRenderer: React.FC<GeneArtworkFilterQueryRend
   const { match } = useRouter()
 
   return (
-    <SystemQueryRenderer<GeneArtworkFilterQuery>
-      environment={relayEnvironment}
-      query={graphql`
-        query GeneArtworkFilterQuery(
-          $slug: String!
-          $input: FilterArtworksInput
-          $aggregations: [ArtworkAggregation]
-          $shouldFetchCounts: Boolean!
-        ) {
-          gene(id: $slug) {
-            ...GeneArtworkFilter_gene
-              @arguments(
-                input: $input
-                aggregations: $aggregations
-                shouldFetchCounts: $shouldFetchCounts
-              )
+    <LazyArtworkGrid>
+      <SystemQueryRenderer<GeneArtworkFilterQuery>
+        environment={relayEnvironment}
+        query={graphql`
+          query GeneArtworkFilterQuery(
+            $slug: String!
+            $input: FilterArtworksInput
+            $aggregations: [ArtworkAggregation]
+            $shouldFetchCounts: Boolean!
+          ) {
+            gene(id: $slug) {
+              ...GeneArtworkFilter_gene
+                @arguments(
+                  input: $input
+                  aggregations: $aggregations
+                  shouldFetchCounts: $shouldFetchCounts
+                )
+            }
           }
-        }
-      `}
-      variables={initializeVariablesWithFilterState(match.params, match)}
-      fetchPolicy="store-and-network"
-      placeholder={<ArtworkFilterPlaceholder />}
-      render={({ error, props }) => {
-        if (error || !props?.gene) {
-          return <ArtworkFilterPlaceholder />
-        }
+        `}
+        variables={initializeVariablesWithFilterState(match.params, match)}
+        fetchPolicy="store-and-network"
+        placeholder={<ArtworkFilterPlaceholder />}
+        render={({ error, props }) => {
+          if (error || !props?.gene) {
+            return <ArtworkFilterPlaceholder />
+          }
 
-        return <GeneArtworkFilterRefetchContainer gene={props.gene} {...rest} />
-      }}
-    />
+          return (
+            <GeneArtworkFilterRefetchContainer gene={props.gene} {...rest} />
+          )
+        }}
+      />
+    </LazyArtworkGrid>
   )
 }
 

--- a/src/Apps/Show/Components/ShowArtworks.tsx
+++ b/src/Apps/Show/Components/ShowArtworks.tsx
@@ -16,6 +16,7 @@ import { getInitialFilterState } from "Components/ArtworkFilter/Utils/getInitial
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { ArtworkFilterPlaceholder } from "Components/ArtworkFilter/ArtworkFilterPlaceholder"
 import { ShowArtworksFilterQuery } from "__generated__/ShowArtworksFilterQuery.graphql"
+import { LazyArtworkGrid } from "Components/ArtworkGrid/LazyArtworkGrid"
 
 interface ShowArtworksFilterProps extends BoxProps {
   show: ShowArtworks_show$data
@@ -129,31 +130,33 @@ export const ShowArtworkFilterQueryRenderer: React.FC<ShowArtworkFilterQueryRend
   const { match } = useRouter()
 
   return (
-    <SystemQueryRenderer<ShowArtworksFilterQuery>
-      environment={relayEnvironment}
-      query={graphql`
-        query ShowArtworksFilterQuery(
-          $slug: String!
-          $input: FilterArtworksInput
-          $aggregations: [ArtworkAggregation]
-        ) {
-          show(id: $slug) {
-            ...ShowArtworks_show
-              @arguments(input: $input, aggregations: $aggregations)
+    <LazyArtworkGrid>
+      <SystemQueryRenderer<ShowArtworksFilterQuery>
+        environment={relayEnvironment}
+        query={graphql`
+          query ShowArtworksFilterQuery(
+            $slug: String!
+            $input: FilterArtworksInput
+            $aggregations: [ArtworkAggregation]
+          ) {
+            show(id: $slug) {
+              ...ShowArtworks_show
+                @arguments(input: $input, aggregations: $aggregations)
+            }
           }
-        }
-      `}
-      variables={initializeVariablesWithFilterState(match.params, match)}
-      fetchPolicy="store-and-network"
-      placeholder={<ArtworkFilterPlaceholder />}
-      render={({ error, props }) => {
-        if (error || !props?.show) {
-          return <ArtworkFilterPlaceholder />
-        }
+        `}
+        variables={initializeVariablesWithFilterState(match.params, match)}
+        fetchPolicy="store-and-network"
+        placeholder={<ArtworkFilterPlaceholder />}
+        render={({ error, props }) => {
+          if (error || !props?.show) {
+            return <ArtworkFilterPlaceholder />
+          }
 
-        return <ShowArtworksRefetchContainer show={props.show} {...rest} />
-      }}
-    />
+          return <ShowArtworksRefetchContainer show={props.show} {...rest} />
+        }}
+      />
+    </LazyArtworkGrid>
   )
 }
 

--- a/src/Apps/Tag/Components/TagArtworkFilter.tsx
+++ b/src/Apps/Tag/Components/TagArtworkFilter.tsx
@@ -16,6 +16,7 @@ import { ArtworkFilterPlaceholder } from "Components/ArtworkFilter/ArtworkFilter
 import { paramsToCamelCase } from "Components/ArtworkFilter/Utils/paramsCasing"
 import { allowedFilters } from "Components/ArtworkFilter/Utils/allowedFilters"
 import { TagArtworkFilterQuery } from "__generated__/TagArtworkFilterQuery.graphql"
+import { LazyArtworkGrid } from "Components/ArtworkGrid/LazyArtworkGrid"
 
 interface TagArtworkFilterProps {
   tag: TagArtworkFilter_tag$data
@@ -108,36 +109,38 @@ export const TagArtworkFilterQueryRenderer: React.FC<TagArtworkFilterQueryRender
   const { match } = useRouter()
 
   return (
-    <SystemQueryRenderer<TagArtworkFilterQuery>
-      environment={relayEnvironment}
-      query={graphql`
-        query TagArtworkFilterQuery(
-          $slug: String!
-          $input: FilterArtworksInput
-          $aggregations: [ArtworkAggregation]
-          $shouldFetchCounts: Boolean!
-        ) {
-          tag(id: $slug) {
-            ...TagArtworkFilter_tag
-              @arguments(
-                input: $input
-                aggregations: $aggregations
-                shouldFetchCounts: $shouldFetchCounts
-              )
+    <LazyArtworkGrid>
+      <SystemQueryRenderer<TagArtworkFilterQuery>
+        environment={relayEnvironment}
+        query={graphql`
+          query TagArtworkFilterQuery(
+            $slug: String!
+            $input: FilterArtworksInput
+            $aggregations: [ArtworkAggregation]
+            $shouldFetchCounts: Boolean!
+          ) {
+            tag(id: $slug) {
+              ...TagArtworkFilter_tag
+                @arguments(
+                  input: $input
+                  aggregations: $aggregations
+                  shouldFetchCounts: $shouldFetchCounts
+                )
+            }
           }
-        }
-      `}
-      variables={initializeVariablesWithFilterState(match.params, match)}
-      fetchPolicy="store-and-network"
-      placeholder={<ArtworkFilterPlaceholder />}
-      render={({ error, props }) => {
-        if (error || !props?.tag) {
-          return <ArtworkFilterPlaceholder />
-        }
+        `}
+        variables={initializeVariablesWithFilterState(match.params, match)}
+        fetchPolicy="store-and-network"
+        placeholder={<ArtworkFilterPlaceholder />}
+        render={({ error, props }) => {
+          if (error || !props?.tag) {
+            return <ArtworkFilterPlaceholder />
+          }
 
-        return <TagArtworkFilterRefetchContainer tag={props.tag} {...rest} />
-      }}
-    />
+          return <TagArtworkFilterRefetchContainer tag={props.tag} {...rest} />
+        }}
+      />
+    </LazyArtworkGrid>
   )
 }
 

--- a/src/Components/ArtworkGrid/LazyArtworkGrid.tsx
+++ b/src/Components/ArtworkGrid/LazyArtworkGrid.tsx
@@ -1,0 +1,18 @@
+import StaticContainer from "found/StaticContainer"
+import { useRouter } from "found"
+
+/**
+ * When loading artwork grids / filter lazily we need to ensure that rerenders
+ * don't occur when the route changes, which then triggers the skeleton loading
+ * state. This component will prevent rerenders when the route changes, signalled
+ * by `match.elements` being undefined per the router.
+ */
+export const LazyArtworkGrid: React.FC = ({ children }) => {
+  const { match } = useRouter()
+
+  return (
+    <StaticContainer shouldUpdate={!!match.elements}>
+      {children}
+    </StaticContainer>
+  )
+}


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Need to make sure we don't rerender lazy grids if a user has clicked on a route (triggering state update in router via url bar update). So adds a new (maybe too generic) `LazyArtworkGrid` component that we can wrap things in. 
