### PR TITLE
fix(dia-1090): adds h1 tag to artist CV pages

### DIFF
--- a/src/Apps/Artist/Routes/CV/ArtistCVRoute.tsx
+++ b/src/Apps/Artist/Routes/CV/ArtistCVRoute.tsx
@@ -1,4 +1,4 @@
-import { Join, Spacer } from "@artsy/palette"
+import { Stack, Text } from "@artsy/palette"
 import { MetaTags } from "Components/MetaTags"
 import type { ArtistCVRoute_viewer$data } from "__generated__/ArtistCVRoute_viewer.graphql"
 import type * as React from "react"
@@ -18,9 +18,13 @@ const ArtistCVRoute: React.FC<React.PropsWithChildren<ArtistCVRouteProps>> = ({
 
   return (
     <>
-      <MetaTags title={`${viewer?.soloShows?.name} - CV | Artsy`} />
+      <MetaTags title={`${viewer?.soloShows?.name} CV | Artsy`} />
 
-      <Join separator={<Spacer y={4} />}>
+      <Stack gap={4}>
+        <Text as="h1" variant="xl">
+          {viewer.soloShows?.name} CV
+        </Text>
+
         <ArtistCVGroupRefetchContainer
           artist={viewer.soloShows}
           title="Solo shows"
@@ -35,7 +39,7 @@ const ArtistCVRoute: React.FC<React.PropsWithChildren<ArtistCVRouteProps>> = ({
           artist={viewer.fairBooths}
           title="Fair booths"
         />
-      </Join>
+      </Stack>
     </>
   )
 }

--- a/src/Apps/Artist/Routes/CV/Components/ArtistCVGroup.tsx
+++ b/src/Apps/Artist/Routes/CV/Components/ArtistCVGroup.tsx
@@ -44,7 +44,9 @@ const ArtistCVGroup: FC<React.PropsWithChildren<ArtistCVGroupProps>> = ({
     return (
       <GridColumns>
         <Column span={12}>
-          <Text variant="lg-display">{title}</Text>
+          <Text as="h2" variant="lg-display">
+            {title}
+          </Text>
         </Column>
 
         <Column span={8} start={4}>

--- a/src/__generated__/NotificationQuery.graphql.ts
+++ b/src/__generated__/NotificationQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1ad59c0ebe07548b073ff4702a26c6f4>>
+ * @generated SignedSource<<4ab0a0a185aa737b889876e01515b479>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -1194,7 +1194,7 @@ return {
                                   {
                                     "alias": null,
                                     "args": null,
-                                    "concreteType": "ARImage",
+                                    "concreteType": "GravityARImage",
                                     "kind": "LinkedField",
                                     "name": "image",
                                     "plural": false,
@@ -1202,7 +1202,7 @@ return {
                                       {
                                         "alias": null,
                                         "args": null,
-                                        "concreteType": "ImageURLs",
+                                        "concreteType": "GravityImageURLs",
                                         "kind": "LinkedField",
                                         "name": "imageURLs",
                                         "plural": false,

--- a/src/__generated__/NotificationViewingRoom_viewingRoom.graphql.ts
+++ b/src/__generated__/NotificationViewingRoom_viewingRoom.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c0e1a0e6f540244cc21f6edae551dbbe>>
+ * @generated SignedSource<<65abc3f61fa50168b5891107a12eeebf>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -58,7 +58,7 @@ const node: ReaderFragment = {
     {
       "alias": null,
       "args": null,
-      "concreteType": "ARImage",
+      "concreteType": "GravityARImage",
       "kind": "LinkedField",
       "name": "image",
       "plural": false,
@@ -66,7 +66,7 @@ const node: ReaderFragment = {
         {
           "alias": null,
           "args": null,
-          "concreteType": "ImageURLs",
+          "concreteType": "GravityImageURLs",
           "kind": "LinkedField",
           "name": "imageURLs",
           "plural": false,

--- a/src/__generated__/PartnerViewingRoomsGrid_Test_Query.graphql.ts
+++ b/src/__generated__/PartnerViewingRoomsGrid_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<33a1b2456102b57735d3e59308401b00>>
+ * @generated SignedSource<<8a3acbeb4d9e6b63023969240c9b45c8>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -149,7 +149,7 @@ return {
                       {
                         "alias": "coverImage",
                         "args": null,
-                        "concreteType": "ARImage",
+                        "concreteType": "GravityARImage",
                         "kind": "LinkedField",
                         "name": "image",
                         "plural": false,
@@ -157,7 +157,7 @@ return {
                           {
                             "alias": null,
                             "args": null,
-                            "concreteType": "ImageURLs",
+                            "concreteType": "GravityImageURLs",
                             "kind": "LinkedField",
                             "name": "imageURLs",
                             "plural": false,
@@ -296,14 +296,14 @@ return {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "ARImage"
+          "type": "GravityARImage"
         },
         "viewingRoomsConnection.viewingRoomsConnection.edges.node.coverImage.height": (v3/*: any*/),
         "viewingRoomsConnection.viewingRoomsConnection.edges.node.coverImage.imageURLs": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "ImageURLs"
+          "type": "GravityImageURLs"
         },
         "viewingRoomsConnection.viewingRoomsConnection.edges.node.coverImage.imageURLs.normalized": (v4/*: any*/),
         "viewingRoomsConnection.viewingRoomsConnection.edges.node.coverImage.width": (v3/*: any*/),

--- a/src/__generated__/PartnerViewingRoomsGrid_ViewingRoomsQuery.graphql.ts
+++ b/src/__generated__/PartnerViewingRoomsGrid_ViewingRoomsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c0e9cb527550fba81b0246bdbaa0bc52>>
+ * @generated SignedSource<<921c5a1cca4dc3f33289d4850de8109b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -188,7 +188,7 @@ return {
                       {
                         "alias": "coverImage",
                         "args": null,
-                        "concreteType": "ARImage",
+                        "concreteType": "GravityARImage",
                         "kind": "LinkedField",
                         "name": "image",
                         "plural": false,
@@ -196,7 +196,7 @@ return {
                           {
                             "alias": null,
                             "args": null,
-                            "concreteType": "ImageURLs",
+                            "concreteType": "GravityImageURLs",
                             "kind": "LinkedField",
                             "name": "imageURLs",
                             "plural": false,

--- a/src/__generated__/ShowApp_Test_Query.graphql.ts
+++ b/src/__generated__/ShowApp_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4851314f4b2d3567c9a65c46e124aa5a>>
+ * @generated SignedSource<<bcccfd8b95bc04e030e8ea65b785680d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -285,7 +285,7 @@ return {
                       {
                         "alias": null,
                         "args": null,
-                        "concreteType": "ARImage",
+                        "concreteType": "GravityARImage",
                         "kind": "LinkedField",
                         "name": "image",
                         "plural": false,
@@ -293,7 +293,7 @@ return {
                           {
                             "alias": null,
                             "args": null,
-                            "concreteType": "ImageURLs",
+                            "concreteType": "GravityImageURLs",
                             "kind": "LinkedField",
                             "name": "imageURLs",
                             "plural": false,
@@ -881,13 +881,13 @@ return {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "ARImage"
+          "type": "GravityARImage"
         },
         "show.viewingRoomsConnection.edges.node.image.imageURLs": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "ImageURLs"
+          "type": "GravityImageURLs"
         },
         "show.viewingRoomsConnection.edges.node.image.imageURLs.normalized": (v16/*: any*/),
         "show.viewingRoomsConnection.edges.node.internalID": (v18/*: any*/),

--- a/src/__generated__/ShowViewingRoom_Test_Query.graphql.ts
+++ b/src/__generated__/ShowViewingRoom_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<593c1f1bfe02e016c5729c51facbbe0c>>
+ * @generated SignedSource<<a44719e01c47e9f4f2fb05cd7a169b6a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -228,7 +228,7 @@ return {
                       {
                         "alias": null,
                         "args": null,
-                        "concreteType": "ARImage",
+                        "concreteType": "GravityARImage",
                         "kind": "LinkedField",
                         "name": "image",
                         "plural": false,
@@ -236,7 +236,7 @@ return {
                           {
                             "alias": null,
                             "args": null,
-                            "concreteType": "ImageURLs",
+                            "concreteType": "GravityImageURLs",
                             "kind": "LinkedField",
                             "name": "imageURLs",
                             "plural": false,
@@ -316,13 +316,13 @@ return {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "ARImage"
+          "type": "GravityARImage"
         },
         "show.viewingRoomsConnection.edges.node.image.imageURLs": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "ImageURLs"
+          "type": "GravityImageURLs"
         },
         "show.viewingRoomsConnection.edges.node.image.imageURLs.normalized": (v6/*: any*/),
         "show.viewingRoomsConnection.edges.node.internalID": (v4/*: any*/),

--- a/src/__generated__/ShowViewingRoom_show.graphql.ts
+++ b/src/__generated__/ShowViewingRoom_show.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bae99bd2e04cc01911b3452860a71525>>
+ * @generated SignedSource<<8b8238716f5b1c2e4da9255bdf45bf82>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -161,7 +161,7 @@ return {
                 {
                   "alias": null,
                   "args": null,
-                  "concreteType": "ARImage",
+                  "concreteType": "GravityARImage",
                   "kind": "LinkedField",
                   "name": "image",
                   "plural": false,
@@ -169,7 +169,7 @@ return {
                     {
                       "alias": null,
                       "args": null,
-                      "concreteType": "ImageURLs",
+                      "concreteType": "GravityImageURLs",
                       "kind": "LinkedField",
                       "name": "imageURLs",
                       "plural": false,

--- a/src/__generated__/ViewingRoomApp_ClosedTest_Query.graphql.ts
+++ b/src/__generated__/ViewingRoomApp_ClosedTest_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0e1570e23b01dd7e749c2cebf7547d5c>>
+ * @generated SignedSource<<87c771b863bbd62e53d6f7b3f38f307e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -152,7 +152,7 @@ return {
           {
             "alias": null,
             "args": null,
-            "concreteType": "ARImage",
+            "concreteType": "GravityARImage",
             "kind": "LinkedField",
             "name": "image",
             "plural": false,
@@ -160,7 +160,7 @@ return {
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "ImageURLs",
+                "concreteType": "GravityImageURLs",
                 "kind": "LinkedField",
                 "name": "imageURLs",
                 "plural": false,
@@ -250,13 +250,13 @@ return {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "ARImage"
+          "type": "GravityARImage"
         },
         "viewingRoom.image.imageURLs": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "ImageURLs"
+          "type": "GravityImageURLs"
         },
         "viewingRoom.image.imageURLs.normalized": (v4/*: any*/),
         "viewingRoom.internalID": (v5/*: any*/),

--- a/src/__generated__/ViewingRoomApp_DraftTest_Query.graphql.ts
+++ b/src/__generated__/ViewingRoomApp_DraftTest_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<11b6a9cf730092ff4c6bd0e746a1df89>>
+ * @generated SignedSource<<71edc3b7b55f3ffb9ef43e20c7227a5f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -152,7 +152,7 @@ return {
           {
             "alias": null,
             "args": null,
-            "concreteType": "ARImage",
+            "concreteType": "GravityARImage",
             "kind": "LinkedField",
             "name": "image",
             "plural": false,
@@ -160,7 +160,7 @@ return {
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "ImageURLs",
+                "concreteType": "GravityImageURLs",
                 "kind": "LinkedField",
                 "name": "imageURLs",
                 "plural": false,
@@ -250,13 +250,13 @@ return {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "ARImage"
+          "type": "GravityARImage"
         },
         "viewingRoom.image.imageURLs": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "ImageURLs"
+          "type": "GravityImageURLs"
         },
         "viewingRoom.image.imageURLs.normalized": (v4/*: any*/),
         "viewingRoom.internalID": (v5/*: any*/),

--- a/src/__generated__/ViewingRoomApp_LoggedOutTest_Query.graphql.ts
+++ b/src/__generated__/ViewingRoomApp_LoggedOutTest_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e20d7e92ed7436c35d8e780a23457656>>
+ * @generated SignedSource<<542f9362ae25406742db3608435a1592>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -152,7 +152,7 @@ return {
           {
             "alias": null,
             "args": null,
-            "concreteType": "ARImage",
+            "concreteType": "GravityARImage",
             "kind": "LinkedField",
             "name": "image",
             "plural": false,
@@ -160,7 +160,7 @@ return {
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "ImageURLs",
+                "concreteType": "GravityImageURLs",
                 "kind": "LinkedField",
                 "name": "imageURLs",
                 "plural": false,
@@ -250,13 +250,13 @@ return {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "ARImage"
+          "type": "GravityARImage"
         },
         "viewingRoom.image.imageURLs": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "ImageURLs"
+          "type": "GravityImageURLs"
         },
         "viewingRoom.image.imageURLs.normalized": (v4/*: any*/),
         "viewingRoom.internalID": (v5/*: any*/),

--- a/src/__generated__/ViewingRoomApp_OpenTest_Query.graphql.ts
+++ b/src/__generated__/ViewingRoomApp_OpenTest_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ea920b7805f8f6d87216b6c683afaa18>>
+ * @generated SignedSource<<3f5567959945c27cd958be528fb92530>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -152,7 +152,7 @@ return {
           {
             "alias": null,
             "args": null,
-            "concreteType": "ARImage",
+            "concreteType": "GravityARImage",
             "kind": "LinkedField",
             "name": "image",
             "plural": false,
@@ -160,7 +160,7 @@ return {
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "ImageURLs",
+                "concreteType": "GravityImageURLs",
                 "kind": "LinkedField",
                 "name": "imageURLs",
                 "plural": false,
@@ -250,13 +250,13 @@ return {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "ARImage"
+          "type": "GravityARImage"
         },
         "viewingRoom.image.imageURLs": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "ImageURLs"
+          "type": "GravityImageURLs"
         },
         "viewingRoom.image.imageURLs.normalized": (v4/*: any*/),
         "viewingRoom.internalID": (v5/*: any*/),

--- a/src/__generated__/ViewingRoomApp_ScheduledTest_Query.graphql.ts
+++ b/src/__generated__/ViewingRoomApp_ScheduledTest_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<84b1c561440ef5de422eb3e2563f6dfb>>
+ * @generated SignedSource<<b84ab8c836506d4a091a0a6a5b1d9e80>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -152,7 +152,7 @@ return {
           {
             "alias": null,
             "args": null,
-            "concreteType": "ARImage",
+            "concreteType": "GravityARImage",
             "kind": "LinkedField",
             "name": "image",
             "plural": false,
@@ -160,7 +160,7 @@ return {
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "ImageURLs",
+                "concreteType": "GravityImageURLs",
                 "kind": "LinkedField",
                 "name": "imageURLs",
                 "plural": false,
@@ -250,13 +250,13 @@ return {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "ARImage"
+          "type": "GravityARImage"
         },
         "viewingRoom.image.imageURLs": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "ImageURLs"
+          "type": "GravityImageURLs"
         },
         "viewingRoom.image.imageURLs.normalized": (v4/*: any*/),
         "viewingRoom.internalID": (v5/*: any*/),

--- a/src/__generated__/ViewingRoomCard_Test_Query.graphql.ts
+++ b/src/__generated__/ViewingRoomCard_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b19a6250be5d86ac621b5417814e772c>>
+ * @generated SignedSource<<6cf93a3c34083f4ddae772878d36c69d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -192,7 +192,7 @@ return {
                       {
                         "alias": "coverImage",
                         "args": null,
-                        "concreteType": "ARImage",
+                        "concreteType": "GravityARImage",
                         "kind": "LinkedField",
                         "name": "image",
                         "plural": false,
@@ -200,7 +200,7 @@ return {
                           {
                             "alias": null,
                             "args": null,
-                            "concreteType": "ImageURLs",
+                            "concreteType": "GravityImageURLs",
                             "kind": "LinkedField",
                             "name": "imageURLs",
                             "plural": false,
@@ -287,14 +287,14 @@ return {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "ARImage"
+          "type": "GravityARImage"
         },
         "partner.viewingRoomsConnection.edges.node.coverImage.height": (v4/*: any*/),
         "partner.viewingRoomsConnection.edges.node.coverImage.imageURLs": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "ImageURLs"
+          "type": "GravityImageURLs"
         },
         "partner.viewingRoomsConnection.edges.node.coverImage.imageURLs.normalized": (v5/*: any*/),
         "partner.viewingRoomsConnection.edges.node.coverImage.width": (v4/*: any*/),

--- a/src/__generated__/ViewingRoomCard_viewingRoom.graphql.ts
+++ b/src/__generated__/ViewingRoomCard_viewingRoom.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<81f7c6fc3107e8ce0823f2473ae049c6>>
+ * @generated SignedSource<<4fdb539b8830380690d085f9988b6ced>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -58,7 +58,7 @@ const node: ReaderFragment = {
     {
       "alias": "coverImage",
       "args": null,
-      "concreteType": "ARImage",
+      "concreteType": "GravityARImage",
       "kind": "LinkedField",
       "name": "image",
       "plural": false,
@@ -66,7 +66,7 @@ const node: ReaderFragment = {
         {
           "alias": null,
           "args": null,
-          "concreteType": "ImageURLs",
+          "concreteType": "GravityImageURLs",
           "kind": "LinkedField",
           "name": "imageURLs",
           "plural": false,

--- a/src/__generated__/ViewingRoomHeader_viewingRoom.graphql.ts
+++ b/src/__generated__/ViewingRoomHeader_viewingRoom.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b5642d45300354b5498ce7b3e72fa575>>
+ * @generated SignedSource<<3c460e4fb89141595391e5c91f079e3c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -40,7 +40,7 @@ const node: ReaderFragment = {
     {
       "alias": null,
       "args": null,
-      "concreteType": "ARImage",
+      "concreteType": "GravityARImage",
       "kind": "LinkedField",
       "name": "image",
       "plural": false,
@@ -48,7 +48,7 @@ const node: ReaderFragment = {
         {
           "alias": null,
           "args": null,
-          "concreteType": "ImageURLs",
+          "concreteType": "GravityImageURLs",
           "kind": "LinkedField",
           "name": "imageURLs",
           "plural": false,

--- a/src/__generated__/ViewingRoomMeta_viewingRoom.graphql.ts
+++ b/src/__generated__/ViewingRoomMeta_viewingRoom.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<304cf8f8547345b4ad5faecc13af2cab>>
+ * @generated SignedSource<<ef131ab9f6a2ef5fff16fb40b01dc512>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -56,7 +56,7 @@ const node: ReaderFragment = {
     {
       "alias": null,
       "args": null,
-      "concreteType": "ARImage",
+      "concreteType": "GravityARImage",
       "kind": "LinkedField",
       "name": "image",
       "plural": false,
@@ -64,7 +64,7 @@ const node: ReaderFragment = {
         {
           "alias": null,
           "args": null,
-          "concreteType": "ImageURLs",
+          "concreteType": "GravityImageURLs",
           "kind": "LinkedField",
           "name": "imageURLs",
           "plural": false,

--- a/src/__generated__/ViewingRoomPublishedNotification_test_Query.graphql.ts
+++ b/src/__generated__/ViewingRoomPublishedNotification_test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<cd117998e85d2f9315b4e555f115dcd4>>
+ * @generated SignedSource<<b958c709fa2e868b33d8fe403821c390>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -263,7 +263,7 @@ return {
                                       {
                                         "alias": null,
                                         "args": null,
-                                        "concreteType": "ARImage",
+                                        "concreteType": "GravityARImage",
                                         "kind": "LinkedField",
                                         "name": "image",
                                         "plural": false,
@@ -271,7 +271,7 @@ return {
                                           {
                                             "alias": null,
                                             "args": null,
-                                            "concreteType": "ImageURLs",
+                                            "concreteType": "GravityImageURLs",
                                             "kind": "LinkedField",
                                             "name": "imageURLs",
                                             "plural": false,
@@ -424,14 +424,14 @@ return {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "ARImage"
+          "type": "GravityARImage"
         },
         "notificationsConnection.edges.node.item.viewingRoomsConnection.edges.node.image.height": (v7/*: any*/),
         "notificationsConnection.edges.node.item.viewingRoomsConnection.edges.node.image.imageURLs": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "ImageURLs"
+          "type": "GravityImageURLs"
         },
         "notificationsConnection.edges.node.item.viewingRoomsConnection.edges.node.image.imageURLs.normalized": (v6/*: any*/),
         "notificationsConnection.edges.node.item.viewingRoomsConnection.edges.node.image.width": (v7/*: any*/),

--- a/src/__generated__/ViewingRoomsApp_Test_Query.graphql.ts
+++ b/src/__generated__/ViewingRoomsApp_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<729304e7999a1eb0063c8c4509247cd6>>
+ * @generated SignedSource<<91fb8c79b47fcf72abe837347b893751>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -107,7 +107,7 @@ v3 = {
 v4 = {
   "alias": null,
   "args": null,
-  "concreteType": "ARImage",
+  "concreteType": "GravityARImage",
   "kind": "LinkedField",
   "name": "image",
   "plural": false,
@@ -115,7 +115,7 @@ v4 = {
     {
       "alias": null,
       "args": null,
-      "concreteType": "ImageURLs",
+      "concreteType": "GravityImageURLs",
       "kind": "LinkedField",
       "name": "imageURLs",
       "plural": false,
@@ -213,13 +213,13 @@ v14 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "ARImage"
+  "type": "GravityARImage"
 },
 v15 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "ImageURLs"
+  "type": "GravityImageURLs"
 },
 v16 = {
   "enumValues": null,

--- a/src/__generated__/ViewingRoomsFeaturedRail_featuredViewingRooms.graphql.ts
+++ b/src/__generated__/ViewingRoomsFeaturedRail_featuredViewingRooms.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fe3916e039b408190f81345938f95b9e>>
+ * @generated SignedSource<<c2ae717dc292857e3b652f1a6d8f7818>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -89,7 +89,7 @@ return {
             {
               "alias": null,
               "args": null,
-              "concreteType": "ARImage",
+              "concreteType": "GravityARImage",
               "kind": "LinkedField",
               "name": "image",
               "plural": false,
@@ -97,7 +97,7 @@ return {
                 {
                   "alias": null,
                   "args": null,
-                  "concreteType": "ImageURLs",
+                  "concreteType": "GravityImageURLs",
                   "kind": "LinkedField",
                   "name": "imageURLs",
                   "plural": false,

--- a/src/__generated__/ViewingRoomsLatestGrid_ViewingRoomsAppQuery.graphql.ts
+++ b/src/__generated__/ViewingRoomsLatestGrid_ViewingRoomsAppQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d4f372551afd9afde2ab727fda572f8e>>
+ * @generated SignedSource<<fd8a7c243c0428af734af73799fb62dd>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -157,7 +157,7 @@ return {
                       {
                         "alias": null,
                         "args": null,
-                        "concreteType": "ARImage",
+                        "concreteType": "GravityARImage",
                         "kind": "LinkedField",
                         "name": "image",
                         "plural": false,
@@ -165,7 +165,7 @@ return {
                           {
                             "alias": null,
                             "args": null,
-                            "concreteType": "ImageURLs",
+                            "concreteType": "GravityImageURLs",
                             "kind": "LinkedField",
                             "name": "imageURLs",
                             "plural": false,

--- a/src/__generated__/ViewingRoomsLatestGrid_viewingRooms.graphql.ts
+++ b/src/__generated__/ViewingRoomsLatestGrid_viewingRooms.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0c538609fde44097976ecac8e4cd2691>>
+ * @generated SignedSource<<8d77550215e1a5c2a3c02be9e577c8d7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -121,7 +121,7 @@ return {
                 {
                   "alias": null,
                   "args": null,
-                  "concreteType": "ARImage",
+                  "concreteType": "GravityARImage",
                   "kind": "LinkedField",
                   "name": "image",
                   "plural": false,
@@ -129,7 +129,7 @@ return {
                     {
                       "alias": null,
                       "args": null,
-                      "concreteType": "ImageURLs",
+                      "concreteType": "GravityImageURLs",
                       "kind": "LinkedField",
                       "name": "imageURLs",
                       "plural": false,

--- a/src/__generated__/partnerRoutes_ViewingRoomsQuery.graphql.ts
+++ b/src/__generated__/partnerRoutes_ViewingRoomsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3a303ab1359c372338008485a0d03f6c>>
+ * @generated SignedSource<<cdaa6c8f7744a7caa20237b6b580a9ea>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -107,7 +107,7 @@ v4 = [
           {
             "alias": "coverImage",
             "args": null,
-            "concreteType": "ARImage",
+            "concreteType": "GravityARImage",
             "kind": "LinkedField",
             "name": "image",
             "plural": false,
@@ -115,7 +115,7 @@ v4 = [
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "ImageURLs",
+                "concreteType": "GravityImageURLs",
                 "kind": "LinkedField",
                 "name": "imageURLs",
                 "plural": false,

--- a/src/__generated__/showRoutes_ShowQuery.graphql.ts
+++ b/src/__generated__/showRoutes_ShowQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fa3c3a5c27c74a545886d1795e6b0d6c>>
+ * @generated SignedSource<<21a24f228123fbb1abf66c4c69055cd8>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -258,7 +258,7 @@ return {
                       {
                         "alias": null,
                         "args": null,
-                        "concreteType": "ARImage",
+                        "concreteType": "GravityARImage",
                         "kind": "LinkedField",
                         "name": "image",
                         "plural": false,
@@ -266,7 +266,7 @@ return {
                           {
                             "alias": null,
                             "args": null,
-                            "concreteType": "ImageURLs",
+                            "concreteType": "GravityImageURLs",
                             "kind": "LinkedField",
                             "name": "imageURLs",
                             "plural": false,

--- a/src/__generated__/viewingRoomRoutes_ViewingRoomQuery.graphql.ts
+++ b/src/__generated__/viewingRoomRoutes_ViewingRoomQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7058e5fed049d36cecf9c546c0485d08>>
+ * @generated SignedSource<<a3d6bd9aa4a87b27c3f464925b6f0e9e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -111,7 +111,7 @@ return {
           {
             "alias": null,
             "args": null,
-            "concreteType": "ARImage",
+            "concreteType": "GravityARImage",
             "kind": "LinkedField",
             "name": "image",
             "plural": false,
@@ -119,7 +119,7 @@ return {
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "ImageURLs",
+                "concreteType": "GravityImageURLs",
                 "kind": "LinkedField",
                 "name": "imageURLs",
                 "plural": false,

--- a/src/__generated__/viewingRoomRoutes_ViewingRoomsAppQuery.graphql.ts
+++ b/src/__generated__/viewingRoomRoutes_ViewingRoomsAppQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<514f04608430c0681486b897e3dd55c2>>
+ * @generated SignedSource<<6119fcf28f0104b919ffdca2f588e6e8>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -82,7 +82,7 @@ v7 = {
 v8 = {
   "alias": null,
   "args": null,
-  "concreteType": "ARImage",
+  "concreteType": "GravityARImage",
   "kind": "LinkedField",
   "name": "image",
   "plural": false,
@@ -90,7 +90,7 @@ v8 = {
     {
       "alias": null,
       "args": null,
-      "concreteType": "ImageURLs",
+      "concreteType": "GravityImageURLs",
       "kind": "LinkedField",
       "name": "imageURLs",
       "plural": false,


### PR DESCRIPTION
This PR implements semantic heading structure on artist CV pages by adding the h1 tag and marking up subheaders with h2 tags.

![](https://capture.static.damonzucconi.com/Screen-Shot-2025-01-28-08-03-40.95-33glATQq9UEhyQLUQcnl8ns3vdLPC6wpMWPQcQ5AtwYKMiobPHQWH3wlLDyU0WDcB2EXpRQouKlXP5zLMpKxAPmE8JZ8PZqEV1li.png)

