### PR TITLE
fix(EMI-2213): failed payment redirect

### DIFF
--- a/src/Apps/Order/redirects.tsx
+++ b/src/Apps/Order/redirects.tsx
@@ -160,18 +160,18 @@ const goToRespondIfMyLastOfferIsNotMostRecentOffer: OrderPredicate = ({
 }
 
 const goToRespondIfAwaitingBuyerResponse: OrderPredicate = ({ order }) => {
-  if (order.awaitingResponseFrom === "BUYER")
+  if (order.awaitingResponseFrom === "BUYER") {
     if (order.displayState === "PAYMENT_FAILED") {
       return {
         path: `/orders/${order.internalID}/payment/new`,
         reason: "Payment failed",
       }
-    } else {
-      return {
-        path: `/orders/${order.internalID}/respond`,
-        reason: "Still awaiting buyer response",
-      }
     }
+    return {
+      path: `/orders/${order.internalID}/respond`,
+      reason: "Still awaiting buyer response",
+    }
+  }
 }
 
 export const redirects: RedirectRecord<OrderQuery> = {

--- a/src/Apps/Order/redirects.tsx
+++ b/src/Apps/Order/redirects.tsx
@@ -160,12 +160,18 @@ const goToRespondIfMyLastOfferIsNotMostRecentOffer: OrderPredicate = ({
 }
 
 const goToRespondIfAwaitingBuyerResponse: OrderPredicate = ({ order }) => {
-  if (order.awaitingResponseFrom === "BUYER") {
-    return {
-      path: `/orders/${order.internalID}/respond`,
-      reason: "Still awaiting buyer response",
+  if (order.awaitingResponseFrom === "BUYER")
+    if (order.displayState !== "PAYMENT_FAILED") {
+      return {
+        path: `/orders/${order.internalID}/respond`,
+        reason: "Still awaiting buyer response",
+      }
+    } else {
+      return {
+        path: `/orders/${order.internalID}/payment/new`,
+        reason: "Payment failed",
+      }
     }
-  }
 }
 
 export const redirects: RedirectRecord<OrderQuery> = {

--- a/src/Apps/Order/redirects.tsx
+++ b/src/Apps/Order/redirects.tsx
@@ -161,15 +161,15 @@ const goToRespondIfMyLastOfferIsNotMostRecentOffer: OrderPredicate = ({
 
 const goToRespondIfAwaitingBuyerResponse: OrderPredicate = ({ order }) => {
   if (order.awaitingResponseFrom === "BUYER")
-    if (order.displayState !== "PAYMENT_FAILED") {
-      return {
-        path: `/orders/${order.internalID}/respond`,
-        reason: "Still awaiting buyer response",
-      }
-    } else {
+    if (order.displayState === "PAYMENT_FAILED") {
       return {
         path: `/orders/${order.internalID}/payment/new`,
         reason: "Payment failed",
+      }
+    } else {
+      return {
+        path: `/orders/${order.internalID}/respond`,
+        reason: "Still awaiting buyer response",
       }
     }
 }


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2213]

### Description

Adding a redirect for the payment failed scenario, so the user is presented with the payment/new route instead of an infinite loop

https://github.com/user-attachments/assets/6ff9bf7d-a210-4b27-86e3-14e0dd307278



[EMI-2213]: https://artsyproduct.atlassian.net/browse/EMI-2213?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ