### PR TITLE
fix: Retain useClientQuery queries

### DIFF
--- a/src/Utils/Hooks/useClientQuery.ts
+++ b/src/Utils/Hooks/useClientQuery.ts
@@ -1,6 +1,11 @@
 import { useUpdateEffect } from "@artsy/palette"
 import { useEffect, useRef, useState } from "react"
-import { Environment, fetchQuery, GraphQLTaggedNode } from "react-relay"
+import {
+  Disposable,
+  Environment,
+  fetchQuery,
+  GraphQLTaggedNode,
+} from "react-relay"
 import {
   CacheConfig,
   createOperationDescriptor,
@@ -29,6 +34,7 @@ export const useClientQuery = <T extends OperationType>({
   const { relayEnvironment } = useSystemContext()
 
   const [data, setData] = useState<T["response"] | null>(null)
+  const [disposable, setDisposable] = useState<Disposable | null>(null)
   const [error, setError] = useState<Error | null>(null)
   const [loading, setLoading] = useState(true)
 
@@ -59,7 +65,9 @@ export const useClientQuery = <T extends OperationType>({
       )
 
       // Retain the operation to prevent it from being garbage collected. Garbage collection can compromise type safety (e.g. non-nullable values being `null`), potentially leading to runtime errors.
-      relayEnvironment.retain(operation)
+      const disposable = relayEnvironment.retain(operation)
+
+      setDisposable(disposable)
     } catch (err) {
       setError(err)
       setLoading(false)
@@ -85,6 +93,7 @@ export const useClientQuery = <T extends OperationType>({
   }, [
     cacheConfig,
     data,
+    disposable,
     environment,
     error,
     query,
@@ -93,5 +102,5 @@ export const useClientQuery = <T extends OperationType>({
     variables,
   ])
 
-  return { data, error, loading: skip ? false : loading, refetch }
+  return { data, disposable, error, loading: skip ? false : loading, refetch }
 }

--- a/src/Utils/Hooks/useClientQuery.ts
+++ b/src/Utils/Hooks/useClientQuery.ts
@@ -1,11 +1,13 @@
+import { useUpdateEffect } from "@artsy/palette"
 import { useEffect, useRef, useState } from "react"
 import { Environment, fetchQuery, GraphQLTaggedNode } from "react-relay"
 import {
   CacheConfig,
+  createOperationDescriptor,
   FetchQueryFetchPolicy,
+  getRequest,
   OperationType,
 } from "relay-runtime"
-import { useUpdateEffect } from "@artsy/palette"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 
 export const useClientQuery = <T extends OperationType>({
@@ -50,6 +52,14 @@ export const useClientQuery = <T extends OperationType>({
 
       setData(res)
       setLoading(false)
+
+      const operation = createOperationDescriptor(
+        getRequest(query),
+        variables ?? {}
+      )
+
+      // Retain the operation to prevent it from being garbage collected. Garbage collection can compromise type safety (e.g. non-nullable values being `null`), potentially leading to runtime errors.
+      relayEnvironment.retain(operation)
     } catch (err) {
       setError(err)
       setLoading(false)


### PR DESCRIPTION
Resolves [Slack Bug Thread](https://artsy.slack.com/archives/C07PRTJSD6G/p1727723121828589)
## Description

To prevent runtime issues from queries being garbage collected by Relay, I think it would be a good idea to [retain](https://relay.dev/docs/guided-tour/accessing-data-without-react/retaining-queries/) all queries fetched with `useClientQuery`.

This fix should resolve the [garbage collection issue](https://artsy.slack.com/archives/C07PRTJSD6G/p1727723121828589). 

I am also open to removing `useClientQuery` entirely in favor of `useLazyLoadQuery`. While `useClientQuery` has a great interface (no `Suspense` 🥳 ), it may be better to only use Relay's standard ways for data fetching (`QueryRenderer`, `fetchQuery` only for callbacks, and `useLazyLoadQueries`). 

