### PR TITLE
feat: move to 4 artworks wide for auction pages

### DIFF
--- a/src/Components/ArtworkGrid/ArtworkGrid.tsx
+++ b/src/Components/ArtworkGrid/ArtworkGrid.tsx
@@ -244,7 +244,7 @@ export class ArtworkGridContainer extends React.Component<
       <GridColumns width="100%">
         {nodes.map(artwork => {
           return (
-            <Column span={[6, 4]} key={artwork.internalID} minWidth={0}>
+            <Column span={[6, 3]} key={artwork.internalID} minWidth={0}>
               <FlatGridItemFragmentContainer artwork={artwork} />
             </Column>
           )


### PR DESCRIPTION
Pretty simple! The auctions team would like the auction page grid layout to have 4 artwork columns instead of 3 (which confusingly means changing this span number from a 4 to a 3).