### PR TITLE
chore(MyC): put sharing widget behind a feature flag

### DIFF
--- a/src/Apps/Settings/Routes/MyCollection/MyCollectionRoute.tsx
+++ b/src/Apps/Settings/Routes/MyCollection/MyCollectionRoute.tsx
@@ -14,6 +14,7 @@ import {
   graphql,
 } from "react-relay"
 import { EmptyMyCollectionPage } from "./Components/EmptyMyCollectionPage"
+import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
 
 export interface MyCollectionRouteProps {
   me: MyCollectionRoute_me$data
@@ -23,6 +24,8 @@ export interface MyCollectionRouteProps {
 const MyCollectionRoute: FC<
   React.PropsWithChildren<MyCollectionRouteProps>
 > = ({ me, relay }) => {
+  const enableShare = useFeatureFlag("onyx_shareable-my-collection")
+
   const { addCollectedArtwork: trackAddCollectedArtwork } =
     useMyCollectionTracking()
   const [isLoading, setLoading] = useState(false)
@@ -62,14 +65,16 @@ const MyCollectionRoute: FC<
       {total > 0 ? (
         <Stack gap={2}>
           <Flex backgroundColor="white100" justifyContent="flex-end" gap={1}>
-            <Button
-              size={["small", "large"]}
-              variant="secondaryBlack"
-              Icon={ShareIcon}
-              onClick={() => setMode("Share")}
-            >
-              Share
-            </Button>
+            {enableShare && (
+              <Button
+                size={["small", "large"]}
+                variant="secondaryBlack"
+                Icon={ShareIcon}
+                onClick={() => setMode("Share")}
+              >
+                Share
+              </Button>
+            )}
 
             <Button
               // @ts-ignore


### PR DESCRIPTION
The type of this PR is: **Chore**

This PR solves [ONYX-1569]

### Description

Simply puts the MyC sharing widget behind a flag again (this time managed by Onyx: `onyx_shareable-my-collection`) while we sort out the details of this feature.

The flag is disabled in production, and enabled in dev/staging by opting in user IDs.

[See ticket](https://artsyproduct.atlassian.net/browse/ONYX-1569) for some relevant stats related to usage of this feature so far.

| Before <br/>(or with user id explicitly opted in) | After |
|--------|--------|
| ![before or opt](https://github.com/user-attachments/assets/cfd0b570-b147-4a3d-9aae-1481e79f5f71) | ![after](https://github.com/user-attachments/assets/02c70fe0-c5af-4870-b3e0-3b153504a853) | 



[ONYX-1569]: https://artsyproduct.atlassian.net/browse/ONYX-1569?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ