### PR TITLE
fix: Require logged in user for  all`/favorites/alerts/` sub route

### DIFF
--- a/src/Apps/Favorites/favoritesRoutes.tsx
+++ b/src/Apps/Favorites/favoritesRoutes.tsx
@@ -87,11 +87,6 @@ export const favoritesRoutes: RouteProps[] = [
         onClientSideRender: () => {
           Alerts.preload()
         },
-        onServerSideRender: ({ req, res }) => {
-          if (!req.user) {
-            res.redirect("/")
-          }
-        },
         query: graphql`
           query favoritesRoutesAlertsAppEditQuery {
             me {

--- a/src/Server/middleware/userRequiredMiddleware.ts
+++ b/src/Server/middleware/userRequiredMiddleware.ts
@@ -4,7 +4,7 @@ const USER_REQUIRED_ROUTES = [
   "/notifications",
   "/orders(.*)",
   "/my-collection/artworks(.*)",
-  "/favorites/alerts",
+  "/favorites/alerts(.*)",
   "/settings/payments",
   "/settings/purchases(.*)",
   "/settings/shipping",


### PR DESCRIPTION
Addresses [ONYX-1248]

## Description

Require logged-in user for `/favorites/alerts/$id/edit` route instead of redirecting to `/`.

<img width="1493" alt="Screenshot 2024-11-05 at 16 41 31" src="https://github.com/user-attachments/assets/d16197fd-bb71-4f6b-b2aa-738f7dd611ba">


[ONYX-1248]: https://artsyproduct.atlassian.net/browse/ONYX-1248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ