### PR TITLE
fix(artwork): improves fallback when images are missing geometry

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkLightbox.tsx
+++ b/src/Apps/Artwork/Components/ArtworkLightbox.tsx
@@ -89,6 +89,7 @@ const ArtworkLightbox: React.FC<
         cursor={onClick ? "zoom-in" : "default"}
         tabIndex={onClick ? undefined : -1}
         onClick={onClick}
+        overflow="hidden"
         {...rest}
       >
         <ResponsiveBox
@@ -136,12 +137,15 @@ const ArtworkLightbox: React.FC<
                 }
               : {})}
             width="100%"
-            height={"100%"}
+            height="100%"
             src={lightboxImage.src}
             srcSet={lightboxImage.srcSet}
             alt={artwork.formattedMetadata ?? ""}
             position="relative"
             preventRightClick={!isTeam}
+            style={{
+              objectFit: "cover",
+            }}
           />
         </ResponsiveBox>
       </Clickable>


### PR DESCRIPTION
![](https://capture.static.damonzucconi.com/Screen-Shot-2025-03-11-09-00-29.43-lHxRJ4HCuiN1oSUmrnxOBmdA74U1uU3jYVDw2Q74z517Kb5hslZtj7zI1P77VVGZBRvIIEyuYskbtoGb9oCEOsMtxTO86NZZ6SPZ.png)

When inserting images into the gallery, we determine the container size by finding the maximum height across all images then create a static container height. This prevents UI shifting during carousel navigation. However, when images are missing geometry data, we encounter an issue where the container sizing becomes incorrect. Since these images default to a 1:1 aspect ratio instead of their correct aspect ratio, they stretch to fill the container, resulting in distorted images and a broken UI.

While there's no elegant solution really, this is a practical fix for these edge cases.