### PR TITLE
fix: specify correct non-crossorigin mode on image host preconnect hints

### DIFF
--- a/src/Server/middleware/linkHeadersMiddleware.ts
+++ b/src/Server/middleware/linkHeadersMiddleware.ts
@@ -18,7 +18,7 @@ export function linkHeadersMiddleware(
   if (!res.headersSent) {
     res.header("Link", [
       `<${CDN_URL}>; rel=preconnect; crossorigin`,
-      `<${GEMINI_CLOUDFRONT_URL}>; rel=preconnect; crossorigin`,
+      `<${GEMINI_CLOUDFRONT_URL}>; rel=preconnect;`,
       `<${WEBFONT_URL}>; rel=preconnect; crossorigin`,
       `<${WEBFONT_URL}/all-webfonts.css>; rel=preload; as=style`,
       `<${WEBFONT_URL}/ll-unica77_regular.woff2>; rel=preload; as=font; crossorigin`,

--- a/src/html.ts
+++ b/src/html.ts
@@ -49,7 +49,7 @@ export function buildHtmlTemplate({
 
       <!-- Preconnect to CDNs -->
       <link rel="preconnect" href="${cdnUrl}" crossorigin />
-      <link rel="preconnect" href="${imageCdnUrl}" crossorigin />
+      <link rel="preconnect" href="${imageCdnUrl}" />
 
       <!-- Create preload tags for most common fonts -->
       <link rel="preconnect" href="${fontUrl}" crossorigin />


### PR DESCRIPTION
Fixes `crossorigin` mode of image host in `<link>` preconnect tags and `Link` headers. Ultimately, this will also fix them in Cloudflare's `103` (early hints) responses. This was flagged by a recent page-speed report.