### PR TITLE
fix(consignment inquiry): correct routing for email form

### DIFF
--- a/src/Apps/Sell/Routes/ConsignmentInquiry/ConsignmentInquiryConfirmation.tsx
+++ b/src/Apps/Sell/Routes/ConsignmentInquiry/ConsignmentInquiryConfirmation.tsx
@@ -13,7 +13,7 @@ export const ConsignmentInquiryConfirmation: React.FC = () => {
       <Spacer y={4} />
 
       <Button
-        width={["100%", "20%"]}
+        width={["100%", "auto"]}
         data-test-id="back-to-sell-with-artsy-button"
         size="large"
         variant="primaryBlack"

--- a/src/Apps/Sell/sellRoutes.tsx
+++ b/src/Apps/Sell/sellRoutes.tsx
@@ -579,8 +579,7 @@ export const sellRoutes: RouteProps[] = [
             },
           },
           {
-            path: "inquiry/:recipientEmail?",
-            getComponent: () => ConsignmentInquiryContainer,
+            path: ":recipientEmail?",
             children: [
               {
                 path: "",


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [ONYX-1401]

### Description

- The consignment inquiry flow was added in https://github.com/artsy/force/pull/11578

- Then those routes were re-organized in https://github.com/artsy/force/pull/14419

This resulted in some extraneous nesting that broke the inquiry email flow:


![387841704-d0acb203-47cd-4d45-afb9-3ba23f27da0a](https://github.com/user-attachments/assets/7615859e-3bde-4639-9915-bc3ce610ce8b)



[ONYX-1401]: https://artsyproduct.atlassian.net/browse/ONYX-1401?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ