### PR TITLE
fix(artwork): Fix deepzoom

### DIFF
--- a/src/Components/DeepZoom/DeepZoom.tsx
+++ b/src/Components/DeepZoom/DeepZoom.tsx
@@ -95,7 +95,8 @@ const DeepZoom: React.FC<React.PropsWithChildren<DeepZoomProps>> = ({
       osdViewerRef.current.destroy()
       osdViewerRef.current = null
     }
-  }, [image.deepZoom])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [image.deepZoom, deepZoomRef?.current])
 
   const zoomBy = (amount: number) => {
     if (!osdViewerRef.current) return


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Noticed that deepzoom was no longer working, but passing the ref into the dependency array fixed it. Some change between React 17 and 18? Not too sure. 

(My internet is slow, just heads up): 

https://github.com/user-attachments/assets/fed6732b-ecde-487f-9c7c-d6911b79ae34

