### PR TITLE
fix: use getENV instead of server side context to check IS_MOBILE

### DIFF
--- a/src/Apps/Artwork/artworkRoutes.tsx
+++ b/src/Apps/Artwork/artworkRoutes.tsx
@@ -2,6 +2,7 @@ import loadable from "@loadable/component"
 import { graphql } from "react-relay"
 import { updateContext } from "Server/middleware/bootstrapSharifyAndContextLocalsMiddleware"
 import { RouteProps } from "System/Router/Route"
+import { getENV } from "Utils/getENV"
 
 const ArtworkApp = loadable(
   () => import(/* webpackChunkName: "artworkBundle" */ "./ArtworkApp"),
@@ -18,9 +19,9 @@ export const artworkRoutes: RouteProps[] = [
     onClientSideRender: () => {
       ArtworkApp.preload()
     },
-    prepareVariables: ({ artworkID }, { context }) => {
+    prepareVariables: ({ artworkID }) => {
       // We want to defer loading the sidebar for mobile as it is below-the-fold.
-      const loadSidebar = !context?.isMobile
+      const loadSidebar = !getENV("IS_MOBILE")
 
       return {
         artworkID,

--- a/src/System/Router/Utils/serverAppContext.ts
+++ b/src/System/Router/Utils/serverAppContext.ts
@@ -12,7 +12,6 @@ export const getServerAppContext = (
     initialMatchingMediaQueries: res.locals.sd.IS_MOBILE ? ["xs"] : undefined,
     user: req.user,
     isEigen: req.header("User-Agent")?.match("Artsy-Mobile") != null,
-    isMobile: res.locals.sd.IS_MOBILE,
     featureFlags: res.locals.sd.FEATURE_FLAGS,
     userPreferences: res.locals.sd.USER_PREFERENCES,
     ...context,

--- a/src/System/Router/__tests__/serverRouter.jest.enzyme.tsx
+++ b/src/System/Router/__tests__/serverRouter.jest.enzyme.tsx
@@ -179,7 +179,6 @@ describe("serverRouter", () => {
               "initialMatchingMediaQueries",
               "isEigen",
               "isLoggedIn",
-              "isMobile",
               "relayEnvironment",
               "router",
               "routes",


### PR DESCRIPTION
This was coming up with `loadSidebar: true` on the client, since `context.isMobile` was undefined.

Rather than use context for these, seems like we should just use `getENV` as that works as expected everywhere.