### PR TITLE
fix(artwork): Fix cutoff on closed auction artworks

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/SuggestedArtworksShelf.tsx
+++ b/src/Apps/Artwork/Components/ArtworkAuctionCreateAlertHeader/SuggestedArtworksShelf.tsx
@@ -32,6 +32,7 @@ export const SuggestedArtworksShelf: FC<SuggestedArtworksShelfProps> = ({
     suggestedArtworksCount > NUMBER_OF_ARTWORKS_TO_SHOW
 
   if (!displaySuggestedArtworksSection) return null
+
   return (
     <>
       <Column span={12} display={["none", "block"]}>
@@ -46,7 +47,7 @@ export const SuggestedArtworksShelf: FC<SuggestedArtworksShelfProps> = ({
           gap={2}
           justifyContent="center"
           overflow="hidden"
-          height="340px"
+          height="350px"
         >
           {artworks.map(artwork => (
             <ShelfArtworkFragmentContainer


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Fixes cutoff on closed auction artworks. 

@dblandin - i can't find the ticket for this, but its on y'alls board somewhere.  

Before:
<img width="1245" alt="Screenshot 2024-11-01 at 9 50 52 AM" src="https://github.com/user-attachments/assets/88e8cb9a-62c8-4500-9ce4-fe69a618e4cd">

After: 

<img width="1105" alt="Screenshot 2024-11-01 at 10 05 05 AM" src="https://github.com/user-attachments/assets/eb1cb5b3-63b1-43db-ab3a-116d4e3061b8">


cc @artsy/diamond-devs 
