### PR TITLE
fix: header image in writer feature layout not formatting properly

### DIFF
--- a/src/Apps/Article/Components/ArticleHero.tsx
+++ b/src/Apps/Article/Components/ArticleHero.tsx
@@ -108,15 +108,27 @@ const ArticleHero: FC<ArticleHeroProps> = ({ article, fixed = true }) => {
             )}
 
             {image && (
-              <Image
-                src={image.src}
-                srcSet={image.srcSet}
+              <Box
+                position="relative"
                 width="100%"
-                height={height}
-                style={{ objectFit: "cover" }}
-                alt=""
-                lazyLoad
-              />
+                minHeight={height}
+                height="100%"
+                bg="black10"
+              >
+                <Image
+                  src={image.src}
+                  srcSet={image.srcSet}
+                  width="100%"
+                  height="100%"
+                  style={{
+                    objectFit: "cover",
+                    position: "absolute",
+                    top: 0,
+                    left: 0,
+                  }}
+                  alt=""
+                />
+              </Box>
             )}
           </Box>
         </FullBleed>


### PR DESCRIPTION
In certain cases and viewport widths, the left column extends beyond the right column's height due to longer headline text. The solution is to change the `height` property to `min-height` to accommodate this, while also addressing Firefox-specific image height rendering behavior.