### PR TITLE
perf(EMI-1685): re-enable slow test

### DIFF
--- a/src/Apps/Order/Routes/Shipping/Components/__tests__/SavedAddresses.jest.tsx
+++ b/src/Apps/Order/Routes/Shipping/Components/__tests__/SavedAddresses.jest.tsx
@@ -25,8 +25,8 @@ jest.mock("Utils/Hooks/useMatchMedia", () => ({
   __internal__useMatchMedia: () => ({}),
 }))
 
-// TODO: Can we get away with less?
-jest.setTimeout(10000)
+// Long-running tests when we `fillAddressFormFields()`
+jest.setTimeout(15000)
 
 let testProps: SavedAddressesProps
 let mockShippingContext: ShippingContextProps

--- a/src/Apps/Order/Routes/Shipping/Components/__tests__/SavedAddresses.jest.tsx
+++ b/src/Apps/Order/Routes/Shipping/Components/__tests__/SavedAddresses.jest.tsx
@@ -28,20 +28,6 @@ jest.mock("Utils/Hooks/useMatchMedia", () => ({
 // Long-running tests when we `fillAddressFormFields()`
 jest.setTimeout(15000)
 
-jest.mock("@artsy/palette", () => {
-  const originalModule = jest.requireActual("@artsy/palette")
-  return {
-    ...originalModule,
-    Input: ({ title, id, ...props }) => (
-      <>
-        {/* eslint-disable-next-line jsx-a11y/label-has-for */}
-        <label htmlFor={id}>{title}</label>
-        <input id={id} {...props} />
-      </>
-    ),
-  }
-})
-
 let testProps: SavedAddressesProps
 let mockShippingContext: ShippingContextProps
 const mockFormikSubmit = jest.fn()

--- a/src/Apps/Order/Routes/Shipping/Components/__tests__/SavedAddresses.jest.tsx
+++ b/src/Apps/Order/Routes/Shipping/Components/__tests__/SavedAddresses.jest.tsx
@@ -220,9 +220,8 @@ describe("Saved Addresses", () => {
       })
     })
 
-    // Test takes too long to run
-    // eslint-disable-next-line jest/no-disabled-tests
-    it.skip("calls the parent formik context onSubmit when the user saves a new address", async () => {
+    // Previously disabled due to timeouts
+    it("calls the parent formik context onSubmit when the user saves a new address", async () => {
       renderWithRelay({
         Me: () => ({
           addressConnection: basicAddressList,

--- a/src/Apps/Order/Routes/Shipping/Components/__tests__/SavedAddresses.jest.tsx
+++ b/src/Apps/Order/Routes/Shipping/Components/__tests__/SavedAddresses.jest.tsx
@@ -17,7 +17,11 @@ import { MockBoot } from "DevTools/MockBoot"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
 import { graphql } from "react-relay"
 import { SavedAddressesTestQuery } from "__generated__/SavedAddressesTestQuery.graphql"
-import { fillAddressFormFields } from "Components/Address/__tests__/utils"
+import {
+  ADDRESS_FORM_INPUTS,
+  fillAddressFormFields,
+} from "Components/Address/__tests__/utils"
+import { act } from "react"
 
 jest.unmock("react-relay")
 jest.mock("react-tracking")
@@ -179,6 +183,147 @@ describe("Saved Addresses", () => {
     expect(testProps.onSelect).not.toHaveBeenCalled()
   })
 
+  describe.only("comparison", () => {
+    it("original", async () => {
+      console.time("initial: filling form")
+      renderWithRelay({
+        Me: () => ({
+          addressConnection: basicAddressList,
+        }),
+      })
+
+      const validAddress = {
+        name: "Test Name",
+        addressLine1: "1 Main St",
+        addressLine2: "Basement",
+        city: "Madrid",
+        region: "NY",
+        postalCode: "28001",
+        country: "ES",
+        phoneNumber: "555-555-5555",
+      }
+      const addAddressButton = screen.getByText("Add a new address")
+      await userEvent.click(addAddressButton)
+
+      screen.getByText("Add address")
+
+      console.time("fillAddressFormFields - initial implementation")
+      const wrapperTestId = "addressFormFields"
+      const wrapper = screen.getByTestId(wrapperTestId)
+      const { country, phoneNumber, ...defaultTextInputs } = validAddress
+
+      const promises: Promise<void>[] = []
+      if (country) {
+        promises.push(
+          new Promise<void>(async resolve => {
+            const countrySelect = within(wrapper).getByLabelText(
+              ADDRESS_FORM_INPUTS.country.label
+            )
+
+            userEvent.selectOptions(countrySelect, [country])
+
+            resolve()
+          })
+        )
+      }
+
+      Object.entries(defaultTextInputs).forEach(([key, value]) => {
+        const input = within(wrapper).getByLabelText(
+          ADDRESS_FORM_INPUTS[key].label
+        )
+
+        userEvent.paste(input, value)
+      })
+
+      if (phoneNumber) {
+        const phoneNumberInput = within(wrapper).getByLabelText(
+          ADDRESS_FORM_INPUTS.phoneNumber.label
+        )
+
+        userEvent.paste(phoneNumberInput, phoneNumber)
+      }
+
+      await Promise.all(promises)
+      console.timeEnd("fillAddressFormFields - initial implementation")
+
+      console.timeEnd("initial: filling form")
+      console.time("initial: clicking save")
+
+      await flushPromiseQueue()
+      // console.timeLog("initial: clicking save", "flushed promises")
+
+      mockExecuteUserAddressAction.mockResolvedValueOnce({
+        data: { ...validAddress },
+      })
+
+      await waitFor(async () => {
+        await userEvent.click(screen.getByText("Save"))
+      })
+
+      console.timeEnd("initial: clicking save")
+      console.time("initial: waiting for onSelect")
+
+      await waitFor(() =>
+        expect(testProps.onSelect).toHaveBeenCalledWith(
+          expect.objectContaining(validAddress)
+        )
+      )
+
+      expect(testProps.onSelect).toHaveBeenCalledTimes(1)
+      console.timeEnd("initial: waiting for onSelect")
+    })
+
+    it("with 'improvements'", async () => {
+      console.time("new: filling form")
+      renderWithRelay({
+        Me: () => ({
+          addressConnection: basicAddressList,
+        }),
+      })
+
+      const validAddress = {
+        name: "Test Name",
+        addressLine1: "1 Main St",
+        addressLine2: "Basement",
+        city: "Madrid",
+        region: "NY",
+        postalCode: "28001",
+        country: "ES",
+        phoneNumber: "555-555-5555",
+      }
+      const addAddressButton = screen.getByText("Add a new address")
+      userEvent.click(addAddressButton)
+
+      screen.getByText("Add address")
+
+      await fillAddressFormFields(validAddress)
+      console.timeEnd("new: filling form")
+      console.time("new: clicking save")
+
+      mockExecuteUserAddressAction.mockResolvedValueOnce({
+        data: { ...validAddress },
+      })
+
+      await waitFor(() => {
+        userEvent.click(screen.getByText("Save"))
+      })
+
+      console.timeEnd("new: clicking save")
+      console.time("new: waiting for onSelect")
+
+      await waitFor(
+        () =>
+          expect(testProps.onSelect).toHaveBeenCalledWith(
+            expect.objectContaining(validAddress)
+          ),
+        // Bottleneck waiting for form updates
+        { timeout: 4000 }
+      )
+      expect(testProps.onSelect).toHaveBeenCalledTimes(1)
+      console.timeEnd("new: waiting for onSelect")
+    })
+  })
+
   describe("Creating a new address", () => {
     it("loads the address modal in new address mode", async () => {
       renderWithRelay({
@@ -222,6 +367,7 @@ describe("Saved Addresses", () => {
 
     // Previously disabled due to timeouts
     it("calls the parent formik context onSubmit when the user saves a new address", async () => {
+      console.time("test")
       renderWithRelay({
         Me: () => ({
           addressConnection: basicAddressList,
@@ -239,26 +385,32 @@ describe("Saved Addresses", () => {
         phoneNumber: "555-555-5555",
       }
       const addAddressButton = screen.getByText("Add a new address")
-      await userEvent.click(addAddressButton)
+      userEvent.click(addAddressButton)
 
       screen.getByText("Add address")
 
       await fillAddressFormFields(validAddress)
-
-      await flushPromiseQueue()
+      console.timeLog("test", "filled form")
 
       mockExecuteUserAddressAction.mockResolvedValueOnce({
         data: { ...validAddress },
       })
 
-      await userEvent.click(screen.getByText("Save"))
+      await waitFor(() => {
+        userEvent.click(screen.getByText("Save"))
+      })
 
-      await waitFor(() =>
-        expect(testProps.onSelect).toHaveBeenCalledWith(
-          expect.objectContaining(validAddress)
-        )
+      console.timeLog("test", "clicked save")
+
+      await waitFor(
+        () =>
+          expect(testProps.onSelect).toHaveBeenCalledWith(
+            expect.objectContaining(validAddress)
+          ),
+        // Bottleneck waiting for form updates
+        { timeout: 4000 }
       )
-
+      console.timeEnd("test")
       expect(testProps.onSelect).toHaveBeenCalledTimes(1)
     })
   })

--- a/src/Apps/Order/Routes/Shipping/Components/__tests__/SavedAddresses.jest.tsx
+++ b/src/Apps/Order/Routes/Shipping/Components/__tests__/SavedAddresses.jest.tsx
@@ -17,11 +17,7 @@ import { MockBoot } from "DevTools/MockBoot"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
 import { graphql } from "react-relay"
 import { SavedAddressesTestQuery } from "__generated__/SavedAddressesTestQuery.graphql"
-import {
-  ADDRESS_FORM_INPUTS,
-  fillAddressFormFields,
-} from "Components/Address/__tests__/utils"
-import { act } from "react"
+import { fillAddressFormFields } from "Components/Address/__tests__/utils"
 
 jest.unmock("react-relay")
 jest.mock("react-tracking")
@@ -29,6 +25,7 @@ jest.mock("Utils/Hooks/useMatchMedia", () => ({
   __internal__useMatchMedia: () => ({}),
 }))
 
+// TODO: Can we get away with less?
 jest.setTimeout(10000)
 
 let testProps: SavedAddressesProps
@@ -183,147 +180,6 @@ describe("Saved Addresses", () => {
     expect(testProps.onSelect).not.toHaveBeenCalled()
   })
 
-  describe.only("comparison", () => {
-    it("original", async () => {
-      console.time("initial: filling form")
-      renderWithRelay({
-        Me: () => ({
-          addressConnection: basicAddressList,
-        }),
-      })
-
-      const validAddress = {
-        name: "Test Name",
-        addressLine1: "1 Main St",
-        addressLine2: "Basement",
-        city: "Madrid",
-        region: "NY",
-        postalCode: "28001",
-        country: "ES",
-        phoneNumber: "555-555-5555",
-      }
-      const addAddressButton = screen.getByText("Add a new address")
-      await userEvent.click(addAddressButton)
-
-      screen.getByText("Add address")
-
-      console.time("fillAddressFormFields - initial implementation")
-      const wrapperTestId = "addressFormFields"
-      const wrapper = screen.getByTestId(wrapperTestId)
-      const { country, phoneNumber, ...defaultTextInputs } = validAddress
-
-      const promises: Promise<void>[] = []
-      if (country) {
-        promises.push(
-          new Promise<void>(async resolve => {
-            const countrySelect = within(wrapper).getByLabelText(
-              ADDRESS_FORM_INPUTS.country.label
-            )
-
-            userEvent.selectOptions(countrySelect, [country])
-
-            resolve()
-          })
-        )
-      }
-
-      Object.entries(defaultTextInputs).forEach(([key, value]) => {
-        const input = within(wrapper).getByLabelText(
-          ADDRESS_FORM_INPUTS[key].label
-        )
-
-        userEvent.paste(input, value)
-      })
-
-      if (phoneNumber) {
-        const phoneNumberInput = within(wrapper).getByLabelText(
-          ADDRESS_FORM_INPUTS.phoneNumber.label
-        )
-
-        userEvent.paste(phoneNumberInput, phoneNumber)
-      }
-
-      await Promise.all(promises)
-      console.timeEnd("fillAddressFormFields - initial implementation")
-
-      console.timeEnd("initial: filling form")
-      console.time("initial: clicking save")
-
-      await flushPromiseQueue()
-      // console.timeLog("initial: clicking save", "flushed promises")
-
-      mockExecuteUserAddressAction.mockResolvedValueOnce({
-        data: { ...validAddress },
-      })
-
-      await waitFor(async () => {
-        await userEvent.click(screen.getByText("Save"))
-      })
-
-      console.timeEnd("initial: clicking save")
-      console.time("initial: waiting for onSelect")
-
-      await waitFor(() =>
-        expect(testProps.onSelect).toHaveBeenCalledWith(
-          expect.objectContaining(validAddress)
-        )
-      )
-
-      expect(testProps.onSelect).toHaveBeenCalledTimes(1)
-      console.timeEnd("initial: waiting for onSelect")
-    })
-
-    it("with 'improvements'", async () => {
-      console.time("new: filling form")
-      renderWithRelay({
-        Me: () => ({
-          addressConnection: basicAddressList,
-        }),
-      })
-
-      const validAddress = {
-        name: "Test Name",
-        addressLine1: "1 Main St",
-        addressLine2: "Basement",
-        city: "Madrid",
-        region: "NY",
-        postalCode: "28001",
-        country: "ES",
-        phoneNumber: "555-555-5555",
-      }
-      const addAddressButton = screen.getByText("Add a new address")
-      userEvent.click(addAddressButton)
-
-      screen.getByText("Add address")
-
-      await fillAddressFormFields(validAddress)
-      console.timeEnd("new: filling form")
-      console.time("new: clicking save")
-
-      mockExecuteUserAddressAction.mockResolvedValueOnce({
-        data: { ...validAddress },
-      })
-
-      await waitFor(() => {
-        userEvent.click(screen.getByText("Save"))
-      })
-
-      console.timeEnd("new: clicking save")
-      console.time("new: waiting for onSelect")
-
-      await waitFor(
-        () =>
-          expect(testProps.onSelect).toHaveBeenCalledWith(
-            expect.objectContaining(validAddress)
-          ),
-        // Bottleneck waiting for form updates
-        { timeout: 4000 }
-      )
-      expect(testProps.onSelect).toHaveBeenCalledTimes(1)
-      console.timeEnd("new: waiting for onSelect")
-    })
-  })
-
   describe("Creating a new address", () => {
     it("loads the address modal in new address mode", async () => {
       renderWithRelay({
@@ -367,7 +223,6 @@ describe("Saved Addresses", () => {
 
     // Previously disabled due to timeouts
     it("calls the parent formik context onSubmit when the user saves a new address", async () => {
-      console.time("test")
       renderWithRelay({
         Me: () => ({
           addressConnection: basicAddressList,
@@ -390,27 +245,24 @@ describe("Saved Addresses", () => {
       screen.getByText("Add address")
 
       await fillAddressFormFields(validAddress)
-      console.timeLog("test", "filled form")
 
       mockExecuteUserAddressAction.mockResolvedValueOnce({
         data: { ...validAddress },
       })
 
-      await waitFor(() => {
-        userEvent.click(screen.getByText("Save"))
-      })
-
-      console.timeLog("test", "clicked save")
-
       await waitFor(
-        () =>
-          expect(testProps.onSelect).toHaveBeenCalledWith(
-            expect.objectContaining(validAddress)
-          ),
+        () => {
+          userEvent.click(screen.getByText("Save"))
+        },
         // Bottleneck waiting for form updates
         { timeout: 4000 }
       )
-      console.timeEnd("test")
+
+      await waitFor(() =>
+        expect(testProps.onSelect).toHaveBeenCalledWith(
+          expect.objectContaining(validAddress)
+        )
+      )
       expect(testProps.onSelect).toHaveBeenCalledTimes(1)
     })
   })

--- a/src/Apps/Order/Routes/Shipping/Components/__tests__/SavedAddresses.jest.tsx
+++ b/src/Apps/Order/Routes/Shipping/Components/__tests__/SavedAddresses.jest.tsx
@@ -28,6 +28,20 @@ jest.mock("Utils/Hooks/useMatchMedia", () => ({
 // Long-running tests when we `fillAddressFormFields()`
 jest.setTimeout(15000)
 
+jest.mock("@artsy/palette", () => {
+  const originalModule = jest.requireActual("@artsy/palette")
+  return {
+    ...originalModule,
+    Input: ({ title, id, ...props }) => (
+      <>
+        {/* eslint-disable-next-line jsx-a11y/label-has-for */}
+        <label htmlFor={id}>{title}</label>
+        <input id={id} {...props} />
+      </>
+    ),
+  }
+})
+
 let testProps: SavedAddressesProps
 let mockShippingContext: ShippingContextProps
 const mockFormikSubmit = jest.fn()

--- a/src/Components/Address/__tests__/utils.ts
+++ b/src/Components/Address/__tests__/utils.ts
@@ -65,7 +65,6 @@ export const fillAddressFormFields = async (
   address: Partial<Address>,
   options: { clearInputs?: boolean; wrapperTestId?: string } = {}
 ) => {
-  console.time("fillAddressFormFields")
   const { clearInputs = false, wrapperTestId = "addressFormFields" } = options
 
   const wrapper = screen.getByTestId(wrapperTestId)
@@ -107,5 +106,4 @@ export const fillAddressFormFields = async (
       userEvent.paste(phoneNumberInput, phoneNumber)
     })
   }
-  console.timeEnd("fillAddressFormFields")
 }


### PR DESCRIPTION
The type of this PR is: **Perf**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR relates to [EMI-1685]
cc @artsy/emerald-devs 

### Description
**Note: after enabling the test it immediately failed due to a timeout. I therefore increased the timeout to make the test pass. Open to feedback on the approach, and we could check out the intermediate commit if we want to try more improvements.**

This PR makes refinements to some of our test helpers and re-enables a test that has been skipped. The test has been ported from enzyme and hopefully performance will be better now.

The intermediate commit 330b3539251c69f9090124ac4d99a233127845ce shows two different implementations of the once-problematic test for comparison. In short the improvements in this PR don't make a meaningful difference in runtime. Repeated runs in that commit show roughly the same timing, with the unoptimized initial code seeming to win slightly more often (difference usually ~100ms, but sometimes the newer implementation wins). The advantage is that we spend less time waiting for arbitrary `flushPromiseQueue()`s to resolve. One possible explanation for this difference is that the calls to `act()` around address form filling helpers may be adding a few ms. Otherwise the time spent waiting for the `flushPromiseQueue()` after filling in the form seems to mostly move into the form-filling time with `act()`.

On my M1 mac this re-enabled test usually took about 5100 ms. However depending on the load of the system it could sometime climb up past 8000ms. This sensitivity has been worse in CI, which is why we disabled the spec to begin with.

Longer but still pretty naive analysis of the different optimizations i have tried [in slack here](https://artsy.slack.com/archives/C2TQ4PT8R/p1733252086261459?thread_ts=1733245233.848769&cid=C2TQ4PT8R) 🔒. I noticed the biggest improvement (~1600ms) by stubbing out the palette Input in tests with a very basic html input/label, but this wouldn't be good for testing purposes.

Related changes
- In [this PR](https://github.com/artsy/force/commit/78d40839a9dd9699b2e717dbaefbdf4c84bf2369#diff-33851a69a0b6c5b35f9e2f3b152c1792af02bbb718ac49e2036f555a7c74b273R218) I changed the test file name, and from looking at the diff on this page I can't see where the original skipped test was added. The
- related test was disabled in https://github.com/artsy/force/pull/13435

[EMI-1685]: https://artsyproduct.atlassian.net/browse/EMI-1685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ