### PR TITLE
fix: Avoid remount on Search page

### DIFF
--- a/src/Apps/Search/Routes/SearchResultsArtworks.tsx
+++ b/src/Apps/Search/Routes/SearchResultsArtworks.tsx
@@ -1,17 +1,19 @@
-import * as React from "react"
 import { SearchResultsArtworks_viewer$data } from "__generated__/SearchResultsArtworks_viewer.graphql"
+import { SearchResultsArtworksFilters } from "Apps/Search/Components/SearchResultsArtworksFilters"
 import { ZeroState } from "Apps/Search/Components/ZeroState"
 import { ArtworkFilter } from "Components/ArtworkFilter"
-import { updateUrl } from "Components/ArtworkFilter/Utils/urlBuilder"
-import { createFragmentContainer, graphql } from "react-relay"
-import { useRouter } from "System/Hooks/useRouter"
 import {
   Counts,
   SharedArtworkFilterContextProps,
 } from "Components/ArtworkFilter/ArtworkFilterContext"
-import { useSystemContext } from "System/Hooks/useSystemContext"
-import { SearchResultsArtworksFilters } from "Apps/Search/Components/SearchResultsArtworksFilters"
+import { updateUrl } from "Components/ArtworkFilter/Utils/urlBuilder"
+import * as React from "react"
 import { useEffect, useState } from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { useRouter } from "System/Hooks/useRouter"
+import { useSystemContext } from "System/Hooks/useSystemContext"
+
+const SEARCH_PATH_NAME = "/search"
 
 interface SearchResultsRouteProps {
   viewer: SearchResultsArtworks_viewer$data
@@ -27,8 +29,13 @@ export const SearchResultsArtworksRoute: React.FC<SearchResultsRouteProps> = pro
   const { sidebar } = viewer
 
   useEffect(() => {
+    const term = match.location.query.term
+
+    // This is to avoid remounting the component when moving away from the search page (e.g. by clicking on a search result).
+    if (match.location.pathname !== SEARCH_PATH_NAME || !term) return
+
     // refresh artwork filter on query change
-    setSearchFilterKey(match.location.query.term)
+    setSearchFilterKey(term)
   }, [match.location.query.term])
 
   return (


### PR DESCRIPTION
Addresses [ONYX-861]

* Related fix: https://github.com/artsy/force/pull/13567
* PR that introduced the remount issue: https://github.com/artsy/force/pull/12941

## Description

With this fix, we avoid the remount on the Search page when clicking on a search item that was caused by the updated `key` prop.


[ONYX-861]: https://artsyproduct.atlassian.net/browse/ONYX-861?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ