### PR TITLE
fix: expand scrollview on signed press

### DIFF
--- a/src/Components/ArtworkFilter/ArtworkFilters/FilterExpandable.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/FilterExpandable.tsx
@@ -4,8 +4,8 @@ import type React from "react"
 import { useRef } from "react"
 
 export const FilterExpandable: React.FC<
-  React.PropsWithChildren<ExpandableProps>
-> = ({ expanded, ...rest }) => {
+  React.PropsWithChildren<ExpandableProps & { ignoreBounds?: boolean }>
+> = ({ expanded, ignoreBounds = false, ...rest }) => {
   const ref = useRef<HTMLDivElement | null>(null)
 
   // Note: `IS_MOBILE` requires a full page load
@@ -19,7 +19,7 @@ export const FilterExpandable: React.FC<
       const anchor = ref.current
       if (!anchor) return
       const { top } = anchor.getBoundingClientRect()
-      if (top < window.innerHeight) return
+      if (top < window.innerHeight && !ignoreBounds) return
       anchor.scrollIntoView({ block: "end" })
     })
   }

--- a/src/Components/ArtworkFilter/ArtworkFilters/SignedFilter.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/SignedFilter.tsx
@@ -31,7 +31,11 @@ export const SignedFilter: React.FC<SignedFilterProps> = ({ expanded }) => {
   }
 
   return (
-    <FilterExpandable label={label} expanded={isSelected || expanded}>
+    <FilterExpandable
+      label={label}
+      expanded={isSelected || expanded}
+      ignoreBounds
+    >
       <Checkbox
         selected={!!currentSelectedFilters?.signed}
         onSelect={handleOnSelect}


### PR DESCRIPTION
The type of this PR is: **fix**

### Description

**Context:** https://www.notion.so/artsy/mWeb-last-filter-group-signed-remains-hidden-when-expanded-18ccab0764a080c3afa6cb099e8b3f1c?pvs=4

This PR fixes the issue of the hidden last item on the filters.
https://github.com/user-attachments/assets/4447184e-43e5-415d-9114-3a6fe8646485
<!-- Implementation description -->
