### PR TITLE
fix(filters): allow "framed" and "signed" as filter criteria, but not alert criteria

### DIFF
--- a/src/Components/Alert/AlertProvider.tsx
+++ b/src/Components/Alert/AlertProvider.tsx
@@ -94,7 +94,7 @@ export const AlertProvider: FC<React.PropsWithChildren<AlertProviderProps>> = ({
     if (isEditMode || isAlertArtworksView) return
     const criteria = getAllowedSearchCriteria(initialCriteria ?? {})
 
-    // `forSale` is not allowed as a filter criterion,
+    // `forSale` is allowed as a filter criterion,
     // but NOT as an alert criterion, so we remove it.
     // (Alerts, by definition, stipulate forSale=true
     // when they are created in Gravity.)

--- a/src/Components/SavedSearchAlert/constants.ts
+++ b/src/Components/SavedSearchAlert/constants.ts
@@ -32,7 +32,6 @@ export const allowedSearchCriteriaKeys = [
   "attributionClass",
   "colors",
   "forSale",
-  "framed",
   "height",
   "includeArtworksByFollowedArtists",
   "inquireableOnly",
@@ -42,7 +41,6 @@ export const allowedSearchCriteriaKeys = [
   "offerable",
   "partnerIDs",
   "priceRange",
-  "signed",
   "sizes",
   "width",
 ]

--- a/src/Components/SavedSearchAlert/useActiveFilterPills.ts
+++ b/src/Components/SavedSearchAlert/useActiveFilterPills.ts
@@ -6,13 +6,13 @@ import type { ArtworkFilters } from "Components/ArtworkFilter/ArtworkFilterTypes
 import { DEFAULT_METRIC } from "Utils/metrics"
 import { isArray } from "lodash"
 import { extractPillsFromCriteria } from "./Utils/extractPills"
-import { getAllowedSearchCriteria } from "./Utils/savedSearchCriteria"
+import { allowedFilters } from "Components/ArtworkFilter/Utils/allowedFilters"
 import type { FilterPill } from "./types"
 
 export const useActiveFilterPills = (defaultPills: FilterPill[] = []) => {
   const { aggregations, setFilter, filters } = useArtworkFilterContext()
 
-  const criteria = getAllowedSearchCriteria(filters ?? {})
+  const criteria = allowedFilters(filters ?? {})
 
   const metric = filters?.metric ?? DEFAULT_METRIC
 


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [ONYX-1576]

### Description

The new framed and signed filters from the recent Hackathon have not been released due to incompatibility with our alerts UX.

After some [discussion](https://artsy.slack.com/archives/C05EQL4R5N0/p1741273678919609) we decided that it is acceptable to release these filters _without_ alert support until/unless we have more confidence in them as alert criteria.

This PR simply removes `framed` and `signed` from the allowlist for _alert_ criteria. (They remain in the allowlist for _filter_ criteria.)


| Before | After |
|--------|--------|
| ![broke](https://github.com/user-attachments/assets/c98cca16-4a45-44b4-9a84-86c48aebee69) | ![fixed](https://github.com/user-attachments/assets/f2d3b612-c813-48a7-8cfc-521c9d9ae7bd) | 




[ONYX-1576]: https://artsyproduct.atlassian.net/browse/ONYX-1576?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ