### PR TITLE
chore: align framed and signed copy with app

### DIFF
--- a/src/Components/ArtworkFilter/ArtworkFilters/FramedFilter.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/FramedFilter.tsx
@@ -37,7 +37,7 @@ export const FramedFilter: React.FC<FramedFilterProps> = ({ expanded }) => {
         onSelect={handleOnSelect}
         my={1}
       >
-        Only framed works
+        Show only framed works
       </Checkbox>
     </FilterExpandable>
   )

--- a/src/Components/ArtworkFilter/ArtworkFilters/SignedFilter.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/SignedFilter.tsx
@@ -37,7 +37,7 @@ export const SignedFilter: React.FC<SignedFilterProps> = ({ expanded }) => {
         onSelect={handleOnSelect}
         my={1}
       >
-        Only signed works
+        Show only signed works
       </Checkbox>
     </FilterExpandable>
   )

--- a/src/Components/ArtworkFilter/ArtworkFilters/__tests__/FramedFilter.jest.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/__tests__/FramedFilter.jest.tsx
@@ -16,7 +16,7 @@ const render = createArtworkFilterTestRenderer()
 describe(FramedFilter, () => {
   it("renders a toggle", () => {
     render(<FramedFilter expanded />)
-    expect(screen.getByText("Only framed works")).toBeInTheDocument()
+    expect(screen.getByText("Show only framed works")).toBeInTheDocument()
   })
 
   it("updates context on filter change", () => {

--- a/src/Components/ArtworkFilter/ArtworkFilters/__tests__/SignedFilter.jest.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/__tests__/SignedFilter.jest.tsx
@@ -16,7 +16,7 @@ const render = createArtworkFilterTestRenderer()
 describe(SignedFilter, () => {
   it("renders a signed toggle", () => {
     render(<SignedFilter expanded />)
-    expect(screen.getByText("Only signed works")).toBeInTheDocument()
+    expect(screen.getByText("Show only signed works")).toBeInTheDocument()
   })
 
   it("updates context on filter change", () => {


### PR DESCRIPTION
The type of this PR is: **chore**


This PR solves https://www.notion.so/artsy/Position-name-and-copy-of-framed-filter-differs-between-app-and-web-18ccab0764a0809b8440f23dad62f25f?pvs=4

### Description
align copy with app
<!-- Implementation description -->
