### PR TITLE
chore: add high fetch priority to preload links when applicable

### DIFF
--- a/src/Apps/Article/Components/ArticleZoomGallery/ArticleZoomGalleryFigure.tsx
+++ b/src/Apps/Article/Components/ArticleZoomGallery/ArticleZoomGalleryFigure.tsx
@@ -122,6 +122,7 @@ const ArticleZoomGalleryFigure: FC<
               as="image"
               imagesrcset={source.img.srcSet}
               media={source.media.preload}
+              fetchPriority="high"
             />
           )
         })}

--- a/src/Apps/Artwork/Components/ArtworkLightboxPlaceholder.tsx
+++ b/src/Apps/Artwork/Components/ArtworkLightboxPlaceholder.tsx
@@ -24,7 +24,14 @@ export const ArtworkLightboxPlaceholder: React.FC<
 
   return (
     <>
-      {preload && <Link rel="preload" as="image" href={placeholder.src} />}
+      {preload && (
+        <Link
+          rel="preload"
+          as="image"
+          href={placeholder.src}
+          fetchPriority="high"
+        />
+      )}
 
       <Box
         position="absolute"

--- a/src/Apps/Fair/Components/FairHeader/FairHeaderImage.tsx
+++ b/src/Apps/Fair/Components/FairHeader/FairHeaderImage.tsx
@@ -37,6 +37,7 @@ export const FairHeaderImage: React.FC<
         as="image"
         imagesrcset={mobile.srcSet}
         media={`(max-width: ${BREAKPOINTS.sm}px)`}
+        fetchPriority="high"
       />
 
       <Media at="xs">

--- a/src/Components/HeaderIcon.tsx
+++ b/src/Components/HeaderIcon.tsx
@@ -16,7 +16,13 @@ export const HeaderIcon: React.FC<React.PropsWithChildren<HeaderIconProps>> = ({
 
   return (
     <>
-      <Link rel="preload" as="image" href={img.src} imagesrcset={img.srcSet} />
+      <Link
+        rel="preload"
+        as="image"
+        href={img.src}
+        imagesrcset={img.srcSet}
+        fetchPriority="high"
+      />
 
       <ResponsiveBox
         aspectWidth={1}


### PR DESCRIPTION
Documentation [indicates](https://www.debugbear.com/blog/fetchpriority-attribute) that `<link rel="preload" as="image" ...` elements can support a `fetchpriority` attribute. I'd have thought preloading was enough for the browser to fetch at a high priority, but let's see if adding this reduces warnings or helps LCP further. At the moment, the browser calculates a "low" priority for the artwork placeholder image despite the many signals to the contrary.

<img width="1782" alt="Screenshot 2025-01-13 at 8 54 54 AM" src="https://github.com/user-attachments/assets/8b1bd364-d212-41b8-9d8e-8a5546825684" />
