### PR TITLE
feat: including digital art in artwork grid filters 

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -12187,6 +12187,7 @@ scalar JSON
 type Job {
   # HTML of job listing
   content: String!
+  departmentName: String!
 
   # The url of the job listing on Greenhouse
   externalURL: String!

--- a/src/Apps/Artwork/Utils/createCollectUrl.tsx
+++ b/src/Apps/Artwork/Utils/createCollectUrl.tsx
@@ -47,6 +47,7 @@ const filterCategories = {
   Architecture: "architecture",
   "Books and Portfolios": "books-and-portfolios",
   "Design/Decorative Art": "design",
+  "Digital Art": "digital-art",
   "Drawing, Collage or other Work on Paper": "work-on-paper",
   "Fashion Design and Wearable Art": "fashion-design-and-wearable-art",
   Installation: "installation",

--- a/src/Apps/MyCollection/Routes/EditArtwork/Utils/categoryOptions.ts
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Utils/categoryOptions.ts
@@ -22,9 +22,9 @@ export const categoryOptions = [
   { text: "Textile Arts", value: "Textile Arts" },
   { text: "Posters", value: "Posters" },
   { text: "Books and Portfolios", value: "Books and Portfolios" },
-  { text: "Other", value: "Other" },
   { text: "Ephemera or Merchandise", value: "Ephemera or Merchandise" },
   { text: "Reproduction", value: "Reproduction" },
   { text: "NFT", value: "NFT" },
   { text: "Digital Art", value: "Digital Art" },
+  { text: "Other", value: "Other" },
 ]

--- a/src/Apps/MyCollection/Routes/EditArtwork/Utils/categoryOptions.ts
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Utils/categoryOptions.ts
@@ -26,4 +26,5 @@ export const categoryOptions = [
   { text: "Ephemera or Merchandise", value: "Ephemera or Merchandise" },
   { text: "Reproduction", value: "Reproduction" },
   { text: "NFT", value: "NFT" },
+  { text: "Digital Art", value: "Digital Art" },
 ]

--- a/src/Components/Alert/Components/Filters/__tests__/Medium.jest.enzyme.tsx
+++ b/src/Components/Alert/Components/Filters/__tests__/Medium.jest.enzyme.tsx
@@ -27,7 +27,7 @@ describe("MediumFilter", () => {
   it("displays all mediums", () => {
     const wrapper = getWrapper()
 
-    expect(wrapper.find("Checkbox").length).toBe(14)
+    expect(wrapper.find("Checkbox").length).toBe(15)
 
     expect(wrapper.html()).toContain("Painting")
   })

--- a/src/Components/ArtworkFilter/ArtworkFilters/MediumFilter.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/MediumFilter.tsx
@@ -15,7 +15,9 @@ export interface MediumFilterProps {
   expanded?: boolean
 }
 
-export const MediumFilter: FC<React.PropsWithChildren<MediumFilterProps>> = ({ expanded }) => {
+export const MediumFilter: FC<React.PropsWithChildren<MediumFilterProps>> = ({
+  expanded,
+}) => {
   const { aggregations, counts, setFilter } = useArtworkFilterContext()
   const { additionalGeneIDs = [], medium } = useCurrentlySelectedFilters()
 
@@ -91,4 +93,5 @@ export const MEDIUM_OPTIONS = [
   { value: "performance-art", name: "Performance Art" },
   { value: "reproduction", name: "Reproduction" },
   { value: "ephemera-or-merchandise", name: "Ephemera or Merchandise" },
+  { value: "digital-art", name: "Digital Art" },
 ]


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [AMBER-1121]

### Description

Here I'm including 'Digital Art' in the list of medium filters in the artwork grid so it can be used in front-end marketplace searches, allowing collectors to search specifically for digital artworks. (Partners can also now set 'Digital Art' as the medium in the artwork form in CMS.)

<!-- Implementation description -->
![Screenshot 2024-12-10 at 7 53 06 AM](https://github.com/user-attachments/assets/21cc724b-1792-4d20-85f7-105fdcfd22c0)


[AMBER-1121]: https://artsyproduct.atlassian.net/browse/AMBER-1121?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ