### PR TITLE
fix: add additional line to the artwork metadata placeholder

### DIFF
--- a/src/Components/Artwork/Details/Details.tsx
+++ b/src/Components/Artwork/Details/Details.tsx
@@ -8,17 +8,17 @@ import { SaveArtworkToListsButtonQueryRenderer } from "Components/Artwork/SaveBu
 import { SaveButtonQueryRenderer } from "Components/Artwork/SaveButton/SaveButton"
 import { useArtworkGridContext } from "Components/ArtworkGrid/ArtworkGridContext"
 import { RouterLink, type RouterLinkProps } from "System/Components/RouterLink"
+import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
+import { useTimer } from "Utils/Hooks/useTimer"
 import type { Details_artwork$data } from "__generated__/Details_artwork.graphql"
 import { isFunction } from "lodash"
 import type * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
 import { BidTimerLine } from "./BidTimerLine"
+import { LegacyPrimaryLabelLine } from "./LegacyPrimaryLabelLine"
 import { PrimaryLabelLineQueryRenderer } from "./PrimaryLabelLine"
 import { SaleMessageQueryRenderer } from "./SaleMessage"
-import { useTimer } from "Utils/Hooks/useTimer"
-import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
-import { LegacyPrimaryLabelLine } from "./LegacyPrimaryLabelLine"
 
 export interface DetailsProps {
   artwork: Details_artwork$data
@@ -563,6 +563,10 @@ export const DetailsPlaceholder: React.FC<
 > = ({ hideArtistName, hidePartnerName, hideSaleInfo }) => {
   return (
     <>
+      <SkeletonText variant="sm-display" lineHeight={LINE_HEIGHT_PX}>
+        Primary Label
+      </SkeletonText>
+
       {!hideArtistName && (
         <SkeletonText variant="sm-display" lineHeight={LINE_HEIGHT_PX}>
           Artist Name

--- a/src/Components/Artwork/Details/Details.tsx
+++ b/src/Components/Artwork/Details/Details.tsx
@@ -36,9 +36,10 @@ export interface DetailsProps {
 }
 
 const LINE_HEIGHT = 22
+const LINE_HEIGHT_PX = `${LINE_HEIGHT}px`
 const NUM_OF_LINES = 5
 const CONTAINER_HEIGHT = LINE_HEIGHT * NUM_OF_LINES
-const LINE_HEIGHT_PX = LINE_HEIGHT + "px"
+const CONTAINER_HEIGHT_PX = `${CONTAINER_HEIGHT}px`
 
 const StyledConditionalLink = styled(RouterLink)`
   color: ${themeGet("colors.black100")};
@@ -401,7 +402,7 @@ export const Details: React.FC<React.PropsWithChildren<DetailsProps>> = ({
   }
 
   return (
-    <Box height={CONTAINER_HEIGHT + "px"}>
+    <Box height={CONTAINER_HEIGHT_PX}>
       {isAuctionArtwork && (
         <Flex flexDirection="row">
           <Join separator={<Spacer x={1} />}>
@@ -562,11 +563,7 @@ export const DetailsPlaceholder: React.FC<
   React.PropsWithChildren<DetailsPlaceholderProps>
 > = ({ hideArtistName, hidePartnerName, hideSaleInfo }) => {
   return (
-    <>
-      <SkeletonText variant="sm-display" lineHeight={LINE_HEIGHT_PX}>
-        Primary Label
-      </SkeletonText>
-
+    <Box height={CONTAINER_HEIGHT_PX}>
       {!hideArtistName && (
         <SkeletonText variant="sm-display" lineHeight={LINE_HEIGHT_PX}>
           Artist Name
@@ -588,6 +585,6 @@ export const DetailsPlaceholder: React.FC<
           Price
         </SkeletonText>
       )}
-    </>
+    </Box>
   )
 }

--- a/src/Components/ArtworkGrid/ArtworkGrid.tsx
+++ b/src/Components/ArtworkGrid/ArtworkGrid.tsx
@@ -85,8 +85,11 @@ export class ArtworkGridContainer extends React.Component<
 
   private get _columnCount(): number[] {
     const columnCount = this.props.columnCount
-    // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-    return typeof columnCount === "number" ? [columnCount] : columnCount
+
+    if (typeof columnCount === "number") {
+      return [columnCount]
+    }
+    return Array.isArray(columnCount) ? columnCount : []
   }
 
   componentDidMount() {
@@ -100,7 +103,6 @@ export class ArtworkGridContainer extends React.Component<
 
   componentWillUnmount() {
     if (this.state.interval) {
-      // @ts-ignore
       clearInterval(this.state.interval)
     }
   }
@@ -164,7 +166,7 @@ export class ArtworkGridContainer extends React.Component<
     )
 
     for (let column = 0; column < columnCount; column++) {
-      const artworkComponents = []
+      const artworkComponents: React.ReactNode[] = []
       for (let row = 0; row < sectionedArtworks[column].length; row++) {
         /**
          * The position of the image in the grid represented
@@ -176,14 +178,17 @@ export class ArtworkGridContainer extends React.Component<
         const artwork = sectionedArtworks[column][row]
 
         artworkComponents.push(
-          // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
           <GridItem
             contextModule={contextModule}
             artwork={artwork}
             hideSaleInfo={hideSaleInfo}
             key={artwork.id}
-            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
-            lazyLoad={artworkIndex >= preloadImageCount}
+            lazyLoad={
+              !!(
+                typeof preloadImageCount === "number" &&
+                artworkIndex >= preloadImageCount
+              )
+            }
             onClick={() => {
               if (this.props.onBrickClick) {
                 this.props.onBrickClick(artwork, artworkIndex)
@@ -200,7 +205,7 @@ export class ArtworkGridContainer extends React.Component<
             savedListId={this.props.savedListId}
             renderSaveButton={this.props.renderSaveButton}
             popoverContent={
-              firstP1Artwork?.id == artwork.id
+              firstP1Artwork?.id === artwork.id
                 ? this.props.popoverContent
                 : null
             }
@@ -210,11 +215,13 @@ export class ArtworkGridContainer extends React.Component<
         )
         // Setting a marginBottom on the artwork component didn’t work, so using a spacer view instead.
         if (row < sectionedArtworks[column].length - 1) {
+          const safeRow = row ?? "default-row"
+          const safeArtworkId = artwork.id ?? "default-id"
+
           artworkComponents.push(
-            // @ts-expect-error PLEASE_FIX_ME_STRICT_NULL_CHECK_MIGRATION
             <div
               style={spacerStyle}
-              key={"spacer-" + row + "-" + artwork.id}
+              key={`spacer-${safeRow}-${safeArtworkId}`}
             />,
           )
         }
@@ -277,10 +284,7 @@ export class ArtworkGridContainer extends React.Component<
     return columnBreakpointProps.map(([count, props], i) => (
       // We always create all Media instances, so using i as key is fine.
       <Media {...props} key={i}>
-        {/*
-        FIXME: REACT_18_MIGRATION
-        @ts-ignore */}
-        {(className, renderChildren) => {
+        {(className: string, renderChildren: boolean) => {
           return (
             <InnerContainer className={className}>
               {renderChildren &&


### PR DESCRIPTION
This PR solves [EMI-2256] (https://artsyproduct.atlassian.net/browse/EMI-2256)

### Description

This seems to be too easy of a fix but seems to work for me on all the screens that I was checking. The thing I'm not sure about if we need to make this line conditional. Like is there rails that would never include this 5th line?

Also remember @starsirius that you said that you've hardcoded the hight in some rail and wonder if we should clean that up and see if things are still working.


[EMI-2256]: https://artsyproduct.atlassian.net/browse/EMI-2256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ