### PR TITLE
fix(artist): Attempt to improve LCP

### DIFF
--- a/src/Apps/Artist/Components/ArtistHeader/ArtistHeaderImage.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/ArtistHeaderImage.tsx
@@ -1,9 +1,13 @@
-import { BoxProps, Image, ResponsiveBox } from "@artsy/palette"
-import { FullBleedHeader } from "Components/FullBleedHeader/FullBleedHeader"
+import { BoxProps, FullBleed, Image, ResponsiveBox } from "@artsy/palette"
 import { FC } from "react"
-import { maxDimensionsByArea, resized } from "Utils/resized"
+import { cropped, maxDimensionsByArea, resized } from "Utils/resized"
 import { BREAKPOINTS, Media } from "Utils/Responsive"
 import { Link } from "react-head"
+
+const MOBILE_SIZE = {
+  width: 450,
+  height: 320,
+}
 
 interface ArtistHeaderImageProps
   extends Omit<BoxProps, "maxHeight" | "maxWidth"> {
@@ -21,16 +25,14 @@ export const ArtistHeaderImage: FC<ArtistHeaderImageProps> = ({
   })
 
   const desktop = resized(image.src, { width: max.width, height: max.height })
+  const mobile = cropped(image.src, {
+    width: MOBILE_SIZE.width,
+    height: MOBILE_SIZE.height,
+    quality: 60,
+  })
 
   return (
     <>
-      <Link
-        rel="preload"
-        href={image.src}
-        as="image"
-        media={`(max-width: ${BREAKPOINTS.sm}px)`}
-      />
-
       <Link
         rel="preload"
         href={desktop.src}
@@ -39,8 +41,37 @@ export const ArtistHeaderImage: FC<ArtistHeaderImageProps> = ({
         media={`(min-width: ${BREAKPOINTS.sm}px)`}
       />
 
+      <Link
+        rel="preload"
+        href={mobile.src}
+        as="image"
+        imagesrcset={mobile.srcSet}
+        media={`(min-width: ${BREAKPOINTS.sm}px)`}
+      />
+
       <Media at="xs">
-        <FullBleedHeader src={image.src} />
+        <FullBleed>
+          <ResponsiveBox
+            aspectWidth={MOBILE_SIZE.width}
+            aspectHeight={MOBILE_SIZE.height}
+            maxWidth={700}
+            minWidth={MOBILE_SIZE.width}
+            maxHeight={MOBILE_SIZE.height}
+            minHeight={MOBILE_SIZE.height}
+          >
+            <Image
+              width="100%"
+              height="100%"
+              src={mobile.src}
+              srcSet={mobile.srcSet}
+              fetchPriority="high"
+              style={{
+                minWidth: MOBILE_SIZE.width,
+                minHeight: MOBILE_SIZE.height,
+              }}
+            />
+          </ResponsiveBox>
+        </FullBleed>
       </Media>
 
       <Media greaterThan="xs">


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

This is not the prettiest PR, and its not as nice as things are currently (with the fixed scrolling backdrop, etc), but given our LCP scores, its likely worth it. 

Simplifies the artist header image on mobile by skipping out on FullBleedHeader (and all of its nice features) in favor of a ResponsiveBox + Image 

Still looks the same: 

<img width="478" alt="Screenshot 2024-11-01 at 2 24 09 PM" src="https://github.com/user-attachments/assets/7c41d5da-c92d-460a-a5cf-dc0deb95a351">

But (local) lighthouse LCP performance score has significantly improved:

Before:

<img width="281" alt="Screenshot 2024-11-01 at 11 38 19 AM" src="https://github.com/user-attachments/assets/3d635eb3-1824-4883-871d-56eef56b3ac0">

After:

<img width="231" alt="Screenshot 2024-11-01 at 2 30 02 PM" src="https://github.com/user-attachments/assets/dc8377f4-8586-4948-b822-fdf127ace318">






