### PR TITLE
chore: move to page size of 40 for auction page (4 column wide)

### DIFF
--- a/src/Apps/Auction/Components/__tests__/AuctionArtworkFilter.jest.enzyme.tsx
+++ b/src/Apps/Auction/Components/__tests__/AuctionArtworkFilter.jest.enzyme.tsx
@@ -80,7 +80,7 @@ describe("AuctionArtworkFilter", () => {
     it("returns default arguments", () => {
       expect(getArtworkFilterInputArgs()).toEqual({
         aggregations: ["ARTIST", "MEDIUM", "TOTAL", "MATERIALS_TERMS"],
-        first: 39,
+        first: 40,
       })
     })
   })

--- a/src/Apps/Auction/Components/getArtworkFilterInputArgs.ts
+++ b/src/Apps/Auction/Components/getArtworkFilterInputArgs.ts
@@ -4,6 +4,6 @@ export const getArtworkFilterInputArgs = (user?: User) => {
   // Shared with auctionRoutes
   return {
     aggregations,
-    first: 39,
+    first: 40,
   }
 }


### PR DESCRIPTION
Since moving to a 4 artwork column wide form on the auction page, requesting 39 (not evenly divisible) leaves an incomplete row, so let's move to 40.