### PR TITLE
chore: removes share lists feature flag

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves/Components/SavesArtworksHeader.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves/Components/SavesArtworksHeader.tsx
@@ -11,7 +11,6 @@ import {
 import { ArtworkListContextualMenu } from "Apps/CollectorProfile/Routes/Saves/Components/Actions/ArtworkListContextualMenu"
 import { ClientSuspense } from "Components/ClientSuspense"
 import { ShareCollectionDialog } from "Components/ShareCollectionDialog"
-import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
 import type { SavesArtworksHeaderQuery } from "__generated__/SavesArtworksHeaderQuery.graphql"
 import { type FC, useState } from "react"
 import { graphql, useLazyLoadQuery } from "react-relay"
@@ -30,8 +29,6 @@ const SavesArtworksHeader: FC<
   const collection = me?.collection
 
   const [mode, setMode] = useState<"Idle" | "Share">("Idle")
-
-  const enableShare = useFeatureFlag("diamond_shareable-artwork-lists")
 
   const handleShare = () => {
     setMode("Share")
@@ -72,16 +69,14 @@ const SavesArtworksHeader: FC<
             )}
           </Stack>
 
-          {enableShare && (
-            <Button
-              size="small"
-              variant="secondaryBlack"
-              onClick={handleShare}
-              Icon={ShareIcon}
-            >
-              Share
-            </Button>
-          )}
+          <Button
+            size="small"
+            variant="secondaryBlack"
+            onClick={handleShare}
+            Icon={ShareIcon}
+          >
+            Share
+          </Button>
         </Stack>
 
         {!collection.default && collection && (

--- a/src/Apps/Settings/Routes/MyCollection/MyCollectionRoute.tsx
+++ b/src/Apps/Settings/Routes/MyCollection/MyCollectionRoute.tsx
@@ -5,7 +5,6 @@ import { MyCollectionArtworkGrid } from "Apps/Settings/Routes/MyCollection/Compo
 import { MetaTags } from "Components/MetaTags"
 import { ShareCollectionDialog } from "Components/ShareCollectionDialog"
 import { RouterLink } from "System/Components/RouterLink"
-import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
 import { cleanLocalImages } from "Utils/localImageHelpers"
 import type { MyCollectionRoute_me$data } from "__generated__/MyCollectionRoute_me.graphql"
 import { type FC, useEffect, useState } from "react"
@@ -24,8 +23,6 @@ export interface MyCollectionRouteProps {
 const MyCollectionRoute: FC<
   React.PropsWithChildren<MyCollectionRouteProps>
 > = ({ me, relay }) => {
-  const enableShare = useFeatureFlag("diamond_shareable-artwork-lists")
-
   const { addCollectedArtwork: trackAddCollectedArtwork } =
     useMyCollectionTracking()
   const [isLoading, setLoading] = useState(false)
@@ -65,16 +62,14 @@ const MyCollectionRoute: FC<
       {total > 0 ? (
         <Stack gap={2}>
           <Flex backgroundColor="white100" justifyContent="flex-end" gap={1}>
-            {enableShare && (
-              <Button
-                size={["small", "large"]}
-                variant="secondaryBlack"
-                Icon={ShareIcon}
-                onClick={() => setMode("Share")}
-              >
-                Share
-              </Button>
-            )}
+            <Button
+              size={["small", "large"]}
+              variant="secondaryBlack"
+              Icon={ShareIcon}
+              onClick={() => setMode("Share")}
+            >
+              Share
+            </Button>
 
             <Button
               // @ts-ignore


### PR DESCRIPTION
The share lists feature has been enabled in production since the hackathon and has been successfully launched. We can proceed with removing the feature flag.