### PR TITLE
revert(router): Hand revert #14962 =>  'dont lazy load artist artworks grid' 

### DIFF
--- a/src/Apps/Artist/Routes/WorksForSale/Utils/getWorksForSaleRouteVariables.ts
+++ b/src/Apps/Artist/Routes/WorksForSale/Utils/getWorksForSaleRouteVariables.ts
@@ -26,8 +26,5 @@ export function getWorksForSaleRouteVariables({ artistID }, { location }) {
     aggregations,
     artistID,
     includeBlurHash: false,
-    // If the route was prefetched, we want `isPrefetched: true` so the query
-    // can be resolved immediately w/ the already-fetched variables.
-    isPrefetched: !!location?.state?.isPrefetched,
   }
 }

--- a/src/Apps/Artist/artistRoutes.tsx
+++ b/src/Apps/Artist/artistRoutes.tsx
@@ -138,17 +138,9 @@ export const artistRoutes: RouteProps[] = [
         },
         prepareVariables: getWorksForSaleRouteVariables,
         query: graphql`
-          query artistRoutes_WorksForSaleQuery(
-            $artistID: String!
-            $isPrefetched: Boolean!
-            $aggregations: [ArtworkAggregation]
-          ) {
+          query artistRoutes_WorksForSaleQuery($artistID: String!) {
             artist(id: $artistID) @principalField {
               ...ArtistWorksForSaleRoute_artist
-                @arguments(
-                  isPrefetched: $isPrefetched
-                  aggregations: $aggregations
-                )
             }
           }
         `,

--- a/src/Components/Rail/RailHeader.tsx
+++ b/src/Components/Rail/RailHeader.tsx
@@ -1,6 +1,8 @@
 import { Box, Flex, SkeletonText, Sup, Text as BaseText } from "@artsy/palette"
+import { useRouter } from "found"
 import * as React from "react"
 import { RouterLink } from "System/Components/RouterLink"
+import { getENV } from "Utils/getENV"
 import { getInternalHref } from "Utils/url"
 
 export interface RailHeaderProps {
@@ -45,9 +47,7 @@ export const RailHeader: React.FC<React.PropsWithChildren<RailHeaderProps>> = ({
 
   const showViewAll = Boolean(viewAllLabel && _viewAllHref)
 
-  // FIXME: Understand what this does. disabling because query params are
-  // breaking slugID parsing on auctions pages and that's bad.
-  // const viewAllHref = useReturnTo(_viewAllHref)
+  const viewAllHref = useReturnTo(_viewAllHref)
 
   return (
     <Flex justifyContent="space-between" alignItems="center">
@@ -61,7 +61,7 @@ export const RailHeader: React.FC<React.PropsWithChildren<RailHeaderProps>> = ({
         >
           <RailHeaderTitle
             title={title}
-            viewAllHref={_viewAllHref}
+            viewAllHref={viewAllHref}
             viewAllOnClick={viewAllOnClick}
           />{" "}
           {countLabel && countLabel > 1 && (
@@ -90,7 +90,7 @@ export const RailHeader: React.FC<React.PropsWithChildren<RailHeaderProps>> = ({
           flexShrink={0}
           // @ts-ignore
           as={RouterLink}
-          to={_viewAllHref}
+          to={viewAllHref}
           onClick={viewAllOnClick}
         >
           {viewAllLabel}
@@ -100,8 +100,6 @@ export const RailHeader: React.FC<React.PropsWithChildren<RailHeaderProps>> = ({
   )
 }
 
-// FIXME; Reenable once we understand what this does
-/**
 const useReturnTo = (href?: string | null): string | null => {
   const router = useRouter()
 
@@ -120,4 +118,3 @@ const useReturnTo = (href?: string | null): string | null => {
     return href
   }
 }
-*/

--- a/src/System/Components/RouterLink.tsx
+++ b/src/System/Components/RouterLink.tsx
@@ -52,12 +52,7 @@ export const RouterLink: React.FC<React.PropsWithChildren<
     const isPrefetchOnEnterEnabled =
       isPrefetchOnEnterEnabledLoggedIn || isPrefetchOnEnterEnabledLoggedOut
 
-    // When a prefetch is completed, propagate that in the router state.
-    const [isPrefetched, setIsPrefetched] = React.useState(false)
-    const { prefetch } = usePrefetchRoute({
-      initialPath: to as string,
-      onComplete: () => setIsPrefetched(true),
-    })
+    const { prefetch } = usePrefetchRoute(to as string)
 
     const routes = router?.matcher?.routeConfig ?? []
     const matcher = router?.matcher
@@ -93,10 +88,7 @@ export const RouterLink: React.FC<React.PropsWithChildren<
       return (
         <RouterAwareLink
           inline={inline}
-          to={{
-            pathname: to ?? "",
-            state: { isPrefetched },
-          }}
+          to={to ?? ""}
           onMouseOver={handleMouseOver}
           ref={isPrefetchOnEnterEnabled ? (intersectionRef as any) : null}
           {...rest}

--- a/src/System/Components/__tests__/RouterLink.jest.tsx
+++ b/src/System/Components/__tests__/RouterLink.jest.tsx
@@ -9,7 +9,7 @@ jest.mock("System/Router/Utils/shouldUpdateScroll", () => ({
 
 jest.mock("found", () => ({
   ...jest.requireActual("found"),
-  Link: ({ to }) => (to.pathname === "/foo" ? "FooLink" : "Link"),
+  Link: ({ to }) => (to === "/foo" ? "FooLink" : "Link"),
 }))
 
 jest.mock("Components/NavBar/NavBar", () => ({

--- a/src/System/Hooks/__tests__/usePrefetchRoute.jest.tsx
+++ b/src/System/Hooks/__tests__/usePrefetchRoute.jest.tsx
@@ -43,9 +43,7 @@ describe("usePrefetchRoute", () => {
 
   it("should return null if prefetchDisabled is true", () => {
     mockUseRouter.mockReturnValueOnce({ match: { elements: null } })
-    const { result } = renderHook(() =>
-      usePrefetchRoute({ initialPath: "/test-path" })
-    )
+    const { result } = renderHook(() => usePrefetchRoute("/test-path"))
     expect(result.current.prefetch()).toBeNull()
   })
 
@@ -71,9 +69,7 @@ describe("usePrefetchRoute", () => {
       subscribe: jest.fn(() => mockSubscription),
     })
 
-    const { result } = renderHook(() =>
-      usePrefetchRoute({ initialPath: "/foo/bar" })
-    )
+    const { result } = renderHook(() => usePrefetchRoute("/foo/bar"))
 
     const subscriptions = result.current.prefetch()
     expect(subscriptions).toHaveLength(1)
@@ -81,7 +77,7 @@ describe("usePrefetchRoute", () => {
     expect(mockFetchQuery).toHaveBeenCalledWith(
       mockEnvironment,
       "TestQuery",
-      { id: "bar", isPrefetched: true },
+      { id: "bar" },
       expect.anything()
     )
   })
@@ -111,7 +107,7 @@ describe("usePrefetchRoute", () => {
     expect(mockFetchQuery).toHaveBeenCalledWith(
       mockEnvironment,
       "TestQuery",
-      { id: "bar", isPrefetched: true },
+      { id: "bar" },
       expect.anything()
     )
   })
@@ -135,9 +131,7 @@ describe("usePrefetchRoute", () => {
 
     console.error = jest.fn()
 
-    const { result } = renderHook(() =>
-      usePrefetchRoute({ initialPath: "/foo/bar" })
-    )
+    const { result } = renderHook(() => usePrefetchRoute("/foo/bar"))
     result.current.prefetch()
 
     expect(console.error).toHaveBeenCalledWith(
@@ -169,9 +163,7 @@ describe("usePrefetchRoute", () => {
 
     console.log = jest.fn()
 
-    const { result } = renderHook(() =>
-      usePrefetchRoute({ initialPath: "/foo/bar" })
-    )
+    const { result } = renderHook(() => usePrefetchRoute("/foo/bar"))
     result.current.prefetch()
 
     expect(console.log).toHaveBeenCalledWith(
@@ -182,29 +174,6 @@ describe("usePrefetchRoute", () => {
       "[usePrefetchRoute] Completed:",
       "/foo/bar"
     )
-  })
-
-  it("should call onComplete callback when prefetch is complete", () => {
-    const mockRoute = {
-      match: { params: { id: "bar" } },
-      route: {
-        path: "/foo/:id",
-        query: "TestQuery",
-      },
-    }
-
-    mockFindRoutesByPath.mockReturnValue([mockRoute])
-    mockTake.mockReturnValue([mockRoute])
-    console.log = jest.fn()
-
-    const onComplete = jest.fn()
-
-    const { result } = renderHook(() =>
-      usePrefetchRoute({ initialPath: "/foo/bar", onComplete })
-    )
-    result.current.prefetch()
-
-    expect(onComplete).toHaveBeenCalled()
   })
 
   it("should pass along route TTLs to fetchQuery metadata", () => {
@@ -222,15 +191,13 @@ describe("usePrefetchRoute", () => {
     mockTake.mockReturnValue([mockRoute])
     console.log = jest.fn()
 
-    const { result } = renderHook(() =>
-      usePrefetchRoute({ initialPath: "/foo/bar" })
-    )
+    const { result } = renderHook(() => usePrefetchRoute("/foo/bar"))
     result.current.prefetch()
 
     expect(mockFetchQuery).toHaveBeenCalledWith(
       {},
       "TestQuery",
-      { id: "bar", isPrefetched: true },
+      { id: "bar" },
       {
         fetchPolicy: "store-or-network",
         networkCacheConfig: { force: false, metadata: { maxAge: 1000 } },

--- a/src/System/Hooks/usePrefetchRoute.tsx
+++ b/src/System/Hooks/usePrefetchRoute.tsx
@@ -8,17 +8,9 @@ import { useSystemContext } from "System/Hooks/useSystemContext"
 import { findRoutesByPath } from "System/Router/Utils/routeUtils"
 import { isDevelopment } from "Utils/device"
 
-interface UsePrefetchRouteProps {
+export const usePrefetchRoute = (
   initialPath?: string
-  onComplete?: () => void
-}
-
-export const usePrefetchRoute = ({
-  initialPath,
-  onComplete,
-}: UsePrefetchRouteProps = {}): {
-  prefetch: (path?: string) => Array<Subscription | null> | null
-} => {
+): { prefetch: (path?: string) => Array<Subscription | null> | null } => {
   const { relayEnvironment } = useSystemContext()
 
   const { match } = useRouter()
@@ -68,25 +60,19 @@ export const usePrefetchRoute = ({
           return null
         }
 
-        const subscription = fetchQuery(
-          relayEnvironment,
-          query,
-          { ...variables, isPrefetched: true }, // Inject a variable to indicate this is a prefetch
-          {
-            fetchPolicy: "store-or-network",
-            networkCacheConfig: {
-              force: false,
-              metadata: {
-                maxAge: serverCacheTTL,
-              },
+        const subscription = fetchQuery(relayEnvironment, query, variables, {
+          fetchPolicy: "store-or-network",
+          networkCacheConfig: {
+            force: false,
+            metadata: {
+              maxAge: serverCacheTTL,
             },
-          }
-        ).subscribe({
+          },
+        }).subscribe({
           start: () => {
             if (isDevelopment) {
               console.log("[usePrefetchRoute] Starting prefetch:", path)
             }
-
             // Prefetch bundle split JS alongside data, if defined
             foundRoute.route.onPreloadJS?.()
           },
@@ -94,14 +80,11 @@ export const usePrefetchRoute = ({
             if (isDevelopment) {
               console.log("[usePrefetchRoute] Completed:", path)
             }
-
-            onComplete?.()
           },
           error: () => {
             console.error("[usePrefetchRoute] Error prefetching:", path)
           },
         })
-
         return subscription
       })
 

--- a/src/__generated__/ArtistWorksForSaleRoute_artist.graphql.ts
+++ b/src/__generated__/ArtistWorksForSaleRoute_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4e0529a6ff76ab04b2327c23812debb0>>
+ * @generated SignedSource<<b7e14378138a293120d777e914709647>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,28 +9,14 @@
 // @ts-nocheck
 
 import { ReaderFragment } from 'relay-runtime';
-export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ARTIST_SERIES" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "LOCATION_CITY" | "MAJOR_PERIOD" | "MATERIALS_TERMS" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "SIMPLE_PRICE_HISTOGRAM" | "TOTAL" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type ArtistWorksForSaleRoute_artist$data = {
   readonly meta: {
     readonly description: string;
     readonly title: string;
   };
-  readonly sidebarAggregations?: {
-    readonly aggregations: ReadonlyArray<{
-      readonly counts: ReadonlyArray<{
-        readonly count: number;
-        readonly name: string;
-        readonly value: string;
-      } | null | undefined> | null | undefined;
-      readonly slice: ArtworkAggregation | null | undefined;
-    } | null | undefined> | null | undefined;
-    readonly counts: {
-      readonly total: any | null | undefined;
-    } | null | undefined;
-  } | null | undefined;
   readonly slug: string;
-  readonly " $fragmentSpreads": FragmentRefs<"ArtistArtworkFilter_artist" | "ArtistWorksForSaleEmpty_artist">;
+  readonly " $fragmentSpreads": FragmentRefs<"ArtistWorksForSaleEmpty_artist">;
   readonly " $fragmentType": "ArtistWorksForSaleRoute_artist";
 };
 export type ArtistWorksForSaleRoute_artist$key = {
@@ -39,124 +25,11 @@ export type ArtistWorksForSaleRoute_artist$key = {
 };
 
 const node: ReaderFragment = {
-  "argumentDefinitions": [
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "aggregations"
-    },
-    {
-      "defaultValue": false,
-      "kind": "LocalArgument",
-      "name": "isPrefetched"
-    }
-  ],
+  "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
   "name": "ArtistWorksForSaleRoute_artist",
   "selections": [
-    {
-      "condition": "isPrefetched",
-      "kind": "Condition",
-      "passingValue": true,
-      "selections": [
-        {
-          "args": null,
-          "kind": "FragmentSpread",
-          "name": "ArtistArtworkFilter_artist"
-        },
-        {
-          "alias": "sidebarAggregations",
-          "args": [
-            {
-              "kind": "Variable",
-              "name": "aggregations",
-              "variableName": "aggregations"
-            },
-            {
-              "kind": "Literal",
-              "name": "first",
-              "value": 1
-            }
-          ],
-          "concreteType": "FilterArtworksConnection",
-          "kind": "LinkedField",
-          "name": "filterArtworksConnection",
-          "plural": false,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "concreteType": "FilterArtworksCounts",
-              "kind": "LinkedField",
-              "name": "counts",
-              "plural": false,
-              "selections": [
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "total",
-                  "storageKey": null
-                }
-              ],
-              "storageKey": null
-            },
-            {
-              "alias": null,
-              "args": null,
-              "concreteType": "ArtworksAggregationResults",
-              "kind": "LinkedField",
-              "name": "aggregations",
-              "plural": true,
-              "selections": [
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "slice",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "concreteType": "AggregationCount",
-                  "kind": "LinkedField",
-                  "name": "counts",
-                  "plural": true,
-                  "selections": [
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "name",
-                      "storageKey": null
-                    },
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "value",
-                      "storageKey": null
-                    },
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "count",
-                      "storageKey": null
-                    }
-                  ],
-                  "storageKey": null
-                }
-              ],
-              "storageKey": null
-            }
-          ],
-          "storageKey": null
-        }
-      ]
-    },
     {
       "args": null,
       "kind": "FragmentSpread",
@@ -205,6 +78,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "2c8c6a3fb495ca2922aae8991575ce6c";
+(node as any).hash = "56ace60bb345662cc4e015388f66be28";
 
 export default node;

--- a/src/__generated__/artistRoutes_WorksForSaleQuery.graphql.ts
+++ b/src/__generated__/artistRoutes_WorksForSaleQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e7e63f83207b256c094a43437dffa37a>>
+ * @generated SignedSource<<60e473dda8cec1e4992263fb1c66a041>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,11 +10,8 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ARTIST_SERIES" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "LOCATION_CITY" | "MAJOR_PERIOD" | "MATERIALS_TERMS" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "SIMPLE_PRICE_HISTOGRAM" | "TOTAL" | "%future added value";
 export type artistRoutes_WorksForSaleQuery$variables = {
-  aggregations?: ReadonlyArray<ArtworkAggregation | null | undefined> | null | undefined;
   artistID: string;
-  isPrefetched: boolean;
 };
 export type artistRoutes_WorksForSaleQuery$data = {
   readonly artist: {
@@ -27,180 +24,37 @@ export type artistRoutes_WorksForSaleQuery = {
 };
 
 const node: ConcreteRequest = (function(){
-var v0 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "aggregations"
-},
-v1 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "artistID"
-},
-v2 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "isPrefetched"
-},
-v3 = [
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "artistID"
+  }
+],
+v1 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "artistID"
   }
-],
-v4 = {
-  "kind": "Variable",
-  "name": "aggregations",
-  "variableName": "aggregations"
-},
-v5 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v6 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-},
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "slug",
-  "storageKey": null
-},
-v8 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "title",
-  "storageKey": null
-},
-v9 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v10 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "cursor",
-  "storageKey": null
-},
-v11 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "page",
-  "storageKey": null
-},
-v12 = [
-  (v10/*: any*/),
-  (v11/*: any*/),
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "isCurrent",
-    "storageKey": null
-  }
-],
-v13 = [
-  (v9/*: any*/)
-],
-v14 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "href",
-  "storageKey": null
-},
-v15 = {
-  "kind": "Literal",
-  "name": "version",
-  "value": [
-    "larger",
-    "large"
-  ]
-},
-v16 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "endAt",
-  "storageKey": null
-},
-v17 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "display",
-    "storageKey": null
-  }
-],
-v18 = [
-  {
-    "kind": "Literal",
-    "name": "shallow",
-    "value": true
-  }
-],
-v19 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "lotID",
-  "storageKey": null
-},
-v20 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "extendedBiddingEndAt",
-  "storageKey": null
-},
-v21 = [
-  (v6/*: any*/),
-  (v9/*: any*/)
 ];
 return {
   "fragment": {
-    "argumentDefinitions": [
-      (v0/*: any*/),
-      (v1/*: any*/),
-      (v2/*: any*/)
-    ],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "artistRoutes_WorksForSaleQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v3/*: any*/),
+        "args": (v1/*: any*/),
         "concreteType": "Artist",
         "kind": "LinkedField",
         "name": "artist",
         "plural": false,
         "selections": [
           {
-            "args": [
-              (v4/*: any*/),
-              {
-                "kind": "Variable",
-                "name": "isPrefetched",
-                "variableName": "isPrefetched"
-              }
-            ],
+            "args": null,
             "kind": "FragmentSpread",
             "name": "ArtistWorksForSaleRoute_artist"
           }
@@ -213,25 +67,39 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": [
-      (v1/*: any*/),
-      (v2/*: any*/),
-      (v0/*: any*/)
-    ],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "artistRoutes_WorksForSaleQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v3/*: any*/),
+        "args": (v1/*: any*/),
         "concreteType": "Artist",
         "kind": "LinkedField",
         "name": "artist",
         "plural": false,
         "selections": [
-          (v5/*: any*/),
-          (v6/*: any*/),
-          (v7/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "internalID",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
           {
             "alias": null,
             "args": [
@@ -253,834 +121,22 @@ return {
                 "name": "description",
                 "storageKey": null
               },
-              (v8/*: any*/)
-            ],
-            "storageKey": "meta(page:\"ARTWORKS\")"
-          },
-          (v9/*: any*/),
-          {
-            "condition": "isPrefetched",
-            "kind": "Condition",
-            "passingValue": true,
-            "selections": [
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "ArtistCounts",
-                "kind": "LinkedField",
-                "name": "counts",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": "partner_shows",
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "partnerShows",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": "for_sale_artworks",
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "forSaleArtworks",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": "ecommerce_artworks",
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "ecommerceArtworks",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": "auction_artworks",
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "auctionArtworks",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "artworks",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": "has_make_offer_artworks",
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "hasMakeOfferArtworks",
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
-              {
-                "alias": "filtered_artworks",
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "first",
-                    "value": 30
-                  }
-                ],
-                "concreteType": "FilterArtworksConnection",
-                "kind": "LinkedField",
-                "name": "filterArtworksConnection",
-                "plural": false,
-                "selections": [
-                  (v9/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "FilterArtworksCounts",
-                    "kind": "LinkedField",
-                    "name": "counts",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "format",
-                            "value": "0,0"
-                          }
-                        ],
-                        "kind": "ScalarField",
-                        "name": "total",
-                        "storageKey": "total(format:\"0,0\")"
-                      }
-                    ],
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "PageInfo",
-                    "kind": "LinkedField",
-                    "name": "pageInfo",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "hasNextPage",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "endCursor",
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "PageCursors",
-                    "kind": "LinkedField",
-                    "name": "pageCursors",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "PageCursor",
-                        "kind": "LinkedField",
-                        "name": "around",
-                        "plural": true,
-                        "selections": (v12/*: any*/),
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "PageCursor",
-                        "kind": "LinkedField",
-                        "name": "first",
-                        "plural": false,
-                        "selections": (v12/*: any*/),
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "PageCursor",
-                        "kind": "LinkedField",
-                        "name": "last",
-                        "plural": false,
-                        "selections": (v12/*: any*/),
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "PageCursor",
-                        "kind": "LinkedField",
-                        "name": "previous",
-                        "plural": false,
-                        "selections": [
-                          (v10/*: any*/),
-                          (v11/*: any*/)
-                        ],
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "FilterArtworksEdge",
-                    "kind": "LinkedField",
-                    "name": "edges",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Artwork",
-                        "kind": "LinkedField",
-                        "name": "node",
-                        "plural": false,
-                        "selections": (v13/*: any*/),
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  },
-                  {
-                    "kind": "InlineFragment",
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": null,
-                        "kind": "LinkedField",
-                        "name": "edges",
-                        "plural": true,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "__typename",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "Artwork",
-                            "kind": "LinkedField",
-                            "name": "node",
-                            "plural": false,
-                            "selections": [
-                              (v7/*: any*/),
-                              (v14/*: any*/),
-                              (v5/*: any*/),
-                              {
-                                "alias": null,
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "includeAll",
-                                    "value": false
-                                  }
-                                ],
-                                "concreteType": "Image",
-                                "kind": "LinkedField",
-                                "name": "image",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "aspectRatio",
-                                    "storageKey": null
-                                  },
-                                  (v5/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "placeholder",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": [
-                                      (v15/*: any*/)
-                                    ],
-                                    "kind": "ScalarField",
-                                    "name": "url",
-                                    "storageKey": "url(version:[\"larger\",\"large\"])"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "versions",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "blurhashDataURL",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": [
-                                      (v15/*: any*/),
-                                      {
-                                        "kind": "Literal",
-                                        "name": "width",
-                                        "value": 445
-                                      }
-                                    ],
-                                    "concreteType": "ResizedImageUrl",
-                                    "kind": "LinkedField",
-                                    "name": "resized",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "src",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "srcSet",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "width",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "height",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": "resized(version:[\"larger\",\"large\"],width:445)"
-                                  }
-                                ],
-                                "storageKey": "image(includeAll:false)"
-                              },
-                              (v8/*: any*/),
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "imageTitle",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "artistNames",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "date",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "CollectorSignals",
-                                "kind": "LinkedField",
-                                "name": "collectorSignals",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "primaryLabel",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "AuctionCollectorSignals",
-                                    "kind": "LinkedField",
-                                    "name": "auction",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "bidCount",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "lotClosesAt",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "liveBiddingStarted",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "registrationEndsAt",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "onlineBiddingExtended",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "PartnerOfferToCollector",
-                                    "kind": "LinkedField",
-                                    "name": "partnerOffer",
-                                    "plural": false,
-                                    "selections": [
-                                      (v16/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "Money",
-                                        "kind": "LinkedField",
-                                        "name": "priceWithDiscount",
-                                        "plural": false,
-                                        "selections": (v17/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      (v9/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": null
-                              },
-                              {
-                                "alias": "sale_message",
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "saleMessage",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": "cultural_maker",
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "culturalMaker",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": (v18/*: any*/),
-                                "concreteType": "Artist",
-                                "kind": "LinkedField",
-                                "name": "artist",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "ArtistTargetSupply",
-                                    "kind": "LinkedField",
-                                    "name": "targetSupply",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isP1",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  (v9/*: any*/)
-                                ],
-                                "storageKey": "artist(shallow:true)"
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "ArtworkPriceInsights",
-                                "kind": "LinkedField",
-                                "name": "marketPriceInsights",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "demandRank",
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": (v18/*: any*/),
-                                "concreteType": "Artist",
-                                "kind": "LinkedField",
-                                "name": "artists",
-                                "plural": true,
-                                "selections": [
-                                  (v9/*: any*/),
-                                  (v14/*: any*/),
-                                  (v6/*: any*/)
-                                ],
-                                "storageKey": "artists(shallow:true)"
-                              },
-                              {
-                                "alias": "collecting_institution",
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "collectingInstitution",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": (v18/*: any*/),
-                                "concreteType": "Partner",
-                                "kind": "LinkedField",
-                                "name": "partner",
-                                "plural": false,
-                                "selections": [
-                                  (v6/*: any*/),
-                                  (v14/*: any*/),
-                                  (v9/*: any*/)
-                                ],
-                                "storageKey": "partner(shallow:true)"
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "Sale",
-                                "kind": "LinkedField",
-                                "name": "sale",
-                                "plural": false,
-                                "selections": [
-                                  (v16/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "cascadingEndTimeIntervalMinutes",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "extendedBiddingIntervalMinutes",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "startAt",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "is_auction",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isAuction",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "is_closed",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isClosed",
-                                    "storageKey": null
-                                  },
-                                  (v9/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isOpen",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "extendedBiddingPeriodMinutes",
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": null
-                              },
-                              {
-                                "alias": "sale_artwork",
-                                "args": null,
-                                "concreteType": "SaleArtwork",
-                                "kind": "LinkedField",
-                                "name": "saleArtwork",
-                                "plural": false,
-                                "selections": [
-                                  (v19/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "lotLabel",
-                                    "storageKey": null
-                                  },
-                                  (v16/*: any*/),
-                                  (v20/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "formattedEndDateTime",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "SaleArtworkCounts",
-                                    "kind": "LinkedField",
-                                    "name": "counts",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": "bidder_positions",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "bidderPositions",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "highest_bid",
-                                    "args": null,
-                                    "concreteType": "SaleArtworkHighestBid",
-                                    "kind": "LinkedField",
-                                    "name": "highestBid",
-                                    "plural": false,
-                                    "selections": (v17/*: any*/),
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "opening_bid",
-                                    "args": null,
-                                    "concreteType": "SaleArtworkOpeningBid",
-                                    "kind": "LinkedField",
-                                    "name": "openingBid",
-                                    "plural": false,
-                                    "selections": (v17/*: any*/),
-                                    "storageKey": null
-                                  },
-                                  (v9/*: any*/)
-                                ],
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "SaleArtwork",
-                                "kind": "LinkedField",
-                                "name": "saleArtwork",
-                                "plural": false,
-                                "selections": [
-                                  (v19/*: any*/),
-                                  (v9/*: any*/),
-                                  (v16/*: any*/),
-                                  (v20/*: any*/)
-                                ],
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "AttributionClass",
-                                "kind": "LinkedField",
-                                "name": "attributionClass",
-                                "plural": false,
-                                "selections": (v21/*: any*/),
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "ArtworkMedium",
-                                "kind": "LinkedField",
-                                "name": "mediumType",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Gene",
-                                    "kind": "LinkedField",
-                                    "name": "filterGene",
-                                    "plural": false,
-                                    "selections": (v21/*: any*/),
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "isUnlisted",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": "image_title",
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "imageTitle",
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          },
-                          {
-                            "kind": "InlineFragment",
-                            "selections": (v13/*: any*/),
-                            "type": "Node",
-                            "abstractKey": "__isNode"
-                          }
-                        ],
-                        "storageKey": null
-                      }
-                    ],
-                    "type": "ArtworkConnectionInterface",
-                    "abstractKey": "__isArtworkConnectionInterface"
-                  }
-                ],
-                "storageKey": "filterArtworksConnection(first:30)"
-              },
-              {
-                "alias": "sidebarAggregations",
-                "args": [
-                  (v4/*: any*/),
-                  {
-                    "kind": "Literal",
-                    "name": "first",
-                    "value": 1
-                  }
-                ],
-                "concreteType": "FilterArtworksConnection",
-                "kind": "LinkedField",
-                "name": "filterArtworksConnection",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "FilterArtworksCounts",
-                    "kind": "LinkedField",
-                    "name": "counts",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "total",
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "ArtworksAggregationResults",
-                    "kind": "LinkedField",
-                    "name": "aggregations",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "slice",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "AggregationCount",
-                        "kind": "LinkedField",
-                        "name": "counts",
-                        "plural": true,
-                        "selections": [
-                          (v6/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "value",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "count",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  },
-                  (v9/*: any*/)
-                ],
+                "kind": "ScalarField",
+                "name": "title",
                 "storageKey": null
               }
-            ]
+            ],
+            "storageKey": "meta(page:\"ARTWORKS\")"
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
           }
         ],
         "storageKey": null
@@ -1088,16 +144,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a26d12f0aced10f510137e79dc28633b",
+    "cacheID": "5623c26ede9cc7e86d5a8249bef95bc7",
     "id": null,
     "metadata": {},
     "name": "artistRoutes_WorksForSaleQuery",
     "operationKind": "query",
-    "text": "query artistRoutes_WorksForSaleQuery(\n  $artistID: String!\n  $isPrefetched: Boolean!\n  $aggregations: [ArtworkAggregation]\n) {\n  artist(id: $artistID) @principalField {\n    ...ArtistWorksForSaleRoute_artist_1uAUE9\n    id\n  }\n}\n\nfragment ArtistArtworkFilter_artist on Artist {\n  name\n  counts {\n    partner_shows: partnerShows\n    for_sale_artworks: forSaleArtworks\n    ecommerce_artworks: ecommerceArtworks\n    auction_artworks: auctionArtworks\n    artworks\n    has_make_offer_artworks: hasMakeOfferArtworks\n  }\n  filtered_artworks: filterArtworksConnection(first: 30) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n  internalID\n  slug\n}\n\nfragment ArtistWorksForSaleEmpty_artist on Artist {\n  internalID\n  name\n}\n\nfragment ArtistWorksForSaleRoute_artist_1uAUE9 on Artist {\n  ...ArtistArtworkFilter_artist @include(if: $isPrefetched)\n  sidebarAggregations: filterArtworksConnection(aggregations: $aggregations, first: 1) @include(if: $isPrefetched) {\n    counts {\n      total\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  ...ArtistWorksForSaleEmpty_artist\n  slug\n  meta(page: ARTWORKS) {\n    description\n    title\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n"
+    "text": "query artistRoutes_WorksForSaleQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) @principalField {\n    ...ArtistWorksForSaleRoute_artist\n    id\n  }\n}\n\nfragment ArtistWorksForSaleEmpty_artist on Artist {\n  internalID\n  name\n}\n\nfragment ArtistWorksForSaleRoute_artist on Artist {\n  ...ArtistWorksForSaleEmpty_artist\n  slug\n  meta(page: ARTWORKS) {\n    description\n    title\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "d31e75d5917d7087399f1ff654330366";
+(node as any).hash = "875716fecee7260100706e351b5dce01";
 
 export default node;


### PR DESCRIPTION
The type of this PR is: **Revert**

Note: https://github.com/artsy/force/pull/14989 is the right way to do this without reverting, but i can't figure out why tests are breaking in a timely way for the seriousness of this bug, so hand reverting https://github.com/artsy/force/pull/14962 for the time being. Lets revert this once #14989 is figured out. 

