### PR TITLE
feat(performance): Add PreloadWebpackPlugin for preloading initial JS chunks and simplify html pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -274,6 +274,7 @@
     "@types/yup": "^0.29.13",
     "@typescript-eslint/eslint-plugin": "2.30.0",
     "@typescript-eslint/parser": "4.18.0",
+    "@vue/preload-webpack-plugin": "^2.0.0",
     "@wojtekmaj/enzyme-adapter-react-17": "0.6.6",
     "babel-jest": "^29.5.0",
     "babel-loader": "8.2.3",

--- a/src/html.ejs
+++ b/src/html.ejs
@@ -43,12 +43,9 @@
 </head>
 
 <body>
+  <!-- Inject route-level bundle-split scripts from loadable-components -->
+  <!-- Other scripts are injected via HTMLWebpackPlugin during webpack build time -->
   <%%- content.scripts %>
-
-  <%% if (!disable.scripts) { %>
-    <!-- String concatenation is needed allow outputting a template tag -->
-    <%- htmlWebpackPlugin.tags.bodyTags.map((originalTag) => { const tag = { ...originalTag, attributes: { ...originalTag.attributes } }; tag.attributes['src'] = "<" + "%= cdnUrl %" + ">" + originalTag.attributes['src']; tag.attributes['async'] = true; return tag; }) %>
-  <%% } %>
 
 
   <%% if (!disable.segment && !sd.THIRD_PARTIES_DISABLED && sd.SEGMENT_WRITE_KEY) { %>

--- a/webpack/envs/clientDevelopmentConfig.js
+++ b/webpack/envs/clientDevelopmentConfig.js
@@ -76,8 +76,9 @@ export const clientDevelopmentConfig = () => {
       }),
       new HtmlWebpackPlugin({
         filename: path.resolve(basePath, "public", "html.ejs"),
-        inject: false,
         template: path.resolve(basePath, "src/html.ejs"),
+        inject: true,
+        scriptLoading: "defer",
       }),
       new ReactRefreshWebpackPlugin({
         overlay: false,

--- a/webpack/envs/clientProductionConfig.js
+++ b/webpack/envs/clientProductionConfig.js
@@ -62,13 +62,14 @@ const clientProductionConfig = () => {
       }),
       new HtmlWebpackPlugin({
         filename: path.resolve(basePath, "public", "html.ejs"),
-        inject: false,
+        template: path.resolve(basePath, "src/html.ejs"),
+        inject: true,
+        scriptLoading: "defer",
         minify: {
           collapseWhitespace: true,
           conservativeCollapse: true,
           removeComments: true,
         },
-        template: path.resolve(basePath, "src/html.ejs"),
       }),
       process.env.WEBPACK_BUNDLE_REPORT &&
         new BundleAnalyzerPlugin({

--- a/webpack/sharedPlugins.js
+++ b/webpack/sharedPlugins.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 import { RetryChunkLoadPlugin } from "webpack-retry-chunk-load-plugin"
+import PreloadWebpackPlugin from "@vue/preload-webpack-plugin"
 import NodePolyfillPlugin from "node-polyfill-webpack-plugin"
 import webpack from "webpack"
 
@@ -25,5 +26,11 @@ export const sharedPlugins = () => [
     cacheBust: `function() {
       return "cache-bust=" + Date.now();
     }`,
+  }),
+
+  new PreloadWebpackPlugin({
+    rel: "preload",
+    as: "script",
+    include: "initial",
   }),
 ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -5880,6 +5880,11 @@
     "@typescript-eslint/types" "4.9.1"
     eslint-visitor-keys "^2.0.0"
 
+"@vue/preload-webpack-plugin@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@vue/preload-webpack-plugin/-/preload-webpack-plugin-2.0.0.tgz#a43bfc087e91f7d0efb0086100148f4b16437b68"
+  integrity sha512-RoorRB50WehYbsiWu497q8egZBYlrvOo9KBUG41uth4O023Cbs+7POLm9uw2CAiViBAIhvpw1Y4w4i+MZxOfXw==
+
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.1.tgz#2bfd767eae1a6996f432ff7e8d7fc75679c0b6a7"


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [DIA-969]

### Description

This adds support for preload hints around initial JS chunks that are shipped down to the page via https://github.com/vuejs/preload-webpack-plugin. 

Idea first came from reading [this blogpost](https://mmazzarolo.com/blog/2024-08-13-async-chunk-preloading-on-load) and dug around a bit and realized that webpack can do this all for us. 

Example output:

<img width="979" alt="Screenshot 2024-11-04 at 12 33 35 PM" src="https://github.com/user-attachments/assets/d4f86c4a-388e-4ecb-85d0-d58e6d230b37">

Also refactored / simplified our html setup by not manually defining JS chunk output in our html template, and instead let HTMLWebpackPlugin do the work it was originally designed to do 🤷 

cc @artsy/diamond-devs 

[DIA-969]: https://artsyproduct.atlassian.net/browse/DIA-969?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ