### PR TITLE
fix(auctions): Disable returnTo query param in rail titles

### DIFF
--- a/cypress/e2e/auction.cy.ts
+++ b/cypress/e2e/auction.cy.ts
@@ -5,5 +5,8 @@ describe("Auction", () => {
     visitWithStatusRetries("auction/shared-live-mocktion-k8s")
     cy.get("h1").should("contain", "Shared Live Mocktion K8S")
     cy.title().should("contain", "Shared Live Mocktion K8S | Artsy")
+
+    // Default sort state; ensures grid loads
+    cy.get("div").should("contain", "Lot Number (asc.)")
   })
 })

--- a/src/Apps/Auction/Components/AuctionArtworkFilter.tsx
+++ b/src/Apps/Auction/Components/AuctionArtworkFilter.tsx
@@ -29,9 +29,9 @@ interface AuctionArtworkFilterProps {
   viewer: AuctionArtworkFilter_viewer$data
 }
 
-const AuctionArtworkFilter: React.FC<React.PropsWithChildren<AuctionArtworkFilterProps>> = ({
-  viewer,
-}) => {
+const AuctionArtworkFilter: React.FC<React.PropsWithChildren<
+  AuctionArtworkFilterProps
+>> = ({ viewer }) => {
   const { user } = useSystemContext()
   const { match } = useRouter()
 
@@ -122,7 +122,9 @@ export const AuctionArtworkFilterRefetchContainer = createRefetchContainer(
 
 interface AuctionArtworkFilterQueryRendererProps {}
 
-export const AuctionArtworkFilterQueryRenderer: React.FC<React.PropsWithChildren<AuctionArtworkFilterQueryRendererProps>> = rest => {
+export const AuctionArtworkFilterQueryRenderer: React.FC<React.PropsWithChildren<
+  AuctionArtworkFilterQueryRendererProps
+>> = rest => {
   const { relayEnvironment } = useSystemContext()
   const { match } = useRouter()
 

--- a/src/Components/Rail/RailHeader.tsx
+++ b/src/Components/Rail/RailHeader.tsx
@@ -1,8 +1,6 @@
 import { Box, Flex, SkeletonText, Sup, Text as BaseText } from "@artsy/palette"
 import * as React from "react"
 import { RouterLink } from "System/Components/RouterLink"
-import { useRouter } from "System/Hooks/useRouter"
-import { getENV } from "Utils/getENV"
 import { getInternalHref } from "Utils/url"
 
 export interface RailHeaderProps {
@@ -103,6 +101,7 @@ export const RailHeader: React.FC<React.PropsWithChildren<RailHeaderProps>> = ({
 }
 
 // FIXME; Reenable once we understand what this does
+/**
 const useReturnTo = (href?: string | null): string | null => {
   const router = useRouter()
 
@@ -121,3 +120,4 @@ const useReturnTo = (href?: string | null): string | null => {
     return href
   }
 }
+*/

--- a/src/Components/Rail/RailHeader.tsx
+++ b/src/Components/Rail/RailHeader.tsx
@@ -20,11 +20,9 @@ type RailHeaderTitleProps = Pick<
   "title" | "viewAllHref" | "viewAllOnClick"
 >
 
-export const RailHeaderTitle: React.FC<React.PropsWithChildren<RailHeaderTitleProps>> = ({
-  viewAllHref,
-  viewAllOnClick,
-  title,
-}) => {
+export const RailHeaderTitle: React.FC<React.PropsWithChildren<
+  RailHeaderTitleProps
+>> = ({ viewAllHref, viewAllOnClick, title }) => {
   if (!viewAllHref) return <>{title}</>
 
   const href = getInternalHref(viewAllHref)
@@ -49,7 +47,9 @@ export const RailHeader: React.FC<React.PropsWithChildren<RailHeaderProps>> = ({
 
   const showViewAll = Boolean(viewAllLabel && _viewAllHref)
 
-  const viewAllHref = useReturnTo(_viewAllHref)
+  // FIXME: Understand what this does. disabling because query params are
+  // breaking slugID parsing on auctions pages and that's bad.
+  // const viewAllHref = useReturnTo(_viewAllHref)
 
   return (
     <Flex justifyContent="space-between" alignItems="center">
@@ -63,7 +63,7 @@ export const RailHeader: React.FC<React.PropsWithChildren<RailHeaderProps>> = ({
         >
           <RailHeaderTitle
             title={title}
-            viewAllHref={viewAllHref}
+            viewAllHref={_viewAllHref}
             viewAllOnClick={viewAllOnClick}
           />{" "}
           {countLabel && countLabel > 1 && (
@@ -92,7 +92,7 @@ export const RailHeader: React.FC<React.PropsWithChildren<RailHeaderProps>> = ({
           flexShrink={0}
           // @ts-ignore
           as={RouterLink}
-          to={viewAllHref}
+          to={_viewAllHref}
           onClick={viewAllOnClick}
         >
           {viewAllLabel}
@@ -102,6 +102,7 @@ export const RailHeader: React.FC<React.PropsWithChildren<RailHeaderProps>> = ({
   )
 }
 
+// FIXME; Reenable once we understand what this does
 const useReturnTo = (href?: string | null): string | null => {
   const router = useRouter()
 


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

For some reason the `returnTo` query param is polluting the query that gets dispatched to render the auction/id artwork grid. So disabling that less urgent feature in our artwork rails for now while we figure out a) what it does; and b) how to fix / diagnose the underlying issue. 

Also updated auction smoke test to check for artwork grid existence.  

cc @artsy/diamond-devs 