### PR TITLE
fix: Remove filters with `null` values from the URL

### DIFF
--- a/src/Components/ArtworkFilter/Utils/urlBuilder.tsx
+++ b/src/Components/ArtworkFilter/Utils/urlBuilder.tsx
@@ -15,7 +15,9 @@ export const buildUrl = (
   const params = removeDefaultValues(state, {
     defaultValues: options?.defaultValues,
   })
-  const queryString = qs.stringify(paramsToSnakeCase(params))
+  const queryString = qs.stringify(paramsToSnakeCase(params), {
+    skipNulls: true,
+  })
 
   let pathname = options?.pathname
   if (!pathname && typeof window !== "undefined") {


### PR DESCRIPTION
Addresses [ONYX-699]

- Related PR: https://github.com/artsy/force/pull/14816

## Description

Currently, we add filters with `null` values ([examples](https://github.com/artsy/force/blob/main/src/Components/ArtworkFilter/ArtworkFilterContext.tsx#L544)) to the URL as `?filterName=`. I suppose we can remove these values from the URL without any issues, which would result in a cleaner URL.

With this change, all filters with `null` values will be omitted when constructing the URL from the filters.




**Example:**

`/artist/gerhard-richter?for_sale=` -> `/gerhard-richter`


[ONYX-699]: https://artsyproduct.atlassian.net/browse/ONYX-699?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ