### PR TITLE
refactor(collections): modify redirects to be purely server-side

### DIFF
--- a/cypress/e2e/collection.cy.js
+++ b/cypress/e2e/collection.cy.js
@@ -38,3 +38,19 @@ describe("/collection/:id (a collection hub)", () => {
     artworkGridRenders()
   })
 })
+
+describe("redirection", () => {
+  it("redirects selected collections to artist series", () => {
+    visitWithStatusRetries("/collection/albrecht-durer-engraving")
+    cy.location("pathname").should(
+      "eq",
+      "/artist-series/albrecht-durer-etchings-and-engravings"
+    )
+
+    visitWithStatusRetries("/collection/zeng-fanzhi-mask-series")
+    cy.location("pathname").should(
+      "eq",
+      "/artist-series/zeng-fanzhi-ceng-fan-zhi-mask-series"
+    )
+  })
+})

--- a/cypress/e2e/collection.cy.js
+++ b/cypress/e2e/collection.cy.js
@@ -1,8 +1,7 @@
 import { artworkGridRenders } from "../helpers/artworkGridRenders"
 import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
 
-// FIXME: Remove skip once Staging is back up
-describe.skip("/collection/:id", () => {
+describe("/collection/:id", () => {
   beforeEach(() => {
     visitWithStatusRetries("/collection/emerging-photographers")
   })
@@ -13,7 +12,7 @@ describe.skip("/collection/:id", () => {
       .should("have.attr", "content")
       .and(
         "eq",
-        "Buy, bid, and inquire on Emerging Photographers on Artsy. Today’s leading photographers are pushing the medium into new territories&mdash;experimenting with digital manipulation, unleashing the power of new macro …"
+        "Buy, bid, and inquire on Emerging Photographers on Artsy. Today’s leading photographers are pushing the medium into new territories—experimenting with digital manipulation, unleashing the power of new macro lenses..."
       )
 
     cy.get("h1").should("contain", "Emerging Photographers")
@@ -21,8 +20,7 @@ describe.skip("/collection/:id", () => {
   })
 })
 
-// FIXME: Remove skip once Staging is back up
-describe.skip("/collection/:id (a collection hub)", () => {
+describe("/collection/:id (a collection hub)", () => {
   beforeEach(() => {
     visitWithStatusRetries("/collection/contemporary")
   })
@@ -33,7 +31,7 @@ describe.skip("/collection/:id (a collection hub)", () => {
       .should("have.attr", "content")
       .and(
         "eq",
-        "Buy, bid, and inquire on Contemporary Art on Artsy. Spanning from 1970 to the present day, the contemporary period of art history represents the most diverse and widely-collected era of artistic production. …"
+        "Buy, bid, and inquire on Contemporary Art on Artsy. Spanning from 1970 to the present day, the contemporary period of art history represents the most diverse and widely-collected era of artistic production. ..."
       )
 
     cy.get("h1").should("contain", "Contemporary")

--- a/src/Apps/Collect/Server/__tests__/redirectCollectionToArtistSeries.jest.ts
+++ b/src/Apps/Collect/Server/__tests__/redirectCollectionToArtistSeries.jest.ts
@@ -1,4 +1,5 @@
 import { redirectCollectionToArtistSeries } from "Apps/Collect/Server/redirectCollectionToArtistSeries"
+import { ArtsyRequest, ArtsyResponse } from "Server/middleware/artsyExpress"
 
 describe("redirectCollectionToArtistSeries", () => {
   it("does not redirect for a non-migrated artist series", () => {
@@ -11,7 +12,13 @@ describe("redirectCollectionToArtistSeries", () => {
       redirect: jest.fn(),
       locals: { sd: {} },
     }
-    redirectCollectionToArtistSeries({ req, res })
+    const next = jest.fn()
+
+    redirectCollectionToArtistSeries(
+      (req as unknown) as ArtsyRequest,
+      (res as unknown) as ArtsyResponse,
+      next
+    )
     expect(res.redirect).not.toHaveBeenCalled()
   })
 
@@ -28,8 +35,14 @@ describe("redirectCollectionToArtistSeries", () => {
         sd: {},
       },
     }
+    const next = jest.fn()
 
-    redirectCollectionToArtistSeries({ req, res })
+    redirectCollectionToArtistSeries(
+      (req as unknown) as ArtsyRequest,
+      (res as unknown) as ArtsyResponse,
+      next
+    )
+
     expect(spy).toHaveBeenCalledWith(
       301,
       "/artist-series/kaws-4-foot-companion"

--- a/src/Apps/Collect/Server/redirectCollectionToArtistSeries.ts
+++ b/src/Apps/Collect/Server/redirectCollectionToArtistSeries.ts
@@ -1,11 +1,19 @@
 import { collectionToArtistSeriesSlugMap } from "Apps/Collect/Utils/collectionToArtistSeriesSlugMap"
+import { NextFunction } from "express"
+import { ArtsyRequest, ArtsyResponse } from "Server/middleware/artsyExpress"
 
-export function redirectCollectionToArtistSeries({ req, res }) {
+export function redirectCollectionToArtistSeries(
+  req: ArtsyRequest,
+  res: ArtsyResponse,
+  next: NextFunction
+) {
   const collectionSlug: string = req.params.slug
   const seriesSlug: string = collectionToArtistSeriesSlugMap[collectionSlug]
 
   if (seriesSlug) {
     const artistSeriesPath = `/artist-series/${seriesSlug}`
     res.redirect(301, artistSeriesPath)
+  } else {
+    next()
   }
 }

--- a/src/Apps/Collect/collectRoutes.tsx
+++ b/src/Apps/Collect/collectRoutes.tsx
@@ -1,7 +1,6 @@
 import loadable from "@loadable/component"
 import { RouteProps } from "System/Router/Route"
 import { graphql } from "react-relay"
-import { redirectCollectionToArtistSeries } from "./Server/redirectCollectionToArtistSeries"
 import { getInitialFilterState } from "Components/ArtworkFilter/Utils/getInitialFilterState"
 import { serverCacheTTLs } from "Apps/serverCacheTTLs"
 
@@ -64,7 +63,6 @@ export const collectRoutes: RouteProps[] = [
     path: "/collection/:slug",
     serverCacheTTL: serverCacheTTLs.collections,
     getComponent: () => CollectionApp,
-    onServerSideRender: redirectCollectionToArtistSeries,
     onPreloadJS: () => {
       CollectionApp.preload()
     },

--- a/src/server.ts
+++ b/src/server.ts
@@ -17,6 +17,7 @@ import { setupServerRouter } from "System/Router/serverRouter"
 import { getRoutes } from "System/Router/Utils/routeUtils"
 import { initializeMiddleware } from "middleware"
 import { errorHandlerMiddleware } from "Server/middleware/errorHandler"
+import { redirectCollectionToArtistSeries } from "Apps/Collect/Server/redirectCollectionToArtistSeries"
 
 const app = express()
 
@@ -24,6 +25,12 @@ const app = express()
 initializeMiddleware(app)
 
 const { routes, routePaths } = getRoutes()
+
+// Pre-emptive redirects
+//
+// These selectively match routes that would otherwise be handled by
+// the route matchers below
+app.get("/collection/:slug", redirectCollectionToArtistSeries)
 
 // React app routes
 app.get(


### PR DESCRIPTION
The type of this PR is: **Refactor**

This PR solves [ONYX-1445]

### Description

See [thread](https://artsy.slack.com/archives/C05EEBNEF71/p1733943061015619?thread_ts=1733940262.518139&cid=C05EEBNEF71) for context.

At [multiple](https://github.com/artsy/force/pull/6177) [various](https://github.com/artsy/force/pull/6509) [points](https://github.com/artsy/force/pull/12687) we've migrated artist series-esque `MarketingCollections` to "true" `ArtistSeries`.

We therefore added some redirect mappings for those collections. 

But that mapping file itself was unbeknownst to us adding >100k to the bundle size.

This refactors the redirection strategy to happen purely server-side at the Express layer rather than in the React SSR layer, in order to avoid this bundle bloat!





[ONYX-1445]: https://artsyproduct.atlassian.net/browse/ONYX-1445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ