### PR TITLE
chore(perf): Avoid conflicting hints to preload and defer initial JS

### DIFF
--- a/src/Server/middleware/linkHeadersMiddleware.ts
+++ b/src/Server/middleware/linkHeadersMiddleware.ts
@@ -1,7 +1,6 @@
 import type { NextFunction } from "express"
 import type { ArtsyRequest, ArtsyResponse } from "./artsyExpress"
 import { CDN_URL, GEMINI_CLOUDFRONT_URL, WEBFONT_URL } from "Server/config"
-import { getWebpackEarlyHints } from "Server/getWebpackEarlyHints"
 
 /**
  * Link headers allow 103: Early Hints to be sent to the client (by Cloudflare).
@@ -13,8 +12,6 @@ export function linkHeadersMiddleware(
   res: ArtsyResponse,
   next: NextFunction
 ) {
-  const { linkHeaders } = getWebpackEarlyHints()
-
   if (!res.headersSent) {
     res.header("Link", [
       `<${CDN_URL}>; rel=preconnect; crossorigin`,
@@ -24,7 +21,6 @@ export function linkHeadersMiddleware(
       `<${WEBFONT_URL}/ll-unica77_regular.woff2>; rel=preload; as=font; crossorigin`,
       `<${WEBFONT_URL}/ll-unica77_medium.woff2>; rel=preload; as=font; crossorigin`,
       `<${WEBFONT_URL}/ll-unica77_italic.woff2>; rel=preload; as=font; crossorigin`,
-      ...linkHeaders,
     ])
   }
 

--- a/src/System/Router/Utils/collectAssets.tsx
+++ b/src/System/Router/Utils/collectAssets.tsx
@@ -85,7 +85,7 @@ export const collectAssets = async ({
         }
       })()
 
-      return `<script defer src="${scriptUrl}"></script>`
+      return `<script src="${scriptUrl}"></script>`
     })
 
     initialScripts.push(...runtimeScripts)

--- a/src/System/Router/Utils/collectAssets.tsx
+++ b/src/System/Router/Utils/collectAssets.tsx
@@ -85,7 +85,7 @@ export const collectAssets = async ({
         }
       })()
 
-      return `<script src="${scriptUrl}"></script>`
+      return `<script defer src="${scriptUrl}"></script>`
     })
 
     initialScripts.push(...runtimeScripts)

--- a/src/System/Router/renderServerApp.tsx
+++ b/src/System/Router/renderServerApp.tsx
@@ -5,7 +5,6 @@ import { loadAssetManifest } from "Server/manifest"
 import { ENABLE_SSR_STREAMING } from "Server/config"
 import { getENV } from "Utils/getENV"
 import { ServerAppResults } from "System/Router/serverRouter"
-import { getWebpackEarlyHints } from "Server/getWebpackEarlyHints"
 import { RenderToStreamResult } from "System/Router/Utils/renderToStream"
 import { buildHtmlTemplate, HTMLProps } from "html"
 
@@ -48,15 +47,12 @@ export const renderServerApp = ({
 
   const scripts = extractScriptTags?.()
 
-  const { linkPreloadTags } = getWebpackEarlyHints()
-
   const options: HTMLProps = {
     cdnUrl: NODE_ENV === "production" ? (CDN_URL as string) : "",
     content: {
       body: html,
       sharifyData: sharify.script(),
       head: headTagsString,
-      linkPreloadTags,
       scripts,
       style: styleTags,
     },


### PR DESCRIPTION
This addresses warnings from tools like DebugBear about:

```
Asynchronous or deferred resource should not be preloaded.
Preloading can negate the benefits of marking resources as "async" or "defer". Consider removing this hint.
```

Currently, we specify in `Link:` headers and `<link>` tags that initial JS bundles should be preloaded. But [the actual `<script>` tags](https://github.com/artsy/force/blob/fbc48823c4add465ee20f82ebfa352948d300c7b/src/System/Router/Utils/collectAssets.tsx#L88) specify they should be `defer`red. After this PR, the initial JS chunks _won't_ be preloaded, but will be downloaded only once the `<script>` tags are encountered, and executed whenever the browser decides to execute `defer`red scripts.

This definitely addresses the DebugBear warnings. The waterfalls seem the same... script execution (~1s in throttled simulations!) happens at the end. It also frees bandwidth to fetch the main image, which is necessary for the LCP event. The thing I'm not 100% sure about is: does this delay later events like dom-ready or TTI? It didn't in my analyses but seems like it could be a possibility.


