### PR TITLE
chore: avoid loading extensive @artsy libraries until necessary

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "@artsy/palette": "^39.0.4",
     "@artsy/palette-charts": "^38.0.4",
     "@artsy/react-html-parser": "^3.0.2",
-    "@artsy/to-title-case": "^1.1.0",
     "@artsy/xapp": "2.0.0",
     "@babel/runtime": "7.13.10",
     "@loadable/component": "5.15.2",

--- a/webpack/bundleSplitting.js
+++ b/webpack/bundleSplitting.js
@@ -2,6 +2,14 @@
 import crypto from "crypto"
 
 const FRAMEWORK_BUNDLES = ["react", "react-dom", "@sentry"]
+const ARTSY_FRAMEWORK_BUNDLES = [
+  "detect-responsive-traits",
+  "dismissible",
+  "fresnel",
+  "img",
+  "palette",
+  "palette-tokens",
+]
 const TOTAL_PAGES = 12
 
 export const splitChunks = {
@@ -13,7 +21,12 @@ export const splitChunks = {
     "artsy-framework": {
       name: "artsy-framework",
       chunks: "all",
-      test: /.*node_modules[\\/](@artsy)[\\/]/,
+      // Include only @artsy/* modules commonly required on client
+      test: new RegExp(
+        `(?<!node_modules.*)[\\\\/]node_modules[\\\\/]@artsy[\\\\/](${ARTSY_FRAMEWORK_BUNDLES.join(
+          `|`
+        )})[\\\\/]`
+      ),
       priority: 40,
       enforce: true,
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -117,15 +117,6 @@
   resolved "https://registry.yarnpkg.com/@artsy/react-html-parser/-/react-html-parser-3.0.2.tgz#6213d662441acf0bd8c9ee953aa77ac8d9cf1cdd"
   integrity sha512-FXiRSqfSvwpz/QgwaqFvjJsbDmo9qMGpvUp/0p1V6muaJbGnfxkTSxAYWmYlFst6bmjhVxCYKxvgQhEVE03Wfg==
 
-"@artsy/to-title-case@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@artsy/to-title-case/-/to-title-case-1.1.0.tgz#ed22a9d926d88edc7b3833900c6c6cef9d5bc282"
-  integrity sha512-n2GISILNv3X9xVjkUC1thoOl7rVKPeDskobQJsC5G8poFpF4HNxxSJD97NjvCK3Ai1RplSMsN2MCmMAy7plx9Q==
-  dependencies:
-    lodash.deburr "^4.1.0"
-    lodash.isnumber "^3.0.3"
-    lodash.upperfirst "^4.3.1"
-
 "@artsy/xapp@2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@artsy/xapp/-/xapp-2.0.0.tgz#ca29d4a09f6d3e73a03d630f01a23518fa5de73f"
@@ -16306,11 +16297,6 @@ lodash.debounce@^4.0.8:
   resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
   integrity sha1-gteb/zCmfEAF/9XiUVMArZyk168=
 
-lodash.deburr@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/lodash.deburr/-/lodash.deburr-4.1.0.tgz#ddb1bbb3ef07458c0177ba07de14422cb033ff9b"
-  integrity sha512-m/M1U1f3ddMCs6Hq2tAsYThTBDaAKFDX3dwDo97GEYzamXi9SqUpjWi/Rrj/gf3X2n8ktwgZrlP1z6E3v/IExQ==
-
 lodash.defaults@^4.0.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
@@ -16480,11 +16466,6 @@ lodash.uniqby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.uniqby/-/lodash.uniqby-4.7.0.tgz#d99c07a669e9e6d24e1362dfe266c67616af1302"
   integrity sha512-e/zcLx6CSbmaEgFHCA7BnoQKyCtKMxnuWrJygbwPs/AIn+IMKl66L8/s+wBUn5LRw2pZx3bUHibiV1b6aTWIww==
-
-lodash.upperfirst@^4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/lodash.upperfirst/-/lodash.upperfirst-4.3.1.tgz#1365edf431480481ef0d1c68957a5ed99d49f7ce"
-  integrity sha512-sReKOYJIJf74dhJONhU4e0/shzi1trVbSWDOhKYE5XV2O+H7Sb2Dihwuc7xWxVl+DgFPyTqIN3zMfT9cq5iWDg==
 
 lodash@4.17.21, lodash@^4.17.10, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.3.0, lodash@~3.10.1:
   version "4.17.21"
@@ -19471,7 +19452,7 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-"react-17@npm:react@17.0.2":
+"react-17@npm:react@17.0.2", react@17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
   integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
@@ -19513,16 +19494,7 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-"react-dom-17@npm:react-dom@17.0.2":
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
-  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    scheduler "^0.20.2"
-
-react-dom@17.0.2:
+"react-dom-17@npm:react-dom@17.0.2", react-dom@17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
   integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
@@ -19783,14 +19755,6 @@ react-waypoint@8.0.0:
   dependencies:
     consolidated-events "^1.1.0"
     prop-types "^15.0.0"
-
-react@17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Based on Chrome's coverage tooling, @dzucconi and I identified that the `artsy-framework` bundle was a little too liberal in the modules it included. Because that bundle is `preload`ed, that meant that _all_ of the referenced code was being loaded on all pages, and with a high priority.

* `@artsy/to-title-case` appears unused, so we removed it.
* `@artsy/icons` is designed for icons to be imported individually, and [occasionally](https://github.com/artsy/icons/pull/54) gains a bloated image, so is excluded.
* Modules like `@artsy/xapp` and `/multienv` should only be required server-side.
* Other libs like `@artsy/commerce_helpers`, `/dismissible`, `/express-reloadable`, `/palette-charts`, and `react-html-parser` should only be needed in a few places, so load them there.
* Q: What about `@artsy/cohesion`? It's needed for almost every route, but it also changes frequently so invalidates caching of these other libraries (which are more stable). Maybe we should add it back into this list.

Co-authored by: @dzucconi 