### PR TITLE
chore: removes palette from debug routes

### DIFF
--- a/src/Apps/Debug/DebugAuthRoute.tsx
+++ b/src/Apps/Debug/DebugAuthRoute.tsx
@@ -17,7 +17,7 @@ import { merge } from "lodash"
 import { type FC, useState } from "react"
 import { Title } from "react-head"
 
-export const DebugAuth: FC<React.PropsWithChildren<unknown>> = () => {
+export const DebugAuthRoute: FC<React.PropsWithChildren<unknown>> = () => {
   const { showAuthDialog } = useAuthDialog()
 
   const [state, setState] = useState<

--- a/src/Apps/Debug/DebugBaselineRoute.tsx
+++ b/src/Apps/Debug/DebugBaselineRoute.tsx
@@ -2,7 +2,7 @@ import { Text } from "@artsy/palette"
 import type * as React from "react"
 import { Title } from "react-head"
 
-export const DebugApp: React.FC<React.PropsWithChildren<{}>> = () => {
+export const DebugBaselineRoute: React.FC<React.PropsWithChildren<{}>> = () => {
   return (
     <>
       <Title>Baseline</Title>

--- a/src/Apps/Debug/DebugClientError404Route.tsx
+++ b/src/Apps/Debug/DebugClientError404Route.tsx
@@ -1,0 +1,10 @@
+import { Text } from "@artsy/palette"
+import { RouterLink } from "System/Components/RouterLink"
+
+export const DebugClientError404Route = () => {
+  return (
+    <Text mt={4} variant="sm-display">
+      <RouterLink to="/artist/example-404">Click to 404</RouterLink>
+    </Text>
+  )
+}

--- a/src/Apps/Debug/DebugClientError500Route.tsx
+++ b/src/Apps/Debug/DebugClientError500Route.tsx
@@ -1,0 +1,27 @@
+import { Clickable, Text } from "@artsy/palette"
+import { useState } from "react"
+
+export const DebugClientError500Route = () => {
+  const [error, setError] = useState(false)
+
+  return (
+    <>
+      {error && (
+        // @ts-ignore
+        // eslint-disable-next-line react/jsx-no-undef
+        <Example />
+      )}
+
+      <Text mt={4} variant="sm-display">
+        <Clickable
+          textDecoration="underline"
+          onClick={() => {
+            setError(true)
+          }}
+        >
+          Click to 500
+        </Clickable>
+      </Text>
+    </>
+  )
+}

--- a/src/Apps/Debug/debugRoutes.tsx
+++ b/src/Apps/Debug/debugRoutes.tsx
@@ -1,22 +1,31 @@
-import { Clickable, Text } from "@artsy/palette"
 import loadable from "@loadable/component"
-import { RouterLink } from "System/Components/RouterLink"
 import type { RouteProps } from "System/Router/Route"
 import { HttpError } from "found"
-import { useState } from "react"
 
-const DebugApp = loadable(
-  () => import(/* webpackChunkName: "debugBundle" */ "./DebugApp"),
-  { resolveComponent: component => component.DebugApp }
+const DebugBaselineRoute = loadable(
+  () => import(/* webpackChunkName: "debugBundle" */ "./DebugBaselineRoute"),
+  { resolveComponent: component => component.DebugBaselineRoute }
 )
 
-const DebugAuth = loadable(
-  () => import(/* webpackChunkName: "debugBundle" */ "./DebugAuth"),
-  { resolveComponent: component => component.DebugAuth }
+const DebugAuthRoute = loadable(
+  () => import(/* webpackChunkName: "debugBundle" */ "./DebugAuthRoute"),
+  { resolveComponent: component => component.DebugAuthRoute }
+)
+
+const DebugClientError404Route = loadable(
+  () =>
+    import(/* webpackChunkName: "debugBundle" */ "./DebugClientError404Route"),
+  { resolveComponent: component => component.DebugClientError404Route }
+)
+
+const DebugClientError500Route = loadable(
+  () =>
+    import(/* webpackChunkName: "debugBundle" */ "./DebugClientError500Route"),
+  { resolveComponent: component => component.DebugClientError500Route }
 )
 
 /**
- * This route is just for testing baseline page shell stuff -- Lighthouse,
+ * These routes are just for testing baseline page shell stuff -- Lighthouse,
  * Calibre, assets loaded on page, and other debugging things that might
  * impact global performance.
  */
@@ -26,13 +35,11 @@ export const debugRoutes: RouteProps[] = [
     children: [
       {
         path: "baseline",
-        // layout: "LogoOnly",
-        Component: DebugApp,
+        Component: DebugBaselineRoute,
       },
-      // TODO: Remove this route once new AuthDialog is deployed
       {
         path: "auth",
-        Component: DebugAuth,
+        Component: DebugAuthRoute,
       },
       {
         path: "error-404",
@@ -42,13 +49,7 @@ export const debugRoutes: RouteProps[] = [
       },
       {
         path: "client-error-404",
-        Component: () => {
-          return (
-            <Text mt={4} variant="sm-display">
-              <RouterLink to="/artist/example-404">Click to 404</RouterLink>
-            </Text>
-          )
-        },
+        Component: DebugClientError404Route,
       },
       {
         path: "error-500",
@@ -58,29 +59,7 @@ export const debugRoutes: RouteProps[] = [
       },
       {
         path: "client-error-500",
-        Component: () => {
-          const [error, setError] = useState(false)
-
-          return (
-            <>
-              {error && (
-                // @ts-ignore
-                // eslint-disable-next-line react/jsx-no-undef
-                <Example />
-              )}
-              <Text mt={4} variant="sm-display">
-                <Clickable
-                  textDecoration="underline"
-                  onClick={() => {
-                    setError(true)
-                  }}
-                >
-                  Click to 500
-                </Clickable>
-              </Text>
-            </>
-          )
-        },
+        Component: DebugClientError500Route,
       },
     ],
   },


### PR DESCRIPTION
Not really going to move the needle much but this is a reasonable change. Should only load route code when the route is requested.

The only other place I noticed this was this strange thing where we redirect to a 404 page but have a 200 status code? https://github.com/artsy/force/blob/f52da8f0d093eed7dde6d700fd95226eb942925f/src/Apps/Order/orderRoutes.tsx#L315-L325 — will look at that separately.