### PR TITLE
fix(onboarding): prevents overly long names from overflowing the diaglog

### DIFF
--- a/src/Components/Onboarding/Views/OnboardingWelcome.tsx
+++ b/src/Components/Onboarding/Views/OnboardingWelcome.tsx
@@ -21,12 +21,17 @@ export const OnboardingWelcome = () => {
       left={<OnboardingWelcomeAnimatedPanel ref={register(0)} />}
       leftProps={{ display: "block", flexBasis: ["30%", "50%"] }}
       right={
-        <Flex flexDirection="column" justifyContent="space-between" p={[2, 4]}>
+        <Flex
+          flexDirection="column"
+          justifyContent="space-between"
+          p={[2, 4]}
+          overflowY="auto"
+        >
           {/* Vertically centers next Box */}
           <Box />
 
           <Box width="100%">
-            <Text ref={register(1)} variant={["xl", "xxl"]}>
+            <Text ref={register(1)} variant={["xl", "xxl"]} hyphenate>
               Welcome to Artsy{user ? `, ${user.name}` : ""}.
             </Text>
 


### PR DESCRIPTION
This fixes an issue where long names were horizontally overflowing the dialog. We simply hyphenate and then allow the parent pane to scroll vertically if needed.

![](https://capture.static.damonzucconi.com/Screen-Shot-2025-02-14-08-08-03.18-l7C28gtjux01KqoaWaDBUcWcrlcktGDRtTSMIllLXCtFaRQe0xX4Hqlml2Bhrw47TZP9aLB8XFdTYd5VwqAqHCSN71OaiXoRDZlY.png)