### PR TITLE
fix(EMI-1934): address autocomplete keyboard navigation issue

### DIFF
--- a/src/Apps/Order/Routes/Shipping/Components/FulfillmentDetailsForm.tsx
+++ b/src/Apps/Order/Routes/Shipping/Components/FulfillmentDetailsForm.tsx
@@ -380,7 +380,6 @@ const FulfillmentDetailsFormLayout = (
                   title="Address line 1"
                   value={values.attributes.addressLine1}
                   onChange={withBackToFulfillmentDetails(handleChange)}
-                  onBlur={handleBlur}
                   onSelect={option => {
                     const selectedAddress = option.address
                     setValues({
@@ -404,8 +403,8 @@ const FulfillmentDetailsFormLayout = (
                       ?.addressLine1
                   }
                   data-testid="AddressForm_addressLine1"
-                  onClear={function (): void {
-                    throw new Error("Function not implemented.")
+                  onClear={() => {
+                    setFieldValue("attributes.addressLine1", "")
                   }}
                 />
               </Column>

--- a/src/Components/Address/AddressAutocompleteInput.tsx
+++ b/src/Components/Address/AddressAutocompleteInput.tsx
@@ -147,7 +147,7 @@ const reducer = (state: State, action: Action): State => {
  * See AddressAutocompleteInput.jest.tsx for implementation examples.
  *
  * *note: The onBlur prop is disabled because it causes issues with keyboard
- * navigation.*
+ * navigation. see https://github.com/artsy/force/pull/14963 for more info.*
  */
 export const AddressAutocompleteInput = ({
   address,

--- a/src/Components/Address/AddressAutocompleteInput.tsx
+++ b/src/Components/Address/AddressAutocompleteInput.tsx
@@ -32,7 +32,10 @@ interface AutocompleteTrackingValues {
 }
 
 export interface AddressAutocompleteInputProps
-  extends Partial<AutocompleteInputProps<AddressAutocompleteSuggestion>> {
+  extends Omit<
+    Partial<AutocompleteInputProps<AddressAutocompleteSuggestion>>,
+    "onBlur"
+  > {
   /* The address [including at least a country] to use for autocomplete suggestions */
   address: Partial<Address> & { country: Address["country"] }
 
@@ -143,8 +146,8 @@ const reducer = (state: State, action: Action): State => {
  * fetching address suggestions from an autocomplete provider.
  * See AddressAutocompleteInput.jest.tsx for implementation examples.
  *
- * *note: Passing formik's handleBlur to the onBlur prop of this component
- * causes issues with keyboard navigation.*
+ * *note: The onBlur prop is disabled because it causes issues with keyboard
+ * navigation.*
  */
 export const AddressAutocompleteInput = ({
   address,

--- a/src/Components/Address/AddressAutocompleteInput.tsx
+++ b/src/Components/Address/AddressAutocompleteInput.tsx
@@ -140,9 +140,11 @@ const reducer = (state: State, action: Action): State => {
 
 /**
  * A wrapper around the Palette AutocompleteInput that handles efficiently
- * fetching address suggestions from an autocomplete provider. Use the
- * `useAddressAutocompleteTracking` hook to get pre-loaded tracking helpers.
+ * fetching address suggestions from an autocomplete provider.
  * See AddressAutocompleteInput.jest.tsx for implementation examples.
+ *
+ * *note: Passing formik's handleBlur to the onBlur prop of this component
+ * causes issues with keyboard navigation.*
  */
 export const AddressAutocompleteInput = ({
   address,

--- a/src/Components/Address/AddressFormFields.tsx
+++ b/src/Components/Address/AddressFormFields.tsx
@@ -146,7 +146,6 @@ export const AddressFormFields = <V extends FormikContextWithAddress>(
           title="Street address"
           value={values.address.addressLine1}
           onChange={handleChange}
-          onBlur={handleBlur}
           onSelect={option => {
             const selectedAddress = option.address
             setValues({


### PR DESCRIPTION
The type of this PR is: **FIX**

Paired with @dzucconi on diagnosis

This PR Resolves [EMI-1934] by removing the `onBlur` prop from our address autocomplete input. It also fixes what is probably a minor bug due to a missing onClear() prop.

### Description

This PR fixes an issue where keyboard navigation does not work on the first down-arrow press. We traced this issue to the incoming `onBlur={handleBlur}` prop we pass in from the formik context - it is triggered on the first down arrow press, but the first enter press does not trigger the `onSelect` prop. After the second down arrow press a subsequent enter press does trigger the correct behavior, but for the still-selected first option. A third down arrow press highlights the second option. To put it another way, the first down arrow press triggers that `onBlur` from formik and the UI highlights the first option, but the second option makes the behavior of pressing enter catch up to that option.

In addition, variations of this code don't work either:
<img width="610" alt="image" src="https://github.com/user-attachments/assets/1d3e7a74-30d9-4eb5-bf06-f61c26953d29">
- using other formik props to validate/touch the field ❌ 
- using `setImmediate()` or `setTimeout()` to try and defer these things till after the [palette `AutocompleteInput` ](https://github.com/artsy/palette/blob/ded06f2ad4829e135a8694e7b0aecaf8a65c0a0d/packages/palette/src/elements/AutocompleteInput/AutocompleteInput.tsx)has had time to do its thing.

<details><summary>Screencap showing the input keyboard nav working, but with a tradeoff of delayed validation on this one field in a form until clicking submit</summary>

![2024-12-09 16 30 06](https://github.com/user-attachments/assets/eee6d6aa-8f85-411e-afab-579113d0593f)

</details> 

cc @artsy/emerald-devs 


[EMI-1934]: https://artsyproduct.atlassian.net/browse/EMI-1934?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ