### PR TITLE
fix(linter): Migrate exhaustive-deps ignore

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -27,6 +27,7 @@
       },
       "complexity": {
         "noBannedTypes": "off",
+        "noExtraBooleanCast": "off",
         "noExcessiveNestedTestSuites": "off",
         "noForEach": "off",
         "noUselessFragments": "off",

--- a/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilterMobileActionSheet.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilterMobileActionSheet.tsx
@@ -31,6 +31,7 @@ export const AuctionFilterMobileActionSheet: FC<
     filterContext.stagedFilters
   )
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     // While mobile sheet is mounted, the effect of the user's filter selections
     // should be merely staged until the Apply button is pressed, rather than
@@ -45,7 +46,6 @@ export const AuctionFilterMobileActionSheet: FC<
     return () => {
       filterContext.setShouldStageFilterChanges?.(false)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const applyFilters = () => {

--- a/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/KeywordFilter.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/AuctionFilters/KeywordFilter.tsx
@@ -15,18 +15,18 @@ export const KeywordFilter: React.FC<React.PropsWithChildren<unknown>> = () => {
     filterContext.setFilter?.("keyword", text)
   }
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   const handleChangeText = useMemo(
     () => debounce(updateKeywordFilter, DEBOUNCE_DELAY),
     // FIXME:
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [filterContext]
   )
 
   // Stop the invocation of the debounced function after unmounting
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     return () => handleChangeText?.cancel?.()
     // FIXME:
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   return (

--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -97,6 +97,7 @@ export const ArtworkApp: React.FC<React.PropsWithChildren<Props>> = props => {
 
   // If the user is expecting a partner offer, require login and remove
   // the query param from the URL after login.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     const expectingPartnerOffer = !!match?.location?.query?.partner_offer_id
     const isLoggedIn = !!me
@@ -119,7 +120,6 @@ export const ArtworkApp: React.FC<React.PropsWithChildren<Props>> = props => {
       url.searchParams.delete("partner_offer_id")
       silentReplace(url.toString())
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const isPrivateArtwork = artwork?.isUnlisted && artwork?.partner
@@ -209,6 +209,8 @@ export const ArtworkApp: React.FC<React.PropsWithChildren<Props>> = props => {
    * the `trackingMiddleware` file as we need to pass along additional metadata.
    *
    */
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     if (!!submittedOrderId) {
       // TODO: Look into using router push
@@ -216,7 +218,6 @@ export const ArtworkApp: React.FC<React.PropsWithChildren<Props>> = props => {
       silentPush(props.match.location.pathname)
     }
     track()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   if (match?.location?.query?.creating_order) {

--- a/src/Apps/Artwork/Components/ArtworkErrorApp/ArtworkErrorApp.tsx
+++ b/src/Apps/Artwork/Components/ArtworkErrorApp/ArtworkErrorApp.tsx
@@ -46,10 +46,9 @@ export const ArtworkErrorApp: React.FC<
     }
   }, [])
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     trackPageview()
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   return (

--- a/src/Apps/Artwork/Components/ArtworkVideoPlayer/ArtworkVideoPlayer.tsx
+++ b/src/Apps/Artwork/Components/ArtworkVideoPlayer/ArtworkVideoPlayer.tsx
@@ -59,6 +59,7 @@ const ArtworkVideoPlayer: FC<
     }, 0)
   }
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     window.addEventListener("blur", trackClickedPlayVideo)
 
@@ -67,7 +68,6 @@ const ArtworkVideoPlayer: FC<
     return () => {
       window.removeEventListener("blur", trackClickedPlayVideo)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   if (!activeVideo || activeVideo.__typename === "%other") {

--- a/src/Apps/Auction/AuctionApp.tsx
+++ b/src/Apps/Auction/AuctionApp.tsx
@@ -54,10 +54,9 @@ export const AuctionApp: React.FC<React.PropsWithChildren<AuctionAppProps>> = ({
 
   const isFullBleedHeaderFixed = !cascadingEndTimeIntervalMinutes
 
-  // Track page view
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     tracking.auctionPageView({ sale, me })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const websocketEnabled = !!extendedBiddingIntervalMinutes

--- a/src/Apps/Auction/Routes/AuctionConfirmRegistrationRoute.tsx
+++ b/src/Apps/Auction/Routes/AuctionConfirmRegistrationRoute.tsx
@@ -68,6 +68,7 @@ const AuctionConfirmRegistrationRoute: React.FC<
   }
 
   // Track page view or redirect
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     if (redirectToSaleHome(sale)) {
       router.replace(`/auction/${sale.slug}`)
@@ -76,7 +77,6 @@ const AuctionConfirmRegistrationRoute: React.FC<
     } else {
       tracking.confirmRegistrationPageView()
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   // Will redirect to /register above on page mount

--- a/src/Apps/Auction/Routes/AuctionRegistrationRoute.tsx
+++ b/src/Apps/Auction/Routes/AuctionRegistrationRoute.tsx
@@ -43,6 +43,7 @@ const AuctionRegistrationRoute: React.FC<
   }
 
   // Track page view or redirect
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     if (redirectToSaleHome(sale)) {
       router.replace(`/auction/${sale.slug}`)
@@ -51,7 +52,6 @@ const AuctionRegistrationRoute: React.FC<
     } else {
       tracking.registrationPageView()
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   // Will redirect to /confirm-registration above on page mount

--- a/src/Apps/Auction/Routes/Bid/Components/PricingTransparency.tsx
+++ b/src/Apps/Auction/Routes/Bid/Components/PricingTransparency.tsx
@@ -95,13 +95,13 @@ export const PricingTransparencyQueryRenderer = ({
   // when the url changes after user places a successful bid and we redirect
   // back to artwork/id. If / when we remove the transition to the auction page
   // from artwork/id we can remove this hack.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   const variables = useMemo(() => {
     return {
       saleId,
       artworkId,
       bidAmountMinor,
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [bidAmountMinor])
 
   return (

--- a/src/Apps/CollectorProfile/Routes/Saves/CollectorProfileSavesRoute.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves/CollectorProfileSavesRoute.tsx
@@ -80,15 +80,13 @@ const CollectorProfileSavesRoute: FC<
    * For this reason, 404 error will be displayed immediately.
    * To prevent this from happening, `useMemo` is used here
    */
-  const selectedArtworkList = useMemo(
-    () => {
-      return artworkLists.find(
-        artworkList => artworkList.internalID === selectedArtworkListId
-      )
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [selectedArtworkListId]
-  )
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
+  const selectedArtworkList = useMemo(() => {
+    return artworkLists.find(
+      artworkList => artworkList.internalID === selectedArtworkListId
+    )
+  }, [selectedArtworkListId])
 
   // TODO: Should be at routing level
   if (!selectedArtworkList) {

--- a/src/Apps/Components/AppShell.tsx
+++ b/src/Apps/Components/AppShell.tsx
@@ -33,6 +33,7 @@ export const AppShell: React.FC<
   // Check to see if a route has a onServerSideRender key; if so call it. Used
   // typically to preload bundle-split components (import()) while the route is
   // fetching data in the background.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     try {
       if (match) {
@@ -44,8 +45,6 @@ export const AppShell: React.FC<
     } catch (error) {
       logger.error(error)
     }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [routeConfig])
 
   // Let our end-to-end tests know that the app is hydrated and ready to go

--- a/src/Apps/Conversations/components/ConversationReply.tsx
+++ b/src/Apps/Conversations/components/ConversationReply.tsx
@@ -137,9 +137,9 @@ export const ConversationReply: FC<
     }
   )
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     resetForm()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data?.internalID, resetForm])
 
   // Listen for Command+Enter keypress
@@ -196,7 +196,7 @@ export const ConversationReply: FC<
               // Set original height each time so scrollHeight is also
               // calculated when the content shrinks.
               field.style.height = TEXT_AREA_MIN_HEIGHT
-              setTextAreaHeight(field.scrollHeight + "px")
+              setTextAreaHeight(`${field.scrollHeight}px`)
               field.style.height = textAreaHeight
             }}
             onChange={({ value }) => setFieldValue("message", value)}

--- a/src/Apps/Conversations/components/Sidebar/ConversationsSidebar.tsx
+++ b/src/Apps/Conversations/components/Sidebar/ConversationsSidebar.tsx
@@ -44,6 +44,7 @@ export const ConversationsSidebar: React.FC<
     totalDisplayedCount = SIDEBAR_FETCH_PAGE_SIZE
   }
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     if (!match.params.conversationId) {
       return
@@ -72,7 +73,6 @@ export const ConversationsSidebar: React.FC<
 
     // No need for conversationID, as we want to preserve the sidebar state
     // across renders.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [totalDisplayedCount])
 
   // Refetch messages in the background, but only when a user has scrolled to

--- a/src/Apps/Conversations/components/Sidebar/ConversationsSidebarItem.tsx
+++ b/src/Apps/Conversations/components/Sidebar/ConversationsSidebarItem.tsx
@@ -28,12 +28,11 @@ export const ConversationsSidebarItem: React.FC<
   // sends the user to the messages view.
   const isHighlighted = isSelected && !getENV("IS_MOBILE")
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     if (isSelected) {
       scrollRef.current?.scrollIntoView?.({ block: "center" })
     }
-    // Only want this to fire on mount
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const item = data?.items?.[0]?.item

--- a/src/Apps/Conversations/hooks/useLoadMore.ts
+++ b/src/Apps/Conversations/hooks/useLoadMore.ts
@@ -34,6 +34,7 @@ export const useLoadMore = ({
     return isFunction(isLoadingNext) ? isLoadingNext() : isLoadingNext
   }
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     if (shouldLoadMore && hasMore() && !isLoading() && when !== false) {
       loadNext(pageSize, () => {
@@ -42,7 +43,6 @@ export const useLoadMore = ({
     } else {
       setLoadMore(false)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [shouldLoadMore, isLoadingNext, loadNext, when, pageSize])
 
   const loadMore = useCallback(() => {

--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormImages.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormImages.tsx
@@ -62,6 +62,7 @@ export const MyCollectionArtworkFormImages: React.FC<
     return photos.filter(c => !(c.geminiToken || c.url) && !c.loading)
   }
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     const imagesToUpload = getImagesToUpload(values.newPhotos)
 
@@ -70,7 +71,6 @@ export const MyCollectionArtworkFormImages: React.FC<
 
       setFieldValue("newPhotos", [...values.newPhotos])
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [values.newPhotos])
 
   const handleDrop = (acceptedFiles: File[]) => {

--- a/src/Apps/Order/Components/AddressVerificationFlow.tsx
+++ b/src/Apps/Order/Components/AddressVerificationFlow.tsx
@@ -151,6 +151,7 @@ const AddressVerificationFlow: React.FC<
   >(addressOptions[0]?.key)
 
   // perform only once when the flow first loads
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     if (verificationPath === VerificationPath.ERROR_IMMEDIATE_CONFIRM) {
       const fallbackOption = fallbackFromFormValues(verificationInput)
@@ -168,7 +169,6 @@ const AddressVerificationFlow: React.FC<
             : "review and confirm",
       })
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const chooseAddress = useCallback(() => {
@@ -187,6 +187,7 @@ const AddressVerificationFlow: React.FC<
       setShowModal(false)
       onChosenAddress(verifiedBy, selectedAddress.address)
     }
+    // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   }, [addressOptions, onChosenAddress, selectedAddressKey])
 
   const handleCloseModal = ({
@@ -210,7 +211,7 @@ const AddressVerificationFlow: React.FC<
       VerificationPath.IMMEDIATE_CONFIRM,
     ].includes(verificationPath)
   ) {
-    return <div data-testid="emptyAddressVerification"></div>
+    return <div data-testid="emptyAddressVerification" />
   }
 
   return !showModal ? null : (

--- a/src/Apps/Order/Components/OrderStepper.tsx
+++ b/src/Apps/Order/Components/OrderStepper.tsx
@@ -63,8 +63,6 @@ export const OrderStepper: FC<React.PropsWithChildren<OrderStepperProps>> = ({
     }
 
     setCompletedSteps(completedSteps)
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [order])
 
   const handleStepClick = (step: string) => {

--- a/src/Apps/Order/Components/PriceOptions.tsx
+++ b/src/Apps/Order/Components/PriceOptions.tsx
@@ -63,15 +63,13 @@ export const PriceOptions: React.FC<
     selectedPriceOption || "price-option-max"
   )
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     if (lastOffer) {
       onChange(lastOffer)
     } else {
       onChange(selectedPriceValue!)
     }
-
-    // need this to run only once
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   useEffect(() => {
@@ -83,7 +81,6 @@ export const PriceOptions: React.FC<
 
   useEffect(() => {
     if (toggle) trackClick("Different amount", 0)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [toggle])
 
   const trackClick = (offer: string, amount: number) => {

--- a/src/Apps/Order/Hooks/useStripePaymentBySetupIntentId.tsx
+++ b/src/Apps/Order/Hooks/useStripePaymentBySetupIntentId.tsx
@@ -21,6 +21,7 @@ export function useStripePaymentBySetupIntentId(orderId: string) {
     null
   )
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     // pull necessary params from Stripe redirect URL
     const {
@@ -51,7 +52,6 @@ export function useStripePaymentBySetupIntentId(orderId: string) {
     }
 
     setIsProcessingRedirect(false)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [orderId, match])
 
   const setPaymentBySetupIntentId = async (

--- a/src/Apps/Order/OrderApp.tsx
+++ b/src/Apps/Order/OrderApp.tsx
@@ -45,6 +45,7 @@ const OrderApp: FC<React.PropsWithChildren<OrderAppProps>> = props => {
 
   const removeNavigationListenerRef = useRef<null | (() => void)>(null)
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     if (!removeNavigationListenerRef.current) {
       removeNavigationListenerRef.current = router.addNavigationListener(
@@ -61,7 +62,6 @@ const OrderApp: FC<React.PropsWithChildren<OrderAppProps>> = props => {
       }
       window.removeEventListener("beforeunload", preventHardReload)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const handleTransition = () => newLocation => {

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -103,6 +103,7 @@ export const PaymentRoute: FC<
 
   const { jumpTo } = useJump()
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     const bankAccountsArray =
       selectedPaymentMethod !== "SEPA_DEBIT"
@@ -119,12 +120,11 @@ export const PaymentRoute: FC<
         id: bankAccountOnOrder.internalID,
       })
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [order])
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     setSelectedPaymentMethod(getInitialPaymentMethodValue(order))
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [order])
 
   /*
@@ -361,6 +361,7 @@ export const PaymentRoute: FC<
   }
 
   // complete payment when balance check is disabled and bank account is set
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     if (
       !balanceCheckEnabled &&
@@ -370,7 +371,6 @@ export const PaymentRoute: FC<
     ) {
       handlePaymentStepComplete()
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     isPaymentSetupSuccessful,
     selectedBankAccountId,
@@ -379,6 +379,7 @@ export const PaymentRoute: FC<
   ])
 
   // show error modal when payment setup error is set
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     if (paymentSetupError) {
       let title = "An error occurred"
@@ -411,7 +412,6 @@ export const PaymentRoute: FC<
         width,
       })
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [paymentSetupError])
 
   const setOrderPayment = (

--- a/src/Apps/Order/Routes/Shipping/Components/AddressModal.tsx
+++ b/src/Apps/Order/Routes/Shipping/Components/AddressModal.tsx
@@ -187,13 +187,13 @@ const AddressModalForm: FC<
     addressModalAction.type === "edit" ? Object.keys(errors.address || {}) : []
 
   // Touch fields that have errors on edit
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     if (attributeErrorFieldsForEdit.length > 0) {
       attributeErrorFieldsForEdit.forEach(field => {
         setFieldTouched(`attributes.${field}`, true)
       })
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [attributeErrorFieldsForEdit.length])
 
   if (!addressModalAction) {

--- a/src/Apps/Order/Routes/Shipping/Components/FulfillmentDetails.tsx
+++ b/src/Apps/Order/Routes/Shipping/Components/FulfillmentDetails.tsx
@@ -68,6 +68,8 @@ export const FulfillmentDetails: FC<
    * If the view ever has no saved addresses, force new address form mode for
    * the rest of its life and reset values
    */
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     const formLoaded =
       typeof shippingContext.state.fulfillmentDetailsFormikContext.setValues ===
@@ -88,13 +90,14 @@ export const FulfillmentDetails: FC<
       )
       shippingContext.actions.setShippingFormMode("new_address")
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasSavedAddresses])
 
   /*
    * Re-save fulfillment details on load if they are already saved &
    * require artsy shipping
    */
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     const { savedFulfillmentDetails } = shippingContext.orderData
 
@@ -125,7 +128,6 @@ export const FulfillmentDetails: FC<
 
       refreshShippingQuotes()
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   /**

--- a/src/Apps/Order/Routes/Shipping/Components/FulfillmentDetailsForm.tsx
+++ b/src/Apps/Order/Routes/Shipping/Components/FulfillmentDetailsForm.tsx
@@ -113,9 +113,10 @@ const FulfillmentDetailsFormLayout = (
    * Expose formik context to entire shipping route
    * via `shippingContext.state.fulfillmentDetailsCtx`
    */
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     shippingContext.actions.setFulfillmentDetailsFormikContext(formikContext)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [formikContext.values, formikContext.isValid])
 
   // Wrapper for change handlers that sets the stage to fulfillment_details
@@ -136,6 +137,7 @@ const FulfillmentDetailsFormLayout = (
 
   const serializedValues = JSON.stringify(formikContext.values)
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   const handleSelectSavedAddress = useCallback(
     async (address: SavedAddressType) => {
       shippingContext.actions.setStage("fulfillment_details")
@@ -150,7 +152,6 @@ const FulfillmentDetailsFormLayout = (
 
       await formikContext.submitForm()
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [formikContext.setValues, formikContext.submitForm, serializedValues]
   )
 
@@ -339,7 +340,7 @@ const FulfillmentDetailsFormLayout = (
                   tabIndex={tabbableIf("new_address")}
                   selected={values.attributes.country}
                   onSelect={withBackToFulfillmentDetails(selected => {
-                    setFieldValue(`attributes.country`, selected)
+                    setFieldValue("attributes.country", selected)
                   })}
                   disabled={
                     !!shippingContext.orderData.lockShippingCountryTo &&
@@ -595,6 +596,7 @@ const VALIDATION_SCHEMA = Yup.object().shape({
 
   attributes: Yup.object().when("fulfillmentType", {
     is: FulfillmentType.SHIP,
+    // biome-ignore lint/suspicious/noThenProperty: <explanation>
     then: schema => schema.shape(ADDRESS_VALIDATION_SHAPE),
     otherwise: schema => schema.shape(BASIC_PHONE_VALIDATION_SHAPE),
   }),

--- a/src/Apps/Order/Routes/Shipping/Components/SavedAddresses.tsx
+++ b/src/Apps/Order/Routes/Shipping/Components/SavedAddresses.tsx
@@ -55,6 +55,7 @@ export const SavedAddresses: FC<
   const addressSavedToOrderID = savedAddressOnOrder?.internalID
 
   // Automatically select (save) best available address ID if it isn't present
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     const activeAndNoAddressSaved =
       props.active &&
@@ -75,7 +76,6 @@ export const SavedAddresses: FC<
     if (bestAddress) {
       selectAndSubmitAddress(bestAddress)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     props.active,
     addressList.length,

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -72,11 +72,11 @@ const ShippingRouteLayout: FC<
 
   const { jumpTo } = useJump()
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     if (shippingContext.state.stage === "shipping_quotes") {
       jumpTo("shippingOptionsTop", { behavior: "smooth" })
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [shippingContext.state.stage])
 
   return (

--- a/src/Apps/Order/Utils/scrollToFieldError.tsx
+++ b/src/Apps/Order/Utils/scrollToFieldError.tsx
@@ -14,6 +14,7 @@ const getFirstFieldErrorName = errors => {
 export const ScrollToFieldError = () => {
   const { submitCount, isValid, errors } = useFormikContext()
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     if (isValid) return
 
@@ -26,7 +27,6 @@ export const ScrollToFieldError = () => {
     if (!field) return
 
     field.scrollIntoView({ behavior: "smooth", block: "center" })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [submitCount])
 
   return null

--- a/src/Apps/Page/PageApp.tsx
+++ b/src/Apps/Page/PageApp.tsx
@@ -41,6 +41,7 @@ const PageApp: FC<React.PropsWithChildren<PageAppProps>> = ({ page }) => {
     }
   }, [page.internalID])
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     if (PAGE_SLUGS_WITH_AUTH_REQUIRED.includes(page.internalID) && !user?.id) {
       showAuthDialog({
@@ -53,7 +54,6 @@ const PageApp: FC<React.PropsWithChildren<PageAppProps>> = ({ page }) => {
         },
       })
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [page, user])
 
   const canonical = TOP_LEVEL_PAGE_SLUG_ALLOWLIST.includes(match.params.id)

--- a/src/Apps/Partner/Routes/Artists/ArtistsRoute.tsx
+++ b/src/Apps/Partner/Routes/Artists/ArtistsRoute.tsx
@@ -24,11 +24,11 @@ export const ArtistsRoute: React.FC<
 
   const { jumpTo } = useJump()
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     if (match.params.artistId && isLoaded && isMobile !== null) {
       jumpTo("PartnerArtistDetails")
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isLoaded, isMobile, match.params.artistId])
 
   return (

--- a/src/Apps/PartnerOffer/Routes/PartnerOfferCheckout.tsx
+++ b/src/Apps/PartnerOffer/Routes/PartnerOfferCheckout.tsx
@@ -51,9 +51,9 @@ export const PartnerOfferCheckout: FC<
     }
   }, [partnerCheckoutMutation, partnerOfferId, router])
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     handleRedirect()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   return (

--- a/src/Apps/Sell/Components/ArtistAutocomplete.tsx
+++ b/src/Apps/Sell/Components/ArtistAutocomplete.tsx
@@ -112,9 +112,9 @@ export const ArtistAutoComplete: React.FC<
     }
   }
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   const handleSuggestionsFetchRequested = useMemo(
     () => debounce(updateSuggestions, DEBOUNCE_DELAY),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   )
 

--- a/src/Apps/Sell/Components/SubmissionHeader.tsx
+++ b/src/Apps/Sell/Components/SubmissionHeader.tsx
@@ -79,6 +79,7 @@ export const SubmissionHeader: React.FC<
 
   const submitForm = formik?.submitForm
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   const submitAndSaveCallback = useCallback(async () => {
     if (!submission) return
 
@@ -96,8 +97,6 @@ export const SubmissionHeader: React.FC<
     } finally {
       setIsSubmitting(false)
     }
-    // FIXME:
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [submitForm, submission, step, routerPush])
 
   const onAfterAuthCallback = useCallback(async () => {

--- a/src/Apps/Sell/SellFlowContext.tsx
+++ b/src/Apps/Sell/SellFlowContext.tsx
@@ -188,6 +188,7 @@ export const SellFlowContextProvider: React.FC<
     handleNext()
   }
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     const newStep = steps[index]
 
@@ -205,10 +206,8 @@ export const SellFlowContextProvider: React.FC<
       return
 
     router.push(
-      `/sell/submissions/${submission?.externalId}/${newStep}` +
-        testSubmissionQueryParams
+      `/sell/submissions/${submission?.externalId}/${newStep}${testSubmissionQueryParams}`
     )
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [index, isNewSubmission, submission, steps])
 
   const createSubmission = (values: CreateSubmissionMutationInput) => {
@@ -227,7 +226,7 @@ export const SellFlowContextProvider: React.FC<
       logger.error("Error creating submission.", err)
       sendToast({
         variant: "error",
-        message: "Something went wrong." + ` ${err?.[0]?.message} || ""`,
+        message: `Something went wrong. ${err?.[0]?.message} || ""`,
       })
       throw err
     })
@@ -252,7 +251,7 @@ export const SellFlowContextProvider: React.FC<
       logger.error("Error updating submission.", err)
       sendToast({
         variant: "error",
-        message: "Something went wrong." + ` ${err?.[0]?.message || ""}`,
+        message: `Something went wrong. ${err?.[0]?.message || ""}`,
       })
       throw err
     })
@@ -282,7 +281,7 @@ export const SellFlowContextProvider: React.FC<
         logger.error("Error updating submission's my collection artwork..", err)
         sendToast({
           variant: "error",
-          message: "Something went wrong." + ` ${err?.[0]?.message || ""}`,
+          message: `Something went wrong. ${err?.[0]?.message || ""}`,
         })
         throw err
       })

--- a/src/Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp.tsx
+++ b/src/Apps/Settings/Routes/SavedSearchAlerts/SavedSearchAlertsApp.tsx
@@ -71,6 +71,7 @@ export const SavedSearchAlertsApp: React.FC<
 
   const [viewOption, setViewOption] = useState<"EDIT" | "ARTWORKS" | null>(null)
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     if (!alerts || !alerts[0]) return
     if (match?.params?.alertID) return
@@ -88,7 +89,6 @@ export const SavedSearchAlertsApp: React.FC<
       setViewOption("EDIT")
       silentPush(`/favorites/alerts/${alerts[0].internalID}/edit`)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isMobile, match.params])
 
   const closeModal = () => {
@@ -202,6 +202,7 @@ export const SavedSearchAlertsApp: React.FC<
   const alertID = match?.params?.alertID ?? editAlertEntity?.id
   const path = match.location.pathname
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     if (!alertID) return
 
@@ -245,8 +246,6 @@ export const SavedSearchAlertsApp: React.FC<
           silentPush(`/favorites/alerts/${alert.internalID}/edit`)
         }
       })
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [alertID, relayEnvironment])
 
   const list = useMemo(

--- a/src/Components/Address/AddressAutocompleteInput.tsx
+++ b/src/Components/Address/AddressAutocompleteInput.tsx
@@ -293,6 +293,7 @@ export const AddressAutocompleteInput = ({
   const serializedOptions = JSON.stringify(autocompleteOptions)
   const serializedPreviousOptions = JSON.stringify(previousOptions)
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     if (
       serviceAvailability?.enabled &&
@@ -303,7 +304,6 @@ export const AddressAutocompleteInput = ({
         providerSuggestions.length
       )
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [serviceAvailability, serializedOptions, serializedPreviousOptions])
 
   if (definitelyDisabled) {
@@ -371,9 +371,7 @@ const fetchSuggestionsWithThrottle = throttle(
       params["selected"] = selected
     }
 
-    const url =
-      "https://us-autocomplete-pro.api.smarty.com/lookup?" +
-      new URLSearchParams(params).toString()
+    const url = `https://us-autocomplete-pro.api.smarty.com/lookup?${new URLSearchParams(params).toString()}`
 
     const response = await fetch(url)
     const json = await response.json()

--- a/src/Components/Address/AddressForm.tsx
+++ b/src/Components/Address/AddressForm.tsx
@@ -115,11 +115,11 @@ export const AddressForm: React.FC<
     onChangeValue(key, value)
   }
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   React.useEffect(() => {
     if (key) {
       onChange(address, key)
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [address, key])
 
   const onChangeValue = (key: keyof Address, value: string) => {

--- a/src/Components/Artwork/useArtworkLists.ts
+++ b/src/Components/Artwork/useArtworkLists.ts
@@ -19,6 +19,7 @@ export const useArtworkLists = (options: SaveArtworkToListsOptions) => {
   const { saveArtworkToLists: saveToLists, openSelectListsForArtworkModal } =
     useSaveArtworkToLists(options)
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     if (
       !value ||
@@ -59,7 +60,6 @@ export const useArtworkLists = (options: SaveArtworkToListsOptions) => {
 
     clearValue()
     fetchSavedStatusAndPerformAction()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value, clearValue])
 
   const showToastByAction = (action: ResultAction, isInAuction: boolean) => {

--- a/src/Components/ArtworkFilter/ArtworkFilterMobileOverlay.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilterMobileOverlay.tsx
@@ -28,6 +28,7 @@ export const ArtworkFilterMobileOverlay: React.FC<
     contentRef.current.scrollTop = 0
   }
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     // While mobile sheet is mounted, the effect of the user's filter selections
     // should be merely staged until the Apply button is pressed, rather than
@@ -46,7 +47,6 @@ export const ArtworkFilterMobileOverlay: React.FC<
     }
     // FIXME: Unclear how to unwind this hack at the moment; satisfying the deps causes
     // this to immediately un-apply the changes. Leaving it as-is for now.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   // Enumerate the difference between prior and currently selected filters

--- a/src/Components/ArtworkFilter/ArtworkFilters/ArtistsFilter.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/ArtistsFilter.tsx
@@ -94,14 +94,13 @@ export const ArtistsFilter: FC<React.PropsWithChildren<ArtistsFilterProps>> = ({
   )
   const label = `Artists${filtersCount}`
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     if (artists?.counts && relayEnvironment && user) {
       fetchFollowedArtists({ relayEnvironment, fairID }).then(data => {
         setFollowedArtists?.(data)
       })
     }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   if (!(artists && artists.counts)) {

--- a/src/Components/ArtworkFilter/ArtworkFilters/KeywordFilter.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/KeywordFilter.tsx
@@ -26,9 +26,9 @@ export const KeywordFilter: React.FC<React.PropsWithChildren<unknown>> = () => {
     setFilterRef.current("keyword", textOrUndefined)
   }
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   const handleDebounce = useMemo(
     () => debounce(updateKeywordFilter, DEBOUNCE_DELAY),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   )
 
@@ -38,11 +38,12 @@ export const KeywordFilter: React.FC<React.PropsWithChildren<unknown>> = () => {
   }
 
   // Stop the invocation of the debounced function after unmounting
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     return () => handleDebounce.cancel?.()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     setValue(keyword ?? "")
   }, [keyword, setValue])

--- a/src/Components/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/SizeFilter.tsx
@@ -157,15 +157,14 @@ export const SizeFilter: React.FC<React.PropsWithChildren<SizeFilterProps>> = ({
     setFilters?.(updatedFilters, { force: false })
   }
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
-    if (width == "*-*" || height === "*-*") {
+    if (width === "*-*" || height === "*-*") {
       setCustomSize({
         width: parseSizeRange(width, metric),
         height: parseSizeRange(height, metric),
       })
     }
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [width, height])
 
   useEffect(() => {

--- a/src/Components/ArtworkFilter/ArtworkFilters/__tests__/AvailabilityFilter.jest.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/__tests__/AvailabilityFilter.jest.tsx
@@ -52,14 +52,13 @@ describe(AvailabilityFilter, () => {
       const MobileVersionOfAvailabilityFilter = () => {
         const filterContext = useArtworkFilterContext()
 
+        // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
         useEffect(() => {
           // on mount, initialize the staged filters
           filterContext.setShouldStageFilterChanges?.(true)
           if (filterContext.filters) {
             filterContext.setStagedFilters?.(filterContext.filters)
           }
-
-          // eslint-disable-next-line react-hooks/exhaustive-deps
         }, [])
 
         return <AvailabilityFilter expanded />

--- a/src/Components/BankDebitForm/BankDebitProvider.tsx
+++ b/src/Components/BankDebitForm/BankDebitProvider.tsx
@@ -52,6 +52,7 @@ export const BankDebitProvider: FC<React.PropsWithChildren<Props>> = ({
   const [bankDebitSetupError, setBankDebitSetupError] = useState(false)
   const { submitMutation } = CreateBankDebitSetupForOrder()
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     const fetchData = async () => {
       try {
@@ -85,7 +86,6 @@ export const BankDebitProvider: FC<React.PropsWithChildren<Props>> = ({
     if (!stripeClient) {
       fetchData()
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const { theme } = useTheme()
@@ -164,7 +164,7 @@ export const BankDebitProvider: FC<React.PropsWithChildren<Props>> = ({
         isLoading={isStripePaymentElementLoading && !bankDebitSetupError}
       >
         {isStripePaymentElementLoading && !bankDebitSetupError && (
-          <Box height={300}></Box>
+          <Box height={300} />
         )}
         <Spacer y={2} />
         {stripeClient && (

--- a/src/Components/DeepZoom/DeepZoom.tsx
+++ b/src/Components/DeepZoom/DeepZoom.tsx
@@ -40,6 +40,7 @@ const DeepZoom: React.FC<React.PropsWithChildren<DeepZoomProps>> = ({
     }))
   }
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     if (!deepZoomRef.current) return
 
@@ -96,7 +97,6 @@ const DeepZoom: React.FC<React.PropsWithChildren<DeepZoomProps>> = ({
       osdViewerRef.current.destroy()
       osdViewerRef.current = null
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [image.deepZoom, deepZoomRef?.current])
 
   const zoomBy = (amount: number) => {

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -88,11 +88,11 @@ export const NavBar: React.FC<React.PropsWithChildren<unknown>> = track(
 
   // Prefetch most clicked links.
   // See: https://artsy.slack.com/archives/C05EEBNEF71/p1726074422149369?thread_ts=1726073316.088559&cid=C05EEBNEF71
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     const PREFETCH_NAVBAR_LINKS = ["/artists", "/collect"]
 
     PREFETCH_NAVBAR_LINKS.forEach(prefetch)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const handleMobileNavClick = (

--- a/src/Components/Onboarding/Hooks/useOnboardingFadeTransition.tsx
+++ b/src/Components/Onboarding/Hooks/useOnboardingFadeTransition.tsx
@@ -13,6 +13,7 @@ export const useOnboardingFadeTransition = ({
     initialStatus: "Out",
   })
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     const init = async () => {
       await wait(100)
@@ -20,8 +21,6 @@ export const useOnboardingFadeTransition = ({
     }
 
     init()
-
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const handleNext = async () => {

--- a/src/Components/PhotoUpload/Components/PhotoDropzone.tsx
+++ b/src/Components/PhotoUpload/Components/PhotoDropzone.tsx
@@ -50,12 +50,11 @@ export const PhotoDropzone: React.FC<
     multiple: true,
   })
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     const errors = concatDropzoneErrors(fileRejections, customErrors)
 
     onReject(errors)
-    // FIXME: Remove this disable
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [customErrors, fileRejections])
 
   return (

--- a/src/Components/Search/Mobile/Overlay.tsx
+++ b/src/Components/Search/Mobile/Overlay.tsx
@@ -50,6 +50,7 @@ export const Overlay: FC<React.PropsWithChildren<OverlayProps>> = ({
   const [inputValue, setInputValue] = useState("")
   const disablePills = !shouldStartSearching(inputValue)
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     inputRef.current?.focus()
 
@@ -58,7 +59,6 @@ export const Overlay: FC<React.PropsWithChildren<OverlayProps>> = ({
       context_module: selectedPill.analyticsContextModule,
     })
     // When selecting another pill - this effect shouldn't be executed again, so we disable the linting rule
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   const refetch = useCallback(

--- a/src/Components/Search/Mobile/SearchResultsList.tsx
+++ b/src/Components/Search/Mobile/SearchResultsList.tsx
@@ -38,6 +38,7 @@ const SearchResultsList: FC<
   const tracking = useTracking()
   const options = extractNodes(viewer.searchConnection)
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     if (viewer.searchConnection) {
       tracking.trackEvent({
@@ -50,7 +51,6 @@ const SearchResultsList: FC<
       })
     }
     // When selecting another pill - this effect shouldn't be executed again, so we disable the linting rule
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [viewer.searchConnection])
 
   const formattedOptions: SuggestionItemOptionProps[] = formatOptions(

--- a/src/DevTools/MockRouter.tsx
+++ b/src/DevTools/MockRouter.tsx
@@ -38,6 +38,7 @@ export const MockRouter: React.FC<React.PropsWithChildren<MockRouterProps>> = ({
   const [MockRouterApp, setMockRouterApp] =
     useState<React.ReactElement<any> | null>(null)
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     const initRouter = async () => {
       try {
@@ -76,7 +77,6 @@ export const MockRouter: React.FC<React.PropsWithChildren<MockRouterProps>> = ({
     }
 
     initRouter()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
   if (!MockRouterApp) {

--- a/src/System/Hooks/usePrefetchRoute.tsx
+++ b/src/System/Hooks/usePrefetchRoute.tsx
@@ -28,6 +28,7 @@ export const usePrefetchRoute = ({
   // If we're transitioning routes, we don't want to prefetch
   const prefetchDisabled = !prefetchFeatureFlagEnabled || !match?.elements
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   const prefetch = useCallback(
     (path = initialPath) => {
       if (prefetchDisabled) {
@@ -107,7 +108,6 @@ export const usePrefetchRoute = ({
 
       return querySubscriptions
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [initialPath, prefetchDisabled]
   )
 

--- a/src/Utils/Hooks/useClientQuery.ts
+++ b/src/Utils/Hooks/useClientQuery.ts
@@ -74,6 +74,7 @@ export const useClientQuery = <T extends OperationType>({
     }
   }
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     if (key.current !== prevKey.current) {
       setData(null)
@@ -89,7 +90,6 @@ export const useClientQuery = <T extends OperationType>({
 
     // https://github.com/facebook/react/issues/25149
     // Excludes `T`
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     cacheConfig,
     data,

--- a/src/Utils/Hooks/useDebounce.ts
+++ b/src/Utils/Hooks/useDebounce.ts
@@ -15,7 +15,7 @@ export const useDebounce = ({
   delay = 200,
   settings,
 }: UseDebounce) => {
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   return useCallback(debounce(callback, delay, settings), [callback, delay])
 }
 

--- a/src/Utils/localImageHelpers.ts
+++ b/src/Utils/localImageHelpers.ts
@@ -99,9 +99,9 @@ export const useLocalImageStorage = (
     }
   }
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     changeLocalImage()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [key])
 
   return localImage


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

The new linter requires that react exhaustive-deps ignores to near useEffect, not near the dep array. This fixes that. 
