### PR TITLE
fix: fixes and simplifies route complete hook

### DIFF
--- a/src/Utils/Hooks/useRouteComplete.ts
+++ b/src/Utils/Hooks/useRouteComplete.ts
@@ -1,30 +1,21 @@
-import { useEffect, useState } from "react"
-import { usePrevious } from "Utils/Hooks/usePrevious"
+import { useEffect } from "react"
 import { useRouter } from "System/Hooks/useRouter"
 
 /**
- * Checks to see if a route was previously fetching and has completed.
+ * Checks to see if a route has completed fetching.
  */
 export const useRouteComplete = ({
   onComplete,
 }: { onComplete?(): void } = {}) => {
-  const [isComplete, setIsComplete] = useState(false)
   const { match } = useRouter()
+
   const isFetching = !match.elements
-  const prevFetching = usePrevious(isFetching)
+  const isComplete = !isFetching
 
   useEffect(() => {
-    if (prevFetching && !isFetching) {
-      setIsComplete(true)
-      onComplete && onComplete()
+    if (!isFetching) return
+    onComplete?.()
+  }, [isFetching, onComplete])
 
-      // Wait till after the next tick to set to false, to give react tree
-      // ability to execute related tracking handlers
-      setTimeout(() => {
-        setIsComplete(false)
-      }, 0)
-    }
-  }, [isFetching, onComplete, prevFetching])
-
-  return { isComplete }
+  return { isFetching, isComplete }
 }


### PR DESCRIPTION
This simplifies the hook by removing the state management which fixes the problem we were having of it not firing on cached pages. Thanks to @damassi for noting we could directly check match elements. I'm preserving this implementation to maintain compatibility for existing consumers and it's a more clear semantically.