### PR TITLE
feat(dx): Open browser on yarn start during dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
       - run:
           name: Run Jest Tests
           command: |
-            yarn jest --reporters=default --maxWorkers 4 --reporters=jest-junit --shard=$(expr $CIRCLE_NODE_INDEX + 1)/$CIRCLE_NODE_TOTAL
+            yarn jest --reporters=default --maxWorkers 2 --reporters=jest-junit --shard=$(expr $CIRCLE_NODE_INDEX + 1)/$CIRCLE_NODE_TOTAL
           environment:
             JEST_JUNIT_OUTPUT_DIR: reports/junit
             JEST_JUNIT_ADD_FILE_ATTRIBUTE: "true"
@@ -85,7 +85,7 @@ jobs:
       - run:
           name: Run Legacy Jest Tests
           command: |
-            yarn jest-enzyme --maxWorkers 4 --reporters=default --reporters=jest-junit --shard=$(expr $CIRCLE_NODE_INDEX + 1)/$CIRCLE_NODE_TOTAL
+            yarn jest-enzyme --maxWorkers 2 --reporters=default --reporters=jest-junit --shard=$(expr $CIRCLE_NODE_INDEX + 1)/$CIRCLE_NODE_TOTAL
           environment:
             JEST_JUNIT_OUTPUT_DIR: reports/junit
             JEST_JUNIT_ADD_FILE_ATTRIBUTE: "true"

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -2,6 +2,7 @@ import "./Server/loadenv"
 import express from "express"
 import { createRsbuild, loadConfig, logger } from "@rsbuild/core"
 import { createReloadable } from "@artsy/express-reloadable"
+import { execSync } from "child_process"
 
 export async function startDevServer() {
   // Wait for multienv to load envs
@@ -33,11 +34,14 @@ export async function startDevServer() {
   mountAndReload(outputPath)
 
   const httpServer = await startServer(app, () => {
+    const url = `http://localhost:${rsbuildServer.port}`
+
     rsbuildServer.afterListen()
 
-    logger.log(
-      `[Force] Server started at http://localhost:${rsbuildServer.port}`
-    )
+    logger.log(`[Force] Server started at ${url}`)
+
+    // Open the browser
+    execSync(`open ${url}`)
   })
 
   rsbuildServer.connectWebSocket({ server: httpServer })


### PR DESCRIPTION
The type of this PR is: **Feat**

### Description

Now that it doesn't take a painful minute to actually serve the app in a browser window, during development automatically open the browser when the server is done booting.

cc @artsy/diamond-devs 
