### PR TITLE
fix(artwork): Attempt to fix mysterious flashing details

### DIFF
--- a/src/Apps/Artwork/ArtworkApp.tsx
+++ b/src/Apps/Artwork/ArtworkApp.tsx
@@ -69,25 +69,29 @@ interface BelowTheFoldArtworkDetailsProps {
 
 const BelowTheFoldArtworkDetails: React.FC<
   React.PropsWithChildren<BelowTheFoldArtworkDetailsProps>
-> = ({ artists, slug }) => (
-  <>
-    <Spacer y={6} />
-    <Join separator={<Spacer y={2} />}>
-      <ArtworkDetailsQueryRenderer slug={slug} />
+> = ({ artists, slug }) => {
+  return (
+    <>
+      <Spacer y={6} />
+      <Join separator={<Spacer y={2} />}>
+        <ArtworkDetailsQueryRenderer slug={slug} />
 
-      <PricingContextQueryRenderer slug={slug} />
+        <PricingContextQueryRenderer slug={slug} />
 
-      {!!artists &&
-        artists.map(artist => {
-          if (!artist) return null
+        {!!artists &&
+          artists.map(artist => {
+            if (!artist) return null
 
-          return <ArtistInfoQueryRenderer key={artist.id} slug={artist.slug} />
-        })}
+            return (
+              <ArtistInfoQueryRenderer key={artist.id} slug={artist.slug} />
+            )
+          })}
 
-      <ArtworkDetailsPartnerInfoQueryRenderer slug={slug} />
-    </Join>
-  </>
-)
+        <ArtworkDetailsPartnerInfoQueryRenderer slug={slug} />
+      </Join>
+    </>
+  )
+}
 
 export const ArtworkApp: React.FC<React.PropsWithChildren<Props>> = props => {
   const { artwork, me, referrer, tracking } = props

--- a/src/Apps/Artwork/Components/ArtworkDetails/index.tsx
+++ b/src/Apps/Artwork/Components/ArtworkDetails/index.tsx
@@ -150,7 +150,6 @@ export const ArtworkDetailsQueryRenderer: React.FC<
   return (
     <Box data-test="ArtworkDetailsQueryRenderer">
       <SystemQueryRenderer<ArtworkDetailsQuery>
-        lazyLoad
         environment={relayEnvironment}
         variables={{ slug }}
         placeholder={PLACEHOLDER}


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [PBRW-479]

### Description

First reported in the [bugs channel](https://artsy.slack.com/archives/C07PRTJSD6G/p1739468756482839), was noticed that on certain artworks there's a strange flashing behavior. 

Its hard to repo, but for now lets disable lazy loading (when scrolling into view) on that component. Its already lazy loaded via a QueryRenderer, so in a sense it just makes the page feel more stable (as an improvement). 

cc @artsy/amber-devs 



[PBRW-479]: https://artsyproduct.atlassian.net/browse/PBRW-479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ