### PR TITLE
chore: revert prefetching artist works over lazily loading

### DIFF
--- a/src/Apps/Artist/Routes/WorksForSale/Utils/getWorksForSaleRouteVariables.ts
+++ b/src/Apps/Artist/Routes/WorksForSale/Utils/getWorksForSaleRouteVariables.ts
@@ -26,8 +26,5 @@ export function getWorksForSaleRouteVariables({ artistID }, { location }) {
     aggregations,
     artistID,
     includeBlurHash: false,
-    // If the route was prefetched, we want `isPrefetched: true` so the query
-    // can be resolved immediately w/ the already-fetched variables.
-    isPrefetched: !!location?.state?.isPrefetched,
   }
 }

--- a/src/Apps/Artist/artistRoutes.tsx
+++ b/src/Apps/Artist/artistRoutes.tsx
@@ -140,19 +140,9 @@ export const artistRoutes: RouteProps[] = [
         },
         prepareVariables: getWorksForSaleRouteVariables,
         query: graphql`
-          query artistRoutes_WorksForSaleQuery(
-            $artistID: String!
-            $isPrefetched: Boolean!
-            $aggregations: [ArtworkAggregation]
-            $input: FilterArtworksInput
-          ) {
+          query artistRoutes_WorksForSaleQuery($artistID: String!) {
             artist(id: $artistID) @principalField {
               ...ArtistWorksForSaleRoute_artist
-                @arguments(
-                  isPrefetched: $isPrefetched
-                  aggregations: $aggregations
-                  input: $input
-                )
             }
           }
         `,

--- a/src/__generated__/ArtistWorksForSaleRoute_artist.graphql.ts
+++ b/src/__generated__/ArtistWorksForSaleRoute_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<47a0b5d7ce55cf1ae3c4daed5fd7d457>>
+ * @generated SignedSource<<e0839057497f61489b966df6cb29af03>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,7 +9,6 @@
 // @ts-nocheck
 
 import { ReaderFragment } from 'relay-runtime';
-export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ARTIST_SERIES" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "LOCATION_CITY" | "MAJOR_PERIOD" | "MATERIALS_TERMS" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "SIMPLE_PRICE_HISTOGRAM" | "TOTAL" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type ArtistWorksForSaleRoute_artist$data = {
   readonly meta: {
@@ -17,21 +16,8 @@ export type ArtistWorksForSaleRoute_artist$data = {
     readonly title: string;
   };
   readonly name: string | null | undefined;
-  readonly sidebarAggregations?: {
-    readonly aggregations: ReadonlyArray<{
-      readonly counts: ReadonlyArray<{
-        readonly count: number;
-        readonly name: string;
-        readonly value: string;
-      } | null | undefined> | null | undefined;
-      readonly slice: ArtworkAggregation | null | undefined;
-    } | null | undefined> | null | undefined;
-    readonly counts: {
-      readonly total: any | null | undefined;
-    } | null | undefined;
-  } | null | undefined;
   readonly slug: string;
-  readonly " $fragmentSpreads": FragmentRefs<"ArtistArtworkFilter_artist" | "ArtistWorksForSaleEmpty_artist">;
+  readonly " $fragmentSpreads": FragmentRefs<"ArtistWorksForSaleEmpty_artist">;
   readonly " $fragmentType": "ArtistWorksForSaleRoute_artist";
 };
 export type ArtistWorksForSaleRoute_artist$key = {
@@ -39,138 +25,12 @@ export type ArtistWorksForSaleRoute_artist$key = {
   readonly " $fragmentSpreads": FragmentRefs<"ArtistWorksForSaleRoute_artist">;
 };
 
-const node: ReaderFragment = (function(){
-var v0 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-};
-return {
-  "argumentDefinitions": [
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "aggregations"
-    },
-    {
-      "defaultValue": null,
-      "kind": "LocalArgument",
-      "name": "input"
-    },
-    {
-      "defaultValue": false,
-      "kind": "LocalArgument",
-      "name": "isPrefetched"
-    }
-  ],
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
   "name": "ArtistWorksForSaleRoute_artist",
   "selections": [
-    {
-      "condition": "isPrefetched",
-      "kind": "Condition",
-      "passingValue": true,
-      "selections": [
-        {
-          "args": [
-            {
-              "kind": "Variable",
-              "name": "input",
-              "variableName": "input"
-            }
-          ],
-          "kind": "FragmentSpread",
-          "name": "ArtistArtworkFilter_artist"
-        },
-        {
-          "alias": "sidebarAggregations",
-          "args": [
-            {
-              "kind": "Variable",
-              "name": "aggregations",
-              "variableName": "aggregations"
-            },
-            {
-              "kind": "Literal",
-              "name": "first",
-              "value": 1
-            }
-          ],
-          "concreteType": "FilterArtworksConnection",
-          "kind": "LinkedField",
-          "name": "filterArtworksConnection",
-          "plural": false,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "concreteType": "FilterArtworksCounts",
-              "kind": "LinkedField",
-              "name": "counts",
-              "plural": false,
-              "selections": [
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "total",
-                  "storageKey": null
-                }
-              ],
-              "storageKey": null
-            },
-            {
-              "alias": null,
-              "args": null,
-              "concreteType": "ArtworksAggregationResults",
-              "kind": "LinkedField",
-              "name": "aggregations",
-              "plural": true,
-              "selections": [
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "slice",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "concreteType": "AggregationCount",
-                  "kind": "LinkedField",
-                  "name": "counts",
-                  "plural": true,
-                  "selections": [
-                    (v0/*: any*/),
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "value",
-                      "storageKey": null
-                    },
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "count",
-                      "storageKey": null
-                    }
-                  ],
-                  "storageKey": null
-                }
-              ],
-              "storageKey": null
-            }
-          ],
-          "storageKey": null
-        }
-      ]
-    },
     {
       "args": null,
       "kind": "FragmentSpread",
@@ -183,7 +43,13 @@ return {
       "name": "slug",
       "storageKey": null
     },
-    (v0/*: any*/),
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
     {
       "alias": null,
       "args": [
@@ -219,8 +85,7 @@ return {
   "type": "Artist",
   "abstractKey": null
 };
-})();
 
-(node as any).hash = "b4ac2ab5fe9e92b59fc2f900ce6b6d4e";
+(node as any).hash = "3f3df19a6ee2a905d86136f0d1af61eb";
 
 export default node;

--- a/src/__generated__/artistRoutes_WorksForSaleQuery.graphql.ts
+++ b/src/__generated__/artistRoutes_WorksForSaleQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<56ef8b8b7e3994a560f78666827b86c6>>
+ * @generated SignedSource<<f848de5dc3a2ca2739b8a04837d5eec2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,64 +10,8 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type ArtworkAggregation = "ARTIST" | "ARTIST_NATIONALITY" | "ARTIST_SERIES" | "ATTRIBUTION_CLASS" | "COLOR" | "DIMENSION_RANGE" | "FOLLOWED_ARTISTS" | "GALLERY" | "INSTITUTION" | "LOCATION_CITY" | "MAJOR_PERIOD" | "MATERIALS_TERMS" | "MEDIUM" | "MERCHANDISABLE_ARTISTS" | "PARTNER" | "PARTNER_CITY" | "PERIOD" | "PRICE_RANGE" | "SIMPLE_PRICE_HISTOGRAM" | "TOTAL" | "%future added value";
-export type ArtworkSizes = "LARGE" | "MEDIUM" | "SMALL" | "%future added value";
-export type FilterArtworksInput = {
-  acquireable?: boolean | null | undefined;
-  additionalGeneIDs?: ReadonlyArray<string | null | undefined> | null | undefined;
-  after?: string | null | undefined;
-  aggregationPartnerCities?: ReadonlyArray<string | null | undefined> | null | undefined;
-  aggregations?: ReadonlyArray<ArtworkAggregation | null | undefined> | null | undefined;
-  artistID?: string | null | undefined;
-  artistIDs?: ReadonlyArray<string | null | undefined> | null | undefined;
-  artistNationalities?: ReadonlyArray<string | null | undefined> | null | undefined;
-  artistSeriesID?: string | null | undefined;
-  artistSeriesIDs?: ReadonlyArray<string | null | undefined> | null | undefined;
-  atAuction?: boolean | null | undefined;
-  attributionClass?: ReadonlyArray<string | null | undefined> | null | undefined;
-  before?: string | null | undefined;
-  color?: string | null | undefined;
-  colors?: ReadonlyArray<string | null | undefined> | null | undefined;
-  dimensionRange?: string | null | undefined;
-  excludeArtworkIDs?: ReadonlyArray<string | null | undefined> | null | undefined;
-  extraAggregationGeneIDs?: ReadonlyArray<string | null | undefined> | null | undefined;
-  first?: number | null | undefined;
-  forSale?: boolean | null | undefined;
-  geneID?: string | null | undefined;
-  geneIDs?: ReadonlyArray<string | null | undefined> | null | undefined;
-  height?: string | null | undefined;
-  includeArtworksByFollowedArtists?: boolean | null | undefined;
-  includeMediumFilterInAggregation?: boolean | null | undefined;
-  inquireableOnly?: boolean | null | undefined;
-  keyword?: string | null | undefined;
-  keywordMatchExact?: boolean | null | undefined;
-  last?: number | null | undefined;
-  locationCities?: ReadonlyArray<string | null | undefined> | null | undefined;
-  majorPeriods?: ReadonlyArray<string | null | undefined> | null | undefined;
-  marketable?: boolean | null | undefined;
-  marketingCollectionID?: string | null | undefined;
-  materialsTerms?: ReadonlyArray<string | null | undefined> | null | undefined;
-  medium?: string | null | undefined;
-  offerable?: boolean | null | undefined;
-  page?: number | null | undefined;
-  partnerCities?: ReadonlyArray<string | null | undefined> | null | undefined;
-  partnerID?: string | null | undefined;
-  partnerIDs?: ReadonlyArray<string | null | undefined> | null | undefined;
-  period?: string | null | undefined;
-  periods?: ReadonlyArray<string | null | undefined> | null | undefined;
-  priceRange?: string | null | undefined;
-  saleID?: string | null | undefined;
-  size?: number | null | undefined;
-  sizes?: ReadonlyArray<ArtworkSizes | null | undefined> | null | undefined;
-  sort?: string | null | undefined;
-  tagID?: string | null | undefined;
-  width?: string | null | undefined;
-};
 export type artistRoutes_WorksForSaleQuery$variables = {
-  aggregations?: ReadonlyArray<ArtworkAggregation | null | undefined> | null | undefined;
   artistID: string;
-  input?: FilterArtworksInput | null | undefined;
-  isPrefetched: boolean;
 };
 export type artistRoutes_WorksForSaleQuery$data = {
   readonly artist: {
@@ -80,192 +24,37 @@ export type artistRoutes_WorksForSaleQuery = {
 };
 
 const node: ConcreteRequest = (function(){
-var v0 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "aggregations"
-},
-v1 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "artistID"
-},
-v2 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "input"
-},
-v3 = {
-  "defaultValue": null,
-  "kind": "LocalArgument",
-  "name": "isPrefetched"
-},
-v4 = [
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "artistID"
+  }
+],
+v1 = [
   {
     "kind": "Variable",
     "name": "id",
     "variableName": "artistID"
   }
-],
-v5 = {
-  "kind": "Variable",
-  "name": "aggregations",
-  "variableName": "aggregations"
-},
-v6 = {
-  "kind": "Variable",
-  "name": "input",
-  "variableName": "input"
-},
-v7 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v8 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-},
-v9 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "slug",
-  "storageKey": null
-},
-v10 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "title",
-  "storageKey": null
-},
-v11 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v12 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "cursor",
-  "storageKey": null
-},
-v13 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "page",
-  "storageKey": null
-},
-v14 = [
-  (v12/*: any*/),
-  (v13/*: any*/),
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "isCurrent",
-    "storageKey": null
-  }
-],
-v15 = [
-  (v11/*: any*/)
-],
-v16 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "href",
-  "storageKey": null
-},
-v17 = {
-  "kind": "Literal",
-  "name": "version",
-  "value": [
-    "larger",
-    "large"
-  ]
-},
-v18 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "endAt",
-  "storageKey": null
-},
-v19 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "display",
-    "storageKey": null
-  }
-],
-v20 = [
-  {
-    "kind": "Literal",
-    "name": "shallow",
-    "value": true
-  }
-],
-v21 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "lotID",
-  "storageKey": null
-},
-v22 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "extendedBiddingEndAt",
-  "storageKey": null
-},
-v23 = [
-  (v8/*: any*/),
-  (v11/*: any*/)
 ];
 return {
   "fragment": {
-    "argumentDefinitions": [
-      (v0/*: any*/),
-      (v1/*: any*/),
-      (v2/*: any*/),
-      (v3/*: any*/)
-    ],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Fragment",
     "metadata": null,
     "name": "artistRoutes_WorksForSaleQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v4/*: any*/),
+        "args": (v1/*: any*/),
         "concreteType": "Artist",
         "kind": "LinkedField",
         "name": "artist",
         "plural": false,
         "selections": [
           {
-            "args": [
-              (v5/*: any*/),
-              (v6/*: any*/),
-              {
-                "kind": "Variable",
-                "name": "isPrefetched",
-                "variableName": "isPrefetched"
-              }
-            ],
+            "args": null,
             "kind": "FragmentSpread",
             "name": "ArtistWorksForSaleRoute_artist"
           }
@@ -278,26 +67,39 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": [
-      (v1/*: any*/),
-      (v3/*: any*/),
-      (v0/*: any*/),
-      (v2/*: any*/)
-    ],
+    "argumentDefinitions": (v0/*: any*/),
     "kind": "Operation",
     "name": "artistRoutes_WorksForSaleQuery",
     "selections": [
       {
         "alias": null,
-        "args": (v4/*: any*/),
+        "args": (v1/*: any*/),
         "concreteType": "Artist",
         "kind": "LinkedField",
         "name": "artist",
         "plural": false,
         "selections": [
-          (v7/*: any*/),
-          (v8/*: any*/),
-          (v9/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "internalID",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
           {
             "alias": null,
             "args": [
@@ -319,835 +121,22 @@ return {
                 "name": "description",
                 "storageKey": null
               },
-              (v10/*: any*/)
-            ],
-            "storageKey": "meta(page:\"ARTWORKS\")"
-          },
-          (v11/*: any*/),
-          {
-            "condition": "isPrefetched",
-            "kind": "Condition",
-            "passingValue": true,
-            "selections": [
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "ArtistCounts",
-                "kind": "LinkedField",
-                "name": "counts",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": "partner_shows",
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "partnerShows",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": "for_sale_artworks",
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "forSaleArtworks",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": "ecommerce_artworks",
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "ecommerceArtworks",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": "auction_artworks",
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "auctionArtworks",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "artworks",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": "has_make_offer_artworks",
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "hasMakeOfferArtworks",
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
-              {
-                "alias": "filtered_artworks",
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "first",
-                    "value": 30
-                  },
-                  (v6/*: any*/)
-                ],
-                "concreteType": "FilterArtworksConnection",
-                "kind": "LinkedField",
-                "name": "filterArtworksConnection",
-                "plural": false,
-                "selections": [
-                  (v11/*: any*/),
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "FilterArtworksCounts",
-                    "kind": "LinkedField",
-                    "name": "counts",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": [
-                          {
-                            "kind": "Literal",
-                            "name": "format",
-                            "value": "0,0"
-                          }
-                        ],
-                        "kind": "ScalarField",
-                        "name": "total",
-                        "storageKey": "total(format:\"0,0\")"
-                      }
-                    ],
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "PageInfo",
-                    "kind": "LinkedField",
-                    "name": "pageInfo",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "hasNextPage",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "endCursor",
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "PageCursors",
-                    "kind": "LinkedField",
-                    "name": "pageCursors",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "PageCursor",
-                        "kind": "LinkedField",
-                        "name": "around",
-                        "plural": true,
-                        "selections": (v14/*: any*/),
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "PageCursor",
-                        "kind": "LinkedField",
-                        "name": "first",
-                        "plural": false,
-                        "selections": (v14/*: any*/),
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "PageCursor",
-                        "kind": "LinkedField",
-                        "name": "last",
-                        "plural": false,
-                        "selections": (v14/*: any*/),
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "PageCursor",
-                        "kind": "LinkedField",
-                        "name": "previous",
-                        "plural": false,
-                        "selections": [
-                          (v12/*: any*/),
-                          (v13/*: any*/)
-                        ],
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "FilterArtworksEdge",
-                    "kind": "LinkedField",
-                    "name": "edges",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Artwork",
-                        "kind": "LinkedField",
-                        "name": "node",
-                        "plural": false,
-                        "selections": (v15/*: any*/),
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  },
-                  {
-                    "kind": "InlineFragment",
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": null,
-                        "kind": "LinkedField",
-                        "name": "edges",
-                        "plural": true,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "__typename",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "Artwork",
-                            "kind": "LinkedField",
-                            "name": "node",
-                            "plural": false,
-                            "selections": [
-                              (v9/*: any*/),
-                              (v16/*: any*/),
-                              (v7/*: any*/),
-                              {
-                                "alias": null,
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "includeAll",
-                                    "value": false
-                                  }
-                                ],
-                                "concreteType": "Image",
-                                "kind": "LinkedField",
-                                "name": "image",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "aspectRatio",
-                                    "storageKey": null
-                                  },
-                                  (v7/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "placeholder",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": [
-                                      (v17/*: any*/)
-                                    ],
-                                    "kind": "ScalarField",
-                                    "name": "url",
-                                    "storageKey": "url(version:[\"larger\",\"large\"])"
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "versions",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "blurhashDataURL",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": [
-                                      (v17/*: any*/),
-                                      {
-                                        "kind": "Literal",
-                                        "name": "width",
-                                        "value": 445
-                                      }
-                                    ],
-                                    "concreteType": "ResizedImageUrl",
-                                    "kind": "LinkedField",
-                                    "name": "resized",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "src",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "srcSet",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "width",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "height",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": "resized(version:[\"larger\",\"large\"],width:445)"
-                                  }
-                                ],
-                                "storageKey": "image(includeAll:false)"
-                              },
-                              (v10/*: any*/),
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "imageTitle",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "artistNames",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "date",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "CollectorSignals",
-                                "kind": "LinkedField",
-                                "name": "collectorSignals",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "primaryLabel",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "AuctionCollectorSignals",
-                                    "kind": "LinkedField",
-                                    "name": "auction",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "bidCount",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "lotClosesAt",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "liveBiddingStarted",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "registrationEndsAt",
-                                        "storageKey": null
-                                      },
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "onlineBiddingExtended",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "PartnerOfferToCollector",
-                                    "kind": "LinkedField",
-                                    "name": "partnerOffer",
-                                    "plural": false,
-                                    "selections": [
-                                      (v18/*: any*/),
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "concreteType": "Money",
-                                        "kind": "LinkedField",
-                                        "name": "priceWithDiscount",
-                                        "plural": false,
-                                        "selections": (v19/*: any*/),
-                                        "storageKey": null
-                                      },
-                                      (v11/*: any*/)
-                                    ],
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": null
-                              },
-                              {
-                                "alias": "sale_message",
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "saleMessage",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": "cultural_maker",
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "culturalMaker",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": (v20/*: any*/),
-                                "concreteType": "Artist",
-                                "kind": "LinkedField",
-                                "name": "artist",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "ArtistTargetSupply",
-                                    "kind": "LinkedField",
-                                    "name": "targetSupply",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": null,
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "isP1",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  (v11/*: any*/)
-                                ],
-                                "storageKey": "artist(shallow:true)"
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "ArtworkPriceInsights",
-                                "kind": "LinkedField",
-                                "name": "marketPriceInsights",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "demandRank",
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": (v20/*: any*/),
-                                "concreteType": "Artist",
-                                "kind": "LinkedField",
-                                "name": "artists",
-                                "plural": true,
-                                "selections": [
-                                  (v11/*: any*/),
-                                  (v16/*: any*/),
-                                  (v8/*: any*/)
-                                ],
-                                "storageKey": "artists(shallow:true)"
-                              },
-                              {
-                                "alias": "collecting_institution",
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "collectingInstitution",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": (v20/*: any*/),
-                                "concreteType": "Partner",
-                                "kind": "LinkedField",
-                                "name": "partner",
-                                "plural": false,
-                                "selections": [
-                                  (v8/*: any*/),
-                                  (v16/*: any*/),
-                                  (v11/*: any*/)
-                                ],
-                                "storageKey": "partner(shallow:true)"
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "Sale",
-                                "kind": "LinkedField",
-                                "name": "sale",
-                                "plural": false,
-                                "selections": [
-                                  (v18/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "cascadingEndTimeIntervalMinutes",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "extendedBiddingIntervalMinutes",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "startAt",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "is_auction",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isAuction",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "is_closed",
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isClosed",
-                                    "storageKey": null
-                                  },
-                                  (v11/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "isOpen",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "extendedBiddingPeriodMinutes",
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": null
-                              },
-                              {
-                                "alias": "sale_artwork",
-                                "args": null,
-                                "concreteType": "SaleArtwork",
-                                "kind": "LinkedField",
-                                "name": "saleArtwork",
-                                "plural": false,
-                                "selections": [
-                                  (v21/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "lotLabel",
-                                    "storageKey": null
-                                  },
-                                  (v18/*: any*/),
-                                  (v22/*: any*/),
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "kind": "ScalarField",
-                                    "name": "formattedEndDateTime",
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "SaleArtworkCounts",
-                                    "kind": "LinkedField",
-                                    "name": "counts",
-                                    "plural": false,
-                                    "selections": [
-                                      {
-                                        "alias": "bidder_positions",
-                                        "args": null,
-                                        "kind": "ScalarField",
-                                        "name": "bidderPositions",
-                                        "storageKey": null
-                                      }
-                                    ],
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "highest_bid",
-                                    "args": null,
-                                    "concreteType": "SaleArtworkHighestBid",
-                                    "kind": "LinkedField",
-                                    "name": "highestBid",
-                                    "plural": false,
-                                    "selections": (v19/*: any*/),
-                                    "storageKey": null
-                                  },
-                                  {
-                                    "alias": "opening_bid",
-                                    "args": null,
-                                    "concreteType": "SaleArtworkOpeningBid",
-                                    "kind": "LinkedField",
-                                    "name": "openingBid",
-                                    "plural": false,
-                                    "selections": (v19/*: any*/),
-                                    "storageKey": null
-                                  },
-                                  (v11/*: any*/)
-                                ],
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "SaleArtwork",
-                                "kind": "LinkedField",
-                                "name": "saleArtwork",
-                                "plural": false,
-                                "selections": [
-                                  (v21/*: any*/),
-                                  (v11/*: any*/),
-                                  (v18/*: any*/),
-                                  (v22/*: any*/)
-                                ],
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "AttributionClass",
-                                "kind": "LinkedField",
-                                "name": "attributionClass",
-                                "plural": false,
-                                "selections": (v23/*: any*/),
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "concreteType": "ArtworkMedium",
-                                "kind": "LinkedField",
-                                "name": "mediumType",
-                                "plural": false,
-                                "selections": [
-                                  {
-                                    "alias": null,
-                                    "args": null,
-                                    "concreteType": "Gene",
-                                    "kind": "LinkedField",
-                                    "name": "filterGene",
-                                    "plural": false,
-                                    "selections": (v23/*: any*/),
-                                    "storageKey": null
-                                  }
-                                ],
-                                "storageKey": null
-                              },
-                              {
-                                "alias": null,
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "isUnlisted",
-                                "storageKey": null
-                              },
-                              {
-                                "alias": "image_title",
-                                "args": null,
-                                "kind": "ScalarField",
-                                "name": "imageTitle",
-                                "storageKey": null
-                              }
-                            ],
-                            "storageKey": null
-                          },
-                          {
-                            "kind": "InlineFragment",
-                            "selections": (v15/*: any*/),
-                            "type": "Node",
-                            "abstractKey": "__isNode"
-                          }
-                        ],
-                        "storageKey": null
-                      }
-                    ],
-                    "type": "ArtworkConnectionInterface",
-                    "abstractKey": "__isArtworkConnectionInterface"
-                  }
-                ],
-                "storageKey": null
-              },
-              {
-                "alias": "sidebarAggregations",
-                "args": [
-                  (v5/*: any*/),
-                  {
-                    "kind": "Literal",
-                    "name": "first",
-                    "value": 1
-                  }
-                ],
-                "concreteType": "FilterArtworksConnection",
-                "kind": "LinkedField",
-                "name": "filterArtworksConnection",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "FilterArtworksCounts",
-                    "kind": "LinkedField",
-                    "name": "counts",
-                    "plural": false,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "total",
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "ArtworksAggregationResults",
-                    "kind": "LinkedField",
-                    "name": "aggregations",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "slice",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "AggregationCount",
-                        "kind": "LinkedField",
-                        "name": "counts",
-                        "plural": true,
-                        "selections": [
-                          (v8/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "value",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "count",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  },
-                  (v11/*: any*/)
-                ],
+                "kind": "ScalarField",
+                "name": "title",
                 "storageKey": null
               }
-            ]
+            ],
+            "storageKey": "meta(page:\"ARTWORKS\")"
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
           }
         ],
         "storageKey": null
@@ -1155,16 +144,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e9410583a6611bfdaaaeccaab7e98b72",
+    "cacheID": "1a9748f76857f144106918c1f6db9562",
     "id": null,
     "metadata": {},
     "name": "artistRoutes_WorksForSaleQuery",
     "operationKind": "query",
-    "text": "query artistRoutes_WorksForSaleQuery(\n  $artistID: String!\n  $isPrefetched: Boolean!\n  $aggregations: [ArtworkAggregation]\n  $input: FilterArtworksInput\n) {\n  artist(id: $artistID) @principalField {\n    ...ArtistWorksForSaleRoute_artist_2Yc0ig\n    id\n  }\n}\n\nfragment ArtistArtworkFilter_artist_2VV6jB on Artist {\n  counts {\n    partner_shows: partnerShows\n    for_sale_artworks: forSaleArtworks\n    ecommerce_artworks: ecommerceArtworks\n    auction_artworks: auctionArtworks\n    artworks\n    has_make_offer_artworks: hasMakeOfferArtworks\n  }\n  filtered_artworks: filterArtworksConnection(first: 30, input: $input) {\n    id\n    counts {\n      total(format: \"0,0\")\n    }\n    ...ArtworkFilterArtworkGrid_filtered_artworks\n  }\n  internalID\n  name\n  slug\n  meta(page: ARTWORKS) {\n    title\n  }\n}\n\nfragment ArtistWorksForSaleEmpty_artist on Artist {\n  internalID\n  name\n}\n\nfragment ArtistWorksForSaleRoute_artist_2Yc0ig on Artist {\n  ...ArtistArtworkFilter_artist_2VV6jB @include(if: $isPrefetched)\n  sidebarAggregations: filterArtworksConnection(aggregations: $aggregations, first: 1) @include(if: $isPrefetched) {\n    counts {\n      total\n    }\n    aggregations {\n      slice\n      counts {\n        name\n        value\n        count\n      }\n    }\n    id\n  }\n  ...ArtistWorksForSaleEmpty_artist\n  slug\n  name\n  meta(page: ARTWORKS) {\n    description\n    title\n  }\n}\n\nfragment ArtworkFilterArtworkGrid_filtered_artworks on FilterArtworksConnection {\n  id\n  pageInfo {\n    hasNextPage\n    endCursor\n  }\n  pageCursors {\n    ...Pagination_pageCursors\n  }\n  edges {\n    node {\n      id\n    }\n  }\n  ...ArtworkGrid_artworks_3QDGWC\n}\n\nfragment ArtworkGrid_artworks_3QDGWC on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork_3QDGWC\n      ...FlatGridItem_artwork_13vYwd\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork_1ZRKfT on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...LegacyPrimaryLabelLine_artwork\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_13vYwd on Artwork {\n  ...Metadata_artwork_1ZRKfT\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n    blurhashDataURL\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_3QDGWC on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n    blurhashDataURL\n  }\n  artistNames\n  href\n  ...Metadata_artwork_1ZRKfT\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment LegacyPrimaryLabelLine_artwork on Artwork {\n  collectorSignals {\n    primaryLabel\n  }\n}\n\nfragment Metadata_artwork_1ZRKfT on Artwork {\n  ...Details_artwork_1ZRKfT\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  internalID\n  collectorSignals {\n    primaryLabel\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n}\n"
+    "text": "query artistRoutes_WorksForSaleQuery(\n  $artistID: String!\n) {\n  artist(id: $artistID) @principalField {\n    ...ArtistWorksForSaleRoute_artist\n    id\n  }\n}\n\nfragment ArtistWorksForSaleEmpty_artist on Artist {\n  internalID\n  name\n}\n\nfragment ArtistWorksForSaleRoute_artist on Artist {\n  ...ArtistWorksForSaleEmpty_artist\n  slug\n  name\n  meta(page: ARTWORKS) {\n    description\n    title\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "a263a39583cfac1c5fbec1e24e826984";
+(node as any).hash = "875716fecee7260100706e351b5dce01";
 
 export default node;


### PR DESCRIPTION
As a UX optimization - we would load the works grid on an artist route while in a prefetching context, versus the standard behavior of lazily loading the grid only after a user landed on an artist route.

This had the affect of increasing ElasticSearch traffic, resulting in some latency/alerts. Since this UX optimization isn't strictly _necessary_, was just a nice discretionary thing - let's revert. We typically wouldn't want to accept a trade-off of an optional improvement that has a negative affect on ElasticSearch.