### PR TITLE
fix(artwork): avoids double loading images on desktop

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkLightbox.tsx
+++ b/src/Apps/Artwork/Components/ArtworkLightbox.tsx
@@ -65,16 +65,12 @@ const ArtworkLightbox: React.FC<
     lightboxImage = mobileLightboxSource
   }
 
-  // Always preload the 2x image for mobile lightbox if available
-  const preloadImage = mobileLightboxSource?.srcSet?.match(/ ([^ ]+) 2x/)?.[1]
-
   return (
     <>
       {isDefault && (
         <Link
           rel="preload"
           as="image"
-          href={preloadImage}
           imageSrcSet={lightboxImage.srcSet}
           fetchPriority="high"
         />


### PR DESCRIPTION
This change initially stemmed from https://github.com/artsy/force/pull/15008

While investigating the blurhash LCP stuff, I noticed we were loading both the 50 and 80 quality images on desktop but only using the 80. This removes the forced mobile preloading and just loads the selected version depending on your device. 

You can verify this change by disabling the img tag and seeing the correct versions get pre-loaded.

I would also suggest that we use the same quality image for both mobile and desktop. I'd be more concerned with latency and images not being populated in an edge vs the bandwidth savings. But I don't have any data to back up my intuition here. I guess we're using the lower quality to just game the Lighthouse metrics?