### PR TITLE
feat(performance): Add INP optimization strategy for mobile web

### DIFF
--- a/src/Apps/Components/INPOptimizer.tsx
+++ b/src/Apps/Components/INPOptimizer.tsx
@@ -1,0 +1,95 @@
+/**
+ * This enables better INP (interaction to next paint) scores for select pages
+ * by circumventing the unavoidable overhead cost of rendering pages via our router.
+ *
+ * Only enabled on mobile! Since that's where our INP scores are failing.
+ *
+ * The flow:
+ *   - If a page is prefetched, on first render return null
+ *   - On second render, return the children
+ *
+ * By returning null on the first render pass, we get a snappy INP score at the
+ * cost of an almost imperceptible render flash. Since it happens on page
+ * transition, its not too noticeable.
+ */
+
+import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
+import { isServer } from "Utils/device"
+import { getENV } from "Utils/getENV"
+import { useRouter } from "found"
+import { useEffect, useState } from "react"
+
+// Routes to enable INP optimization for
+const INP_TARGET_PATHS = ["artwork", "artist"]
+
+interface INPOptimizerProps {
+  enabled: boolean
+}
+
+export const INPOptimizer: React.FC<
+  React.PropsWithChildren<INPOptimizerProps>
+> = ({ children, enabled }) => {
+  const { match } = useRouter()
+  const [isSecondRender, setIsSecondRender] = useState(false)
+
+  const isPrefetched = match?.location?.state?.isPrefetched === true
+
+  useEffect(() => {
+    if (isPrefetched) {
+      setIsSecondRender(true)
+    }
+  }, [isPrefetched])
+
+  if (!enabled) {
+    return children
+  }
+
+  if (isPrefetched && !isSecondRender) {
+    return null
+  }
+
+  return children
+}
+
+export const useEnableINPOptimizer = () => {
+  const { match } = useRouter()
+
+  // Only enable on mobile!
+  const isMobile = getENV("IS_MOBILE")
+
+  const inpOptimizationEnabled = useFeatureFlag(
+    "diamond_experimental-inp-optimization",
+  )
+
+  const targetPathRegex = new RegExp(
+    `^\\/(${INP_TARGET_PATHS.join("|")})\\/[^/]+$`,
+    "i",
+  )
+
+  const enableINPOptimizer = (() => {
+    if (!inpOptimizationEnabled) {
+      return false
+    }
+
+    if (!isMobile) {
+      return false
+    }
+
+    if (match.location.state?.disableINPOptimizer === true) {
+      return false
+    }
+
+    if (isServer) {
+      return false
+    }
+    // Don't enable if BACK/FORWARD navigation/buttons clicked
+    if (match.location.action === "POP") {
+      return false
+    }
+
+    // Only enable for select pages that have bad INP scores
+    return targetPathRegex.test(match.location.pathname)
+  })()
+
+  return enableINPOptimizer
+}

--- a/src/Apps/Components/Layouts/index.tsx
+++ b/src/Apps/Components/Layouts/index.tsx
@@ -1,4 +1,8 @@
 import { usePrevious } from "@artsy/palette"
+import {
+  INPOptimizer,
+  useEnableINPOptimizer,
+} from "Apps/Components/INPOptimizer"
 import { LayoutBlank } from "Apps/Components/Layouts/LayoutBlank"
 import { LayoutContainerOnly } from "Apps/Components/Layouts/LayoutContainerOnly"
 import { LayoutDefault } from "Apps/Components/Layouts/LayoutDefault"
@@ -6,6 +10,7 @@ import { LayoutFullBleed } from "Apps/Components/Layouts/LayoutFullBleed"
 import { LayoutLogoOnly } from "Apps/Components/Layouts/LayoutLogoOnly"
 import { LayoutNavOnly } from "Apps/Components/Layouts/LayoutNavOnly"
 import { useRouter } from "System/Hooks/useRouter"
+import type React from "react"
 import type { FC, ReactNode } from "react"
 
 export interface BaseLayoutProps {
@@ -32,11 +37,10 @@ export const Layout: FC<React.PropsWithChildren<LayoutProps>> = ({
   children,
 }) => {
   const { match } = useRouter()
+  const enableINPOptimizer = useEnableINPOptimizer()
 
   const isFetching = !match.elements
 
-  // If we're fetching, we want to render the previous layout and not execute
-  // the new one right away.
   const previousVariant = usePrevious(variant)
   const Previous = LAYOUTS[previousVariant]
 
@@ -46,5 +50,18 @@ export const Layout: FC<React.PropsWithChildren<LayoutProps>> = ({
 
   const Component = LAYOUTS[variant]
 
-  return <Component>{children}</Component>
+  return (
+    <Component>
+      {enableINPOptimizer ? (
+        <INPOptimizer
+          key={match.location.pathname}
+          enabled={enableINPOptimizer}
+        >
+          {children}
+        </INPOptimizer>
+      ) : (
+        children
+      )}
+    </Component>
+  )
 }

--- a/src/Apps/Components/__tests__/INPOptimizer.jest.tsx
+++ b/src/Apps/Components/__tests__/INPOptimizer.jest.tsx
@@ -1,0 +1,128 @@
+import { renderHook } from "@testing-library/react"
+import { useEnableINPOptimizer } from "Apps/Components/INPOptimizer"
+import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
+import { getENV } from "Utils/getENV"
+import { useRouter } from "found"
+
+jest.mock("found", () => ({
+  useRouter: jest.fn(),
+}))
+jest.mock("System/Hooks/useFeatureFlag", () => ({
+  useFeatureFlag: jest.fn(),
+}))
+jest.mock("Utils/device", () => ({
+  isServer: false,
+}))
+jest.mock("Utils/getENV", () => ({
+  // For `getENV("IS_MOBILE")
+  getENV: jest.fn().mockReturnValue(true),
+}))
+
+describe("useEnableINPOptimizer", () => {
+  const mockUseRouter = useRouter as jest.Mock
+  const mockUseFeatureFlag = useFeatureFlag as jest.Mock
+  const mockGetEnv = getENV as jest.Mock
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  it("returns false if the feature flag is disabled", () => {
+    mockUseFeatureFlag.mockReturnValue(false)
+    mockUseRouter.mockReturnValue({
+      match: {
+        location: {
+          state: {},
+          action: "PUSH",
+          pathname: "/artwork/some-id",
+        },
+      },
+    })
+
+    const { result } = renderHook(() => useEnableINPOptimizer())
+    expect(result.current).toBe(false)
+  })
+
+  it("returns false if disableINPOptimizer is true in location state", () => {
+    mockUseFeatureFlag.mockReturnValue(true)
+    mockUseRouter.mockReturnValue({
+      match: {
+        location: {
+          state: { disableINPOptimizer: true },
+          action: "PUSH",
+          pathname: "/artwork/some-id",
+        },
+      },
+    })
+
+    const { result } = renderHook(() => useEnableINPOptimizer())
+    expect(result.current).toBe(false)
+  })
+
+  it("returns false if navigation action is POP", () => {
+    mockUseFeatureFlag.mockReturnValue(true)
+    mockUseRouter.mockReturnValue({
+      match: {
+        location: {
+          state: {},
+          action: "POP",
+          pathname: "/artwork/some-id",
+        },
+      },
+    })
+
+    const { result } = renderHook(() => useEnableINPOptimizer())
+    expect(result.current).toBe(false)
+  })
+
+  it("returns true for valid paths when all conditions are met", () => {
+    mockGetEnv.mockReturnValue(true)
+    mockUseFeatureFlag.mockReturnValue(true)
+    mockUseRouter.mockReturnValue({
+      match: {
+        location: {
+          state: {},
+          action: "PUSH",
+          pathname: "/artwork/some-id",
+        },
+      },
+    })
+
+    const { result } = renderHook(() => useEnableINPOptimizer())
+    expect(result.current).toBe(true)
+  })
+
+  it("returns false for invalid paths even if all other conditions are met", () => {
+    mockUseFeatureFlag.mockReturnValue(true)
+    mockUseRouter.mockReturnValue({
+      match: {
+        location: {
+          state: {},
+          action: "PUSH",
+          pathname: "/invalid-path",
+        },
+      },
+    })
+
+    const { result } = renderHook(() => useEnableINPOptimizer())
+    expect(result.current).toBe(false)
+  })
+
+  it("returns false if desktop", () => {
+    mockGetEnv.mockReturnValue(false)
+
+    mockUseFeatureFlag.mockReturnValue(true)
+    mockUseRouter.mockReturnValue({
+      match: {
+        location: {
+          state: {},
+          action: "PUSH",
+          pathname: "/invalid-path",
+        },
+      },
+    })
+
+    const { result } = renderHook(() => useEnableINPOptimizer())
+    expect(result.current).toBe(false)
+  })
+})

--- a/src/Components/Artwork/Details/PrimaryLabelLine.tsx
+++ b/src/Components/Artwork/Details/PrimaryLabelLine.tsx
@@ -17,8 +17,9 @@ export const PrimaryLabelLine: React.FC<
   const { hideSignals, updateSignals } = useArtworkGridContext()
   const partnerOffer = artwork?.collectorSignals?.partnerOffer
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
-    if (updateSignals && artwork) {
+    if (updateSignals && artwork?.internalID) {
       const signals: string[] = []
 
       if (partnerOffer) {
@@ -28,9 +29,10 @@ export const PrimaryLabelLine: React.FC<
       if (label) {
         signals.push(label)
       }
+
       updateSignals(artwork.internalID, signals)
     }
-  }, [updateSignals, partnerOffer, label, artwork])
+  }, [partnerOffer, label, artwork?.internalID])
 
   if (!!partnerOffer) {
     return (

--- a/src/Components/RouteTabs.tsx
+++ b/src/Components/RouteTabs.tsx
@@ -6,18 +6,30 @@ import {
   type BaseTabsProps,
 } from "@artsy/palette"
 import { RouterLink, type RouterLinkProps } from "System/Components/RouterLink"
-import { useIsRouteActive } from "System/Hooks/useRouter"
+import { useIsRouteActive, useRouter } from "System/Hooks/useRouter"
 import type * as React from "react"
+import { useMemo } from "react"
 import { useTracking } from "react-tracking"
 
 export const RouteTab: React.FC<
   React.PropsWithChildren<BaseTabProps & RouterLinkProps>
 > = ({ children, to, ...rest }) => {
+  const { router } = useRouter()
   const tracking = useTracking()
 
   const options = {
     exact: rest.exact !== undefined ? rest.exact : true,
   }
+
+  const location = useMemo(() => {
+    const pathname = to as string
+
+    if (!router || typeof to !== "string") {
+      return { pathname, query: {} }
+    }
+
+    return router.createLocation(pathname)
+  }, [router, to])
 
   return (
     <BaseTab
@@ -25,7 +37,18 @@ export const RouteTab: React.FC<
       // @ts-ignore
       to={to}
       active={useIsRouteActive(to, options)}
-      onClick={() => {
+      onClick={event => {
+        event.preventDefault()
+
+        router?.push({
+          ...location,
+          state: {
+            // See: INPOptimizer.tsx. This is to prevent render flashes when
+            // transitioning _internal_ to a page, such as clicking a tab bar.
+            disableINPOptimizer: true,
+          },
+        })
+
         tracking.trackEvent({
           action_type: DeprecatedAnalyticsSchema.ActionType.Click,
           destination_path: to,


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [DIA-1049]

### Description

This adds a new optimization strategy around INP via an `INPOptimizer` component. 

**Feature Flag:**
- `diamond_experimental-inp-optimization` 

**Impact Areas:**
- Only on **mobile**!
- `/artwork/:id`
- `/artist/:id` 

**Review App:**
- https://inp-test-2.artsy.net/

If ☝️ is successful in google search console and we see big drops we can expand this site-wide. 

**Issue**: 

We get subpar INP scores on artwork / artist due to the overhead involved in clicking on a link, then transitioning via our router to a new fully rendered page. There's an unavoidable overhead baked into using it. 

**The Fix**: 

The fix is straightforward. Instead of transiting from fully-rendered page to fully-rendered page, we instead transition to a blank page -- but for only **one** single render cycle. Once the blank page lands (with a nice INP score, since transitioning like this is pretty instant), we set some state telling normal rendering to proceed and to display things as expected. This makes things feel snappier on click!

**Before:**

<img width="398" alt="Screenshot 2025-01-17 at 3 26 23 PM" src="https://github.com/user-attachments/assets/5f86fa13-9019-404f-b799-e8e0a7890550" />

**After:**

<img width="541" alt="Screenshot 2025-01-17 at 11 59 59 AM" src="https://github.com/user-attachments/assets/25c9c980-1db1-4cb2-8825-46ec69132ca7" />

https://github.com/user-attachments/assets/7b5fa388-c466-4274-9653-f4d04e49740f

cc @artsy/diamond-devs 


[DIA-1049]: https://artsyproduct.atlassian.net/browse/DIA-1049?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ