### PR TITLE
feat(EMI-2308): render Payment Element UI and enable dynamic payment methods for connected accounts

### DIFF
--- a/src/Apps/Checkout/Components/PaymentForm.tsx
+++ b/src/Apps/Checkout/Components/PaymentForm.tsx
@@ -13,7 +13,7 @@ import { getENV } from "Utils/getENV"
 
 const stripePromise = loadStripe(getENV("STRIPE_PUBLISHABLE_KEY"))
 
-export const PaymentForm = () => {
+export const PaymentForm: React.FC = () => {
   const orderOptions: StripeElementsUpdateOptions = {
     amount: 12345,
     currency: "eur",

--- a/src/Apps/Checkout/Components/PaymentForm/index.tsx
+++ b/src/Apps/Checkout/Components/PaymentForm/index.tsx
@@ -9,8 +9,9 @@ import { Box, Text, Spacer } from "@artsy/palette"
 import { useState } from "react"
 import { FadeInBox } from "Components/FadeInBox"
 import { Collapse } from "Apps/Order/Components/Collapse"
+import { getENV } from "Utils/getENV"
 
-const stripePromise = loadStripe("pk_test_h9x96nuEG26CZFlE05aSA41o009gNRFRAZ")
+const stripePromise = loadStripe(getENV("STRIPE_PUBLISHABLE_KEY"))
 
 export const PaymentForm = () => {
   const orderOptions: StripeElementsUpdateOptions = {

--- a/src/Apps/Checkout/Components/PaymentForm/index.tsx
+++ b/src/Apps/Checkout/Components/PaymentForm/index.tsx
@@ -1,0 +1,151 @@
+import { Elements, useElements, PaymentElement } from "@stripe/react-stripe-js"
+import {
+  type StripeElementsOptions,
+  type StripeElementsUpdateOptions,
+  type StripePaymentElementOptions,
+  loadStripe,
+} from "@stripe/stripe-js"
+import { Box, Text, Spacer } from "@artsy/palette"
+import { useState } from "react"
+import { FadeInBox } from "Components/FadeInBox"
+import { Collapse } from "Apps/Order/Components/Collapse"
+
+const stripePromise = loadStripe("pk_test_h9x96nuEG26CZFlE05aSA41o009gNRFRAZ")
+
+export const PaymentForm = () => {
+  const orderOptions: StripeElementsUpdateOptions = {
+    amount: 12345,
+    currency: "eur",
+    // onBehalfOf: "acct_14FIYS4fSw9JrcJy", // US
+    onBehalfOf: "acct_1KMqw0A6DHSUKBik", // DE
+  }
+
+  const options: StripeElementsOptions = {
+    mode: "payment",
+    appearance: {
+      variables: {
+        accordionItemSpacing: "10px",
+      },
+      rules: {
+        ".AccordionItem": {
+          border: "none",
+          backgroundColor: "#EFEFEF",
+        },
+        ".AccordionItem:focus-visible": {
+          border: "1px solid black",
+        },
+        ".AccordionItem--selected": {
+          border: "1px solid black",
+        },
+      },
+    },
+    ...orderOptions,
+  }
+
+  return (
+    <Elements stripe={stripePromise} options={options}>
+      <PaymentFormContent />
+    </Elements>
+  )
+}
+
+const PaymentFormContent = () => {
+  const elements = useElements()
+  const [selectedPaymentMethod, setSelectedPaymentMethod] = useState("new")
+
+  const paymentElementOptions: StripePaymentElementOptions = {
+    layout: {
+      type: "accordion",
+      spacedAccordionItems: true,
+      defaultCollapsed: true,
+      radios: false,
+    },
+  }
+
+  const onChange = event => {
+    const { elementType, collapsed } = event
+    if (elementType === "payment" && !collapsed) {
+      setSelectedPaymentMethod("new")
+    }
+  }
+
+  const onReady = event => {
+    console.log(event.getValue())
+  }
+
+  const onClickSavedPaymentMethods = () => {
+    setSelectedPaymentMethod("saved")
+    elements?.getElement("payment")?.collapse()
+  }
+
+  const onClickWirePaymentMethods = () => {
+    setSelectedPaymentMethod("wire")
+    elements?.getElement("payment")?.collapse()
+  }
+
+  return (
+    <form>
+      <FadeInBox>
+        <Box
+          backgroundColor="#EFEFEF"
+          borderRadius="5px"
+          padding="1rem"
+          marginBottom="10px"
+          style={{ cursor: "pointer" }}
+          onClick={onClickSavedPaymentMethods}
+        >
+          <Text>Saved Payment Methods</Text>
+          <Collapse open={selectedPaymentMethod === "saved"}>
+            <Text variant="sm" p="10px">
+              Visa ....1234
+            </Text>
+            <Text variant="sm" p="10px">
+              Visa ....5678
+            </Text>
+          </Collapse>
+        </Box>
+      </FadeInBox>
+
+      <PaymentElement
+        options={paymentElementOptions}
+        onChange={onChange}
+        onReady={onReady}
+      />
+
+      <Spacer y={1} />
+      <FadeInBox>
+        <Box
+          backgroundColor="#EFEFEF"
+          borderRadius="5px"
+          padding="1rem"
+          marginBottom="10px"
+          style={{ cursor: "pointer" }}
+          onClick={onClickWirePaymentMethods}
+        >
+          <Text>Wire Transfer</Text>
+          <Collapse open={selectedPaymentMethod === "wire"}>
+            <Text color="black60" variant="sm">
+              <ul
+                style={{
+                  paddingLeft: "2rem",
+                  margin: "1rem 0",
+                  listStyle: "disc",
+                }}
+              >
+                <li>
+                  To pay by wire transfer, complete checkout to view banking
+                  details and wire transfer instructions.
+                </li>
+                <li>
+                  Please inform your bank that you will be responsible for all
+                  wire transfer fees.
+                </li>
+              </ul>
+            </Text>
+          </Collapse>
+        </Box>
+      </FadeInBox>
+      <Spacer y={2} />
+    </form>
+  )
+}

--- a/src/Apps/Checkout/Routes/CheckoutOverviewRoute.tsx
+++ b/src/Apps/Checkout/Routes/CheckoutOverviewRoute.tsx
@@ -1,5 +1,6 @@
 import type * as React from "react"
 import { Text } from "@artsy/palette"
+import { PaymentForm } from "Apps/Checkout/Components/PaymentForm"
 
 export const CheckoutOverviewRoute: React.FC<
   React.PropsWithChildren<unknown>
@@ -7,6 +8,8 @@ export const CheckoutOverviewRoute: React.FC<
   return (
     <>
       <Text variant="xl">Checkout</Text>
+
+      <PaymentForm />
     </>
   )
 }


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [EMI-2308]

### Description
This maps to [step 1](https://www.notion.so/artsy/Stripe-Payment-Element-189cab0764a080cebe0bcb2fea09295f?pvs=4#191cab0764a0808f91b1e5009dc51919) of the payment flow in the tech plan. The [design](https://www.figma.com/design/kaBdUapJIWs9YL9ATlPDzw/Checkout-Redesign?node-id=1304-27470&t=bNrEN8Xc3hA5IRFB-4) is not fully done yet, but we can start developing the payment flow and come back to polish the visual when ready.

The idea is to have a functional payment element under the new `/checkout` route with the `onBehalfOf` param working as intended, which can be seen in the video below.

https://github.com/user-attachments/assets/31291cef-e75c-4c54-b9ac-57caab052f3d



@artsy/emerald-devs 


[EMI-2308]: https://artsyproduct.atlassian.net/browse/EMI-2308?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ