### PR TITLE
chore(bootstrap): remove client entrypoint streaming bundle

### DIFF
--- a/webpack/bundleSplitting.js
+++ b/webpack/bundleSplitting.js
@@ -18,14 +18,6 @@ export const splitChunks = {
   cacheGroups: {
     default: false,
     defaultVendors: false,
-    // Contains the entrypoint for the client used for quick React rehydration
-    bootstrap: {
-      name: "bootstrap",
-      test: /src[\\/]client\.tsx$/,
-      chunks: "all",
-      enforce: true,
-      priority: 45,
-    },
     "artsy-framework": {
       name: "artsy-framework",
       chunks: "all",


### PR DESCRIPTION
The type of this PR is: **Chore**

### Description

Generating this new (~8kb) chunk was an optimization for streaming, but since streaming is currently off we don't need it. Diagnosing whether this might be whats leading to a large increase in transferred js (according to [calibre](https://capture.static.damonzucconi.com/Screen-Shot-2024-12-02-07-52-28.76-9IbI4OkfirSSgc8Kg5ytyYUpgBCVvTOERBQmBL3GQo0rtJoIzsdHXcxD4kOfpLPYnUzpiRj9LYRTfV2KZTgJRR00cTKbZwfObuAY.png)) but not too sure. It could also be React 18 or Relay 18.  

cc @artsy/diamond-devs 
