### PR TITLE
fix: Correctly unset availability filter

### DIFF
--- a/src/Components/ArtworkFilter/ArtworkFilters/AvailabilityFilter.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/AvailabilityFilter.tsx
@@ -11,8 +11,10 @@ interface AvailabilityFilterProps {
   expanded?: boolean
 }
 
-export const AvailabilityFilter: React.FC<AvailabilityFilterProps> = ({ expanded }) => {
-  const { setFilter } = useArtworkFilterContext()
+export const AvailabilityFilter: React.FC<AvailabilityFilterProps> = ({
+  expanded,
+}) => {
+  const { unsetFilter, setFilter } = useArtworkFilterContext()
   const currentSelectedFilters = useCurrentlySelectedFilters()
 
   const filtersCount = useFilterLabelCountByKey(
@@ -22,11 +24,19 @@ export const AvailabilityFilter: React.FC<AvailabilityFilterProps> = ({ expanded
 
   const isSelected = currentSelectedFilters?.forSale
 
+  const handleOnSelect = (selected: boolean) => {
+    if (selected) {
+      setFilter("forSale", true)
+    } else {
+      unsetFilter("forSale")
+    }
+  }
+
   return (
     <FilterExpandable label={label} expanded={isSelected || expanded}>
       <Checkbox
         selected={!!currentSelectedFilters?.forSale}
-        onSelect={selected => setFilter("forSale", selected)}
+        onSelect={handleOnSelect}
         my={1}
       >
         Only works for sale

--- a/src/Components/ArtworkFilter/ArtworkFilters/__tests__/AvailabilityFilter.jest.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/__tests__/AvailabilityFilter.jest.tsx
@@ -1,10 +1,10 @@
 import { screen } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import { useArtworkFilterContext } from "Components/ArtworkFilter/ArtworkFilterContext"
 import {
   createArtworkFilterTestRenderer,
   currentArtworkFilterContext,
 } from "Components/ArtworkFilter/ArtworkFilters/__tests__/Utils"
-import { useArtworkFilterContext } from "Components/ArtworkFilter/ArtworkFilterContext"
 import { AvailabilityFilter } from "Components/ArtworkFilter/ArtworkFilters/AvailabilityFilter"
 import { useEffect } from "react"
 import { __internal__useMatchMedia } from "Utils/Hooks/useMatchMedia"
@@ -27,7 +27,7 @@ describe(AvailabilityFilter, () => {
     expect(currentArtworkFilterContext().filters?.forSale).toBeTruthy()
 
     userEvent.click(screen.getAllByRole("checkbox")[0])
-    expect(currentArtworkFilterContext().filters?.forSale).toBeFalsy()
+    expect(currentArtworkFilterContext().filters?.forSale).toBeNull()
   })
 
   it("clears local input state after Clear All", () => {
@@ -37,7 +37,7 @@ describe(AvailabilityFilter, () => {
 
     userEvent.click(screen.getByText("Clear all"))
 
-    expect(currentArtworkFilterContext().filters?.forSale).toBeFalsy()
+    expect(currentArtworkFilterContext().filters?.forSale).toBeUndefined()
   })
 
   describe("mobile-specific behavior", () => {


### PR DESCRIPTION
Addresses [ONYX-699]

## Description

Currently, unchecking the "Only works for sale" filter on the artwork grid does not remove the filter; instead, it filters for artworks that are not for sale.

With this change, the filter will be **removed** correctly when unchecked.


----

In https://github.com/artsy/force/pull/14817, I'm making sure the filter does not appear in the URL as `for_sale=`.


<img width="2056" alt="Screenshot 2024-11-07 at 15 50 24" src="https://github.com/user-attachments/assets/539549d4-aa30-4a5a-89cb-98586040ea9d">


[ONYX-699]: https://artsyproduct.atlassian.net/browse/ONYX-699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ