### PR TITLE
fix(viewing-rooms): corrects image dimensions

### DIFF
--- a/src/Apps/ViewingRoom/Routes/Works/ViewingRoomWorksRoute.tsx
+++ b/src/Apps/ViewingRoom/Routes/Works/ViewingRoomWorksRoute.tsx
@@ -47,13 +47,11 @@ const ViewingRoomWorksRoute: React.FC<
                             <Image
                               src={img.src}
                               srcSet={img.srcSet}
+                              width={(img.width ?? 0) * 0.5}
+                              height={(img.height ?? 0) * 0.5}
                               lazyLoad
                               alt=""
-                              style={{
-                                display: "block",
-                                width: (img.width ?? 0) * 0.5,
-                                height: (img.height ?? 0) * 0.5,
-                              }}
+                              display="block"
                             />
                           </Media>
 
@@ -61,13 +59,11 @@ const ViewingRoomWorksRoute: React.FC<
                             <Image
                               src={img.src}
                               srcSet={img.srcSet}
+                              width={img.width}
+                              height={img.height}
                               lazyLoad
                               alt=""
-                              style={{
-                                display: "block",
-                                width: img.width ?? 0,
-                                height: img.height ?? 0,
-                              }}
+                              display="block"
                             />
                           </Media>
                         </React.Fragment>


### PR DESCRIPTION
Small bug from the image component rewrite. I still feel like we should require width and height. I think there is no valid argument against that, and if you want to use a custom image then you should just use a simple `img` tag. 