### PR TITLE
chore(EMI-2293): update hook deps and docs

### DIFF
--- a/docs/unleash_a-b_testing.md
+++ b/docs/unleash_a-b_testing.md
@@ -111,9 +111,10 @@ function MyComponent() {
   })
 
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Only track experiment viewed once
   useEffect(() => {
     trackFeatureVariant()
-  })
+  }, [])
 
   return (
     // Your Components

--- a/src/Components/ArtsyShippingEstimate.tsx
+++ b/src/Components/ArtsyShippingEstimate.tsx
@@ -51,9 +51,10 @@ export const ArtsyShippingEstimate = (props: ArtsyShippingEstimateProps) => {
     variantName: variant?.name ?? "control",
   })
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: Only track experiment viewed once
   useEffect(() => {
     trackFeatureVariant()
-  })
+  }, [])
 
   if (variant?.name === "experiment") {
     return <ArtsyShippingEstimateLoader {...props} />


### PR DESCRIPTION
The type of this PR is: **chore**
followup to [EMI-2293]

### Description
This PR updates our shipping estimate widget `useEffect(trackExperimentViewed` call to have an explicit empty dependency array. It also update the docs to include this array.

[EMI-2293]: https://artsyproduct.atlassian.net/browse/EMI-2293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ