### PR TITLE
chore(EMI-2276): Tracking for shipping estimate widget

### DIFF
--- a/src/Components/ArtsyShippingEstimate.tsx
+++ b/src/Components/ArtsyShippingEstimate.tsx
@@ -243,6 +243,7 @@ const useWidgetObserver = ({
     const targetNode = document.getElementsByClassName("artajs__modal")[0]
     if (!targetNode) {
       console.error("*** Widget target node not found")
+      return
     }
     // Options for the observer (which mutations to observe)
     const config = { attributes: true, childList: true, subtree: true }
@@ -254,6 +255,7 @@ const useWidgetObserver = ({
         setVisiblePrice(price)
       }
     }
+
     // Create an observer instance linked to the callback function
     const observer = new MutationObserver(callback)
     widgetObserver.current = observer

--- a/src/Components/ArtsyShippingEstimate.tsx
+++ b/src/Components/ArtsyShippingEstimate.tsx
@@ -88,49 +88,6 @@ export const ArtsyShippingEstimate = ({
     }
   }, [closeWidget])
 
-  const widgetConfig = {
-    style: {
-      color: {
-        border: "none",
-        buttonBackground: "#1023D7",
-        buttonBackgroundHover: "#1023D7",
-        buttonBackgroundDisabled: "#C2C2C2",
-        buttonText: "#FFFFFF",
-        buttonTextHover: "#FFFFFF",
-        buttonTextDisabled: "#FFFFFF",
-      },
-      position: "center" as any,
-      pricingDisplay: "range" as any,
-      fontFamily:
-        '"ll-unica77", "Helvetica Neue", Helvetica, Arial, sans-serif',
-      fontSize: 16,
-      width: 440,
-      height: 440,
-    },
-    text: {
-      detailOriginLabel: "(origin)",
-      detailDestinationLabel: "(destination)",
-      returnLinkLabel: "Change Destination",
-      header: {
-        title: "Estimate shipping cost",
-      },
-      destination: {
-        descriptionLabel: "",
-        buttonText: "Get Shipping Estimate",
-        countryLabel: "Destination Country",
-        zipLabel: "Destination City/Zip Code",
-        cityLabel: "Destination City",
-      },
-      quoted: {
-        shipFromLabel: "",
-        shipToLabel: "",
-        disclaimerLabel: "",
-        rangeLabel: "Shipping estimated between",
-        artaInsuranceLabel: "",
-      },
-    },
-  }
-
   useEffect(() => {
     if (state.loaded || !Arta) {
       return
@@ -312,6 +269,48 @@ const ARTWORK_FRAGMENT = graphql`
     # shippingWeight # may need to be added?
   }
 `
+
+const widgetConfig = {
+  style: {
+    color: {
+      border: "none",
+      buttonBackground: "#1023D7",
+      buttonBackgroundHover: "#1023D7",
+      buttonBackgroundDisabled: "#C2C2C2",
+      buttonText: "#FFFFFF",
+      buttonTextHover: "#FFFFFF",
+      buttonTextDisabled: "#FFFFFF",
+    },
+    position: "center" as any,
+    pricingDisplay: "range" as any,
+    fontFamily: '"ll-unica77", "Helvetica Neue", Helvetica, Arial, sans-serif',
+    fontSize: 16,
+    width: 440,
+    height: 440,
+  },
+  text: {
+    detailOriginLabel: "(origin)",
+    detailDestinationLabel: "(destination)",
+    returnLinkLabel: "Change Destination",
+    header: {
+      title: WIDGET_TITLE,
+    },
+    destination: {
+      descriptionLabel: "",
+      buttonText: "Get Shipping Estimate",
+      countryLabel: "Destination Country",
+      zipLabel: "Destination City/Zip Code",
+      cityLabel: "Destination City",
+    },
+    quoted: {
+      shipFromLabel: "",
+      shipToLabel: "",
+      disclaimerLabel: "",
+      rangeLabel: "Shipping estimated between",
+      artaInsuranceLabel: "",
+    },
+  },
+} as const
 
 const FRAMED_CATEGORY_MAP = {
   Photography: "photograph_framed",


### PR DESCRIPTION
The type of this PR is: **Chore**
cc @artsy/emerald-devs 

This PR solves [EMI-2276]
depends on https://github.com/artsy/cohesion/pull/555

### Description
This PR implements tracking for the shipping estimate test. We track both opening the widget and viewing an estimate, including the min/max values, origin/destination strings and currency. Because the widget doesn't have an api for the estimate event, the view event is triggered using a [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) which watches the dom for changes.

Tests: I don't think this is worth testing due to the amount of mocking that would be required to manipulate the dom. I think we should manually test instead.


[EMI-2276]: https://artsyproduct.atlassian.net/browse/EMI-2276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ