### PR TITLE
fix(EMI-2298): prevent rendering initial blank render on reload before order data is received

### DIFF
--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -72,6 +72,10 @@ const ShippingRouteLayout: FC<
 > = ({ me, order }) => {
   const shippingContext = useShippingContext()
 
+  if (shippingContext.state.isLoading) {
+    return null
+  }
+
   const { jumpTo } = useJump()
 
   const expressCheckoutPrototypeEnabled = useFeatureFlag(


### PR DESCRIPTION
After some tracing seems like what happens in both flickering of the screen and the strange double render when coming back and reloading the shipping from different tab the issue is that the empty data is rendered before the actual render with proper data happens. 

Introducing the loading state to prevent this blank render. It does mean that with the slower network speed the page will stay blank for longer before the actual data is rendered. But seems like a better compromise compared to this strange flickering or double rendering.....

Alternative we can come up with some loading state or render some other skeleton but that seems more complicated and maybe not worth it before we do more proper one page setup.
