### PR TITLE
fix: Disable Artsy logo link for Eigen

### DIFF
--- a/src/Apps/Components/Layouts/LayoutLogoOnly.tsx
+++ b/src/Apps/Components/Layouts/LayoutLogoOnly.tsx
@@ -6,11 +6,14 @@ import type { BaseLayoutProps } from "Apps/Components/Layouts"
 import { LayoutMain } from "Apps/Components/Layouts/Components/LayoutMain"
 import { NavBarPrimaryLogo } from "Components/NavBar/NavBarPrimaryLogo"
 import { RouterLink } from "System/Components/RouterLink"
+import { useSystemContext } from "System/Hooks/useSystemContext"
 import type { FC } from "react"
 
 export const LayoutLogoOnly: FC<React.PropsWithChildren<BaseLayoutProps>> = ({
   children,
 }) => {
+  const { isEigen } = useSystemContext()
+
   return (
     <>
       <AppToasts />
@@ -20,7 +23,7 @@ export const LayoutLogoOnly: FC<React.PropsWithChildren<BaseLayoutProps>> = ({
           <HorizontalPadding>
             <Spacer y={[2, 4]} />
 
-            <RouterLink to="/" display="block">
+            <RouterLink to={isEigen ? undefined : "/"} display="block">
               <NavBarPrimaryLogo />
             </RouterLink>
 

--- a/src/Components/NavBar/NavBarPrimaryLogo.tsx
+++ b/src/Components/NavBar/NavBarPrimaryLogo.tsx
@@ -1,14 +1,17 @@
 import ArtsyMarkIcon from "@artsy/icons/ArtsyMarkIcon"
 import { themeGet } from "@styled-system/theme-get"
 import { RouterLink, type RouterLinkProps } from "System/Components/RouterLink"
+import { useSystemContext } from "System/Hooks/useSystemContext"
 import type * as React from "react"
 import styled from "styled-components"
 
 export const NavBarPrimaryLogo: React.FC<
   React.PropsWithChildren<Omit<RouterLinkProps, "to" | "ref">>
 > = props => {
+  const { isEigen } = useSystemContext()
+
   return (
-    <HitArea to="/" {...props} aria-label="Artsy">
+    <HitArea to={isEigen ? undefined : "/"} {...props} aria-label="Artsy">
       <ArtsyMarkIcon height={40} width={40} />
     </HitArea>
   )


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves []

### Description
This PR updates the Artsy Logo `to` prop when the client is Eigen to disable navigating to the homepage in the Order App

<!-- Implementation description -->
