### PR TITLE
feat(prefetching): Prefetch JS alongside network responses

### DIFF
--- a/src/Apps/Alert/alertRoutes.tsx
+++ b/src/Apps/Alert/alertRoutes.tsx
@@ -12,7 +12,7 @@ export const alertRoutes: RouteProps[] = [
   {
     path: "/dev/alert",
     getComponent: () => AlertApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       AlertApp.preload()
     },
   },

--- a/src/Apps/ArtQuiz/artQuizRoutes.tsx
+++ b/src/Apps/ArtQuiz/artQuizRoutes.tsx
@@ -44,7 +44,7 @@ export const artQuizRoutes: RouteProps[] = [
       res.redirect("/art-quiz/welcome")
     },
     getComponent: () => ArtQuizApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       ArtQuizWelcome.preload()
       ArtQuizArtworks.preload()
       ArtQuizResults.preload()
@@ -86,7 +86,7 @@ export const artQuizRoutes: RouteProps[] = [
         path: "artworks",
         getComponent: () => ArtQuizArtworks,
         layout: "NavOnly",
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           ArtQuizArtworks.preload()
         },
         onServerSideRender: artQuizServerSideRedirect,
@@ -109,7 +109,7 @@ export const artQuizRoutes: RouteProps[] = [
         path: "results",
         getComponent: () => ArtQuizResults,
         layout: "NavOnly",
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           ArtQuizResults.preload()
         },
         onServerSideRender: artQuizServerSideRedirect,

--- a/src/Apps/Article/articleRoutes.tsx
+++ b/src/Apps/Article/articleRoutes.tsx
@@ -23,7 +23,7 @@ export const articleRoutes: RouteProps[] = [
   {
     path: "/article/:id",
     Component: ArticleApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       ArticleApp.preload()
     },
     query: graphql`

--- a/src/Apps/Articles/articlesRoutes.tsx
+++ b/src/Apps/Articles/articlesRoutes.tsx
@@ -21,7 +21,7 @@ export const articlesRoutes: RouteProps[] = [
   {
     path: "/articles",
     Component: ArticlesApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       ArticlesApp.preload()
     },
     query: graphql`
@@ -36,7 +36,7 @@ export const articlesRoutes: RouteProps[] = [
   {
     path: "/news",
     Component: NewsApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       NewsApp.preload()
     },
     query: graphql`
@@ -51,7 +51,7 @@ export const articlesRoutes: RouteProps[] = [
   {
     path: "/channel/:id",
     Component: ChannelApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       ChannelApp.preload()
     },
     query: graphql`

--- a/src/Apps/Artist/artistRoutes.tsx
+++ b/src/Apps/Artist/artistRoutes.tsx
@@ -115,7 +115,7 @@ export const artistRoutes: RouteProps[] = [
     serverCacheTTL: serverCacheTTLs.artist,
     getComponent: () => ArtistApp,
     onServerSideRender: enableArtistPageCTA,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       ArtistApp.preload()
       OverviewRoute.preload()
       WorksForSaleRoute.preload()
@@ -133,7 +133,7 @@ export const artistRoutes: RouteProps[] = [
         serverCacheTTL: serverCacheTTLs.artist,
         getComponent: () => WorksForSaleRoute,
         onServerSideRender: redirectWithCanonicalParams,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           WorksForSaleRoute.preload()
         },
         prepareVariables: getWorksForSaleRouteVariables,
@@ -149,7 +149,7 @@ export const artistRoutes: RouteProps[] = [
         path: "auction-results",
         serverCacheTTL: serverCacheTTLs.artist,
         getComponent: () => AuctionResultsRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           AuctionResultsRoute.preload()
         },
         prepareVariables: ({ artistID }, props) => {
@@ -207,7 +207,7 @@ export const artistRoutes: RouteProps[] = [
         serverCacheTTL: serverCacheTTLs.artist,
         getComponent: () => OverviewRoute,
         onServerSideRender: enableArtistPageCTA,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           OverviewRoute.preload()
         },
         query: graphql`
@@ -237,7 +237,7 @@ export const artistRoutes: RouteProps[] = [
         path: "articles/:artworkId?",
         serverCacheTTL: serverCacheTTLs.artist,
         getComponent: () => ArticlesRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           ArticlesRoute.preload()
         },
         query: graphql`
@@ -251,7 +251,7 @@ export const artistRoutes: RouteProps[] = [
       {
         path: "consign",
         getComponent: () => ConsignRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           ConsignRoute.preload()
         },
         query: graphql`
@@ -284,7 +284,7 @@ export const artistRoutes: RouteProps[] = [
         path: "cv",
         serverCacheTTL: serverCacheTTLs.artist,
         getComponent: () => CVRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           CVRoute.preload()
         },
         query: graphql`
@@ -299,7 +299,7 @@ export const artistRoutes: RouteProps[] = [
         path: "series",
         serverCacheTTL: serverCacheTTLs.artist,
         getComponent: () => ArtistSeriesRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           ArtistSeriesRoute.preload()
         },
         query: graphql`
@@ -314,7 +314,7 @@ export const artistRoutes: RouteProps[] = [
         path: "shows",
         serverCacheTTL: serverCacheTTLs.artist,
         getComponent: () => ShowsRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           ShowsRoute.preload()
         },
         query: graphql`
@@ -342,7 +342,7 @@ export const artistRoutes: RouteProps[] = [
     serverCacheTTL: serverCacheTTLs.artist,
     getComponent: () => AuctionResultRoute,
     onServerSideRender: enableArtistPageCTA,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       AuctionResultRoute.preload()
     },
     query: graphql`

--- a/src/Apps/ArtistSeries/artistSeriesRoutes.tsx
+++ b/src/Apps/ArtistSeries/artistSeriesRoutes.tsx
@@ -15,7 +15,7 @@ export const artistSeriesRoutes: RouteProps[] = [
     path: "/artist-series/:slug",
     serverCacheTTL: serverCacheTTLs.artistSeries,
     getComponent: () => ArtistSeriesApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       ArtistSeriesApp.preload()
     },
     query: graphql`

--- a/src/Apps/Artists/artistsRoutes.tsx
+++ b/src/Apps/Artists/artistsRoutes.tsx
@@ -30,16 +30,16 @@ export const artistsRoutes: RouteProps[] = [
     path: "/artists",
     serverCacheTTL: serverCacheTTLs.artists,
     getComponent: () => ArtistsApp,
-    onClientSideRender: () => {
-      return ArtistsApp.preload()
+    onPreloadJS: () => {
+      ArtistsApp.preload()
     },
     children: [
       {
         path: "",
         serverCacheTTL: serverCacheTTLs.artists,
         getComponent: () => ArtistsIndexRoute,
-        onClientSideRender: () => {
-          return ArtistsIndexRoute.preload()
+        onPreloadJS: () => {
+          ArtistsIndexRoute.preload()
         },
         query: graphql`
           query artistsRoutes_ArtistsQuery @cacheable {
@@ -56,8 +56,8 @@ export const artistsRoutes: RouteProps[] = [
         path: "artists-starting-with-:letter([a-zA-Z])",
         serverCacheTTL: serverCacheTTLs.artists,
         getComponent: () => ArtistsByLetterRoute,
-        onClientSideRender: () => {
-          return ArtistsByLetterRoute.preload()
+        onPreloadJS: () => {
+          ArtistsByLetterRoute.preload()
         },
         prepareVariables: (params, props) => {
           return {

--- a/src/Apps/Artwork/artworkRoutes.tsx
+++ b/src/Apps/Artwork/artworkRoutes.tsx
@@ -16,7 +16,7 @@ export const artworkRoutes: RouteProps[] = [
     path: "/artwork/:artworkID/:optional?", // There's a `confirm-bid` nested route.
     fetchPolicy: "store-and-network",
     getComponent: () => ArtworkApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       ArtworkApp.preload()
     },
     prepareVariables: ({ artworkID }) => {

--- a/src/Apps/Auction/auctionRoutes.tsx
+++ b/src/Apps/Auction/auctionRoutes.tsx
@@ -52,7 +52,7 @@ export const auctionRoutes: RouteProps[] = [
     path: "/auction/:slug?",
     getComponent: () => AuctionApp,
     serverCacheTTL: serverCacheTTLs.auction,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       AuctionApp.preload()
     },
     query: graphql`

--- a/src/Apps/Auctions/EndingSoonAuctions/endingSoonAuctionsRoutes.tsx
+++ b/src/Apps/Auctions/EndingSoonAuctions/endingSoonAuctionsRoutes.tsx
@@ -10,7 +10,7 @@ export const endingSoonAuctionsRoutes: RouteProps[] = [
   {
     path: "/auctions/lots-for-you-ending-soon",
     getComponent: () => EndingSoonAuctions,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       EndingSoonAuctions.preload()
     },
     query: graphql`

--- a/src/Apps/Auctions/auctionsRoutes.tsx
+++ b/src/Apps/Auctions/auctionsRoutes.tsx
@@ -54,7 +54,7 @@ export const auctionsRoutes: RouteProps[] = [
     path: "/auctions",
     ignoreScrollBehaviorBetweenChildren: true,
     getComponent: () => AuctionsApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       AuctionsApp.preload()
     },
     children: [

--- a/src/Apps/Authentication/authenticationRoutes.tsx
+++ b/src/Apps/Authentication/authenticationRoutes.tsx
@@ -67,7 +67,7 @@ export const authenticationRoutes: RouteProps[] = [
 
       runAuthMiddleware(props)
     },
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       LoginRoute.preload()
     },
   },
@@ -102,7 +102,7 @@ export const authenticationRoutes: RouteProps[] = [
 
       runAuthMiddleware({ req, res })
     },
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       ResetPasswordRoute.preload()
     },
   },
@@ -120,7 +120,7 @@ export const authenticationRoutes: RouteProps[] = [
 
       runAuthMiddleware(props)
     },
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       SignupRoute.preload()
     },
   },

--- a/src/Apps/BuyerGuarantee/buyerGuaranteeRoutes.tsx
+++ b/src/Apps/BuyerGuarantee/buyerGuaranteeRoutes.tsx
@@ -22,14 +22,14 @@ export const buyerGuaranteeRoutes: RouteProps[] = [
   {
     path: "/buyer-guarantee",
     getComponent: () => BuyerGuaranteeApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       BuyerGuaranteeApp.preload()
     },
     children: [
       {
         path: "",
         getComponent: () => BuyerGuaranteeIndexRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           return BuyerGuaranteeIndexRoute.preload()
         },
       },

--- a/src/Apps/Categories/categoriesRoutes.tsx
+++ b/src/Apps/Categories/categoriesRoutes.tsx
@@ -15,7 +15,7 @@ export const categoriesRoutes: RouteProps[] = [
     path: "/categories",
     serverCacheTTL: serverCacheTTLs.categories,
     getComponent: () => CategoriesApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       CategoriesApp.preload()
     },
     query: graphql`

--- a/src/Apps/Collect/collectRoutes.tsx
+++ b/src/Apps/Collect/collectRoutes.tsx
@@ -29,7 +29,7 @@ export const collectRoutes: RouteProps[] = [
     path: "/collect/:medium?",
     serverCacheTTL: serverCacheTTLs.collect,
     getComponent: () => CollectApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       CollectApp.preload()
     },
     prepareVariables: initializeVariablesWithFilterState,
@@ -39,7 +39,7 @@ export const collectRoutes: RouteProps[] = [
     path: "/collect/color/:color?",
     serverCacheTTL: serverCacheTTLs.collect,
     getComponent: () => CollectApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       CollectApp.preload()
     },
     prepareVariables: initializeVariablesWithFilterState,
@@ -49,7 +49,7 @@ export const collectRoutes: RouteProps[] = [
     path: "/collections",
     serverCacheTTL: serverCacheTTLs.collections,
     getComponent: () => CollectionsApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       CollectionsApp.preload()
     },
     query: graphql`
@@ -65,7 +65,7 @@ export const collectRoutes: RouteProps[] = [
     serverCacheTTL: serverCacheTTLs.collections,
     getComponent: () => CollectionApp,
     onServerSideRender: redirectCollectionToArtistSeries,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       CollectionApp.preload()
     },
     prepareVariables: initializeVariablesWithFilterState,

--- a/src/Apps/CollectorProfile/collectorProfileRoutes.tsx
+++ b/src/Apps/CollectorProfile/collectorProfileRoutes.tsx
@@ -108,7 +108,7 @@ export const collectorProfileRoutes: RouteProps[] = [
   {
     path: "/collector-profile",
     getComponent: () => CollectorProfileApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       CollectorProfileApp.preload()
     },
     query: graphql`
@@ -122,14 +122,14 @@ export const collectorProfileRoutes: RouteProps[] = [
       {
         path: "artists",
         getComponent: () => Artists,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           Artists.preload()
         },
       },
       {
         path: "my-collection",
         getComponent: () => MyCollectionRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           MyCollectionRoute.preload()
         },
         query: graphql`
@@ -144,7 +144,7 @@ export const collectorProfileRoutes: RouteProps[] = [
       {
         path: "insights",
         getComponent: () => InsightsRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           InsightsRoute.preload()
         },
         onServerSideRender: handleServerSideRender,
@@ -162,7 +162,7 @@ export const collectorProfileRoutes: RouteProps[] = [
     path: "/collector-profile/my-collection/artworks/new",
     layout: "ContainerOnly",
     getComponent: () => MyCollectionCreateArtwork,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       MyCollectionCreateArtwork.preload()
     },
     query: graphql`
@@ -176,7 +176,7 @@ export const collectorProfileRoutes: RouteProps[] = [
   {
     path: "/collector-profile/my-collection/artwork/:artworkID",
     getComponent: () => MyCollectionArtwork,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       MyCollectionArtwork.preload()
     },
     query: graphql`
@@ -194,7 +194,7 @@ export const collectorProfileRoutes: RouteProps[] = [
     path: "/collector-profile/my-collection/artworks/:slug/edit",
     layout: "ContainerOnly",
     getComponent: () => MyCollectionEditArtwork,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       MyCollectionEditArtwork.preload()
     },
     query: graphql`
@@ -214,7 +214,7 @@ export const collectorProfileRoutes: RouteProps[] = [
     path: "/collector-profile/my-collection/artwork/:artworkID/price-estimate",
     layout: "ContainerOnly",
     getComponent: () => PriceEstimateContactInformation,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       PriceEstimateContactInformation.preload()
     },
     query: graphql`
@@ -235,7 +235,7 @@ export const collectorProfileRoutes: RouteProps[] = [
       "/collector-profile/my-collection/artwork/:artworkID/price-estimate/success",
     layout: "ContainerOnly",
     getComponent: () => PriceEstimateConfirmation,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       PriceEstimateConfirmation.preload()
     },
   },

--- a/src/Apps/Components/AppShell.tsx
+++ b/src/Apps/Components/AppShell.tsx
@@ -1,6 +1,5 @@
 import { useNetworkOfflineMonitor } from "Utils/Hooks/useNetworkOfflineMonitor"
 import { Match } from "found"
-import { isFunction } from "lodash"
 import { useEffect } from "react"
 import * as React from "react"
 import createLogger from "Utils/logger"
@@ -19,7 +18,9 @@ interface AppShellProps {
   match?: Match
 }
 
-export const AppShell: React.FC<React.PropsWithChildren<AppShellProps>> = props => {
+export const AppShell: React.FC<React.PropsWithChildren<
+  AppShellProps
+>> = props => {
   useSetupAuth()
 
   const { onboardingComponent } = useOnboardingModal()
@@ -33,13 +34,17 @@ export const AppShell: React.FC<React.PropsWithChildren<AppShellProps>> = props 
   // typically to preload bundle-split components (import()) while the route is
   // fetching data in the background.
   useEffect(() => {
-    if (isFunction(routeConfig?.onClientSideRender) && match) {
-      try {
-        routeConfig?.onClientSideRender({ match })
-      } catch (error) {
-        logger.error(error)
+    try {
+      if (match) {
+        routeConfig?.onClientSideRender?.({ match })
       }
+
+      // Preload current route's JS bundle
+      routeConfig?.onPreloadJS?.()
+    } catch (error) {
+      logger.error(error)
     }
+
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [routeConfig])
 

--- a/src/Apps/Components/__tests__/AppShell.jest.tsx
+++ b/src/Apps/Components/__tests__/AppShell.jest.tsx
@@ -63,8 +63,8 @@ describe("AppShell", () => {
           {
             path: "/foo",
             Component: () => <div />,
-            onClientSideRender: ({ match }) => {
-              expect(match.location.pathname).toBe("/foo")
+            onClientSideRender: props => {
+              expect(props?.match.location.pathname).toBe("/foo")
               onClientSideRender()
             },
           },
@@ -80,6 +80,35 @@ describe("AppShell", () => {
 
     await waitFor(() => {
       expect(onClientSideRender).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  it("calls the matched routes `onPreloadJS` function if found", async () => {
+    const spy = jest.fn()
+    const { ClientRouter } = await setupClientRouter({
+      history: {
+        protocol: "memory",
+      },
+      initialRoute: "/foo",
+      routes: buildAppRoutes([
+        [
+          {
+            path: "/foo",
+            Component: () => <div />,
+            onPreloadJS: spy,
+          },
+        ],
+      ]),
+    })
+
+    render(
+      <SystemContextProvider>
+        <ClientRouter />
+      </SystemContextProvider>
+    )
+
+    await waitFor(() => {
+      expect(spy).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/Apps/Example/exampleRoutes.tsx
+++ b/src/Apps/Example/exampleRoutes.tsx
@@ -75,7 +75,7 @@ export const exampleRoutes: RouteProps[] = [
   {
     path: "/example",
     getComponent: () => ExampleApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       ExampleApp.preload()
     },
     query: graphql`
@@ -93,7 +93,7 @@ export const exampleRoutes: RouteProps[] = [
       {
         path: "artist/:slug",
         getComponent: () => ArtistRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           ArtistRoute.preload()
         },
         query: graphql`
@@ -108,7 +108,7 @@ export const exampleRoutes: RouteProps[] = [
       {
         path: "artwork/:slug",
         getComponent: () => ArtworkRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           ArtworkRoute.preload()
         },
         query: graphql`
@@ -123,7 +123,7 @@ export const exampleRoutes: RouteProps[] = [
       {
         path: "artwork-filter",
         getComponent: () => ArtworkFilterRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           ArtworkRoute.preload()
         },
         query: graphql`
@@ -144,7 +144,7 @@ export const exampleRoutes: RouteProps[] = [
       {
         path: "add-to-collection",
         getComponent: () => AddToCollectionRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           AddToCollectionRoute.preload()
         },
         query: graphql`
@@ -158,7 +158,7 @@ export const exampleRoutes: RouteProps[] = [
       {
         path: "search",
         getComponent: () => SearchRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           SearchRoute.preload()
         },
       },

--- a/src/Apps/Fair/fairRoutes.tsx
+++ b/src/Apps/Fair/fairRoutes.tsx
@@ -45,7 +45,7 @@ export const fairRoutes: RouteProps[] = [
     path: "/fair/:slug?",
     ignoreScrollBehaviorBetweenChildren: true,
     getComponent: () => FairApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       FairApp.preload()
     },
     query: graphql`
@@ -59,7 +59,7 @@ export const fairRoutes: RouteProps[] = [
       {
         path: "",
         getComponent: () => FairOverviewRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           FairOverviewRoute.preload()
         },
         query: graphql`
@@ -73,7 +73,7 @@ export const fairRoutes: RouteProps[] = [
       {
         path: "exhibitors(.*)?",
         getComponent: () => FairExhibitorsRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           FairExhibitorsRoute.preload()
         },
         query: graphql`
@@ -94,7 +94,7 @@ export const fairRoutes: RouteProps[] = [
       {
         path: "artworks(.*)?",
         getComponent: () => FairArtworksRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           FairArtworksRoute.preload()
         },
       },
@@ -105,7 +105,7 @@ export const fairRoutes: RouteProps[] = [
   {
     path: "/fair/:slug",
     getComponent: () => FairSubApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       FairSubApp.preload()
     },
     query: graphql`
@@ -119,7 +119,7 @@ export const fairRoutes: RouteProps[] = [
       {
         path: "articles",
         getComponent: () => FairArticlesRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           FairArticlesRoute.preload()
         },
         query: graphql`

--- a/src/Apps/FairOrginizer/fairOrganizerRoutes.tsx
+++ b/src/Apps/FairOrginizer/fairOrganizerRoutes.tsx
@@ -33,13 +33,15 @@ export const fairOrganizerRoutes: RouteProps[] = [
   {
     path: "/fair-organizer/:slug",
     getComponent: () => FairOrganizerApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       FairOrganizerApp.preload()
     },
     render: ({ Component, props }) => {
       if (Component && props) {
         const { fairOrganizer } = props as Props
-        const { profile, runningFairs } = fairOrganizer!
+        const { profile, runningFairs } = fairOrganizer as NonNullable<
+          Props["fairOrganizer"]
+        >
         if (!profile) {
           return <ErrorPage code={404} />
         }
@@ -80,7 +82,7 @@ export const fairOrganizerRoutes: RouteProps[] = [
   {
     path: "/fair-organizer/:slug/articles",
     getComponent: () => FairOrganizerDedicatedArticles,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       FairOrganizerDedicatedArticles.preload()
     },
     prepareVariables: ({ slug }, { location }) => {

--- a/src/Apps/Fairs/fairsRoutes.tsx
+++ b/src/Apps/Fairs/fairsRoutes.tsx
@@ -20,15 +20,15 @@ export const fairsRoutes: RouteProps[] = [
   {
     path: "/art-fairs",
     getComponent: () => FairsApp,
-    onClientSideRender: () => {
-      return FairsApp.preload()
+    onPreloadJS: () => {
+      FairsApp.preload()
     },
     children: [
       {
         path: "",
         getComponent: () => FairsIndexRoute,
-        onClientSideRender: () => {
-          return FairsIndexRoute.preload()
+        onPreloadJS: () => {
+          FairsIndexRoute.preload()
         },
         query: graphql`
           query fairsRoutes_FairsQuery @cacheable {

--- a/src/Apps/Favorites/favoritesRoutes.tsx
+++ b/src/Apps/Favorites/favoritesRoutes.tsx
@@ -38,7 +38,7 @@ export const favoritesRoutes: RouteProps[] = [
   {
     path: "/favorites",
     getComponent: () => FavoritesApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       FavoritesApp.preload()
     },
     children: [
@@ -46,7 +46,7 @@ export const favoritesRoutes: RouteProps[] = [
         path: "saves/:id?",
         ignoreScrollBehavior: true,
         getComponent: () => Saves,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           Saves.preload()
         },
         query: graphql`
@@ -60,7 +60,7 @@ export const favoritesRoutes: RouteProps[] = [
       {
         path: "follows",
         getComponent: () => Follows,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           Follows.preload()
         },
       },
@@ -68,7 +68,7 @@ export const favoritesRoutes: RouteProps[] = [
         path: "alerts",
         getComponent: () => Alerts,
         layout: "NavOnly",
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           Alerts.preload()
         },
         query: graphql`
@@ -84,7 +84,7 @@ export const favoritesRoutes: RouteProps[] = [
         getComponent: () => Alerts,
         layout: "NavOnly",
 
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           Alerts.preload()
         },
         query: graphql`
@@ -100,7 +100,7 @@ export const favoritesRoutes: RouteProps[] = [
         layout: "NavOnly",
 
         getComponent: () => Alerts,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           Alerts.preload()
         },
         query: graphql`

--- a/src/Apps/Feature/featureRoutes.tsx
+++ b/src/Apps/Feature/featureRoutes.tsx
@@ -13,7 +13,7 @@ export const featureRoutes: RouteProps[] = [
   {
     path: "/feature/:slug",
     getComponent: () => FeatureApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       FeatureApp.preload()
     },
     query: graphql`

--- a/src/Apps/Gene/geneRoutes.tsx
+++ b/src/Apps/Gene/geneRoutes.tsx
@@ -25,8 +25,8 @@ export const geneRoutes: RouteProps[] = [
     serverCacheTTL: serverCacheTTLs.gene,
     getComponent: () => GeneApp,
     onServerSideRender: redirectGeneToCollection,
-    onClientSideRender: () => {
-      return GeneApp.preload()
+    onPreloadJS: () => {
+      GeneApp.preload()
     },
     children: [
       {
@@ -43,8 +43,8 @@ export const geneRoutes: RouteProps[] = [
         path: "",
         serverCacheTTL: serverCacheTTLs.gene,
         getComponent: () => GeneShowRoute,
-        onClientSideRender: () => {
-          return GeneShowRoute.preload()
+        onPreloadJS: () => {
+          GeneShowRoute.preload()
         },
         query: graphql`
           query geneRoutes_GeneShowQuery($slug: String!) {

--- a/src/Apps/Home/homeRoutes.tsx
+++ b/src/Apps/Home/homeRoutes.tsx
@@ -11,7 +11,7 @@ export const homeRoutes: RouteProps[] = [
   {
     path: "/",
     getComponent: () => HomeApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       HomeApp.preload()
     },
     prepareVariables: (_params, props) => {

--- a/src/Apps/IdentityVerification/identityVerificationRoutes.tsx
+++ b/src/Apps/IdentityVerification/identityVerificationRoutes.tsx
@@ -30,21 +30,21 @@ export const identityVerificationRoutes: RouteProps[] = [
   {
     path: "/identity-verification/processing",
     getComponent: () => Processing,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       Processing.preload()
     },
   },
   {
     path: "/identity-verification/error",
     getComponent: () => Error,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       Error.preload()
     },
   },
   {
     path: "/identity-verification/:id",
     getComponent: () => IdentityVerificationApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       IdentityVerificationApp.preload()
     },
     query: graphql`

--- a/src/Apps/Invoice/invoiceRoutes.tsx
+++ b/src/Apps/Invoice/invoiceRoutes.tsx
@@ -34,7 +34,7 @@ export const invoiceRoutes: RouteProps[] = [
     path: "/invoice/:token",
     layout: "LogoOnly",
     getComponent: () => InvoiceApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       InvoiceApp.preload()
     },
     query: graphql`
@@ -49,7 +49,7 @@ export const invoiceRoutes: RouteProps[] = [
         path: "",
         layout: "LogoOnly",
         getComponent: () => InvoiceDetailRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           InvoiceDetailRoute.preload()
         },
         query: graphql`
@@ -66,7 +66,7 @@ export const invoiceRoutes: RouteProps[] = [
         path: "payment",
         layout: "LogoOnly",
         getComponent: () => InvoicePaymentRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           InvoicePaymentRoute.preload()
         },
         query: graphql`

--- a/src/Apps/Jobs/jobsRoutes.tsx
+++ b/src/Apps/Jobs/jobsRoutes.tsx
@@ -16,7 +16,7 @@ export const jobsRoutes: RouteProps[] = [
   {
     path: "/jobs",
     getComponent: () => JobsApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       JobsApp.preload()
     },
     query: graphql`
@@ -30,7 +30,7 @@ export const jobsRoutes: RouteProps[] = [
   {
     path: "/job/:id",
     getComponent: () => JobApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       JobApp.preload()
     },
     query: graphql`

--- a/src/Apps/Marketing/marketingRoutes.tsx
+++ b/src/Apps/Marketing/marketingRoutes.tsx
@@ -21,14 +21,14 @@ export const marketingRoutes: RouteProps[] = [
   {
     path: "/meet-your-new-art-advisor",
     getComponent: () => MarketingMeetArtAdvisorRoute,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       MarketingMeetArtAdvisorRoute.preload()
     },
   },
   {
     path: "/find-the-art-you-love",
     getComponent: () => MarketingFindArtYouLoveRoute,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       MarketingFindArtYouLoveRoute.preload()
     },
   },

--- a/src/Apps/MyCollection/myCollectionRoutes.tsx
+++ b/src/Apps/MyCollection/myCollectionRoutes.tsx
@@ -60,7 +60,7 @@ export const myCollectionRoutes: RouteProps[] = [
   {
     path: "/my-collection/artwork/:artworkID",
     getComponent: () => MyCollectionArtwork,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       MyCollectionArtwork.preload()
     },
     query: graphql`
@@ -78,7 +78,7 @@ export const myCollectionRoutes: RouteProps[] = [
     path: "/my-collection/artwork/:artworkID/price-estimate",
     layout: "ContainerOnly",
     getComponent: () => PriceEstimateContactInformation,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       PriceEstimateContactInformation.preload()
     },
     query: graphql`
@@ -98,7 +98,7 @@ export const myCollectionRoutes: RouteProps[] = [
     path: "/my-collection/artwork/:artworkID/price-estimate/success",
     layout: "ContainerOnly",
     getComponent: () => PriceEstimateConfirmation,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       PriceEstimateConfirmation.preload()
     },
   },
@@ -109,7 +109,7 @@ export const myCollectionRoutes: RouteProps[] = [
         path: "artworks/new",
         layout: "ContainerOnly",
         getComponent: () => MyCollectionCreateArtwork,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           MyCollectionCreateArtwork.preload()
         },
         query: graphql`
@@ -127,7 +127,7 @@ export const myCollectionRoutes: RouteProps[] = [
         path: "artworks/:slug/edit",
         layout: "ContainerOnly",
         getComponent: () => MyCollectionEditArtwork,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           MyCollectionEditArtwork.preload()
         },
         query: graphql`

--- a/src/Apps/MyCollectionInsights/myCollectionInsightsCollectorProfileRoutes.tsx
+++ b/src/Apps/MyCollectionInsights/myCollectionInsightsCollectorProfileRoutes.tsx
@@ -22,7 +22,7 @@ export const myCollectionInsightsCollectorProfileRoutes: RouteProps[] = [
     path:
       "/collector-profile/my-collection/median-sale-price-at-auction/:artistID",
     getComponent: () => MyCollectionInsightsMedianSalePriceAtAuction,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       MyCollectionInsightsMedianSalePriceAtAuction.preload()
     },
     query: graphql`

--- a/src/Apps/MyCollectionInsights/myCollectionInsightsRoutes.tsx
+++ b/src/Apps/MyCollectionInsights/myCollectionInsightsRoutes.tsx
@@ -17,7 +17,7 @@ export const myCollectionInsightsRoutes: RouteProps[] = [
   {
     path: "/my-collection/median-sale-price-at-auction/:artistID",
     getComponent: () => MyCollectionInsightsMedianSalePriceAtAuction,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       MyCollectionInsightsMedianSalePriceAtAuction.preload()
     },
     query: graphql`

--- a/src/Apps/NewForYou/newForYouRoutes.tsx
+++ b/src/Apps/NewForYou/newForYouRoutes.tsx
@@ -15,7 +15,7 @@ export const newForYouRoutes: RouteProps[] = [
   {
     path: "/new-for-you",
     getComponent: () => NewForYouApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       NewForYouApp.preload()
     },
     prepareVariables: (params, props) => {

--- a/src/Apps/NewWorksFromGalleriesYouFollow/newWorksFromGalleriesYouFollowRoutes.tsx
+++ b/src/Apps/NewWorksFromGalleriesYouFollow/newWorksFromGalleriesYouFollowRoutes.tsx
@@ -17,7 +17,7 @@ export const newWorksFromGalleriesYouFollowRoutes: RouteProps[] = [
   {
     path: "/new-works-from-galleries-you-follow",
     getComponent: () => NewWorksFromGalleriesYouFollowApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       NewWorksFromGalleriesYouFollowApp.preload()
     },
     query: graphql`

--- a/src/Apps/Notifications/notificationsRoutes.ts
+++ b/src/Apps/Notifications/notificationsRoutes.ts
@@ -15,7 +15,7 @@ export const notificationsRoutes: RouteProps[] = [
     path: "/notifications",
     layout: "FullBleed",
     getComponent: () => NotificationsApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       NotificationsApp.preload()
     },
     query: graphql`
@@ -30,7 +30,7 @@ export const notificationsRoutes: RouteProps[] = [
     path: "/notification/:notificationId",
     layout: "FullBleed",
     getComponent: () => NotificationsApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       NotificationsApp.preload()
     },
     query: graphql`

--- a/src/Apps/Onboarding/onboardingRoutes.tsx
+++ b/src/Apps/Onboarding/onboardingRoutes.tsx
@@ -12,7 +12,7 @@ export const onboardingRoutes: RouteProps[] = [
   {
     path: "/onboarding2",
     getComponent: () => OnboardingApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       OnboardingApp.preload()
     },
   },

--- a/src/Apps/Order/orderRoutes.tsx
+++ b/src/Apps/Order/orderRoutes.tsx
@@ -89,7 +89,7 @@ export const orderRoutes: RouteProps[] = [
     path: "/order(2|s)/:orderID",
     layout: "LogoOnly",
     Component: OrderApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       OrderApp.preload()
       OfferRoute.preload()
     },

--- a/src/Apps/Page/pageRoutes.tsx
+++ b/src/Apps/Page/pageRoutes.tsx
@@ -36,7 +36,7 @@ export const PAGE_SLUGS_WITH_AUTH_REQUIRED = [
 
 const PAGE_ROUTE_CONFIG = {
   getComponent: () => PageApp,
-  onClientSideRender: () => {
+  onPreloadJS: () => {
     PageApp.preload()
   },
   query: graphql`

--- a/src/Apps/Partner/partnerRoutes.tsx
+++ b/src/Apps/Partner/partnerRoutes.tsx
@@ -68,7 +68,7 @@ export const partnerRoutes: RouteProps[] = [
     path: "/partner/:partnerId",
     ignoreScrollBehaviorBetweenChildren: true,
     getComponent: () => PartnerApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       PartnerApp.preload()
     },
     query: graphql`
@@ -107,7 +107,7 @@ export const partnerRoutes: RouteProps[] = [
       {
         path: "",
         getComponent: () => OverviewRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           OverviewRoute.preload()
         },
         query: graphql`
@@ -130,7 +130,7 @@ export const partnerRoutes: RouteProps[] = [
       {
         path: "shows",
         getComponent: () => ShowsRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           ShowsRoute.preload()
         },
         query: graphql`
@@ -171,7 +171,7 @@ export const partnerRoutes: RouteProps[] = [
       {
         path: "viewing-rooms",
         getComponent: () => ViewingRoomsRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           ViewingRoomsRoute.preload()
         },
         query: graphql`
@@ -192,7 +192,7 @@ export const partnerRoutes: RouteProps[] = [
       {
         path: "works",
         getComponent: () => WorksRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           WorksRoute.preload()
         },
         query: graphql`
@@ -235,7 +235,7 @@ export const partnerRoutes: RouteProps[] = [
         path: "artists/:artistId?",
         ignoreScrollBehavior: true,
         getComponent: () => ArtistsRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           ArtistsRoute.preload()
         },
         query: graphql`
@@ -276,7 +276,7 @@ export const partnerRoutes: RouteProps[] = [
       {
         path: "articles",
         getComponent: () => ArticlesRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           ArticlesRoute.preload()
         },
         prepareVariables: (params, { location }) => {
@@ -324,7 +324,7 @@ export const partnerRoutes: RouteProps[] = [
       {
         path: "contact",
         getComponent: () => ContactRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           ContactRoute.preload()
         },
         query: graphql`

--- a/src/Apps/PartnerOffer/partnerOfferRoutes.tsx
+++ b/src/Apps/PartnerOffer/partnerOfferRoutes.tsx
@@ -15,7 +15,7 @@ export const partnerOfferRoutes: RouteProps[] = [
   {
     path: "/partner-offer/:partnerOfferID/checkout",
     getComponent: () => PartnerOfferCheckoutRoute,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       PartnerOfferCheckoutRoute.preload()
     },
     onServerSideRender: checkIfLoggedIn,

--- a/src/Apps/Partners/partnersRoutes.ts
+++ b/src/Apps/Partners/partnersRoutes.ts
@@ -22,7 +22,7 @@ export const partnersRoutes: RouteProps[] = [
   {
     path: "/galleries",
     getComponent: () => GalleriesRoute,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       return GalleriesRoute.preload()
     },
     query: graphql`
@@ -36,7 +36,7 @@ export const partnersRoutes: RouteProps[] = [
   {
     path: "/institutions",
     getComponent: () => InstitutionsRoute,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       return InstitutionsRoute.preload()
     },
     query: graphql`

--- a/src/Apps/Preferences/preferencesRoutes.tsx
+++ b/src/Apps/Preferences/preferencesRoutes.tsx
@@ -13,7 +13,7 @@ export const preferencesRoutes: RouteProps[] = [
   {
     path: "/unsubscribe",
     getComponent: () => PreferencesApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       PreferencesApp.preload()
     },
     prepareVariables: (_params, props) => {

--- a/src/Apps/Press/pressRoutes.tsx
+++ b/src/Apps/Press/pressRoutes.tsx
@@ -14,7 +14,7 @@ export const pressRoutes: RouteProps[] = [
     path: "/press/in-the-media",
 
     getComponent: () => PressApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       PressApp.preload()
     },
     query: graphql`
@@ -29,7 +29,7 @@ export const pressRoutes: RouteProps[] = [
     path: "/press/press-releases",
 
     getComponent: () => PressApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       PressApp.preload()
     },
     query: graphql`

--- a/src/Apps/PriceDatabase/priceDatabaseRoutes.tsx
+++ b/src/Apps/PriceDatabase/priceDatabaseRoutes.tsx
@@ -10,7 +10,7 @@ export const priceDatabaseRoutes: RouteProps[] = [
   {
     path: "/price-database",
     getComponent: () => PriceDatabaseApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       PriceDatabaseApp.preload()
     },
   },

--- a/src/Apps/Sale/saleRoutes.tsx
+++ b/src/Apps/Sale/saleRoutes.tsx
@@ -18,7 +18,7 @@ export const saleRoutes: RouteProps[] = [
     path: "/sale/:slug",
     serverCacheTTL: serverCacheTTLs.sale,
     getComponent: () => SaleApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       SaleApp.preload()
     },
     query: graphql`

--- a/src/Apps/SaleAgreements/saleAgreementsRoutes.tsx
+++ b/src/Apps/SaleAgreements/saleAgreementsRoutes.tsx
@@ -21,7 +21,7 @@ export const saleAgreementsRoutes: RouteProps[] = [
   {
     path: "/supplemental-cos",
     getComponent: () => SaleAgreementsApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       SaleAgreementsApp.preload()
     },
     query: graphql`
@@ -35,7 +35,7 @@ export const saleAgreementsRoutes: RouteProps[] = [
   {
     path: "/supplemental-cos/:id",
     getComponent: () => SaleAgreementRoute,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       SaleAgreementRoute.preload()
     },
     query: graphql`

--- a/src/Apps/Search/searchRoutes.tsx
+++ b/src/Apps/Search/searchRoutes.tsx
@@ -76,7 +76,7 @@ const entityTabs = Object.entries(tabsToEntitiesMap).map(([key, entities]) => {
   return {
     path: key,
     getComponent: () => SearchResultsEntity,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       SearchResultsEntity.preload()
     },
     prepareVariables: (params, { location }) => {
@@ -105,7 +105,7 @@ export const searchRoutes: RouteProps[] = [
     path: "/search",
     getComponent: () => SearchApp,
     onServerSideRender: redirectQueryToTerm,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       SearchApp.preload()
     },
     query: graphql`
@@ -120,7 +120,7 @@ export const searchRoutes: RouteProps[] = [
       {
         path: "",
         getComponent: () => SearchResultsArtworks,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           SearchResultsArtworks.preload()
         },
         prepareVariables: (params, { location, context }) => {
@@ -165,7 +165,7 @@ export const searchRoutes: RouteProps[] = [
       {
         path: "artists",
         getComponent: () => SearchResultsArtists,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           SearchResultsArtists.preload()
         },
         prepareVariables,

--- a/src/Apps/Sell/sellRoutes.tsx
+++ b/src/Apps/Sell/sellRoutes.tsx
@@ -195,12 +195,15 @@ const ConsignmentInquiryContainer = loadable(
 export const sellRoutes: RouteProps[] = [
   {
     path: "/sell",
+    onPreloadJS: () => {
+      MarketingLandingApp.preload()
+    },
     children: [
       {
         path: "",
         layout: "FullBleed",
         getComponent: () => MarketingLandingApp,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           MarketingLandingApp.preload()
         },
       },
@@ -208,7 +211,7 @@ export const sellRoutes: RouteProps[] = [
         path: "faq",
         layout: "NavOnly",
         getComponent: () => FAQApp,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           FAQApp.preload()
         },
       },
@@ -219,7 +222,7 @@ export const sellRoutes: RouteProps[] = [
         path: "intro",
         layout: "ContainerOnly",
         Component: IntroRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           IntroRoute.preload()
         },
       },
@@ -227,7 +230,7 @@ export const sellRoutes: RouteProps[] = [
         path: "submissions/new",
         layout: "ContainerOnly",
         Component: NewRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           NewRoute.preload()
         },
       },
@@ -235,7 +238,7 @@ export const sellRoutes: RouteProps[] = [
         path: "artist-not-eligible/:artistID",
         layout: "ContainerOnly",
         Component: ArtistNotEligibleRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           ArtistNotEligibleRoute.preload()
         },
         query: graphql`
@@ -253,7 +256,7 @@ export const sellRoutes: RouteProps[] = [
         path: "submissions/new/collection",
         layout: "ContainerOnly",
         Component: NewFromMyCollectionRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           NewFromMyCollectionRoute.preload()
         },
         onServerSideRender: checkIfLoggedIn,
@@ -262,7 +265,7 @@ export const sellRoutes: RouteProps[] = [
       {
         path: "submissions/:id",
         Component: SubmissionRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           SubmissionRoute.preload()
         },
         query: graphql`
@@ -280,7 +283,7 @@ export const sellRoutes: RouteProps[] = [
             path: "artist",
             layout: "ContainerOnly",
             Component: ArtistRoute,
-            onClientSideRender: () => {
+            onPreloadJS: () => {
               ArtistRoute.preload()
             },
             query: graphql`
@@ -298,7 +301,7 @@ export const sellRoutes: RouteProps[] = [
             path: "title",
             layout: "ContainerOnly",
             Component: TitleRoute,
-            onClientSideRender: () => {
+            onPreloadJS: () => {
               TitleRoute.preload()
             },
             query: graphql`
@@ -316,7 +319,7 @@ export const sellRoutes: RouteProps[] = [
             path: "photos",
             layout: "ContainerOnly",
             Component: PhotosRoute,
-            onClientSideRender: () => {
+            onPreloadJS: () => {
               PhotosRoute.preload()
             },
             query: graphql`
@@ -334,7 +337,7 @@ export const sellRoutes: RouteProps[] = [
             path: "details",
             layout: "ContainerOnly",
             Component: DetailsRoute,
-            onClientSideRender: () => {
+            onPreloadJS: () => {
               DetailsRoute.preload()
             },
             query: graphql`
@@ -355,7 +358,7 @@ export const sellRoutes: RouteProps[] = [
             path: "purchase-history",
             layout: "ContainerOnly",
             Component: PurchaseHistoryRoute,
-            onClientSideRender: () => {
+            onPreloadJS: () => {
               PurchaseHistoryRoute.preload()
             },
             query: graphql`
@@ -376,7 +379,7 @@ export const sellRoutes: RouteProps[] = [
             path: "dimensions",
             layout: "ContainerOnly",
             Component: DimensionsRoute,
-            onClientSideRender: () => {
+            onPreloadJS: () => {
               DimensionsRoute.preload()
             },
             query: graphql`
@@ -397,7 +400,7 @@ export const sellRoutes: RouteProps[] = [
             path: "phone-number",
             layout: "ContainerOnly",
             Component: PhoneNumberRoute,
-            onClientSideRender: () => {
+            onPreloadJS: () => {
               PhoneNumberRoute.preload()
             },
             query: graphql`
@@ -421,7 +424,7 @@ export const sellRoutes: RouteProps[] = [
             path: "thank-you",
             layout: "ContainerOnly",
             Component: ThankYouRoute,
-            onClientSideRender: () => {
+            onPreloadJS: () => {
               ThankYouRoute.preload()
             },
             onServerSideRender: checkIfLoggedIn,
@@ -443,7 +446,7 @@ export const sellRoutes: RouteProps[] = [
             path: "shipping-location",
             layout: "ContainerOnly",
             Component: ShippingLocationRoute,
-            onClientSideRender: () => {
+            onPreloadJS: () => {
               ShippingLocationRoute.preload()
             },
             onServerSideRender: checkIfLoggedIn,
@@ -465,7 +468,7 @@ export const sellRoutes: RouteProps[] = [
             path: "frame",
             layout: "ContainerOnly",
             Component: FrameRoute,
-            onClientSideRender: () => {
+            onPreloadJS: () => {
               FrameRoute.preload()
             },
             onServerSideRender: checkIfLoggedIn,
@@ -484,7 +487,7 @@ export const sellRoutes: RouteProps[] = [
             path: "additional-documents",
             layout: "ContainerOnly",
             Component: AdditionalDocumentsRoute,
-            onClientSideRender: () => {
+            onPreloadJS: () => {
               AdditionalDocumentsRoute.preload()
             },
             onServerSideRender: checkIfLoggedIn,
@@ -503,7 +506,7 @@ export const sellRoutes: RouteProps[] = [
             path: "condition",
             layout: "ContainerOnly",
             Component: ConditionRoute,
-            onClientSideRender: () => {
+            onPreloadJS: () => {
               ConditionRoute.preload()
             },
             onServerSideRender: checkIfLoggedIn,
@@ -522,7 +525,7 @@ export const sellRoutes: RouteProps[] = [
             path: "thank-you-post-approval",
             layout: "ContainerOnly",
             Component: ThankYouRoute,
-            onClientSideRender: () => {
+            onPreloadJS: () => {
               ThankYouRoute.preload()
             },
             onServerSideRender: checkIfLoggedIn,
@@ -550,7 +553,7 @@ export const sellRoutes: RouteProps[] = [
             path: "",
             getComponent: () => ConsignmentInquiryApp,
             layout: "ContainerOnly",
-            onClientSideRender: () => {
+            onPreloadJS: () => {
               ConsignmentInquiryApp.preload()
             },
             query: graphql`
@@ -574,7 +577,7 @@ export const sellRoutes: RouteProps[] = [
             path: "sent",
             layout: "ContainerOnly",
             getComponent: () => ConsignmentInquiryConfirmationApp,
-            onClientSideRender: () => {
+            onPreloadJS: () => {
               ConsignmentInquiryConfirmationApp.preload()
             },
           },
@@ -585,7 +588,7 @@ export const sellRoutes: RouteProps[] = [
                 path: "",
                 getComponent: () => ConsignmentInquiryApp,
                 layout: "ContainerOnly",
-                onClientSideRender: () => {
+                onPreloadJS: () => {
                   ConsignmentInquiryApp.preload()
                 },
                 query: graphql`
@@ -609,7 +612,7 @@ export const sellRoutes: RouteProps[] = [
                 path: "sent",
                 layout: "ContainerOnly",
                 getComponent: () => ConsignmentInquiryConfirmationApp,
-                onClientSideRender: () => {
+                onPreloadJS: () => {
                   ConsignmentInquiryConfirmationApp.preload()
                 },
               },

--- a/src/Apps/Settings/settingsRoutes.tsx
+++ b/src/Apps/Settings/settingsRoutes.tsx
@@ -107,7 +107,7 @@ export const settingsRoutes: RouteProps[] = [
   {
     path: "/settings",
     getComponent: () => SettingsApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       SettingsApp.preload()
     },
     query: graphql`
@@ -121,7 +121,7 @@ export const settingsRoutes: RouteProps[] = [
       {
         path: "auctions",
         getComponent: () => AuctionsRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           AuctionsRoute.preload()
         },
         onServerSideRender: handleServerSideRender,
@@ -136,7 +136,7 @@ export const settingsRoutes: RouteProps[] = [
       {
         path: "edit-profile",
         getComponent: () => EditProfileRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           EditProfileRoute.preload()
         },
         onServerSideRender: handleServerSideRender,
@@ -151,7 +151,7 @@ export const settingsRoutes: RouteProps[] = [
       {
         path: "payments",
         getComponent: () => PaymentsRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           PaymentsRoute.preload()
         },
         onServerSideRender: handleServerSideRender,
@@ -166,7 +166,7 @@ export const settingsRoutes: RouteProps[] = [
       {
         path: "purchases",
         getComponent: () => PurchasesRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           PurchasesRoute.preload()
         },
         onServerSideRender: handleServerSideRender,
@@ -187,7 +187,7 @@ export const settingsRoutes: RouteProps[] = [
       {
         path: "insights",
         getComponent: () => InsightsRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           InsightsRoute.preload()
         },
         onServerSideRender: handleServerSideRender,
@@ -202,7 +202,7 @@ export const settingsRoutes: RouteProps[] = [
       {
         path: "edit-settings",
         getComponent: () => EditSettingsRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           EditSettingsRoute.preload()
         },
         onServerSideRender: handleServerSideRender,
@@ -217,7 +217,7 @@ export const settingsRoutes: RouteProps[] = [
       {
         path: "delete",
         getComponent: () => DeleteAccountRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           DeleteAccountRoute.preload()
         },
         onServerSideRender: handleServerSideRender,
@@ -232,7 +232,7 @@ export const settingsRoutes: RouteProps[] = [
       {
         path: "shipping",
         getComponent: () => ShippingRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           ShippingRoute.preload()
         },
         onServerSideRender: handleServerSideRender,

--- a/src/Apps/Show/showRoutes.tsx
+++ b/src/Apps/Show/showRoutes.tsx
@@ -26,7 +26,7 @@ export const showRoutes: RouteProps[] = [
   {
     getComponent: () => ShowApp,
     path: "/show/:slug",
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       ShowApp.preload()
     },
     query: graphql`
@@ -44,7 +44,7 @@ export const showRoutes: RouteProps[] = [
       {
         getComponent: () => ShowInfoRoute,
         path: "info",
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           ShowInfoRoute.preload()
         },
         query: graphql`
@@ -64,7 +64,7 @@ export const showRoutes: RouteProps[] = [
     ],
     getComponent: () => ShowSubApp,
     path: "/show/:slug",
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       ShowSubApp.preload()
     },
     query: graphql`

--- a/src/Apps/Shows/showsRoutes.tsx
+++ b/src/Apps/Shows/showsRoutes.tsx
@@ -36,14 +36,14 @@ export const showsRoutes: RouteProps[] = [
   {
     path: "/shows",
     getComponent: () => ShowsApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       return ShowsApp.preload()
     },
     children: [
       {
         path: "",
         getComponent: () => ShowsIndexRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           return ShowsIndexRoute.preload()
         },
         query: graphql`
@@ -60,7 +60,7 @@ export const showsRoutes: RouteProps[] = [
       {
         path: "all-cities",
         getComponent: () => ShowsAllCities,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           return ShowsAllCities.preload()
         },
         query: graphql`
@@ -74,7 +74,7 @@ export const showsRoutes: RouteProps[] = [
       {
         path: ":slug",
         getComponent: () => ShowsCityRoute,
-        onClientSideRender: () => {
+        onPreloadJS: () => {
           return ShowsCityRoute.preload()
         },
         prepareVariables: ({ slug }: { slug: string }, props) => {

--- a/src/Apps/Tag/tagRoutes.tsx
+++ b/src/Apps/Tag/tagRoutes.tsx
@@ -13,7 +13,7 @@ export const tagRoutes: RouteProps[] = [
   {
     path: "/tag/:slug",
     getComponent: () => TagApp,
-    onClientSideRender: () => {
+    onPreloadJS: () => {
       TagApp.preload()
     },
 

--- a/src/System/Hooks/usePrefetchRoute.tsx
+++ b/src/System/Hooks/usePrefetchRoute.tsx
@@ -73,6 +73,9 @@ export const usePrefetchRoute = (
             if (isDevelopment) {
               console.log("[usePrefetchRoute] Starting prefetch:", path)
             }
+
+            // Prefetch bundle split JS alongside data, if defined
+            foundRoute.route.onPreloadJS?.()
           },
           complete: () => {
             if (isDevelopment) {

--- a/src/System/Router/Route.tsx
+++ b/src/System/Router/Route.tsx
@@ -22,6 +22,7 @@ interface Route extends RouteObjectBase {
    * Render hooks
    */
 
+  onPreloadJS?: () => void
   onClientSideRender?: (props: { match: Match }) => void
   onServerSideRender?: (props: {
     req: ArtsyRequest


### PR DESCRIPTION
The type of this PR is: **Feat**

### Description

Very nice UX improvement in one line of code, which eliminates any blank screen behavior when transitioning between routes in our app (if a user hasn't visited the route before, and thus hasn't async downloaded the js for said route)! 

Adds a new route callback `onPrefetchJS` to request JS ahead of time (when the `usePrefetchRoute` hook is invoked), and renamed most `onClientSideRender` hooks as we typically preload bundle split JS there. 

https://github.com/user-attachments/assets/b4a507a3-5f03-4c01-9857-e68789a7d687


cc @artsy/diamond-devs 
