### PR TITLE
fix(preconnect): Remove unnecessary crossorigin attributes

### DIFF
--- a/src/Apps/Artist/Components/ArtistHeader/ArtistHeaderImage.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/ArtistHeaderImage.tsx
@@ -39,6 +39,7 @@ export const ArtistHeaderImage: FC<ArtistHeaderImageProps> = ({
         as="image"
         imagesrcset={desktop.srcSet}
         media={`(min-width: ${BREAKPOINTS.sm}px)`}
+        fetchPriority="high"
       />
 
       <Link
@@ -47,6 +48,7 @@ export const ArtistHeaderImage: FC<ArtistHeaderImageProps> = ({
         as="image"
         imagesrcset={mobile.srcSet}
         media={`(max-width: ${BREAKPOINTS.sm}px)`}
+        fetchPriority="high"
       />
 
       <Media at="xs">

--- a/src/html.ejs
+++ b/src/html.ejs
@@ -6,15 +6,15 @@
   <meta charset='utf-8' />
 
   <!-- Preconnect to CDNs -->
-  <link rel="preconnect" href="<%%= cdnUrl %>" crossorigin />
-  <link rel="preconnect" href="<%%= imageCdnUrl %>" crossorigin />
+  <link rel="preconnect" href="<%%= cdnUrl %>" />
+  <link rel="preconnect" href="<%%= imageCdnUrl %>" />
 
   <!-- Create preload tags for most common fonts -->
-  <link rel="preconnect" href="<%%= fontUrl %>" crossorigin />
+  <link rel="preconnect" href="<%%= fontUrl %>"  />
   <link rel="preload" href="<%%= fontUrl %>/all-webfonts.css" as="style" />
-  <link rel="preload" href="<%%= fontUrl %>/ll-unica77_regular.woff2" as="font" type="font/woff2" crossorigin />
-  <link rel="preload" href="<%%= fontUrl %>/ll-unica77_medium.woff2" as="font" type="font/woff2" crossorigin />
-  <link rel="preload" href="<%%= fontUrl %>/ll-unica77_italic.woff2" as="font" type="font/woff2" crossorigin />
+  <link rel="preload" href="<%%= fontUrl %>/ll-unica77_regular.woff2" as="font" type="font/woff2" />
+  <link rel="preload" href="<%%= fontUrl %>/ll-unica77_medium.woff2" as="font" type="font/woff2" />
+  <link rel="preload" href="<%%= fontUrl %>/ll-unica77_italic.woff2" as="font" type="font/woff2" />
 
   <%% if (!disable.scripts) { %>
     <!-- Create preload tags for dynamic chunks -->


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Been looking at this nicer (realtime) page analysis tool ([debugbear](https://www.debugbear.com/test/website-speed/ZCsVHyUb/overview?info=errors&metric=hints.errors)) and noticed that it returned a `preconnect` crossorigin error related to our cdn. Since this is public (as with our other cdn urls) I went ahead and removed that flag to address this error:

<img width="1169" alt="Screenshot 2024-11-03 at 4 11 29 PM" src="https://github.com/user-attachments/assets/71d6a109-e64e-4835-b73c-684aa4882773">

Not sure if i'm missing anything here but seems fine. 

Also flagged our prefetch hint as not being high priority (not an actual image, but...?), so added the attribute to fix that too. 