### PR TITLE
chore: remove sell when you are ready art advisor

### DIFF
--- a/src/Apps/Marketing/Routes/MarketingMeetArtAdvisorRoute.tsx
+++ b/src/Apps/Marketing/Routes/MarketingMeetArtAdvisorRoute.tsx
@@ -60,16 +60,6 @@ export const MarketingMeetArtAdvisorRoute: FC<
                 href: "/collector-profile/my-collection",
               },
             },
-            {
-              title: "When you’re ready to sell, we can help.",
-              subtitle:
-                "Earn more and worry less with our expert guidance, tailored to you.",
-              src: "https://files.artsy.net/images/marketing_meet_04_april-14.jpg",
-              cta: {
-                label: "Learn More",
-                href: "/sell",
-              },
-            },
           ]}
         />
 


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [ONYX-1533]

### Description

This PR removes "Sell when you are ready from art advisor"

| Before | After |
|--------|--------|
| <img width="1369" alt="Screenshot 2025-02-10 at 14 26 00" src="https://github.com/user-attachments/assets/9a7e3655-e111-4933-9d14-f496a154e60b" /> | <img width="1467" alt="Screenshot 2025-02-10 at 14 25 52" src="https://github.com/user-attachments/assets/9f22963e-f070-42f1-9206-bfa06fa82c43" /> | 



<!-- Implementation description -->
