### PR TITLE
feat: allow list management entry point to occur on artwork page for auction artworks

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActionsSaveButton.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActionsSaveButton.tsx
@@ -7,7 +7,6 @@ import { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import createLogger from "Utils/logger"
 import { ArtworkActionsSaveButton_artwork$data } from "__generated__/ArtworkActionsSaveButton_artwork.graphql"
-import { useSaveArtwork } from "Components/Artwork/SaveButton/useSaveArtwork"
 
 const logger = createLogger("ArtworkActionsSaveButton")
 
@@ -42,33 +41,9 @@ export const ArtworkActionsSaveButton: FC<ArtworkActionsSaveButtonProps> = ({
     },
   })
 
-  const { handleSave: saveToDefaultCollection } = useSaveArtwork({
-    isSaved: artwork.isSavedToAnyList,
-    artwork: {
-      internalID: artwork.internalID,
-      id: artwork.id,
-      slug: artwork.slug,
-      collectorSignals: {
-        auction: {
-          lotWatcherCount:
-            artwork.collectorSignals?.auction?.lotWatcherCount ?? 0,
-        },
-      },
-    },
-    contextModule: ContextModule.artworkImage,
-  })
-
   const handleSave = async () => {
     try {
       await saveArtworkToLists()
-    } catch (error) {
-      logger.error(error)
-    }
-  }
-
-  const handleSaveArtworkInAuction = async () => {
-    try {
-      await saveToDefaultCollection()
     } catch (error) {
       logger.error(error)
     }
@@ -79,7 +54,7 @@ export const ArtworkActionsSaveButton: FC<ArtworkActionsSaveButtonProps> = ({
       <ArtworkActionsWatchLotButtonFragmentContainer
         isSaved={artwork.isSavedToAnyList}
         artwork={artwork}
-        onClick={handleSaveArtworkInAuction}
+        onClick={handleSave}
         canShowRegistrationPopover
       />
     )

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkActionsSaveButton.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkActionsSaveButton.jest.tsx
@@ -7,7 +7,6 @@ import { MockBoot } from "DevTools/MockBoot"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapper"
 import { graphql } from "react-relay"
 import { ArtworkActionsSaveButton_Test_Query } from "__generated__/ArtworkActionsSaveButton_Test_Query.graphql"
-import { wait } from "Utils/wait"
 import { fetchQuery } from "react-relay"
 import { act } from "react-dom/test-utils"
 
@@ -107,19 +106,15 @@ describe("ArtworkActionsSaveButton", () => {
       expect(await screen.findByText("Add to a List")).toBeInTheDocument()
     })
 
-    it("should not display the toast message when artwork is in auction", async () => {
+    it("should display the toast message when artwork is in auction", async () => {
       renderWithRelay({
         Artwork: () => unsavedAuctionArtwork,
       })
 
       fireEvent.click(screen.getByText("Watch lot"))
 
-      // giving the toast some time to appear. Without this line, the test succeeds
-      // even when the toast is being displayed
-      await wait(500)
-
-      expect(screen.queryByText("Artwork saved")).not.toBeInTheDocument()
-      expect(screen.queryByText("Add to a List")).not.toBeInTheDocument()
+      expect(await screen.findByText("Artwork saved")).toBeInTheDocument()
+      expect(await screen.findByText("Add to a List")).toBeInTheDocument()
     })
 
     it("should open the modal when `Add to a List` button was pressed", async () => {


### PR DESCRIPTION
Replacing `isSaved` / `isSavedToList` by `isSavedToAnyList` winds up feeling unusual on the artwork page when the artwork is in an auction _and_ is saved to a custom list (which is allowed on rails).

This is b/c the artwork page 'Watch Lot' functionality only adds/removes from the default list - there's no entry point to list selection if the artwork is saved to custom lists.

I'm not quite sure why we wouldn't do that - in general we should only make exceptions in truly exceptional cases. Not finding much explanation in the previous PR (+ JIRA ticket) - https://github.com/artsy/force/pull/12605

I think we can relax this.



https://github.com/user-attachments/assets/da74e7db-4067-4183-9795-bf6e5010612a


