### PR TITLE
feat: add signed as filter param to filterArtworksConnection

### DIFF
--- a/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilters.tsx
@@ -12,6 +12,7 @@ import { MaterialsFilter } from "Components/ArtworkFilter/ArtworkFilters/Materia
 import { MediumFilter } from "Components/ArtworkFilter/ArtworkFilters/MediumFilter"
 import { PartnersFilter } from "Components/ArtworkFilter/ArtworkFilters/PartnersFilter"
 import { PriceRangeFilter } from "Components/ArtworkFilter/ArtworkFilters/PriceRangeFilter"
+import { SignedFilter } from "Components/ArtworkFilter/ArtworkFilters/SignedFilter"
 import { SizeFilter } from "Components/ArtworkFilter/ArtworkFilters/SizeFilter"
 import { TimePeriodFilter } from "Components/ArtworkFilter/ArtworkFilters/TimePeriodFilter"
 import { WaysToBuyFilter } from "Components/ArtworkFilter/ArtworkFilters/WaysToBuyFilter"
@@ -27,6 +28,9 @@ export const ArtistArtworkFilters: React.FC<
     "onyx_only_framed_artworks_filter",
   )
   const { user } = useSystemContext()
+  const enableShowOnlySignedArtworksFilter = useFeatureFlag(
+    "onyx_only_signed_artworks_filter",
+  )
 
   return (
     <Join separator={<Spacer y={4} />}>
@@ -46,6 +50,7 @@ export const ArtistArtworkFilters: React.FC<
       <ColorFilter />
       <PartnersFilter />
       {enableShowOnlyFramedArtworksFilter && <FramedFilter />}
+      {enableShowOnlySignedArtworksFilter && <SignedFilter />}
     </Join>
   )
 }

--- a/src/Apps/Collect/Routes/Collection/Components/CollectionArtworksFilter.tsx
+++ b/src/Apps/Collect/Routes/Collection/Components/CollectionArtworksFilter.tsx
@@ -16,6 +16,7 @@ import { MaterialsFilter } from "Components/ArtworkFilter/ArtworkFilters/Materia
 import { MediumFilter } from "Components/ArtworkFilter/ArtworkFilters/MediumFilter"
 import { PartnersFilter } from "Components/ArtworkFilter/ArtworkFilters/PartnersFilter"
 import { PriceRangeFilter } from "Components/ArtworkFilter/ArtworkFilters/PriceRangeFilter"
+import { SignedFilter } from "Components/ArtworkFilter/ArtworkFilters/SignedFilter"
 import { SizeFilter } from "Components/ArtworkFilter/ArtworkFilters/SizeFilter"
 import { TimePeriodFilter } from "Components/ArtworkFilter/ArtworkFilters/TimePeriodFilter"
 import { WaysToBuyFilter } from "Components/ArtworkFilter/ArtworkFilters/WaysToBuyFilter"
@@ -46,6 +47,10 @@ export const CollectionArtworksFilter: React.FC<
   const enableShowOnlyFramedArtworksFilter = useFeatureFlag(
     "onyx_only_framed_artworks_filter",
   )
+  const enableShowOnlySignedArtworksFilter = useFeatureFlag(
+    "onyx_only_signed_artworks_filter",
+  )
+
   const { relay, collection, aggregations, counts } = props
   const { slug, query } = collection
   const isArtistCollection = query?.artistIDs?.length === 1
@@ -70,6 +75,7 @@ export const CollectionArtworksFilter: React.FC<
       <ColorFilter expanded />
       <PartnersFilter expanded />
       {enableShowOnlyFramedArtworksFilter && <FramedFilter expanded />}
+      {enableShowOnlySignedArtworksFilter && <SignedFilter expanded />}
     </Join>
   )
 

--- a/src/Apps/Search/Components/SearchResultsArtworksFilters.tsx
+++ b/src/Apps/Search/Components/SearchResultsArtworksFilters.tsx
@@ -10,6 +10,7 @@ import { MaterialsFilter } from "Components/ArtworkFilter/ArtworkFilters/Materia
 import { MediumFilter } from "Components/ArtworkFilter/ArtworkFilters/MediumFilter"
 import { PartnersFilter } from "Components/ArtworkFilter/ArtworkFilters/PartnersFilter"
 import { PriceRangeFilter } from "Components/ArtworkFilter/ArtworkFilters/PriceRangeFilter"
+import { SignedFilter } from "Components/ArtworkFilter/ArtworkFilters/SignedFilter"
 import { SizeFilter } from "Components/ArtworkFilter/ArtworkFilters/SizeFilter"
 import { TimePeriodFilter } from "Components/ArtworkFilter/ArtworkFilters/TimePeriodFilter"
 import { WaysToBuyFilter } from "Components/ArtworkFilter/ArtworkFilters/WaysToBuyFilter"
@@ -20,6 +21,9 @@ export const SearchResultsArtworksFilters = () => {
     "onyx_only_framed_artworks_filter",
   )
 
+  const enableShowOnlySignedArtworksFilter = useFeatureFlag(
+    "onyx_only_signed_artworks_filter",
+  )
   return (
     <Join separator={<Spacer y={4} />}>
       <ArtistsFilter expanded />
@@ -36,6 +40,7 @@ export const SearchResultsArtworksFilters = () => {
       <ColorFilter expanded />
       <PartnersFilter expanded />
       {enableShowOnlyFramedArtworksFilter && <FramedFilter expanded />}
+      {enableShowOnlySignedArtworksFilter && <SignedFilter expanded />}
     </Join>
   )
 }

--- a/src/Components/Alert/AlertProvider.tsx
+++ b/src/Components/Alert/AlertProvider.tsx
@@ -94,7 +94,7 @@ export const AlertProvider: FC<React.PropsWithChildren<AlertProviderProps>> = ({
     if (isEditMode || isAlertArtworksView) return
     const criteria = getAllowedSearchCriteria(initialCriteria ?? {})
 
-    // `forSale` and `framed` are allowed as a filter criterion,
+    // `forSale` is not allowed as a filter criterion,
     // but NOT as an alert criterion, so we remove it.
     // (Alerts, by definition, stipulate forSale=true
     // when they are created in Gravity.)

--- a/src/Components/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilterContext.tsx
@@ -55,6 +55,7 @@ export enum FilterParamName {
   medium = "medium",
   partnerIDs = "partnerIDs",
   priceRange = "priceRange",
+  signed = "signed",
   sizes = "sizes",
   sort = "sort",
   timePeriod = "majorPeriods",
@@ -145,6 +146,7 @@ export enum SelectedFiltersCountsLabels {
   medium = "medium",
   partnerIDs = "partnerIDs",
   priceRange = "priceRange",
+  signed = "signed",
   sizes = "sizes",
   sort = "sort",
   timePeriod = "majorPeriods",
@@ -489,6 +491,7 @@ const artworkFilterReducer = (
         "includeArtworksByFollowedArtists",
         "inquireableOnly",
         "offerable",
+        "signed",
       ]
       booleanFilterTypes.forEach(filter => {
         if (name === filter) {
@@ -541,6 +544,7 @@ const artworkFilterReducer = (
         "inquireableOnly",
         "offerable",
         "partnerID",
+        "signed",
       ]
       filters.forEach(filter => {
         if (name === filter) {
@@ -652,7 +656,8 @@ export const getSelectedFiltersCounts = (
         break
       }
 
-      case paramName === FilterParamName.framed: {
+      case paramName === FilterParamName.framed:
+      case paramName === FilterParamName.signed: {
         if (paramValue) {
           counts[paramName] = 1
         }

--- a/src/Components/ArtworkFilter/ArtworkFilterTypes.ts
+++ b/src/Components/ArtworkFilter/ArtworkFilterTypes.ts
@@ -36,6 +36,7 @@ export interface ArtworkFilters extends MultiSelectArtworkFilters {
   page?: number
   partnerID?: string
   priceRange?: string
+  signed?: boolean
   sort?: string
   term?: string
   width?: string

--- a/src/Components/ArtworkFilter/ArtworkFilters/SignedFilter.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/SignedFilter.tsx
@@ -1,0 +1,44 @@
+import { Checkbox } from "@artsy/palette"
+import {
+  SelectedFiltersCountsLabels,
+  useArtworkFilterContext,
+  useCurrentlySelectedFilters,
+} from "Components/ArtworkFilter/ArtworkFilterContext"
+import { FilterExpandable } from "Components/ArtworkFilter/ArtworkFilters/FilterExpandable"
+import { useFilterLabelCountByKey } from "Components/ArtworkFilter/Utils/useFilterLabelCountByKey"
+
+interface SignedFilterProps {
+  expanded?: boolean
+}
+
+export const SignedFilter: React.FC<SignedFilterProps> = ({ expanded }) => {
+  const { unsetFilter, setFilter } = useArtworkFilterContext()
+  const currentSelectedFilters = useCurrentlySelectedFilters()
+
+  const filtersCount = useFilterLabelCountByKey(
+    SelectedFiltersCountsLabels.signed,
+  )
+  const label = `Signed${filtersCount}`
+
+  const isSelected = currentSelectedFilters?.signed
+
+  const handleOnSelect = (selected: boolean) => {
+    if (selected) {
+      setFilter("signed", true)
+    } else {
+      unsetFilter("signed")
+    }
+  }
+
+  return (
+    <FilterExpandable label={label} expanded={isSelected || expanded}>
+      <Checkbox
+        selected={!!currentSelectedFilters?.signed}
+        onSelect={handleOnSelect}
+        my={1}
+      >
+        Only signed works
+      </Checkbox>
+    </FilterExpandable>
+  )
+}

--- a/src/Components/ArtworkFilter/ArtworkFilters/__tests__/SignedFilter.jest.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/__tests__/SignedFilter.jest.tsx
@@ -1,0 +1,108 @@
+import { screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { useArtworkFilterContext } from "Components/ArtworkFilter/ArtworkFilterContext"
+import { SignedFilter } from "Components/ArtworkFilter/ArtworkFilters/SignedFilter"
+import {
+  createArtworkFilterTestRenderer,
+  currentArtworkFilterContext,
+} from "Components/ArtworkFilter/ArtworkFilters/__tests__/Utils"
+import { __internal__useMatchMedia } from "Utils/Hooks/useMatchMedia"
+import { useEffect } from "react"
+
+jest.mock("Utils/Hooks/useMatchMedia")
+
+const render = createArtworkFilterTestRenderer()
+
+describe(SignedFilter, () => {
+  it("renders a signed toggle", () => {
+    render(<SignedFilter expanded />)
+    expect(screen.getByText("Only signed works")).toBeInTheDocument()
+  })
+
+  it("updates context on filter change", () => {
+    render(<SignedFilter expanded />)
+    expect(currentArtworkFilterContext().filters?.signed).toBeFalsy()
+
+    userEvent.click(screen.getAllByRole("checkbox")[0])
+    expect(currentArtworkFilterContext().filters?.signed).toBeTruthy()
+
+    userEvent.click(screen.getAllByRole("checkbox")[0])
+    expect(currentArtworkFilterContext().filters?.signed).toBeNull()
+  })
+
+  it("clears local input state after Clear All", () => {
+    render(<SignedFilter expanded />)
+    userEvent.click(screen.getAllByRole("checkbox")[0])
+    expect(currentArtworkFilterContext().filters?.signed).toBeTruthy()
+
+    userEvent.click(screen.getByText("Clear all"))
+
+    expect(currentArtworkFilterContext().filters?.signed).toBeUndefined()
+  })
+
+  describe("mobile-specific behavior", () => {
+    beforeEach(() => {
+      // Simulate the media query that checks for xs size and returns true
+      ;(__internal__useMatchMedia as jest.Mock).mockImplementation(() => true)
+
+      /*
+       * A test component that simulates the usage of
+       * the SignedFilter inside ArtworkFilterMobileOverlay
+       */
+      const MobileVersionOfSignedFilter = () => {
+        const filterContext = useArtworkFilterContext()
+
+        // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
+        useEffect(() => {
+          // on mount, initialize the staged filters
+          filterContext.setShouldStageFilterChanges?.(true)
+          if (filterContext.filters) {
+            filterContext.setStagedFilters?.(filterContext.filters)
+          }
+        }, [])
+
+        return <SignedFilter expanded />
+      }
+      render(<MobileVersionOfSignedFilter />)
+    })
+
+    afterEach(() => {
+      jest.clearAllMocks()
+    })
+
+    it("stages the filter change instead of applying", () => {
+      expect(currentArtworkFilterContext().filters?.signed).toBeFalsy()
+
+      userEvent.click(screen.getAllByRole("checkbox")[0])
+
+      expect(currentArtworkFilterContext().filters?.signed).toBeFalsy()
+      expect(currentArtworkFilterContext().stagedFilters?.signed).toBeTruthy()
+    })
+
+    it("displays a filter count inline", () => {
+      expect(screen.getByText("Signed")).toBeInTheDocument()
+      expect(screen.queryByText("Signed • 1")).not.toBeInTheDocument()
+
+      userEvent.click(screen.getAllByRole("checkbox")[0])
+
+      expect(screen.getByText("Signed • 1")).toBeInTheDocument()
+    })
+  })
+
+  describe("the `expanded` prop", () => {
+    it("hides the filter controls when not set", () => {
+      render(<SignedFilter />)
+      expect(screen.queryAllByRole("checkbox").length).toBe(0)
+    })
+
+    it("hides the filter controls when `false`", () => {
+      render(<SignedFilter expanded={false} />)
+      expect(screen.queryAllByRole("checkbox").length).toBe(0)
+    })
+
+    it("shows the filter controls when `true`", () => {
+      render(<SignedFilter expanded />)
+      expect(screen.queryAllByRole("checkbox").length).not.toBe(0)
+    })
+  })
+})

--- a/src/Components/ArtworkFilter/ArtworkFilters/index.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/index.tsx
@@ -2,6 +2,7 @@ import { Join, Spacer } from "@artsy/palette"
 import { AvailabilityFilter } from "Components/ArtworkFilter/ArtworkFilters/AvailabilityFilter"
 import { FramedFilter } from "Components/ArtworkFilter/ArtworkFilters/FramedFilter"
 import { KeywordFilter } from "Components/ArtworkFilter/ArtworkFilters/KeywordFilter"
+import { SignedFilter } from "Components/ArtworkFilter/ArtworkFilters/SignedFilter"
 import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
 import type * as React from "react"
 import { ArtistNationalityFilter } from "./ArtistNationalityFilter"
@@ -28,6 +29,9 @@ export const ArtworkFilters: React.FC<
   const enableShowOnlyFramedArtworksFilter = useFeatureFlag(
     "onyx_only_framed_artworks_filter",
   )
+  const enableShowOnlySignedArtworksFilter = useFeatureFlag(
+    "onyx_only_signed_artworks_filter",
+  )
   const { user } = props
 
   return (
@@ -47,6 +51,7 @@ export const ArtworkFilters: React.FC<
       <ColorFilter expanded />
       <PartnersFilter expanded />
       {enableShowOnlyFramedArtworksFilter && <FramedFilter expanded />}
+      {enableShowOnlySignedArtworksFilter && <SignedFilter expanded />}
     </Join>
   )
 }

--- a/src/Components/ArtworkFilter/Utils/allowedFilters.ts
+++ b/src/Components/ArtworkFilter/Utils/allowedFilters.ts
@@ -38,6 +38,7 @@ const BOOLEAN_INPUT_ARGS = [
   "keywordMatchExact",
   "marketable",
   "offerable",
+  "signed",
 ]
 
 /**
@@ -89,6 +90,7 @@ const SUPPORTED_INPUT_ARGS = [
   "periods",
   "priceRange",
   "saleID",
+  "signed",
   "size",
   "sizes",
   "sort",

--- a/src/Components/SavedSearchAlert/Utils/__tests__/extractPills.jest.ts
+++ b/src/Components/SavedSearchAlert/Utils/__tests__/extractPills.jest.ts
@@ -177,6 +177,24 @@ describe("extractPillsFromDefaultCriteria", () => {
     ])
   })
 
+  it("should support signed", () => {
+    const result = extractPillsFromDefaultCriteria({
+      signed: {
+        displayValue: "Signed",
+        value: true,
+      },
+    })
+
+    expect(result).toEqual([
+      {
+        isDefault: true,
+        displayValue: "Signed",
+        value: "true",
+        field: "signed",
+      },
+    ])
+  })
+
   it("should support framed", () => {
     const result = extractPillsFromDefaultCriteria({
       framed: {

--- a/src/Components/SavedSearchAlert/Utils/extractPills.ts
+++ b/src/Components/SavedSearchAlert/Utils/extractPills.ts
@@ -203,6 +203,14 @@ export const extractPillsFromCriteria = ({
         }
         break
       }
+      case "signed": {
+        result = {
+          field: paramName,
+          value: paramValue,
+          displayValue: "Signed",
+        }
+        break
+      }
       default: {
         result = null
       }

--- a/src/Components/SavedSearchAlert/constants.ts
+++ b/src/Components/SavedSearchAlert/constants.ts
@@ -42,6 +42,7 @@ export const allowedSearchCriteriaKeys = [
   "offerable",
   "partnerIDs",
   "priceRange",
+  "signed",
   "sizes",
   "width",
 ]

--- a/src/Components/SavedSearchAlert/types.ts
+++ b/src/Components/SavedSearchAlert/types.ts
@@ -20,6 +20,7 @@ export interface SearchCriteriaAttributes {
   offerable?: boolean | null
   partnerIDs?: string[] | null
   priceRange?: string | null
+  signed?: boolean | null
   sizes?: string[] | null
   width?: string | null
 }

--- a/src/__generated__/NotificationQuery.graphql.ts
+++ b/src/__generated__/NotificationQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4ab0a0a185aa737b889876e01515b479>>
+ * @generated SignedSource<<1ad59c0ebe07548b073ff4702a26c6f4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -1194,7 +1194,7 @@ return {
                                   {
                                     "alias": null,
                                     "args": null,
-                                    "concreteType": "GravityARImage",
+                                    "concreteType": "ARImage",
                                     "kind": "LinkedField",
                                     "name": "image",
                                     "plural": false,
@@ -1202,7 +1202,7 @@ return {
                                       {
                                         "alias": null,
                                         "args": null,
-                                        "concreteType": "GravityImageURLs",
+                                        "concreteType": "ImageURLs",
                                         "kind": "LinkedField",
                                         "name": "imageURLs",
                                         "plural": false,

--- a/src/__generated__/NotificationViewingRoom_viewingRoom.graphql.ts
+++ b/src/__generated__/NotificationViewingRoom_viewingRoom.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<65abc3f61fa50168b5891107a12eeebf>>
+ * @generated SignedSource<<c0e1a0e6f540244cc21f6edae551dbbe>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -58,7 +58,7 @@ const node: ReaderFragment = {
     {
       "alias": null,
       "args": null,
-      "concreteType": "GravityARImage",
+      "concreteType": "ARImage",
       "kind": "LinkedField",
       "name": "image",
       "plural": false,
@@ -66,7 +66,7 @@ const node: ReaderFragment = {
         {
           "alias": null,
           "args": null,
-          "concreteType": "GravityImageURLs",
+          "concreteType": "ImageURLs",
           "kind": "LinkedField",
           "name": "imageURLs",
           "plural": false,

--- a/src/__generated__/PartnerViewingRoomsGrid_Test_Query.graphql.ts
+++ b/src/__generated__/PartnerViewingRoomsGrid_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8a3acbeb4d9e6b63023969240c9b45c8>>
+ * @generated SignedSource<<33a1b2456102b57735d3e59308401b00>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -149,7 +149,7 @@ return {
                       {
                         "alias": "coverImage",
                         "args": null,
-                        "concreteType": "GravityARImage",
+                        "concreteType": "ARImage",
                         "kind": "LinkedField",
                         "name": "image",
                         "plural": false,
@@ -157,7 +157,7 @@ return {
                           {
                             "alias": null,
                             "args": null,
-                            "concreteType": "GravityImageURLs",
+                            "concreteType": "ImageURLs",
                             "kind": "LinkedField",
                             "name": "imageURLs",
                             "plural": false,
@@ -296,14 +296,14 @@ return {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "GravityARImage"
+          "type": "ARImage"
         },
         "viewingRoomsConnection.viewingRoomsConnection.edges.node.coverImage.height": (v3/*: any*/),
         "viewingRoomsConnection.viewingRoomsConnection.edges.node.coverImage.imageURLs": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "GravityImageURLs"
+          "type": "ImageURLs"
         },
         "viewingRoomsConnection.viewingRoomsConnection.edges.node.coverImage.imageURLs.normalized": (v4/*: any*/),
         "viewingRoomsConnection.viewingRoomsConnection.edges.node.coverImage.width": (v3/*: any*/),

--- a/src/__generated__/PartnerViewingRoomsGrid_ViewingRoomsQuery.graphql.ts
+++ b/src/__generated__/PartnerViewingRoomsGrid_ViewingRoomsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<921c5a1cca4dc3f33289d4850de8109b>>
+ * @generated SignedSource<<c0e9cb527550fba81b0246bdbaa0bc52>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -188,7 +188,7 @@ return {
                       {
                         "alias": "coverImage",
                         "args": null,
-                        "concreteType": "GravityARImage",
+                        "concreteType": "ARImage",
                         "kind": "LinkedField",
                         "name": "image",
                         "plural": false,
@@ -196,7 +196,7 @@ return {
                           {
                             "alias": null,
                             "args": null,
-                            "concreteType": "GravityImageURLs",
+                            "concreteType": "ImageURLs",
                             "kind": "LinkedField",
                             "name": "imageURLs",
                             "plural": false,

--- a/src/__generated__/ShowApp_Test_Query.graphql.ts
+++ b/src/__generated__/ShowApp_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bcccfd8b95bc04e030e8ea65b785680d>>
+ * @generated SignedSource<<4851314f4b2d3567c9a65c46e124aa5a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -285,7 +285,7 @@ return {
                       {
                         "alias": null,
                         "args": null,
-                        "concreteType": "GravityARImage",
+                        "concreteType": "ARImage",
                         "kind": "LinkedField",
                         "name": "image",
                         "plural": false,
@@ -293,7 +293,7 @@ return {
                           {
                             "alias": null,
                             "args": null,
-                            "concreteType": "GravityImageURLs",
+                            "concreteType": "ImageURLs",
                             "kind": "LinkedField",
                             "name": "imageURLs",
                             "plural": false,
@@ -881,13 +881,13 @@ return {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "GravityARImage"
+          "type": "ARImage"
         },
         "show.viewingRoomsConnection.edges.node.image.imageURLs": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "GravityImageURLs"
+          "type": "ImageURLs"
         },
         "show.viewingRoomsConnection.edges.node.image.imageURLs.normalized": (v16/*: any*/),
         "show.viewingRoomsConnection.edges.node.internalID": (v18/*: any*/),

--- a/src/__generated__/ShowViewingRoom_Test_Query.graphql.ts
+++ b/src/__generated__/ShowViewingRoom_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a44719e01c47e9f4f2fb05cd7a169b6a>>
+ * @generated SignedSource<<593c1f1bfe02e016c5729c51facbbe0c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -228,7 +228,7 @@ return {
                       {
                         "alias": null,
                         "args": null,
-                        "concreteType": "GravityARImage",
+                        "concreteType": "ARImage",
                         "kind": "LinkedField",
                         "name": "image",
                         "plural": false,
@@ -236,7 +236,7 @@ return {
                           {
                             "alias": null,
                             "args": null,
-                            "concreteType": "GravityImageURLs",
+                            "concreteType": "ImageURLs",
                             "kind": "LinkedField",
                             "name": "imageURLs",
                             "plural": false,
@@ -316,13 +316,13 @@ return {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "GravityARImage"
+          "type": "ARImage"
         },
         "show.viewingRoomsConnection.edges.node.image.imageURLs": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "GravityImageURLs"
+          "type": "ImageURLs"
         },
         "show.viewingRoomsConnection.edges.node.image.imageURLs.normalized": (v6/*: any*/),
         "show.viewingRoomsConnection.edges.node.internalID": (v4/*: any*/),

--- a/src/__generated__/ShowViewingRoom_show.graphql.ts
+++ b/src/__generated__/ShowViewingRoom_show.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8b8238716f5b1c2e4da9255bdf45bf82>>
+ * @generated SignedSource<<bae99bd2e04cc01911b3452860a71525>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -161,7 +161,7 @@ return {
                 {
                   "alias": null,
                   "args": null,
-                  "concreteType": "GravityARImage",
+                  "concreteType": "ARImage",
                   "kind": "LinkedField",
                   "name": "image",
                   "plural": false,
@@ -169,7 +169,7 @@ return {
                     {
                       "alias": null,
                       "args": null,
-                      "concreteType": "GravityImageURLs",
+                      "concreteType": "ImageURLs",
                       "kind": "LinkedField",
                       "name": "imageURLs",
                       "plural": false,

--- a/src/__generated__/ViewingRoomApp_ClosedTest_Query.graphql.ts
+++ b/src/__generated__/ViewingRoomApp_ClosedTest_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<87c771b863bbd62e53d6f7b3f38f307e>>
+ * @generated SignedSource<<0e1570e23b01dd7e749c2cebf7547d5c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -152,7 +152,7 @@ return {
           {
             "alias": null,
             "args": null,
-            "concreteType": "GravityARImage",
+            "concreteType": "ARImage",
             "kind": "LinkedField",
             "name": "image",
             "plural": false,
@@ -160,7 +160,7 @@ return {
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "GravityImageURLs",
+                "concreteType": "ImageURLs",
                 "kind": "LinkedField",
                 "name": "imageURLs",
                 "plural": false,
@@ -250,13 +250,13 @@ return {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "GravityARImage"
+          "type": "ARImage"
         },
         "viewingRoom.image.imageURLs": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "GravityImageURLs"
+          "type": "ImageURLs"
         },
         "viewingRoom.image.imageURLs.normalized": (v4/*: any*/),
         "viewingRoom.internalID": (v5/*: any*/),

--- a/src/__generated__/ViewingRoomApp_DraftTest_Query.graphql.ts
+++ b/src/__generated__/ViewingRoomApp_DraftTest_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<71edc3b7b55f3ffb9ef43e20c7227a5f>>
+ * @generated SignedSource<<11b6a9cf730092ff4c6bd0e746a1df89>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -152,7 +152,7 @@ return {
           {
             "alias": null,
             "args": null,
-            "concreteType": "GravityARImage",
+            "concreteType": "ARImage",
             "kind": "LinkedField",
             "name": "image",
             "plural": false,
@@ -160,7 +160,7 @@ return {
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "GravityImageURLs",
+                "concreteType": "ImageURLs",
                 "kind": "LinkedField",
                 "name": "imageURLs",
                 "plural": false,
@@ -250,13 +250,13 @@ return {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "GravityARImage"
+          "type": "ARImage"
         },
         "viewingRoom.image.imageURLs": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "GravityImageURLs"
+          "type": "ImageURLs"
         },
         "viewingRoom.image.imageURLs.normalized": (v4/*: any*/),
         "viewingRoom.internalID": (v5/*: any*/),

--- a/src/__generated__/ViewingRoomApp_LoggedOutTest_Query.graphql.ts
+++ b/src/__generated__/ViewingRoomApp_LoggedOutTest_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<542f9362ae25406742db3608435a1592>>
+ * @generated SignedSource<<e20d7e92ed7436c35d8e780a23457656>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -152,7 +152,7 @@ return {
           {
             "alias": null,
             "args": null,
-            "concreteType": "GravityARImage",
+            "concreteType": "ARImage",
             "kind": "LinkedField",
             "name": "image",
             "plural": false,
@@ -160,7 +160,7 @@ return {
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "GravityImageURLs",
+                "concreteType": "ImageURLs",
                 "kind": "LinkedField",
                 "name": "imageURLs",
                 "plural": false,
@@ -250,13 +250,13 @@ return {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "GravityARImage"
+          "type": "ARImage"
         },
         "viewingRoom.image.imageURLs": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "GravityImageURLs"
+          "type": "ImageURLs"
         },
         "viewingRoom.image.imageURLs.normalized": (v4/*: any*/),
         "viewingRoom.internalID": (v5/*: any*/),

--- a/src/__generated__/ViewingRoomApp_OpenTest_Query.graphql.ts
+++ b/src/__generated__/ViewingRoomApp_OpenTest_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3f5567959945c27cd958be528fb92530>>
+ * @generated SignedSource<<ea920b7805f8f6d87216b6c683afaa18>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -152,7 +152,7 @@ return {
           {
             "alias": null,
             "args": null,
-            "concreteType": "GravityARImage",
+            "concreteType": "ARImage",
             "kind": "LinkedField",
             "name": "image",
             "plural": false,
@@ -160,7 +160,7 @@ return {
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "GravityImageURLs",
+                "concreteType": "ImageURLs",
                 "kind": "LinkedField",
                 "name": "imageURLs",
                 "plural": false,
@@ -250,13 +250,13 @@ return {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "GravityARImage"
+          "type": "ARImage"
         },
         "viewingRoom.image.imageURLs": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "GravityImageURLs"
+          "type": "ImageURLs"
         },
         "viewingRoom.image.imageURLs.normalized": (v4/*: any*/),
         "viewingRoom.internalID": (v5/*: any*/),

--- a/src/__generated__/ViewingRoomApp_ScheduledTest_Query.graphql.ts
+++ b/src/__generated__/ViewingRoomApp_ScheduledTest_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b84ab8c836506d4a091a0a6a5b1d9e80>>
+ * @generated SignedSource<<84b1c561440ef5de422eb3e2563f6dfb>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -152,7 +152,7 @@ return {
           {
             "alias": null,
             "args": null,
-            "concreteType": "GravityARImage",
+            "concreteType": "ARImage",
             "kind": "LinkedField",
             "name": "image",
             "plural": false,
@@ -160,7 +160,7 @@ return {
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "GravityImageURLs",
+                "concreteType": "ImageURLs",
                 "kind": "LinkedField",
                 "name": "imageURLs",
                 "plural": false,
@@ -250,13 +250,13 @@ return {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "GravityARImage"
+          "type": "ARImage"
         },
         "viewingRoom.image.imageURLs": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "GravityImageURLs"
+          "type": "ImageURLs"
         },
         "viewingRoom.image.imageURLs.normalized": (v4/*: any*/),
         "viewingRoom.internalID": (v5/*: any*/),

--- a/src/__generated__/ViewingRoomCard_Test_Query.graphql.ts
+++ b/src/__generated__/ViewingRoomCard_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6cf93a3c34083f4ddae772878d36c69d>>
+ * @generated SignedSource<<b19a6250be5d86ac621b5417814e772c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -192,7 +192,7 @@ return {
                       {
                         "alias": "coverImage",
                         "args": null,
-                        "concreteType": "GravityARImage",
+                        "concreteType": "ARImage",
                         "kind": "LinkedField",
                         "name": "image",
                         "plural": false,
@@ -200,7 +200,7 @@ return {
                           {
                             "alias": null,
                             "args": null,
-                            "concreteType": "GravityImageURLs",
+                            "concreteType": "ImageURLs",
                             "kind": "LinkedField",
                             "name": "imageURLs",
                             "plural": false,
@@ -287,14 +287,14 @@ return {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "GravityARImage"
+          "type": "ARImage"
         },
         "partner.viewingRoomsConnection.edges.node.coverImage.height": (v4/*: any*/),
         "partner.viewingRoomsConnection.edges.node.coverImage.imageURLs": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "GravityImageURLs"
+          "type": "ImageURLs"
         },
         "partner.viewingRoomsConnection.edges.node.coverImage.imageURLs.normalized": (v5/*: any*/),
         "partner.viewingRoomsConnection.edges.node.coverImage.width": (v4/*: any*/),

--- a/src/__generated__/ViewingRoomCard_viewingRoom.graphql.ts
+++ b/src/__generated__/ViewingRoomCard_viewingRoom.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4fdb539b8830380690d085f9988b6ced>>
+ * @generated SignedSource<<81f7c6fc3107e8ce0823f2473ae049c6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -58,7 +58,7 @@ const node: ReaderFragment = {
     {
       "alias": "coverImage",
       "args": null,
-      "concreteType": "GravityARImage",
+      "concreteType": "ARImage",
       "kind": "LinkedField",
       "name": "image",
       "plural": false,
@@ -66,7 +66,7 @@ const node: ReaderFragment = {
         {
           "alias": null,
           "args": null,
-          "concreteType": "GravityImageURLs",
+          "concreteType": "ImageURLs",
           "kind": "LinkedField",
           "name": "imageURLs",
           "plural": false,

--- a/src/__generated__/ViewingRoomHeader_viewingRoom.graphql.ts
+++ b/src/__generated__/ViewingRoomHeader_viewingRoom.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3c460e4fb89141595391e5c91f079e3c>>
+ * @generated SignedSource<<b5642d45300354b5498ce7b3e72fa575>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -40,7 +40,7 @@ const node: ReaderFragment = {
     {
       "alias": null,
       "args": null,
-      "concreteType": "GravityARImage",
+      "concreteType": "ARImage",
       "kind": "LinkedField",
       "name": "image",
       "plural": false,
@@ -48,7 +48,7 @@ const node: ReaderFragment = {
         {
           "alias": null,
           "args": null,
-          "concreteType": "GravityImageURLs",
+          "concreteType": "ImageURLs",
           "kind": "LinkedField",
           "name": "imageURLs",
           "plural": false,

--- a/src/__generated__/ViewingRoomMeta_viewingRoom.graphql.ts
+++ b/src/__generated__/ViewingRoomMeta_viewingRoom.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ef131ab9f6a2ef5fff16fb40b01dc512>>
+ * @generated SignedSource<<304cf8f8547345b4ad5faecc13af2cab>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -56,7 +56,7 @@ const node: ReaderFragment = {
     {
       "alias": null,
       "args": null,
-      "concreteType": "GravityARImage",
+      "concreteType": "ARImage",
       "kind": "LinkedField",
       "name": "image",
       "plural": false,
@@ -64,7 +64,7 @@ const node: ReaderFragment = {
         {
           "alias": null,
           "args": null,
-          "concreteType": "GravityImageURLs",
+          "concreteType": "ImageURLs",
           "kind": "LinkedField",
           "name": "imageURLs",
           "plural": false,

--- a/src/__generated__/ViewingRoomPublishedNotification_test_Query.graphql.ts
+++ b/src/__generated__/ViewingRoomPublishedNotification_test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b958c709fa2e868b33d8fe403821c390>>
+ * @generated SignedSource<<cd117998e85d2f9315b4e555f115dcd4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -263,7 +263,7 @@ return {
                                       {
                                         "alias": null,
                                         "args": null,
-                                        "concreteType": "GravityARImage",
+                                        "concreteType": "ARImage",
                                         "kind": "LinkedField",
                                         "name": "image",
                                         "plural": false,
@@ -271,7 +271,7 @@ return {
                                           {
                                             "alias": null,
                                             "args": null,
-                                            "concreteType": "GravityImageURLs",
+                                            "concreteType": "ImageURLs",
                                             "kind": "LinkedField",
                                             "name": "imageURLs",
                                             "plural": false,
@@ -424,14 +424,14 @@ return {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "GravityARImage"
+          "type": "ARImage"
         },
         "notificationsConnection.edges.node.item.viewingRoomsConnection.edges.node.image.height": (v7/*: any*/),
         "notificationsConnection.edges.node.item.viewingRoomsConnection.edges.node.image.imageURLs": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "GravityImageURLs"
+          "type": "ImageURLs"
         },
         "notificationsConnection.edges.node.item.viewingRoomsConnection.edges.node.image.imageURLs.normalized": (v6/*: any*/),
         "notificationsConnection.edges.node.item.viewingRoomsConnection.edges.node.image.width": (v7/*: any*/),

--- a/src/__generated__/ViewingRoomsApp_Test_Query.graphql.ts
+++ b/src/__generated__/ViewingRoomsApp_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<91fb8c79b47fcf72abe837347b893751>>
+ * @generated SignedSource<<729304e7999a1eb0063c8c4509247cd6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -107,7 +107,7 @@ v3 = {
 v4 = {
   "alias": null,
   "args": null,
-  "concreteType": "GravityARImage",
+  "concreteType": "ARImage",
   "kind": "LinkedField",
   "name": "image",
   "plural": false,
@@ -115,7 +115,7 @@ v4 = {
     {
       "alias": null,
       "args": null,
-      "concreteType": "GravityImageURLs",
+      "concreteType": "ImageURLs",
       "kind": "LinkedField",
       "name": "imageURLs",
       "plural": false,
@@ -213,13 +213,13 @@ v14 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "GravityARImage"
+  "type": "ARImage"
 },
 v15 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "GravityImageURLs"
+  "type": "ImageURLs"
 },
 v16 = {
   "enumValues": null,

--- a/src/__generated__/ViewingRoomsFeaturedRail_featuredViewingRooms.graphql.ts
+++ b/src/__generated__/ViewingRoomsFeaturedRail_featuredViewingRooms.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c2ae717dc292857e3b652f1a6d8f7818>>
+ * @generated SignedSource<<fe3916e039b408190f81345938f95b9e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -89,7 +89,7 @@ return {
             {
               "alias": null,
               "args": null,
-              "concreteType": "GravityARImage",
+              "concreteType": "ARImage",
               "kind": "LinkedField",
               "name": "image",
               "plural": false,
@@ -97,7 +97,7 @@ return {
                 {
                   "alias": null,
                   "args": null,
-                  "concreteType": "GravityImageURLs",
+                  "concreteType": "ImageURLs",
                   "kind": "LinkedField",
                   "name": "imageURLs",
                   "plural": false,

--- a/src/__generated__/ViewingRoomsLatestGrid_ViewingRoomsAppQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomsLatestGrid_ViewingRoomsAppQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fd8a7c243c0428af734af73799fb62dd>>
+ * @generated SignedSource<<d4f372551afd9afde2ab727fda572f8e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -157,7 +157,7 @@ return {
                       {
                         "alias": null,
                         "args": null,
-                        "concreteType": "GravityARImage",
+                        "concreteType": "ARImage",
                         "kind": "LinkedField",
                         "name": "image",
                         "plural": false,
@@ -165,7 +165,7 @@ return {
                           {
                             "alias": null,
                             "args": null,
-                            "concreteType": "GravityImageURLs",
+                            "concreteType": "ImageURLs",
                             "kind": "LinkedField",
                             "name": "imageURLs",
                             "plural": false,

--- a/src/__generated__/ViewingRoomsLatestGrid_viewingRooms.graphql.ts
+++ b/src/__generated__/ViewingRoomsLatestGrid_viewingRooms.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8d77550215e1a5c2a3c02be9e577c8d7>>
+ * @generated SignedSource<<0c538609fde44097976ecac8e4cd2691>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -121,7 +121,7 @@ return {
                 {
                   "alias": null,
                   "args": null,
-                  "concreteType": "GravityARImage",
+                  "concreteType": "ARImage",
                   "kind": "LinkedField",
                   "name": "image",
                   "plural": false,
@@ -129,7 +129,7 @@ return {
                     {
                       "alias": null,
                       "args": null,
-                      "concreteType": "GravityImageURLs",
+                      "concreteType": "ImageURLs",
                       "kind": "LinkedField",
                       "name": "imageURLs",
                       "plural": false,

--- a/src/__generated__/partnerRoutes_ViewingRoomsQuery.graphql.ts
+++ b/src/__generated__/partnerRoutes_ViewingRoomsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<cdaa6c8f7744a7caa20237b6b580a9ea>>
+ * @generated SignedSource<<3a303ab1359c372338008485a0d03f6c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -107,7 +107,7 @@ v4 = [
           {
             "alias": "coverImage",
             "args": null,
-            "concreteType": "GravityARImage",
+            "concreteType": "ARImage",
             "kind": "LinkedField",
             "name": "image",
             "plural": false,
@@ -115,7 +115,7 @@ v4 = [
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "GravityImageURLs",
+                "concreteType": "ImageURLs",
                 "kind": "LinkedField",
                 "name": "imageURLs",
                 "plural": false,

--- a/src/__generated__/showRoutes_ShowQuery.graphql.ts
+++ b/src/__generated__/showRoutes_ShowQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<21a24f228123fbb1abf66c4c69055cd8>>
+ * @generated SignedSource<<fa3c3a5c27c74a545886d1795e6b0d6c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -258,7 +258,7 @@ return {
                       {
                         "alias": null,
                         "args": null,
-                        "concreteType": "GravityARImage",
+                        "concreteType": "ARImage",
                         "kind": "LinkedField",
                         "name": "image",
                         "plural": false,
@@ -266,7 +266,7 @@ return {
                           {
                             "alias": null,
                             "args": null,
-                            "concreteType": "GravityImageURLs",
+                            "concreteType": "ImageURLs",
                             "kind": "LinkedField",
                             "name": "imageURLs",
                             "plural": false,

--- a/src/__generated__/viewingRoomRoutes_ViewingRoomQuery.graphql.ts
+++ b/src/__generated__/viewingRoomRoutes_ViewingRoomQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a3d6bd9aa4a87b27c3f464925b6f0e9e>>
+ * @generated SignedSource<<7058e5fed049d36cecf9c546c0485d08>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -111,7 +111,7 @@ return {
           {
             "alias": null,
             "args": null,
-            "concreteType": "GravityARImage",
+            "concreteType": "ARImage",
             "kind": "LinkedField",
             "name": "image",
             "plural": false,
@@ -119,7 +119,7 @@ return {
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "GravityImageURLs",
+                "concreteType": "ImageURLs",
                 "kind": "LinkedField",
                 "name": "imageURLs",
                 "plural": false,

--- a/src/__generated__/viewingRoomRoutes_ViewingRoomsAppQuery.graphql.ts
+++ b/src/__generated__/viewingRoomRoutes_ViewingRoomsAppQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6119fcf28f0104b919ffdca2f588e6e8>>
+ * @generated SignedSource<<514f04608430c0681486b897e3dd55c2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -82,7 +82,7 @@ v7 = {
 v8 = {
   "alias": null,
   "args": null,
-  "concreteType": "GravityARImage",
+  "concreteType": "ARImage",
   "kind": "LinkedField",
   "name": "image",
   "plural": false,
@@ -90,7 +90,7 @@ v8 = {
     {
       "alias": null,
       "args": null,
-      "concreteType": "GravityImageURLs",
+      "concreteType": "ImageURLs",
       "kind": "LinkedField",
       "name": "imageURLs",
       "plural": false,


### PR DESCRIPTION
The type of this PR is: **feat**

This PR adds signed as a filter param to `filterArtworksConnection` 

Related PRs https://github.com/artsy/metaphysics/pull/6382 and https://github.com/artsy/gravity/pull/18512


https://github.com/user-attachments/assets/7a4dfb36-7155-4dc0-b655-2118ce150874


