### PR TITLE
chore: add tracking to update payment method

### DIFF
--- a/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchasesRow.tsx
+++ b/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchasesRow.tsx
@@ -27,7 +27,12 @@ import CheckmarkFillIcon from "@artsy/icons/CheckmarkFillIcon"
 import PendingIcon from "@artsy/icons/PendingIcon"
 import AlertStrokeIcon from "@artsy/icons/AlertStrokeIcon"
 import { useTracking } from "react-tracking"
-import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
+import {
+  ActionType,
+  ContextModule,
+  OwnerType,
+  ClickedChangePaymentMethod,
+} from "@artsy/cohesion"
 
 const ORDER_LABELS = {
   APPROVED: "Confirmed",
@@ -97,12 +102,14 @@ const SettingsPurchasesRow: FC<SettingsPurchasesRowProps> = ({ order }) => {
 
   const { trackEvent } = useTracking()
   const trackChangePaymentMethodClick = (orderID: string) => () => {
-    trackEvent({
+    const payload: ClickedChangePaymentMethod = {
       action: ActionType.clickedChangePaymentMethod,
       context_module: ContextModule.ordersHistory,
       context_page_owner_type: OwnerType.ordersHistory,
       context_page_owner_id: orderID,
-    })
+    }
+
+    trackEvent(payload)
   }
 
   const getOrderLink = order => {


### PR DESCRIPTION
Adding tracking call for when 'update payment' button is clicked on order history.

Should finish this one: [EMI-2130](https://artsyproduct.atlassian.net/browse/EMI-2130)

Not sure if there is a better way to do it as because it's a hook React wanted me to move it inside function declaration. 

[EMI-2130]: https://artsyproduct.atlassian.net/browse/EMI-2130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ