### PR TITLE
chore(jobs): removes dependency on department nested jobs field

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -12187,6 +12187,7 @@ scalar JSON
 type Job {
   # HTML of job listing
   content: String!
+  departmentName: String!
 
   # The url of the job listing on Greenhouse
   externalURL: String!

--- a/src/__generated__/JobsFilter_viewer.graphql.ts
+++ b/src/__generated__/JobsFilter_viewer.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<cc660b017bb2aff1d3af0bbf4086ebc9>>
+ * @generated SignedSource<<2a71ef57164d680ca40592d1a6764a64>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,15 +11,8 @@
 import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type JobsFilter_viewer$data = {
-  readonly departments: ReadonlyArray<{
-    readonly id: string;
-    readonly jobs: ReadonlyArray<{
-      readonly id: string;
-      readonly " $fragmentSpreads": FragmentRefs<"JobLink_job">;
-    }>;
-    readonly name: string;
-  }>;
   readonly jobs: ReadonlyArray<{
+    readonly departmentName: string;
     readonly id: string;
     readonly location: string;
     readonly " $fragmentSpreads": FragmentRefs<"JobLink_job">;
@@ -31,20 +24,7 @@ export type JobsFilter_viewer$key = {
   readonly " $fragmentSpreads": FragmentRefs<"JobsFilter_viewer">;
 };
 
-const node: ReaderFragment = (function(){
-var v0 = {
-  "args": null,
-  "kind": "FragmentSpread",
-  "name": "JobLink_job"
-},
-v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-};
-return {
+const node: ReaderFragment = {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
@@ -58,45 +38,30 @@ return {
       "name": "jobs",
       "plural": true,
       "selections": [
-        (v0/*: any*/),
-        (v1/*: any*/),
+        {
+          "args": null,
+          "kind": "FragmentSpread",
+          "name": "JobLink_job"
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "id",
+          "storageKey": null
+        },
         {
           "alias": null,
           "args": null,
           "kind": "ScalarField",
           "name": "location",
           "storageKey": null
-        }
-      ],
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "concreteType": "Department",
-      "kind": "LinkedField",
-      "name": "departments",
-      "plural": true,
-      "selections": [
-        (v1/*: any*/),
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "name",
-          "storageKey": null
         },
         {
           "alias": null,
           "args": null,
-          "concreteType": "Job",
-          "kind": "LinkedField",
-          "name": "jobs",
-          "plural": true,
-          "selections": [
-            (v0/*: any*/),
-            (v1/*: any*/)
-          ],
+          "kind": "ScalarField",
+          "name": "departmentName",
           "storageKey": null
         }
       ],
@@ -106,8 +71,7 @@ return {
   "type": "Viewer",
   "abstractKey": null
 };
-})();
 
-(node as any).hash = "5764dc61fad90d31d46ceb9ba92f41e0";
+(node as any).hash = "1e422c2a88d8fb876274311737f8873b";
 
 export default node;

--- a/src/__generated__/jobsRoutes_JobsQuery.graphql.ts
+++ b/src/__generated__/jobsRoutes_JobsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bf6e96278898468c72b54bba3000d0dc>>
+ * @generated SignedSource<<ae431bf074879bc4c7bf972f676770c0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -21,41 +21,7 @@ export type jobsRoutes_JobsQuery = {
   variables: jobsRoutes_JobsQuery$variables;
 };
 
-const node: ConcreteRequest = (function(){
-var v0 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v1 = {
-  "alias": null,
-  "args": null,
-  "concreteType": "Job",
-  "kind": "LinkedField",
-  "name": "jobs",
-  "plural": true,
-  "selections": [
-    (v0/*: any*/),
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "title",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "location",
-      "storageKey": null
-    }
-  ],
-  "storageKey": null
-};
-return {
+const node: ConcreteRequest = {
   "fragment": {
     "argumentDefinitions": [],
     "kind": "Fragment",
@@ -96,24 +62,42 @@ return {
         "name": "viewer",
         "plural": false,
         "selections": [
-          (v1/*: any*/),
           {
             "alias": null,
             "args": null,
-            "concreteType": "Department",
+            "concreteType": "Job",
             "kind": "LinkedField",
-            "name": "departments",
+            "name": "jobs",
             "plural": true,
             "selections": [
-              (v0/*: any*/),
               {
                 "alias": null,
                 "args": null,
                 "kind": "ScalarField",
-                "name": "name",
+                "name": "id",
                 "storageKey": null
               },
-              (v1/*: any*/)
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "title",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "location",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "departmentName",
+                "storageKey": null
+              }
             ],
             "storageKey": null
           }
@@ -123,15 +107,14 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e6485e2c892b1917180aa09814990f2c",
+    "cacheID": "24fc6f2cb565c686b6c7ed1f7a187e4a",
     "id": null,
     "metadata": {},
     "name": "jobsRoutes_JobsQuery",
     "operationKind": "query",
-    "text": "query jobsRoutes_JobsQuery @cacheable {\n  viewer {\n    ...JobsApp_viewer\n  }\n}\n\nfragment JobLink_job on Job {\n  id\n  title\n  location\n}\n\nfragment JobsApp_viewer on Viewer {\n  ...JobsFilter_viewer\n}\n\nfragment JobsFilter_viewer on Viewer {\n  jobs {\n    ...JobLink_job\n    id\n    location\n  }\n  departments {\n    id\n    name\n    jobs {\n      ...JobLink_job\n      id\n    }\n  }\n}\n"
+    "text": "query jobsRoutes_JobsQuery @cacheable {\n  viewer {\n    ...JobsApp_viewer\n  }\n}\n\nfragment JobLink_job on Job {\n  id\n  title\n  location\n}\n\nfragment JobsApp_viewer on Viewer {\n  ...JobsFilter_viewer\n}\n\nfragment JobsFilter_viewer on Viewer {\n  jobs {\n    ...JobLink_job\n    id\n    location\n    departmentName\n  }\n}\n"
   }
 };
-})();
 
 (node as any).hash = "f111bf42d552fb795ffe2d669568297c";
 


### PR DESCRIPTION
This change removes the dependency on querying jobs through departments, as this functionality won't be available when we switch to the Ashby API. Instead, we're implementing manual grouping that will be compatible with the new API's capabilities. This approach allows us to seamlessly swap the underlying API while maintaining the page's existing functionality. I'll follow up with the corresponding changes in Metaphysics and merge once we're ready to transition to the new service.