### PR TITLE
fix(article): Add missing image key

### DIFF
--- a/src/Apps/Articles/Components/ArticlesIndexArticle.tsx
+++ b/src/Apps/Articles/Components/ArticlesIndexArticle.tsx
@@ -68,6 +68,7 @@ const ArticlesIndexArticle: FC<ArticlesIndexArticleProps> = ({
           >
             {image && (
               <Image
+                key={image.src}
                 src={image.src}
                 srcSet={image.srcSet}
                 width="100%"


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Noticed that now that we've removed lazy loading on LCP images, we need a key to (instantly) refresh things, otherwise on SPA transition to another article the image from the previous article will remain for a moment while the other one loads in the background. 

cc @artsy/diamond-devs 