### PR TITLE
fix(artwork): correctly tracks on artwork => artwork nav

### DIFF
--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -217,8 +217,11 @@ export const ArtworkApp: React.FC<React.PropsWithChildren<Props>> = props => {
       // this.props.router.replace(this.props.match.location.pathname)
       silentPush(props.match.location.pathname)
     }
-    track()
   }, [])
+
+  useEffect(() => {
+    track()
+  }, [track])
 
   if (match?.location?.query?.creating_order) {
     return (


### PR DESCRIPTION
Fixed tracking for artwork-to-artwork navigation alongside the other criteria @mzikherman noted. Issue was resolved by adding track to the dependency array and separating it into its own effect.