### PR TITLE
fix: Update the term on the search page correctly

### DIFF
--- a/src/Apps/Search/SearchApp.tsx
+++ b/src/Apps/Search/SearchApp.tsx
@@ -1,4 +1,3 @@
-import React from "react"
 import {
   Box,
   FullBleed,
@@ -8,17 +7,17 @@ import {
   Text,
 } from "@artsy/palette"
 import { SearchApp_viewer$data } from "__generated__/SearchApp_viewer.graphql"
+import { AppContainer } from "Apps/Components/AppContainer"
 import { NavigationTabsFragmentContainer as NavigationTabs } from "Apps/Search/Components/NavigationTabs"
 import { SearchMeta } from "Apps/Search/Components/SearchMeta"
 import { RecentlyViewed } from "Components/RecentlyViewed"
-import { createFragmentContainer, graphql } from "react-relay"
-import { ZeroState } from "./Components/ZeroState"
-import { useRouter } from "System/Hooks/useRouter"
 import { Sticky } from "Components/Sticky"
-import { AppContainer } from "Apps/Components/AppContainer"
+import React from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+import { useRouter } from "System/Hooks/useRouter"
+import { ZeroState } from "./Components/ZeroState"
 
 import { Jump } from "Utils/Hooks/useJump"
-import { usePrevious } from "@artsy/palette"
 
 export interface SearchAppProps {
   viewer: SearchApp_viewer$data
@@ -50,7 +49,7 @@ export const SearchApp: React.FC<SearchAppProps> = ({ viewer, children }) => {
   const { query } = location
   const { aggregations } = searchConnection ?? {}
 
-  const term = usePrevious(query.term ?? "")
+  const term = query.term
   const typeAggregation = aggregations?.find(agg => agg?.slice === "TYPE")
     ?.counts
 


### PR DESCRIPTION
Resolves [ONYX-1384](https://artsyproduct.atlassian.net/browse/ONYX-1384)


## Description

Entering a new search term on the search page does not always update the text on the page. This PR fixes the issue.

<img width="963" alt="Screenshot 2024-11-05 at 11 42 12" src="https://github.com/user-attachments/assets/66bbd6aa-bb92-4dbc-bc6c-125ae357c7d7">


**Steps to reproduce:**

Type "richter" in search input, press enter
Type "warhol" in search input, press enter
Type "richter" in search input, press enter

Outcome before this fix:

`... results for "warhol"` is still displayed

Expected outcome:

`... results for "richter"` should be displayed


https://github.com/user-attachments/assets/d1bb780c-1b1a-4c4a-92d3-4dcc363e8025



[ONYX-1384]: https://artsyproduct.atlassian.net/browse/ONYX-1384?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ