### PR TITLE
chore: avoid duplicating main artwork image elements, especially <link rel="preload"...

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
@@ -10,6 +10,7 @@ import { Media } from "Utils/Responsive"
 import { ArtworkActionsFragmentContainer as ArtworkActions } from "./ArtworkActions"
 import { ArtworkImageBrowserLargeFragmentContainer } from "./ArtworkImageBrowserLarge"
 import { ArtworkImageBrowserSmallFragmentContainer } from "./ArtworkImageBrowserSmall"
+import { getENV } from "Utils/getENV"
 
 // Dimension used to scale both images and videos
 export const MAX_DIMENSION = 800
@@ -19,10 +20,9 @@ interface ArtworkImageBrowserProps {
   isMyCollectionArtwork?: boolean
 }
 
-export const ArtworkImageBrowser: React.FC<React.PropsWithChildren<ArtworkImageBrowserProps>> = ({
-  artwork,
-  isMyCollectionArtwork,
-}) => {
+export const ArtworkImageBrowser: React.FC<React.PropsWithChildren<
+  ArtworkImageBrowserProps
+>> = ({ artwork, isMyCollectionArtwork }) => {
   const { figures } = artwork
 
   const { index: activeIndex, handleNext, handlePrev, setCursor } = useCursor({
@@ -81,32 +81,35 @@ export const ArtworkImageBrowser: React.FC<React.PropsWithChildren<ArtworkImageB
     return null
   }
 
+  const isMobile = getENV("IS_MOBILE")
+
   return (
     <Box
       // Keyed to the artwork ID so that state is reset on route changes
       key={artwork.internalID}
       data-test={ContextModule.artworkImage}
     >
-      <Media at="xs">
-        <ArtworkImageBrowserSmallFragmentContainer
-          artwork={artwork}
-          activeIndex={activeIndex}
-          setActiveIndex={setCursor}
-          maxHeight={maxHeight}
-        />
-      </Media>
-
-      <Media greaterThan="xs">
-        <ArtworkImageBrowserLargeFragmentContainer
-          artwork={artwork}
-          activeIndex={activeIndex}
-          onNext={handleNext}
-          onPrev={handlePrev}
-          onChange={setCursor}
-          maxHeight={maxHeight}
-        />
-      </Media>
-
+      {isMobile ? (
+        <Media at="xs">
+          <ArtworkImageBrowserSmallFragmentContainer
+            artwork={artwork}
+            activeIndex={activeIndex}
+            setActiveIndex={setCursor}
+            maxHeight={maxHeight}
+          />
+        </Media>
+      ) : (
+        <Media greaterThan="xs">
+          <ArtworkImageBrowserLargeFragmentContainer
+            artwork={artwork}
+            activeIndex={activeIndex}
+            onNext={handleNext}
+            onPrev={handlePrev}
+            onChange={setCursor}
+            maxHeight={maxHeight}
+          />
+        </Media>
+      )}
       {!isMyCollectionArtwork && (
         <>
           <Spacer y={2} />

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
@@ -6,7 +6,6 @@ import * as React from "react"
 import { useMemo } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useCursor } from "use-cursor"
-import { Media } from "Utils/Responsive"
 import { ArtworkActionsFragmentContainer as ArtworkActions } from "./ArtworkActions"
 import { ArtworkImageBrowserLargeFragmentContainer } from "./ArtworkImageBrowserLarge"
 import { ArtworkImageBrowserSmallFragmentContainer } from "./ArtworkImageBrowserSmall"
@@ -90,25 +89,21 @@ export const ArtworkImageBrowser: React.FC<React.PropsWithChildren<
       data-test={ContextModule.artworkImage}
     >
       {isMobile ? (
-        <Media at="xs">
-          <ArtworkImageBrowserSmallFragmentContainer
-            artwork={artwork}
-            activeIndex={activeIndex}
-            setActiveIndex={setCursor}
-            maxHeight={maxHeight}
-          />
-        </Media>
+        <ArtworkImageBrowserSmallFragmentContainer
+          artwork={artwork}
+          activeIndex={activeIndex}
+          setActiveIndex={setCursor}
+          maxHeight={maxHeight}
+        />
       ) : (
-        <Media greaterThan="xs">
-          <ArtworkImageBrowserLargeFragmentContainer
-            artwork={artwork}
-            activeIndex={activeIndex}
-            onNext={handleNext}
-            onPrev={handlePrev}
-            onChange={setCursor}
-            maxHeight={maxHeight}
-          />
-        </Media>
+        <ArtworkImageBrowserLargeFragmentContainer
+          artwork={artwork}
+          activeIndex={activeIndex}
+          onNext={handleNext}
+          onPrev={handlePrev}
+          onChange={setCursor}
+          maxHeight={maxHeight}
+        />
       )}
       {!isMyCollectionArtwork && (
         <>


### PR DESCRIPTION
This consolidates `<link rel="preload" as="image"...` elements on artwork pages to just 2, the low-quality placeholder and the main image that replaces it. Previously, these were duplicated in the DOM.

It "breaks" the responsiveness of the artwork page, drastically increasing or reducing the size of an artwork page's browser tag might result in the main image element disappearing. You mentioned allowing the image element to flex instead. Feel free to push that, either to this PR or a different one?