### PR TITLE
feat(EMI-2294): move and style express checkout element

### DIFF
--- a/src/Apps/Order/Routes/Payment/ExpressCheckoutPrototype/ExpressCheckout.tsx
+++ b/src/Apps/Order/Routes/Payment/ExpressCheckoutPrototype/ExpressCheckout.tsx
@@ -4,11 +4,14 @@ import {
   useElements,
   useStripe,
 } from "@stripe/react-stripe-js"
+import type { StripeExpressCheckoutElementOptions } from "@stripe/stripe-js"
+import { useState } from "react"
 
 export const ExpressCheckout = () => {
   const elements = useElements()
   const stripe = useStripe()
   const clientSecret = "client_secret_id"
+  const [isReady, setIsReady] = useState(false)
 
   const onConfirm = async () => {
     if (!stripe || !elements) {
@@ -28,12 +31,31 @@ export const ExpressCheckout = () => {
     }
   }
 
+  const expressCheckoutOptions: StripeExpressCheckoutElementOptions = {
+    buttonTheme: {
+      applePay: "white-outline",
+    },
+    buttonHeight: 50,
+  }
+
   return (
     <>
-      <Text variant="lg-display">Express checkout</Text>
-      <Spacer y={1} />
-      <ExpressCheckoutElement onConfirm={onConfirm} />
-      <Spacer y={4} />
+      {isReady && (
+        <>
+          <Text variant="lg-display">Express checkout</Text>
+          <Spacer y={1} />
+        </>
+      )}
+      <ExpressCheckoutElement
+        options={expressCheckoutOptions}
+        onConfirm={onConfirm}
+        onReady={e => {
+          if (!!e.availablePaymentMethods) {
+            setIsReady(true)
+          }
+        }}
+      />
+      {isReady && <Spacer y={4} />}
     </>
   )
 }

--- a/src/Apps/Order/Routes/Payment/ExpressCheckoutPrototype/ExpressCheckoutProvider.tsx
+++ b/src/Apps/Order/Routes/Payment/ExpressCheckoutPrototype/ExpressCheckoutProvider.tsx
@@ -2,9 +2,20 @@ import { Elements } from "@stripe/react-stripe-js"
 import { type StripeElementsOptions, loadStripe } from "@stripe/stripe-js"
 import { ExpressCheckout } from "Apps/Order/Routes/Payment/ExpressCheckoutPrototype/ExpressCheckout"
 import { getENV } from "Utils/getENV"
+import { graphql, useFragment } from "react-relay"
 
 export const ExpressCheckoutProvider = ({ order }) => {
-  const { buyerTotalCents } = order
+  const data = useFragment(
+    graphql`
+      fragment ExpressCheckoutProvider_order on CommerceOrder {
+        internalID
+        buyerTotalCents
+      }
+    `,
+    order,
+  )
+
+  const { buyerTotalCents } = data
 
   if (!buyerTotalCents) {
     return null
@@ -14,15 +25,18 @@ export const ExpressCheckoutProvider = ({ order }) => {
     mode: "payment",
     amount: buyerTotalCents,
     currency: "usd",
+    appearance: {
+      variables: {
+        borderRadius: "50px",
+      },
+    },
   }
 
   const stripePromise = loadStripe(getENV("STRIPE_PUBLISHABLE_KEY"))
 
   return (
-    <>
-      <Elements stripe={stripePromise} options={options}>
-        <ExpressCheckout />
-      </Elements>
-    </>
+    <Elements stripe={stripePromise} options={options}>
+      <ExpressCheckout />
+    </Elements>
   )
 }

--- a/src/Apps/Order/Routes/Payment/PaymentContent.tsx
+++ b/src/Apps/Order/Routes/Payment/PaymentContent.tsx
@@ -19,10 +19,8 @@ import {
   CreditCardPickerFragmentContainer,
 } from "Apps/Order/Components/CreditCardPicker"
 import { SaveAndContinueButton } from "Apps/Order/Components/SaveAndContinueButton"
-import { ExpressCheckoutProvider } from "Apps/Order/Routes/Payment/ExpressCheckoutPrototype/ExpressCheckoutProvider"
 import type { CommitMutation } from "Apps/Order/Utils/commitMutation"
 import { RouterLink } from "System/Components/RouterLink"
-import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
 import { Jump } from "Utils/Hooks/useJump"
 import { extractNodes } from "Utils/extractNodes"
 import type { Payment_me$data } from "__generated__/Payment_me.graphql"
@@ -77,19 +75,8 @@ export const PaymentContent: FC<React.PropsWithChildren<Props>> = props => {
     }
   }, [order, selectedPaymentMethod, tracking])
 
-  const expressCheckoutPrototypeEnabled = useFeatureFlag(
-    "emerald_stripe-express-checkout-prototype",
-  )
-
   return (
     <>
-      {/* Express Checkout */}
-      {expressCheckoutPrototypeEnabled && (
-        <>
-          <ExpressCheckoutProvider order={order} />
-        </>
-      )}
-
       {order.availablePaymentMethods.length > 1 && (
         <>
           <Text variant="lg-display">Payment method</Text>

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -9,12 +9,14 @@ import {
 } from "Apps/Order/Components/OrderStepper"
 import { TransactionDetailsSummaryItemFragmentContainer as TransactionDetailsSummaryItem } from "Apps/Order/Components/TransactionDetailsSummaryItem"
 import { type Dialog, injectDialog } from "Apps/Order/Dialogs"
+import { ExpressCheckoutProvider } from "Apps/Order/Routes/Payment/ExpressCheckoutPrototype/ExpressCheckoutProvider"
 import { FulfillmentDetails } from "Apps/Order/Routes/Shipping/Components/FulfillmentDetails"
 import { SaveAndContinueButton } from "Apps/Order/Routes/Shipping/Components/SaveAndContinueButton"
 import { ShippingQuotes } from "Apps/Order/Routes/Shipping/Components/ShippingQuotes"
 import { useShippingContext } from "Apps/Order/Routes/Shipping/Hooks/useShippingContext"
 import { ShippingContextProvider } from "Apps/Order/Routes/Shipping/ShippingContext"
 import { Analytics } from "System/Contexts/AnalyticsContext"
+import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
 import { Jump, useJump } from "Utils/Hooks/useJump"
 import { Media } from "Utils/Responsive"
 import type {
@@ -72,6 +74,10 @@ const ShippingRouteLayout: FC<
 
   const { jumpTo } = useJump()
 
+  const expressCheckoutPrototypeEnabled = useFeatureFlag(
+    "emerald_stripe-express-checkout-prototype",
+  )
+
   // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
     if (shippingContext.state.stage === "shipping_quotes") {
@@ -96,6 +102,11 @@ const ShippingRouteLayout: FC<
                 : {}
             }
           >
+            {expressCheckoutPrototypeEnabled &&
+              !shippingContext.orderData.isOffer && (
+                <ExpressCheckoutProvider order={order} />
+              )}
+
             <FulfillmentDetails me={me} order={order} />
 
             <Jump id="shippingOptionsTop" />
@@ -143,6 +154,7 @@ const ORDER_FRAGMENT = graphql`
     ...TransactionDetailsSummaryItem_order
     ...OrderStepper_order
     ...ShippingQuotes_order
+    ...ExpressCheckoutProvider_order
     internalID
   }
 `

--- a/src/__generated__/ExpressCheckoutProvider_order.graphql.ts
+++ b/src/__generated__/ExpressCheckoutProvider_order.graphql.ts
@@ -1,0 +1,50 @@
+/**
+ * @generated SignedSource<<5951cfa5127a8c3962bb9f83c5be5007>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ExpressCheckoutProvider_order$data = {
+  readonly buyerTotalCents: number | null | undefined;
+  readonly internalID: string;
+  readonly " $fragmentType": "ExpressCheckoutProvider_order";
+};
+export type ExpressCheckoutProvider_order$key = {
+  readonly " $data"?: ExpressCheckoutProvider_order$data;
+  readonly " $fragmentSpreads": FragmentRefs<"ExpressCheckoutProvider_order">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ExpressCheckoutProvider_order",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "internalID",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "buyerTotalCents",
+      "storageKey": null
+    }
+  ],
+  "type": "CommerceOrder",
+  "abstractKey": "__isCommerceOrder"
+};
+
+(node as any).hash = "0173f5ca191bf4ac4286b339a6bbf224";
+
+export default node;

--- a/src/__generated__/ShippingTestQuery.graphql.ts
+++ b/src/__generated__/ShippingTestQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c702f4c9e41ddd79ef08039fa1e938dc>>
+ * @generated SignedSource<<220aa30fd849d767932e9ea52989c956>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -56,6 +56,7 @@ export type ShippingTestQuery$rawResponse = {
     readonly __typename: "CommerceOfferOrder";
     readonly __isCommerceOrder: "CommerceOfferOrder";
     readonly buyerTotal: string | null | undefined;
+    readonly buyerTotalCents: number | null | undefined;
     readonly code: string;
     readonly currencyCode: string;
     readonly displayState: CommerceOrderDisplayStateEnum;
@@ -209,6 +210,7 @@ export type ShippingTestQuery$rawResponse = {
     readonly __typename: string;
     readonly __isCommerceOrder: string;
     readonly buyerTotal: string | null | undefined;
+    readonly buyerTotalCents: number | null | undefined;
     readonly code: string;
     readonly currencyCode: string;
     readonly displayState: CommerceOrderDisplayStateEnum;
@@ -498,7 +500,14 @@ v22 = {
   "name": "buyerTotal",
   "storageKey": "buyerTotal(precision:2)"
 },
-v23 = [
+v23 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "buyerTotalCents",
+  "storageKey": null
+},
+v24 = [
   (v2/*: any*/),
   {
     "alias": null,
@@ -519,13 +528,7 @@ v23 = [
   (v20/*: any*/),
   (v21/*: any*/),
   (v22/*: any*/),
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "buyerTotalCents",
-    "storageKey": null
-  },
+  (v23/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -542,41 +545,35 @@ v23 = [
   },
   (v12/*: any*/)
 ],
-v24 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "String"
-},
 v25 = {
   "enumValues": null,
-  "nullable": true,
+  "nullable": false,
   "plural": false,
   "type": "String"
 },
 v26 = {
   "enumValues": null,
-  "nullable": false,
+  "nullable": true,
   "plural": false,
-  "type": "ID"
+  "type": "String"
 },
 v27 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
-  "type": "Boolean"
+  "type": "ID"
 },
 v28 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
-  "type": "Int"
+  "type": "Boolean"
 },
 v29 = {
   "enumValues": null,
-  "nullable": true,
+  "nullable": false,
   "plural": false,
-  "type": "CommerceOffer"
+  "type": "Int"
 },
 v30 = {
   "enumValues": null,
@@ -585,6 +582,12 @@ v30 = {
   "type": "Int"
 },
 v31 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "CommerceOffer"
+},
+v32 = {
   "enumValues": [
     "BUYER",
     "SELLER"
@@ -593,13 +596,13 @@ v31 = {
   "plural": false,
   "type": "CommerceOrderParticipantEnum"
 },
-v32 = {
+v33 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Boolean"
 },
-v33 = {
+v34 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -1054,7 +1057,7 @@ return {
                 "kind": "LinkedField",
                 "name": "lastOffer",
                 "plural": false,
-                "selections": (v23/*: any*/),
+                "selections": (v24/*: any*/),
                 "storageKey": null
               },
               {
@@ -1064,7 +1067,7 @@ return {
                 "kind": "LinkedField",
                 "name": "myLastOffer",
                 "plural": false,
-                "selections": (v23/*: any*/),
+                "selections": (v24/*: any*/),
                 "storageKey": null
               }
             ],
@@ -1116,6 +1119,7 @@ return {
             ],
             "storageKey": null
           },
+          (v23/*: any*/),
           (v12/*: any*/)
         ],
         "storageKey": "commerceOrder(id:\"unused\")"
@@ -1226,7 +1230,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4db0a72581f354620ebf4b83a3b14dae",
+    "cacheID": "afa442b27ce77614e62d006850777f3b",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -1254,41 +1258,42 @@ return {
           "plural": false,
           "type": "UserAddress"
         },
-        "me.addressConnection.edges.node.addressLine1": (v24/*: any*/),
-        "me.addressConnection.edges.node.addressLine2": (v25/*: any*/),
-        "me.addressConnection.edges.node.addressLine3": (v25/*: any*/),
-        "me.addressConnection.edges.node.city": (v24/*: any*/),
-        "me.addressConnection.edges.node.country": (v24/*: any*/),
-        "me.addressConnection.edges.node.id": (v26/*: any*/),
-        "me.addressConnection.edges.node.internalID": (v26/*: any*/),
-        "me.addressConnection.edges.node.isDefault": (v27/*: any*/),
-        "me.addressConnection.edges.node.name": (v25/*: any*/),
-        "me.addressConnection.edges.node.phoneNumber": (v25/*: any*/),
-        "me.addressConnection.edges.node.postalCode": (v25/*: any*/),
-        "me.addressConnection.edges.node.region": (v25/*: any*/),
-        "me.addressConnection.totalCount": (v28/*: any*/),
-        "me.email": (v25/*: any*/),
-        "me.id": (v26/*: any*/),
+        "me.addressConnection.edges.node.addressLine1": (v25/*: any*/),
+        "me.addressConnection.edges.node.addressLine2": (v26/*: any*/),
+        "me.addressConnection.edges.node.addressLine3": (v26/*: any*/),
+        "me.addressConnection.edges.node.city": (v25/*: any*/),
+        "me.addressConnection.edges.node.country": (v25/*: any*/),
+        "me.addressConnection.edges.node.id": (v27/*: any*/),
+        "me.addressConnection.edges.node.internalID": (v27/*: any*/),
+        "me.addressConnection.edges.node.isDefault": (v28/*: any*/),
+        "me.addressConnection.edges.node.name": (v26/*: any*/),
+        "me.addressConnection.edges.node.phoneNumber": (v26/*: any*/),
+        "me.addressConnection.edges.node.postalCode": (v26/*: any*/),
+        "me.addressConnection.edges.node.region": (v26/*: any*/),
+        "me.addressConnection.totalCount": (v29/*: any*/),
+        "me.email": (v26/*: any*/),
+        "me.id": (v27/*: any*/),
         "me.location": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "MyLocation"
         },
-        "me.location.country": (v25/*: any*/),
-        "me.location.id": (v26/*: any*/),
-        "me.name": (v25/*: any*/),
+        "me.location.country": (v26/*: any*/),
+        "me.location.id": (v27/*: any*/),
+        "me.name": (v26/*: any*/),
         "order": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "CommerceOrder"
         },
-        "order.__isCommerceOrder": (v24/*: any*/),
-        "order.__typename": (v24/*: any*/),
-        "order.buyerTotal": (v25/*: any*/),
-        "order.code": (v24/*: any*/),
-        "order.currencyCode": (v24/*: any*/),
+        "order.__isCommerceOrder": (v25/*: any*/),
+        "order.__typename": (v25/*: any*/),
+        "order.buyerTotal": (v26/*: any*/),
+        "order.buyerTotalCents": (v30/*: any*/),
+        "order.code": (v25/*: any*/),
+        "order.currencyCode": (v25/*: any*/),
         "order.displayState": {
           "enumValues": [
             "ABANDONED",
@@ -1307,21 +1312,21 @@ return {
           "plural": false,
           "type": "CommerceOrderDisplayStateEnum"
         },
-        "order.id": (v26/*: any*/),
-        "order.internalID": (v26/*: any*/),
-        "order.itemsTotal": (v25/*: any*/),
-        "order.lastOffer": (v29/*: any*/),
-        "order.lastOffer.amount": (v25/*: any*/),
-        "order.lastOffer.amountCents": (v28/*: any*/),
-        "order.lastOffer.buyerTotal": (v25/*: any*/),
+        "order.id": (v27/*: any*/),
+        "order.internalID": (v27/*: any*/),
+        "order.itemsTotal": (v26/*: any*/),
+        "order.lastOffer": (v31/*: any*/),
+        "order.lastOffer.amount": (v26/*: any*/),
+        "order.lastOffer.amountCents": (v29/*: any*/),
+        "order.lastOffer.buyerTotal": (v26/*: any*/),
         "order.lastOffer.buyerTotalCents": (v30/*: any*/),
-        "order.lastOffer.fromParticipant": (v31/*: any*/),
-        "order.lastOffer.id": (v26/*: any*/),
-        "order.lastOffer.internalID": (v26/*: any*/),
-        "order.lastOffer.note": (v25/*: any*/),
-        "order.lastOffer.shippingTotal": (v25/*: any*/),
+        "order.lastOffer.fromParticipant": (v32/*: any*/),
+        "order.lastOffer.id": (v27/*: any*/),
+        "order.lastOffer.internalID": (v27/*: any*/),
+        "order.lastOffer.note": (v26/*: any*/),
+        "order.lastOffer.shippingTotal": (v26/*: any*/),
         "order.lastOffer.shippingTotalCents": (v30/*: any*/),
-        "order.lastOffer.taxTotal": (v25/*: any*/),
+        "order.lastOffer.taxTotal": (v26/*: any*/),
         "order.lastOffer.taxTotalCents": (v30/*: any*/),
         "order.lineItems": {
           "enumValues": null,
@@ -1347,35 +1352,35 @@ return {
           "plural": false,
           "type": "Artwork"
         },
-        "order.lineItems.edges.node.artwork.artsyShippingInternational": (v32/*: any*/),
-        "order.lineItems.edges.node.artwork.euShippingOrigin": (v32/*: any*/),
-        "order.lineItems.edges.node.artwork.id": (v26/*: any*/),
-        "order.lineItems.edges.node.artwork.isUnlisted": (v27/*: any*/),
-        "order.lineItems.edges.node.artwork.onlyShipsDomestically": (v32/*: any*/),
-        "order.lineItems.edges.node.artwork.pickupAvailable": (v32/*: any*/),
-        "order.lineItems.edges.node.artwork.processWithArtsyShippingDomestic": (v32/*: any*/),
-        "order.lineItems.edges.node.artwork.shippingCountry": (v25/*: any*/),
-        "order.lineItems.edges.node.artwork.shippingOrigin": (v25/*: any*/),
-        "order.lineItems.edges.node.artwork.slug": (v26/*: any*/),
+        "order.lineItems.edges.node.artwork.artsyShippingInternational": (v33/*: any*/),
+        "order.lineItems.edges.node.artwork.euShippingOrigin": (v33/*: any*/),
+        "order.lineItems.edges.node.artwork.id": (v27/*: any*/),
+        "order.lineItems.edges.node.artwork.isUnlisted": (v28/*: any*/),
+        "order.lineItems.edges.node.artwork.onlyShipsDomestically": (v33/*: any*/),
+        "order.lineItems.edges.node.artwork.pickupAvailable": (v33/*: any*/),
+        "order.lineItems.edges.node.artwork.processWithArtsyShippingDomestic": (v33/*: any*/),
+        "order.lineItems.edges.node.artwork.shippingCountry": (v26/*: any*/),
+        "order.lineItems.edges.node.artwork.shippingOrigin": (v26/*: any*/),
+        "order.lineItems.edges.node.artwork.slug": (v27/*: any*/),
         "order.lineItems.edges.node.artworkOrEditionSet": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtworkOrEditionSetType"
         },
-        "order.lineItems.edges.node.artworkOrEditionSet.__isNode": (v24/*: any*/),
-        "order.lineItems.edges.node.artworkOrEditionSet.__typename": (v24/*: any*/),
-        "order.lineItems.edges.node.artworkOrEditionSet.id": (v26/*: any*/),
-        "order.lineItems.edges.node.artworkOrEditionSet.price": (v25/*: any*/),
+        "order.lineItems.edges.node.artworkOrEditionSet.__isNode": (v25/*: any*/),
+        "order.lineItems.edges.node.artworkOrEditionSet.__typename": (v25/*: any*/),
+        "order.lineItems.edges.node.artworkOrEditionSet.id": (v27/*: any*/),
+        "order.lineItems.edges.node.artworkOrEditionSet.price": (v26/*: any*/),
         "order.lineItems.edges.node.artworkVersion": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtworkVersion"
         },
-        "order.lineItems.edges.node.artworkVersion.artistNames": (v25/*: any*/),
-        "order.lineItems.edges.node.artworkVersion.date": (v25/*: any*/),
-        "order.lineItems.edges.node.artworkVersion.id": (v26/*: any*/),
+        "order.lineItems.edges.node.artworkVersion.artistNames": (v26/*: any*/),
+        "order.lineItems.edges.node.artworkVersion.date": (v26/*: any*/),
+        "order.lineItems.edges.node.artworkVersion.id": (v27/*: any*/),
         "order.lineItems.edges.node.artworkVersion.image": {
           "enumValues": null,
           "nullable": true,
@@ -1388,12 +1393,12 @@ return {
           "plural": false,
           "type": "ResizedImageUrl"
         },
-        "order.lineItems.edges.node.artworkVersion.image.resized.url": (v24/*: any*/),
-        "order.lineItems.edges.node.artworkVersion.title": (v25/*: any*/),
-        "order.lineItems.edges.node.id": (v26/*: any*/),
-        "order.lineItems.edges.node.selectedShippingQuote": (v33/*: any*/),
-        "order.lineItems.edges.node.selectedShippingQuote.id": (v26/*: any*/),
-        "order.lineItems.edges.node.selectedShippingQuote.typeName": (v24/*: any*/),
+        "order.lineItems.edges.node.artworkVersion.image.resized.url": (v25/*: any*/),
+        "order.lineItems.edges.node.artworkVersion.title": (v26/*: any*/),
+        "order.lineItems.edges.node.id": (v27/*: any*/),
+        "order.lineItems.edges.node.selectedShippingQuote": (v34/*: any*/),
+        "order.lineItems.edges.node.selectedShippingQuote.id": (v27/*: any*/),
+        "order.lineItems.edges.node.selectedShippingQuote.typeName": (v25/*: any*/),
         "order.lineItems.edges.node.shippingQuoteOptions": {
           "enumValues": null,
           "nullable": true,
@@ -1406,12 +1411,12 @@ return {
           "plural": true,
           "type": "CommerceShippingQuoteEdge"
         },
-        "order.lineItems.edges.node.shippingQuoteOptions.edges.node": (v33/*: any*/),
-        "order.lineItems.edges.node.shippingQuoteOptions.edges.node.id": (v26/*: any*/),
-        "order.lineItems.edges.node.shippingQuoteOptions.edges.node.isSelected": (v27/*: any*/),
-        "order.lineItems.edges.node.shippingQuoteOptions.edges.node.price": (v25/*: any*/),
-        "order.lineItems.edges.node.shippingQuoteOptions.edges.node.priceCents": (v28/*: any*/),
-        "order.lineItems.edges.node.shippingQuoteOptions.edges.node.typeName": (v24/*: any*/),
+        "order.lineItems.edges.node.shippingQuoteOptions.edges.node": (v34/*: any*/),
+        "order.lineItems.edges.node.shippingQuoteOptions.edges.node.id": (v27/*: any*/),
+        "order.lineItems.edges.node.shippingQuoteOptions.edges.node.isSelected": (v28/*: any*/),
+        "order.lineItems.edges.node.shippingQuoteOptions.edges.node.price": (v26/*: any*/),
+        "order.lineItems.edges.node.shippingQuoteOptions.edges.node.priceCents": (v29/*: any*/),
+        "order.lineItems.edges.node.shippingQuoteOptions.edges.node.typeName": (v25/*: any*/),
         "order.mode": {
           "enumValues": [
             "BUY",
@@ -1421,18 +1426,18 @@ return {
           "plural": false,
           "type": "CommerceOrderModeEnum"
         },
-        "order.myLastOffer": (v29/*: any*/),
-        "order.myLastOffer.amount": (v25/*: any*/),
-        "order.myLastOffer.amountCents": (v28/*: any*/),
-        "order.myLastOffer.buyerTotal": (v25/*: any*/),
+        "order.myLastOffer": (v31/*: any*/),
+        "order.myLastOffer.amount": (v26/*: any*/),
+        "order.myLastOffer.amountCents": (v29/*: any*/),
+        "order.myLastOffer.buyerTotal": (v26/*: any*/),
         "order.myLastOffer.buyerTotalCents": (v30/*: any*/),
-        "order.myLastOffer.fromParticipant": (v31/*: any*/),
-        "order.myLastOffer.id": (v26/*: any*/),
-        "order.myLastOffer.internalID": (v26/*: any*/),
-        "order.myLastOffer.note": (v25/*: any*/),
-        "order.myLastOffer.shippingTotal": (v25/*: any*/),
+        "order.myLastOffer.fromParticipant": (v32/*: any*/),
+        "order.myLastOffer.id": (v27/*: any*/),
+        "order.myLastOffer.internalID": (v27/*: any*/),
+        "order.myLastOffer.note": (v26/*: any*/),
+        "order.myLastOffer.shippingTotal": (v26/*: any*/),
         "order.myLastOffer.shippingTotalCents": (v30/*: any*/),
-        "order.myLastOffer.taxTotal": (v25/*: any*/),
+        "order.myLastOffer.taxTotal": (v26/*: any*/),
         "order.myLastOffer.taxTotalCents": (v30/*: any*/),
         "order.paymentMethodDetails": {
           "enumValues": null,
@@ -1440,36 +1445,36 @@ return {
           "plural": false,
           "type": "PaymentMethodUnion"
         },
-        "order.paymentMethodDetails.__typename": (v24/*: any*/),
-        "order.paymentMethodDetails.id": (v26/*: any*/),
-        "order.paymentMethodDetails.isManualPayment": (v27/*: any*/),
-        "order.paymentSet": (v27/*: any*/),
+        "order.paymentMethodDetails.__typename": (v25/*: any*/),
+        "order.paymentMethodDetails.id": (v27/*: any*/),
+        "order.paymentMethodDetails.isManualPayment": (v28/*: any*/),
+        "order.paymentSet": (v28/*: any*/),
         "order.requestedFulfillment": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "CommerceRequestedFulfillmentUnion"
         },
-        "order.requestedFulfillment.__typename": (v24/*: any*/),
-        "order.requestedFulfillment.addressLine1": (v25/*: any*/),
-        "order.requestedFulfillment.addressLine2": (v25/*: any*/),
-        "order.requestedFulfillment.city": (v25/*: any*/),
-        "order.requestedFulfillment.country": (v25/*: any*/),
-        "order.requestedFulfillment.name": (v25/*: any*/),
-        "order.requestedFulfillment.phoneNumber": (v25/*: any*/),
-        "order.requestedFulfillment.postalCode": (v25/*: any*/),
-        "order.requestedFulfillment.region": (v25/*: any*/),
+        "order.requestedFulfillment.__typename": (v25/*: any*/),
+        "order.requestedFulfillment.addressLine1": (v26/*: any*/),
+        "order.requestedFulfillment.addressLine2": (v26/*: any*/),
+        "order.requestedFulfillment.city": (v26/*: any*/),
+        "order.requestedFulfillment.country": (v26/*: any*/),
+        "order.requestedFulfillment.name": (v26/*: any*/),
+        "order.requestedFulfillment.phoneNumber": (v26/*: any*/),
+        "order.requestedFulfillment.postalCode": (v26/*: any*/),
+        "order.requestedFulfillment.region": (v26/*: any*/),
         "order.sellerDetails": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "OrderParty"
         },
-        "order.sellerDetails.__isNode": (v24/*: any*/),
-        "order.sellerDetails.__typename": (v24/*: any*/),
-        "order.sellerDetails.id": (v26/*: any*/),
-        "order.sellerDetails.name": (v25/*: any*/),
-        "order.shippingTotal": (v25/*: any*/),
+        "order.sellerDetails.__isNode": (v25/*: any*/),
+        "order.sellerDetails.__typename": (v25/*: any*/),
+        "order.sellerDetails.id": (v27/*: any*/),
+        "order.sellerDetails.name": (v26/*: any*/),
+        "order.shippingTotal": (v26/*: any*/),
         "order.shippingTotalCents": (v30/*: any*/),
         "order.source": {
           "enumValues": [
@@ -1482,13 +1487,13 @@ return {
           "plural": false,
           "type": "CommerceOrderSourceEnum"
         },
-        "order.taxTotal": (v25/*: any*/),
+        "order.taxTotal": (v26/*: any*/),
         "order.taxTotalCents": (v30/*: any*/)
       }
     },
     "name": "ShippingTestQuery",
     "operationKind": "query",
-    "text": "query ShippingTestQuery {\n  order: commerceOrder(id: \"unused\") {\n    __typename\n    ...Shipping_order\n    id\n  }\n  me {\n    ...Shipping_me\n    id\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  currencyCode\n  mode\n  source\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        artwork {\n          slug\n          shippingOrigin\n          isUnlisted\n          id\n        }\n        artworkVersion {\n          date\n          artistNames\n          title\n          image {\n            resized(width: 185) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment FulfillmentDetailsForm_me on Me {\n  name\n  email\n  id\n  location {\n    country\n    id\n  }\n  addressConnection(first: 30) {\n    totalCount\n  }\n}\n\nfragment FulfillmentDetailsForm_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  lineItems {\n    edges {\n      node {\n        artwork {\n          pickupAvailable\n          id\n        }\n        id\n      }\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...OrderStepper_order\n}\n\nfragment OrderStepper_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  mode\n  paymentSet\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      id\n    }\n    ... on BankAccount {\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        shippingQuoteOptions {\n          edges {\n            node {\n              isSelected\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SaveAndContinueButton_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n}\n\nfragment ShippingContext_me_dXEtb on Me {\n  name\n  addressConnection(first: 30) {\n    edges {\n      node {\n        id\n        internalID\n        addressLine1\n        addressLine2\n        addressLine3\n        city\n        country\n        isDefault\n        name\n        phoneNumber\n        postalCode\n        region\n      }\n    }\n  }\n}\n\nfragment ShippingContext_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  mode\n  requestedFulfillment {\n    __typename\n    ... on CommercePickup {\n      phoneNumber\n    }\n    ... on CommerceShip {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n    ... on CommerceShipArta {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        shippingQuoteOptions {\n          edges {\n            node {\n              id\n              isSelected\n            }\n          }\n        }\n        artwork {\n          processWithArtsyShippingDomestic\n          artsyShippingInternational\n          onlyShipsDomestically\n          euShippingOrigin\n          shippingCountry\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ShippingQuotes_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  lineItems {\n    edges {\n      node {\n        shippingQuoteOptions {\n          edges {\n            node {\n              id\n              isSelected\n              price(precision: 2)\n              priceCents\n              typeName\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Shipping_me on Me {\n  ...FulfillmentDetailsForm_me\n  ...ShippingContext_me_dXEtb\n}\n\nfragment Shipping_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  ...ShippingContext_order\n  ...FulfillmentDetailsForm_order\n  ...SaveAndContinueButton_order\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...OrderStepper_order\n  ...ShippingQuotes_order\n  internalID\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  __typename\n  requestedFulfillment {\n    __typename\n  }\n  code\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        selectedShippingQuote {\n          typeName\n          id\n        }\n        id\n      }\n    }\n  }\n  mode\n  source\n  displayState\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  currencyCode\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n"
+    "text": "query ShippingTestQuery {\n  order: commerceOrder(id: \"unused\") {\n    __typename\n    ...Shipping_order\n    id\n  }\n  me {\n    ...Shipping_me\n    id\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  currencyCode\n  mode\n  source\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        artwork {\n          slug\n          shippingOrigin\n          isUnlisted\n          id\n        }\n        artworkVersion {\n          date\n          artistNames\n          title\n          image {\n            resized(width: 185) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ExpressCheckoutProvider_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  buyerTotalCents\n}\n\nfragment FulfillmentDetailsForm_me on Me {\n  name\n  email\n  id\n  location {\n    country\n    id\n  }\n  addressConnection(first: 30) {\n    totalCount\n  }\n}\n\nfragment FulfillmentDetailsForm_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  lineItems {\n    edges {\n      node {\n        artwork {\n          pickupAvailable\n          id\n        }\n        id\n      }\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...OrderStepper_order\n}\n\nfragment OrderStepper_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  mode\n  paymentSet\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      id\n    }\n    ... on BankAccount {\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        shippingQuoteOptions {\n          edges {\n            node {\n              isSelected\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SaveAndContinueButton_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n}\n\nfragment ShippingContext_me_dXEtb on Me {\n  name\n  addressConnection(first: 30) {\n    edges {\n      node {\n        id\n        internalID\n        addressLine1\n        addressLine2\n        addressLine3\n        city\n        country\n        isDefault\n        name\n        phoneNumber\n        postalCode\n        region\n      }\n    }\n  }\n}\n\nfragment ShippingContext_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  mode\n  requestedFulfillment {\n    __typename\n    ... on CommercePickup {\n      phoneNumber\n    }\n    ... on CommerceShip {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n    ... on CommerceShipArta {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        shippingQuoteOptions {\n          edges {\n            node {\n              id\n              isSelected\n            }\n          }\n        }\n        artwork {\n          processWithArtsyShippingDomestic\n          artsyShippingInternational\n          onlyShipsDomestically\n          euShippingOrigin\n          shippingCountry\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ShippingQuotes_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  lineItems {\n    edges {\n      node {\n        shippingQuoteOptions {\n          edges {\n            node {\n              id\n              isSelected\n              price(precision: 2)\n              priceCents\n              typeName\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Shipping_me on Me {\n  ...FulfillmentDetailsForm_me\n  ...ShippingContext_me_dXEtb\n}\n\nfragment Shipping_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  ...ShippingContext_order\n  ...FulfillmentDetailsForm_order\n  ...SaveAndContinueButton_order\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...OrderStepper_order\n  ...ShippingQuotes_order\n  ...ExpressCheckoutProvider_order\n  internalID\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  __typename\n  requestedFulfillment {\n    __typename\n  }\n  code\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        selectedShippingQuote {\n          typeName\n          id\n        }\n        id\n      }\n    }\n  }\n  mode\n  source\n  displayState\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  currencyCode\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/Shipping_order.graphql.ts
+++ b/src/__generated__/Shipping_order.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ab13f3f4bb4bd91376478fbcf7c93e0f>>
+ * @generated SignedSource<<71810a06a266004a6c232d6590fe9be7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,7 +12,7 @@ import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type Shipping_order$data = {
   readonly internalID: string;
-  readonly " $fragmentSpreads": FragmentRefs<"ArtworkSummaryItem_order" | "FulfillmentDetailsForm_order" | "OrderStepper_order" | "SaveAndContinueButton_order" | "ShippingContext_order" | "ShippingQuotes_order" | "TransactionDetailsSummaryItem_order">;
+  readonly " $fragmentSpreads": FragmentRefs<"ArtworkSummaryItem_order" | "ExpressCheckoutProvider_order" | "FulfillmentDetailsForm_order" | "OrderStepper_order" | "SaveAndContinueButton_order" | "ShippingContext_order" | "ShippingQuotes_order" | "TransactionDetailsSummaryItem_order">;
   readonly " $fragmentType": "Shipping_order";
 };
 export type Shipping_order$key = {
@@ -62,6 +62,11 @@ const node: ReaderFragment = {
       "name": "ShippingQuotes_order"
     },
     {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "ExpressCheckoutProvider_order"
+    },
+    {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
@@ -73,6 +78,6 @@ const node: ReaderFragment = {
   "abstractKey": "__isCommerceOrder"
 };
 
-(node as any).hash = "7cb307555b00ab6c4a9474586a1c3943";
+(node as any).hash = "f3a69448511e07dd6831e7bc063c2f47";
 
 export default node;

--- a/src/__generated__/orderRoutes_ShippingQuery.graphql.ts
+++ b/src/__generated__/orderRoutes_ShippingQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<de1b2453b598bcd73c0051534786fe50>>
+ * @generated SignedSource<<af6b2d7cf13f7664a7a58e9de32c5978>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -193,7 +193,14 @@ v23 = {
   "name": "buyerTotal",
   "storageKey": "buyerTotal(precision:2)"
 },
-v24 = [
+v24 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "buyerTotalCents",
+  "storageKey": null
+},
+v25 = [
   (v3/*: any*/),
   {
     "alias": null,
@@ -214,13 +221,7 @@ v24 = [
   (v21/*: any*/),
   (v22/*: any*/),
   (v23/*: any*/),
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "buyerTotalCents",
-    "storageKey": null
-  },
+  (v24/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -686,7 +687,7 @@ return {
                 "kind": "LinkedField",
                 "name": "lastOffer",
                 "plural": false,
-                "selections": (v24/*: any*/),
+                "selections": (v25/*: any*/),
                 "storageKey": null
               },
               {
@@ -696,7 +697,7 @@ return {
                 "kind": "LinkedField",
                 "name": "myLastOffer",
                 "plural": false,
-                "selections": (v24/*: any*/),
+                "selections": (v25/*: any*/),
                 "storageKey": null
               }
             ],
@@ -748,6 +749,7 @@ return {
             ],
             "storageKey": null
           },
+          (v24/*: any*/),
           (v13/*: any*/)
         ],
         "storageKey": null
@@ -858,12 +860,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c9b7a4f80edc35ca792cd4f8b5151271",
+    "cacheID": "7914016c37ce38c9774187b4ca2bc3a9",
     "id": null,
     "metadata": {},
     "name": "orderRoutes_ShippingQuery",
     "operationKind": "query",
-    "text": "query orderRoutes_ShippingQuery(\n  $orderID: ID!\n) {\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...Shipping_order\n    id\n  }\n  me {\n    ...Shipping_me\n    id\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  currencyCode\n  mode\n  source\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        artwork {\n          slug\n          shippingOrigin\n          isUnlisted\n          id\n        }\n        artworkVersion {\n          date\n          artistNames\n          title\n          image {\n            resized(width: 185) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment FulfillmentDetailsForm_me on Me {\n  name\n  email\n  id\n  location {\n    country\n    id\n  }\n  addressConnection(first: 30) {\n    totalCount\n  }\n}\n\nfragment FulfillmentDetailsForm_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  lineItems {\n    edges {\n      node {\n        artwork {\n          pickupAvailable\n          id\n        }\n        id\n      }\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...OrderStepper_order\n}\n\nfragment OrderStepper_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  mode\n  paymentSet\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      id\n    }\n    ... on BankAccount {\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        shippingQuoteOptions {\n          edges {\n            node {\n              isSelected\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SaveAndContinueButton_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n}\n\nfragment ShippingContext_me_dXEtb on Me {\n  name\n  addressConnection(first: 30) {\n    edges {\n      node {\n        id\n        internalID\n        addressLine1\n        addressLine2\n        addressLine3\n        city\n        country\n        isDefault\n        name\n        phoneNumber\n        postalCode\n        region\n      }\n    }\n  }\n}\n\nfragment ShippingContext_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  mode\n  requestedFulfillment {\n    __typename\n    ... on CommercePickup {\n      phoneNumber\n    }\n    ... on CommerceShip {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n    ... on CommerceShipArta {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        shippingQuoteOptions {\n          edges {\n            node {\n              id\n              isSelected\n            }\n          }\n        }\n        artwork {\n          processWithArtsyShippingDomestic\n          artsyShippingInternational\n          onlyShipsDomestically\n          euShippingOrigin\n          shippingCountry\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ShippingQuotes_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  lineItems {\n    edges {\n      node {\n        shippingQuoteOptions {\n          edges {\n            node {\n              id\n              isSelected\n              price(precision: 2)\n              priceCents\n              typeName\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Shipping_me on Me {\n  ...FulfillmentDetailsForm_me\n  ...ShippingContext_me_dXEtb\n}\n\nfragment Shipping_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  ...ShippingContext_order\n  ...FulfillmentDetailsForm_order\n  ...SaveAndContinueButton_order\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...OrderStepper_order\n  ...ShippingQuotes_order\n  internalID\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  __typename\n  requestedFulfillment {\n    __typename\n  }\n  code\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        selectedShippingQuote {\n          typeName\n          id\n        }\n        id\n      }\n    }\n  }\n  mode\n  source\n  displayState\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  currencyCode\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n"
+    "text": "query orderRoutes_ShippingQuery(\n  $orderID: ID!\n) {\n  order: commerceOrder(id: $orderID) {\n    __typename\n    ...Shipping_order\n    id\n  }\n  me {\n    ...Shipping_me\n    id\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  currencyCode\n  mode\n  source\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        artwork {\n          slug\n          shippingOrigin\n          isUnlisted\n          id\n        }\n        artworkVersion {\n          date\n          artistNames\n          title\n          image {\n            resized(width: 185) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ExpressCheckoutProvider_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  buyerTotalCents\n}\n\nfragment FulfillmentDetailsForm_me on Me {\n  name\n  email\n  id\n  location {\n    country\n    id\n  }\n  addressConnection(first: 30) {\n    totalCount\n  }\n}\n\nfragment FulfillmentDetailsForm_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  lineItems {\n    edges {\n      node {\n        artwork {\n          pickupAvailable\n          id\n        }\n        id\n      }\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...OrderStepper_order\n}\n\nfragment OrderStepper_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  mode\n  paymentSet\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      id\n    }\n    ... on BankAccount {\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        shippingQuoteOptions {\n          edges {\n            node {\n              isSelected\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SaveAndContinueButton_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n}\n\nfragment ShippingContext_me_dXEtb on Me {\n  name\n  addressConnection(first: 30) {\n    edges {\n      node {\n        id\n        internalID\n        addressLine1\n        addressLine2\n        addressLine3\n        city\n        country\n        isDefault\n        name\n        phoneNumber\n        postalCode\n        region\n      }\n    }\n  }\n}\n\nfragment ShippingContext_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  mode\n  requestedFulfillment {\n    __typename\n    ... on CommercePickup {\n      phoneNumber\n    }\n    ... on CommerceShip {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n    ... on CommerceShipArta {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        shippingQuoteOptions {\n          edges {\n            node {\n              id\n              isSelected\n            }\n          }\n        }\n        artwork {\n          processWithArtsyShippingDomestic\n          artsyShippingInternational\n          onlyShipsDomestically\n          euShippingOrigin\n          shippingCountry\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ShippingQuotes_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  lineItems {\n    edges {\n      node {\n        shippingQuoteOptions {\n          edges {\n            node {\n              id\n              isSelected\n              price(precision: 2)\n              priceCents\n              typeName\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Shipping_me on Me {\n  ...FulfillmentDetailsForm_me\n  ...ShippingContext_me_dXEtb\n}\n\nfragment Shipping_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  ...ShippingContext_order\n  ...FulfillmentDetailsForm_order\n  ...SaveAndContinueButton_order\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...OrderStepper_order\n  ...ShippingQuotes_order\n  ...ExpressCheckoutProvider_order\n  internalID\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  __typename\n  requestedFulfillment {\n    __typename\n  }\n  code\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        selectedShippingQuote {\n          typeName\n          id\n        }\n        id\n      }\n    }\n  }\n  mode\n  source\n  displayState\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  currencyCode\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/useSaveFulfillmentDetailsMutation.graphql.ts
+++ b/src/__generated__/useSaveFulfillmentDetailsMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<67ecbde17b4a277a9eaf82030655d86c>>
+ * @generated SignedSource<<623eb5c3c9d8208bfcf729db2548e17e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -266,7 +266,14 @@ v19 = {
   "name": "buyerTotal",
   "storageKey": "buyerTotal(precision:2)"
 },
-v20 = [
+v20 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "buyerTotalCents",
+  "storageKey": null
+},
+v21 = [
   (v3/*: any*/),
   {
     "alias": null,
@@ -287,13 +294,7 @@ v20 = [
   (v17/*: any*/),
   (v18/*: any*/),
   (v19/*: any*/),
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "buyerTotalCents",
-    "storageKey": null
-  },
+  (v20/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -790,7 +791,7 @@ return {
                             "kind": "LinkedField",
                             "name": "lastOffer",
                             "plural": false,
-                            "selections": (v20/*: any*/),
+                            "selections": (v21/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -800,7 +801,7 @@ return {
                             "kind": "LinkedField",
                             "name": "myLastOffer",
                             "plural": false,
-                            "selections": (v20/*: any*/),
+                            "selections": (v21/*: any*/),
                             "storageKey": null
                           }
                         ],
@@ -852,6 +853,7 @@ return {
                         ],
                         "storageKey": null
                       },
+                      (v20/*: any*/),
                       (v9/*: any*/)
                     ],
                     "storageKey": null
@@ -870,12 +872,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ed2b405b4fe82a140cf38b487ea12478",
+    "cacheID": "6f3ced552e4f65ac5a4d66bbf0fc37ad",
     "id": null,
     "metadata": {},
     "name": "useSaveFulfillmentDetailsMutation",
     "operationKind": "mutation",
-    "text": "mutation useSaveFulfillmentDetailsMutation(\n  $input: CommerceSetShippingInput!\n) {\n  commerceSetShipping(input: $input) {\n    orderOrError {\n      __typename\n      ... on CommerceOrderWithMutationSuccess {\n        order {\n          internalID\n          __typename\n          __isCommerceOrder: __typename\n          ...Shipping_order\n          id\n        }\n      }\n      ... on CommerceOrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n      ... on CommerceOrderRequiresAction {\n        __typename\n      }\n    }\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  currencyCode\n  mode\n  source\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        artwork {\n          slug\n          shippingOrigin\n          isUnlisted\n          id\n        }\n        artworkVersion {\n          date\n          artistNames\n          title\n          image {\n            resized(width: 185) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment FulfillmentDetailsForm_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  lineItems {\n    edges {\n      node {\n        artwork {\n          pickupAvailable\n          id\n        }\n        id\n      }\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...OrderStepper_order\n}\n\nfragment OrderStepper_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  mode\n  paymentSet\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      id\n    }\n    ... on BankAccount {\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        shippingQuoteOptions {\n          edges {\n            node {\n              isSelected\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SaveAndContinueButton_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n}\n\nfragment ShippingContext_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  mode\n  requestedFulfillment {\n    __typename\n    ... on CommercePickup {\n      phoneNumber\n    }\n    ... on CommerceShip {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n    ... on CommerceShipArta {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        shippingQuoteOptions {\n          edges {\n            node {\n              id\n              isSelected\n            }\n          }\n        }\n        artwork {\n          processWithArtsyShippingDomestic\n          artsyShippingInternational\n          onlyShipsDomestically\n          euShippingOrigin\n          shippingCountry\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ShippingQuotes_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  lineItems {\n    edges {\n      node {\n        shippingQuoteOptions {\n          edges {\n            node {\n              id\n              isSelected\n              price(precision: 2)\n              priceCents\n              typeName\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Shipping_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  ...ShippingContext_order\n  ...FulfillmentDetailsForm_order\n  ...SaveAndContinueButton_order\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...OrderStepper_order\n  ...ShippingQuotes_order\n  internalID\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  __typename\n  requestedFulfillment {\n    __typename\n  }\n  code\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        selectedShippingQuote {\n          typeName\n          id\n        }\n        id\n      }\n    }\n  }\n  mode\n  source\n  displayState\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  currencyCode\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n"
+    "text": "mutation useSaveFulfillmentDetailsMutation(\n  $input: CommerceSetShippingInput!\n) {\n  commerceSetShipping(input: $input) {\n    orderOrError {\n      __typename\n      ... on CommerceOrderWithMutationSuccess {\n        order {\n          internalID\n          __typename\n          __isCommerceOrder: __typename\n          ...Shipping_order\n          id\n        }\n      }\n      ... on CommerceOrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n      ... on CommerceOrderRequiresAction {\n        __typename\n      }\n    }\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  currencyCode\n  mode\n  source\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        artwork {\n          slug\n          shippingOrigin\n          isUnlisted\n          id\n        }\n        artworkVersion {\n          date\n          artistNames\n          title\n          image {\n            resized(width: 185) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ExpressCheckoutProvider_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  buyerTotalCents\n}\n\nfragment FulfillmentDetailsForm_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  lineItems {\n    edges {\n      node {\n        artwork {\n          pickupAvailable\n          id\n        }\n        id\n      }\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...OrderStepper_order\n}\n\nfragment OrderStepper_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  mode\n  paymentSet\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      id\n    }\n    ... on BankAccount {\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        shippingQuoteOptions {\n          edges {\n            node {\n              isSelected\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SaveAndContinueButton_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n}\n\nfragment ShippingContext_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  mode\n  requestedFulfillment {\n    __typename\n    ... on CommercePickup {\n      phoneNumber\n    }\n    ... on CommerceShip {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n    ... on CommerceShipArta {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        shippingQuoteOptions {\n          edges {\n            node {\n              id\n              isSelected\n            }\n          }\n        }\n        artwork {\n          processWithArtsyShippingDomestic\n          artsyShippingInternational\n          onlyShipsDomestically\n          euShippingOrigin\n          shippingCountry\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ShippingQuotes_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  lineItems {\n    edges {\n      node {\n        shippingQuoteOptions {\n          edges {\n            node {\n              id\n              isSelected\n              price(precision: 2)\n              priceCents\n              typeName\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Shipping_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  ...ShippingContext_order\n  ...FulfillmentDetailsForm_order\n  ...SaveAndContinueButton_order\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...OrderStepper_order\n  ...ShippingQuotes_order\n  ...ExpressCheckoutProvider_order\n  internalID\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  __typename\n  requestedFulfillment {\n    __typename\n  }\n  code\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        selectedShippingQuote {\n          typeName\n          id\n        }\n        id\n      }\n    }\n  }\n  mode\n  source\n  displayState\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  currencyCode\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/useSelectShippingQuoteMutation.graphql.ts
+++ b/src/__generated__/useSelectShippingQuoteMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<18a3bb8473d2d0e4f4b996b04a0481d4>>
+ * @generated SignedSource<<fa6674ef12392331ab5eefa9bfb8d10e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -245,7 +245,14 @@ v19 = {
   "name": "buyerTotal",
   "storageKey": "buyerTotal(precision:2)"
 },
-v20 = [
+v20 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "buyerTotalCents",
+  "storageKey": null
+},
+v21 = [
   (v5/*: any*/),
   {
     "alias": null,
@@ -266,13 +273,7 @@ v20 = [
   (v17/*: any*/),
   (v18/*: any*/),
   (v19/*: any*/),
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "buyerTotalCents",
-    "storageKey": null
-  },
+  (v20/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -767,7 +768,7 @@ return {
                             "kind": "LinkedField",
                             "name": "lastOffer",
                             "plural": false,
-                            "selections": (v20/*: any*/),
+                            "selections": (v21/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -777,7 +778,7 @@ return {
                             "kind": "LinkedField",
                             "name": "myLastOffer",
                             "plural": false,
-                            "selections": (v20/*: any*/),
+                            "selections": (v21/*: any*/),
                             "storageKey": null
                           }
                         ],
@@ -829,6 +830,7 @@ return {
                         ],
                         "storageKey": null
                       },
+                      (v20/*: any*/),
                       (v9/*: any*/)
                     ],
                     "storageKey": null
@@ -847,12 +849,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "38c4e19ceafe6e1749dd865a5f15ebfb",
+    "cacheID": "6d653bc287f3c1b0dabbdeb6bc63aab2",
     "id": null,
     "metadata": {},
     "name": "useSelectShippingQuoteMutation",
     "operationKind": "mutation",
-    "text": "mutation useSelectShippingQuoteMutation(\n  $input: CommerceSelectShippingOptionInput!\n) {\n  commerceSelectShippingOption(input: $input) {\n    orderOrError {\n      __typename\n      ... on CommerceOrderWithMutationSuccess {\n        order {\n          __typename\n          ...Shipping_order\n          id\n        }\n      }\n      ... on CommerceOrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n    }\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  currencyCode\n  mode\n  source\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        artwork {\n          slug\n          shippingOrigin\n          isUnlisted\n          id\n        }\n        artworkVersion {\n          date\n          artistNames\n          title\n          image {\n            resized(width: 185) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment FulfillmentDetailsForm_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  lineItems {\n    edges {\n      node {\n        artwork {\n          pickupAvailable\n          id\n        }\n        id\n      }\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...OrderStepper_order\n}\n\nfragment OrderStepper_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  mode\n  paymentSet\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      id\n    }\n    ... on BankAccount {\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        shippingQuoteOptions {\n          edges {\n            node {\n              isSelected\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SaveAndContinueButton_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n}\n\nfragment ShippingContext_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  mode\n  requestedFulfillment {\n    __typename\n    ... on CommercePickup {\n      phoneNumber\n    }\n    ... on CommerceShip {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n    ... on CommerceShipArta {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        shippingQuoteOptions {\n          edges {\n            node {\n              id\n              isSelected\n            }\n          }\n        }\n        artwork {\n          processWithArtsyShippingDomestic\n          artsyShippingInternational\n          onlyShipsDomestically\n          euShippingOrigin\n          shippingCountry\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ShippingQuotes_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  lineItems {\n    edges {\n      node {\n        shippingQuoteOptions {\n          edges {\n            node {\n              id\n              isSelected\n              price(precision: 2)\n              priceCents\n              typeName\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Shipping_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  ...ShippingContext_order\n  ...FulfillmentDetailsForm_order\n  ...SaveAndContinueButton_order\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...OrderStepper_order\n  ...ShippingQuotes_order\n  internalID\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  __typename\n  requestedFulfillment {\n    __typename\n  }\n  code\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        selectedShippingQuote {\n          typeName\n          id\n        }\n        id\n      }\n    }\n  }\n  mode\n  source\n  displayState\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  currencyCode\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n"
+    "text": "mutation useSelectShippingQuoteMutation(\n  $input: CommerceSelectShippingOptionInput!\n) {\n  commerceSelectShippingOption(input: $input) {\n    orderOrError {\n      __typename\n      ... on CommerceOrderWithMutationSuccess {\n        order {\n          __typename\n          ...Shipping_order\n          id\n        }\n      }\n      ... on CommerceOrderWithMutationFailure {\n        error {\n          type\n          code\n          data\n        }\n      }\n    }\n  }\n}\n\nfragment ArtworkSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  sellerDetails {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  currencyCode\n  mode\n  source\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        artwork {\n          slug\n          shippingOrigin\n          isUnlisted\n          id\n        }\n        artworkVersion {\n          date\n          artistNames\n          title\n          image {\n            resized(width: 185) {\n              url\n            }\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ExpressCheckoutProvider_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  buyerTotalCents\n}\n\nfragment FulfillmentDetailsForm_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  lineItems {\n    edges {\n      node {\n        artwork {\n          pickupAvailable\n          id\n        }\n        id\n      }\n    }\n  }\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...OrderStepper_order\n}\n\nfragment OrderStepper_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  mode\n  paymentSet\n  requestedFulfillment {\n    __typename\n  }\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      id\n    }\n    ... on BankAccount {\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        artwork {\n          slug\n          id\n        }\n        shippingQuoteOptions {\n          edges {\n            node {\n              isSelected\n              id\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment SaveAndContinueButton_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n}\n\nfragment ShippingContext_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  internalID\n  mode\n  requestedFulfillment {\n    __typename\n    ... on CommercePickup {\n      phoneNumber\n    }\n    ... on CommerceShip {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n    ... on CommerceShipArta {\n      name\n      addressLine1\n      addressLine2\n      city\n      region\n      country\n      postalCode\n      phoneNumber\n    }\n  }\n  lineItems {\n    edges {\n      node {\n        shippingQuoteOptions {\n          edges {\n            node {\n              id\n              isSelected\n            }\n          }\n        }\n        artwork {\n          processWithArtsyShippingDomestic\n          artsyShippingInternational\n          onlyShipsDomestically\n          euShippingOrigin\n          shippingCountry\n          id\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ShippingQuotes_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  lineItems {\n    edges {\n      node {\n        shippingQuoteOptions {\n          edges {\n            node {\n              id\n              isSelected\n              price(precision: 2)\n              priceCents\n              typeName\n            }\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment Shipping_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  ...ShippingContext_order\n  ...FulfillmentDetailsForm_order\n  ...SaveAndContinueButton_order\n  ...ArtworkSummaryItem_order\n  ...TransactionDetailsSummaryItem_order\n  ...OrderStepper_order\n  ...ShippingQuotes_order\n  ...ExpressCheckoutProvider_order\n  internalID\n}\n\nfragment TransactionDetailsSummaryItem_order on CommerceOrder {\n  __isCommerceOrder: __typename\n  __typename\n  requestedFulfillment {\n    __typename\n  }\n  code\n  lineItems {\n    edges {\n      node {\n        artworkOrEditionSet {\n          __typename\n          ... on Artwork {\n            price\n          }\n          ... on EditionSet {\n            price\n            id\n          }\n          ... on Node {\n            __isNode: __typename\n            id\n          }\n        }\n        selectedShippingQuote {\n          typeName\n          id\n        }\n        id\n      }\n    }\n  }\n  mode\n  source\n  displayState\n  shippingTotal(precision: 2)\n  shippingTotalCents\n  taxTotal(precision: 2)\n  taxTotalCents\n  itemsTotal(precision: 2)\n  buyerTotal(precision: 2)\n  currencyCode\n  ... on CommerceOfferOrder {\n    lastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n    myLastOffer {\n      internalID\n      amount(precision: 2)\n      amountCents\n      shippingTotal(precision: 2)\n      shippingTotalCents\n      taxTotal(precision: 2)\n      taxTotalCents\n      buyerTotal(precision: 2)\n      buyerTotalCents\n      fromParticipant\n      note\n      id\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2294]

### Description

This PR:
- Moves the express checkout element to the shipping route page
- Does not display header of spacers unless their are available payment methods
- Styles to button to match designs 

<!-- Implementation description -->

### Express checkout with Apple Pay

https://github.com/user-attachments/assets/ca9a0977-eb73-41a1-aacf-a6880169bfb7


### Express checkout with no available payment methods 

https://github.com/user-attachments/assets/a02a1b96-16e1-422f-8a6c-8426b00c39bc



[EMI-2294]: https://artsyproduct.atlassian.net/browse/EMI-2294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ