### PR TITLE
fix: Revert lazy loading notifications dropdown

### DIFF
--- a/src/Components/NavBar/Menus/NavBarNotifications.tsx
+++ b/src/Components/NavBar/Menus/NavBarNotifications.tsx
@@ -1,36 +1,17 @@
-import { Box, Flex, Spinner } from "@artsy/palette"
-import loadable from "@loadable/component"
-
-const Notifications = loadable(
-  () =>
-    import(
-      /* webpackChunkName: "notificationsBundle" */
-      "Components/Notifications/Notifications"
-    ),
-  { resolveComponent: component => component.Notifications }
-)
+import { Box } from "@artsy/palette"
+import { Notifications } from "Components/Notifications/Notifications"
 
 interface NavBarNotificationsProps {
   unreadCounts: number
   onHide: () => void
 }
 
-export const NavBarNotifications: React.FC<React.PropsWithChildren<NavBarNotificationsProps>> = ({
-  onHide,
-  ...rest
-}) => {
+export const NavBarNotifications: React.FC<React.PropsWithChildren<
+  NavBarNotificationsProps
+>> = ({ onHide, ...rest }) => {
   return (
     <Box width={420}>
-      <Notifications
-        mode="dropdown"
-        fallback={
-          <Flex height={600}>
-            <Spinner m="auto" />
-          </Flex>
-        }
-        onHide={onHide}
-        {...rest}
-      />
+      <Notifications mode="dropdown" onHide={onHide} {...rest} />
     </Box>
   )
 }


### PR DESCRIPTION
- [Related Slack Thread](https://artsy.slack.com/archives/C07PRTJSD6G/p1727723121828589)
## Description

This reverts lazy loading notifications dropdown (https://github.com/artsy/force/pull/14490) to find out if this causes the bug described in the Slack thread. I cannot reproduce the bug locally and it only happens in Chrome.