### PR TITLE
fix: reorder some script tags to fix some weirdness around Segment analytics not loading

### DIFF
--- a/src/html.ts
+++ b/src/html.ts
@@ -82,20 +82,21 @@ export function buildHtmlTemplate({
     </head>
 
     <body>
-      ${content.scripts || ""}
-
-      <div id="react-modal-container"></div>
-      <div id="root">${content.body || ""}</div>
 
       ${(() => {
         if (!disable.segment) {
           return `
-            <script defer type="text/javascript">
-              !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";}}();
-            </script>
-          `
+              <script defer type="text/javascript">
+                !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";}}();
+              </script>
+            `
         }
       })()}
+
+      ${content.scripts || ""}
+
+      <div id="react-modal-container"></div>
+      <div id="root">${content.body || ""}</div>
     </body>
     </html>
   `


### PR DESCRIPTION
With the original ordering, I was not able to get analytics working locally. `window.analytics` would be `undefined`, and the Segment script tags aren't even included in the DOM, nor is the lib being loaded from the Segment CDN.

This ordering seems to work(?).

Seems sus to me, but...