### PR TITLE
fix(dia-1058): avoid extraneous app download ctas on homepage

### DIFF
--- a/src/Apps/Home/Components/HomeFeaturedMarketNews.tsx
+++ b/src/Apps/Home/Components/HomeFeaturedMarketNews.tsx
@@ -86,7 +86,7 @@ const HomeFeaturedMarketNews: React.FC<
               {firstArticle.vertical}
             </Text>
 
-            <Text variant={["lg", "xl"]} mt={0.5}>
+            <Text variant={["lg-display", "xl"]} mt={0.5}>
               {firstArticle.title}
             </Text>
 

--- a/src/Components/AppDownloadBanner.tsx
+++ b/src/Components/AppDownloadBanner.tsx
@@ -2,6 +2,7 @@ import { ActionType, type ClickedDownloadAppHeader } from "@artsy/cohesion"
 import ChevronSmallRightIcon from "@artsy/icons/ChevronSmallRightIcon"
 import { Box, Text } from "@artsy/palette"
 import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
+import { useRouter } from "System/Hooks/useRouter"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import { useDeviceDetection } from "Utils/Hooks/useDeviceDetection"
 import { type FC, useEffect } from "react"
@@ -54,6 +55,12 @@ export const AppDownloadBanner: FC<
     }
 
     trackEvent(trackingEvent)
+  }
+
+  const { match } = useRouter()
+
+  if (match?.location?.pathname === "/") {
+    return null
   }
 
   return (

--- a/src/Components/NavBar/useNavBarHeight.ts
+++ b/src/Components/NavBar/useNavBarHeight.ts
@@ -1,5 +1,10 @@
+import { useRouter } from "System/Hooks/useRouter"
 import { useSystemContext } from "System/Hooks/useSystemContext"
-import { DESKTOP_NAV_BAR_HEIGHT, MOBILE_NAV_HEIGHT } from "./constants"
+import {
+  DESKTOP_NAV_BAR_HEIGHT,
+  MOBILE_APP_DOWNLOAD_BANNER_HEIGHT,
+  MOBILE_NAV_HEIGHT,
+} from "./constants"
 
 export const useNavBarHeight = (): {
   height: [number, number]
@@ -13,7 +18,12 @@ export const useNavBarHeight = (): {
     return { height: [0, 0], mobile: 0, desktop: 0 }
   }
 
-  const mobile = MOBILE_NAV_HEIGHT
+  const { match } = useRouter()
+
+  const mobile =
+    MOBILE_NAV_HEIGHT -
+    // App download banner is disabled on the home page
+    (match?.location?.pathname === "/" ? MOBILE_APP_DOWNLOAD_BANNER_HEIGHT : 0)
   const desktop = DESKTOP_NAV_BAR_HEIGHT
 
   return { height: [mobile, desktop], mobile, desktop }


### PR DESCRIPTION
This implementation disables the top download banner specifically on the homepage, which adjusts the global nav height accordingly. The footer banner is also disabled on the homepage only. The system treats homepage visits as standard route changes—the banner will hide when arriving on the homepage if previously displayed, then reappear when navigating away via route change.