### PR TITLE
fix: navigate to newly created conversation after offer submit

### DIFF
--- a/src/Apps/Artwork/Components/SubmittedOrderModal/SubmittedOrderModal.tsx
+++ b/src/Apps/Artwork/Components/SubmittedOrderModal/SubmittedOrderModal.tsx
@@ -14,10 +14,13 @@ interface SubmittedOrderModalProps {
   submittedOrder: SubmittedOrderModal_submittedOrder$data
 }
 
-const SubmittedOrderModal: FC<React.PropsWithChildren<SubmittedOrderModalProps>> = ({
-  submittedOrder,
-}) => {
+const SubmittedOrderModal: FC<React.PropsWithChildren<
+  SubmittedOrderModalProps
+>> = ({ submittedOrder }) => {
   const [isOpen, setIsOpen] = useState(true)
+  const linkUrl = submittedOrder.impulseConversationId
+    ? `/user/conversations/${submittedOrder.impulseConversationId}`
+    : "/user/conversations"
 
   if (!isOpen) return null
 
@@ -33,7 +36,7 @@ const SubmittedOrderModal: FC<React.PropsWithChildren<SubmittedOrderModalProps>>
       <Message>{description}</Message>
       <Spacer y={2} />
       <Text>{continueToInboxText}</Text>
-      <RouterLink to="/user/conversations" onClick={handleClose}>
+      <RouterLink to={linkUrl} onClick={handleClose}>
         <Button mt={2} width="100%">
           Go to Inbox
         </Button>
@@ -48,14 +51,15 @@ export const SubmittedOrderModalFragmentContainer = createFragmentContainer(
     submittedOrder: graphql`
       fragment SubmittedOrderModal_submittedOrder on CommerceOrder {
         stateExpiresAt(format: "MMM D")
+        impulseConversationId
       }
     `,
   }
 )
 
-export const SubmittedOrderModalQueryRenderer: FC<React.PropsWithChildren<{ orderId: string }>> = ({
-  orderId,
-}) => {
+export const SubmittedOrderModalQueryRenderer: FC<React.PropsWithChildren<{
+  orderId: string
+}>> = ({ orderId }) => {
   return (
     <SystemQueryRenderer<SubmittedOrderModalQuery>
       variables={{ orderId }}
@@ -74,6 +78,7 @@ export const SubmittedOrderModalQueryRenderer: FC<React.PropsWithChildren<{ orde
         query SubmittedOrderModalQuery($orderId: ID!) {
           submittedOrder: commerceOrder(id: $orderId) {
             ...SubmittedOrderModal_submittedOrder
+            impulseConversationId
           }
         }
       `}

--- a/src/Apps/Artwork/Components/SubmittedOrderModal/__tests__/SubmittedOrderModal.jest.tsx
+++ b/src/Apps/Artwork/Components/SubmittedOrderModal/__tests__/SubmittedOrderModal.jest.tsx
@@ -8,6 +8,14 @@ jest.unmock("react-relay")
 const mockedResolver = {
   CommerceOrder: () => ({
     stateExpiresAt: "Feb 28",
+    impulseConversationId: null,
+  }),
+}
+
+const mockedResolverWithConversation = {
+  CommerceOrder: () => ({
+    stateExpiresAt: "Sept 10",
+    impulseConversationId: "12345",
   }),
 }
 
@@ -56,5 +64,13 @@ describe("SubmittedOrderModal", () => {
     await waitFor(() =>
       expect(screen.queryByRole("dialog")).not.toBeInTheDocument()
     )
+  })
+
+  it("links to proper conversation when conversation id is present", async () => {
+    renderWithRelay(mockedResolverWithConversation)
+
+    const button = await screen.findByRole("link")
+    expect(button).toHaveAttribute("href", "/user/conversations/12345")
+    expect(within(button).getByText("Go to Inbox")).toBeInTheDocument()
   })
 })

--- a/src/__generated__/SubmittedOrderModalQuery.graphql.ts
+++ b/src/__generated__/SubmittedOrderModalQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<dbce47cbb45db6daa1a8bf53e6cf3457>>
+ * @generated SignedSource<<c3ddd141c0e63de1d63b980ff0c4ed20>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,6 +15,7 @@ export type SubmittedOrderModalQuery$variables = {
 };
 export type SubmittedOrderModalQuery$data = {
   readonly submittedOrder: {
+    readonly impulseConversationId: string | null | undefined;
     readonly " $fragmentSpreads": FragmentRefs<"SubmittedOrderModal_submittedOrder">;
   } | null | undefined;
 };
@@ -37,7 +38,14 @@ v1 = [
     "name": "id",
     "variableName": "orderId"
   }
-];
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "impulseConversationId",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -57,7 +65,8 @@ return {
             "args": null,
             "kind": "FragmentSpread",
             "name": "SubmittedOrderModal_submittedOrder"
-          }
+          },
+          (v2/*: any*/)
         ],
         "storageKey": null
       }
@@ -103,6 +112,7 @@ return {
             "name": "stateExpiresAt",
             "storageKey": "stateExpiresAt(format:\"MMM D\")"
           },
+          (v2/*: any*/),
           {
             "alias": null,
             "args": null,
@@ -116,16 +126,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "cbe9dd80a69d5b0f4bbe57cf87a31c04",
+    "cacheID": "9e16052ca5e02190f9995a01c9b1c83d",
     "id": null,
     "metadata": {},
     "name": "SubmittedOrderModalQuery",
     "operationKind": "query",
-    "text": "query SubmittedOrderModalQuery(\n  $orderId: ID!\n) {\n  submittedOrder: commerceOrder(id: $orderId) {\n    __typename\n    ...SubmittedOrderModal_submittedOrder\n    id\n  }\n}\n\nfragment SubmittedOrderModal_submittedOrder on CommerceOrder {\n  __isCommerceOrder: __typename\n  stateExpiresAt(format: \"MMM D\")\n}\n"
+    "text": "query SubmittedOrderModalQuery(\n  $orderId: ID!\n) {\n  submittedOrder: commerceOrder(id: $orderId) {\n    __typename\n    ...SubmittedOrderModal_submittedOrder\n    impulseConversationId\n    id\n  }\n}\n\nfragment SubmittedOrderModal_submittedOrder on CommerceOrder {\n  __isCommerceOrder: __typename\n  stateExpiresAt(format: \"MMM D\")\n  impulseConversationId\n}\n"
   }
 };
 })();
 
-(node as any).hash = "cca4549f309c54f7c8f3655e1c6ca730";
+(node as any).hash = "2e9856bda0da465ce5cc03349f7e38ce";
 
 export default node;

--- a/src/__generated__/SubmittedOrderModal_Test_Query.graphql.ts
+++ b/src/__generated__/SubmittedOrderModal_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e3e200719d19fea68cc96d085f155e6d>>
+ * @generated SignedSource<<b53e6de99008069f219946cb809b7a31>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -32,6 +32,12 @@ var v0 = [
 v1 = {
   "enumValues": null,
   "nullable": false,
+  "plural": false,
+  "type": "String"
+},
+v2 = {
+  "enumValues": null,
+  "nullable": true,
   "plural": false,
   "type": "String"
 };
@@ -104,6 +110,13 @@ return {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
+            "name": "impulseConversationId",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
             "name": "id",
             "storageKey": null
           }
@@ -113,7 +126,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4444e17f70c00a9bb4533e0f8206fd37",
+    "cacheID": "9a7919e0cfb8f61f5c6c01819f85cd26",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -131,17 +144,13 @@ return {
           "plural": false,
           "type": "ID"
         },
-        "submittedOrder.stateExpiresAt": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "String"
-        }
+        "submittedOrder.impulseConversationId": (v2/*: any*/),
+        "submittedOrder.stateExpiresAt": (v2/*: any*/)
       }
     },
     "name": "SubmittedOrderModal_Test_Query",
     "operationKind": "query",
-    "text": "query SubmittedOrderModal_Test_Query {\n  submittedOrder: commerceOrder(id: \"some-id\") {\n    __typename\n    ...SubmittedOrderModal_submittedOrder\n    id\n  }\n}\n\nfragment SubmittedOrderModal_submittedOrder on CommerceOrder {\n  __isCommerceOrder: __typename\n  stateExpiresAt(format: \"MMM D\")\n}\n"
+    "text": "query SubmittedOrderModal_Test_Query {\n  submittedOrder: commerceOrder(id: \"some-id\") {\n    __typename\n    ...SubmittedOrderModal_submittedOrder\n    id\n  }\n}\n\nfragment SubmittedOrderModal_submittedOrder on CommerceOrder {\n  __isCommerceOrder: __typename\n  stateExpiresAt(format: \"MMM D\")\n  impulseConversationId\n}\n"
   }
 };
 })();

--- a/src/__generated__/SubmittedOrderModal_submittedOrder.graphql.ts
+++ b/src/__generated__/SubmittedOrderModal_submittedOrder.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ef06ae01a06a844cbc872458a29370bf>>
+ * @generated SignedSource<<06c2a887c7da70b5afa9c9be258e4666>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,6 +11,7 @@
 import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type SubmittedOrderModal_submittedOrder$data = {
+  readonly impulseConversationId: string | null | undefined;
   readonly stateExpiresAt: string | null | undefined;
   readonly " $fragmentType": "SubmittedOrderModal_submittedOrder";
 };
@@ -37,12 +38,19 @@ const node: ReaderFragment = {
       "kind": "ScalarField",
       "name": "stateExpiresAt",
       "storageKey": "stateExpiresAt(format:\"MMM D\")"
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "impulseConversationId",
+      "storageKey": null
     }
   ],
   "type": "CommerceOrder",
   "abstractKey": "__isCommerceOrder"
 };
 
-(node as any).hash = "5bedd1fb7819d00faa9db23ee7653eb2";
+(node as any).hash = "3ee8ecf521df52e72908c1805d634071";
 
 export default node;


### PR DESCRIPTION
re: https://artsyproduct.atlassian.net/browse/EMI-2239

I'm actually not 100% sure why the default selecting first conversation is not working in this case. My guess is that the conversation is created async and maybe somehow not refreshed in the original conversations used when navigating. But this explicit conversation reference seems to work and is logical - so going with this.
