### PR TITLE
chore(EMI-2277): add tests for shipping estimate widget

### DIFF
--- a/src/Components/ArtsyShippingEstimate.tsx
+++ b/src/Components/ArtsyShippingEstimate.tsx
@@ -63,12 +63,11 @@ export const ArtsyShippingEstimate = ({
   }, [state.widget])
 
   useEffect(() => {
-    if (!estimateInput || !ARTA_API_KEY) {
-      setState({ loaded: true, widget: null })
+    if (state.loaded || !Arta) {
       return
     }
-
-    if (state.loaded || !Arta) {
+    if (!estimateInput || !ARTA_API_KEY) {
+      setState({ loaded: true, widget: null })
       return
     }
 
@@ -104,7 +103,7 @@ export const ArtsyShippingEstimate = ({
   }
 
   if (!state.widget) {
-    return <Spacer y={2} />
+    return <Spacer data-testid="loaded-no-widget" y={2} />
   }
 
   const estimateWidget = state.widget
@@ -116,7 +115,10 @@ export const ArtsyShippingEstimate = ({
   return (
     <LinkButton
       tabIndex={0}
-      onClick={() => estimateWidget.open()}
+      onClick={e => {
+        e.preventDefault()
+        estimateWidget.open()
+      }}
       onKeyDown={e => {
         if (e.key === "Enter") {
           e.preventDefault()

--- a/src/Components/__tests__/ArtsyShippingEstimate.jest.tsx
+++ b/src/Components/__tests__/ArtsyShippingEstimate.jest.tsx
@@ -43,6 +43,18 @@ jest.mock("Utils/Hooks/useLoadScript", () => {
   }
 })
 
+const validArtworkData = {
+  isFramed: true,
+  category: "Painting",
+  shippingOrigin: "New York, USA",
+  priceCurrency: "USD",
+  listPrice: {
+    major: 1000,
+  },
+  heightCm: 100,
+  widthCm: 100,
+}
+
 const TestWrapper = ({ artwork }) => {
   const [show, setShow] = useState(true)
 
@@ -76,22 +88,25 @@ const { renderWithRelay } =
 
 describe("ArtsyShippingEstimate", () => {
   describe("with an artwork that cannot be estimated", () => {
-    const mockArtworkData = {
-      isFramed: true,
-      category: "Painting",
-      shippingOrigin: "USA",
-
-      priceCurrency: "USD",
-      listPrice: {
-        major: 1000,
-      },
-      heightCm: 100,
-      widthCm: 100,
-    }
-
-    it("does not render the widget", async () => {
+    it("does not render the widget if the shippingOrigin is missing a city", async () => {
       renderWithRelay({
-        Artwork: () => mockArtworkData,
+        Artwork: () => ({
+          ...validArtworkData,
+          shippingOrigin: "USA",
+        }),
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId("loaded-no-widget")).toBeInTheDocument()
+      })
+    })
+
+    it("does not render the widget if the artwork is missing dimensions", async () => {
+      renderWithRelay({
+        Artwork: () => ({
+          ...validArtworkData,
+          widthCm: null,
+        }),
       })
 
       await waitFor(() => {
@@ -99,24 +114,9 @@ describe("ArtsyShippingEstimate", () => {
       })
     })
   })
+
   describe("with a valid artwork", () => {
-    const mockArtworkData = {
-      isFramed: true,
-      category: "Painting",
-      shippingOrigin: "New York, USA",
-      shippingCountry: "USA",
-      location: {
-        country: "USA",
-        postalCode: "10001",
-        city: "New York",
-      },
-      priceCurrency: "USD",
-      listPrice: {
-        major: 1000,
-      },
-      heightCm: 100,
-      widthCm: 100,
-    }
+    const mockArtworkData = { ...validArtworkData }
 
     it("renders the widget", async () => {
       renderWithRelay({

--- a/src/Components/__tests__/ArtsyShippingEstimate.jest.tsx
+++ b/src/Components/__tests__/ArtsyShippingEstimate.jest.tsx
@@ -1,0 +1,154 @@
+import type { default as Arta } from "@artaio/arta-browser"
+import type ArtaEstimate from "@artaio/arta-browser/dist/estimate"
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { ArtsyShippingEstimate } from "Components/ArtsyShippingEstimate"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
+import type { ArtsyShippingEstimate_Test_Query } from "__generated__/ArtsyShippingEstimate_Test_Query.graphql"
+import { useEffect, useState } from "react"
+
+import { graphql } from "react-relay"
+
+jest.unmock("react-relay")
+
+jest.mock("Utils/getENV", () => ({
+  getENV: jest.fn((() => "mock-api-key") as any),
+}))
+
+let mockArtaEstimate: ArtaEstimate
+
+beforeEach(() => {
+  mockArtaEstimate = {
+    open: jest.fn(),
+    close: jest.fn(),
+    isReady: true,
+    isOpen: false,
+    validate: jest.fn(() => Promise.resolve(undefined)),
+  } as unknown as ArtaEstimate
+})
+
+const mockArtaModule: typeof Arta = {
+  init: jest.fn(),
+  estimate: jest.fn(() => mockArtaEstimate),
+} as unknown as typeof Arta
+
+jest.mock("Utils/Hooks/useLoadScript", () => {
+  return {
+    useLoadScript: jest.fn(({ onReady }) => {
+      useEffect(() => {
+        ;(window as any).Arta = mockArtaModule
+        onReady()
+      }, [onReady])
+    }),
+  }
+})
+
+const TestWrapper = ({ artwork }) => {
+  const [show, setShow] = useState(true)
+
+  return (
+    <div>
+      {show ? (
+        <ArtsyShippingEstimate artwork={artwork} />
+      ) : (
+        <div>Unmounted</div>
+      )}
+      <div>
+        <button type="button" onClick={() => setShow(!show)}>
+          Toggle
+        </button>
+      </div>
+    </div>
+  )
+}
+
+const { renderWithRelay } =
+  setupTestWrapperTL<ArtsyShippingEstimate_Test_Query>({
+    Component: TestWrapper,
+    query: graphql`
+      query ArtsyShippingEstimate_Test_Query @relay_test_operation {
+        artwork(id: "example") {
+          ...ArtsyShippingEstimate_artwork
+        }
+      }
+    `,
+  })
+
+describe("ArtsyShippingEstimate", () => {
+  describe("with an artwork that cannot be estimated", () => {
+    const mockArtworkData = {
+      isFramed: true,
+      category: "Painting",
+      shippingOrigin: "USA",
+
+      priceCurrency: "USD",
+      listPrice: {
+        major: 1000,
+      },
+      heightCm: 100,
+      widthCm: 100,
+    }
+
+    it("does not render the widget", async () => {
+      renderWithRelay({
+        Artwork: () => mockArtworkData,
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId("loaded-no-widget")).toBeInTheDocument()
+      })
+    })
+  })
+  describe("with a valid artwork", () => {
+    const mockArtworkData = {
+      isFramed: true,
+      category: "Painting",
+      shippingOrigin: "New York, USA",
+      shippingCountry: "USA",
+      location: {
+        country: "USA",
+        postalCode: "10001",
+        city: "New York",
+      },
+      priceCurrency: "USD",
+      listPrice: {
+        major: 1000,
+      },
+      heightCm: 100,
+      widthCm: 100,
+    }
+
+    it("renders the widget", async () => {
+      renderWithRelay({
+        Artwork: () => mockArtworkData,
+      })
+
+      await waitFor(() => {
+        expect(screen.getByText("Estimate Shipping Cost")).toBeInTheDocument()
+      })
+
+      await userEvent.click(screen.getByText("Estimate Shipping Cost"))
+      expect(mockArtaEstimate.open).toHaveBeenCalledTimes(1)
+    })
+
+    it("closes the widget when unmounted", async () => {
+      renderWithRelay({
+        Artwork: () => mockArtworkData,
+      })
+
+      await waitFor(async () => {
+        await userEvent.click(screen.getByText("Estimate Shipping Cost"))
+      })
+
+      expect(mockArtaEstimate.open).toHaveBeenCalledTimes(1)
+
+      // This would be set by the library
+      mockArtaEstimate.isOpen = true
+
+      await userEvent.click(screen.getByText("Toggle"))
+      await waitFor(() => {
+        expect(mockArtaEstimate.close).toHaveBeenCalledTimes(1)
+      })
+    })
+  })
+})

--- a/src/__generated__/ArtsyShippingEstimate_Test_Query.graphql.ts
+++ b/src/__generated__/ArtsyShippingEstimate_Test_Query.graphql.ts
@@ -1,0 +1,320 @@
+/**
+ * @generated SignedSource<<ad05f8f0ae0d54897bdfb6580f84257d>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ArtsyShippingEstimate_Test_Query$variables = Record<PropertyKey, never>;
+export type ArtsyShippingEstimate_Test_Query$data = {
+  readonly artwork: {
+    readonly " $fragmentSpreads": FragmentRefs<"ArtsyShippingEstimate_artwork">;
+  } | null | undefined;
+};
+export type ArtsyShippingEstimate_Test_Query = {
+  response: ArtsyShippingEstimate_Test_Query$data;
+  variables: ArtsyShippingEstimate_Test_Query$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "example"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "major",
+    "storageKey": null
+  }
+],
+v3 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v4 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Float"
+},
+v5 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v6 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "Float"
+},
+v7 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Money"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ArtsyShippingEstimate_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ArtsyShippingEstimate_artwork"
+          }
+        ],
+        "storageKey": "artwork(id:\"example\")"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "ArtsyShippingEstimate_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isFramed",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "category",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "shippingOrigin",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "shippingCountry",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Location",
+            "kind": "LinkedField",
+            "name": "location",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "country",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "postalCode",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "city",
+                "storageKey": null
+              },
+              (v1/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "priceCurrency",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "listPrice",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "__typename",
+                "storageKey": null
+              },
+              {
+                "kind": "InlineFragment",
+                "selections": (v2/*: any*/),
+                "type": "Money",
+                "abstractKey": null
+              },
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Money",
+                    "kind": "LinkedField",
+                    "name": "minPrice",
+                    "plural": false,
+                    "selections": (v2/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Money",
+                    "kind": "LinkedField",
+                    "name": "maxPrice",
+                    "plural": false,
+                    "selections": (v2/*: any*/),
+                    "storageKey": null
+                  }
+                ],
+                "type": "PriceRange",
+                "abstractKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "heightCm",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "widthCm",
+            "storageKey": null
+          },
+          (v1/*: any*/)
+        ],
+        "storageKey": "artwork(id:\"example\")"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "d8d6e0dd445f676172374534ed6e8555",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "artwork": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artwork"
+        },
+        "artwork.category": (v3/*: any*/),
+        "artwork.heightCm": (v4/*: any*/),
+        "artwork.id": (v5/*: any*/),
+        "artwork.isFramed": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Boolean"
+        },
+        "artwork.listPrice": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ListPrice"
+        },
+        "artwork.listPrice.__typename": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "String"
+        },
+        "artwork.listPrice.major": (v6/*: any*/),
+        "artwork.listPrice.maxPrice": (v7/*: any*/),
+        "artwork.listPrice.maxPrice.major": (v6/*: any*/),
+        "artwork.listPrice.minPrice": (v7/*: any*/),
+        "artwork.listPrice.minPrice.major": (v6/*: any*/),
+        "artwork.location": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Location"
+        },
+        "artwork.location.city": (v3/*: any*/),
+        "artwork.location.country": (v3/*: any*/),
+        "artwork.location.id": (v5/*: any*/),
+        "artwork.location.postalCode": (v3/*: any*/),
+        "artwork.priceCurrency": (v3/*: any*/),
+        "artwork.shippingCountry": (v3/*: any*/),
+        "artwork.shippingOrigin": (v3/*: any*/),
+        "artwork.widthCm": (v4/*: any*/)
+      }
+    },
+    "name": "ArtsyShippingEstimate_Test_Query",
+    "operationKind": "query",
+    "text": "query ArtsyShippingEstimate_Test_Query {\n  artwork(id: \"example\") {\n    ...ArtsyShippingEstimate_artwork\n    id\n  }\n}\n\nfragment ArtsyShippingEstimate_artwork on Artwork {\n  isFramed\n  category\n  shippingOrigin\n  shippingCountry\n  location {\n    country\n    postalCode\n    city\n    id\n  }\n  priceCurrency\n  listPrice {\n    __typename\n    ... on Money {\n      major\n    }\n    ... on PriceRange {\n      minPrice {\n        major\n      }\n      maxPrice {\n        major\n      }\n    }\n  }\n  heightCm\n  widthCm\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "f25a2d3c9606aed9c04d558609a067dc";
+
+export default node;


### PR DESCRIPTION
The type of this PR is: **chore**
Resolves [EMI-2277]

### Description
This PR adds some tests for the shipping widget. Due to the way we load it from a script tag the tests are a little strange; maybe there is a better way. We have the library in our dev dependencies for example, but i'm just mocking out the entire lib with `jest.fn()`s.

We can add more tests or things for the specific complex estimate params creation as we go - wanted to get a solid base to work off.

It also corrects two minor bugs not visible outside staging.

cc @artsy/emerald-devs 

[EMI-2277]: https://artsyproduct.atlassian.net/browse/EMI-2277?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ