### PR TITLE
fix(EMI-2293): use experimental groups instead of release feature flag for estimate widget

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebar.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebar.tsx
@@ -93,6 +93,9 @@ export const ArtworkSidebar: React.FC<
 
   const artworkEcommerceAvailable = !!(isAcquireable || isOfferable)
 
+  // TODO: Arta Estimate widget experiment!
+  // This code determins if Arta widget code should be loaded
+  // Either remove or properly implement when experiment is complete
   const allArtsyShipping =
     !!artsyShippingDomestic && !!artsyShippingInternational
   const artsyImpliedShipping =

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebar.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebar.tsx
@@ -28,7 +28,6 @@ import { ArtworkSidebarPrivateArtwork } from "Apps/Artwork/Components/ArtworkSid
 import { PrivateArtworkAdditionalInfo } from "Apps/Artwork/Components/ArtworkSidebar/PrivateArtworkAdditionalInfo"
 import { lotIsClosed } from "Apps/Artwork/Utils/lotIsClosed"
 import { ArtsyShippingEstimate } from "Components/ArtsyShippingEstimate"
-import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { useAuctionWebsocket } from "Utils/Hooks/useAuctionWebsocket"
@@ -94,12 +93,6 @@ export const ArtworkSidebar: React.FC<
 
   const artworkEcommerceAvailable = !!(isAcquireable || isOfferable)
 
-  // TODO: Arta Estimate widget experiment!
-  // This code determins if Arta widget code should be loaded
-  // Either remove or properly implement when experiment is
-  const artsyShippingEstimateEnabled = useFeatureFlag(
-    "emerald_shipping-estimate-widget",
-  )
   const allArtsyShipping =
     !!artsyShippingDomestic && !!artsyShippingInternational
   const artsyImpliedShipping =
@@ -118,7 +111,6 @@ export const ArtworkSidebar: React.FC<
         : shippingWeight <= 150
   }
   const displayArtaEstimate =
-    artsyShippingEstimateEnabled &&
     (allArtsyShipping || artsyImpliedShipping) &&
     (!isEdition || isOneEdition) &&
     isWeightArtaEstimatable

--- a/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebar.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/__tests__/ArtworkSidebar.jest.tsx
@@ -2,7 +2,6 @@ import { fireEvent, screen } from "@testing-library/react"
 import { ArtworkSidebarFragmentContainer } from "Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebar"
 import { ArtsyShippingEstimate } from "Components/ArtsyShippingEstimate"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
-import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
 import { DateTime } from "luxon"
 import { graphql } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -14,11 +13,6 @@ jest.mock("react-tracking")
 const MockArtsyShippingEstimate = ArtsyShippingEstimate as jest.Mock
 jest.mock("Components/ArtsyShippingEstimate", () => ({
   ArtsyShippingEstimate: jest.fn(() => <div>ArtsyShippingEstimate</div>),
-}))
-
-const mockUseFeatureFlag = useFeatureFlag as jest.Mock
-jest.mock("System/Hooks/useFeatureFlag", () => ({
-  useFeatureFlag: jest.fn(),
 }))
 
 jest.mock(
@@ -216,9 +210,6 @@ describe("ArtworkSidebarArtists", () => {
 
   describe("Shipping and taxes section", () => {
     describe("Shipping estimate feature flag enabled", () => {
-      beforeEach(() => {
-        mockUseFeatureFlag.mockReturnValue(true)
-      })
       it("renders ArtsyShippingEstimate if work is arta shipped globablly", () => {
         renderWithRelay({
           Artwork: () => ({

--- a/src/Components/ArtsyShippingEstimate.tsx
+++ b/src/Components/ArtsyShippingEstimate.tsx
@@ -13,6 +13,10 @@ import {
 } from "@artsy/cohesion"
 import { Link, Spacer, Text } from "@artsy/palette"
 import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
+import {
+  useFeatureVariant,
+  useTrackFeatureVariant,
+} from "System/Hooks/useFeatureFlag"
 import { useLoadScript } from "Utils/Hooks/useLoadScript"
 import { getENV } from "Utils/getENV"
 import type {
@@ -39,7 +43,29 @@ interface ArtsyShippingEstimateProps {
   artwork: ArtsyShippingEstimate_artwork$key
 }
 
-export const ArtsyShippingEstimate = ({
+export const ArtsyShippingEstimate = (props: ArtsyShippingEstimateProps) => {
+  // TODO: Arta Estimate widget experiment!
+  // This code determins if Arta widget code should be loaded
+  // Either remove or properly implement when experiment is
+  const variant = useFeatureVariant("emerald_shipping-estimate-widget")
+
+  const { trackFeatureVariant } = useTrackFeatureVariant({
+    experimentName: "emerald_shipping-estimate-widget",
+    variantName: variant?.name ?? "control",
+  })
+
+  useEffect(() => {
+    trackFeatureVariant()
+  })
+
+  if (variant?.name === "experiment") {
+    return <ArtsyShippingEstimateLoader {...props} />
+  }
+
+  return null
+}
+
+const ArtsyShippingEstimateLoader = ({
   artwork,
 }: ArtsyShippingEstimateProps) => {
   const { trackEvent } = useTracking()

--- a/src/Components/ArtsyShippingEstimate.tsx
+++ b/src/Components/ArtsyShippingEstimate.tsx
@@ -44,9 +44,6 @@ interface ArtsyShippingEstimateProps {
 }
 
 export const ArtsyShippingEstimate = (props: ArtsyShippingEstimateProps) => {
-  // TODO: Arta Estimate widget experiment!
-  // This code determins if Arta widget code should be loaded
-  // Either remove or properly implement when experiment is
   const variant = useFeatureVariant("emerald_shipping-estimate-widget")
 
   const { trackFeatureVariant } = useTrackFeatureVariant({


### PR DESCRIPTION
The type of this PR is: **fix**


This PR solves [EMI-2293]

### Description

This PR updates our conditional widget rendering code to use experimental groups instead of a release feature flag and adds tracking to do it.

[EMI-2293]: https://artsyproduct.atlassian.net/browse/EMI-2293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ