### PR TITLE
chore: update `yarn clean` script to clean rspack cache

### DIFF
--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -3,6 +3,10 @@
 set -ex
 
 rm -rf .cache
-rm -rf dist
+echo '[Force] Cleaned .cache directory'
 
-echo '[Force] Cleaned build directory'
+rm -rf dist
+echo '[Force] Cleaned dist directory'
+
+rm -rf node_modules/.cache/rspack
+echo '[Force] Cleaned node_modules/.cache/rspack'


### PR DESCRIPTION
The type of this PR is: **chore**
#minor

This PR updates the `yarn clean` script to empty the rspack cache. I also made the echoed output a little more verbose.