### PR TITLE
fix(show): updates meta description format

### DIFF
--- a/src/Apps/Show/Components/ShowMeta.tsx
+++ b/src/Apps/Show/Components/ShowMeta.tsx
@@ -18,9 +18,9 @@ const ShowMeta: React.FC<React.PropsWithChildren<ShowMetaProps>> = ({
     formattedEndAt,
   },
 }) => {
-  const fallbackDescription = `Explore ${name} from ${
+  const fallbackDescription = `Explore ${name} presented by ${
     partner ? `${partner.name} on` : ""
-  } Artsy. ${formattedStartAt} - ${formattedEndAt}.`
+  } Artsy. On view from ${formattedStartAt} to ${formattedEndAt}.`
 
   return (
     <MetaTags


### PR DESCRIPTION
Updates the meta description format for show pages to use more conversational language. This change addresses an issue where some meta descriptions are not appearing in search engine results pages (SERP). While Google's handling of meta descriptions can be unpredictable - sometimes modifying or excluding them without clear reasoning - this update to a more conversational format may improve their likelihood of being displayed.

> Google will sometimes use the [<meta name="description"> tag](https://developers.google.com/search/docs/crawling-indexing/special-tags) from a page to generate a snippet in search results, if we think it gives users a more accurate description than would be possible purely from the on-page content. A meta description tag generally informs and interests users with a short, relevant summary of what a particular page is about. They are like a pitch that convince the user that the page is exactly what they're looking for. There's no limit on how long a meta description can be, but the snippet is truncated in Google Search results as needed, typically to fit the device width.

https://developers.google.com/search/docs/appearance/snippet