### PR TITLE
fix: allow forque link to be exposed to client-side nav'd pages

### DIFF
--- a/src/Server/bootstrapSharify.ts
+++ b/src/Server/bootstrapSharify.ts
@@ -91,6 +91,7 @@ export const bootstrapSharify = () => {
       "TARGET_CAMPAIGN_URL",
       "TEAM_BLOGS",
       "THIRD_PARTIES_DISABLED,",
+      "TOOLS_URL",
       "TRACK_PAGELOAD_PATHS",
       "USER_PREFERENCES",
       "VOLLEY_ENDPOINT",


### PR DESCRIPTION
Lil update to sharify to [allow the inspect images link to work](https://artsy.slack.com/archives/C045UP78DG8/p1734719548758179?thread_ts=1732742421.746579&cid=C045UP78DG8) when you get to an artwork page via client-side nav.