### PR TITLE
fix(EMI-2036): use last submitted offer for new payment route

### DIFF
--- a/src/Apps/Order/Routes/NewPayment/index.tsx
+++ b/src/Apps/Order/Routes/NewPayment/index.tsx
@@ -337,7 +337,10 @@ export const NewPaymentRoute: FC<
         <Flex flexDirection="column">
           <Flex flexDirection="column">
             <ArtworkSummaryItem order={order} />
-            <TransactionDetailsSummaryItem order={order} />
+            <TransactionDetailsSummaryItem
+              order={order}
+              useLastSubmittedOffer
+            />
           </Flex>
           <BuyerGuarantee
             contextModule={ContextModule.ordersNewPayment}


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2036]

### Description

Use last submitted offer in new payment route to avoid having the buyer see his old offer when fixing the payment. Checked also other uses of the component.

Before:
<img width="1756" alt="Screenshot 2025-01-14 at 14 25 00" src="https://github.com/user-attachments/assets/8bc9791c-8f7c-470d-a8b8-6dcacddc7ce0" />
After:
<img width="1756" alt="Screenshot 2025-01-14 at 14 24 37" src="https://github.com/user-attachments/assets/50b19be6-48e0-4c4e-9654-135ae3a6bb3f" />

