### PR TITLE
Feat: update order history tab to reflect counteroffer received state

### DIFF
--- a/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchasesRow.tsx
+++ b/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchasesRow.tsx
@@ -77,6 +77,10 @@ const ORDER_COLORS = {
   PAYMENT_FAILED: "red100",
 } as const
 
+type CommerceBuyerOrderOfferStateEnum =
+  | CommerceBuyerOfferActionEnum
+  | CommerceOrderDisplayStateEnum
+
 const getPaymentMethodText = (
   paymentMethodDetails: SettingsPurchasesRow_order$data["paymentMethodDetails"]
 ) => {
@@ -93,7 +97,7 @@ const getPaymentMethodText = (
 }
 
 const getOrderActionButton = (
-  displayState: CommerceBuyerOfferActionEnum | CommerceOrderDisplayStateEnum,
+  displayState: CommerceBuyerOrderOfferStateEnum,
   orderId: string
 ) => {
   switch (displayState) {
@@ -142,9 +146,7 @@ const SettingsPurchasesRow: FC<React.PropsWithChildren<
   const [lineItem] = extractNodes(order?.lineItems)
   const { artwork, artworkVersion, fulfillments } = lineItem
   const { requestedFulfillment, buyerAction } = order
-  let displayState:
-    | CommerceBuyerOfferActionEnum
-    | CommerceOrderDisplayStateEnum = order.displayState
+  let displayState: CommerceBuyerOrderOfferStateEnum = order.displayState
 
   if (displayState == "SUBMITTED" && buyerAction == "OFFER_RECEIVED") {
     displayState = "OFFER_RECEIVED"

--- a/src/Apps/Settings/Routes/Purchases/Components/__tests__/SettingsPurchases.jest.tsx
+++ b/src/Apps/Settings/Routes/Purchases/Components/__tests__/SettingsPurchases.jest.tsx
@@ -123,4 +123,77 @@ describe("SettingsPurchases", () => {
       expect(button).toHaveAttribute("href", "/orders/123/payment/new")
     })
   })
+
+  describe("order with offer awaiting for collector reply", () => {
+    it("renders Counteroffer received status", () => {
+      renderWithRelay({
+        Me: () => ({
+          orders: {
+            edges: [
+              {
+                node: {
+                  code: "123",
+                  state: "SUBMITTED",
+                  displayState: "SUBMITTED",
+                  buyerAction: "OFFER_RECEIVED",
+                },
+              },
+            ],
+          },
+        }),
+      })
+
+      expect(screen.getByText("Counteroffer received")).toBeInTheDocument()
+    })
+
+    it("renders the order number with a link to respond to the offer", () => {
+      renderWithRelay({
+        Me: () => ({
+          orders: {
+            edges: [
+              {
+                node: {
+                  code: "123",
+                  internalID: "123",
+                  state: "SUBMITTED",
+                  displayState: "SUBMITTED",
+                  buyerAction: "OFFER_RECEIVED",
+                },
+              },
+            ],
+          },
+        }),
+      })
+
+      const link = screen.getByRole("link", { name: /123/i })
+      expect(link).toBeInTheDocument()
+      expect(link).toHaveAttribute("href", "/orders/123/status")
+    })
+
+    it("renders a button to respond to the offer", () => {
+      renderWithRelay({
+        Me: () => ({
+          orders: {
+            edges: [
+              {
+                node: {
+                  code: "123",
+                  internalID: "123",
+                  state: "SUBMITTED",
+                  displayState: "SUBMITTED",
+                  buyerAction: "OFFER_RECEIVED",
+                },
+              },
+            ],
+          },
+        }),
+      })
+
+      const button = screen.getByRole("link", {
+        name: /Respond to Counteroffer/i,
+      })
+      expect(button).toBeInTheDocument()
+      expect(button).toHaveAttribute("href", "/orders/123/status")
+    })
+  })
 })

--- a/src/__generated__/SettingsPurchasesQuery.graphql.ts
+++ b/src/__generated__/SettingsPurchasesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<63e653a4bbc6ff31900701edfd21dbfc>>
+ * @generated SignedSource<<a831908a3c4d93f6b88386a0f3608c4b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -644,6 +644,20 @@ return {
                         ],
                         "storageKey": null
                       },
+                      {
+                        "kind": "InlineFragment",
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "buyerAction",
+                            "storageKey": null
+                          }
+                        ],
+                        "type": "CommerceOfferOrder",
+                        "abstractKey": null
+                      },
                       (v9/*: any*/)
                     ],
                     "storageKey": null
@@ -661,12 +675,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "0e68e05ecea561aa5adfa73fc0d65164",
+    "cacheID": "1bafb80e658e0abb9e07619771e62059",
     "id": null,
     "metadata": {},
     "name": "SettingsPurchasesQuery",
     "operationKind": "query",
-    "text": "query SettingsPurchasesQuery(\n  $states: [CommerceOrderStateEnum!]\n  $first: Int!\n  $after: String\n) {\n  me {\n    ...SettingsPurchases_me_4tp0sF\n    id\n  }\n}\n\nfragment CommercePagination_pageCursors on CommercePageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SettingsPurchasesRow_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  source\n  internalID\n  code\n  displayState\n  state\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      lastDigits\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  buyerTotal(precision: 2)\n  createdAt\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artworkVersion {\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          id\n        }\n        artwork {\n          href\n          partner {\n            href\n            initials\n            name\n            profile {\n              icon {\n                cropped(width: 45, height: 45) {\n                  src\n                  srcSet\n                }\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          title\n          artistNames\n          artists(shallow: true) {\n            href\n            id\n          }\n          id\n        }\n        fulfillments(first: 1) {\n          edges {\n            node {\n              trackingId\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SettingsPurchases_me_4tp0sF on Me {\n  name\n  orders(states: $states, first: $first, after: $after) {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...CommercePagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        code\n        ...SettingsPurchasesRow_order\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query SettingsPurchasesQuery(\n  $states: [CommerceOrderStateEnum!]\n  $first: Int!\n  $after: String\n) {\n  me {\n    ...SettingsPurchases_me_4tp0sF\n    id\n  }\n}\n\nfragment CommercePagination_pageCursors on CommercePageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SettingsPurchasesRow_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  source\n  internalID\n  code\n  displayState\n  state\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      lastDigits\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  buyerTotal(precision: 2)\n  createdAt\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artworkVersion {\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          id\n        }\n        artwork {\n          href\n          partner {\n            href\n            initials\n            name\n            profile {\n              icon {\n                cropped(width: 45, height: 45) {\n                  src\n                  srcSet\n                }\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          title\n          artistNames\n          artists(shallow: true) {\n            href\n            id\n          }\n          id\n        }\n        fulfillments(first: 1) {\n          edges {\n            node {\n              trackingId\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    buyerAction\n  }\n}\n\nfragment SettingsPurchases_me_4tp0sF on Me {\n  name\n  orders(states: $states, first: $first, after: $after) {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...CommercePagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        code\n        ...SettingsPurchasesRow_order\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SettingsPurchasesRow_order.graphql.ts
+++ b/src/__generated__/SettingsPurchasesRow_order.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a8c10122f417efc37db57ab8d926632f>>
+ * @generated SignedSource<<3b775811d9e35c601dc32bf1fcb8a2fe>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,11 +9,13 @@
 // @ts-nocheck
 
 import { ReaderFragment } from 'relay-runtime';
+export type CommerceBuyerOfferActionEnum = "OFFER_ACCEPTED" | "OFFER_ACCEPTED_CONFIRM_NEEDED" | "OFFER_RECEIVED" | "OFFER_RECEIVED_CONFIRM_NEEDED" | "PAYMENT_FAILED" | "PROVISIONAL_OFFER_ACCEPTED" | "%future added value";
 export type CommerceOrderDisplayStateEnum = "ABANDONED" | "APPROVED" | "CANCELED" | "FULFILLED" | "IN_TRANSIT" | "PAYMENT_FAILED" | "PENDING" | "PROCESSING" | "PROCESSING_APPROVAL" | "REFUNDED" | "SUBMITTED" | "%future added value";
 export type CommerceOrderSourceEnum = "artwork_page" | "inquiry" | "partner_offer" | "private_sale" | "%future added value";
 export type CommerceOrderStateEnum = "ABANDONED" | "APPROVED" | "CANCELED" | "FULFILLED" | "IN_REVIEW" | "PENDING" | "PROCESSING_APPROVAL" | "REFUNDED" | "SUBMITTED" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type SettingsPurchasesRow_order$data = {
+  readonly buyerAction?: CommerceBuyerOfferActionEnum | null | undefined;
   readonly buyerTotal: string | null | undefined;
   readonly code: string;
   readonly createdAt: string;
@@ -473,6 +475,20 @@ return {
         }
       ],
       "storageKey": null
+    },
+    {
+      "kind": "InlineFragment",
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "buyerAction",
+          "storageKey": null
+        }
+      ],
+      "type": "CommerceOfferOrder",
+      "abstractKey": null
     }
   ],
   "type": "CommerceOrder",
@@ -480,6 +496,6 @@ return {
 };
 })();
 
-(node as any).hash = "4a896a515342b1fcc037206f76bb1dbd";
+(node as any).hash = "0d315366543908efb10c9d1bd70233a5";
 
 export default node;

--- a/src/__generated__/SettingsPurchases_Test_Query.graphql.ts
+++ b/src/__generated__/SettingsPurchases_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7fbd90b3dbea85926ad5b4efe46b09e3>>
+ * @generated SignedSource<<6906ca9d20ac67469c5ecea1f7e29383>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -665,6 +665,20 @@ return {
                         ],
                         "storageKey": null
                       },
+                      {
+                        "kind": "InlineFragment",
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "buyerAction",
+                            "storageKey": null
+                          }
+                        ],
+                        "type": "CommerceOfferOrder",
+                        "abstractKey": null
+                      },
                       (v5/*: any*/)
                     ],
                     "storageKey": null
@@ -682,7 +696,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "6d267189bf8afbe5847f11b6e8fbb862",
+    "cacheID": "4b72c52726e937f531c304ad14db3eca",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -714,6 +728,19 @@ return {
         },
         "me.orders.edges.node.__isCommerceOrder": (v10/*: any*/),
         "me.orders.edges.node.__typename": (v10/*: any*/),
+        "me.orders.edges.node.buyerAction": {
+          "enumValues": [
+            "OFFER_ACCEPTED",
+            "OFFER_ACCEPTED_CONFIRM_NEEDED",
+            "OFFER_RECEIVED",
+            "OFFER_RECEIVED_CONFIRM_NEEDED",
+            "PAYMENT_FAILED",
+            "PROVISIONAL_OFFER_ACCEPTED"
+          ],
+          "nullable": true,
+          "plural": false,
+          "type": "CommerceBuyerOfferActionEnum"
+        },
         "me.orders.edges.node.buyerTotal": (v9/*: any*/),
         "me.orders.edges.node.code": (v10/*: any*/),
         "me.orders.edges.node.createdAt": (v10/*: any*/),
@@ -917,7 +944,7 @@ return {
     },
     "name": "SettingsPurchases_Test_Query",
     "operationKind": "query",
-    "text": "query SettingsPurchases_Test_Query {\n  me {\n    ...SettingsPurchases_me\n    id\n  }\n}\n\nfragment CommercePagination_pageCursors on CommercePageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SettingsPurchasesRow_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  source\n  internalID\n  code\n  displayState\n  state\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      lastDigits\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  buyerTotal(precision: 2)\n  createdAt\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artworkVersion {\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          id\n        }\n        artwork {\n          href\n          partner {\n            href\n            initials\n            name\n            profile {\n              icon {\n                cropped(width: 45, height: 45) {\n                  src\n                  srcSet\n                }\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          title\n          artistNames\n          artists(shallow: true) {\n            href\n            id\n          }\n          id\n        }\n        fulfillments(first: 1) {\n          edges {\n            node {\n              trackingId\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SettingsPurchases_me on Me {\n  name\n  orders(states: [APPROVED, CANCELED, FULFILLED, REFUNDED, SUBMITTED, PROCESSING_APPROVAL], first: 10) {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...CommercePagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        code\n        ...SettingsPurchasesRow_order\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query SettingsPurchases_Test_Query {\n  me {\n    ...SettingsPurchases_me\n    id\n  }\n}\n\nfragment CommercePagination_pageCursors on CommercePageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SettingsPurchasesRow_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  source\n  internalID\n  code\n  displayState\n  state\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      lastDigits\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  buyerTotal(precision: 2)\n  createdAt\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artworkVersion {\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          id\n        }\n        artwork {\n          href\n          partner {\n            href\n            initials\n            name\n            profile {\n              icon {\n                cropped(width: 45, height: 45) {\n                  src\n                  srcSet\n                }\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          title\n          artistNames\n          artists(shallow: true) {\n            href\n            id\n          }\n          id\n        }\n        fulfillments(first: 1) {\n          edges {\n            node {\n              trackingId\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    buyerAction\n  }\n}\n\nfragment SettingsPurchases_me on Me {\n  name\n  orders(states: [APPROVED, CANCELED, FULFILLED, REFUNDED, SUBMITTED, PROCESSING_APPROVAL], first: 10) {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...CommercePagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        code\n        ...SettingsPurchasesRow_order\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/settingsRoutes_PurchasesRouteQuery.graphql.ts
+++ b/src/__generated__/settingsRoutes_PurchasesRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<29f6bdba6e968f7c8779aa3b9ce25703>>
+ * @generated SignedSource<<582f6b8037b14c1d8748ccaaa63c7eb9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -617,6 +617,20 @@ return {
                         ],
                         "storageKey": null
                       },
+                      {
+                        "kind": "InlineFragment",
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "buyerAction",
+                            "storageKey": null
+                          }
+                        ],
+                        "type": "CommerceOfferOrder",
+                        "abstractKey": null
+                      },
                       (v5/*: any*/)
                     ],
                     "storageKey": null
@@ -634,12 +648,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "40fc06dcd23f5da95b583f2fa464ab74",
+    "cacheID": "d77db0bf6c8ffce9268f19a7c51deece",
     "id": null,
     "metadata": {},
     "name": "settingsRoutes_PurchasesRouteQuery",
     "operationKind": "query",
-    "text": "query settingsRoutes_PurchasesRouteQuery {\n  me {\n    ...SettingsPurchasesRoute_me\n    id\n  }\n}\n\nfragment CommercePagination_pageCursors on CommercePageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SettingsPurchasesRoute_me on Me {\n  ...SettingsPurchases_me\n}\n\nfragment SettingsPurchasesRow_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  source\n  internalID\n  code\n  displayState\n  state\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      lastDigits\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  buyerTotal(precision: 2)\n  createdAt\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artworkVersion {\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          id\n        }\n        artwork {\n          href\n          partner {\n            href\n            initials\n            name\n            profile {\n              icon {\n                cropped(width: 45, height: 45) {\n                  src\n                  srcSet\n                }\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          title\n          artistNames\n          artists(shallow: true) {\n            href\n            id\n          }\n          id\n        }\n        fulfillments(first: 1) {\n          edges {\n            node {\n              trackingId\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SettingsPurchases_me on Me {\n  name\n  orders(states: [APPROVED, CANCELED, FULFILLED, REFUNDED, SUBMITTED, PROCESSING_APPROVAL], first: 10) {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...CommercePagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        code\n        ...SettingsPurchasesRow_order\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query settingsRoutes_PurchasesRouteQuery {\n  me {\n    ...SettingsPurchasesRoute_me\n    id\n  }\n}\n\nfragment CommercePagination_pageCursors on CommercePageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment SettingsPurchasesRoute_me on Me {\n  ...SettingsPurchases_me\n}\n\nfragment SettingsPurchasesRow_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  source\n  internalID\n  code\n  displayState\n  state\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      lastDigits\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  buyerTotal(precision: 2)\n  createdAt\n  currencyCode\n  lineItems {\n    edges {\n      node {\n        artworkVersion {\n          image {\n            cropped(width: 45, height: 45) {\n              src\n              srcSet\n            }\n          }\n          id\n        }\n        artwork {\n          href\n          partner {\n            href\n            initials\n            name\n            profile {\n              icon {\n                cropped(width: 45, height: 45) {\n                  src\n                  srcSet\n                }\n              }\n              id\n            }\n            id\n          }\n          shippingOrigin\n          title\n          artistNames\n          artists(shallow: true) {\n            href\n            id\n          }\n          id\n        }\n        fulfillments(first: 1) {\n          edges {\n            node {\n              trackingId\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n  ... on CommerceOfferOrder {\n    buyerAction\n  }\n}\n\nfragment SettingsPurchases_me on Me {\n  name\n  orders(states: [APPROVED, CANCELED, FULFILLED, REFUNDED, SUBMITTED, PROCESSING_APPROVAL], first: 10) {\n    totalCount\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n    pageCursors {\n      ...CommercePagination_pageCursors\n    }\n    edges {\n      node {\n        __typename\n        code\n        ...SettingsPurchasesRow_order\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
This PR solves https://artsyproduct.atlassian.net/browse/EMI-2204

### Description

Opted in for combining displayState and buyerAction on the client here to cover 'counteroffer received' state.

Looks like this now:

![Screenshot 2024-12-05 at 3 58 46 PM](https://github.com/user-attachments/assets/6948ad27-70a4-494e-ab3b-5f6bf38f8c3c)
