### PR TITLE
feat: adds download app split test

### DIFF
--- a/src/Apps/Home/Components/HomeHeroUnits/HomeHeroUnit.tsx
+++ b/src/Apps/Home/Components/HomeHeroUnits/HomeHeroUnit.tsx
@@ -18,38 +18,37 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { HomeHeroUnit_heroUnit$data } from "__generated__/HomeHeroUnit_heroUnit.graphql"
 import { getInternalHref } from "Utils/url"
 
-interface HomeHeroUnitProps {
-  heroUnit: HomeHeroUnit_heroUnit$data
+export interface HomeHeroUnitBaseProps {
+  title: string
+  body: string
+  imageUrl?: string | null
+  credit?: string | null
+  label?: string | null
+  link: {
+    text: string
+    url: {
+      desktop: string
+      mobile: string
+    }
+  }
   index: number
   onClick?: () => void
 }
 
-export const HomeHeroUnit: React.FC<React.PropsWithChildren<HomeHeroUnitProps>> = props => {
-  return (
-    <Box width="100%" height="100%">
-      <Media at="xs">
-        <HomeHeroUnitSmall {...props} />
-      </Media>
-
-      <Media greaterThan="xs">
-        <HomeHeroUnitLarge {...props} />
-      </Media>
-    </Box>
-  )
-}
-
-const HomeHeroUnitSmall: React.FC<React.PropsWithChildren<HomeHeroUnitProps>> = ({
-  heroUnit,
+const HomeHeroUnitBaseSmall: React.FC<HomeHeroUnitBaseProps> = ({
+  title,
+  body,
+  imageUrl,
+  link,
   index,
   onClick,
 }) => {
-  const imageUrl = heroUnit.image?.imageURL
-  const image = imageUrl && cropped(imageUrl, { width: 500, height: 333 })
-  const href = getInternalHref(heroUnit.link.url)
+  const image = imageUrl ? cropped(imageUrl, { width: 500, height: 333 }) : null
+  const href = getInternalHref(link.url.mobile)
 
   return (
     <RouterLink
-      aria-label={`${heroUnit.title} - ${heroUnit.body}`}
+      aria-label={`${title} - ${body}`}
       bg="black5"
       display="block"
       height="100%"
@@ -78,32 +77,37 @@ const HomeHeroUnitSmall: React.FC<React.PropsWithChildren<HomeHeroUnitProps>> = 
 
       <Box p={4}>
         <Text as={index === 0 ? "h1" : "h2"} variant="lg-display" lineClamp={3}>
-          {heroUnit.title}
+          {title}
         </Text>
 
         <Spacer y={1} />
 
         <Text variant="xs" color="black60" lineClamp={4}>
-          {heroUnit.body}
+          {body}
         </Text>
 
         <Spacer y={1} />
 
-        <Text variant="xs">{heroUnit.link.text}</Text>
+        <Text variant="xs">{link.text}</Text>
       </Box>
     </RouterLink>
   )
 }
 
-const HomeHeroUnitLarge: React.FC<React.PropsWithChildren<HomeHeroUnitProps>> = ({
-  heroUnit,
+const HomeHeroUnitBaseLarge: React.FC<HomeHeroUnitBaseProps> = ({
+  title,
+  body,
+  imageUrl,
+  credit,
+  label,
+  link,
   index,
   onClick,
 }) => {
-  const imageUrl = heroUnit.image?.imageURL
-  const image = imageUrl && cropped(imageUrl, { width: 1270, height: 500 })
-  const href = getInternalHref(heroUnit.link.url)
-
+  const image = imageUrl
+    ? cropped(imageUrl, { width: 1270, height: 500 })
+    : null
+  const href = getInternalHref(link.url.desktop)
   const { theme } = useTheme()
 
   const background =
@@ -113,7 +117,7 @@ const HomeHeroUnitLarge: React.FC<React.PropsWithChildren<HomeHeroUnitProps>> = 
 
   return (
     <RouterLink
-      aria-label={`${heroUnit.title} - ${heroUnit.body}`}
+      aria-label={`${title} - ${body}`}
       display="block"
       onClick={onClick}
       textDecoration="none"
@@ -130,13 +134,12 @@ const HomeHeroUnitLarge: React.FC<React.PropsWithChildren<HomeHeroUnitProps>> = 
                 srcSet={image.srcSet}
                 style={{ objectFit: "cover" }}
                 width="100%"
-                // LCP optimization
                 lazyLoad={index > 0}
                 fetchPriority={index > 0 ? "auto" : "high"}
               />
             )}
 
-            {heroUnit.credit && (
+            {credit && (
               <Box
                 position="absolute"
                 bottom={0}
@@ -147,7 +150,7 @@ const HomeHeroUnitLarge: React.FC<React.PropsWithChildren<HomeHeroUnitProps>> = 
                 pt={6}
                 background={background}
               >
-                <HomeHeroUnitCredit>{heroUnit.credit}</HomeHeroUnitCredit>
+                <HomeHeroUnitCredit>{credit}</HomeHeroUnitCredit>
               </Box>
             )}
           </Box>
@@ -163,10 +166,9 @@ const HomeHeroUnitLarge: React.FC<React.PropsWithChildren<HomeHeroUnitProps>> = 
               span={8}
               start={3}
             >
-              {heroUnit.label && (
+              {label && (
                 <>
-                  <Text variant="xs">{heroUnit.label}</Text>
-
+                  <Text variant="xs">{label}</Text>
                   <Spacer y={1} />
                 </>
               )}
@@ -176,7 +178,7 @@ const HomeHeroUnitLarge: React.FC<React.PropsWithChildren<HomeHeroUnitProps>> = 
                 lineClamp={3}
                 variant={["lg-display", "xl", "xl"]}
               >
-                {heroUnit.title}
+                {title}
               </Text>
 
               <Spacer y={2} />
@@ -186,7 +188,7 @@ const HomeHeroUnitLarge: React.FC<React.PropsWithChildren<HomeHeroUnitProps>> = 
                 lineClamp={4}
                 variant={["xs", "sm-display", "lg-display"]}
               >
-                {heroUnit.body}
+                {body}
               </Text>
 
               <Spacer y={[2, 2, 4]} />
@@ -194,7 +196,7 @@ const HomeHeroUnitLarge: React.FC<React.PropsWithChildren<HomeHeroUnitProps>> = 
               <GridColumns>
                 <Column span={[12, 12, 6]}>
                   <Button variant="secondaryBlack" width="100%" tabIndex={-1}>
-                    {heroUnit.link.text}
+                    {link.text}
                   </Button>
                 </Column>
               </GridColumns>
@@ -203,6 +205,51 @@ const HomeHeroUnitLarge: React.FC<React.PropsWithChildren<HomeHeroUnitProps>> = 
         </Column>
       </GridColumns>
     </RouterLink>
+  )
+}
+
+export const HomeHeroUnitBase: React.FC<HomeHeroUnitBaseProps> = props => {
+  return (
+    <Box width="100%" height="100%">
+      <Media at="xs">
+        <HomeHeroUnitBaseSmall {...props} />
+      </Media>
+
+      <Media greaterThan="xs">
+        <HomeHeroUnitBaseLarge {...props} />
+      </Media>
+    </Box>
+  )
+}
+
+interface HomeHeroUnitProps {
+  heroUnit: HomeHeroUnit_heroUnit$data
+  index: number
+  onClick?: () => void
+}
+
+export const HomeHeroUnit: React.FC<HomeHeroUnitProps> = ({
+  heroUnit,
+  index,
+  onClick,
+}) => {
+  return (
+    <HomeHeroUnitBase
+      title={heroUnit.title}
+      body={heroUnit.body}
+      imageUrl={heroUnit.image?.imageURL}
+      credit={heroUnit.credit}
+      label={heroUnit.label}
+      link={{
+        text: heroUnit.link.text,
+        url: {
+          desktop: heroUnit.link.url,
+          mobile: heroUnit.link.url,
+        },
+      }}
+      index={index}
+      onClick={onClick}
+    />
   )
 }
 

--- a/src/Apps/Home/Components/HomeHeroUnits/HomeHeroUnitLoggedOut.tsx
+++ b/src/Apps/Home/Components/HomeHeroUnits/HomeHeroUnitLoggedOut.tsx
@@ -1,0 +1,48 @@
+import * as React from "react"
+import { HomeHeroUnitBase, HomeHeroUnitBaseProps } from "./HomeHeroUnit"
+import { useDeviceDetection } from "Utils/Hooks/useDeviceDetection"
+import { useFeatureVariant } from "System/Hooks/useFeatureFlag"
+
+export const HomeHeroUnitLoggedOut: React.FC<{ index: number }> = ({
+  index,
+}) => {
+  const { downloadAppUrl } = useDeviceDetection()
+
+  const variants: Record<string, Omit<HomeHeroUnitBaseProps, "index">> = {
+    control: {
+      title: "The art world online",
+      body:
+        "Artsy is the world’s leading platform to discover, buy, and manage the art you love",
+      imageUrl: "https://files.artsy.net/images/01_Artsy_App-Download-HP.jpg",
+      link: {
+        text: "Get the App",
+        url: { desktop: "/meet-your-new-art-advisor", mobile: downloadAppUrl },
+      },
+      credit: "France-Lise McGurn, 90s mirror, 2023. Margot Samel",
+    },
+    experiment: {
+      title: "Your guide to the art world",
+      body: "Artsy makes it easy to discover artists and artworks you’ll love",
+      imageUrl: "https://files.artsy.net/images/02_Artsy_App-Download-HP.jpg",
+      link: {
+        text: "Get the App",
+        url: { desktop: "/meet-your-new-art-advisor", mobile: downloadAppUrl },
+      },
+      credit: "Sam Gilliam, Annie, 2021. David Kordansky Gallery",
+    },
+  }
+
+  const featureVariant = useFeatureVariant("diamond_hero-app-download")
+  const variant = variants[featureVariant?.name || "control"]
+
+  return (
+    <HomeHeroUnitBase
+      title={variant.title}
+      body={variant.body}
+      imageUrl={variant.imageUrl}
+      link={variant.link}
+      index={index}
+      credit={variant.credit}
+    />
+  )
+}

--- a/src/Apps/Home/Components/HomeHeroUnits/HomeHeroUnits.tsx
+++ b/src/Apps/Home/Components/HomeHeroUnits/HomeHeroUnits.tsx
@@ -4,21 +4,28 @@ import { HomeHeroUnitFragmentContainer } from "./HomeHeroUnit"
 import { createFragmentContainer, graphql } from "react-relay"
 import { HomeHeroUnits_heroUnits$data } from "__generated__/HomeHeroUnits_heroUnits.graphql"
 import { extractNodes } from "Utils/extractNodes"
+import { useSystemContext } from "System/Hooks/useSystemContext"
+import { HomeHeroUnitLoggedOut } from "./HomeHeroUnitLoggedOut"
 
 interface HomeHeroUnitsProps {
   heroUnits: HomeHeroUnits_heroUnits$data
 }
 
-export const HomeHeroUnits: React.FC<React.PropsWithChildren<HomeHeroUnitsProps>> = ({ heroUnits }) => {
+export const HomeHeroUnits: React.FC<React.PropsWithChildren<
+  HomeHeroUnitsProps
+>> = ({ heroUnits }) => {
+  const { isLoggedIn } = useSystemContext()
   const nodes = extractNodes(heroUnits)
 
   return (
     <HeroCarousel>
+      {!isLoggedIn && <HomeHeroUnitLoggedOut index={0} />}
       {nodes.map((heroUnit, index) => {
         return (
           <HomeHeroUnitFragmentContainer
             heroUnit={heroUnit}
-            index={index}
+            // Increment index if we inserted the logged out unit
+            index={!isLoggedIn ? index + 1 : index}
             key={index}
           />
         )

--- a/src/Apps/Marketing/Components/MarketingHeader.tsx
+++ b/src/Apps/Marketing/Components/MarketingHeader.tsx
@@ -17,14 +17,12 @@ interface MarketingHeaderProps {
   subtitle: string
   src: string
   accentColor: string
+  children?: React.ReactNode
 }
 
-export const MarketingHeader: FC<React.PropsWithChildren<MarketingHeaderProps>> = ({
-  title,
-  subtitle,
-  src,
-  accentColor,
-}) => {
+export const MarketingHeader: FC<React.PropsWithChildren<
+  MarketingHeaderProps
+>> = ({ title, subtitle, src, accentColor, children }) => {
   const height = useFullBleedHeaderHeight()
 
   const images = {
@@ -54,7 +52,14 @@ export const MarketingHeader: FC<React.PropsWithChildren<MarketingHeaderProps>> 
 
               <Spacer y={[1, 2, 2, 4]} />
 
-              <Text variant="lg">{subtitle}</Text>
+              <Text
+                variant={["sm", "sm", "md", "md"]}
+                style={{ textWrap: "balance" }}
+              >
+                {subtitle}
+              </Text>
+
+              {children}
             </Column>
 
             <Column span={7} bg={accentColor} overflow="hidden">
@@ -88,6 +93,8 @@ export const MarketingHeader: FC<React.PropsWithChildren<MarketingHeaderProps>> 
             <Spacer y={0.5} />
 
             <Text variant="sm">{subtitle}</Text>
+
+            {children}
           </HorizontalPadding>
         </FullBleed>
       </Media>

--- a/src/Apps/Marketing/Components/MarketingHeaderSpitTest.tsx
+++ b/src/Apps/Marketing/Components/MarketingHeaderSpitTest.tsx
@@ -1,0 +1,62 @@
+import { Image, Spacer, Stack, Text } from "@artsy/palette"
+import { MarketingHeader } from "./MarketingHeader"
+import { Device, useDeviceDetection } from "Utils/Hooks/useDeviceDetection"
+import { useFeatureVariant } from "System/Hooks/useFeatureFlag"
+import { FC } from "react"
+
+export const MarketingHeaderSplitTest: FC = () => {
+  const { downloadAppUrl, device } = useDeviceDetection()
+
+  const variants = {
+    control: {
+      title: "The art world online",
+      subtitle:
+        "Artsy is the world's leading platform to discover, buy, and manage the art you love",
+      src:
+        "https://files.artsy.net/images/01_Artsy_App-Download-Landing-Page.jpg",
+    },
+    experiment: {
+      title: "Your guide to the art world",
+      subtitle:
+        "Artsy makes it easy to discover artists and artworks you'll love",
+      src:
+        "https://files.artsy.net/images/02_Artsy_App-Download-Landing-Page.jpg",
+    },
+  }
+
+  const featureVariant = useFeatureVariant("diamond_hero-app-download")
+  const variant = variants[featureVariant?.name || "control"]
+
+  return (
+    <MarketingHeader
+      title={variant.title}
+      subtitle={variant.subtitle}
+      src={variant.src}
+      accentColor={variant.accentColor}
+    >
+      <Spacer y={2} />
+
+      <Stack
+        as="a"
+        href={downloadAppUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        gap={2}
+        flexDirection="row"
+        alignItems="center"
+        style={{ textDecoration: "none" }}
+      >
+        {device === Device.Android && <Image src={ANDROID_QR_CODE} />}
+        {(device === Device.iPhone || device === Device.Unknown) && (
+          <Image src={APPLE_QR_CODE} width={66} height={66} />
+        )}
+
+        <Text variant={["sm", "sm", "md", "md"]}>Get the app</Text>
+      </Stack>
+    </MarketingHeader>
+  )
+}
+
+const APPLE_QR_CODE = "https://files.artsy.net/images/Artsy_App-Store_Apple.svg"
+const ANDROID_QR_CODE =
+  "https://files.artsy.net/images/Artsy_App-Store_Andriod.svg"

--- a/src/Apps/Marketing/Routes/MarketingMeetArtAdvisorRoute.tsx
+++ b/src/Apps/Marketing/Routes/MarketingMeetArtAdvisorRoute.tsx
@@ -8,13 +8,14 @@ import {
   Text,
 } from "@artsy/palette"
 import { MarketingAlternatingStack } from "Apps/Marketing/Components/MarketingAlternatingStack"
-import { MarketingHeader } from "Apps/Marketing/Components/MarketingHeader"
-import { BRAND_PALETTE } from "Apps/Marketing/Utils/brandPalette"
+import { MarketingHeaderSplitTest } from "Apps/Marketing/Components/MarketingHeaderSpitTest"
 import { MetaTags } from "Components/MetaTags"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import { FC } from "react"
 
-export const MarketingMeetArtAdvisorRoute: FC<React.PropsWithChildren<unknown>> = () => {
+export const MarketingMeetArtAdvisorRoute: FC<React.PropsWithChildren<
+  unknown
+>> = () => {
   const { isEigen } = useSystemContext()
 
   return (
@@ -25,12 +26,7 @@ export const MarketingMeetArtAdvisorRoute: FC<React.PropsWithChildren<unknown>> 
       />
 
       <Join separator={<Spacer y={6} />}>
-        <MarketingHeader
-          title="Meet your new art advisor."
-          subtitle="See what you can do on Artsy—the best tool for art collectors."
-          src="https://files.artsy.net/images/marketing_meet_header_april-14.jpg"
-          accentColor={BRAND_PALETTE.blue}
-        />
+        <MarketingHeaderSplitTest />
 
         <MarketingAlternatingStack
           cards={[


### PR DESCRIPTION
Closes [DIA-1030](https://artsyproduct.atlassian.net/browse/DIA-1030)

![](https://capture.static.damonzucconi.com/Screen-Shot-2024-12-13-08-45-13.81-c5E28UuPqVE2nSRS6weAe6OGJGjBCKA6W4bfGmf7amFxWqsvkliubHdNE3doGTWNWKnuCUS1nH0qT8EGCmDGiybtayalbwAYmF57.png)

-----

This uses the `diamond_hero-app-download` flag with a 50/50 split between `experiment` and `control` to display different copy and images.

We'll probably want to go in and replace the assets because they were exported incorrectly. They are passable for now and I can't fix it myself without the sources.

Draft until I get tracking details.