### PR TITLE
fix(AMBER-1099): [Viewing Room] Jillian Ross Viewing Room Bug/Formatting

### DIFF
--- a/src/Apps/ViewingRoom/Routes/Works/Components/ViewingRoomArtworkDetails.tsx
+++ b/src/Apps/ViewingRoom/Routes/Works/Components/ViewingRoomArtworkDetails.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { Button, GridColumns, Column, Text } from "@artsy/palette"
+import { Button, GridColumns, Column, HTML, ReadMore } from "@artsy/palette"
 import { ViewingRoomArtworkDetails_artwork$data } from "__generated__/ViewingRoomArtworkDetails_artwork.graphql"
 import { createFragmentContainer, graphql } from "react-relay"
 import { RouterLink } from "System/Components/RouterLink"
@@ -58,9 +58,9 @@ export const ViewingRoomArtworkDetails: React.FC<ViewingRoomArtworkDetailsProps>
       </GridColumns>
 
       {additionalInformation && (
-        <Text variant="md" mt={4}>
-          {additionalInformation}
-        </Text>
+        <HTML variant="md" mt={4}>
+          <ReadMore content={additionalInformation} maxChars={100000} />
+        </HTML>
       )}
     </ManageArtworkForSavesProvider>
   )
@@ -73,7 +73,7 @@ export const ViewingRoomArtworkDetailsFragmentContainer = createFragmentContaine
       fragment ViewingRoomArtworkDetails_artwork on Artwork {
         ...Details_artwork
         id
-        additionalInformation
+        additionalInformation(format: HTML)
         href
       }
     `,


### PR DESCRIPTION
[AMBER-1099](https://artsyproduct.atlassian.net/browse/AMBER-1099)
# Description
Steps to reproduce:

Issues relating to the viewing room William Kentridge : Studio Life Gravures Viewing Room.
Parter: Jillian Ross Print

When looking at this viewing room and then artwork within it 'The Old Gods Have Retired':

1. The formatting of the text 'About the artwork' does not have any line breaks in the preview. Creates a long passage of text which is difficult to read.

2. The video is not showing in the Viewing room 

Artwork listing in CMS here <https://cms.artsy.net/artworks/66fda41ced5b2f0e49ec965f/edit>

Viewing room preview here <https://www.artsy.net/viewing-room/jillian-ross-print-william-kentridge-studio-life-gravures/artworks>

URL Affected: https://www.artsy.net/viewing-room/jillian-ross-print-william-kentridge-studio-life-gravures/artworks

Reporter: Azusa <azusa.hyde@artsymail.com>

__Note:__
The VR page isn't currently set up to handle video, so that portion of the ticket is not a bug. I do have an idea to add this easily that I will explore in a separate ticket.

__Before:__
<img width="763" alt="Screenshot 2024-10-29 at 2 37 56 PM" src="https://github.com/user-attachments/assets/bbb7da7e-dcb6-459d-b9c6-120caca2dafe">
__After:__
<img width="723" alt="Screenshot 2024-10-29 at 2 36 06 PM" src="https://github.com/user-attachments/assets/f6bd1029-8453-4225-b341-9f3af5c69fed">

[AMBER-1099]: https://artsyproduct.atlassian.net/browse/AMBER-1099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ