### PR TITLE
fix: specify biome explicitly for typescript

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,7 @@
 {
-  "editor.rulers": [80],
+  "editor.rulers": [
+    80
+  ],
   "editor.tabSize": 2,
   "javascript.validate.enable": true,
   "search.exclude": {
@@ -12,6 +14,9 @@
   },
   "[json]": {
     "editor.formatOnSave": false
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "biomejs.biome"
   },
   "editor.codeActionsOnSave": {
     "quickfix.biome": "explicit",


### PR DESCRIPTION
This seems to behave well locally where I still have prettier installed. Was seeing prettier doing some formatting (which `biome` undoes in pre-commit hook from command line) on save still.