### PR TITLE
fix(DIA-982): allow recovery codes to be entered on mobile

### DIFF
--- a/src/Components/AuthDialog/Views/AuthDialogLogin.tsx
+++ b/src/Components/AuthDialog/Views/AuthDialogLogin.tsx
@@ -139,7 +139,6 @@ export const AuthDialogLogin: FC = () => {
                   name="authenticationCode"
                   title="Authentication Code"
                   placeholder="Enter an authentication code"
-                  inputMode={"numeric"}
                   onChange={handleChange}
                   onBlur={handleBlur}
                   autoFocus

--- a/src/Components/Inquiry/Views/InquiryLogin.tsx
+++ b/src/Components/Inquiry/Views/InquiryLogin.tsx
@@ -194,7 +194,6 @@ export const InquiryLogin: React.FC = () => {
             name="authenticationCode"
             title="Authentication Code"
             placeholder="Enter an authentication code"
-            inputMode={"numeric"}
             onChange={handleInputChange("authenticationCode")}
             required
             autoFocus


### PR DESCRIPTION
The type of this PR is: Fix

This PR partially solves [DIA-982] by removing the `inputMode="numeric"` property of the authentication code field so that mobile web users can enter a recovery code (which includes alphabet characters) if they need to.

Currently this field only allowed numeric input, so mobile users could only use a 0-9 keyboard. Now they will see the default text keyboard, which means they need to switch to numeric mode for OTPs, but also allows for recovery codes to be entered.



[DIA-982]: https://artsyproduct.atlassian.net/browse/DIA-982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ