### PR TITLE
fix(my-collection): corrects layout for mobile

### DIFF
--- a/src/Apps/CollectorProfile/Components/CollectorProfileHeader/CollectorProfileHeader.tsx
+++ b/src/Apps/CollectorProfile/Components/CollectorProfileHeader/CollectorProfileHeader.tsx
@@ -59,7 +59,7 @@ const CollectorProfileHeader: React.FC<
             {hasBadge && (
               <Stack gap={0.5} flexDirection="row" flexWrap="wrap">
                 {collectorProfile.confirmedBuyerAt && (
-                  <Tooltip content="Confirmed Buyer">
+                  <Tooltip content="Confirmed Buyer" width="fit-content">
                     <Box as="span" style={{ lineHeight: 0 }}>
                       <UserVerifiedIcon />
                     </Box>
@@ -67,7 +67,7 @@ const CollectorProfileHeader: React.FC<
                 )}
 
                 {collectorProfile.isIdentityVerified && (
-                  <Tooltip content="ID Verified">
+                  <Tooltip content="ID Verified" width="fit-content">
                     <Box as="span" style={{ lineHeight: 0 }}>
                       <ShieldIcon />
                     </Box>

--- a/src/Apps/Settings/Routes/MyCollection/MyCollectionRoute.tsx
+++ b/src/Apps/Settings/Routes/MyCollection/MyCollectionRoute.tsx
@@ -67,6 +67,7 @@ const MyCollectionRoute: FC<
           <Flex backgroundColor="white100" justifyContent="flex-end" gap={1}>
             {enableShare && (
               <Button
+                size={["small", "large"]}
                 variant="secondaryBlack"
                 Icon={ShareIcon}
                 onClick={() => setMode("Share")}


### PR DESCRIPTION
Added responsive props to the button and fixed a subtle layout bug where an unsized tooltip was causing horizontal page overflow. The overflow wasn't noticeable until a dialog was opened, which would appear off-center due to the incorrect page width. While tooltips should ideally have a default content width, this change addresses the immediate layout issue.