### PR TITLE
fix: stop propagation of estimate widget open clicks

### DIFF
--- a/src/Components/ArtsyShippingEstimate.tsx
+++ b/src/Components/ArtsyShippingEstimate.tsx
@@ -166,12 +166,14 @@ export const ArtsyShippingEstimate = ({
       tabIndex={0}
       onClick={e => {
         e.preventDefault()
+        e.stopPropagation()
         openWidget()
         trackClickedEstimatePrice()
       }}
       onKeyDown={e => {
         if (e.key === "Enter") {
           e.preventDefault()
+          e.stopPropagation()
           openWidget()
           trackClickedEstimatePrice()
         }


### PR DESCRIPTION
The type of this PR is: **fix**
#minor

This PR calls `event.stopPropagation()` to prevent a click on the estimate widget link from opening the shipping details collapse element.