### PR TITLE
chore: attempt to style Arta widget

### DIFF
--- a/src/Components/ArtsyShippingEstimate.tsx
+++ b/src/Components/ArtsyShippingEstimate.tsx
@@ -62,6 +62,48 @@ export const ArtsyShippingEstimate = ({
     }
   }, [state.widget])
 
+  const widgetConfig = {
+    style: {
+      color: {
+        // border: "none",
+        buttonBackground: "#1023D7",
+        buttonBackgroundHover: "#1023D7",
+        buttonBackgroundDisabled: "#E6E7F5",
+        buttonText: "#FFFFFF",
+        buttonTextHover: "#FFFFFF",
+        buttonTextDisabled: "#cacdec",
+      },
+      position: "center" as any,
+      pricingDisplay: "range" as any,
+      fontFamily:
+        '"ll-unica77", "Helvetica Neue", Helvetica, Arial, sans-serif',
+      width: 440,
+      height: 440,
+    },
+    text: {
+      detailOriginLabel: "(origin)",
+      detailDestinationLabel: "(destination)",
+      returnLinkLabel: "Change Destination",
+      header: {
+        title: "Estimate shipping cost",
+      },
+      destination: {
+        descriptionLabel: "",
+        buttonText: "Get Shipping Estimate",
+        countryLabel: "Destination Country",
+        zipLabel: "Destination Postal/ZIP Code",
+        cityLabel: "Destination City",
+      },
+      quoted: {
+        shipFromLabel: "",
+        shipToLabel: "",
+        disclaimerLabel:
+          "This estimate includes Arta Transit Insurance. Actual shipping costs will be provided at checkout.",
+        rangeLabel: "Shipping estimated between",
+      },
+    },
+  }
+
   useEffect(() => {
     if (state.loaded || !Arta) {
       return
@@ -75,11 +117,7 @@ export const ArtsyShippingEstimate = ({
       Arta.init(ARTA_API_KEY)
 
       const artsyEstimateWidget =
-        Arta &&
-        estimateInput &&
-        Arta.estimate(estimateInput, {
-          text: { header: { title: WIDGET_TITLE } },
-        })
+        Arta && estimateInput && Arta.estimate(estimateInput, widgetConfig)
 
       if (!artsyEstimateWidget) {
         setState({ loaded: true, widget: null })


### PR DESCRIPTION
We do have limited options in what we can currently edit/modify.

For example there does not seem to be a clear way to space things within the modal. We can def contact arta and see if they can add configurable paddings/margins to the widget components but not sure it's worth it at this point. Maybe it looks good enough for now?

I tried to get it as close to the design as currently possible without too much trouble and will ask bunch of questions in slack. Will do a follow up after but think we can merge it as an improvement so people can play with more refined version on staging/prod.

![Screenshot 2025-02-04 at 1 09 39 PM](https://github.com/user-attachments/assets/0643bd3a-b695-46ce-8bd3-6cd94d10dc4a)

![Screenshot 2025-02-04 at 1 12 06 PM](https://github.com/user-attachments/assets/479f7145-248c-41d0-96a4-6b02c78ec2cb)

![Screenshot 2025-02-04 at 1 12 20 PM](https://github.com/user-attachments/assets/0cba80f1-8e37-437f-8d7e-88016d64a2eb)
