### PR TITLE
fix(lcp): Improve LCP on mobile fair page 

### DIFF
--- a/src/Apps/Artist/Components/ArtistHeader/ArtistHeaderImage.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/ArtistHeaderImage.tsx
@@ -46,7 +46,7 @@ export const ArtistHeaderImage: FC<ArtistHeaderImageProps> = ({
         href={mobile.src}
         as="image"
         imagesrcset={mobile.srcSet}
-        media={`(min-width: ${BREAKPOINTS.sm}px)`}
+        media={`(max-width: ${BREAKPOINTS.sm}px)`}
       />
 
       <Media at="xs">

--- a/src/Apps/Fair/Components/FairHeader/FairHeaderImage.tsx
+++ b/src/Apps/Fair/Components/FairHeader/FairHeaderImage.tsx
@@ -2,6 +2,15 @@ import * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { FairHeaderImage_fair$data } from "__generated__/FairHeaderImage_fair.graphql"
 import { FullBleedHeader } from "Components/FullBleedHeader/FullBleedHeader"
+import { BREAKPOINTS, Media } from "Utils/Responsive"
+import { FullBleed, Image, ResponsiveBox } from "@artsy/palette"
+import { Link } from "react-head"
+import { cropped } from "Utils/resized"
+
+const MOBILE_SIZE = {
+  width: 450,
+  height: 320,
+}
 
 interface FairHeaderImageProps {
   fair: FairHeaderImage_fair$data
@@ -10,11 +19,56 @@ interface FairHeaderImageProps {
 export const FairHeaderImage: React.FC<FairHeaderImageProps> = ({
   fair: { image },
 }) => {
-  if (image?.url) {
-    return <FullBleedHeader src={image.url} />
+  if (!image?.url) {
+    return null
   }
 
-  return null
+  const mobile = cropped(image.url, {
+    width: MOBILE_SIZE.width,
+    height: MOBILE_SIZE.height,
+    quality: 60,
+  })
+
+  return (
+    <>
+      <Link
+        rel="preload"
+        href={mobile.src}
+        as="image"
+        imagesrcset={mobile.srcSet}
+        media={`(max-width: ${BREAKPOINTS.sm}px)`}
+      />
+
+      <Media at="xs">
+        <FullBleed>
+          <ResponsiveBox
+            aspectWidth={MOBILE_SIZE.width}
+            aspectHeight={MOBILE_SIZE.height}
+            maxWidth={700}
+            minWidth={MOBILE_SIZE.width}
+            maxHeight={MOBILE_SIZE.height}
+            minHeight={MOBILE_SIZE.height}
+          >
+            <Image
+              width="100%"
+              height="100%"
+              src={mobile.src}
+              srcSet={mobile.srcSet}
+              fetchPriority="high"
+              style={{
+                minWidth: MOBILE_SIZE.width,
+                minHeight: MOBILE_SIZE.height,
+              }}
+            />
+          </ResponsiveBox>
+        </FullBleed>
+      </Media>
+
+      <Media greaterThan="xs">
+        <FullBleedHeader src={image.url} />
+      </Media>
+    </>
+  )
 }
 
 export const FairHeaderImageFragmentContainer = createFragmentContainer(


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Similar to recent [work done on /artist/id](https://github.com/artsy/force/pull/14769), this improves LCP on fair/id by eliminating the fullbleed header and using a simple cropped image.

cc @artsy/diamond-devs 