### PR TITLE
fix: include initial input/sort when prefetching artist artworks

### DIFF
--- a/src/Apps/Artist/Routes/WorksForSale/ArtistWorksForSaleRoute.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/ArtistWorksForSaleRoute.tsx
@@ -117,8 +117,11 @@ export const ArtistWorksForSaleRouteFragmentContainer = createFragmentContainer(
       @argumentDefinitions(
         isPrefetched: { type: "Boolean!", defaultValue: false }
         aggregations: { type: "[ArtworkAggregation]" }
+        input: { type: "FilterArtworksInput" }
       ) {
-        ...ArtistArtworkFilter_artist @include(if: $isPrefetched)
+        ...ArtistArtworkFilter_artist
+          @arguments(input: $input)
+          @include(if: $isPrefetched)
         ...ArtistWorksForSaleEmpty_artist
         slug
         meta(page: ARTWORKS) {

--- a/src/Apps/Artist/artistRoutes.tsx
+++ b/src/Apps/Artist/artistRoutes.tsx
@@ -144,12 +144,14 @@ export const artistRoutes: RouteProps[] = [
             $artistID: String!
             $isPrefetched: Boolean!
             $aggregations: [ArtworkAggregation]
+            $input: FilterArtworksInput
           ) {
             artist(id: $artistID) @principalField {
               ...ArtistWorksForSaleRoute_artist
                 @arguments(
                   isPrefetched: $isPrefetched
                   aggregations: $aggregations
+                  input: $input
                 )
             }
           }

--- a/src/__generated__/ArtistWorksForSaleRoute_artist.graphql.ts
+++ b/src/__generated__/ArtistWorksForSaleRoute_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4e0529a6ff76ab04b2327c23812debb0>>
+ * @generated SignedSource<<01a5eaa6271b1df6ee8b69f9d6405da1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -46,6 +46,11 @@ const node: ReaderFragment = {
       "name": "aggregations"
     },
     {
+      "defaultValue": null,
+      "kind": "LocalArgument",
+      "name": "input"
+    },
+    {
       "defaultValue": false,
       "kind": "LocalArgument",
       "name": "isPrefetched"
@@ -61,7 +66,13 @@ const node: ReaderFragment = {
       "passingValue": true,
       "selections": [
         {
-          "args": null,
+          "args": [
+            {
+              "kind": "Variable",
+              "name": "input",
+              "variableName": "input"
+            }
+          ],
           "kind": "FragmentSpread",
           "name": "ArtistArtworkFilter_artist"
         },
@@ -205,6 +216,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "2c8c6a3fb495ca2922aae8991575ce6c";
+(node as any).hash = "1f34f26d1a343711d35a84e84d16a2df";
 
 export default node;

--- a/src/__generated__/artistRoutes_WorksForSaleQuery.graphql.ts
+++ b/src/__generated__/artistRoutes_WorksForSaleQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b3e9eed7fc13da4400e5adde94481d84>>
+ * @generated SignedSource<<de298dbc7f1a57206cf4e20a73b7a271>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,9 +11,62 @@
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ARTIST_SERIES" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "LOCATION_CITY" | "MAJOR_PERIOD" | "MATERIALS_TERMS" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "SIMPLE_PRICE_HISTOGRAM" | "TOTAL" | "%future added value";
+export type ArtworkSizes = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
+export type FilterArtworksInput = {
+  acquireable?: boolean | null | undefined;
+  additionalGeneIDs?: ReadonlyArray<string | null | undefined> | null | undefined;
+  after?: string | null | undefined;
+  aggregationPartnerCities?: ReadonlyArray<string | null | undefined> | null | undefined;
+  aggregations?: ReadonlyArray<ArtworkAggregation | null | undefined> | null | undefined;
+  artistID?: string | null | undefined;
+  artistIDs?: ReadonlyArray<string | null | undefined> | null | undefined;
+  artistNationalities?: ReadonlyArray<string | null | undefined> | null | undefined;
+  artistSeriesID?: string | null | undefined;
+  artistSeriesIDs?: ReadonlyArray<string | null | undefined> | null | undefined;
+  atAuction?: boolean | null | undefined;
+  attributionClass?: ReadonlyArray<string | null | undefined> | null | undefined;
+  before?: string | null | undefined;
+  color?: string | null | undefined;
+  colors?: ReadonlyArray<string | null | undefined> | null | undefined;
+  dimensionRange?: string | null | undefined;
+  excludeArtworkIDs?: ReadonlyArray<string | null | undefined> | null | undefined;
+  extraAggregationGeneIDs?: ReadonlyArray<string | null | undefined> | null | undefined;
+  first?: number | null | undefined;
+  forSale?: boolean | null | undefined;
+  geneID?: string | null | undefined;
+  geneIDs?: ReadonlyArray<string | null | undefined> | null | undefined;
+  height?: string | null | undefined;
+  includeArtworksByFollowedArtists?: boolean | null | undefined;
+  includeMediumFilterInAggregation?: boolean | null | undefined;
+  inquireableOnly?: boolean | null | undefined;
+  keyword?: string | null | undefined;
+  keywordMatchExact?: boolean | null | undefined;
+  last?: number | null | undefined;
+  locationCities?: ReadonlyArray<string | null | undefined> | null | undefined;
+  majorPeriods?: ReadonlyArray<string | null | undefined> | null | undefined;
+  marketable?: boolean | null | undefined;
+  marketingCollectionID?: string | null | undefined;
+  materialsTerms?: ReadonlyArray<string | null | undefined> | null | undefined;
+  medium?: string | null | undefined;
+  offerable?: boolean | null | undefined;
+  page?: number | null | undefined;
+  partnerCities?: ReadonlyArray<string | null | undefined> | null | undefined;
+  partnerID?: string | null | undefined;
+  partnerIDs?: ReadonlyArray<string | null | undefined> | null | undefined;
+  period?: string | null | undefined;
+  periods?: ReadonlyArray<string | null | undefined> | null | undefined;
+  priceRange?: string | null | undefined;
+  saleID?: string | null | undefined;
+  size?: number | null | undefined;
+  sizes?: ReadonlyArray<ArtworkSizes | null | undefined> | null | undefined;
+  sort?: string | null | undefined;
+  tagID?: string | null | undefined;
+  width?: string | null | undefined;
+};
 export type artistRoutes_WorksForSaleQuery$variables = {
   aggregations?: ReadonlyArray<ArtworkAggregation | null | undefined> | null | undefined;
   artistID: string;
+  input?: FilterArtworksInput | null | undefined;
   isPrefetched: boolean;
 };
 export type artistRoutes_WorksForSaleQuery$data = {
@@ -40,72 +93,82 @@ v1 = {
 v2 = {
   "defaultValue": null,
   "kind": "LocalArgument",
+  "name": "input"
+},
+v3 = {
+  "defaultValue": null,
+  "kind": "LocalArgument",
   "name": "isPrefetched"
 },
-v3 = [
+v4 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "artistID"
   }
 ],
-v4 = {
+v5 = {
   "kind": "Variable",
   "name": "aggregations",
   "variableName": "aggregations"
 },
-v5 = {
+v6 = {
+  "kind": "Variable",
+  "name": "input",
+  "variableName": "input"
+},
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v6 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v7 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "slug",
   "storageKey": null
 },
-v8 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "title",
   "storageKey": null
 },
-v9 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v10 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "cursor",
   "storageKey": null
 },
-v11 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "page",
   "storageKey": null
 },
-v12 = [
-  (v10/*: any*/),
-  (v11/*: any*/),
+v14 = [
+  (v12/*: any*/),
+  (v13/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -114,17 +177,17 @@ v12 = [
     "storageKey": null
   }
 ],
-v13 = [
-  (v9/*: any*/)
+v15 = [
+  (v11/*: any*/)
 ],
-v14 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v15 = {
+v17 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -132,14 +195,14 @@ v15 = {
     "large"
   ]
 },
-v16 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v17 = [
+v19 = [
   {
     "alias": null,
     "args": null,
@@ -148,37 +211,38 @@ v17 = [
     "storageKey": null
   }
 ],
-v18 = [
+v20 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v19 = {
+v21 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v20 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v21 = [
-  (v6/*: any*/),
-  (v9/*: any*/)
+v23 = [
+  (v8/*: any*/),
+  (v11/*: any*/)
 ];
 return {
   "fragment": {
     "argumentDefinitions": [
       (v0/*: any*/),
       (v1/*: any*/),
-      (v2/*: any*/)
+      (v2/*: any*/),
+      (v3/*: any*/)
     ],
     "kind": "Fragment",
     "metadata": null,
@@ -186,7 +250,7 @@ return {
     "selections": [
       {
         "alias": null,
-        "args": (v3/*: any*/),
+        "args": (v4/*: any*/),
         "concreteType": "Artist",
         "kind": "LinkedField",
         "name": "artist",
@@ -194,7 +258,8 @@ return {
         "selections": [
           {
             "args": [
-              (v4/*: any*/),
+              (v5/*: any*/),
+              (v6/*: any*/),
               {
                 "kind": "Variable",
                 "name": "isPrefetched",
@@ -215,23 +280,24 @@ return {
   "operation": {
     "argumentDefinitions": [
       (v1/*: any*/),
-      (v2/*: any*/),
-      (v0/*: any*/)
+      (v3/*: any*/),
+      (v0/*: any*/),
+      (v2/*: any*/)
     ],
     "kind": "Operation",
     "name": "artistRoutes_WorksForSaleQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v3/*: any*/),
+        "args": (v4/*: any*/),
         "concreteType": "Artist",
         "kind": "LinkedField",
         "name": "artist",
         "plural": false,
         "selections": [
-          (v5/*: any*/),
-          (v6/*: any*/),
           (v7/*: any*/),
+          (v8/*: any*/),
+          (v9/*: any*/),
           {
             "alias": null,
             "args": [
@@ -253,11 +319,11 @@ return {
                 "name": "description",
                 "storageKey": null
               },
-              (v8/*: any*/)
+              (v10/*: any*/)
             ],
             "storageKey": "meta(page:\"ARTWORKS\")"
           },
-          (v9/*: any*/),
+          (v11/*: any*/),
           {
             "condition": "isPrefetched",
             "kind": "Condition",
@@ -323,14 +389,15 @@ return {
                     "kind": "Literal",
                     "name": "first",
                     "value": 30
-                  }
+                  },
+                  (v6/*: any*/)
                 ],
                 "concreteType": "FilterArtworksConnection",
                 "kind": "LinkedField",
                 "name": "filterArtworksConnection",
                 "plural": false,
                 "selections": [
-                  (v9/*: any*/),
+                  (v11/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -395,7 +462,7 @@ return {
                         "kind": "LinkedField",
                         "name": "around",
                         "plural": true,
-                        "selections": (v12/*: any*/),
+                        "selections": (v14/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -405,7 +472,7 @@ return {
                         "kind": "LinkedField",
                         "name": "first",
                         "plural": false,
-                        "selections": (v12/*: any*/),
+                        "selections": (v14/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -415,7 +482,7 @@ return {
                         "kind": "LinkedField",
                         "name": "last",
                         "plural": false,
-                        "selections": (v12/*: any*/),
+                        "selections": (v14/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -426,8 +493,8 @@ return {
                         "name": "previous",
                         "plural": false,
                         "selections": [
-                          (v10/*: any*/),
-                          (v11/*: any*/)
+                          (v12/*: any*/),
+                          (v13/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -449,7 +516,7 @@ return {
                         "kind": "LinkedField",
                         "name": "node",
                         "plural": false,
-                        "selections": (v13/*: any*/),
+                        "selections": (v15/*: any*/),
                         "storageKey": null
                       }
                     ],
@@ -481,9 +548,9 @@ return {
                             "name": "node",
                             "plural": false,
                             "selections": [
+                              (v9/*: any*/),
+                              (v16/*: any*/),
                               (v7/*: any*/),
-                              (v14/*: any*/),
-                              (v5/*: any*/),
                               {
                                 "alias": null,
                                 "args": [
@@ -505,7 +572,7 @@ return {
                                     "name": "aspectRatio",
                                     "storageKey": null
                                   },
-                                  (v5/*: any*/),
+                                  (v7/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -516,7 +583,7 @@ return {
                                   {
                                     "alias": null,
                                     "args": [
-                                      (v15/*: any*/)
+                                      (v17/*: any*/)
                                     ],
                                     "kind": "ScalarField",
                                     "name": "url",
@@ -539,7 +606,7 @@ return {
                                   {
                                     "alias": null,
                                     "args": [
-                                      (v15/*: any*/),
+                                      (v17/*: any*/),
                                       {
                                         "kind": "Literal",
                                         "name": "width",
@@ -585,7 +652,7 @@ return {
                                 ],
                                 "storageKey": "image(includeAll:false)"
                               },
-                              (v8/*: any*/),
+                              (v10/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -676,7 +743,7 @@ return {
                                     "name": "partnerOffer",
                                     "plural": false,
                                     "selections": [
-                                      (v16/*: any*/),
+                                      (v18/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -684,10 +751,10 @@ return {
                                         "kind": "LinkedField",
                                         "name": "priceWithDiscount",
                                         "plural": false,
-                                        "selections": (v17/*: any*/),
+                                        "selections": (v19/*: any*/),
                                         "storageKey": null
                                       },
-                                      (v9/*: any*/)
+                                      (v11/*: any*/)
                                     ],
                                     "storageKey": null
                                   }
@@ -710,7 +777,7 @@ return {
                               },
                               {
                                 "alias": null,
-                                "args": (v18/*: any*/),
+                                "args": (v20/*: any*/),
                                 "concreteType": "Artist",
                                 "kind": "LinkedField",
                                 "name": "artist",
@@ -734,7 +801,7 @@ return {
                                     ],
                                     "storageKey": null
                                   },
-                                  (v9/*: any*/)
+                                  (v11/*: any*/)
                                 ],
                                 "storageKey": "artist(shallow:true)"
                               },
@@ -758,15 +825,15 @@ return {
                               },
                               {
                                 "alias": null,
-                                "args": (v18/*: any*/),
+                                "args": (v20/*: any*/),
                                 "concreteType": "Artist",
                                 "kind": "LinkedField",
                                 "name": "artists",
                                 "plural": true,
                                 "selections": [
-                                  (v9/*: any*/),
-                                  (v14/*: any*/),
-                                  (v6/*: any*/)
+                                  (v11/*: any*/),
+                                  (v16/*: any*/),
+                                  (v8/*: any*/)
                                 ],
                                 "storageKey": "artists(shallow:true)"
                               },
@@ -779,15 +846,15 @@ return {
                               },
                               {
                                 "alias": null,
-                                "args": (v18/*: any*/),
+                                "args": (v20/*: any*/),
                                 "concreteType": "Partner",
                                 "kind": "LinkedField",
                                 "name": "partner",
                                 "plural": false,
                                 "selections": [
-                                  (v6/*: any*/),
-                                  (v14/*: any*/),
-                                  (v9/*: any*/)
+                                  (v8/*: any*/),
+                                  (v16/*: any*/),
+                                  (v11/*: any*/)
                                 ],
                                 "storageKey": "partner(shallow:true)"
                               },
@@ -799,7 +866,7 @@ return {
                                 "name": "sale",
                                 "plural": false,
                                 "selections": [
-                                  (v16/*: any*/),
+                                  (v18/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -835,7 +902,7 @@ return {
                                     "name": "isClosed",
                                     "storageKey": null
                                   },
-                                  (v9/*: any*/),
+                                  (v11/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -861,7 +928,7 @@ return {
                                 "name": "saleArtwork",
                                 "plural": false,
                                 "selections": [
-                                  (v19/*: any*/),
+                                  (v21/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -869,8 +936,8 @@ return {
                                     "name": "lotLabel",
                                     "storageKey": null
                                   },
-                                  (v16/*: any*/),
-                                  (v20/*: any*/),
+                                  (v18/*: any*/),
+                                  (v22/*: any*/),
                                   {
                                     "alias": null,
                                     "args": null,
@@ -903,7 +970,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "highestBid",
                                     "plural": false,
-                                    "selections": (v17/*: any*/),
+                                    "selections": (v19/*: any*/),
                                     "storageKey": null
                                   },
                                   {
@@ -913,10 +980,10 @@ return {
                                     "kind": "LinkedField",
                                     "name": "openingBid",
                                     "plural": false,
-                                    "selections": (v17/*: any*/),
+                                    "selections": (v19/*: any*/),
                                     "storageKey": null
                                   },
-                                  (v9/*: any*/)
+                                  (v11/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -928,10 +995,10 @@ return {
                                 "name": "saleArtwork",
                                 "plural": false,
                                 "selections": [
-                                  (v19/*: any*/),
-                                  (v9/*: any*/),
-                                  (v16/*: any*/),
-                                  (v20/*: any*/)
+                                  (v21/*: any*/),
+                                  (v11/*: any*/),
+                                  (v18/*: any*/),
+                                  (v22/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -942,7 +1009,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "attributionClass",
                                 "plural": false,
-                                "selections": (v21/*: any*/),
+                                "selections": (v23/*: any*/),
                                 "storageKey": null
                               },
                               {
@@ -960,7 +1027,7 @@ return {
                                     "kind": "LinkedField",
                                     "name": "filterGene",
                                     "plural": false,
-                                    "selections": (v21/*: any*/),
+                                    "selections": (v23/*: any*/),
                                     "storageKey": null
                                   }
                                 ],
@@ -985,7 +1052,7 @@ return {
                           },
                           {
                             "kind": "InlineFragment",
-                            "selections": (v13/*: any*/),
+                            "selections": (v15/*: any*/),
                             "type": "Node",
                             "abstractKey": "__isNode"
                           }
@@ -997,12 +1064,12 @@ return {
                     "abstractKey": "__isArtworkConnectionInterface"
                   }
                 ],
-                "storageKey": "filterArtworksConnection(first:30)"
+                "storageKey": null
               },
               {
                 "alias": "sidebarAggregations",
                 "args": [
-                  (v4/*: any*/),
+                  (v5/*: any*/),
                   {
                     "kind": "Literal",
                     "name": "first",
@@ -1055,7 +1122,7 @@ return {
                         "name": "counts",
                         "plural": true,
                         "selections": [
-                          (v6/*: any*/),
+                          (v8/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1076,7 +1143,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v9/*: any*/)
+                  (v11/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -1088,16 +1155,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e917cfdd0f09db8b503915128c1addfd",
+    "cacheID": "3c7e20ae1ec163e01ee60eabeedb51c0",
     "id": null,
     "metadata": {},
     "name": "artistRoutes_WorksForSaleQuery",
     "operationKind": "query",
-    "text": "query artistRoutes_WorksForSaleQuery(\n  $artistID: String!\n  $isPrefetched: Boolean!\n  $aggregations: [ArtworkAggregation]\n) {\n  artist(id: $artistID) @principalField {\n    ...ArtistWorksForSaleRoute_artist_1uAUE9\n    id\n  }\n}\n\nfragment ArtistArtworkFilter_artist on Artist {\n  name\n  counts {\n    partner_shows: partnerShows\n    for_sale_artworks: forSaleArtworks\n    ecommerce_artworks: ecommerceArtworks\n    auction_artworks: auctionArtworks\n    artworks\n    has_make_offer_artworks: hasMakeOfferArtworks\n  }\n  filtered_artworks: filterArtworksConnection(first: 30) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n  internalID\n  slug\n}\n\nfragment ArtistWorksForSaleEmpty_artist on Artist {\n  internalID\n  name\n}\n\nfragment ArtistWorksForSaleRoute_artist_1uAUE9 on Artist {\n  ...ArtistArtworkFilter_artist @include(if: $isPrefetched)\n  sidebarAggregations: filterArtworksConnection(aggregations: $aggregations, first: 1) @include(if: $isPrefetched) {\n    counts {\n      total\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  ...ArtistWorksForSaleEmpty_artist\n  slug\n  meta(page: ARTWORKS) {\n    description\n    title\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...LegacyPrimaryLabelLine_artwork\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment LegacyPrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n}\n"
+    "text": "query artistRoutes_WorksForSaleQuery(\n  $artistID: String!\n  $isPrefetched: Boolean!\n  $aggregations: [ArtworkAggregation]\n  $input: FilterArtworksInput\n) {\n  artist(id: $artistID) @principalField {\n    ...ArtistWorksForSaleRoute_artist_2Yc0ig\n    id\n  }\n}\n\nfragment ArtistArtworkFilter_artist_2VV6jB on Artist {\n  name\n  counts {\n    partner_shows: partnerShows\n    for_sale_artworks: forSaleArtworks\n    ecommerce_artworks: ecommerceArtworks\n    auction_artworks: auctionArtworks\n    artworks\n    has_make_offer_artworks: hasMakeOfferArtworks\n  }\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n  internalID\n  slug\n}\n\nfragment ArtistWorksForSaleEmpty_artist on Artist {\n  internalID\n  name\n}\n\nfragment ArtistWorksForSaleRoute_artist_2Yc0ig on Artist {\n  ...ArtistArtworkFilter_artist_2VV6jB @include(if: $isPrefetched)\n  sidebarAggregations: filterArtworksConnection(aggregations: $aggregations, first: 1) @include(if: $isPrefetched) {\n    counts {\n      total\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  ...ArtistWorksForSaleEmpty_artist\n  slug\n  meta(page: ARTWORKS) {\n    description\n    title\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...LegacyPrimaryLabelLine_artwork\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment LegacyPrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "d31e75d5917d7087399f1ff654330366";
+(node as any).hash = "a263a39583cfac1c5fbec1e24e826984";
 
 export default node;


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [ONYX-1475]

### Description

When prefetching an artists's artwork grid content, we are correctly requesting the prepared variables, but  we are not passing the prepared `input` into the fragments as needed. Thus the `{ input : { sort: … } }` argument is missing, which explains the recent reports of unsorted artworks in the grid.

The nature of this bug meant that it was apparent only when client-side navigating to a prefetched artist page (e.g. from an artwork page by clicking on the artist's name).  A direct navigation or hard-refresh would not have repro'd the bug. 

[ONYX-1475]: https://artsyproduct.atlassian.net/browse/ONYX-1475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ