### PR TITLE
feat(EMI-2159): Auction registration address autocomplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "styled-components": "^6.1.13"
   },
   "dependencies": {
-    "@artsy/cohesion": "4.216.0",
+    "@artsy/cohesion": "^4.217.0",
     "@artsy/commerce_helpers": "artsy/commerce_helpers",
     "@artsy/detect-responsive-traits": "^0.1.0",
     "@artsy/dismissible": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "styled-components": "^6.1.13"
   },
   "dependencies": {
-    "@artsy/cohesion": "^4.217.0",
+    "@artsy/cohesion": "4.217.0",
     "@artsy/commerce_helpers": "artsy/commerce_helpers",
     "@artsy/detect-responsive-traits": "^0.1.0",
     "@artsy/dismissible": "^0.3.2",

--- a/src/Apps/Auction/Components/Form/AddressForm.tsx
+++ b/src/Apps/Auction/Components/Form/AddressForm.tsx
@@ -1,4 +1,4 @@
-// import { ContextModule } from "@artsy/cohesion"
+import { ContextModule } from "@artsy/cohesion"
 import { Column, GridColumns, Input } from "@artsy/palette"
 import { useFormContext } from "Apps/Auction/Hooks/useFormContext"
 import { AddressAutocompleteInput } from "Components/Address/AddressAutocompleteInput"
@@ -19,15 +19,14 @@ export const AddressForm = () => {
   const { contextPageOwnerId, contextPageOwnerType } = useAnalyticsContext()
 
   const autocompleteTrackingValues = {
-    contextModule: "auctionRegistration" as any,
-    // contextModule: ContextModule.auctionRegistration,
+    contextModule: ContextModule.auctionRegistration,
     contextOwnerType: contextPageOwnerType,
     contextPageOwnerId: contextPageOwnerId || "",
   }
 
   return (
     <GridColumns>
-      <Column>
+      <Column span={12}>
         <Input
           name="address.name"
           title="Full Name"
@@ -42,7 +41,7 @@ export const AddressForm = () => {
         />
       </Column>
 
-      <Column>
+      <Column span={12}>
         <CountrySelect
           name="address.country"
           title="Country"
@@ -56,7 +55,7 @@ export const AddressForm = () => {
         />
       </Column>
 
-      <Column>
+      <Column span={12}>
         <AddressAutocompleteInput
           trackingValues={autocompleteTrackingValues}
           address={{
@@ -93,7 +92,7 @@ export const AddressForm = () => {
         />
       </Column>
 
-      <Column>
+      <Column span={12}>
         <Input
           name="address.addressLine2"
           title="Apt, floor, suite, etc. (optional)"
@@ -106,7 +105,7 @@ export const AddressForm = () => {
         />
       </Column>
 
-      <Column>
+      <Column span={12}>
         <Input
           name="address.city"
           title="City"
@@ -148,7 +147,7 @@ export const AddressForm = () => {
         />
       </Column>
 
-      <Column>
+      <Column span={12}>
         <Input
           name="phoneNumber"
           title="Phone number"

--- a/src/Apps/Auction/Components/Form/AddressForm.tsx
+++ b/src/Apps/Auction/Components/Form/AddressForm.tsx
@@ -66,8 +66,8 @@ export const AddressForm = () => {
           required
           disableAutocomplete={values.address.region === "AK"}
           name="address.addressLine1"
-          placeholder="Add address"
-          title="Address Line 1"
+          placeholder="Add street address"
+          title="Street address"
           value={values.address.addressLine1}
           onChange={handleChange}
           onBlur={handleBlur}

--- a/src/Apps/Auction/Components/Form/AddressForm.tsx
+++ b/src/Apps/Auction/Components/Form/AddressForm.tsx
@@ -1,42 +1,9 @@
 import { Column, GridColumns, Input } from "@artsy/palette"
 import { useFormContext } from "Apps/Auction/Hooks/useFormContext"
 import { CountrySelect } from "Components/CountrySelect"
-import {
-  AddressAutocompleteInput,
-  useAddressAutocompleteTracking,
-} from "Components/Address/AddressAutocompleteInput"
-import { useState } from "react"
-import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
-// import { ContextModule } from "@artsy/cohesion"
 
 export const AddressForm = () => {
-  const {
-    handleChange,
-    handleBlur,
-    errors,
-    values,
-    touched,
-    setValues,
-    setFieldValue,
-  } = useFormContext()
-  const { contextPageOwnerId, contextPageOwnerType } = useAnalyticsContext()
-
-  const autocompleteTrackingValues = {
-    contextModule: "auctionRegistration" as any, //ContextModule.auctionRegistration,
-    // contextModule: ContextModule.auctionRegistration,
-    contextOwnerType: contextPageOwnerType,
-    contextPageOwnerId: contextPageOwnerId || "",
-  }
-
-  const trackAutoCompleteEdits = (fieldName: string, handleChange) => (
-    ...args
-  ) => {
-    if (hasAutocompletedAddress) {
-      autocompleteTracking.editedAutocompletedAddress(fieldName)
-      setHasAutocompletedAddress(false)
-    }
-    handleChange(...args)
-  }
+  const { handleChange, handleBlur, errors, values, touched } = useFormContext()
 
   return (
     <GridColumns>
@@ -70,47 +37,16 @@ export const AddressForm = () => {
       </Column>
 
       <Column span={12}>
-        <AddressAutocompleteInput
-          address={{
-            country: values.address.country,
-          }}
-          flip={false}
-          required
-          disableAutocomplete={values.address.region === "AK"}
+        <Input
           name="address.addressLine1"
-          placeholder="Add address"
           title="Address Line 1"
-          value={values.address.addressLine1}
-          onChange={trackAutoCompleteEdits("addressLine1", handleChange)}
+          placeholder="Add address"
+          autoComplete="address-line1"
+          value={values.address?.addressLine1}
+          onChange={handleChange}
           onBlur={handleBlur}
-          onSelect={option => {
-            const selectedAddress = option.address
-            setValues({
-              ...values,
-              address: {
-                ...values.address,
-                addressLine1: selectedAddress.addressLine1,
-                addressLine2: selectedAddress.addressLine2,
-                city: selectedAddress.city,
-                region: selectedAddress.region,
-                postalCode: selectedAddress.postalCode,
-                country: selectedAddress.country,
-              },
-            })
-            setHasAutocompletedAddress(true)
-
-            autocompleteTracking.selectedAutocompletedAddress(
-              option,
-              values.address.addressLine1
-            )
-          }}
-          onReceiveAutocompleteResult={(input, count) => {
-            autocompleteTracking.receivedAutocompleteResult(input, count)
-          }}
           error={touched.address?.addressLine1 && errors.address?.addressLine1}
-          onClear={() => {
-            setFieldValue("address.addressLine1", "")
-          }}
+          required
         />
       </Column>
 

--- a/src/Apps/Auction/Components/Form/AddressForm.tsx
+++ b/src/Apps/Auction/Components/Form/AddressForm.tsx
@@ -7,11 +7,11 @@ export const AddressForm = () => {
 
   return (
     <GridColumns>
-      <Column span={12}>
+      <Column>
         <Input
           name="address.name"
           title="Full Name"
-          placeholder="Enter name"
+          placeholder="Add full name"
           autoComplete="name"
           autoFocus
           value={values.address?.name}
@@ -22,7 +22,7 @@ export const AddressForm = () => {
         />
       </Column>
 
-      <Column span={12}>
+      <Column>
         <CountrySelect
           name="address.country"
           title="Country"
@@ -36,11 +36,11 @@ export const AddressForm = () => {
         />
       </Column>
 
-      <Column span={12}>
+      <Column>
         <Input
           name="address.addressLine1"
-          title="Address Line 1"
-          placeholder="Add address"
+          title="Street address"
+          placeholder="Add street address"
           autoComplete="address-line1"
           value={values.address?.addressLine1}
           onChange={handleChange}
@@ -50,11 +50,11 @@ export const AddressForm = () => {
         />
       </Column>
 
-      <Column span={12}>
+      <Column>
         <Input
           name="address.addressLine2"
-          title="Address line 2"
-          placeholder="Add address line 2"
+          title="Apt, floor, suite, etc. (optional)"
+          placeholder="Add apartment, floor, suite, etc."
           autoComplete="address-line2"
           value={values.address?.addressLine2}
           onChange={handleChange}
@@ -63,11 +63,11 @@ export const AddressForm = () => {
         />
       </Column>
 
-      <Column span={12}>
+      <Column>
         <Input
           name="address.city"
           title="City"
-          placeholder="Enter city"
+          placeholder="Add city"
           autoComplete="address-level2"
           value={values.address?.city}
           onChange={handleChange}
@@ -80,8 +80,8 @@ export const AddressForm = () => {
       <Column span={6}>
         <Input
           name="address.region"
-          title="State, Province, or Region"
-          placeholder="Add state, province, or region"
+          title="State, region or province"
+          placeholder="Add state, region or province"
           autoComplete="address-level1"
           value={values.address?.region}
           onChange={handleChange}
@@ -94,8 +94,8 @@ export const AddressForm = () => {
       <Column span={6}>
         <Input
           name="address.postalCode"
-          title="Postal Code"
-          placeholder="Add postal code"
+          title="ZIP/Postal code"
+          placeholder="Add ZIP/Postal code"
           autoComplete="postal-code"
           value={values.address?.postalCode}
           onChange={handleChange}
@@ -105,10 +105,10 @@ export const AddressForm = () => {
         />
       </Column>
 
-      <Column span={12}>
+      <Column>
         <Input
           name="phoneNumber"
-          title="Phone Number"
+          title="Phone number"
           type="tel"
           description="Required for shipping logistics"
           placeholder="Add phone number"

--- a/src/Apps/Auction/Components/Form/AddressForm.tsx
+++ b/src/Apps/Auction/Components/Form/AddressForm.tsx
@@ -1,9 +1,29 @@
+// import { ContextModule } from "@artsy/cohesion"
 import { Column, GridColumns, Input } from "@artsy/palette"
 import { useFormContext } from "Apps/Auction/Hooks/useFormContext"
+import { AddressAutocompleteInput } from "Components/Address/AddressAutocompleteInput"
 import { CountrySelect } from "Components/CountrySelect"
+import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
 
 export const AddressForm = () => {
-  const { handleChange, handleBlur, errors, values, touched } = useFormContext()
+  const {
+    handleChange,
+    handleBlur,
+    errors,
+    values,
+    touched,
+    setValues,
+    setFieldValue,
+  } = useFormContext()
+
+  const { contextPageOwnerId, contextPageOwnerType } = useAnalyticsContext()
+
+  const autocompleteTrackingValues = {
+    contextModule: "auctionRegistration" as any,
+    // contextModule: ContextModule.auctionRegistration,
+    contextOwnerType: contextPageOwnerType,
+    contextPageOwnerId: contextPageOwnerId || "",
+  }
 
   return (
     <GridColumns>
@@ -37,16 +57,39 @@ export const AddressForm = () => {
       </Column>
 
       <Column>
-        <Input
+        <AddressAutocompleteInput
+          trackingValues={autocompleteTrackingValues}
+          address={{
+            country: values.address.country,
+          }}
+          flip={false}
+          required
+          disableAutocomplete={values.address.region === "AK"}
           name="address.addressLine1"
-          title="Street address"
-          placeholder="Add street address"
-          autoComplete="address-line1"
-          value={values.address?.addressLine1}
+          placeholder="Add address"
+          title="Address Line 1"
+          value={values.address.addressLine1}
           onChange={handleChange}
           onBlur={handleBlur}
+          onSelect={option => {
+            const selectedAddress = option.address
+            setValues({
+              ...values,
+              address: {
+                ...values.address,
+                addressLine1: selectedAddress.addressLine1,
+                addressLine2: selectedAddress.addressLine2,
+                city: selectedAddress.city,
+                region: selectedAddress.region,
+                postalCode: selectedAddress.postalCode,
+                country: selectedAddress.country,
+              },
+            })
+          }}
           error={touched.address?.addressLine1 && errors.address?.addressLine1}
-          required
+          onClear={() => {
+            setFieldValue("address.addressLine1", "")
+          }}
         />
       </Column>
 

--- a/src/Apps/Auction/Components/Form/__tests__/AddressForm.jest.enzyme.tsx
+++ b/src/Apps/Auction/Components/Form/__tests__/AddressForm.jest.enzyme.tsx
@@ -29,12 +29,12 @@ describe("AddressForm", () => {
     ;[
       "Full Name",
       "Country",
-      "Postal Code",
-      "Address Line 1",
-      "Address Line 2",
+      "ZIP/Postal code",
+      "Street address",
+      "Apt, floor, suite, etc. (optional)",
       "City",
-      "State, Province, or Region",
-      "Phone Number",
+      "State, region or province",
+      "Phone number",
     ].forEach(label => {
       expect(text).toContain(label)
     })

--- a/src/Apps/Order/Routes/Shipping/Components/FulfillmentDetailsForm.tsx
+++ b/src/Apps/Order/Routes/Shipping/Components/FulfillmentDetailsForm.tsx
@@ -37,13 +37,10 @@ import {
   Formik,
 } from "formik"
 import { pick } from "lodash"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect } from "react"
 import { Collapse } from "Apps/Order/Components/Collapse"
 import { FulfillmentDetailsForm_me$data } from "__generated__/FulfillmentDetailsForm_me.graphql"
-import {
-  AddressAutocompleteInput,
-  useAddressAutocompleteTracking,
-} from "Components/Address/AddressAutocompleteInput"
+import { AddressAutocompleteInput } from "Components/Address/AddressAutocompleteInput"
 import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
 import { useShippingContext } from "Apps/Order/Routes/Shipping/Hooks/useShippingContext"
@@ -85,11 +82,6 @@ const FulfillmentDetailsFormLayout = (
   props: FulfillmentDetailsFormLayoutProps
 ) => {
   const { contextPageOwnerId } = useAnalyticsContext()
-  const autocompleteTracking = useAddressAutocompleteTracking({
-    contextModule: ContextModule.ordersShipping,
-    contextOwnerType: OwnerType.ordersShipping,
-    contextPageOwnerId: contextPageOwnerId || "",
-  })
 
   const shippingContext = useShippingContext()
   const orderTracking = useOrderTracking()
@@ -99,8 +91,6 @@ const FulfillmentDetailsFormLayout = (
     shippingContext.orderData.shippingQuotes &&
     shippingContext.orderData.shippingQuotes.length === 0
   )
-
-  const [hasAutocompletedAddress, setHasAutocompletedAddress] = useState(false)
 
   const formikContext = useFormikContext<FulfillmentValues>()
   const {
@@ -137,16 +127,6 @@ const FulfillmentDetailsFormLayout = (
       shippingContext.actions.goBackToFulfillmentDetails()
     }
     cb(...args)
-  }
-
-  const trackAutoCompleteEdits = (fieldName: string, handleChange) => (
-    ...args
-  ) => {
-    if (hasAutocompletedAddress) {
-      autocompleteTracking.editedAutocompletedAddress(fieldName)
-      setHasAutocompletedAddress(false)
-    }
-    handleChange(...args)
   }
 
   const handleCloseVerification = async () => {
@@ -358,11 +338,9 @@ const FulfillmentDetailsFormLayout = (
                   aria-labelledby="country-select"
                   tabIndex={tabbableIf("new_address")}
                   selected={values.attributes.country}
-                  onSelect={withBackToFulfillmentDetails(
-                    trackAutoCompleteEdits("country", selected => {
-                      setFieldValue(`attributes.country`, selected)
-                    })
-                  )}
+                  onSelect={withBackToFulfillmentDetails(selected => {
+                    setFieldValue(`attributes.country`, selected)
+                  })}
                   disabled={
                     !!shippingContext.orderData.lockShippingCountryTo &&
                     shippingContext.orderData.lockShippingCountryTo !== "EU"
@@ -389,6 +367,11 @@ const FulfillmentDetailsFormLayout = (
                     country: (values.attributes as ShipValues["attributes"])
                       .country,
                   }}
+                  trackingValues={{
+                    contextModule: ContextModule.ordersShipping,
+                    contextOwnerType: OwnerType.ordersShipping,
+                    contextPageOwnerId: contextPageOwnerId || "",
+                  }}
                   flip={false}
                   disableAutocomplete={values.attributes.region === "AK"}
                   tabIndex={tabbableIf("new_address")}
@@ -396,9 +379,7 @@ const FulfillmentDetailsFormLayout = (
                   placeholder="Street address"
                   title="Address line 1"
                   value={values.attributes.addressLine1}
-                  onChange={withBackToFulfillmentDetails(
-                    trackAutoCompleteEdits("addressLine1", handleChange)
-                  )}
+                  onChange={withBackToFulfillmentDetails(handleChange)}
                   onBlur={handleBlur}
                   onSelect={option => {
                     const selectedAddress = option.address
@@ -414,19 +395,7 @@ const FulfillmentDetailsFormLayout = (
                         country: selectedAddress.country,
                       },
                     })
-                    setHasAutocompletedAddress(true)
                     shippingContext.actions.goBackToFulfillmentDetails()
-
-                    autocompleteTracking.selectedAutocompletedAddress(
-                      option,
-                      values.attributes.addressLine1
-                    )
-                  }}
-                  onReceiveAutocompleteResult={(input, count) => {
-                    autocompleteTracking.receivedAutocompleteResult(
-                      input,
-                      count
-                    )
                   }}
                   error={
                     (touched as FormikTouched<ShipValues>).attributes
@@ -447,9 +416,7 @@ const FulfillmentDetailsFormLayout = (
                   placeholder="Apt, floor, suite, etc."
                   title="Address line 2 (optional)"
                   value={values.attributes.addressLine2}
-                  onChange={withBackToFulfillmentDetails(
-                    trackAutoCompleteEdits("addressLine2", handleChange)
-                  )}
+                  onChange={withBackToFulfillmentDetails(handleChange)}
                   onBlur={handleBlur}
                   error={
                     (touched as FormikTouched<ShipValues>).attributes
@@ -467,9 +434,7 @@ const FulfillmentDetailsFormLayout = (
                   placeholder="City"
                   title="City"
                   value={values.attributes.city}
-                  onChange={withBackToFulfillmentDetails(
-                    trackAutoCompleteEdits("city", handleChange)
-                  )}
+                  onChange={withBackToFulfillmentDetails(handleChange)}
                   onBlur={handleBlur}
                   error={
                     (touched as FormikTouched<ShipValues>).attributes?.city &&
@@ -494,9 +459,7 @@ const FulfillmentDetailsFormLayout = (
                   }
                   autoCorrect="off"
                   value={values.attributes.region}
-                  onChange={withBackToFulfillmentDetails(
-                    trackAutoCompleteEdits("region", handleChange)
-                  )}
+                  onChange={withBackToFulfillmentDetails(handleChange)}
                   onBlur={handleBlur}
                   error={
                     (touched as FormikTouched<ShipValues>).attributes?.region &&
@@ -522,9 +485,7 @@ const FulfillmentDetailsFormLayout = (
                   autoCapitalize="characters"
                   autoCorrect="off"
                   value={values.attributes.postalCode}
-                  onChange={withBackToFulfillmentDetails(
-                    trackAutoCompleteEdits("postalCode", handleChange)
-                  )}
+                  onChange={withBackToFulfillmentDetails(handleChange)}
                   onBlur={handleBlur}
                   error={
                     (touched as FormikTouched<ShipValues>).attributes

--- a/src/Apps/Order/Routes/Shipping/Components/__tests__/FulfillmentDetailsForm.jest.tsx
+++ b/src/Apps/Order/Routes/Shipping/Components/__tests__/FulfillmentDetailsForm.jest.tsx
@@ -545,7 +545,7 @@ describe("FulfillmentDetailsForm", () => {
       ).toHaveBeenCalled()
     })
 
-    it("tracks when a user selects an address and the first time they edit it", async () => {
+    it("tracks when a user selects an address", async () => {
       renderTree(testProps)
       await waitFor(async () => {
         const line1Input = screen.getByPlaceholderText("Street address")
@@ -581,23 +581,6 @@ describe("FulfillmentDetailsForm", () => {
         context_owner_type: "orders-shipping",
         input: "401 Broadway",
         item: "401 Broadway, New York NY 10013",
-      })
-
-      // Make 2 edits to the address; track the 1st
-      const line2Input = screen.getByPlaceholderText("Apt, floor, suite, etc.")
-      await userEvent.type(line2Input, "Floor 25")
-
-      const postalCode = screen.getByPlaceholderText("ZIP code")
-      await userEvent.type(postalCode, "-4456")
-
-      await flushPromiseQueue()
-      expect(mockTrackEvent).toHaveBeenCalledTimes(3)
-      expect(mockTrackEvent).toHaveBeenNthCalledWith(3, {
-        action: "editedAutocompletedAddress",
-        context_module: "ordersShipping",
-        context_owner_id: "",
-        context_owner_type: "orders-shipping",
-        field: "addressLine2",
       })
     })
   })

--- a/src/Components/Address/AddressAutocompleteInput.tsx
+++ b/src/Components/Address/AddressAutocompleteInput.tsx
@@ -27,8 +27,6 @@ export interface AddressAutocompleteInputProps
   /* The address [including at least a country] to use for autocomplete suggestions */
   address: Partial<Address> & { country: Address["country"] }
 
-  trackingValues: AddressAutocompleteTrackingValues
-
   disableAutocomplete?: boolean
   onSelect: NonNullable<
     AutocompleteInputProps<AddressAutocompleteSuggestion>["onSelect"]
@@ -73,7 +71,6 @@ interface ServiceAvailability {
  */
 export const AddressAutocompleteInput = ({
   address,
-  trackingValues,
   onReceiveAutocompleteResult,
   disableAutocomplete = false,
   tabIndex,
@@ -93,19 +90,6 @@ export const AddressAutocompleteInput = ({
     ProviderSuggestion[]
   >([])
   const [fetching, setFetching] = useState(false)
-  const [hasAutocompletedAddress, setHasAutocompletedAddress] = useState(false)
-
-  const autocompleteTracking = useAddressAutocompleteTracking(trackingValues)
-
-  const trackAutoCompleteEdits = (fieldName: string, handleChange) => (
-    ...args
-  ) => {
-    if (hasAutocompletedAddress) {
-      autocompleteTracking.editedAutocompletedAddress(fieldName)
-      setHasAutocompletedAddress(false)
-    }
-    handleChange(...args)
-  }
 
   // NOTE: Due to the format of this key (a long string of numbers that cannot be parsed as json)
   // This key must be set in the env as a json string like SMARTY_EMBEDDED_KEY_JSON={ "key": "xxxxxxxxxxxxxxxxxx" }
@@ -121,7 +105,6 @@ export const AddressAutocompleteInput = ({
     fetching: false,
   })
 
-  console.log("***", { apiKey: !!apiKey, isFeatureFlagEnabled, isUSAddress })
   useEffect(() => {
     const isAPIKeyPresent = !!apiKey
     const enabled = isAPIKeyPresent && isFeatureFlagEnabled && isUSAddress
@@ -277,7 +260,6 @@ export const AddressAutocompleteInput = ({
   if (definitelyDisabled) {
     return (
       <Input
-        required={!!autocompleteProps.required}
         tabIndex={tabIndex}
         id={id}
         name={name}
@@ -319,14 +301,14 @@ export const AddressAutocompleteInput = ({
   )
 }
 
-interface AddressAutocompleteTrackingValues {
+interface TrackingValues {
   contextPageOwnerId: string
   contextOwnerType: PageOwnerType
   contextModule: ContextModule
 }
 
 export const useAddressAutocompleteTracking = (
-  trackingValues: AddressAutocompleteTrackingValues
+  trackingValues: TrackingValues
 ) => {
   const { trackEvent } = useTracking()
 

--- a/src/Components/Address/AddressAutocompleteInput.tsx
+++ b/src/Components/Address/AddressAutocompleteInput.tsx
@@ -27,6 +27,8 @@ export interface AddressAutocompleteInputProps
   /* The address [including at least a country] to use for autocomplete suggestions */
   address: Partial<Address> & { country: Address["country"] }
 
+  trackingValues: AddressAutocompleteTrackingValues
+
   disableAutocomplete?: boolean
   onSelect: NonNullable<
     AutocompleteInputProps<AddressAutocompleteSuggestion>["onSelect"]
@@ -71,6 +73,7 @@ interface ServiceAvailability {
  */
 export const AddressAutocompleteInput = ({
   address,
+  trackingValues,
   onReceiveAutocompleteResult,
   disableAutocomplete = false,
   tabIndex,
@@ -90,6 +93,19 @@ export const AddressAutocompleteInput = ({
     ProviderSuggestion[]
   >([])
   const [fetching, setFetching] = useState(false)
+  const [hasAutocompletedAddress, setHasAutocompletedAddress] = useState(false)
+
+  const autocompleteTracking = useAddressAutocompleteTracking(trackingValues)
+
+  const trackAutoCompleteEdits = (fieldName: string, handleChange) => (
+    ...args
+  ) => {
+    if (hasAutocompletedAddress) {
+      autocompleteTracking.editedAutocompletedAddress(fieldName)
+      setHasAutocompletedAddress(false)
+    }
+    handleChange(...args)
+  }
 
   // NOTE: Due to the format of this key (a long string of numbers that cannot be parsed as json)
   // This key must be set in the env as a json string like SMARTY_EMBEDDED_KEY_JSON={ "key": "xxxxxxxxxxxxxxxxxx" }
@@ -105,6 +121,7 @@ export const AddressAutocompleteInput = ({
     fetching: false,
   })
 
+  console.log("***", { apiKey: !!apiKey, isFeatureFlagEnabled, isUSAddress })
   useEffect(() => {
     const isAPIKeyPresent = !!apiKey
     const enabled = isAPIKeyPresent && isFeatureFlagEnabled && isUSAddress
@@ -260,6 +277,7 @@ export const AddressAutocompleteInput = ({
   if (definitelyDisabled) {
     return (
       <Input
+        required={!!autocompleteProps.required}
         tabIndex={tabIndex}
         id={id}
         name={name}
@@ -301,14 +319,14 @@ export const AddressAutocompleteInput = ({
   )
 }
 
-interface TrackingValues {
+interface AddressAutocompleteTrackingValues {
   contextPageOwnerId: string
   contextOwnerType: PageOwnerType
   contextModule: ContextModule
 }
 
 export const useAddressAutocompleteTracking = (
-  trackingValues: TrackingValues
+  trackingValues: AddressAutocompleteTrackingValues
 ) => {
   const { trackEvent } = useTracking()
 

--- a/src/Components/Address/__tests__/AddressAutocompleteInput.jest.tsx
+++ b/src/Components/Address/__tests__/AddressAutocompleteInput.jest.tsx
@@ -4,7 +4,6 @@ import userEvent from "@testing-library/user-event"
 import {
   AddressAutocompleteInput,
   AddressAutocompleteInputProps,
-  useAddressAutocompleteTracking,
 } from "Components/Address/AddressAutocompleteInput"
 import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
 import compact from "lodash/compact"
@@ -82,12 +81,6 @@ const TestImplementation: FC<ImplementationProps> = ({
     address.country,
   ])
 
-  const autocompleteTracking = useAddressAutocompleteTracking({
-    contextModule: ContextModule.ordersShipping,
-    contextOwnerType: OwnerType.ordersShipping,
-    contextPageOwnerId: "1234",
-  })
-
   return (
     <>
       {
@@ -111,14 +104,12 @@ const TestImplementation: FC<ImplementationProps> = ({
               region: suggestion.address.region,
               postalCode: suggestion.address.postalCode,
             })
-            autocompleteTracking.selectedAutocompletedAddress(
-              suggestion,
-              address.line1!
-            )
           })}
-          onReceiveAutocompleteResult={(input, resultCount) =>
-            autocompleteTracking.receivedAutocompleteResult(input, resultCount)
-          }
+          trackingValues={{
+            contextModule: ContextModule.ordersShipping,
+            contextOwnerType: OwnerType.ordersShipping,
+            contextPageOwnerId: "1234",
+          }}
           {...rest}
         />
       }
@@ -140,7 +131,6 @@ const TestImplementation: FC<ImplementationProps> = ({
       <button
         onClick={() => {
           setAddress({ ...address, line2: String(Date.now()) })
-          autocompleteTracking.editedAutocompletedAddress("line2")
         }}
       >
         Edit Address
@@ -308,7 +298,7 @@ describe("AddressAutocompleteInput", () => {
 
     // See TestImplementation for implementation details
     describe("tracking", () => {
-      it("developer can track when suggested addresses update with hook + `onReceiveAutocompleteResult` prop", async () => {
+      it("tracks when autocomplete results are received", async () => {
         render(<TestImplementation />)
 
         const line1Input = screen.getByPlaceholderText("Autocomplete input")
@@ -360,7 +350,7 @@ describe("AddressAutocompleteInput", () => {
         })
       })
 
-      it("developer can use tracking hook with `onSelect` prop to track when an address is selected", async () => {
+      it("tracks when an address is selected", async () => {
         render(<TestImplementation />)
 
         const line1Input = screen.getByPlaceholderText("Autocomplete input")
@@ -381,32 +371,6 @@ describe("AddressAutocompleteInput", () => {
           context_owner_type: "orders-shipping",
           input: "401 Broadway",
           item: "401 Broadway, New York NY 10013",
-        })
-      })
-
-      it("developer can use hook to track when the user edits an autocompleted address", async () => {
-        render(<TestImplementation />)
-
-        const line1Input = screen.getByPlaceholderText("Autocomplete input")
-        await userEvent.paste(line1Input, "401 Broadway")
-
-        const dropdown = await screen.findByRole("listbox", { hidden: true })
-        const option = within(dropdown).getByText(
-          "401 Broadway, New York NY 10013"
-        )
-
-        await userEvent.click(option)
-        await flushPromiseQueue()
-
-        const editAddressButton = screen.getByText("Edit Address")
-        await userEvent.click(editAddressButton)
-
-        expect(mockTrackEvent).toHaveBeenCalledWith({
-          action: "editedAutocompletedAddress",
-          context_module: "ordersShipping",
-          context_owner_id: "1234",
-          context_owner_type: "orders-shipping",
-          field: "line2",
         })
       })
     })

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,7 +15,7 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@artsy/cohesion@^4.217.0":
+"@artsy/cohesion@4.217.0":
   version "4.217.0"
   resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-4.217.0.tgz#7b73b7bde4fc36c68f3bada5d76040cfd164122e"
   integrity sha512-vOVnhD9WgyyDBkBH08zkALsKOSCPi/NxFw7L15D33WR+NytemHW9Z/4XJom8c4z/SjxoFn/o/0GbDjH0r6eDTg==
@@ -9061,10 +9061,10 @@ core-js@2.6.5:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
   integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
 
-core-js@3:
-  version "3.39.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.39.0.tgz#57f7647f4d2d030c32a72ea23a0555b2eaa30f83"
-  integrity sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==
+core-js@3, core-js@^3.0.4, core-js@^3.6.5, core-js@^3.8.2:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.10.0.tgz#9a020547c8b6879f929306949e31496bbe2ae9b3"
+  integrity sha512-MQx/7TLgmmDVamSyfE+O+5BHvG1aUGj/gHhLn1wVtm2B5u1eVIPvh7vkfjwWKNCjrTJB8+He99IntSQ1qP+vYQ==
 
 core-js@3.38.0:
   version "3.38.0"
@@ -9080,11 +9080,6 @@ core-js@^3.0.0:
   version "3.25.2"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.25.2.tgz#2d3670c1455432b53fa780300a6fc1bd8304932c"
   integrity sha512-YB4IAT1bjEfxTJ1XYy11hJAKskO+qmhuDBM8/guIfMz4JvdsAQAqvyb97zXX7JgSrfPLG5mRGFWJwJD39ruq2A==
-
-core-js@^3.0.4, core-js@^3.6.5, core-js@^3.8.2:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.10.0.tgz#9a020547c8b6879f929306949e31496bbe2ae9b3"
-  integrity sha512-MQx/7TLgmmDVamSyfE+O+5BHvG1aUGj/gHhLn1wVtm2B5u1eVIPvh7vkfjwWKNCjrTJB8+He99IntSQ1qP+vYQ==
 
 core-js@^3.3.2:
   version "3.23.4"
@@ -19457,7 +19452,7 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-"react-17@npm:react@17.0.2", react@17.0.2:
+"react-17@npm:react@17.0.2":
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
   integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
@@ -19499,7 +19494,16 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-"react-dom-17@npm:react-dom@17.0.2", react-dom@17.0.2:
+"react-dom-17@npm:react-dom@17.0.2":
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
+  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    scheduler "^0.20.2"
+
+react-dom@17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
   integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
@@ -19760,6 +19764,14 @@ react-waypoint@8.0.0:
   dependencies:
     consolidated-events "^1.1.0"
     prop-types "^15.0.0"
+
+react@17.0.2:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
+  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15,10 +15,10 @@
     "@jridgewell/gen-mapping" "^0.1.0"
     "@jridgewell/trace-mapping" "^0.3.9"
 
-"@artsy/cohesion@4.216.0":
-  version "4.216.0"
-  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-4.216.0.tgz#d686ba5c32f807ddd2aa7d5554512df1f66f4a05"
-  integrity sha512-snuWMlXIbtcjbs4LAyXMLKawy+Zfots0PyY77NyAORHLOMkOHgvRDXwxX0wOOke+DWbpWfjC5pdftcy1qSov4Q==
+"@artsy/cohesion@^4.217.0":
+  version "4.217.0"
+  resolved "https://registry.yarnpkg.com/@artsy/cohesion/-/cohesion-4.217.0.tgz#7b73b7bde4fc36c68f3bada5d76040cfd164122e"
+  integrity sha512-vOVnhD9WgyyDBkBH08zkALsKOSCPi/NxFw7L15D33WR+NytemHW9Z/4XJom8c4z/SjxoFn/o/0GbDjH0r6eDTg==
   dependencies:
     core-js "3"
 
@@ -9061,10 +9061,10 @@ core-js@2.6.5:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
   integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
 
-core-js@3, core-js@^3.0.4, core-js@^3.6.5, core-js@^3.8.2:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.10.0.tgz#9a020547c8b6879f929306949e31496bbe2ae9b3"
-  integrity sha512-MQx/7TLgmmDVamSyfE+O+5BHvG1aUGj/gHhLn1wVtm2B5u1eVIPvh7vkfjwWKNCjrTJB8+He99IntSQ1qP+vYQ==
+core-js@3:
+  version "3.39.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.39.0.tgz#57f7647f4d2d030c32a72ea23a0555b2eaa30f83"
+  integrity sha512-raM0ew0/jJUqkJ0E6e8UDtl+y/7ktFivgWvqw8dNSQeNWoSDLvQ1H/RN3aPXB9tBd4/FhyR4RDPGhsNIMsAn7g==
 
 core-js@3.38.0:
   version "3.38.0"
@@ -9080,6 +9080,11 @@ core-js@^3.0.0:
   version "3.25.2"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.25.2.tgz#2d3670c1455432b53fa780300a6fc1bd8304932c"
   integrity sha512-YB4IAT1bjEfxTJ1XYy11hJAKskO+qmhuDBM8/guIfMz4JvdsAQAqvyb97zXX7JgSrfPLG5mRGFWJwJD39ruq2A==
+
+core-js@^3.0.4, core-js@^3.6.5, core-js@^3.8.2:
+  version "3.10.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.10.0.tgz#9a020547c8b6879f929306949e31496bbe2ae9b3"
+  integrity sha512-MQx/7TLgmmDVamSyfE+O+5BHvG1aUGj/gHhLn1wVtm2B5u1eVIPvh7vkfjwWKNCjrTJB8+He99IntSQ1qP+vYQ==
 
 core-js@^3.3.2:
   version "3.23.4"
@@ -19452,7 +19457,7 @@ rc@^1.0.1, rc@^1.1.6, rc@^1.2.8:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-"react-17@npm:react@17.0.2":
+"react-17@npm:react@17.0.2", react@17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
   integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
@@ -19494,16 +19499,7 @@ react-docgen@^5.0.0:
     node-dir "^0.1.10"
     strip-indent "^3.0.0"
 
-"react-dom-17@npm:react-dom@17.0.2":
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
-  integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    scheduler "^0.20.2"
-
-react-dom@17.0.2:
+"react-dom-17@npm:react-dom@17.0.2", react-dom@17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
   integrity sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==
@@ -19764,14 +19760,6 @@ react-waypoint@8.0.0:
   dependencies:
     consolidated-events "^1.1.0"
     prop-types "^15.0.0"
-
-react@17.0.2:
-  version "17.0.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-17.0.2.tgz#d0b5cc516d29eb3eee383f75b62864cfb6800037"
-  integrity sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==
-  dependencies:
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
The type of this PR is: **FEAT**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2159] and relates to [EMI-2196]

### Description

This PR adds autocomplete for US addresses on auction registration and makes minor changes to the registration form layout to follow our latest specs for address forms.

It also simplifies the autocomplete input with the tradeoff of eliminating tracking for when a user edits an input on an autocompleted address.

<!-- Implementation description -->


[EMI-2159]: https://artsyproduct.atlassian.net/browse/EMI-2159?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[EMI-2196]: https://artsyproduct.atlassian.net/browse/EMI-2196?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ