### PR TITLE
fix: remove a fragment thats been deferred from Fair overview

### DIFF
--- a/src/Apps/Fair/Routes/FairOverview.tsx
+++ b/src/Apps/Fair/Routes/FairOverview.tsx
@@ -65,7 +65,6 @@ export const FairOverviewFragmentContainer = createFragmentContainer(
       fragment FairOverview_fair on Fair {
         ...FairEditorialRailArticles_fair
         ...FairCollections_fair
-        ...FairFollowedArtists_fair
         ...FairAbout_fair
         href
         slug

--- a/src/__generated__/FairOverview_Test_Query.graphql.ts
+++ b/src/__generated__/FairOverview_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<358353821b31c16f3c05f0afc69c2be5>>
+ * @generated SignedSource<<485462a14dfd9934af6fe758f6d6392d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -47,155 +47,45 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "width",
+  "name": "slug",
   "storageKey": null
 },
 v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "slug",
-  "storageKey": null
-},
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v8 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "endAt",
-  "storageKey": null
-},
-v9 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "display",
-    "storageKey": null
-  }
-],
-v10 = [
-  {
-    "kind": "Literal",
-    "name": "shallow",
-    "value": true
-  }
-],
-v11 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-},
-v12 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "lotID",
-  "storageKey": null
-},
-v13 = [
-  (v11/*: any*/),
-  (v7/*: any*/)
-],
-v14 = {
+v5 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v15 = {
+v6 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v16 = {
+v7 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v17 = {
+v8 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Image"
 },
-v18 = {
+v9 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Int"
-},
-v19 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Int"
-},
-v20 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "FilterArtworksConnection"
-},
-v21 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": true,
-  "type": "FilterArtworksEdge"
-},
-v22 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Artwork"
-},
-v23 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Boolean"
-},
-v24 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "Boolean"
-},
-v25 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "SaleArtwork"
-},
-v26 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "FormattedNumber"
 };
 return {
   "fragment": {
@@ -344,8 +234,20 @@ return {
                             "name": "cropped",
                             "plural": false,
                             "selections": [
-                              (v3/*: any*/),
-                              (v4/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "width",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "height",
+                                "storageKey": null
+                              },
                               {
                                 "alias": null,
                                 "args": null,
@@ -366,9 +268,15 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v5/*: any*/),
-                      (v6/*: any*/),
-                      (v7/*: any*/)
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      (v3/*: any*/),
+                      (v4/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -399,8 +307,8 @@ return {
             "name": "marketingCollections",
             "plural": true,
             "selections": [
-              (v7/*: any*/),
-              (v6/*: any*/),
+              (v4/*: any*/),
+              (v3/*: any*/),
               (v2/*: any*/),
               {
                 "alias": "artworks",
@@ -474,486 +382,27 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v7/*: any*/)
+                          (v4/*: any*/)
                         ],
                         "storageKey": null
                       }
                     ],
                     "storageKey": null
                   },
-                  (v7/*: any*/)
+                  (v4/*: any*/)
                 ],
                 "storageKey": "artworksConnection(first:3)"
               }
             ],
             "storageKey": "marketingCollections(size:5)"
           },
-          (v5/*: any*/),
-          (v6/*: any*/),
           {
-            "alias": "followedArtistArtworks",
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "first",
-                "value": 20
-              },
-              {
-                "kind": "Literal",
-                "name": "includeArtworksByFollowedArtists",
-                "value": true
-              }
-            ],
-            "concreteType": "FilterArtworksConnection",
-            "kind": "LinkedField",
-            "name": "filterArtworksConnection",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "FilterArtworksEdge",
-                "kind": "LinkedField",
-                "name": "edges",
-                "plural": true,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Artwork",
-                    "kind": "LinkedField",
-                    "name": "node",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "isUnlisted",
-                        "storageKey": null
-                      },
-                      (v5/*: any*/),
-                      (v1/*: any*/),
-                      (v2/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "date",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "AuctionCollectorSignals",
-                            "kind": "LinkedField",
-                            "name": "auction",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "bidCount",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "lotClosesAt",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "liveBiddingStarted",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "registrationEndsAt",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "onlineBiddingExtended",
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "PartnerOfferToCollector",
-                            "kind": "LinkedField",
-                            "name": "partnerOffer",
-                            "plural": false,
-                            "selections": [
-                              (v8/*: any*/),
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "Money",
-                                "kind": "LinkedField",
-                                "name": "priceWithDiscount",
-                                "plural": false,
-                                "selections": (v9/*: any*/),
-                                "storageKey": null
-                              },
-                              (v7/*: any*/)
-                            ],
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "sale_message",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "saleMessage",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "cultural_maker",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "culturalMaker",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": (v10/*: any*/),
-                        "concreteType": "Artist",
-                        "kind": "LinkedField",
-                        "name": "artist",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "ArtistTargetSupply",
-                            "kind": "LinkedField",
-                            "name": "targetSupply",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "isP1",
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          },
-                          (v7/*: any*/)
-                        ],
-                        "storageKey": "artist(shallow:true)"
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "ArtworkPriceInsights",
-                        "kind": "LinkedField",
-                        "name": "marketPriceInsights",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "demandRank",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": (v10/*: any*/),
-                        "concreteType": "Artist",
-                        "kind": "LinkedField",
-                        "name": "artists",
-                        "plural": true,
-                        "selections": [
-                          (v7/*: any*/),
-                          (v1/*: any*/),
-                          (v11/*: any*/)
-                        ],
-                        "storageKey": "artists(shallow:true)"
-                      },
-                      {
-                        "alias": "collecting_institution",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "collectingInstitution",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": (v10/*: any*/),
-                        "concreteType": "Partner",
-                        "kind": "LinkedField",
-                        "name": "partner",
-                        "plural": false,
-                        "selections": [
-                          (v11/*: any*/),
-                          (v1/*: any*/),
-                          (v7/*: any*/)
-                        ],
-                        "storageKey": "partner(shallow:true)"
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Sale",
-                        "kind": "LinkedField",
-                        "name": "sale",
-                        "plural": false,
-                        "selections": [
-                          (v8/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "cascadingEndTimeIntervalMinutes",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "extendedBiddingIntervalMinutes",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "startAt",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "is_auction",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isAuction",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "is_closed",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isClosed",
-                            "storageKey": null
-                          },
-                          (v7/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isOpen",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "sale_artwork",
-                        "args": null,
-                        "concreteType": "SaleArtwork",
-                        "kind": "LinkedField",
-                        "name": "saleArtwork",
-                        "plural": false,
-                        "selections": [
-                          (v12/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "lotLabel",
-                            "storageKey": null
-                          },
-                          (v8/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "extendedBiddingEndAt",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "formattedEndDateTime",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "SaleArtworkCounts",
-                            "kind": "LinkedField",
-                            "name": "counts",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": "bidder_positions",
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "bidderPositions",
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "highest_bid",
-                            "args": null,
-                            "concreteType": "SaleArtworkHighestBid",
-                            "kind": "LinkedField",
-                            "name": "highestBid",
-                            "plural": false,
-                            "selections": (v9/*: any*/),
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "opening_bid",
-                            "args": null,
-                            "concreteType": "SaleArtworkOpeningBid",
-                            "kind": "LinkedField",
-                            "name": "openingBid",
-                            "plural": false,
-                            "selections": (v9/*: any*/),
-                            "storageKey": null
-                          },
-                          (v7/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "SaleArtwork",
-                        "kind": "LinkedField",
-                        "name": "saleArtwork",
-                        "plural": false,
-                        "selections": [
-                          (v12/*: any*/),
-                          (v7/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "AttributionClass",
-                        "kind": "LinkedField",
-                        "name": "attributionClass",
-                        "plural": false,
-                        "selections": (v13/*: any*/),
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "ArtworkMedium",
-                        "kind": "LinkedField",
-                        "name": "mediumType",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "Gene",
-                            "kind": "LinkedField",
-                            "name": "filterGene",
-                            "plural": false,
-                            "selections": (v13/*: any*/),
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "artistNames",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": "src",
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "version",
-                                "value": [
-                                  "larger",
-                                  "large"
-                                ]
-                              }
-                            ],
-                            "kind": "ScalarField",
-                            "name": "url",
-                            "storageKey": "url(version:[\"larger\",\"large\"])"
-                          },
-                          (v3/*: any*/),
-                          (v4/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "blurhashDataURL",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v6/*: any*/),
-                      (v7/*: any*/)
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
-              (v7/*: any*/)
-            ],
-            "storageKey": "filterArtworksConnection(first:20,includeArtworksByFollowedArtists:true)"
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "endAt",
+            "storageKey": null
           },
-          (v8/*: any*/),
           {
             "alias": null,
             "args": [
@@ -967,14 +416,15 @@ return {
             "name": "about",
             "storageKey": "about(format:\"HTML\")"
           },
-          (v7/*: any*/)
+          (v3/*: any*/),
+          (v4/*: any*/)
         ],
         "storageKey": "fair(id:\"example\")"
       }
     ]
   },
   "params": {
-    "cacheID": "425b3af9b883a5a9f7e4032ade7ce51e",
+    "cacheID": "6e55bdb3d7e23ddf030e96463305f51d",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -984,7 +434,7 @@ return {
           "plural": false,
           "type": "Fair"
         },
-        "fair.about": (v14/*: any*/),
+        "fair.about": (v5/*: any*/),
         "fair.articlesConnection": {
           "enumValues": null,
           "nullable": true,
@@ -997,240 +447,91 @@ return {
           "plural": true,
           "type": "ArticleEdge"
         },
-        "fair.articlesConnection.edges.__typename": (v15/*: any*/),
+        "fair.articlesConnection.edges.__typename": (v6/*: any*/),
         "fair.articlesConnection.edges.node": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Article"
         },
-        "fair.articlesConnection.edges.node.byline": (v14/*: any*/),
-        "fair.articlesConnection.edges.node.href": (v14/*: any*/),
-        "fair.articlesConnection.edges.node.id": (v16/*: any*/),
-        "fair.articlesConnection.edges.node.internalID": (v16/*: any*/),
-        "fair.articlesConnection.edges.node.publishedAt": (v14/*: any*/),
-        "fair.articlesConnection.edges.node.slug": (v14/*: any*/),
-        "fair.articlesConnection.edges.node.thumbnailImage": (v17/*: any*/),
+        "fair.articlesConnection.edges.node.byline": (v5/*: any*/),
+        "fair.articlesConnection.edges.node.href": (v5/*: any*/),
+        "fair.articlesConnection.edges.node.id": (v7/*: any*/),
+        "fair.articlesConnection.edges.node.internalID": (v7/*: any*/),
+        "fair.articlesConnection.edges.node.publishedAt": (v5/*: any*/),
+        "fair.articlesConnection.edges.node.slug": (v5/*: any*/),
+        "fair.articlesConnection.edges.node.thumbnailImage": (v8/*: any*/),
         "fair.articlesConnection.edges.node.thumbnailImage.cropped": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "CroppedImageUrl"
         },
-        "fair.articlesConnection.edges.node.thumbnailImage.cropped.height": (v18/*: any*/),
-        "fair.articlesConnection.edges.node.thumbnailImage.cropped.src": (v15/*: any*/),
-        "fair.articlesConnection.edges.node.thumbnailImage.cropped.srcSet": (v15/*: any*/),
-        "fair.articlesConnection.edges.node.thumbnailImage.cropped.width": (v18/*: any*/),
-        "fair.articlesConnection.edges.node.thumbnailTitle": (v14/*: any*/),
-        "fair.articlesConnection.edges.node.title": (v14/*: any*/),
-        "fair.articlesConnection.edges.node.vertical": (v14/*: any*/),
-        "fair.articlesConnection.totalCount": (v19/*: any*/),
-        "fair.endAt": (v14/*: any*/),
-        "fair.followedArtistArtworks": (v20/*: any*/),
-        "fair.followedArtistArtworks.edges": (v21/*: any*/),
-        "fair.followedArtistArtworks.edges.node": (v22/*: any*/),
-        "fair.followedArtistArtworks.edges.node.artist": {
+        "fair.articlesConnection.edges.node.thumbnailImage.cropped.height": (v9/*: any*/),
+        "fair.articlesConnection.edges.node.thumbnailImage.cropped.src": (v6/*: any*/),
+        "fair.articlesConnection.edges.node.thumbnailImage.cropped.srcSet": (v6/*: any*/),
+        "fair.articlesConnection.edges.node.thumbnailImage.cropped.width": (v9/*: any*/),
+        "fair.articlesConnection.edges.node.thumbnailTitle": (v5/*: any*/),
+        "fair.articlesConnection.edges.node.title": (v5/*: any*/),
+        "fair.articlesConnection.edges.node.vertical": (v5/*: any*/),
+        "fair.articlesConnection.totalCount": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "Artist"
+          "type": "Int"
         },
-        "fair.followedArtistArtworks.edges.node.artist.id": (v16/*: any*/),
-        "fair.followedArtistArtworks.edges.node.artist.targetSupply": {
-          "enumValues": null,
-          "nullable": false,
-          "plural": false,
-          "type": "ArtistTargetSupply"
-        },
-        "fair.followedArtistArtworks.edges.node.artist.targetSupply.isP1": (v23/*: any*/),
-        "fair.followedArtistArtworks.edges.node.artistNames": (v14/*: any*/),
-        "fair.followedArtistArtworks.edges.node.artists": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": true,
-          "type": "Artist"
-        },
-        "fair.followedArtistArtworks.edges.node.artists.href": (v14/*: any*/),
-        "fair.followedArtistArtworks.edges.node.artists.id": (v16/*: any*/),
-        "fair.followedArtistArtworks.edges.node.artists.name": (v14/*: any*/),
-        "fair.followedArtistArtworks.edges.node.attributionClass": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "AttributionClass"
-        },
-        "fair.followedArtistArtworks.edges.node.attributionClass.id": (v16/*: any*/),
-        "fair.followedArtistArtworks.edges.node.attributionClass.name": (v14/*: any*/),
-        "fair.followedArtistArtworks.edges.node.collecting_institution": (v14/*: any*/),
-        "fair.followedArtistArtworks.edges.node.collectorSignals": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "CollectorSignals"
-        },
-        "fair.followedArtistArtworks.edges.node.collectorSignals.auction": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "AuctionCollectorSignals"
-        },
-        "fair.followedArtistArtworks.edges.node.collectorSignals.auction.bidCount": (v18/*: any*/),
-        "fair.followedArtistArtworks.edges.node.collectorSignals.auction.liveBiddingStarted": (v24/*: any*/),
-        "fair.followedArtistArtworks.edges.node.collectorSignals.auction.lotClosesAt": (v14/*: any*/),
-        "fair.followedArtistArtworks.edges.node.collectorSignals.auction.onlineBiddingExtended": (v24/*: any*/),
-        "fair.followedArtistArtworks.edges.node.collectorSignals.auction.registrationEndsAt": (v14/*: any*/),
-        "fair.followedArtistArtworks.edges.node.collectorSignals.partnerOffer": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "PartnerOfferToCollector"
-        },
-        "fair.followedArtistArtworks.edges.node.collectorSignals.partnerOffer.endAt": (v14/*: any*/),
-        "fair.followedArtistArtworks.edges.node.collectorSignals.partnerOffer.id": (v16/*: any*/),
-        "fair.followedArtistArtworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Money"
-        },
-        "fair.followedArtistArtworks.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v14/*: any*/),
-        "fair.followedArtistArtworks.edges.node.collectorSignals.primaryLabel": {
-          "enumValues": [
-            "CURATORS_PICK",
-            "INCREASED_INTEREST",
-            "PARTNER_OFFER"
-          ],
-          "nullable": true,
-          "plural": false,
-          "type": "LabelSignalEnum"
-        },
-        "fair.followedArtistArtworks.edges.node.cultural_maker": (v14/*: any*/),
-        "fair.followedArtistArtworks.edges.node.date": (v14/*: any*/),
-        "fair.followedArtistArtworks.edges.node.href": (v14/*: any*/),
-        "fair.followedArtistArtworks.edges.node.id": (v16/*: any*/),
-        "fair.followedArtistArtworks.edges.node.image": (v17/*: any*/),
-        "fair.followedArtistArtworks.edges.node.image.blurhashDataURL": (v14/*: any*/),
-        "fair.followedArtistArtworks.edges.node.image.height": (v19/*: any*/),
-        "fair.followedArtistArtworks.edges.node.image.src": (v14/*: any*/),
-        "fair.followedArtistArtworks.edges.node.image.width": (v19/*: any*/),
-        "fair.followedArtistArtworks.edges.node.internalID": (v16/*: any*/),
-        "fair.followedArtistArtworks.edges.node.isUnlisted": (v24/*: any*/),
-        "fair.followedArtistArtworks.edges.node.marketPriceInsights": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ArtworkPriceInsights"
-        },
-        "fair.followedArtistArtworks.edges.node.marketPriceInsights.demandRank": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Float"
-        },
-        "fair.followedArtistArtworks.edges.node.mediumType": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ArtworkMedium"
-        },
-        "fair.followedArtistArtworks.edges.node.mediumType.filterGene": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Gene"
-        },
-        "fair.followedArtistArtworks.edges.node.mediumType.filterGene.id": (v16/*: any*/),
-        "fair.followedArtistArtworks.edges.node.mediumType.filterGene.name": (v14/*: any*/),
-        "fair.followedArtistArtworks.edges.node.partner": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Partner"
-        },
-        "fair.followedArtistArtworks.edges.node.partner.href": (v14/*: any*/),
-        "fair.followedArtistArtworks.edges.node.partner.id": (v16/*: any*/),
-        "fair.followedArtistArtworks.edges.node.partner.name": (v14/*: any*/),
-        "fair.followedArtistArtworks.edges.node.sale": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Sale"
-        },
-        "fair.followedArtistArtworks.edges.node.sale.cascadingEndTimeIntervalMinutes": (v19/*: any*/),
-        "fair.followedArtistArtworks.edges.node.sale.endAt": (v14/*: any*/),
-        "fair.followedArtistArtworks.edges.node.sale.extendedBiddingIntervalMinutes": (v19/*: any*/),
-        "fair.followedArtistArtworks.edges.node.sale.id": (v16/*: any*/),
-        "fair.followedArtistArtworks.edges.node.sale.isOpen": (v23/*: any*/),
-        "fair.followedArtistArtworks.edges.node.sale.is_auction": (v23/*: any*/),
-        "fair.followedArtistArtworks.edges.node.sale.is_closed": (v23/*: any*/),
-        "fair.followedArtistArtworks.edges.node.sale.startAt": (v14/*: any*/),
-        "fair.followedArtistArtworks.edges.node.saleArtwork": (v25/*: any*/),
-        "fair.followedArtistArtworks.edges.node.saleArtwork.id": (v16/*: any*/),
-        "fair.followedArtistArtworks.edges.node.saleArtwork.lotID": (v14/*: any*/),
-        "fair.followedArtistArtworks.edges.node.sale_artwork": (v25/*: any*/),
-        "fair.followedArtistArtworks.edges.node.sale_artwork.counts": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "SaleArtworkCounts"
-        },
-        "fair.followedArtistArtworks.edges.node.sale_artwork.counts.bidder_positions": (v26/*: any*/),
-        "fair.followedArtistArtworks.edges.node.sale_artwork.endAt": (v14/*: any*/),
-        "fair.followedArtistArtworks.edges.node.sale_artwork.extendedBiddingEndAt": (v14/*: any*/),
-        "fair.followedArtistArtworks.edges.node.sale_artwork.formattedEndDateTime": (v14/*: any*/),
-        "fair.followedArtistArtworks.edges.node.sale_artwork.highest_bid": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "SaleArtworkHighestBid"
-        },
-        "fair.followedArtistArtworks.edges.node.sale_artwork.highest_bid.display": (v14/*: any*/),
-        "fair.followedArtistArtworks.edges.node.sale_artwork.id": (v16/*: any*/),
-        "fair.followedArtistArtworks.edges.node.sale_artwork.lotID": (v14/*: any*/),
-        "fair.followedArtistArtworks.edges.node.sale_artwork.lotLabel": (v14/*: any*/),
-        "fair.followedArtistArtworks.edges.node.sale_artwork.opening_bid": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "SaleArtworkOpeningBid"
-        },
-        "fair.followedArtistArtworks.edges.node.sale_artwork.opening_bid.display": (v14/*: any*/),
-        "fair.followedArtistArtworks.edges.node.sale_message": (v14/*: any*/),
-        "fair.followedArtistArtworks.edges.node.slug": (v16/*: any*/),
-        "fair.followedArtistArtworks.edges.node.title": (v14/*: any*/),
-        "fair.followedArtistArtworks.id": (v16/*: any*/),
-        "fair.href": (v14/*: any*/),
-        "fair.id": (v16/*: any*/),
-        "fair.internalID": (v16/*: any*/),
+        "fair.endAt": (v5/*: any*/),
+        "fair.href": (v5/*: any*/),
+        "fair.id": (v7/*: any*/),
         "fair.marketingCollections": {
           "enumValues": null,
           "nullable": false,
           "plural": true,
           "type": "MarketingCollection"
         },
-        "fair.marketingCollections.artworks": (v20/*: any*/),
+        "fair.marketingCollections.artworks": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "FilterArtworksConnection"
+        },
         "fair.marketingCollections.artworks.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "FilterArtworksCounts"
         },
-        "fair.marketingCollections.artworks.counts.total": (v26/*: any*/),
-        "fair.marketingCollections.artworks.edges": (v21/*: any*/),
-        "fair.marketingCollections.artworks.edges.node": (v22/*: any*/),
-        "fair.marketingCollections.artworks.edges.node.id": (v16/*: any*/),
-        "fair.marketingCollections.artworks.edges.node.image": (v17/*: any*/),
-        "fair.marketingCollections.artworks.edges.node.image.url": (v14/*: any*/),
-        "fair.marketingCollections.artworks.id": (v16/*: any*/),
-        "fair.marketingCollections.id": (v16/*: any*/),
-        "fair.marketingCollections.slug": (v15/*: any*/),
-        "fair.marketingCollections.title": (v15/*: any*/),
-        "fair.slug": (v16/*: any*/)
+        "fair.marketingCollections.artworks.counts.total": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "FormattedNumber"
+        },
+        "fair.marketingCollections.artworks.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "FilterArtworksEdge"
+        },
+        "fair.marketingCollections.artworks.edges.node": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artwork"
+        },
+        "fair.marketingCollections.artworks.edges.node.id": (v7/*: any*/),
+        "fair.marketingCollections.artworks.edges.node.image": (v8/*: any*/),
+        "fair.marketingCollections.artworks.edges.node.image.url": (v5/*: any*/),
+        "fair.marketingCollections.artworks.id": (v7/*: any*/),
+        "fair.marketingCollections.id": (v7/*: any*/),
+        "fair.marketingCollections.slug": (v6/*: any*/),
+        "fair.marketingCollections.title": (v6/*: any*/),
+        "fair.slug": (v7/*: any*/)
       }
     },
     "name": "FairOverview_Test_Query",
     "operationKind": "query",
-    "text": "query FairOverview_Test_Query {\n  fair(id: \"example\") {\n    ...FairOverview_fair\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FairAbout_fair on Fair {\n  ...FairTimer_fair\n  about(format: HTML)\n}\n\nfragment FairCollection_collection on MarketingCollection {\n  id\n  slug\n  title\n  artworks: artworksConnection(first: 3) {\n    counts {\n      total\n    }\n    edges {\n      node {\n        image {\n          url(version: \"larger\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairCollections_fair on Fair {\n  marketingCollections(size: 5) {\n    id\n    slug\n    ...FairCollection_collection\n  }\n}\n\nfragment FairEditorialRailArticles_fair on Fair {\n  href\n  articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        ...CellArticle_article\n        internalID\n        slug\n        id\n      }\n    }\n  }\n}\n\nfragment FairFollowedArtists_fair on Fair {\n  internalID\n  slug\n  followedArtistArtworks: filterArtworksConnection(includeArtworksByFollowedArtists: true, first: 20) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairOverview_fair on Fair {\n  ...FairEditorialRailArticles_fair\n  ...FairCollections_fair\n  ...FairFollowedArtists_fair\n  ...FairAbout_fair\n  href\n  slug\n  articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {\n    edges {\n      __typename\n    }\n  }\n  marketingCollections(size: 5) {\n    id\n  }\n}\n\nfragment FairTimer_fair on Fair {\n  endAt\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...ExclusiveAccessBadge_artwork\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  isUnlisted\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n    blurhashDataURL\n  }\n}\n"
+    "text": "query FairOverview_Test_Query {\n  fair(id: \"example\") {\n    ...FairOverview_fair\n    id\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairAbout_fair on Fair {\n  ...FairTimer_fair\n  about(format: HTML)\n}\n\nfragment FairCollection_collection on MarketingCollection {\n  id\n  slug\n  title\n  artworks: artworksConnection(first: 3) {\n    counts {\n      total\n    }\n    edges {\n      node {\n        image {\n          url(version: \"larger\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairCollections_fair on Fair {\n  marketingCollections(size: 5) {\n    id\n    slug\n    ...FairCollection_collection\n  }\n}\n\nfragment FairEditorialRailArticles_fair on Fair {\n  href\n  articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        ...CellArticle_article\n        internalID\n        slug\n        id\n      }\n    }\n  }\n}\n\nfragment FairOverview_fair on Fair {\n  ...FairEditorialRailArticles_fair\n  ...FairCollections_fair\n  ...FairAbout_fair\n  href\n  slug\n  articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {\n    edges {\n      __typename\n    }\n  }\n  marketingCollections(size: 5) {\n    id\n  }\n}\n\nfragment FairTimer_fair on Fair {\n  endAt\n}\n"
   }
 };
 })();

--- a/src/__generated__/FairOverview_fair.graphql.ts
+++ b/src/__generated__/FairOverview_fair.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3d30ee5e770b0ed801235733db823023>>
+ * @generated SignedSource<<3e94918c7956bfaa41354741a2a0d987>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -21,7 +21,7 @@ export type FairOverview_fair$data = {
     readonly id: string;
   } | null | undefined>;
   readonly slug: string;
-  readonly " $fragmentSpreads": FragmentRefs<"FairAbout_fair" | "FairCollections_fair" | "FairEditorialRailArticles_fair" | "FairFollowedArtists_fair">;
+  readonly " $fragmentSpreads": FragmentRefs<"FairAbout_fair" | "FairCollections_fair" | "FairEditorialRailArticles_fair">;
   readonly " $fragmentType": "FairOverview_fair";
 };
 export type FairOverview_fair$key = {
@@ -44,11 +44,6 @@ const node: ReaderFragment = {
       "args": null,
       "kind": "FragmentSpread",
       "name": "FairCollections_fair"
-    },
-    {
-      "args": null,
-      "kind": "FragmentSpread",
-      "name": "FairFollowedArtists_fair"
     },
     {
       "args": null,
@@ -138,6 +133,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "1fda5e6f80a86ce85f7c32c2ce9dbbaf";
+(node as any).hash = "b9e870bd9763a25200b90803c0f08826";
 
 export default node;

--- a/src/__generated__/fairRoutes_FairOverviewQuery.graphql.ts
+++ b/src/__generated__/fairRoutes_FairOverviewQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c9ab09747732e5f707366b90058af3e5>>
+ * @generated SignedSource<<d7adc37e3b9931bbdead3102ad6172ac>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -56,78 +56,16 @@ v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "width",
+  "name": "slug",
   "storageKey": null
 },
 v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "height",
-  "storageKey": null
-},
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "slug",
-  "storageKey": null
-},
-v8 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
-},
-v9 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "endAt",
-  "storageKey": null
-},
-v10 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "display",
-    "storageKey": null
-  }
-],
-v11 = [
-  {
-    "kind": "Literal",
-    "name": "shallow",
-    "value": true
-  }
-],
-v12 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-},
-v13 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "lotID",
-  "storageKey": null
-},
-v14 = [
-  (v12/*: any*/),
-  (v8/*: any*/)
-];
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -275,8 +213,20 @@ return {
                             "name": "cropped",
                             "plural": false,
                             "selections": [
-                              (v4/*: any*/),
-                              (v5/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "width",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "height",
+                                "storageKey": null
+                              },
                               {
                                 "alias": null,
                                 "args": null,
@@ -297,9 +247,15 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v6/*: any*/),
-                      (v7/*: any*/),
-                      (v8/*: any*/)
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      (v4/*: any*/),
+                      (v5/*: any*/)
                     ],
                     "storageKey": null
                   },
@@ -330,8 +286,8 @@ return {
             "name": "marketingCollections",
             "plural": true,
             "selections": [
-              (v8/*: any*/),
-              (v7/*: any*/),
+              (v5/*: any*/),
+              (v4/*: any*/),
               (v3/*: any*/),
               {
                 "alias": "artworks",
@@ -405,486 +361,27 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v8/*: any*/)
+                          (v5/*: any*/)
                         ],
                         "storageKey": null
                       }
                     ],
                     "storageKey": null
                   },
-                  (v8/*: any*/)
+                  (v5/*: any*/)
                 ],
                 "storageKey": "artworksConnection(first:3)"
               }
             ],
             "storageKey": "marketingCollections(size:5)"
           },
-          (v6/*: any*/),
-          (v7/*: any*/),
           {
-            "alias": "followedArtistArtworks",
-            "args": [
-              {
-                "kind": "Literal",
-                "name": "first",
-                "value": 20
-              },
-              {
-                "kind": "Literal",
-                "name": "includeArtworksByFollowedArtists",
-                "value": true
-              }
-            ],
-            "concreteType": "FilterArtworksConnection",
-            "kind": "LinkedField",
-            "name": "filterArtworksConnection",
-            "plural": false,
-            "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "FilterArtworksEdge",
-                "kind": "LinkedField",
-                "name": "edges",
-                "plural": true,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Artwork",
-                    "kind": "LinkedField",
-                    "name": "node",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "isUnlisted",
-                        "storageKey": null
-                      },
-                      (v6/*: any*/),
-                      (v2/*: any*/),
-                      (v3/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "date",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "CollectorSignals",
-                        "kind": "LinkedField",
-                        "name": "collectorSignals",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "primaryLabel",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "AuctionCollectorSignals",
-                            "kind": "LinkedField",
-                            "name": "auction",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "bidCount",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "lotClosesAt",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "liveBiddingStarted",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "registrationEndsAt",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "onlineBiddingExtended",
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "PartnerOfferToCollector",
-                            "kind": "LinkedField",
-                            "name": "partnerOffer",
-                            "plural": false,
-                            "selections": [
-                              (v9/*: any*/),
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "Money",
-                                "kind": "LinkedField",
-                                "name": "priceWithDiscount",
-                                "plural": false,
-                                "selections": (v10/*: any*/),
-                                "storageKey": null
-                              },
-                              (v8/*: any*/)
-                            ],
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "sale_message",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "saleMessage",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "cultural_maker",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "culturalMaker",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": (v11/*: any*/),
-                        "concreteType": "Artist",
-                        "kind": "LinkedField",
-                        "name": "artist",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "ArtistTargetSupply",
-                            "kind": "LinkedField",
-                            "name": "targetSupply",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "isP1",
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          },
-                          (v8/*: any*/)
-                        ],
-                        "storageKey": "artist(shallow:true)"
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "ArtworkPriceInsights",
-                        "kind": "LinkedField",
-                        "name": "marketPriceInsights",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "demandRank",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": (v11/*: any*/),
-                        "concreteType": "Artist",
-                        "kind": "LinkedField",
-                        "name": "artists",
-                        "plural": true,
-                        "selections": [
-                          (v8/*: any*/),
-                          (v2/*: any*/),
-                          (v12/*: any*/)
-                        ],
-                        "storageKey": "artists(shallow:true)"
-                      },
-                      {
-                        "alias": "collecting_institution",
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "collectingInstitution",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": (v11/*: any*/),
-                        "concreteType": "Partner",
-                        "kind": "LinkedField",
-                        "name": "partner",
-                        "plural": false,
-                        "selections": [
-                          (v12/*: any*/),
-                          (v2/*: any*/),
-                          (v8/*: any*/)
-                        ],
-                        "storageKey": "partner(shallow:true)"
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Sale",
-                        "kind": "LinkedField",
-                        "name": "sale",
-                        "plural": false,
-                        "selections": [
-                          (v9/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "cascadingEndTimeIntervalMinutes",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "extendedBiddingIntervalMinutes",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "startAt",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "is_auction",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isAuction",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "is_closed",
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isClosed",
-                            "storageKey": null
-                          },
-                          (v8/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "isOpen",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": "sale_artwork",
-                        "args": null,
-                        "concreteType": "SaleArtwork",
-                        "kind": "LinkedField",
-                        "name": "saleArtwork",
-                        "plural": false,
-                        "selections": [
-                          (v13/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "lotLabel",
-                            "storageKey": null
-                          },
-                          (v9/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "extendedBiddingEndAt",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "formattedEndDateTime",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "SaleArtworkCounts",
-                            "kind": "LinkedField",
-                            "name": "counts",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": "bidder_positions",
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "bidderPositions",
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "highest_bid",
-                            "args": null,
-                            "concreteType": "SaleArtworkHighestBid",
-                            "kind": "LinkedField",
-                            "name": "highestBid",
-                            "plural": false,
-                            "selections": (v10/*: any*/),
-                            "storageKey": null
-                          },
-                          {
-                            "alias": "opening_bid",
-                            "args": null,
-                            "concreteType": "SaleArtworkOpeningBid",
-                            "kind": "LinkedField",
-                            "name": "openingBid",
-                            "plural": false,
-                            "selections": (v10/*: any*/),
-                            "storageKey": null
-                          },
-                          (v8/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "SaleArtwork",
-                        "kind": "LinkedField",
-                        "name": "saleArtwork",
-                        "plural": false,
-                        "selections": [
-                          (v13/*: any*/),
-                          (v8/*: any*/)
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "AttributionClass",
-                        "kind": "LinkedField",
-                        "name": "attributionClass",
-                        "plural": false,
-                        "selections": (v14/*: any*/),
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "ArtworkMedium",
-                        "kind": "LinkedField",
-                        "name": "mediumType",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "Gene",
-                            "kind": "LinkedField",
-                            "name": "filterGene",
-                            "plural": false,
-                            "selections": (v14/*: any*/),
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "artistNames",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Image",
-                        "kind": "LinkedField",
-                        "name": "image",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": "src",
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "version",
-                                "value": [
-                                  "larger",
-                                  "large"
-                                ]
-                              }
-                            ],
-                            "kind": "ScalarField",
-                            "name": "url",
-                            "storageKey": "url(version:[\"larger\",\"large\"])"
-                          },
-                          (v4/*: any*/),
-                          (v5/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "blurhashDataURL",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
-                      (v7/*: any*/),
-                      (v8/*: any*/)
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
-              (v8/*: any*/)
-            ],
-            "storageKey": "filterArtworksConnection(first:20,includeArtworksByFollowedArtists:true)"
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "endAt",
+            "storageKey": null
           },
-          (v9/*: any*/),
           {
             "alias": null,
             "args": [
@@ -898,19 +395,20 @@ return {
             "name": "about",
             "storageKey": "about(format:\"HTML\")"
           },
-          (v8/*: any*/)
+          (v4/*: any*/),
+          (v5/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "e38ecd302bf86141cce9693a37f3f6f9",
+    "cacheID": "bc5ff5847608295c5f5eeb95757ae3a0",
     "id": null,
     "metadata": {},
     "name": "fairRoutes_FairOverviewQuery",
     "operationKind": "query",
-    "text": "query fairRoutes_FairOverviewQuery(\n  $slug: String!\n) @cacheable {\n  fair(id: $slug) @principalField {\n    ...FairOverview_fair\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FairAbout_fair on Fair {\n  ...FairTimer_fair\n  about(format: HTML)\n}\n\nfragment FairCollection_collection on MarketingCollection {\n  id\n  slug\n  title\n  artworks: artworksConnection(first: 3) {\n    counts {\n      total\n    }\n    edges {\n      node {\n        image {\n          url(version: \"larger\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairCollections_fair on Fair {\n  marketingCollections(size: 5) {\n    id\n    slug\n    ...FairCollection_collection\n  }\n}\n\nfragment FairEditorialRailArticles_fair on Fair {\n  href\n  articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        ...CellArticle_article\n        internalID\n        slug\n        id\n      }\n    }\n  }\n}\n\nfragment FairFollowedArtists_fair on Fair {\n  internalID\n  slug\n  followedArtistArtworks: filterArtworksConnection(includeArtworksByFollowedArtists: true, first: 20) {\n    edges {\n      node {\n        ...ShelfArtwork_artwork\n        internalID\n        slug\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairOverview_fair on Fair {\n  ...FairEditorialRailArticles_fair\n  ...FairCollections_fair\n  ...FairFollowedArtists_fair\n  ...FairAbout_fair\n  href\n  slug\n  articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {\n    edges {\n      __typename\n    }\n  }\n  marketingCollections(size: 5) {\n    id\n  }\n}\n\nfragment FairTimer_fair on Fair {\n  endAt\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...ExclusiveAccessBadge_artwork\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  isUnlisted\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n    blurhashDataURL\n  }\n}\n"
+    "text": "query fairRoutes_FairOverviewQuery(\n  $slug: String!\n) @cacheable {\n  fair(id: $slug) @principalField {\n    ...FairOverview_fair\n    id\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairAbout_fair on Fair {\n  ...FairTimer_fair\n  about(format: HTML)\n}\n\nfragment FairCollection_collection on MarketingCollection {\n  id\n  slug\n  title\n  artworks: artworksConnection(first: 3) {\n    counts {\n      total\n    }\n    edges {\n      node {\n        image {\n          url(version: \"larger\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairCollections_fair on Fair {\n  marketingCollections(size: 5) {\n    id\n    slug\n    ...FairCollection_collection\n  }\n}\n\nfragment FairEditorialRailArticles_fair on Fair {\n  href\n  articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        ...CellArticle_article\n        internalID\n        slug\n        id\n      }\n    }\n  }\n}\n\nfragment FairOverview_fair on Fair {\n  ...FairEditorialRailArticles_fair\n  ...FairCollections_fair\n  ...FairAbout_fair\n  href\n  slug\n  articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {\n    edges {\n      __typename\n    }\n  }\n  marketingCollections(size: 5) {\n    id\n  }\n}\n\nfragment FairTimer_fair on Fair {\n  endAt\n}\n"
   }
 };
 })();


### PR DESCRIPTION
This query has a very high error rate...b/c it includes a fragment that errors when the user is logged out! There's no effect in the UI as the relevant component doesn't show up.

However, this entire fragment had been moved into a query renderer (guarded behind a logged-in user: https://github.com/artsy/force/blob/bc35b7ffe4dfd469495f36cff343e5cf67c653dd/src/Apps/Fair/Routes/FairOverview.tsx#L51), so this is a case of overfetching - we can safely just remove the whole fragment.