### PR TITLE
chore: bump pod cpu request from 100m to 500m

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -88,7 +88,7 @@ spec:
           periodSeconds: 5
         resources:
           requests:
-            cpu: 100m
+            cpu: 500m
             memory: 500Mi
           limits:
             memory: 1Gi
@@ -207,7 +207,7 @@ spec:
           periodSeconds: 5
         resources:
           requests:
-            cpu: 100m
+            cpu: 500m
             memory: 500Mi
           limits:
             memory: 1Gi


### PR DESCRIPTION
The type of this PR is: **CHORE**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

### Description

<!-- Implementation description -->

CPU usage in staging force has climbed dramatically since the end of January. This seems to be causing some stability issues. I tried temporarily horizontally scaling to 10 pods and it just continued to use all available cpu. I want to test vertical scaling. [Datadog metrics](https://app.datadoghq.com/dashboard/2n5-6tr-ypp/kubernetes-deployments?fromUser=true&refresh_mode=sliding&tpl_var_deployment%5B0%5D=force-web-spotty&tpl_var_env%5B0%5D=staging&tpl_var_hpa%5B0%5D=force-web-spotty&from_ts=1740777157702&to_ts=1740778957702&live=true) for cpu usage. This is not a long term solution. We need to hunt down the cause of the bump.

<img width="1338" alt="Screenshot 2025-02-28 at 3 58 00 PM" src="https://github.com/user-attachments/assets/c13698f7-c8b2-4d5e-b6db-902e0ca00676" />
