### PR TITLE
feat: demonstrate propagating the CDN cache status of artist route queries

### DIFF
--- a/src/Apps/Artist/ArtistApp.tsx
+++ b/src/Apps/Artist/ArtistApp.tsx
@@ -7,15 +7,26 @@ import { RouteTab, RouteTabs } from "Components/RouteTabs"
 import { ArtistMetaFragmentContainer } from "./Components/ArtistMeta/ArtistMeta"
 import { useScrollToOpenArtistAuthModal } from "Utils/Hooks/useScrollToOpenArtistAuthModal"
 import { Jump } from "Utils/Hooks/useJump"
+import { getContext } from "Server/middleware/bootstrapSharifyAndContextLocalsMiddleware"
+import { cdnCacheStatusCacheKey } from "System/Relay/middleware/cdnCacheStatusMiddleware"
+import { Match } from "found"
 
 interface ArtistAppProps {
   artist: ArtistApp_artist$data
+  match: Match
 }
 
 const ArtistApp: React.FC<React.PropsWithChildren<ArtistAppProps>> = ({
   artist,
   children,
+  match,
 }) => {
+  const queryName = "artistRoutes_ArtistAppQuery"
+  const cacheStatus = getContext(
+    cdnCacheStatusCacheKey(queryName, match.params)
+  )
+  console.log("cacheStatus", cacheStatus)
+
   useScrollToOpenArtistAuthModal({ name: artist.name })
 
   return (

--- a/src/Server/middleware/bootstrapSharifyAndContextLocalsMiddleware.ts
+++ b/src/Server/middleware/bootstrapSharifyAndContextLocalsMiddleware.ts
@@ -84,3 +84,8 @@ export function updateContext(key: string, value: any) {
   const asyncLocalStorage = getAsyncLocalStorage()
   asyncLocalStorage.getStore()?.set(key, value)
 }
+
+export function getContext(key: string): any {
+  const asyncLocalStorage = getAsyncLocalStorage()
+  return asyncLocalStorage.getStore()?.get(key)
+}

--- a/src/System/Relay/createRelaySSREnvironment.ts
+++ b/src/System/Relay/createRelaySSREnvironment.ts
@@ -26,6 +26,7 @@ import {
   hasPersonalizedArguments,
   isRequestCacheable,
 } from "System/Relay/isRequestCacheable"
+import { cdnCacheStatusMiddleware } from "System/Relay/middleware/cdnCacheStatusMiddleware"
 
 const logger = createLogger("System/Relay/createRelaySSREnvironment")
 
@@ -138,6 +139,7 @@ export function createRelaySSREnvironment(config: Config = {}) {
     metaphysicsErrorHandlerMiddleware({ checkStatus }),
     cacheHeaderMiddleware({ url, user }),
     cacheLoggerMiddleware(),
+    cdnCacheStatusMiddleware(),
     loggingEnabled && loggerMiddleware(),
     loggingEnabled && metaphysicsExtensionsLoggerMiddleware(),
     loggingEnabled && errorMiddleware({ disableServerMiddlewareTip: true }),

--- a/src/System/Relay/middleware/cdnCacheStatusMiddleware.ts
+++ b/src/System/Relay/middleware/cdnCacheStatusMiddleware.ts
@@ -1,0 +1,24 @@
+import { updateContext } from "Server/middleware/bootstrapSharifyAndContextLocalsMiddleware"
+
+export const cdnCacheStatusCacheKey = (queryName: string, variables: any) => {
+  return `cache-status:${queryName}:${JSON.stringify(variables)}`
+}
+
+export const cdnCacheStatusMiddleware = () => {
+  return next => async req => {
+    const res = await next(req)
+
+    const cacheStatus = res._res.headers.get("cf-cache-status") === "HIT"
+
+    const isRouteQuery = /^.*Routes_/.test(req.operation.name as string)
+
+    if (isRouteQuery) {
+      updateContext(
+        cdnCacheStatusCacheKey(req.operation.name, req.variables),
+        cacheStatus
+      )
+    }
+
+    return res
+  }
+}


### PR DESCRIPTION
This is a bit of a spike:

- demonstrating how you can access the `Cf-Cache-Status` header of a route request in Relay middleware (required https://github.com/artsy/metaphysics/pull/6307)
- store it in an isomorphic way in a cache
- and then access it from component code.

The main use-case I'm aware of is potentially augmenting analytics tracking with this value (like page-view tracking).

**It's imperfect however**: some pages (like the artist page), actually have _two_ queries that happen in order to render the page (the `path: ""` sub app one). In this case we need to pick one query and use the `Cf-Cache-Status` of that query for the page-view tracking?

**Not complete**: As a POC I've logged out the result in a component, but I'm not 100% sure if this kind of access will work seamlessly with our analytics hooks + tracking (I think yes).