### PR TITLE
fix(artwork): adds loading indicator to zoom view

### DIFF
--- a/src/Components/DeepZoom/DeepZoom.tsx
+++ b/src/Components/DeepZoom/DeepZoom.tsx
@@ -1,5 +1,5 @@
 import * as DeprecatedAnalyticsSchema from "@artsy/cohesion/dist/DeprecatedSchema"
-import { Box, Flex, ModalBase } from "@artsy/palette"
+import { Box, Flex, ModalBase, Spinner } from "@artsy/palette"
 import { once } from "lodash"
 import * as React from "react"
 import { DeepZoomCloseButton } from "./DeepZoomCloseButton"
@@ -82,6 +82,7 @@ const DeepZoom: React.FC<React.PropsWithChildren<DeepZoomProps>> = ({
           once(() => {
             setSliderState(prevSliderState => ({
               ...prevSliderState,
+              loading: false,
               min: viewer.viewport.getMinZoom(),
               max: viewer.viewport.getMaxZoom(),
               value: viewer.viewport.getHomeZoom(),
@@ -110,6 +111,7 @@ const DeepZoom: React.FC<React.PropsWithChildren<DeepZoomProps>> = ({
   }
 
   const [sliderState, setSliderState] = useState({
+    loading: true,
     min: 0,
     max: 1,
     step: 0.001,
@@ -141,7 +143,9 @@ const DeepZoom: React.FC<React.PropsWithChildren<DeepZoomProps>> = ({
         height="100vh"
         bg="black100"
         style={{ transition: "opacity 250ms", opacity: isMounted ? 1 : 0 }}
-      />
+      >
+        {sliderState.loading && <Spinner color="white100" />}
+      </Box>
 
       <DeepZoomCloseButton
         position="absolute"


### PR DESCRIPTION
I can't actually tell if something changed since upgrading to React 18 or I'm just noticing it now but the black screen while the deep zoom view loads seemed excessive. I've implemented a loading indicator to provide better user feedback during this delay, ensuring users see something on screen rather than empty space.

https://github.com/user-attachments/assets/00122232-66ce-4a56-8d91-4303f435b290

