### PR TITLE
fix(article): preserves query string if present

### DIFF
--- a/src/Apps/Article/Components/ArticleVisibilityMetadata.tsx
+++ b/src/Apps/Article/Components/ArticleVisibilityMetadata.tsx
@@ -14,7 +14,8 @@ interface ArticleVisibilityMetadataProps {
 const ArticleVisibilityMetadata: FC<
   React.PropsWithChildren<ArticleVisibilityMetadataProps>
 > = ({ article, children }) => {
-  const { silentReplace } = useRouter()
+  const { silentReplace, match } = useRouter()
+
   const { ref } = useIntersectionObserver({
     once: false,
     onIntersection: () => {
@@ -22,7 +23,7 @@ const ArticleVisibilityMetadata: FC<
 
       document.title = `${article.searchTitle || article.title} | Artsy`
 
-      silentReplace(article.href)
+      silentReplace(`${article.href}${match?.location.search}`)
     },
   })
 


### PR DESCRIPTION
The infinite scrolling feature updates the title and URL when encountering new articles during page scroll. While this worked for subsequent articles, the initial article's behavior would strip the query string parameters. This fix preserves any existing query string in the URL, resolving the tracking issue.