### PR TITLE
chore(AMBER-1209): Update the class name on css to match the component

### DIFF
--- a/src/Components/SalesforceWrapper.tsx
+++ b/src/Components/SalesforceWrapper.tsx
@@ -9,20 +9,10 @@ export const SalesforceWrapper: React.FC<{}> = _props => {
   useAppendStylesheet({
     id: "salesforce-chat-styles",
     body: `
-      .embeddedServiceHelpButton .helpButton .uiButton {
-        background: #000000; /* colors.black100 */
-        font-family: "ll-unica77", "Helvetica Neue", Helvetica, Arial, sans-serif; /* fonts.sans */
-        box-shadow: none;
-      }
-    
-      .embeddedServiceHelpButton .helpButton .uiButton:focus {
-        background: #1023D7; /* colors.blue100 */
-      }
-      
       /* Make sure it doesn't render when loaded on desktop and then the window is resized */
       @media (max-width: 767px) { /* mediaQueries.xs */
-        .embeddedServiceHelpButton .helpButton .uiButton {
-          display: none;
+        .embeddedMessagingConversationButton {
+          display: none !important;
         }
       }
     `,


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [AMBER-1209]

### Description
Similar to https://github.com/artsy/volt/pull/8211, but now for collectors

We must not display the SF chat bubble on the mobile version. We handled this during the migration from Zendesk to SF, but our css rule specifies a class that's defined on SF stylesheet, which became outdated after the recent upgrade.

Changes in this PR point update the class name to meet the current definition.

<!-- Implementation description -->

### Before
<img width="452" alt="Screenshot 2024-12-18 at 18 10 55" src="https://github.com/user-attachments/assets/e2da164e-b704-4b58-9fa1-8071c9833b14" />

### After
<img width="472" alt="Screenshot 2024-12-18 at 18 10 00" src="https://github.com/user-attachments/assets/98381d4c-7be1-4c56-bf0e-26932f00a5b2" />

cc @artsy/amber-devs 

[AMBER-1209]: https://artsyproduct.atlassian.net/browse/AMBER-1209?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ