### PR TITLE
chore: tag review app CNAME records accordingly, to make automatic clean-up safe (later)

### DIFF
--- a/scripts/create-review-app-subdomain.js
+++ b/scripts/create-review-app-subdomain.js
@@ -20,8 +20,9 @@ async function addCnameRecord() {
         content: "nginx-staging.artsy.net",
         ttl: 1, // Corresponds to "Auto" in CloudFlare UI
         proxied: true,
+        tags: ["source:review-app"],
       }),
-    }
+    },
   )
   const data = await response.json()
 
@@ -29,7 +30,7 @@ async function addCnameRecord() {
     console.log("CNAME record created:", data.result)
   } else {
     throw new Error(
-      `Error creating CNAME record: ${JSON.stringify(data.errors)}`
+      `Error creating CNAME record: ${JSON.stringify(data.errors)}`,
     )
   }
 }


### PR DESCRIPTION
[Cloudflare docs](https://developers.cloudflare.com/api/resources/dns/subresources/records/methods/create/) indicate that an array of tags (`:`-delimited strings) can be set when creating DNS records. Let's add a tag on any records created automatically by this script to support review apps. That should make it possible to clean up these records later on without too much risk of breaking production.

Caveat: I haven't run this script but errors should surface upon the next review app creation.