### PR TITLE
chore: Add tracking to Alert list actions

### DIFF
--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertListItem.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertListItem.tsx
@@ -1,4 +1,4 @@
-import { ActionType } from "@artsy/cohesion"
+import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
 import { Box, Clickable, Flex, Spacer, Sup, Text } from "@artsy/palette"
 import { SavedSearchAlertListItem_item$data } from "__generated__/SavedSearchAlertListItem_item.graphql"
 import { EditAlertEntity } from "Apps/Settings/Routes/SavedSearchAlerts/types"
@@ -86,8 +86,10 @@ export const SavedSearchAlertListItem: React.FC<React.PropsWithChildren<SavedSea
               textDecoration="underline"
               onClick={() => {
                 trackEvent({
-                  action_type: ActionType.clickedEditAlert,
+                  action_type: ActionType.clickEditAlert,
                   alert_id: item.internalID,
+                  context_module: ContextModule.alertsList,
+                  context_owner_type: OwnerType.savedSearches,
                 })
                 onEditAlertClick({
                   id: item.internalID,
@@ -111,8 +113,10 @@ export const SavedSearchAlertListItem: React.FC<React.PropsWithChildren<SavedSea
             <Clickable
               onClick={() => {
                 trackEvent({
-                  action_type: ActionType.clickedViewArtworks,
+                  action_type: ActionType.clickedArtworkGroup,
                   alert_id: item.internalID,
+                  context_module: ContextModule.alertsList,
+                  context_owner_type: OwnerType.savedSearches,
                 })
                 onViewArtworksClick({
                   id: item.internalID,

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertListItem.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertListItem.tsx
@@ -15,12 +15,9 @@ interface SavedSearchAlertListItemProps {
   onViewArtworksClick: (entity: EditAlertEntity) => void
 }
 
-export const SavedSearchAlertListItem: React.FC<React.PropsWithChildren<SavedSearchAlertListItemProps>> = ({
-  item,
-  variant,
-  onEditAlertClick,
-  onViewArtworksClick,
-}) => {
+export const SavedSearchAlertListItem: React.FC<React.PropsWithChildren<
+  SavedSearchAlertListItemProps
+>> = ({ item, variant, onEditAlertClick, onViewArtworksClick }) => {
   const { jumpTo } = useJump()
   const { trackEvent } = useTracking()
 
@@ -86,7 +83,7 @@ export const SavedSearchAlertListItem: React.FC<React.PropsWithChildren<SavedSea
               textDecoration="underline"
               onClick={() => {
                 trackEvent({
-                  action_type: ActionType.clickEditAlert,
+                  action_type: ActionType.clickedEditAlert,
                   alert_id: item.internalID,
                   context_module: ContextModule.alertsList,
                   context_owner_type: OwnerType.savedSearches,

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertListItem.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/Components/SavedSearchAlertListItem.tsx
@@ -1,7 +1,9 @@
+import { ActionType } from "@artsy/cohesion"
 import { Box, Clickable, Flex, Spacer, Sup, Text } from "@artsy/palette"
-import { createFragmentContainer, graphql } from "react-relay"
 import { SavedSearchAlertListItem_item$data } from "__generated__/SavedSearchAlertListItem_item.graphql"
 import { EditAlertEntity } from "Apps/Settings/Routes/SavedSearchAlerts/types"
+import { createFragmentContainer, graphql } from "react-relay"
+import { useTracking } from "react-tracking"
 import { useJump } from "Utils/Hooks/useJump"
 
 export type SavedSearchAlertListItemVariant = "active" | "inactive"
@@ -19,9 +21,10 @@ export const SavedSearchAlertListItem: React.FC<React.PropsWithChildren<SavedSea
   onEditAlertClick,
   onViewArtworksClick,
 }) => {
-  const matchingArtworksCount = item.artworksConnection?.counts?.total
-
   const { jumpTo } = useJump()
+  const { trackEvent } = useTracking()
+
+  const matchingArtworksCount = item.artworksConnection?.counts?.total
 
   return (
     <Box
@@ -82,14 +85,16 @@ export const SavedSearchAlertListItem: React.FC<React.PropsWithChildren<SavedSea
             <Clickable
               textDecoration="underline"
               onClick={() => {
-                {
-                  onEditAlertClick({
-                    id: item.internalID,
-                    name: item.settings?.name ?? undefined,
-                    artistIds: item.artistIDs as string[],
-                  })
-                  jumpTo("Alerts")
-                }
+                trackEvent({
+                  action_type: ActionType.clickedEditAlert,
+                  alert_id: item.internalID,
+                })
+                onEditAlertClick({
+                  id: item.internalID,
+                  name: item.settings?.name ?? undefined,
+                  artistIds: item.artistIDs as string[],
+                })
+                jumpTo("Alerts")
               }}
             >
               Edit
@@ -105,6 +110,10 @@ export const SavedSearchAlertListItem: React.FC<React.PropsWithChildren<SavedSea
           >
             <Clickable
               onClick={() => {
+                trackEvent({
+                  action_type: ActionType.clickedViewArtworks,
+                  alert_id: item.internalID,
+                })
                 onViewArtworksClick({
                   id: item.internalID,
                   name: item.settings?.name ?? undefined,


### PR DESCRIPTION
Addresses [ONYX-894]

Related Cohesion PR: https://github.com/artsy/cohesion/pull/540

## Description

This PR adds tracking to [Alert list](https://staging.artsy.net/favorites/alerts/180931/edit) actions ("View Artworks" & "Edit").

<img width="1021" alt="Bildschirmfoto 2024-11-28 um 15 56 25" src="https://github.com/user-attachments/assets/5b2deb7e-89c4-4a6c-8640-56af2d6f792c">

[ONYX-894]: https://artsyproduct.atlassian.net/browse/ONYX-894?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ