### PR TITLE
fix: ensures social title is correct

### DIFF
--- a/src/Apps/Article/Components/ArticleMetaTags.tsx
+++ b/src/Apps/Article/Components/ArticleMetaTags.tsx
@@ -13,6 +13,7 @@ const ArticleMetaTags: FC<ArticleMetaTagsProps> = ({ article }) => {
     <>
       <MetaTags
         title={`${article.searchTitle || article.title} | Artsy`}
+        socialTitle={article.title}
         pathname={article.href}
         description={article.searchDescription || article.description}
         imageURL={article.thumbnailImage?.url}

--- a/src/Components/MetaTags.tsx
+++ b/src/Components/MetaTags.tsx
@@ -11,6 +11,8 @@ const DEFAULT_PATHNAME = "/"
 
 interface MetaTagsProps {
   title?: string | null
+  /** Optionally override the title for social media */
+  socialTitle?: string | null
   /** Target a character length of 50–160 characters */
   description?: string | null
   /** Will be cropped to 1200 × 630 (1.9:1) */
@@ -23,12 +25,14 @@ interface MetaTagsProps {
 
 export const MetaTags: React.FC<MetaTagsProps> = ({
   title: _title,
+  socialTitle: _socialTitle,
   description: _description,
   imageURL: _imageURL,
   pathname: _pathname,
   blockRobots,
 }) => {
   const title = _title ?? DEFAULT_TITLE
+  const socialTitle = _socialTitle ?? _title ?? DEFAULT_TITLE
   const description = _description ?? DEFAULT_DESCRIPTION
   const imageURL = _imageURL ?? DEFAULT_IMAGE_URL
   const pathname = _pathname ?? DEFAULT_PATHNAME
@@ -56,14 +60,14 @@ export const MetaTags: React.FC<MetaTagsProps> = ({
       {/* Open Graph / Facebook */}
       <Meta property="og:type" content="website" />
       <Meta property="og:url" content={href} />
-      <Meta property="og:title" content={title} />
+      <Meta property="og:title" content={socialTitle} />
       <Meta property="og:site_name" content="Artsy" />
       <Meta property="og:description" content={description} />
       <Meta property="og:image" content={src} />
       <Meta property="fb:app_id" content="308278682573501" />
 
       {/* Twitter */}
-      <Meta property="twitter:title" content={title} />
+      <Meta property="twitter:title" content={socialTitle} />
       <Meta property="twitter:card" content={card} />
       <Meta property="twitter:url" content={href} />
       <Meta property="twitter:site" content="@artsy" />


### PR DESCRIPTION
Closes: [DIA-758](https://artsyproduct.atlassian.net/browse/DIA-758)

The `MetaTags` component has been updated to accept a `socialTitle` override, allowing different titles for OpenGraph and Twitter meta tags to properly display article titles. However, we've observed that Google may be disregarding the page title tag in favor of the H1 tag content. This behavior isn't something we can directly control, but I'll investigate other instances to confirm this pattern.

[DIA-758]: https://artsyproduct.atlassian.net/browse/DIA-758?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ