### PR TITLE
feat: update myBids screens to respect sale isLiveOpen attribute

### DIFF
--- a/src/Apps/Auction/Components/AuctionActiveBids.tsx
+++ b/src/Apps/Auction/Components/AuctionActiveBids.tsx
@@ -226,12 +226,8 @@ const BidButton: React.FC<
   const { router } = useRouter()
   const { tracking } = useAuctionTracking()
 
-  if (!lotStanding) return null
-
-  const { saleArtwork } = lotStanding
-  if (!saleArtwork) return null
-
-  const { sale } = saleArtwork
+  const saleArtwork = lotStanding?.saleArtwork
+  const sale = saleArtwork?.sale
   if (!sale) return null
 
   if (!!saleArtwork.endedAt) {

--- a/src/Apps/Auction/Components/AuctionActiveBids.tsx
+++ b/src/Apps/Auction/Components/AuctionActiveBids.tsx
@@ -19,6 +19,7 @@ import { RouterLink } from "System/Components/RouterLink"
 import { useRouter } from "System/Hooks/useRouter"
 import { usePoll } from "Utils/Hooks/usePoll"
 import { Media } from "Utils/Responsive"
+import { getENV } from "Utils/getENV"
 import type { AuctionActiveBids_me$data } from "__generated__/AuctionActiveBids_me.graphql"
 import {
   type RelayRefetchProp,
@@ -61,7 +62,7 @@ const AuctionActiveBids: React.FC<
       <Media at="xs">
         {me?.lotStandings?.map((lotStanding, index) => {
           return (
-            <>
+            <Box key={index}>
               <Box my={4}>
                 <Join separator={<Spacer y={0.5} />}>
                   <AuctionLotInfoFragmentContainer
@@ -72,7 +73,7 @@ const AuctionActiveBids: React.FC<
                 </Join>
               </Box>
               <Separator />
-            </>
+            </Box>
           )
         })}
       </Media>
@@ -179,6 +180,13 @@ const BidStatus: React.FC<
   }
 
   switch (true) {
+    case lotStanding.saleArtwork?.sale?.isLiveOpen: {
+      return (
+        <Text variant="xs" color="blue100" display="flex">
+          &nbsp; Bidding live now
+        </Text>
+      )
+    }
     case lotStanding.isHighestBidder: {
       return (
         <Text variant="xs" color="green100" display="flex">
@@ -218,11 +226,15 @@ const BidButton: React.FC<
   const { router } = useRouter()
   const { tracking } = useAuctionTracking()
 
-  if (!lotStanding) {
-    return null
-  }
+  if (!lotStanding) return null
 
-  if (!!lotStanding.saleArtwork?.endedAt) {
+  const { saleArtwork } = lotStanding
+  if (!saleArtwork) return null
+
+  const { sale } = saleArtwork
+  if (!sale) return null
+
+  if (!!saleArtwork.endedAt) {
     return (
       <Box
         alignItems="center"
@@ -237,10 +249,24 @@ const BidButton: React.FC<
     )
   }
 
+  if (!!sale.isLiveOpen) {
+    return (
+      <Button
+        // @ts-ignore
+        as={RouterLink}
+        to={`${getENV("PREDICTION_URL")}/${sale.slug}/login`}
+        width="50%"
+        variant="primaryBlack"
+      >
+        Enter live bidding
+      </Button>
+    )
+  }
+
   // By default, we redirect to /artwork/id on successful bid, but since we're
   // in the ActiveBids component, redirect to /auction/id (i.e., close modal)
-  const redirectTo = `/auction/${lotStanding.saleArtwork?.saleID}`
-  const href = `/auction/${lotStanding.saleArtwork?.saleID}/bid/${lotStanding?.saleArtwork?.slug}?redirectTo=${redirectTo}`
+  const redirectTo = `/auction/${saleArtwork.saleID}`
+  const href = `/auction/${saleArtwork.saleID}/bid/${saleArtwork.slug}?redirectTo=${redirectTo}`
 
   return (
     <Button
@@ -249,13 +275,13 @@ const BidButton: React.FC<
       to={href}
       size={size}
       width="50%"
-      disabled={!!lotStanding.saleArtwork?.endedAt}
+      disabled={!!saleArtwork.endedAt}
       onClick={event => {
         event.preventDefault()
 
         tracking.clickedActiveBid({
-          artworkSlug: lotStanding.saleArtwork?.slug,
-          saleSlug: lotStanding.saleArtwork?.sale?.slug,
+          artworkSlug: saleArtwork.slug,
+          saleSlug: sale.slug,
           userID: me.internalID,
         })
 

--- a/src/Apps/Auction/Components/__tests__/AuctionActiveBids.jest.enzyme.tsx
+++ b/src/Apps/Auction/Components/__tests__/AuctionActiveBids.jest.enzyme.tsx
@@ -135,6 +135,30 @@ describe("AuctionActiveBids", () => {
       })
     })
 
+    describe("auction with live bidding that is already started", () => {
+      it("displays live bidding in process", () => {
+        const { wrapper } = getWrapper({
+          Me: () => ({
+            lotStandings: [
+              {
+                saleArtwork: {
+                  counts: {
+                    bidderPositions: 1,
+                  },
+                  sale: {
+                    slug: "auction-slug",
+                    isLiveOpen: true,
+                  },
+                },
+              },
+            ],
+          }),
+        })
+
+        expect(wrapper.text()).toContain("Bidding live now")
+      })
+    })
+
     describe("current bid", () => {
       it("shows current bid count", () => {
         const { wrapper } = getWrapper({

--- a/src/Apps/Auctions/Components/MyBids/MyBidsBidItem.tsx
+++ b/src/Apps/Auctions/Components/MyBids/MyBidsBidItem.tsx
@@ -127,7 +127,7 @@ export const MyBidsBidItem: React.FC<
                     variant="xs"
                     color="red100"
                     overflowEllipsis
-                    alignItems="center"
+                    display="flex"
                   >
                     <ChevronCircleDownIcon
                       height={15}

--- a/src/Apps/Auctions/Components/MyBids/MyBidsBidItem.tsx
+++ b/src/Apps/Auctions/Components/MyBids/MyBidsBidItem.tsx
@@ -99,7 +99,16 @@ export const MyBidsBidItem: React.FC<
                   </Box>
                 </Text>
 
-                {saleArtwork.isHighestBidder ? (
+                {saleArtwork.sale?.isLiveOpen ? (
+                  <Text
+                    variant="xs"
+                    color="blue100"
+                    overflowEllipsis
+                    display="flex"
+                  >
+                    &nbsp; Bidding live now
+                  </Text>
+                ) : saleArtwork.isHighestBidder ? (
                   <Text
                     variant="xs"
                     color="green100"
@@ -168,6 +177,10 @@ export const MyBidsBidItemFragmentContainer = createFragmentContainer(
         }
         lotLabel
         slug
+        sale {
+          isLiveOpen
+          slug
+        }
       }
     `,
   },

--- a/src/Apps/Settings/Routes/Auctions/Components/SettingsAuctionsLotStanding.tsx
+++ b/src/Apps/Settings/Routes/Auctions/Components/SettingsAuctionsLotStanding.tsx
@@ -6,6 +6,7 @@ import { RouterLink } from "System/Components/RouterLink"
 import type { SettingsAuctionsLotStanding_lotStanding$data } from "__generated__/SettingsAuctionsLotStanding_lotStanding.graphql"
 import { type FC, Fragment } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
+import { getENV } from "Utils/getENV"
 
 interface SettingsAuctionsLotStandingProps {
   lotStanding: SettingsAuctionsLotStanding_lotStanding$data
@@ -25,6 +26,7 @@ const SettingsAuctionsLotStanding: FC<
   if (!artwork || !sale) return null
 
   const image = artwork.image?.cropped
+  const showLotStanding = !sale.isClosed && !sale.isLiveOpen
 
   return (
     <Fragment>
@@ -64,42 +66,55 @@ const SettingsAuctionsLotStanding: FC<
 
       <Column span={2}>
         <Flex alignItems="center">
-          {isLeadingBidder ? (
-            <Text
-              variant="xs"
-              color="green100"
-              overflowEllipsis
-              display="flex"
-              alignItems="center"
-            >
-              <ChevronCircleUpIcon height={15} width={15} fill="green100" />
-              &nbsp; Highest Bid
-            </Text>
-          ) : (
-            <Text
-              variant="xs"
-              color="red100"
-              overflowEllipsis
-              display="flex"
-              alignItems="center"
-            >
-              <ChevronCircleDownIcon height={15} width={15} fill="red100" />
-              &nbsp; Outbid
-            </Text>
-          )}
+          {showLotStanding &&
+            (isLeadingBidder ? (
+              <Text
+                variant="xs"
+                color="green100"
+                overflowEllipsis
+                display="flex"
+                alignItems="center"
+              >
+                <ChevronCircleUpIcon height={15} width={15} fill="green100" />
+                &nbsp; Highest Bid
+              </Text>
+            ) : (
+              <Text
+                variant="xs"
+                color="red100"
+                overflowEllipsis
+                display="flex"
+                alignItems="center"
+              >
+                <ChevronCircleDownIcon height={15} width={15} fill="red100" />
+                &nbsp; Outbid
+              </Text>
+            ))}
         </Flex>
       </Column>
 
       <Column span={2}>
-        <Button
-          // @ts-ignore
-          as={RouterLink}
-          to={artwork.href}
-          width="100%"
-          variant={sale.isClosed ? "secondaryBlack" : "primaryBlack"}
-        >
-          {sale.isClosed ? "View Lot" : "Bid"}
-        </Button>
+        {sale.isLiveOpen ? (
+          <Button
+            // @ts-ignore
+            as={RouterLink}
+            to={`${getENV("PREDICTION_URL")}/${sale.slug}/login`}
+            width="100%"
+            variant="primaryBlack"
+          >
+            Enter live bidding
+          </Button>
+        ) : (
+          <Button
+            // @ts-ignore
+            as={RouterLink}
+            to={artwork.href}
+            width="100%"
+            variant={sale.isClosed ? "secondaryBlack" : "primaryBlack"}
+          >
+            {sale.isClosed ? "View Lot" : "Bid"}
+          </Button>
+        )}
       </Column>
     </Fragment>
   )
@@ -113,6 +128,8 @@ export const SettingsAuctionsLotStandingFragmentContainer =
         saleArtwork {
           lotLabel
           sale {
+            slug
+            isLiveOpen
             isClosed
           }
           artwork {

--- a/src/Apps/Settings/Routes/Auctions/Components/UserActiveBids.tsx
+++ b/src/Apps/Settings/Routes/Auctions/Components/UserActiveBids.tsx
@@ -13,7 +13,7 @@ export const UserActiveBids: React.FC<
   React.PropsWithChildren<UserActiveBidsProps>
 > = ({ me: { activeLotStandings: lotStandings } }) => {
   if (!lotStandings || lotStandings.length === 0) {
-    return <SectionContainer title="Active Bids"></SectionContainer>
+    return <SectionContainer title="Active Bids" />
   }
 
   return (

--- a/src/Apps/Settings/Routes/Auctions/Components/UserBidHistory.tsx
+++ b/src/Apps/Settings/Routes/Auctions/Components/UserBidHistory.tsx
@@ -13,7 +13,7 @@ export const UserBidHistory: React.FC<
   React.PropsWithChildren<UserBidHistoryProps>
 > = ({ me: { inactiveLotStandings: lotStandings } }) => {
   if (!lotStandings || lotStandings.length === 0) {
-    return <SectionContainer title="Bid History"></SectionContainer>
+    return <SectionContainer title="Bid History" />
   }
 
   return (

--- a/src/Apps/Settings/settingsRoutes.tsx
+++ b/src/Apps/Settings/settingsRoutes.tsx
@@ -170,7 +170,7 @@ export const settingsRoutes: RouteProps[] = [
       {
         path: "saves",
         render: () => {
-          throw new RedirectException(`/favorites/saves`, 301)
+          throw new RedirectException("/favorites/saves", 301)
         },
       },
       {

--- a/src/__generated__/MyBidsBidItem_Test_Query.graphql.ts
+++ b/src/__generated__/MyBidsBidItem_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bf40e87f869c48d08215509bd28e8f1e>>
+ * @generated SignedSource<<09b028b6c8bf1a2006ea7abc87240856>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -46,30 +46,37 @@ v2 = [
   }
 ],
 v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v4 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v4 = {
+v5 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v5 = {
+v6 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Int"
 },
-v6 = {
+v7 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v7 = {
+v8 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -269,11 +276,25 @@ return {
             "name": "lotLabel",
             "storageKey": null
           },
+          (v3/*: any*/),
           {
             "alias": null,
             "args": null,
-            "kind": "ScalarField",
-            "name": "slug",
+            "concreteType": "Sale",
+            "kind": "LinkedField",
+            "name": "sale",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isLiveOpen",
+                "storageKey": null
+              },
+              (v3/*: any*/),
+              (v1/*: any*/)
+            ],
             "storageKey": null
           },
           (v1/*: any*/)
@@ -283,7 +304,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "8ac86c18a9477ec93a5fc8d1e3df0bfc",
+    "cacheID": "037f8ab09c02e00a5286e68f14183cc8",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -299,8 +320,8 @@ return {
           "plural": false,
           "type": "Artwork"
         },
-        "saleArtwork.artwork.artistNames": (v3/*: any*/),
-        "saleArtwork.artwork.id": (v4/*: any*/),
+        "saleArtwork.artwork.artistNames": (v4/*: any*/),
+        "saleArtwork.artwork.id": (v5/*: any*/),
         "saleArtwork.artwork.image": {
           "enumValues": null,
           "nullable": true,
@@ -313,23 +334,23 @@ return {
           "plural": false,
           "type": "CroppedImageUrl"
         },
-        "saleArtwork.artwork.image.cropped.height": (v5/*: any*/),
-        "saleArtwork.artwork.image.cropped.src": (v6/*: any*/),
-        "saleArtwork.artwork.image.cropped.srcSet": (v6/*: any*/),
-        "saleArtwork.artwork.image.cropped.width": (v5/*: any*/),
+        "saleArtwork.artwork.image.cropped.height": (v6/*: any*/),
+        "saleArtwork.artwork.image.cropped.src": (v7/*: any*/),
+        "saleArtwork.artwork.image.cropped.srcSet": (v7/*: any*/),
+        "saleArtwork.artwork.image.cropped.width": (v6/*: any*/),
         "saleArtwork.currentBid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkCurrentBid"
         },
-        "saleArtwork.currentBid.display": (v3/*: any*/),
-        "saleArtwork.estimate": (v3/*: any*/),
-        "saleArtwork.id": (v4/*: any*/),
-        "saleArtwork.internalID": (v4/*: any*/),
-        "saleArtwork.isHighestBidder": (v7/*: any*/),
-        "saleArtwork.isWatching": (v7/*: any*/),
-        "saleArtwork.lotLabel": (v3/*: any*/),
+        "saleArtwork.currentBid.display": (v4/*: any*/),
+        "saleArtwork.estimate": (v4/*: any*/),
+        "saleArtwork.id": (v5/*: any*/),
+        "saleArtwork.internalID": (v5/*: any*/),
+        "saleArtwork.isHighestBidder": (v8/*: any*/),
+        "saleArtwork.isWatching": (v8/*: any*/),
+        "saleArtwork.lotLabel": (v4/*: any*/),
         "saleArtwork.lotState": {
           "enumValues": null,
           "nullable": true,
@@ -348,13 +369,22 @@ return {
           "plural": false,
           "type": "Money"
         },
-        "saleArtwork.lotState.sellingPrice.display": (v3/*: any*/),
-        "saleArtwork.slug": (v4/*: any*/)
+        "saleArtwork.lotState.sellingPrice.display": (v4/*: any*/),
+        "saleArtwork.sale": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Sale"
+        },
+        "saleArtwork.sale.id": (v5/*: any*/),
+        "saleArtwork.sale.isLiveOpen": (v8/*: any*/),
+        "saleArtwork.sale.slug": (v5/*: any*/),
+        "saleArtwork.slug": (v5/*: any*/)
       }
     },
     "name": "MyBidsBidItem_Test_Query",
     "operationKind": "query",
-    "text": "query MyBidsBidItem_Test_Query {\n  saleArtwork(id: \"foo\") {\n    ...MyBidsBidItem_saleArtwork\n    id\n  }\n}\n\nfragment MyBidsBidItem_saleArtwork on SaleArtwork {\n  artwork {\n    artistNames\n    image {\n      cropped(width: 55, height: 55) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    id\n  }\n  estimate\n  currentBid {\n    display\n  }\n  internalID\n  isHighestBidder\n  isWatching\n  lotState {\n    bidCount\n    sellingPrice {\n      display\n    }\n  }\n  lotLabel\n  slug\n}\n"
+    "text": "query MyBidsBidItem_Test_Query {\n  saleArtwork(id: \"foo\") {\n    ...MyBidsBidItem_saleArtwork\n    id\n  }\n}\n\nfragment MyBidsBidItem_saleArtwork on SaleArtwork {\n  artwork {\n    artistNames\n    image {\n      cropped(width: 55, height: 55) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    id\n  }\n  estimate\n  currentBid {\n    display\n  }\n  internalID\n  isHighestBidder\n  isWatching\n  lotState {\n    bidCount\n    sellingPrice {\n      display\n    }\n  }\n  lotLabel\n  slug\n  sale {\n    isLiveOpen\n    slug\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/MyBidsBidItem_saleArtwork.graphql.ts
+++ b/src/__generated__/MyBidsBidItem_saleArtwork.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c19fde77c2135cf25c037cc05473a2ce>>
+ * @generated SignedSource<<5438245dece557d2e621b2c47d369baf>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -36,6 +36,10 @@ export type MyBidsBidItem_saleArtwork$data = {
       readonly display: string | null | undefined;
     } | null | undefined;
   } | null | undefined;
+  readonly sale: {
+    readonly isLiveOpen: boolean | null | undefined;
+    readonly slug: string;
+  } | null | undefined;
   readonly slug: string;
   readonly " $fragmentType": "MyBidsBidItem_saleArtwork";
 };
@@ -53,7 +57,14 @@ var v0 = [
     "name": "display",
     "storageKey": null
   }
-];
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+};
 return {
   "argumentDefinitions": [],
   "kind": "Fragment",
@@ -212,11 +223,24 @@ return {
       "name": "lotLabel",
       "storageKey": null
     },
+    (v1/*: any*/),
     {
       "alias": null,
       "args": null,
-      "kind": "ScalarField",
-      "name": "slug",
+      "concreteType": "Sale",
+      "kind": "LinkedField",
+      "name": "sale",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "isLiveOpen",
+          "storageKey": null
+        },
+        (v1/*: any*/)
+      ],
       "storageKey": null
     }
   ],
@@ -225,6 +249,6 @@ return {
 };
 })();
 
-(node as any).hash = "01d8693674c141b25ab9c428b3d632f5";
+(node as any).hash = "3683c859d26011b55f790675df252474";
 
 export default node;

--- a/src/__generated__/MyBidsQuery.graphql.ts
+++ b/src/__generated__/MyBidsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b55ab43d189935230c455e4d674d8978>>
+ * @generated SignedSource<<54eacf4487f6b3d50f0f64190a9e2cc3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -351,6 +351,26 @@ return {
                         "storageKey": null
                       },
                       (v0/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "kind": "LinkedField",
+                        "name": "sale",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isLiveOpen",
+                            "storageKey": null
+                          },
+                          (v0/*: any*/),
+                          (v4/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
                       (v4/*: any*/)
                     ],
                     "storageKey": null
@@ -368,12 +388,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "0126cb198064618a94a3634219985b1f",
+    "cacheID": "1c7b15ce7578f6ec3a6323d36dbc38a7",
     "id": null,
     "metadata": {},
     "name": "MyBidsQuery",
     "operationKind": "query",
-    "text": "query MyBidsQuery {\n  me {\n    ...MyBids_me\n    id\n  }\n}\n\nfragment MyBidsBidHeader_sale on Sale {\n  coverImage {\n    cropped(width: 330, height: 100, version: [\"source\", \"wide\", \"large_rectangle\"]) {\n      src\n      srcSet\n    }\n  }\n  formattedStartDateTime\n  name\n  partner {\n    name\n    id\n  }\n  slug\n}\n\nfragment MyBidsBidItem_saleArtwork on SaleArtwork {\n  artwork {\n    artistNames\n    image {\n      cropped(width: 55, height: 55) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    id\n  }\n  estimate\n  currentBid {\n    display\n  }\n  internalID\n  isHighestBidder\n  isWatching\n  lotState {\n    bidCount\n    sellingPrice {\n      display\n    }\n  }\n  lotLabel\n  slug\n}\n\nfragment MyBids_me on Me {\n  myBids {\n    active {\n      sale {\n        slug\n        ...MyBidsBidHeader_sale\n        id\n      }\n      saleArtworks {\n        ...MyBidsBidItem_saleArtwork\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query MyBidsQuery {\n  me {\n    ...MyBids_me\n    id\n  }\n}\n\nfragment MyBidsBidHeader_sale on Sale {\n  coverImage {\n    cropped(width: 330, height: 100, version: [\"source\", \"wide\", \"large_rectangle\"]) {\n      src\n      srcSet\n    }\n  }\n  formattedStartDateTime\n  name\n  partner {\n    name\n    id\n  }\n  slug\n}\n\nfragment MyBidsBidItem_saleArtwork on SaleArtwork {\n  artwork {\n    artistNames\n    image {\n      cropped(width: 55, height: 55) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    id\n  }\n  estimate\n  currentBid {\n    display\n  }\n  internalID\n  isHighestBidder\n  isWatching\n  lotState {\n    bidCount\n    sellingPrice {\n      display\n    }\n  }\n  lotLabel\n  slug\n  sale {\n    isLiveOpen\n    slug\n    id\n  }\n}\n\nfragment MyBids_me on Me {\n  myBids {\n    active {\n      sale {\n        slug\n        ...MyBidsBidHeader_sale\n        id\n      }\n      saleArtworks {\n        ...MyBidsBidItem_saleArtwork\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/MyBids_Test_Query.graphql.ts
+++ b/src/__generated__/MyBids_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<37446d8513dad8416be0b4f7d5524e5d>>
+ * @generated SignedSource<<4d71db8e31e91ae868286876a754ed90>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -76,33 +76,39 @@ v7 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Image"
+  "type": "Sale"
 },
 v8 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "CroppedImageUrl"
+  "type": "Image"
 },
 v9 = {
   "enumValues": null,
-  "nullable": false,
+  "nullable": true,
   "plural": false,
-  "type": "String"
+  "type": "CroppedImageUrl"
 },
 v10 = {
   "enumValues": null,
-  "nullable": true,
+  "nullable": false,
   "plural": false,
   "type": "String"
 },
 v11 = {
   "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v12 = {
+  "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Int"
 },
-v12 = {
+v13 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -393,6 +399,26 @@ return {
                         "storageKey": null
                       },
                       (v0/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Sale",
+                        "kind": "LinkedField",
+                        "name": "sale",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isLiveOpen",
+                            "storageKey": null
+                          },
+                          (v0/*: any*/),
+                          (v4/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
                       (v4/*: any*/)
                     ],
                     "storageKey": null
@@ -410,7 +436,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "20a1daa2edbe576e726062ce2fb65119",
+    "cacheID": "bbcddbc65be8f7dfc27b5d6160a8cd6d",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -433,19 +459,14 @@ return {
           "plural": true,
           "type": "MyBid"
         },
-        "me.myBids.active.sale": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "Sale"
-        },
-        "me.myBids.active.sale.coverImage": (v7/*: any*/),
-        "me.myBids.active.sale.coverImage.cropped": (v8/*: any*/),
-        "me.myBids.active.sale.coverImage.cropped.src": (v9/*: any*/),
-        "me.myBids.active.sale.coverImage.cropped.srcSet": (v9/*: any*/),
-        "me.myBids.active.sale.formattedStartDateTime": (v10/*: any*/),
+        "me.myBids.active.sale": (v7/*: any*/),
+        "me.myBids.active.sale.coverImage": (v8/*: any*/),
+        "me.myBids.active.sale.coverImage.cropped": (v9/*: any*/),
+        "me.myBids.active.sale.coverImage.cropped.src": (v10/*: any*/),
+        "me.myBids.active.sale.coverImage.cropped.srcSet": (v10/*: any*/),
+        "me.myBids.active.sale.formattedStartDateTime": (v11/*: any*/),
         "me.myBids.active.sale.id": (v6/*: any*/),
-        "me.myBids.active.sale.name": (v10/*: any*/),
+        "me.myBids.active.sale.name": (v11/*: any*/),
         "me.myBids.active.sale.partner": {
           "enumValues": null,
           "nullable": true,
@@ -453,7 +474,7 @@ return {
           "type": "Partner"
         },
         "me.myBids.active.sale.partner.id": (v6/*: any*/),
-        "me.myBids.active.sale.partner.name": (v10/*: any*/),
+        "me.myBids.active.sale.partner.name": (v11/*: any*/),
         "me.myBids.active.sale.slug": (v6/*: any*/),
         "me.myBids.active.saleArtworks": {
           "enumValues": null,
@@ -467,27 +488,27 @@ return {
           "plural": false,
           "type": "Artwork"
         },
-        "me.myBids.active.saleArtworks.artwork.artistNames": (v10/*: any*/),
+        "me.myBids.active.saleArtworks.artwork.artistNames": (v11/*: any*/),
         "me.myBids.active.saleArtworks.artwork.id": (v6/*: any*/),
-        "me.myBids.active.saleArtworks.artwork.image": (v7/*: any*/),
-        "me.myBids.active.saleArtworks.artwork.image.cropped": (v8/*: any*/),
-        "me.myBids.active.saleArtworks.artwork.image.cropped.height": (v11/*: any*/),
-        "me.myBids.active.saleArtworks.artwork.image.cropped.src": (v9/*: any*/),
-        "me.myBids.active.saleArtworks.artwork.image.cropped.srcSet": (v9/*: any*/),
-        "me.myBids.active.saleArtworks.artwork.image.cropped.width": (v11/*: any*/),
+        "me.myBids.active.saleArtworks.artwork.image": (v8/*: any*/),
+        "me.myBids.active.saleArtworks.artwork.image.cropped": (v9/*: any*/),
+        "me.myBids.active.saleArtworks.artwork.image.cropped.height": (v12/*: any*/),
+        "me.myBids.active.saleArtworks.artwork.image.cropped.src": (v10/*: any*/),
+        "me.myBids.active.saleArtworks.artwork.image.cropped.srcSet": (v10/*: any*/),
+        "me.myBids.active.saleArtworks.artwork.image.cropped.width": (v12/*: any*/),
         "me.myBids.active.saleArtworks.currentBid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkCurrentBid"
         },
-        "me.myBids.active.saleArtworks.currentBid.display": (v10/*: any*/),
-        "me.myBids.active.saleArtworks.estimate": (v10/*: any*/),
+        "me.myBids.active.saleArtworks.currentBid.display": (v11/*: any*/),
+        "me.myBids.active.saleArtworks.estimate": (v11/*: any*/),
         "me.myBids.active.saleArtworks.id": (v6/*: any*/),
         "me.myBids.active.saleArtworks.internalID": (v6/*: any*/),
-        "me.myBids.active.saleArtworks.isHighestBidder": (v12/*: any*/),
-        "me.myBids.active.saleArtworks.isWatching": (v12/*: any*/),
-        "me.myBids.active.saleArtworks.lotLabel": (v10/*: any*/),
+        "me.myBids.active.saleArtworks.isHighestBidder": (v13/*: any*/),
+        "me.myBids.active.saleArtworks.isWatching": (v13/*: any*/),
+        "me.myBids.active.saleArtworks.lotLabel": (v11/*: any*/),
         "me.myBids.active.saleArtworks.lotState": {
           "enumValues": null,
           "nullable": true,
@@ -506,13 +527,17 @@ return {
           "plural": false,
           "type": "Money"
         },
-        "me.myBids.active.saleArtworks.lotState.sellingPrice.display": (v10/*: any*/),
+        "me.myBids.active.saleArtworks.lotState.sellingPrice.display": (v11/*: any*/),
+        "me.myBids.active.saleArtworks.sale": (v7/*: any*/),
+        "me.myBids.active.saleArtworks.sale.id": (v6/*: any*/),
+        "me.myBids.active.saleArtworks.sale.isLiveOpen": (v13/*: any*/),
+        "me.myBids.active.saleArtworks.sale.slug": (v6/*: any*/),
         "me.myBids.active.saleArtworks.slug": (v6/*: any*/)
       }
     },
     "name": "MyBids_Test_Query",
     "operationKind": "query",
-    "text": "query MyBids_Test_Query {\n  me {\n    ...MyBids_me\n    id\n  }\n}\n\nfragment MyBidsBidHeader_sale on Sale {\n  coverImage {\n    cropped(width: 330, height: 100, version: [\"source\", \"wide\", \"large_rectangle\"]) {\n      src\n      srcSet\n    }\n  }\n  formattedStartDateTime\n  name\n  partner {\n    name\n    id\n  }\n  slug\n}\n\nfragment MyBidsBidItem_saleArtwork on SaleArtwork {\n  artwork {\n    artistNames\n    image {\n      cropped(width: 55, height: 55) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    id\n  }\n  estimate\n  currentBid {\n    display\n  }\n  internalID\n  isHighestBidder\n  isWatching\n  lotState {\n    bidCount\n    sellingPrice {\n      display\n    }\n  }\n  lotLabel\n  slug\n}\n\nfragment MyBids_me on Me {\n  myBids {\n    active {\n      sale {\n        slug\n        ...MyBidsBidHeader_sale\n        id\n      }\n      saleArtworks {\n        ...MyBidsBidItem_saleArtwork\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query MyBids_Test_Query {\n  me {\n    ...MyBids_me\n    id\n  }\n}\n\nfragment MyBidsBidHeader_sale on Sale {\n  coverImage {\n    cropped(width: 330, height: 100, version: [\"source\", \"wide\", \"large_rectangle\"]) {\n      src\n      srcSet\n    }\n  }\n  formattedStartDateTime\n  name\n  partner {\n    name\n    id\n  }\n  slug\n}\n\nfragment MyBidsBidItem_saleArtwork on SaleArtwork {\n  artwork {\n    artistNames\n    image {\n      cropped(width: 55, height: 55) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n    id\n  }\n  estimate\n  currentBid {\n    display\n  }\n  internalID\n  isHighestBidder\n  isWatching\n  lotState {\n    bidCount\n    sellingPrice {\n      display\n    }\n  }\n  lotLabel\n  slug\n  sale {\n    isLiveOpen\n    slug\n    id\n  }\n}\n\nfragment MyBids_me on Me {\n  myBids {\n    active {\n      sale {\n        slug\n        ...MyBidsBidHeader_sale\n        id\n      }\n      saleArtworks {\n        ...MyBidsBidItem_saleArtwork\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SettingsAuctionsLotStanding_lotStanding.graphql.ts
+++ b/src/__generated__/SettingsAuctionsLotStanding_lotStanding.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<319986c790eadc1c4f1e73ed366aa057>>
+ * @generated SignedSource<<f71985bc6883dc9e7ecf1ee861ea1fa7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,6 +26,8 @@ export type SettingsAuctionsLotStanding_lotStanding$data = {
     readonly lotLabel: string | null | undefined;
     readonly sale: {
       readonly isClosed: boolean | null | undefined;
+      readonly isLiveOpen: boolean | null | undefined;
+      readonly slug: string;
     } | null | undefined;
   } | null | undefined;
   readonly " $fragmentType": "SettingsAuctionsLotStanding_lotStanding";
@@ -71,6 +73,20 @@ const node: ReaderFragment = {
           "name": "sale",
           "plural": false,
           "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "slug",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "isLiveOpen",
+              "storageKey": null
+            },
             {
               "alias": null,
               "args": null,
@@ -159,6 +175,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "a7f0f63cb1451e8d704b21be1a14f99f";
+(node as any).hash = "2b6194438eeee34f5dc34b04a5a95b1d";
 
 export default node;

--- a/src/__generated__/SettingsAuctionsRouteQuery_Test_Query.graphql.ts
+++ b/src/__generated__/SettingsAuctionsRouteQuery_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b47aaeec390d6565c527b1bec2f728fb>>
+ * @generated SignedSource<<ec28f13778c6d54ee773e17fe05a1f15>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -116,6 +116,20 @@ v10 = [
         "name": "sale",
         "plural": false,
         "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isLiveOpen",
+            "storageKey": null
+          },
           (v1/*: any*/),
           (v2/*: any*/)
         ],
@@ -922,7 +936,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "935bda27dab726f3c508703ef02c13a7",
+    "cacheID": "bfd59289a193f6dfc80029873d7a4c7a",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -1011,6 +1025,8 @@ return {
         "me.activeLotStandings.saleArtwork.sale": (v36/*: any*/),
         "me.activeLotStandings.saleArtwork.sale.id": (v16/*: any*/),
         "me.activeLotStandings.saleArtwork.sale.isClosed": (v12/*: any*/),
+        "me.activeLotStandings.saleArtwork.sale.isLiveOpen": (v12/*: any*/),
+        "me.activeLotStandings.saleArtwork.sale.slug": (v16/*: any*/),
         "me.id": (v16/*: any*/),
         "me.inactiveLotStandings": (v11/*: any*/),
         "me.inactiveLotStandings.isLeadingBidder": (v12/*: any*/),
@@ -1091,6 +1107,8 @@ return {
         "me.inactiveLotStandings.saleArtwork.sale": (v36/*: any*/),
         "me.inactiveLotStandings.saleArtwork.sale.id": (v16/*: any*/),
         "me.inactiveLotStandings.saleArtwork.sale.isClosed": (v12/*: any*/),
+        "me.inactiveLotStandings.saleArtwork.sale.isLiveOpen": (v12/*: any*/),
+        "me.inactiveLotStandings.saleArtwork.sale.slug": (v16/*: any*/),
         "me.saleRegistrationsConnection": {
           "enumValues": null,
           "nullable": true,
@@ -1122,7 +1140,7 @@ return {
     },
     "name": "SettingsAuctionsRouteQuery_Test_Query",
     "operationKind": "query",
-    "text": "query SettingsAuctionsRouteQuery_Test_Query {\n  me {\n    ...SettingsAuctionsRoute_me\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  internalID\n  collectorSignals {\n    primaryLabel\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n}\n\nfragment SettingsAuctionsLotStanding_lotStanding on LotStanding {\n  isLeadingBidder\n  saleArtwork {\n    lotLabel\n    sale {\n      isClosed\n      id\n    }\n    artwork {\n      ...Details_artwork\n      href\n      image {\n        cropped(height: 100, width: 100) {\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment SettingsAuctionsRoute_me on Me {\n  ...UserActiveBids_me\n  ...UserBidHistory_me\n  ...UserRegistrationAuctions_me\n}\n\nfragment UserActiveBids_me on Me {\n  activeLotStandings: lotStandings(live: true) {\n    ...SettingsAuctionsLotStanding_lotStanding\n  }\n}\n\nfragment UserBidHistory_me on Me {\n  inactiveLotStandings: lotStandings(live: false) {\n    ...SettingsAuctionsLotStanding_lotStanding\n  }\n}\n\nfragment UserRegistrationAuctions_me on Me {\n  saleRegistrationsConnection(published: true, isAuction: true, sort: CREATED_AT_DESC, first: 10, registered: false) {\n    edges {\n      node {\n        isRegistered\n        sale {\n          id\n          name\n          href\n          startAt(format: \"MMMM D, h:mmA\")\n          isClosed\n          isRegistrationClosed\n        }\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query SettingsAuctionsRouteQuery_Test_Query {\n  me {\n    ...SettingsAuctionsRoute_me\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  internalID\n  collectorSignals {\n    primaryLabel\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n}\n\nfragment SettingsAuctionsLotStanding_lotStanding on LotStanding {\n  isLeadingBidder\n  saleArtwork {\n    lotLabel\n    sale {\n      slug\n      isLiveOpen\n      isClosed\n      id\n    }\n    artwork {\n      ...Details_artwork\n      href\n      image {\n        cropped(height: 100, width: 100) {\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment SettingsAuctionsRoute_me on Me {\n  ...UserActiveBids_me\n  ...UserBidHistory_me\n  ...UserRegistrationAuctions_me\n}\n\nfragment UserActiveBids_me on Me {\n  activeLotStandings: lotStandings(live: true) {\n    ...SettingsAuctionsLotStanding_lotStanding\n  }\n}\n\nfragment UserBidHistory_me on Me {\n  inactiveLotStandings: lotStandings(live: false) {\n    ...SettingsAuctionsLotStanding_lotStanding\n  }\n}\n\nfragment UserRegistrationAuctions_me on Me {\n  saleRegistrationsConnection(published: true, isAuction: true, sort: CREATED_AT_DESC, first: 10, registered: false) {\n    edges {\n      node {\n        isRegistered\n        sale {\n          id\n          name\n          href\n          startAt(format: \"MMMM D, h:mmA\")\n          isClosed\n          isRegistrationClosed\n        }\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/UserActiveBids_Test_Query.graphql.ts
+++ b/src/__generated__/UserActiveBids_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ddb4da44989b359b428ebd59cafd0bdc>>
+ * @generated SignedSource<<6c09ba0f69b572ce1d107a0ad68372a3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -211,6 +211,20 @@ return {
                     "name": "sale",
                     "plural": false,
                     "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isLiveOpen",
+                        "storageKey": null
+                      },
                       {
                         "alias": null,
                         "args": null,
@@ -660,7 +674,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "621ab771a0ff51f17450c09721218506",
+    "cacheID": "c7d3174a3b1f75f56e55aee414d69f52",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -868,12 +882,14 @@ return {
         "me.activeLotStandings.saleArtwork.sale": (v15/*: any*/),
         "me.activeLotStandings.saleArtwork.sale.id": (v11/*: any*/),
         "me.activeLotStandings.saleArtwork.sale.isClosed": (v9/*: any*/),
+        "me.activeLotStandings.saleArtwork.sale.isLiveOpen": (v9/*: any*/),
+        "me.activeLotStandings.saleArtwork.sale.slug": (v11/*: any*/),
         "me.id": (v11/*: any*/)
       }
     },
     "name": "UserActiveBids_Test_Query",
     "operationKind": "query",
-    "text": "query UserActiveBids_Test_Query {\n  me {\n    ...UserActiveBids_me\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  internalID\n  collectorSignals {\n    primaryLabel\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n}\n\nfragment SettingsAuctionsLotStanding_lotStanding on LotStanding {\n  isLeadingBidder\n  saleArtwork {\n    lotLabel\n    sale {\n      isClosed\n      id\n    }\n    artwork {\n      ...Details_artwork\n      href\n      image {\n        cropped(height: 100, width: 100) {\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment UserActiveBids_me on Me {\n  activeLotStandings: lotStandings(live: true) {\n    ...SettingsAuctionsLotStanding_lotStanding\n  }\n}\n"
+    "text": "query UserActiveBids_Test_Query {\n  me {\n    ...UserActiveBids_me\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  internalID\n  collectorSignals {\n    primaryLabel\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n}\n\nfragment SettingsAuctionsLotStanding_lotStanding on LotStanding {\n  isLeadingBidder\n  saleArtwork {\n    lotLabel\n    sale {\n      slug\n      isLiveOpen\n      isClosed\n      id\n    }\n    artwork {\n      ...Details_artwork\n      href\n      image {\n        cropped(height: 100, width: 100) {\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment UserActiveBids_me on Me {\n  activeLotStandings: lotStandings(live: true) {\n    ...SettingsAuctionsLotStanding_lotStanding\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/UserBidHistory_Test_Query.graphql.ts
+++ b/src/__generated__/UserBidHistory_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d8d24ef39d88c15ddd941623c7ba2f61>>
+ * @generated SignedSource<<e09c526e69443858d9a11b5c1c9579c3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -211,6 +211,20 @@ return {
                     "name": "sale",
                     "plural": false,
                     "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "slug",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "isLiveOpen",
+                        "storageKey": null
+                      },
                       {
                         "alias": null,
                         "args": null,
@@ -660,7 +674,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "79c3b181987654e223acb0e34daf7526",
+    "cacheID": "be535d293d360f4723c966a6aa7f136f",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -868,12 +882,14 @@ return {
         "me.inactiveLotStandings.saleArtwork.lotLabel": (v12/*: any*/),
         "me.inactiveLotStandings.saleArtwork.sale": (v15/*: any*/),
         "me.inactiveLotStandings.saleArtwork.sale.id": (v9/*: any*/),
-        "me.inactiveLotStandings.saleArtwork.sale.isClosed": (v10/*: any*/)
+        "me.inactiveLotStandings.saleArtwork.sale.isClosed": (v10/*: any*/),
+        "me.inactiveLotStandings.saleArtwork.sale.isLiveOpen": (v10/*: any*/),
+        "me.inactiveLotStandings.saleArtwork.sale.slug": (v9/*: any*/)
       }
     },
     "name": "UserBidHistory_Test_Query",
     "operationKind": "query",
-    "text": "query UserBidHistory_Test_Query {\n  me {\n    ...UserBidHistory_me\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  internalID\n  collectorSignals {\n    primaryLabel\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n}\n\nfragment SettingsAuctionsLotStanding_lotStanding on LotStanding {\n  isLeadingBidder\n  saleArtwork {\n    lotLabel\n    sale {\n      isClosed\n      id\n    }\n    artwork {\n      ...Details_artwork\n      href\n      image {\n        cropped(height: 100, width: 100) {\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment UserBidHistory_me on Me {\n  inactiveLotStandings: lotStandings(live: false) {\n    ...SettingsAuctionsLotStanding_lotStanding\n  }\n}\n"
+    "text": "query UserBidHistory_Test_Query {\n  me {\n    ...UserBidHistory_me\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  internalID\n  collectorSignals {\n    primaryLabel\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n}\n\nfragment SettingsAuctionsLotStanding_lotStanding on LotStanding {\n  isLeadingBidder\n  saleArtwork {\n    lotLabel\n    sale {\n      slug\n      isLiveOpen\n      isClosed\n      id\n    }\n    artwork {\n      ...Details_artwork\n      href\n      image {\n        cropped(height: 100, width: 100) {\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment UserBidHistory_me on Me {\n  inactiveLotStandings: lotStandings(live: false) {\n    ...SettingsAuctionsLotStanding_lotStanding\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/settingsRoutes_SettingsAuctionsRouteQuery.graphql.ts
+++ b/src/__generated__/settingsRoutes_SettingsAuctionsRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<60493e847d2fde286828cee03cae4551>>
+ * @generated SignedSource<<43eeb7719e24d0d6641d31f677c489f2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -116,6 +116,20 @@ v10 = [
         "name": "sale",
         "plural": false,
         "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isLiveOpen",
+            "storageKey": null
+          },
           (v1/*: any*/),
           (v2/*: any*/)
         ],
@@ -732,12 +746,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "03231d52fceea5782ba1e69508d8f2e0",
+    "cacheID": "4005a4b836253774bf34858acbc6b8dd",
     "id": null,
     "metadata": {},
     "name": "settingsRoutes_SettingsAuctionsRouteQuery",
     "operationKind": "query",
-    "text": "query settingsRoutes_SettingsAuctionsRouteQuery {\n  me {\n    ...SettingsAuctionsRoute_me\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  internalID\n  collectorSignals {\n    primaryLabel\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n}\n\nfragment SettingsAuctionsLotStanding_lotStanding on LotStanding {\n  isLeadingBidder\n  saleArtwork {\n    lotLabel\n    sale {\n      isClosed\n      id\n    }\n    artwork {\n      ...Details_artwork\n      href\n      image {\n        cropped(height: 100, width: 100) {\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment SettingsAuctionsRoute_me on Me {\n  ...UserActiveBids_me\n  ...UserBidHistory_me\n  ...UserRegistrationAuctions_me\n}\n\nfragment UserActiveBids_me on Me {\n  activeLotStandings: lotStandings(live: true) {\n    ...SettingsAuctionsLotStanding_lotStanding\n  }\n}\n\nfragment UserBidHistory_me on Me {\n  inactiveLotStandings: lotStandings(live: false) {\n    ...SettingsAuctionsLotStanding_lotStanding\n  }\n}\n\nfragment UserRegistrationAuctions_me on Me {\n  saleRegistrationsConnection(published: true, isAuction: true, sort: CREATED_AT_DESC, first: 10, registered: false) {\n    edges {\n      node {\n        isRegistered\n        sale {\n          id\n          name\n          href\n          startAt(format: \"MMMM D, h:mmA\")\n          isClosed\n          isRegistrationClosed\n        }\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query settingsRoutes_SettingsAuctionsRouteQuery {\n  me {\n    ...SettingsAuctionsRoute_me\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  internalID\n  collectorSignals {\n    primaryLabel\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n}\n\nfragment SettingsAuctionsLotStanding_lotStanding on LotStanding {\n  isLeadingBidder\n  saleArtwork {\n    lotLabel\n    sale {\n      slug\n      isLiveOpen\n      isClosed\n      id\n    }\n    artwork {\n      ...Details_artwork\n      href\n      image {\n        cropped(height: 100, width: 100) {\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment SettingsAuctionsRoute_me on Me {\n  ...UserActiveBids_me\n  ...UserBidHistory_me\n  ...UserRegistrationAuctions_me\n}\n\nfragment UserActiveBids_me on Me {\n  activeLotStandings: lotStandings(live: true) {\n    ...SettingsAuctionsLotStanding_lotStanding\n  }\n}\n\nfragment UserBidHistory_me on Me {\n  inactiveLotStandings: lotStandings(live: false) {\n    ...SettingsAuctionsLotStanding_lotStanding\n  }\n}\n\nfragment UserRegistrationAuctions_me on Me {\n  saleRegistrationsConnection(published: true, isAuction: true, sort: CREATED_AT_DESC, first: 10, registered: false) {\n    edges {\n      node {\n        isRegistered\n        sale {\n          id\n          name\n          href\n          startAt(format: \"MMMM D, h:mmA\")\n          isClosed\n          isRegistrationClosed\n        }\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Address EMI-2234

This solution is not ideal but as we currently don't have a good way to pull updated current bid info from live auction - add 'live bidding' instead of displaying bid status in relevant screens similar to how we display it on Artwork screen:
![Screenshot 2025-02-19 at 4 32 26 PM](https://github.com/user-attachments/assets/0db148b1-d391-4168-ad93-070163bd2aaa)


|Before|After|
|---|---|
|My Bids screen||
|![Screenshot 2025-02-19 at 4 33 54 PM](https://github.com/user-attachments/assets/d765790d-fc59-4fbc-9545-453e47ac22fd)|![Screenshot 2025-02-19 at 4 35 26 PM](https://github.com/user-attachments/assets/15001cf6-dbdd-455c-8c86-108a38e794fd)
|Auction screen| |
|![Screenshot 2025-02-19 at 4 32 00 PM](https://github.com/user-attachments/assets/5a8e76cd-ee30-4497-92d9-dfe39397d2cd)|![Screenshot 2025-02-19 at 4 31 29 PM](https://github.com/user-attachments/assets/a692b02e-0587-458b-9d20-cf72ee7ec3ae)
|Auctions screen| |
|![Screenshot 2025-02-19 at 5 00 17 PM](https://github.com/user-attachments/assets/595718a3-9e44-43ad-ba82-22415ac052d1)|![Screenshot 2025-02-19 at 5 00 46 PM](https://github.com/user-attachments/assets/ad407f47-d2ac-422e-937e-7566bd1492db)

There is probably some specs failing and I need to figure out what data is available for myBids screen once the auction is closed and bring back either 'Won' or 'Outbid' info there.

