### PR TITLE
fix(EMI-2157): Checkout dead ends due to invisible saved address errors

### DIFF
--- a/src/Apps/Order/Routes/Shipping/Components/AddressModal.tsx
+++ b/src/Apps/Order/Routes/Shipping/Components/AddressModal.tsx
@@ -1,4 +1,4 @@
-import { useState, FC } from "react"
+import { useState, FC, useEffect } from "react"
 import * as Yup from "yup"
 import {
   Button,
@@ -158,13 +158,11 @@ export const AddressModal: FC<AddressModalProps> = ({
         initialValues={initialValues}
         onSubmit={handleSubmit}
       >
-        {
-          <AddressModalForm
-            addressModalAction={addressModalAction}
-            onClose={closeModal}
-            onDeleteAddress={handleDeleteAddress}
-          />
-        }
+        <AddressModalForm
+          addressModalAction={addressModalAction}
+          onClose={closeModal}
+          onDeleteAddress={handleDeleteAddress}
+        />
       </Formik>
     </>
   )
@@ -178,6 +176,31 @@ const AddressModalForm: FC<{
   const shippingContext = useShippingContext()
   const formikContext = useFormikContext<FormValues>()
   const [showDeleteDialog, setShowDeleteDialog] = useState<boolean>(false)
+
+  const {
+    values,
+    touched,
+    errors,
+    handleChange,
+    handleBlur,
+    setFieldValue,
+    setFieldTouched,
+  } = formikContext
+
+  const attributeErrorFieldsForEdit =
+    addressModalAction.type === "edit"
+      ? Object.keys(errors.attributes || {})
+      : []
+
+  // Touch fields that have errors on edit
+  useEffect(() => {
+    if (attributeErrorFieldsForEdit.length > 0) {
+      attributeErrorFieldsForEdit.forEach(field => {
+        setFieldTouched(`attributes.${field}`, true)
+      })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [attributeErrorFieldsForEdit.length])
 
   if (!addressModalAction) {
     return null
@@ -197,15 +220,6 @@ const AddressModalForm: FC<{
       }
     }
   }
-
-  const {
-    values,
-    touched,
-    errors,
-    handleChange,
-    handleBlur,
-    setFieldValue,
-  } = formikContext
 
   const handleModalClose = () => {
     formikContext.resetForm()

--- a/src/Apps/Order/Routes/Shipping/Components/FulfillmentDetailsForm.tsx
+++ b/src/Apps/Order/Routes/Shipping/Components/FulfillmentDetailsForm.tsx
@@ -244,6 +244,11 @@ const FulfillmentDetailsFormLayout = (
   const tabbableIf = (activeForm: AddressFormMode): 0 | -1 =>
     addressFormMode === activeForm ? 0 : -1
 
+  const savedAddressesErrors =
+    (addressFormMode === "saved_addresses" &&
+      Object.entries(errors.attributes || {})) ||
+    []
+
   return (
     <Form data-testid="FulfillmentDetails_form">
       <ScrollToFieldError />
@@ -308,6 +313,12 @@ const FulfillmentDetailsFormLayout = (
             data-testid="savedAddressesCollapse"
             open={addressFormMode === "saved_addresses"}
           >
+            {savedAddressesErrors.length > 0 && (
+              <Text variant="xs" color="red100" mb={2}>
+                The selected address is invalid. Please edit it or select a new
+                address.
+              </Text>
+            )}
             <SavedAddresses
               active={addressFormMode === "saved_addresses"}
               onSelect={handleSelectSavedAddress}

--- a/src/Apps/Order/Routes/Shipping/Utils/shippingUtils.ts
+++ b/src/Apps/Order/Routes/Shipping/Utils/shippingUtils.ts
@@ -62,7 +62,7 @@ export interface ShippingAddressFormValues {
 export const BASIC_PHONE_VALIDATION_SHAPE = {
   phoneNumber: Yup.string()
     .required("Phone number is required")
-    .matches(/^[+\-\d]+$/, "Phone number is required"),
+    .matches(/^[+\-\(\)\d\s]+$/, "Please enter a valid phone number"),
 }
 
 export const ADDRESS_VALIDATION_SHAPE = {


### PR DESCRIPTION
The type of this PR is: **Fix**

Paired with @starsirius 

This PR solves [EMI-2157]

### Description
It's possible for a user to have a saved address that doesn't pass our existing validation methods. In particular we have seen this on phone numbers with spaces or parens. As an immediate fix, we are improving error handling on saved addresses by:
- relaxing phone validation
- showing a message if saved address has errors
- touching saved address error fields in the edit modal on load.





[EMI-2157]: https://artsyproduct.atlassian.net/browse/EMI-2157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ