### PR TITLE
fix: Disable logo clicks only in Order App

### DIFF
--- a/src/Apps/Components/Layouts/LayoutLogoOnly.tsx
+++ b/src/Apps/Components/Layouts/LayoutLogoOnly.tsx
@@ -6,12 +6,14 @@ import type { BaseLayoutProps } from "Apps/Components/Layouts"
 import { LayoutMain } from "Apps/Components/Layouts/Components/LayoutMain"
 import { NavBarPrimaryLogo } from "Components/NavBar/NavBarPrimaryLogo"
 import { RouterLink } from "System/Components/RouterLink"
+import { useRouter } from "System/Hooks/useRouter"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import type { FC } from "react"
 
 export const LayoutLogoOnly: FC<React.PropsWithChildren<BaseLayoutProps>> = ({
   children,
 }) => {
+  const { match } = useRouter()
   const { isEigen } = useSystemContext()
 
   return (
@@ -23,7 +25,15 @@ export const LayoutLogoOnly: FC<React.PropsWithChildren<BaseLayoutProps>> = ({
           <HorizontalPadding>
             <Spacer y={[2, 4]} />
 
-            <RouterLink to={isEigen ? undefined : "/"} display="block">
+            <RouterLink
+              onClick={event => {
+                if (match.location.pathname.includes("/order") && isEigen) {
+                  event.preventDefault()
+                }
+              }}
+              to="/"
+              display="block"
+            >
               <NavBarPrimaryLogo />
             </RouterLink>
 

--- a/src/Components/NavBar/NavBarPrimaryLogo.tsx
+++ b/src/Components/NavBar/NavBarPrimaryLogo.tsx
@@ -1,6 +1,7 @@
 import ArtsyMarkIcon from "@artsy/icons/ArtsyMarkIcon"
 import { themeGet } from "@styled-system/theme-get"
 import { RouterLink, type RouterLinkProps } from "System/Components/RouterLink"
+import { useRouter } from "System/Hooks/useRouter"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import type * as React from "react"
 import styled from "styled-components"
@@ -8,10 +9,20 @@ import styled from "styled-components"
 export const NavBarPrimaryLogo: React.FC<
   React.PropsWithChildren<Omit<RouterLinkProps, "to" | "ref">>
 > = props => {
+  const { match } = useRouter()
   const { isEigen } = useSystemContext()
 
   return (
-    <HitArea to={isEigen ? undefined : "/"} {...props} aria-label="Artsy">
+    <HitArea
+      onClick={event => {
+        if (match.location.pathname.includes("/order") && isEigen) {
+          event.preventDefault()
+        }
+      }}
+      to="/"
+      {...props}
+      aria-label="Artsy"
+    >
       <ArtsyMarkIcon height={40} width={40} />
     </HitArea>
   )


### PR DESCRIPTION
The type of this PR is: **fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves []

### Description

This PR is a follow-up on #15162 

This PR refactors the disabling of the navigating to the homepage to be only happening in the Order App


<!-- Implementation description -->
