### PR TITLE
fix(bundle-stats): Run on main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -299,7 +299,7 @@ workflows:
 
       # Bundle stats for PRs
       - node/run:
-          <<: *not_main_or_staging_or_release
+          <<: *not_staging_or_release
           name: bundle-stats
           context: hokusai
           pkg-manager: yarn


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Noticed that bundle stats stopped running on main after https://github.com/artsy/force/pull/14540; this fixes that. 

@artsy/diamond-devs 