### PR TITLE
fix(early-hints): Fix cors configuration around preloading js assets 

### DIFF
--- a/src/Server/__tests__/getWebpackEarlyHints.jest.ts
+++ b/src/Server/__tests__/getWebpackEarlyHints.jest.ts
@@ -24,12 +24,12 @@ describe("getWebpackEarlyHints", () => {
 
     expect(fs.readFileSync).toHaveBeenCalledWith(HINTS_PATH, "utf-8")
     expect(result.linkHeaders).toEqual([
-      `<https://cdn.example.com/chunk1.js>; rel=preload; as=script; crossorigin`,
-      `<https://cdn.example.com/chunk2.js>; rel=preload; as=script; crossorigin`,
+      `<https://cdn.example.com/chunk1.js>; rel=preload; as=script`,
+      `<https://cdn.example.com/chunk2.js>; rel=preload; as=script`,
     ])
     expect(result.linkPreloadTags).toEqual([
-      `<link rel="preload" as="script" href="https://cdn.example.com/chunk1.js" crossorigin>`,
-      `<link rel="preload" as="script" href="https://cdn.example.com/chunk2.js" crossorigin>`,
+      `<link rel="preload" as="script" href="https://cdn.example.com/chunk1.js">`,
+      `<link rel="preload" as="script" href="https://cdn.example.com/chunk2.js">`,
     ])
   })
 
@@ -43,12 +43,12 @@ describe("getWebpackEarlyHints", () => {
 
     expect(fs.readFileSync).toHaveBeenCalledWith(HINTS_PATH, "utf-8")
     expect(result.linkHeaders).toEqual([
-      `</chunk1.js>; rel=preload; as=script; crossorigin`,
-      `</chunk2.js>; rel=preload; as=script; crossorigin`,
+      `</chunk1.js>; rel=preload; as=script`,
+      `</chunk2.js>; rel=preload; as=script`,
     ])
     expect(result.linkPreloadTags).toEqual([
-      `<link rel="preload" as="script" href="/chunk1.js" crossorigin>`,
-      `<link rel="preload" as="script" href="/chunk2.js" crossorigin>`,
+      `<link rel="preload" as="script" href="/chunk1.js">`,
+      `<link rel="preload" as="script" href="/chunk2.js">`,
     ])
   })
 })

--- a/src/Server/getWebpackEarlyHints.ts
+++ b/src/Server/getWebpackEarlyHints.ts
@@ -34,11 +34,9 @@ export const getWebpackEarlyHints = (): {
 
   const links = chunkFiles.reduce(
     (acc, file) => {
-      acc.linkHeaders.push(
-        `<${cdnUrl}${file}>; rel=preload; as=script; crossorigin`
-      )
+      acc.linkHeaders.push(`<${cdnUrl}${file}>; rel=preload; as=script`)
       acc.linkPreloadTags.push(
-        `<link rel="preload" as="script" href="${cdnUrl}${file}" crossorigin>`
+        `<link rel="preload" as="script" href="${cdnUrl}${file}">`
       )
       return acc
     },


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Fixes CORS config after lots of faffing, but eventually got to a good localhost workflow:

- install nginx via homebrew
- point nginx server at localhost but mapped to artsy domain (I used [nginx.artys.net](http://nginx.artys.net/))
- `yarn build:client:prod`
- WEBPACK_FAST_PROD_BUILD=true yarn build:server:prod` (speed things up, if making changes)
- `yarn start:prod:debug`

The final incantation was:

- crossorigin on Link header CDN preconnect 
- no crossorigin on Link header preload
- no crossorigin on `<link>` tag preload 

Screenshot of local resources loading correctly (high priority, via `<link>` preload, using CDN): 

<img width="790" alt="Screenshot 2024-11-05 at 5 37 05 PM" src="https://github.com/user-attachments/assets/0a965f27-6323-4776-baa5-824d7968c8d3">

cc @artsy/diamond-devs 