### PR TITLE
fix(404): fix missing 404 pages

### DIFF
--- a/cypress/e2e/404.cy.ts
+++ b/cypress/e2e/404.cy.ts
@@ -1,0 +1,10 @@
+describe("404", () => {
+  it("renders 404 page", () => {
+    cy.visit("/oh-no-some-404", { failOnStatusCode: false })
+
+    cy.get("div").should(
+      "contain",
+      "Sorry, the page you were looking for doesn’t exist at this URL."
+    )
+  })
+})

--- a/src/Server/startServer.ts
+++ b/src/Server/startServer.ts
@@ -2,7 +2,6 @@ import http from "http"
 import withGracefulShutdown from "http-shutdown"
 import { once } from "lodash"
 import { initializeArtsyXapp } from "./artsyXapp"
-import { errorHandlerMiddleware } from "./middleware/errorHandler"
 import { APP_URL, NODE_ENV, PORT } from "Server/config"
 import { setupExpressErrorHandler } from "@sentry/node"
 
@@ -16,7 +15,7 @@ export async function startServer(
   app,
   onStart?: () => void
 ): Promise<http.Server> {
-  setupErrorHandling(app)
+  setupExpressErrorHandler(app)
 
   return new Promise(resolve => {
     initializeArtsyXapp(() => {
@@ -62,20 +61,4 @@ export async function startServer(
       process.on("SIGTERM", stopServer)
     })
   })
-}
-
-function setupErrorHandling(app) {
-  // Setup exception reporting
-  setupExpressErrorHandler(app)
-
-  // And error handling
-  app.get("*", (req, res, next) => {
-    const err = new Error()
-    // @ts-ignore -- FIXME: status does not exist on err
-    err.status = 404
-    err.message = "Not Found"
-    next(err)
-  })
-
-  app.use(errorHandlerMiddleware)
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -16,6 +16,7 @@ import { appPreferencesServerRoutes } from "Apps/AppPreferences/appPreferencesSe
 import { setupServerRouter } from "System/Router/serverRouter"
 import { getRoutes } from "System/Router/Utils/routeUtils"
 import { initializeMiddleware } from "middleware"
+import { errorHandlerMiddleware } from "Server/middleware/errorHandler"
 
 const app = express()
 
@@ -56,8 +57,17 @@ app
   .use(adminServerRoutes)
   .use(sitemapsServerApp)
   .use(rssServerApp)
-  // Should be last
+  // Should be second to last
   .use(redirectsServerRoutes)
+  // Final middleware. Errors and anything else should be last
+  .use("*", (req, res, next) => {
+    const err = new Error()
+    // @ts-ignore -- FIXME: status does not exist on err
+    err.status = 404
+    err.message = "Not Found"
+    next(err)
+  })
+  .use(errorHandlerMiddleware)
 
 // This export form is required for express-reloadable
 // TODO: Remove when no longer needed for hot reloading


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Fixes missing 404 pages. Not sure why this works fine locally, but when deployed to prod we needed to move the error handler to server.ts. 

Got to the bottom of this (production) issue by rapidly pushing to a review app branch. With latest infra updates it worked fast and well. 

Also added a smoke test! 
