### PR TITLE
fix(artists): Fix LCP images

### DIFF
--- a/src/Apps/Artists/Routes/ArtistsIndex.tsx
+++ b/src/Apps/Artists/Routes/ArtistsIndex.tsx
@@ -37,6 +37,8 @@ export const ArtistsIndex: React.FC<ArtistsIndexProps> = ({
   const artists = compact(featuredArtistsSet?.artists) ?? []
   const genes = compact(featuredGenesSet?.genes) ?? []
 
+  const isMobile = getENV("IS_MOBILE")
+
   return (
     <>
       <ArtistsIndexMeta />
@@ -72,7 +74,7 @@ export const ArtistsIndex: React.FC<ArtistsIndexProps> = ({
                     featuredLink={featuredLink}
                     index={index}
                     // Improves LCP for above the fold content
-                    lazyLoad={false}
+                    lazyLoad={isMobile ? true : false}
                   />
                 )
               })}
@@ -82,7 +84,7 @@ export const ArtistsIndex: React.FC<ArtistsIndexProps> = ({
 
         {genes.length > 0 && (
           <Join separator={<Spacer y={6} />}>
-            {genes.map((gene, i) => {
+            {genes.map((gene, geneIndex) => {
               if (
                 !gene ||
                 !gene.trendingArtists ||
@@ -92,7 +94,7 @@ export const ArtistsIndex: React.FC<ArtistsIndexProps> = ({
               }
 
               return (
-                <Box key={gene.name ?? i}>
+                <Box key={gene.name ?? geneIndex}>
                   <Box display="flex" justifyContent="space-between">
                     <RouterLink
                       to={gene.href}
@@ -123,15 +125,17 @@ export const ArtistsIndex: React.FC<ArtistsIndexProps> = ({
                     {gene.trendingArtists.map((artist, artistsIndex) => {
                       if (!artist) return null
 
-                      const isMobile = getENV("IS_MOBILE")
-
                       return (
                         <Column key={artist.internalID} span={[12, 6, 3, 3]}>
                           <CellArtistFragmentContainer
                             mode="GRID"
                             artist={artist}
                             // LCP above the fold optimization for mobile
-                            lazyLoad={isMobile ? artistsIndex > 0 : true}
+                            lazyLoad={
+                              isMobile && geneIndex === 0 && artistsIndex === 0
+                                ? false
+                                : true
+                            }
                           />
                         </Column>
                       )


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Noticed that we were incorrectly prioritizing highPriority LCP images on mobile on /artists, and not lazyloading where we should. This fixes that. 

Before:

<img width="1487" alt="Screenshot 2024-11-11 at 1 44 44 PM" src="https://github.com/user-attachments/assets/a76f852a-75ed-40a2-9521-2ed58aa52296">

After: 

<img width="1504" alt="Screenshot 2024-11-11 at 1 43 39 PM" src="https://github.com/user-attachments/assets/473a0c2e-f478-4bbf-8bbb-77a8058d31a6">

cc @artsy/diamond-devs 

