### PR TITLE
chore: remove /sell page

### DIFF
--- a/cypress/e2e/home.cy.ts
+++ b/cypress/e2e/home.cy.ts
@@ -3,6 +3,6 @@ import { visitWithStatusRetries } from "../helpers/visitWithStatusRetries"
 describe("Home", () => {
   it("/", () => {
     visitWithStatusRetries("/")
-    cy.title().should("eq", "Artsy — Discover, Buy, and Sell Fine Art")
+    cy.title().should("eq", "Artsy — Discover and Buy Fine Art")
   })
 })

--- a/src/Apps/Home/Components/HomeMeta.tsx
+++ b/src/Apps/Home/Components/HomeMeta.tsx
@@ -4,7 +4,7 @@ import type * as React from "react"
 export const HomeMeta: React.FC<React.PropsWithChildren<unknown>> = () => {
   return (
     <MetaTags
-      title="Artsy — Discover, Buy, and Sell Fine Art"
+      title="Artsy — Discover and Buy Fine Art"
       description="Artsy is the world’s largest online art marketplace. Browse over 1 million artworks by iconic and emerging artists from 4000+ galleries and top auction houses."
       imageURL="https://files.artsy.net/images/00_home_og.png"
     />

--- a/src/Components/MetaTags.tsx
+++ b/src/Components/MetaTags.tsx
@@ -3,7 +3,7 @@ import { cropped } from "Utils/resized"
 import type * as React from "react"
 import { Link, Meta, Title } from "react-head"
 
-const DEFAULT_TITLE = "Artsy — Discover, Buy, and Sell Fine Art"
+const DEFAULT_TITLE = "Artsy — Discover and Buy Fine Art"
 const DEFAULT_DESCRIPTION =
   "Artsy is the world’s largest online art marketplace. Browse over 1 million artworks by iconic and emerging artists from 4000+ galleries and top auction houses."
 const DEFAULT_IMAGE_URL = "https://files.artsy.net/images/og_image.jpeg"

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -224,16 +224,6 @@ export const NavBar: React.FC<React.PropsWithChildren<unknown>> = track(
                   </Flex>
 
                   <NavBarItemLink
-                    href="/sell"
-                    onMouseOver={() => prefetch("/sell")}
-                    textDecoration="none"
-                    onClick={handleClick}
-                    data-label="Consign"
-                  >
-                    Sell
-                  </NavBarItemLink>
-
-                  <NavBarItemLink
                     href="/price-database"
                     onMouseOver={() => prefetch("/price-database")}
                     textDecoration="none"

--- a/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenu.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenu.tsx
@@ -129,14 +129,6 @@ export const NavBarMobileMenu: React.FC<
             <Separator my={1} />
 
             <NavBarMobileMenuItemLink
-              to="/sell"
-              color="black100"
-              onClick={handleClick}
-            >
-              Sell
-            </NavBarMobileMenuItemLink>
-
-            <NavBarMobileMenuItemLink
               to="/price-database"
               color="black100"
               onClick={handleClick}

--- a/src/Components/NavBar/NavBarMobileMenu/__tests__/NavBarMobileMenu.jest.enzyme.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/__tests__/NavBarMobileMenu.jest.enzyme.tsx
@@ -72,7 +72,6 @@ describe("NavBarMobileMenu", () => {
         ["/art-fairs", "Fairs & Events"],
         ["/shows", "Shows"],
         ["/institutions", "Museums"],
-        ["/sell", "Sell"],
         ["/price-database", "Price Database"],
         ["/articles", "Editorial"],
         ["/signup?intent=signup&contextModule=header", "Sign Up"],

--- a/src/Components/__tests__/MetaTags.jest.enzyme.tsx
+++ b/src/Components/__tests__/MetaTags.jest.enzyme.tsx
@@ -42,7 +42,7 @@ describe("MetaTags", () => {
 
     const tags = getTags()
 
-    expect(tags.title).toEqual("Artsy — Discover, Buy, and Sell Fine Art")
+    expect(tags.title).toEqual("Artsy — Discover and Buy Fine Art")
 
     expect(tags.links).toEqual([
       { href: "https://www.artsy.net/", rel: "canonical" },
@@ -52,7 +52,7 @@ describe("MetaTags", () => {
       {
         name: "title",
         property: null,
-        content: "Artsy — Discover, Buy, and Sell Fine Art",
+        content: "Artsy — Discover and Buy Fine Art",
       },
       {
         name: "description",
@@ -65,7 +65,7 @@ describe("MetaTags", () => {
       {
         name: null,
         property: "og:title",
-        content: "Artsy — Discover, Buy, and Sell Fine Art",
+        content: "Artsy — Discover and Buy Fine Art",
       },
       { name: null, property: "og:site_name", content: "Artsy" },
       {
@@ -88,7 +88,7 @@ describe("MetaTags", () => {
       {
         name: null,
         property: "twitter:title",
-        content: "Artsy — Discover, Buy, and Sell Fine Art",
+        content: "Artsy — Discover and Buy Fine Art",
       },
       { name: null, property: "twitter:card", content: "summary" },
       {
@@ -234,7 +234,7 @@ describe("MetaTags", () => {
 
     const tags = getTags()
 
-    expect(tags.title).toEqual("Artsy — Discover, Buy, and Sell Fine Art")
+    expect(tags.title).toEqual("Artsy — Discover and Buy Fine Art")
 
     expect(tags.links).toEqual([
       { href: "https://www.artsy.net/", rel: "canonical" },
@@ -244,7 +244,7 @@ describe("MetaTags", () => {
       {
         name: "title",
         property: null,
-        content: "Artsy — Discover, Buy, and Sell Fine Art",
+        content: "Artsy — Discover and Buy Fine Art",
       },
       {
         name: "description",
@@ -257,7 +257,7 @@ describe("MetaTags", () => {
       {
         name: null,
         property: "og:title",
-        content: "Artsy — Discover, Buy, and Sell Fine Art",
+        content: "Artsy — Discover and Buy Fine Art",
       },
       { name: null, property: "og:site_name", content: "Artsy" },
       {
@@ -280,7 +280,7 @@ describe("MetaTags", () => {
       {
         name: null,
         property: "twitter:title",
-        content: "Artsy — Discover, Buy, and Sell Fine Art",
+        content: "Artsy — Discover and Buy Fine Art",
       },
       { name: null, property: "twitter:card", content: "summary" },
       {

--- a/src/Server/middleware/hardcodedRedirects.ts
+++ b/src/Server/middleware/hardcodedRedirects.ts
@@ -199,6 +199,7 @@ for (const from in PERMANENT_REDIRECTS) {
 // Temporarily (302) redirect a specific route or route pattern
 const TEMP_REDIRECTS = {
   "/art-appraisals": "/sell",
+  "/sell": "https://partners.artsy.net",
 }
 
 for (const from in TEMP_REDIRECTS) {

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -41,7 +41,6 @@ import { partnerOfferRoutes } from "Apps/PartnerOffer/partnerOfferRoutes"
 import { partnersRoutes } from "Apps/Partners/partnersRoutes"
 import { saleAgreementsRoutes } from "Apps/SaleAgreements/saleAgreementsRoutes"
 import { searchRoutes } from "Apps/Search/searchRoutes"
-import { sellRoutes } from "Apps/Sell/sellRoutes"
 import { settingsRoutes } from "Apps/Settings/settingsRoutes"
 import { showRoutes } from "Apps/Show/showRoutes"
 import { showsRoutes } from "Apps/Shows/showsRoutes"
@@ -116,7 +115,6 @@ const ROUTES = buildAppRoutes([
   saleRoutes,
   saleAgreementsRoutes,
   searchRoutes,
-  sellRoutes,
   settingsRoutes,
   showRoutes,
   showsRoutes,


### PR DESCRIPTION
The type of this PR is: **Chore**

This PR solves [ONYX-1519] and [ONYX-1536]

### Description

First of several PRs to retire consignments from web

Can track progress at review app: https://swa.artsy.net/

This one:

- [x] removes the /sell route and redirects it to partners.artsy.net
- [x] removes **Sell** from desktop and mweb nav menus 
- [x] updates sitewide `<title>` tag



[ONYX-1519]: https://artsyproduct.atlassian.net/browse/ONYX-1519?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ONYX-1536]: https://artsyproduct.atlassian.net/browse/ONYX-1536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ