### PR TITLE
feat: add Link headers corresponding to preconnect and preload instructions (DIA-967)

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "webpack": "node --max_old_space_size=4096 -r @babel/register node_modules/.bin/webpack"
   },
   "resolutions": {
+    "@types/express": "4.17.21",
     "@types/react": "16.9.34",
     "@types/relay-runtime": "14.1.1",
     "chokidar": "3.4.0",
@@ -238,7 +239,7 @@
     "@testing-library/user-event": "^13.1.9",
     "@types/autosuggest-highlight": "3.1.0",
     "@types/enzyme": "3.1.11",
-    "@types/express": "4.16.1",
+    "@types/express": "4.17.21",
     "@types/google-maps": "^3.2.3",
     "@types/isomorphic-fetch": "0.0.34",
     "@types/jest": "27.0.2",

--- a/src/Apps/Authentication/Middleware/redirectPostAuth.ts
+++ b/src/Apps/Authentication/Middleware/redirectPostAuth.ts
@@ -8,7 +8,7 @@ export const redirectPostAuth = ({
   req: ArtsyRequest
   res: ArtsyResponse
 }) => {
-  const redirectTo = req.query["redirectTo"]
+  const redirectTo = req.query["redirectTo"] as string
 
   const configuredAllowedHosts =
     getENV("ALLOWED_REDIRECT_HOSTS")?.split(",") || []

--- a/src/Server/middleware/__tests__/hardcodedRedirects.jest.ts
+++ b/src/Server/middleware/__tests__/hardcodedRedirects.jest.ts
@@ -20,33 +20,33 @@ describe("getRedirectUrl", () => {
   })
 
   it("should redirect to the correct URL with dynamic segments", () => {
-    const req = {
+    const req = ({
       route: { path: "/foo/:id/bar" },
       params: { id: "123" },
       url: "/foo/123/bar",
-    } as ArtsyRequest
+    } as unknown) as ArtsyRequest
 
     const result = getRedirectUrl(req, redirects)
     expect(result).toEqual("/bar/123/foo")
   })
 
   it("should handle multiple dynamic segments", () => {
-    const req = {
+    const req = ({
       route: { path: "/user/:userId/profile/:profileId" },
       params: { userId: "456", profileId: "789" },
       url: "/user/456/profile/789",
-    } as ArtsyRequest
+    } as unknown) as ArtsyRequest
 
     const result = getRedirectUrl(req, redirects)
     expect(result).toEqual("/new-profile/789/456")
   })
 
   it("should include query strings in the redirected URL", () => {
-    const req = {
+    const req = ({
       route: { path: "/user/:userId/profile" },
       params: { userId: "456" },
       url: "/user/456/profile?view=full",
-    } as ArtsyRequest
+    } as unknown) as ArtsyRequest
 
     const result = getRedirectUrl(req, redirects)
     expect(result).toEqual("/profile/456?view=full")

--- a/src/Server/middleware/linkHeadersMiddleware.ts
+++ b/src/Server/middleware/linkHeadersMiddleware.ts
@@ -22,7 +22,7 @@ export function linkHeadersMiddleware(
       `<${WEBFONT_URL}/ll-unica77_regular.woff2>; rel=preload; as=font; crossorigin`,
       `<${WEBFONT_URL}/ll-unica77_medium.woff2>; rel=preload; as=font; crossorigin`,
       `<${WEBFONT_URL}/ll-unica77_italic.woff2>; rel=preload; as=font; crossorigin`,
-    ] as any)
+    ])
   }
   next()
 }

--- a/src/Server/middleware/linkHeadersMiddleware.ts
+++ b/src/Server/middleware/linkHeadersMiddleware.ts
@@ -1,0 +1,28 @@
+import type { NextFunction } from "express"
+import type { ArtsyRequest, ArtsyResponse } from "./artsyExpress"
+
+import { CDN_URL, GEMINI_CLOUDFRONT_URL, WEBFONT_URL } from "Server/config"
+
+/**
+ * Link headers allow 103: Early Hints to be sent to the client (by Cloudflare).
+ * These should correspond to preconnect and preload items from html.ejs.
+ * See: https://developers.cloudflare.com/cache/advanced-configuration/early-hints/
+ */
+export function linkHeadersMiddleware(
+  req: ArtsyRequest,
+  res: ArtsyResponse,
+  next: NextFunction
+) {
+  if (!res.headersSent) {
+    res.header("Link", [
+      `<${CDN_URL}>; rel=preconnect; crossorigin`,
+      `<${GEMINI_CLOUDFRONT_URL}>; rel=preconnect; crossorigin`,
+      `<${WEBFONT_URL}>; rel=preconnect; crossorigin`,
+      `<${WEBFONT_URL}/all-webfonts.css>; rel=preload; as=style`,
+      `<${WEBFONT_URL}/ll-unica77_regular.woff2>; rel=preload; as=font; crossorigin`,
+      `<${WEBFONT_URL}/ll-unica77_medium.woff2>; rel=preload; as=font; crossorigin`,
+      `<${WEBFONT_URL}/ll-unica77_italic.woff2>; rel=preload; as=font; crossorigin`,
+    ] as any)
+  }
+  next()
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -37,6 +37,7 @@ import {
 import { morganMiddleware } from "./Server/middleware/morgan"
 import { ensureSslMiddleware } from "./Server/middleware/ensureSsl"
 import { hstsMiddleware } from "./Server/middleware/hsts"
+import { linkHeadersMiddleware } from "./Server/middleware/linkHeadersMiddleware"
 import { ipFilter } from "./Server/middleware/ipFilter"
 import { sessionMiddleware } from "./Server/middleware/session"
 import { assetMiddleware } from "./Server/middleware/asset"
@@ -98,6 +99,9 @@ export function initializeMiddleware(app) {
   // Need sharify for unleash
   registerFeatureFlagService(UnleashService, UnleashFeatureFlagService)
   app.use(featureFlagMiddleware(UnleashService))
+
+  // Preconnect or preload associated links
+  app.use(linkHeadersMiddleware)
 
   /**
    * Routes for pinging system time and up

--- a/yarn.lock
+++ b/yarn.lock
@@ -5044,13 +5044,24 @@
   dependencies:
     "@types/node" "*"
 
-"@types/express@*", "@types/express@4.16.1":
-  version "4.16.1"
-  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.16.1.tgz#d756bd1a85c34d87eaf44c888bad27ba8a4b7cf0"
-  integrity sha512-V0clmJow23WeyblmACoxbHBu2JKlE5TiIme6Lem14FnPW9gsttyHtk6wq7njcdIWH1njAaFgR8gW09lgY98gQg==
+"@types/express-serve-static-core@^4.17.33":
+  version "4.19.6"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz#e01324c2a024ff367d92c66f48553ced0ab50267"
+  integrity sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==
+  dependencies:
+    "@types/node" "*"
+    "@types/qs" "*"
+    "@types/range-parser" "*"
+    "@types/send" "*"
+
+"@types/express@*", "@types/express@4.17.21":
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/@types/express/-/express-4.17.21.tgz#c26d4a151e60efe0084b23dc3369ebc631ed192d"
+  integrity sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==
   dependencies:
     "@types/body-parser" "*"
-    "@types/express-serve-static-core" "*"
+    "@types/express-serve-static-core" "^4.17.33"
+    "@types/qs" "*"
     "@types/serve-static" "*"
 
 "@types/glob@*", "@types/glob@^7.1.1":
@@ -5258,6 +5269,11 @@
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-2.0.0.tgz#5a7306e367c539b9f6543499de8dd519fac37a8b"
   integrity sha512-A2TAGbTFdBw9azHbpVd+/FkdW2T6msN1uct1O9bH3vTerEHKZhTXJUQXy+hNq1B0RagfU8U+KBdqiZpxjhOUQA==
 
+"@types/mime@^1":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.5.tgz#1ef302e01cf7d2b5a0fa526790c9123bf1d06690"
+  integrity sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"
@@ -5387,6 +5403,11 @@
   dependencies:
     "@types/react" "*"
 
+"@types/qs@*":
+  version "6.9.16"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.16.tgz#52bba125a07c0482d26747d5d4947a64daf8f794"
+  integrity sha512-7i+zxXdPD0T4cKDuxCUXJ4wHcsJLwENa6Z3dCu8cfCK743OGy5Nu1RmAGqDPsoTDINVEcdXKRvR/zre+P2Ku1A==
+
 "@types/qs@6.5.3":
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.5.3.tgz#1c3b71b091eaeaf5924538006b7f70603ce63d38"
@@ -5396,6 +5417,11 @@
   version "6.9.6"
   resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.6.tgz#df9c3c8b31a247ec315e6996566be3171df4b3b1"
   integrity sha512-0/HnwIfW4ki2D8L8c9GVcG5I72s9jP5GSLVF0VIXDW00kmIpA6O33G7a8n59Tmh7Nz0WUC3rSb7PTY/sdW2JzA==
+
+"@types/range-parser@*":
+  version "1.2.7"
+  resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.7.tgz#50ae4353eaaddc04044279812f52c8c65857dbcb"
+  integrity sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==
 
 "@types/react-dom@16.8.4":
   version "16.8.4"
@@ -5488,6 +5514,14 @@
     "@types/react" "*"
     "@types/react-relay" "*"
     "@types/relay-runtime" "*"
+
+"@types/send@*":
+  version "0.17.4"
+  resolved "https://registry.yarnpkg.com/@types/send/-/send-0.17.4.tgz#6619cd24e7270793702e4e6a4b958a9010cfc57a"
+  integrity sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==
+  dependencies:
+    "@types/mime" "^1"
+    "@types/node" "*"
 
 "@types/serve-static@*":
   version "1.13.1"


### PR DESCRIPTION
This PR adds `Link` headers corresponding to the `preconnect` and `preload` declarations already made [at the top of our HTML template](https://github.com/artsy/force/blob/7fc5ed5cb75c865cc0b146072e26258e2772d10c/src/html.ejs#L9-L17).

Once these are part of Force's response, we should be able to toggle on [Cloudflare's intelligent "early hints" handling](https://developers.cloudflare.com/cache/advanced-configuration/early-hints/). Supposedly, `103` responses will automatically be streamed to compatible clients before the server's response is available.

[This thread](https://webmasters.stackexchange.com/questions/89466/when-should-i-use-the-crossorigin-attribute-on-a-preconnect-link) was helpful in understanding the appropriate `crossorigin` settings.

(Very open to feedback about how to better reuse the preconnect/preload logic from elsewhere.)

Once this is ready to merge, I'd suggest we first release on its own, then enable early hints once we're satisfied that there's no adverse impact.

https://artsyproduct.atlassian.net/browse/DIA-967