### PR TITLE
fix: add loading state for payment route of order app so that the screen does not flicker on load

### DIFF
--- a/src/Apps/Order/Routes/Payment/PaymentContext/OrderPaymentContext.tsx
+++ b/src/Apps/Order/Routes/Payment/PaymentContext/OrderPaymentContext.tsx
@@ -20,6 +20,7 @@ export enum OrderPaymentActions {
   SET_STRIPE_CLIENT = "SET_STRIPE_CLIENT",
   SET_IS_SAVING_PAYMENT = "SET_IS_SAVING_PAYMENT",
   SET_IS_STRIPE_PAYMENT_ELEMENT_LOADING = "SET_IS_STRIPE_PAYMENT_ELEMENT_LOADING",
+  SET_IS_LOADING = "SET_IS_LOADING",
 }
 
 type OrderPaymentActionsPayload = {
@@ -31,6 +32,7 @@ type OrderPaymentActionsPayload = {
   [OrderPaymentActions.SET_STRIPE_CLIENT]: null | string
   [OrderPaymentActions.SET_IS_SAVING_PAYMENT]: boolean
   [OrderPaymentActions.SET_IS_STRIPE_PAYMENT_ELEMENT_LOADING]: boolean
+  [OrderPaymentActions.SET_IS_LOADING]: boolean
 }
 
 export type OrderPaymentAction =
@@ -60,6 +62,7 @@ export type OrderPaymentState = {
   stripeClient: null | string
   isSavingPayment: boolean
   isStripePaymentElementLoading: boolean
+  isLoading: boolean
 }
 
 const initialOrderPaymentState = {
@@ -71,6 +74,7 @@ const initialOrderPaymentState = {
   stripeClient: null,
   isSavingPayment: false,
   isStripePaymentElementLoading: true,
+  isLoading: true,
 }
 
 /**
@@ -164,6 +168,12 @@ export const useOrderPaymentContext = () => {
       payload,
     })
 
+  const setIsLoading = payload =>
+    dispatch({
+      type: OrderPaymentActions.SET_IS_LOADING,
+      payload,
+    })
+
   return {
     ...state,
     setSelectedBankAccountId,
@@ -174,5 +184,6 @@ export const useOrderPaymentContext = () => {
     setStripeClient,
     setIsSavingPayment,
     setIsStripePaymentElementLoading,
+    setIsLoading,
   }
 }

--- a/src/Apps/Order/Routes/Payment/PaymentContext/orderPaymentReducer.ts
+++ b/src/Apps/Order/Routes/Payment/PaymentContext/orderPaymentReducer.ts
@@ -57,6 +57,12 @@ export const orderPaymentReducer = (
         isStripePaymentElementLoading: action.payload,
       }
     }
+    case OrderPaymentActions.SET_IS_LOADING: {
+      return {
+        ...state,
+        isLoading: action.payload,
+      }
+    }
     default: {
       return state
     }

--- a/src/Apps/Order/Routes/Payment/index.tsx
+++ b/src/Apps/Order/Routes/Payment/index.tsx
@@ -93,6 +93,8 @@ export const PaymentRoute: FC<
     setBalanceCheckComplete,
     setBankAccountHasInsufficientFunds,
     setIsSavingPayment,
+    isLoading,
+    setIsLoading,
   } = useOrderPaymentContext()
 
   const balanceCheckEnabled =
@@ -100,8 +102,6 @@ export const PaymentRoute: FC<
     selectedPaymentMethod === "US_BANK_ACCOUNT"
 
   const artworkVersion = extractNodes(order.lineItems)[0]?.artworkVersion
-
-  const { jumpTo } = useJump()
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
@@ -220,6 +220,7 @@ export const PaymentRoute: FC<
   }
 
   // sets payment with Credit Card
+  const { jumpTo } = useJump()
   const handleCreditCardContinue = async () => {
     try {
       const result = await CreditCardPicker?.current?.getCreditCardId()
@@ -454,6 +455,17 @@ export const PaymentRoute: FC<
         }
       `,
     })
+  }
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
+  useEffect(() => {
+    if (order && me) {
+      setIsLoading(false)
+    }
+  }, [order, me])
+
+  if (isLoading) {
+    return null
   }
 
   return (

--- a/src/Apps/Order/Routes/__tests__/Payment.jest.enzyme.tsx
+++ b/src/Apps/Order/Routes/__tests__/Payment.jest.enzyme.tsx
@@ -181,6 +181,8 @@ describe("Payment", () => {
           selectedPaymentMethod: "CREDIT_CARD",
           setIsSavingPayment: mockSetIsSavingPayment,
           setSelectedPaymentMethod: jest.fn(),
+          isLoading: false,
+          setIsLoading: jest.fn(),
         }
       })
       const mockTracking = useTracking as jest.Mock
@@ -371,6 +373,8 @@ describe("Payment", () => {
           setSelectedPaymentMethod: jest.fn(),
           setBankAccountSelection: jest.fn(),
           setIsSavingPayment: jest.fn(),
+          isLoading: false,
+          setIsLoading: jest.fn(),
         }
       })
       isCommittingMutation = false
@@ -475,6 +479,8 @@ describe("Payment", () => {
           setSelectedPaymentMethod: jest.fn(),
           setBankAccountSelection: jest.fn(),
           setIsSavingPayment: jest.fn(),
+          isLoading: false,
+          setIsLoading: jest.fn(),
         }
       })
       isCommittingMutation = false
@@ -578,6 +584,8 @@ describe("Payment", () => {
           setSelectedPaymentMethod: jest.fn(),
           setBankAccountSelection: jest.fn(),
           setIsSavingPayment: mockSetIsSavingPayment,
+          isLoading: false,
+          setIsLoading: jest.fn(),
         }
       })
       ;(useSetPayment as jest.Mock).mockImplementation(() => ({
@@ -779,6 +787,8 @@ describe("Payment", () => {
             setSelectedPaymentMethod: jest.fn(),
             setBankAccountSelection: jest.fn(),
             setIsSavingPayment: jest.fn(),
+            isLoading: false,
+            setIsLoading: jest.fn(),
           }
         })
 


### PR DESCRIPTION
Following the pattern introduced for shipping screen https://github.com/artsy/force/pull/15282 adding loading state for the payment route as well.

Seems to fix the flicker and double render on reload.

