### PR TITLE
chore: closes out remaining test code for app download header

### DIFF
--- a/src/Apps/Marketing/Components/MarketingHeaderPrimary.tsx
+++ b/src/Apps/Marketing/Components/MarketingHeaderPrimary.tsx
@@ -1,36 +1,17 @@
 import { Image, Spacer, Stack, Text } from "@artsy/palette"
-import { useFeatureVariant } from "System/Hooks/useFeatureFlag"
 import { Device, useDeviceDetection } from "Utils/Hooks/useDeviceDetection"
 import type { FC } from "react"
 import { MarketingHeader } from "./MarketingHeader"
 
-export const MarketingHeaderSplitTest: FC = () => {
+export const MarketingHeaderPrimary: FC = () => {
   const { downloadAppUrl, device } = useDeviceDetection()
-
-  const variants = {
-    control: {
-      title: "The art world online",
-      subtitle:
-        "Artsy is the world's leading platform to discover, buy, and manage the art you love",
-      src: "https://files.artsy.net/images/01_Artsy_App-Download-Landing-Page.jpg",
-    },
-    experiment: {
-      title: "Your guide to the art world",
-      subtitle:
-        "Artsy makes it easy to discover artists and artworks you'll love",
-      src: "https://files.artsy.net/images/02_Artsy_App-Download-Landing-Page.jpg",
-    },
-  }
-
-  const featureVariant = useFeatureVariant("diamond_hero-app-download")
-  const variant = variants[featureVariant?.name || "control"]
 
   return (
     <MarketingHeader
-      title={variant.title}
-      subtitle={variant.subtitle}
-      src={variant.src}
-      accentColor={variant.accentColor}
+      title="Your guide to the art world"
+      subtitle="Artsy makes it easy to discover artists and artworks you'll love"
+      src="https://files.artsy.net/images/02_Artsy_App-Download-Landing-Page.jpg"
+      accentColor="black10"
     >
       <Spacer y={2} />
 

--- a/src/Apps/Marketing/Routes/MarketingMeetArtAdvisorRoute.tsx
+++ b/src/Apps/Marketing/Routes/MarketingMeetArtAdvisorRoute.tsx
@@ -8,7 +8,7 @@ import {
   Text,
 } from "@artsy/palette"
 import { MarketingAlternatingStack } from "Apps/Marketing/Components/MarketingAlternatingStack"
-import { MarketingHeaderSplitTest } from "Apps/Marketing/Components/MarketingHeaderSpitTest"
+import { MarketingHeaderPrimary } from "Apps/Marketing/Components/MarketingHeaderPrimary"
 import { MetaTags } from "Components/MetaTags"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import type { FC } from "react"
@@ -26,7 +26,7 @@ export const MarketingMeetArtAdvisorRoute: FC<
       />
 
       <Join separator={<Spacer y={6} />}>
-        <MarketingHeaderSplitTest />
+        <MarketingHeaderPrimary />
 
         <MarketingAlternatingStack
           cards={[


### PR DESCRIPTION
This PR addresses an overlooked page from the initial removal, closing out the remaining code in favor of the experiment branch.