### PR TITLE
fix(router): Fix query param issue

### DIFF
--- a/src/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/__tests__/FeaturedCollectionsRails.jest.enzyme.tsx
+++ b/src/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/FeaturedCollectionsRails/__tests__/FeaturedCollectionsRails.jest.enzyme.tsx
@@ -13,6 +13,7 @@ jest.mock("react-tracking")
 jest.mock("found", () => ({
   Link: ({ children, ...props }) => <div {...props}>{children}</div>,
   RouterContext: jest.requireActual("found").RouterContext,
+  useRouter: jest.fn(),
 }))
 
 describe("FeaturedCollectionsRails", () => {

--- a/src/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/__tests__/OtherCollectionsRail.jest.enzyme.tsx
+++ b/src/Apps/Collect/Routes/Collection/Components/CollectionsHubRails/OtherCollectionsRail/__tests__/OtherCollectionsRail.jest.enzyme.tsx
@@ -20,6 +20,7 @@ jest.mock("react-tracking")
 jest.mock("found", () => ({
   Link: props => <div>{props.children}</div>,
   RouterContext: jest.requireActual("found").RouterContext,
+  useRouter: jest.fn(),
 }))
 
 describe("CollectionsRail", () => {

--- a/src/Apps/Home/Components/HomeHeroUnits/HomeHeroUnit.tsx
+++ b/src/Apps/Home/Components/HomeHeroUnits/HomeHeroUnit.tsx
@@ -24,7 +24,9 @@ interface HomeHeroUnitProps {
   onClick?: () => void
 }
 
-export const HomeHeroUnit: React.FC<React.PropsWithChildren<HomeHeroUnitProps>> = props => {
+export const HomeHeroUnit: React.FC<React.PropsWithChildren<
+  HomeHeroUnitProps
+>> = props => {
   return (
     <Box width="100%" height="100%">
       <Media at="xs">
@@ -38,11 +40,9 @@ export const HomeHeroUnit: React.FC<React.PropsWithChildren<HomeHeroUnitProps>> 
   )
 }
 
-const HomeHeroUnitSmall: React.FC<React.PropsWithChildren<HomeHeroUnitProps>> = ({
-  heroUnit,
-  index,
-  onClick,
-}) => {
+const HomeHeroUnitSmall: React.FC<React.PropsWithChildren<
+  HomeHeroUnitProps
+>> = ({ heroUnit, index, onClick }) => {
   const imageUrl = heroUnit.image?.imageURL
   const image = imageUrl && cropped(imageUrl, { width: 500, height: 333 })
   const href = getInternalHref(heroUnit.link.url)
@@ -95,11 +95,9 @@ const HomeHeroUnitSmall: React.FC<React.PropsWithChildren<HomeHeroUnitProps>> = 
   )
 }
 
-const HomeHeroUnitLarge: React.FC<React.PropsWithChildren<HomeHeroUnitProps>> = ({
-  heroUnit,
-  index,
-  onClick,
-}) => {
+const HomeHeroUnitLarge: React.FC<React.PropsWithChildren<
+  HomeHeroUnitProps
+>> = ({ heroUnit, index, onClick }) => {
   const imageUrl = heroUnit.image?.imageURL
   const image = imageUrl && cropped(imageUrl, { width: 1270, height: 500 })
   const href = getInternalHref(heroUnit.link.url)

--- a/src/Components/Rail/RailHeader.tsx
+++ b/src/Components/Rail/RailHeader.tsx
@@ -1,6 +1,8 @@
 import { Box, Flex, SkeletonText, Sup, Text as BaseText } from "@artsy/palette"
+import { useRouter } from "found"
 import * as React from "react"
 import { RouterLink } from "System/Components/RouterLink"
+import { getENV } from "Utils/getENV"
 import { getInternalHref } from "Utils/url"
 
 export interface RailHeaderProps {
@@ -45,9 +47,7 @@ export const RailHeader: React.FC<React.PropsWithChildren<RailHeaderProps>> = ({
 
   const showViewAll = Boolean(viewAllLabel && _viewAllHref)
 
-  // FIXME: Understand what this does. disabling because query params are
-  // breaking slugID parsing on auctions pages and that's bad.
-  // const viewAllHref = useReturnTo(_viewAllHref)
+  const viewAllHref = useReturnTo(_viewAllHref)
 
   return (
     <Flex justifyContent="space-between" alignItems="center">
@@ -61,7 +61,7 @@ export const RailHeader: React.FC<React.PropsWithChildren<RailHeaderProps>> = ({
         >
           <RailHeaderTitle
             title={title}
-            viewAllHref={_viewAllHref}
+            viewAllHref={viewAllHref}
             viewAllOnClick={viewAllOnClick}
           />{" "}
           {countLabel && countLabel > 1 && (
@@ -90,7 +90,7 @@ export const RailHeader: React.FC<React.PropsWithChildren<RailHeaderProps>> = ({
           flexShrink={0}
           // @ts-ignore
           as={RouterLink}
-          to={_viewAllHref}
+          to={viewAllHref}
           onClick={viewAllOnClick}
         >
           {viewAllLabel}
@@ -100,14 +100,12 @@ export const RailHeader: React.FC<React.PropsWithChildren<RailHeaderProps>> = ({
   )
 }
 
-// FIXME; Reenable once we understand what this does
-/**
 const useReturnTo = (href?: string | null): string | null => {
   const router = useRouter()
 
   if (!href) return null
 
-  const referrer = router.match?.location?.pathname
+  const referrer = router?.match?.location?.pathname
 
   if (!referrer) return href
 
@@ -120,4 +118,3 @@ const useReturnTo = (href?: string | null): string | null => {
     return href
   }
 }
-*/

--- a/src/System/Components/RouterLink.tsx
+++ b/src/System/Components/RouterLink.tsx
@@ -89,12 +89,17 @@ export const RouterLink: React.FC<React.PropsWithChildren<
       }
     }
 
+    const location = router?.createLocation?.((to as string) ?? "") ?? {
+      pathname: to,
+      query: {},
+    }
+
     if (isRouterAware) {
       return (
         <RouterAwareLink
           inline={inline}
           to={{
-            pathname: to ?? "",
+            ...location,
             state: { isPrefetched },
           }}
           onMouseOver={handleMouseOver}


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Un-applies https://github.com/artsy/force/pull/14984 and then fixes the underlying issue, which originated in https://github.com/artsy/force/pull/14962. We weren't passing query params across the route in the way that was required.

(Though one would assume passing a string with query params would be sufficient, as a pathname. But no -- pathname is pathname, and query is query, and search is search. When expanding the location (`to`) it expects a full location descriptor which encodes all the props.) 

https://github.com/user-attachments/assets/0cde56a8-3101-4025-b797-45ccefb11810

cc @artsy/diamond-devs 