### PR TITLE
chore: update the test for disqualified message for Arta estimate widget

### DIFF
--- a/src/Components/ArtsyShippingEstimate.tsx
+++ b/src/Components/ArtsyShippingEstimate.tsx
@@ -356,6 +356,13 @@ const widgetConfig = {
       rangeLabel: "Shipping estimated between",
       artaInsuranceLabel: "",
     },
+    disqualified: {
+      shipFromLabel: "",
+      shipToLabel: "",
+      contactEmail: "",
+      emailHeaderLabel: "",
+      emailFooterLabel: "An estimate is not available for this artwork.",
+    },
   },
 } as const
 


### PR DESCRIPTION
Pretty minimal look:

<img width="595" alt="Screenshot 2025-02-05 at 10 19 28 PM" src="https://github.com/user-attachments/assets/338199a4-b18a-4582-abcd-8ee4893803a8" />
