### PR TITLE
feat(early-hints): Add support for emitting webpack .js early hint headers and passing via linkHeadersMiddleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -275,7 +275,6 @@
     "@types/yup": "^0.29.13",
     "@typescript-eslint/eslint-plugin": "2.30.0",
     "@typescript-eslint/parser": "4.18.0",
-    "@vue/preload-webpack-plugin": "^2.0.0",
     "@wojtekmaj/enzyme-adapter-react-17": "0.6.6",
     "babel-jest": "^29.5.0",
     "babel-loader": "8.2.3",

--- a/src/Server/__tests__/getWebpackEarlyHints.jest.ts
+++ b/src/Server/__tests__/getWebpackEarlyHints.jest.ts
@@ -1,0 +1,54 @@
+import fs from "fs"
+import path from "path"
+import { getWebpackEalyHints } from "Server/getWebpackEarlyHints"
+
+jest.mock("fs")
+jest.mock("Server/config", () => ({ CDN_URL: "https://cdn.example.com" }))
+
+const HINTS_PATH = path.join(process.cwd(), "public/assets", "early-hints.json")
+
+describe("getWebpackEalyHints", () => {
+  const mockReadFileSync = fs.readFileSync as jest.Mock
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("should return link headers and preload tags with CDN URL in production", () => {
+    process.env.NODE_ENV = "production"
+    const mockChunkFiles = ["/chunk1.js", "/chunk2.js"]
+
+    mockReadFileSync.mockReturnValueOnce(JSON.stringify(mockChunkFiles))
+
+    const result = getWebpackEalyHints()
+
+    expect(fs.readFileSync).toHaveBeenCalledWith(HINTS_PATH, "utf-8")
+    expect(result.linkHeaders).toEqual([
+      `<https://cdn.example.com/chunk1.js>; rel=preload; as=script; crossorigin`,
+      `<https://cdn.example.com/chunk2.js>; rel=preload; as=script; crossorigin`,
+    ])
+    expect(result.linkPreloadTags).toEqual([
+      `<link rel="preload" as="script" href="https://cdn.example.com/chunk1.js" crossorigin>`,
+      `<link rel="preload" as="script" href="https://cdn.example.com/chunk2.js" crossorigin>`,
+    ])
+  })
+
+  it("should return link headers and preload tags without CDN URL in development", () => {
+    process.env.NODE_ENV = "development"
+    const mockChunkFiles = ["/chunk1.js", "/chunk2.js"]
+
+    mockReadFileSync.mockReturnValueOnce(JSON.stringify(mockChunkFiles))
+
+    const result = getWebpackEalyHints()
+
+    expect(fs.readFileSync).toHaveBeenCalledWith(HINTS_PATH, "utf-8")
+    expect(result.linkHeaders).toEqual([
+      `</chunk1.js>; rel=preload; as=script; crossorigin`,
+      `</chunk2.js>; rel=preload; as=script; crossorigin`,
+    ])
+    expect(result.linkPreloadTags).toEqual([
+      `<link rel="preload" as="script" href="/chunk1.js" crossorigin>`,
+      `<link rel="preload" as="script" href="/chunk2.js" crossorigin>`,
+    ])
+  })
+})

--- a/src/Server/__tests__/getWebpackEarlyHints.jest.ts
+++ b/src/Server/__tests__/getWebpackEarlyHints.jest.ts
@@ -1,13 +1,13 @@
 import fs from "fs"
 import path from "path"
-import { getWebpackEalyHints } from "Server/getWebpackEarlyHints"
+import { getWebpackEarlyHints } from "Server/getWebpackEarlyHints"
 
 jest.mock("fs")
 jest.mock("Server/config", () => ({ CDN_URL: "https://cdn.example.com" }))
 
 const HINTS_PATH = path.join(process.cwd(), "public/assets", "early-hints.json")
 
-describe("getWebpackEalyHints", () => {
+describe("getWebpackEarlyHints", () => {
   const mockReadFileSync = fs.readFileSync as jest.Mock
 
   afterEach(() => {
@@ -20,7 +20,7 @@ describe("getWebpackEalyHints", () => {
 
     mockReadFileSync.mockReturnValueOnce(JSON.stringify(mockChunkFiles))
 
-    const result = getWebpackEalyHints()
+    const result = getWebpackEarlyHints()
 
     expect(fs.readFileSync).toHaveBeenCalledWith(HINTS_PATH, "utf-8")
     expect(result.linkHeaders).toEqual([
@@ -39,7 +39,7 @@ describe("getWebpackEalyHints", () => {
 
     mockReadFileSync.mockReturnValueOnce(JSON.stringify(mockChunkFiles))
 
-    const result = getWebpackEalyHints()
+    const result = getWebpackEarlyHints()
 
     expect(fs.readFileSync).toHaveBeenCalledWith(HINTS_PATH, "utf-8")
     expect(result.linkHeaders).toEqual([

--- a/src/Server/getWebpackEarlyHints.ts
+++ b/src/Server/getWebpackEarlyHints.ts
@@ -4,7 +4,7 @@ import fs from "fs"
 
 const HINTS_PATH = path.join(process.cwd(), "public/assets", "early-hints.json")
 
-export const getWebpackEalyHints = (): {
+export const getWebpackEarlyHints = (): {
   linkHeaders: string[]
   linkPreloadTags: string[]
 } => {

--- a/src/Server/getWebpackEarlyHints.ts
+++ b/src/Server/getWebpackEarlyHints.ts
@@ -17,6 +17,11 @@ export const getWebpackEalyHints = (): {
       "[getWebpackEarlyHints] Could not load webpack early-hints.json:",
       error
     )
+
+    return {
+      linkHeaders: [],
+      linkPreloadTags: [],
+    }
   }
 
   const cdnUrl = (() => {

--- a/src/Server/getWebpackEarlyHints.ts
+++ b/src/Server/getWebpackEarlyHints.ts
@@ -1,0 +1,47 @@
+import { CDN_URL } from "Server/config"
+import path from "path"
+import fs from "fs"
+
+const HINTS_PATH = path.join(process.cwd(), "public/assets", "early-hints.json")
+
+export const getWebpackEalyHints = (): {
+  linkHeaders: string[]
+  linkPreloadTags: string[]
+} => {
+  let chunkFiles
+
+  try {
+    chunkFiles = JSON.parse(fs.readFileSync(HINTS_PATH, "utf-8"))
+  } catch (error) {
+    console.error(
+      "[getWebpackEarlyHints] Could not load webpack early-hints.json:",
+      error
+    )
+  }
+
+  const cdnUrl = (() => {
+    if (process.env.NODE_ENV === "development") {
+      return ""
+    }
+
+    return CDN_URL
+  })()
+
+  const links = chunkFiles.reduce(
+    (acc, file) => {
+      acc.linkHeaders.push(
+        `<${cdnUrl}${file}>; rel=preload; as=script; crossorigin`
+      )
+      acc.linkPreloadTags.push(
+        `<link rel="preload" as="script" href="${cdnUrl}${file}" crossorigin>`
+      )
+      return acc
+    },
+    {
+      linkHeaders: [],
+      linkPreloadTags: [],
+    }
+  )
+
+  return links
+}

--- a/src/Server/middleware/linkHeadersMiddleware.ts
+++ b/src/Server/middleware/linkHeadersMiddleware.ts
@@ -1,8 +1,7 @@
-import path from "path"
-import fs from "fs"
 import type { NextFunction } from "express"
 import type { ArtsyRequest, ArtsyResponse } from "./artsyExpress"
 import { CDN_URL, GEMINI_CLOUDFRONT_URL, WEBFONT_URL } from "Server/config"
+import { getWebpackEalyHints } from "Server/getWebpackEarlyHints"
 
 /**
  * Link headers allow 103: Early Hints to be sent to the client (by Cloudflare).
@@ -14,6 +13,8 @@ export function linkHeadersMiddleware(
   res: ArtsyResponse,
   next: NextFunction
 ) {
+  const { linkHeaders } = getWebpackEalyHints()
+
   if (!res.headersSent) {
     res.header("Link", [
       `<${CDN_URL}>; rel=preconnect; crossorigin`,
@@ -23,40 +24,9 @@ export function linkHeadersMiddleware(
       `<${WEBFONT_URL}/ll-unica77_regular.woff2>; rel=preload; as=font; crossorigin`,
       `<${WEBFONT_URL}/ll-unica77_medium.woff2>; rel=preload; as=font; crossorigin`,
       `<${WEBFONT_URL}/ll-unica77_italic.woff2>; rel=preload; as=font; crossorigin`,
-      ...getWebpackHintHeaders(),
+      ...linkHeaders,
     ])
   }
+
   next()
-}
-
-const getWebpackHintHeaders = () => {
-  let chunkFiles
-
-  try {
-    const earlyHintsPath = path.join(
-      process.cwd(),
-      "public/assets",
-      "early-hints.json"
-    )
-    chunkFiles = JSON.parse(fs.readFileSync(earlyHintsPath, "utf-8"))
-  } catch (error) {
-    console.error(
-      "[linkHeadersMiddleware] Could not load webpack early-hints.json:",
-      error
-    )
-  }
-
-  const cdnUrl = (() => {
-    if (process.env.NODE_ENV === "development") {
-      return ""
-    }
-
-    return CDN_URL
-  })()
-
-  const hintHeaders = chunkFiles.map(
-    file => `<${cdnUrl}${file}>; rel=preload; as=script; crossorigin`
-  )
-
-  return hintHeaders
 }

--- a/src/Server/middleware/linkHeadersMiddleware.ts
+++ b/src/Server/middleware/linkHeadersMiddleware.ts
@@ -1,7 +1,7 @@
 import type { NextFunction } from "express"
 import type { ArtsyRequest, ArtsyResponse } from "./artsyExpress"
 import { CDN_URL, GEMINI_CLOUDFRONT_URL, WEBFONT_URL } from "Server/config"
-import { getWebpackEalyHints } from "Server/getWebpackEarlyHints"
+import { getWebpackEarlyHints } from "Server/getWebpackEarlyHints"
 
 /**
  * Link headers allow 103: Early Hints to be sent to the client (by Cloudflare).
@@ -13,7 +13,7 @@ export function linkHeadersMiddleware(
   res: ArtsyResponse,
   next: NextFunction
 ) {
-  const { linkHeaders } = getWebpackEalyHints()
+  const { linkHeaders } = getWebpackEarlyHints()
 
   if (!res.headersSent) {
     res.header("Link", [

--- a/src/System/Router/renderServerApp.tsx
+++ b/src/System/Router/renderServerApp.tsx
@@ -7,7 +7,7 @@ import { getENV } from "Utils/getENV"
 import { ServerAppResults } from "System/Router/serverRouter"
 import { Transform } from "stream"
 import { ENABLE_SSR_STREAMING } from "Server/config"
-import { getWebpackEalyHints } from "Server/getWebpackEarlyHints"
+import { getWebpackEarlyHints } from "Server/getWebpackEarlyHints"
 
 // TODO: Use the same variables as the asset middleware. Both config and sharify
 // have a default CDN_URL while this does not.
@@ -50,7 +50,7 @@ export const renderServerApp = ({
 
   const scripts = extractScriptTags?.()
 
-  const { linkPreloadTags } = getWebpackEalyHints()
+  const { linkPreloadTags } = getWebpackEarlyHints()
 
   const options = {
     cdnUrl: NODE_ENV === "production" ? CDN_URL : "",

--- a/src/System/Router/renderServerApp.tsx
+++ b/src/System/Router/renderServerApp.tsx
@@ -7,6 +7,7 @@ import { getENV } from "Utils/getENV"
 import { ServerAppResults } from "System/Router/serverRouter"
 import { Transform } from "stream"
 import { ENABLE_SSR_STREAMING } from "Server/config"
+import { getWebpackEalyHints } from "Server/getWebpackEarlyHints"
 
 // TODO: Use the same variables as the asset middleware. Both config and sharify
 // have a default CDN_URL while this does not.
@@ -49,12 +50,15 @@ export const renderServerApp = ({
 
   const scripts = extractScriptTags?.()
 
+  const { linkPreloadTags } = getWebpackEalyHints()
+
   const options = {
     cdnUrl: NODE_ENV === "production" ? CDN_URL : "",
     content: {
       body: html,
       data: sharify.script(),
       head: headTagsString,
+      linkPreloadTags,
       scripts,
       style: styleTags,
     },

--- a/src/dev.js
+++ b/src/dev.js
@@ -50,6 +50,7 @@ const wdm = webpackDevMiddleware(compiler, {
      * @see https://github.com/artsy/reaction/blob/master/src/Artsy/Router/serverRouter.tsx
      */
     return (
+      /early-hints/.test(filePath) ||
       /loadable-stats/.test(filePath) ||
       /manifest/.test(filePath) ||
       /\.ejs/.test(filePath)

--- a/src/html.ejs
+++ b/src/html.ejs
@@ -36,6 +36,8 @@
     <%- htmlWebpackPlugin.tags.headTags.map((originalTag) => { const tag = { ...originalTag, attributes: { ...originalTag.attributes } }; tag.attributes['src'] = "<" + "%= cdnUrl %" + ">" + originalTag.attributes['src']; return tag; }) %>
   <%% } %>
 
+  <%%- content.linkPreloadTags.join("") %>
+
   <%%- content.head %>
   <%%- content.style %>
   <%%- content.data %>

--- a/webpack/plugins/EarlyHintsPlugin.js
+++ b/webpack/plugins/EarlyHintsPlugin.js
@@ -1,0 +1,46 @@
+// @ts-check
+
+import webpack from "webpack"
+
+/**
+ * This plugin generates a JSON file with the list of entry chunk files to
+ * be used by the server to send early hints to the client.
+ */
+
+export class EarlyHintsPlugin {
+  /**
+   * @param {webpack.Compiler} compiler
+   */
+  apply(compiler) {
+    compiler.hooks.thisCompilation.tap("EarlyHintPlugin", compilation => {
+      compilation.hooks.processAssets.tap(
+        {
+          name: "EarlyHintPlugin",
+          stage: webpack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
+        },
+        assets => {
+          const publicPath = compilation.outputOptions.publicPath || ""
+
+          /**
+           * Collect entry chunk files (JavaScript files only)
+           * @type {string[]}
+           */
+          const entryChunkFiles = Array.from(compilation.chunks)
+            .filter(chunk => chunk.canBeInitial()) // Select only entry chunks
+            .reduce((acc, chunk) => {
+              const jsFiles = Array.from(chunk.files)
+                .filter(file => file.endsWith(".js"))
+                .map(file => `${publicPath}${file}`)
+              return acc.concat(jsFiles)
+            }, /** @type {string[]} */ ([]))
+
+          // Output `early-hints.json` to webpack output/publicPath directory
+          assets["early-hints.json"] = new webpack.sources.RawSource(
+            JSON.stringify(entryChunkFiles),
+            false
+          )
+        }
+      )
+    })
+  }
+}

--- a/webpack/sharedPlugins.js
+++ b/webpack/sharedPlugins.js
@@ -2,6 +2,7 @@
 
 import { RetryChunkLoadPlugin } from "webpack-retry-chunk-load-plugin"
 // import PreloadWebpackPlugin from "@vue/preload-webpack-plugin"
+import { EarlyHintsPlugin } from "./plugins/EarlyHintsPlugin"
 import NodePolyfillPlugin from "node-polyfill-webpack-plugin"
 import webpack from "webpack"
 
@@ -33,4 +34,6 @@ export const sharedPlugins = () => [
   //   as: "script",
   //   include: "initial",
   // }),
+
+  new EarlyHintsPlugin(),
 ]

--- a/webpack/sharedPlugins.js
+++ b/webpack/sharedPlugins.js
@@ -1,7 +1,6 @@
 // @ts-check
 
 import { RetryChunkLoadPlugin } from "webpack-retry-chunk-load-plugin"
-// import PreloadWebpackPlugin from "@vue/preload-webpack-plugin"
 import { EarlyHintsPlugin } from "./plugins/EarlyHintsPlugin"
 import NodePolyfillPlugin from "node-polyfill-webpack-plugin"
 import webpack from "webpack"
@@ -28,12 +27,6 @@ export const sharedPlugins = () => [
       return "cache-bust=" + Date.now();
     }`,
   }),
-
-  // new PreloadWebpackPlugin({
-  //   rel: "preload",
-  //   as: "script",
-  //   include: "initial",
-  // }),
 
   new EarlyHintsPlugin(),
 ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -5914,11 +5914,6 @@
     "@typescript-eslint/types" "4.9.1"
     eslint-visitor-keys "^2.0.0"
 
-"@vue/preload-webpack-plugin@^2.0.0":
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/@vue/preload-webpack-plugin/-/preload-webpack-plugin-2.0.0.tgz#a43bfc087e91f7d0efb0086100148f4b16437b68"
-  integrity sha512-RoorRB50WehYbsiWu497q8egZBYlrvOo9KBUG41uth4O023Cbs+7POLm9uw2CAiViBAIhvpw1Y4w4i+MZxOfXw==
-
 "@webassemblyjs/ast@1.11.1":
   version "1.11.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.11.1.tgz#2bfd767eae1a6996f432ff7e8d7fc75679c0b6a7"


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [DIA-972]

### Description

Building on work completed in: 
- https://github.com/artsy/force/pull/14794 

This adds a new Webpack plugin for generating a list of "initial" webpack chunks for `early-hints` (`initial` being, those assets that are required on every page to run the site). On the express side we read the list and then expand the headers that are being passed down via the new `linkHeadersMiddleware`. With this now in place we can take further advantage of the new `<link rel="preload" as="script">` tags that we're now writing to our html template on build. 

**Screenshots:**

1. Can now see that we've got a high fetch priority on our main scripts: 

<img width="557" alt="Screenshot 2024-11-05 at 8 51 59 AM" src="https://github.com/user-attachments/assets/8c280547-1d69-47ee-80fa-a654e3900585">

2. And here are the script link headers as passed over from the server:

<img width="684" alt="Screenshot 2024-11-05 at 9 09 52 AM" src="https://github.com/user-attachments/assets/c61c6613-75b1-4bdf-b7eb-bc2725bb1026">



cc @artsy/diamond-devs 


[DIA-972]: https://artsyproduct.atlassian.net/browse/DIA-972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ