### PR TITLE
fix: Disable prefetching artworks on the Notification page

### DIFF
--- a/src/Components/Notifications/NotificationArtwork.tsx
+++ b/src/Components/Notifications/NotificationArtwork.tsx
@@ -1,14 +1,14 @@
+import { AuthContextModule } from "@artsy/cohesion"
+import { Box, Button, Image } from "@artsy/palette"
+import { NotificationArtwork_artwork$key } from "__generated__/NotificationArtwork_artwork.graphql"
+import { ExclusiveAccessBadge } from "Components/Artwork/ExclusiveAccessBadge"
+import { ManageArtworkForSavesProvider } from "Components/Artwork/ManageArtworkForSaves"
+import Metadata from "Components/Artwork/Metadata"
+import { CARD_MAX_WIDTH } from "Components/Notifications/constants"
 import * as React from "react"
 import { graphql, useFragment } from "react-relay"
 import { RouterLink, RouterLinkProps } from "System/Components/RouterLink"
-import { NotificationArtwork_artwork$key } from "__generated__/NotificationArtwork_artwork.graphql"
-import Metadata from "Components/Artwork/Metadata"
-import { AuthContextModule } from "@artsy/cohesion"
-import { Box, Button, Image } from "@artsy/palette"
-import { ManageArtworkForSavesProvider } from "Components/Artwork/ManageArtworkForSaves"
 import { resized } from "Utils/resized"
-import { CARD_MAX_WIDTH } from "Components/Notifications/constants"
-import { ExclusiveAccessBadge } from "Components/Artwork/ExclusiveAccessBadge"
 
 export interface NotificationArtworkProps
   extends Omit<RouterLinkProps, "to" | "width"> {
@@ -41,6 +41,7 @@ export const NotificationArtwork: React.FC<NotificationArtworkProps> = ({
         to={artwork?.href}
         onClick={onClick}
         display="flex"
+        enablePrefetch={false}
         flexDirection="column"
         textDecoration="none"
         aria-label={label}


### PR DESCRIPTION
## Description

Somehow, prefetching the `artworkRoutes_ArtworkQuery` query seems to cause this error on the Notification page. It looks like prefetching the query causes the removal of the data in the Relay store (maybe by overriding or [garbage collecting](https://relay.dev/docs/guided-tour/accessing-data-without-react/retaining-queries/) the data 🤔).


**Internal error after a few milliseconds:**

<img width="2056" alt="Screenshot 2024-11-07 at 18 51 35" src="https://github.com/user-attachments/assets/bd52c37a-b552-4753-afb9-f5ccff45071c">

**Artwork is visible and disappears after a few milliseconds with this error:**

<img width="2056" alt="Screenshot 2024-11-07 at 18 55 23" src="https://github.com/user-attachments/assets/82e9caba-f610-41e6-9e5c-228da231a161">

