### PR TITLE
fix(EMI-2311): suppress a line for artworkMetadata on offer notification details

### DIFF
--- a/src/Components/Artwork/Details/Details.tsx
+++ b/src/Components/Artwork/Details/Details.tsx
@@ -29,6 +29,7 @@ export interface DetailsProps {
   showSaveButton?: boolean
   showSubmissionStatus?: boolean
   renderSaveButton?: (artworkId: string) => React.ReactNode
+  suppressDisplayLinesCount?: number
 }
 
 const LINE_HEIGHT = 22
@@ -239,6 +240,7 @@ export const Details: React.FC<React.PropsWithChildren<DetailsProps>> = ({
   showSaveButton,
   showSubmissionStatus,
   renderSaveButton,
+  suppressDisplayLinesCount,
   ...rest
 }) => {
   const { isAuctionArtwork, hideLotLabel, saveOnlyToDefaultList } =
@@ -285,8 +287,13 @@ export const Details: React.FC<React.PropsWithChildren<DetailsProps>> = ({
     )
   }
 
+  const adjustedContainerHeight =
+    suppressDisplayLinesCount && suppressDisplayLinesCount > 0
+      ? `${LINE_HEIGHT * (NUM_OF_LINES - suppressDisplayLinesCount)}px`
+      : CONTAINER_HEIGHT_PX
+
   return (
-    <Box height={CONTAINER_HEIGHT_PX}>
+    <Box height={adjustedContainerHeight}>
       {isAuctionArtwork && (
         <Flex flexDirection="row">
           <Join separator={<Spacer x={1} />}>
@@ -412,14 +419,27 @@ export const DetailsFragmentContainer = createFragmentContainer(Details, {
 
 type DetailsPlaceholderProps = Pick<
   DetailsProps,
-  "hidePartnerName" | "hideArtistName" | "hideSaleInfo"
+  | "hidePartnerName"
+  | "hideArtistName"
+  | "hideSaleInfo"
+  | "suppressDisplayLinesCount"
 >
 
 export const DetailsPlaceholder: React.FC<
   React.PropsWithChildren<DetailsPlaceholderProps>
-> = ({ hideArtistName, hidePartnerName, hideSaleInfo }) => {
+> = ({
+  hideArtistName,
+  hidePartnerName,
+  hideSaleInfo,
+  suppressDisplayLinesCount,
+}) => {
+  const adjustedContainerHeight =
+    suppressDisplayLinesCount && suppressDisplayLinesCount > 0
+      ? `${LINE_HEIGHT * (NUM_OF_LINES - suppressDisplayLinesCount)}px`
+      : CONTAINER_HEIGHT_PX
+
   return (
-    <Box height={CONTAINER_HEIGHT_PX}>
+    <Box height={adjustedContainerHeight}>
       {!hideArtistName && (
         <SkeletonText variant="sm-display" lineHeight={LINE_HEIGHT_PX}>
           Artist Name

--- a/src/Components/Artwork/Metadata.tsx
+++ b/src/Components/Artwork/Metadata.tsx
@@ -26,6 +26,7 @@ export interface MetadataProps
   showSubmissionStatus?: boolean
   to?: string | null
   renderSaveButton?: (artworkId: string) => React.ReactNode
+  suppressDisplayLinesCount?: number
 }
 
 export const Metadata: React.FC<React.PropsWithChildren<MetadataProps>> = ({
@@ -42,6 +43,7 @@ export const Metadata: React.FC<React.PropsWithChildren<MetadataProps>> = ({
   showSaveButton,
   showSubmissionStatus,
   renderSaveButton,
+  suppressDisplayLinesCount,
   ...rest
 }) => {
   return (
@@ -64,6 +66,7 @@ export const Metadata: React.FC<React.PropsWithChildren<MetadataProps>> = ({
         showSubmissionStatus={showSubmissionStatus}
         contextModule={contextModule}
         renderSaveButton={renderSaveButton}
+        suppressDisplayLinesCount={suppressDisplayLinesCount}
       />
     </LinkContainer>
   )
@@ -115,19 +118,30 @@ export default createFragmentContainer(Metadata, {
 
 type MetadataPlaceholderProps = Pick<
   MetadataProps,
-  "hidePartnerName" | "hideArtistName" | "hideSaleInfo"
+  | "hidePartnerName"
+  | "hideArtistName"
+  | "hideSaleInfo"
+  | "suppressDisplayLinesCount"
 > &
   BoxProps
 
 export const MetadataPlaceholder: React.FC<
   React.PropsWithChildren<MetadataPlaceholderProps>
-> = ({ mt = 1, hidePartnerName, hideArtistName, hideSaleInfo, ...rest }) => {
+> = ({
+  mt = 1,
+  hidePartnerName,
+  hideArtistName,
+  hideSaleInfo,
+  suppressDisplayLinesCount,
+  ...rest
+}) => {
   return (
     <Box mt={mt} {...rest}>
       <DetailsPlaceholder
         hidePartnerName={hidePartnerName}
         hideArtistName={hideArtistName}
         hideSaleInfo={hideSaleInfo}
+        suppressDisplayLinesCount={suppressDisplayLinesCount}
       />
     </Box>
   )

--- a/src/Components/Notifications/PartnerOfferArtwork.tsx
+++ b/src/Components/Notifications/PartnerOfferArtwork.tsx
@@ -105,6 +105,7 @@ export const PartnerOfferArtwork: FC<
           hideSaleInfo
           maxWidth="100%"
           to={fullyAvailable ? artworkListingHref : href}
+          suppressDisplayLinesCount={1}
         />
 
         {fullyAvailable && (

--- a/src/Components/Notifications/PartnerOfferCreatedNotification.tsx
+++ b/src/Components/Notifications/PartnerOfferCreatedNotification.tsx
@@ -78,7 +78,7 @@ export const PartnerOfferCreatedNotification: FC<
           <Text
             variant="xs"
             fontWeight="bold"
-            aria-label={`Notification type: Offer`}
+            aria-label={"Notification type: Offer"}
           >
             Offer
           </Text>


### PR DESCRIPTION
Not ideal but pretty straightforward way to do it.  In the case of those notifications in notification panel - we are always suppressing the 'salePrice' line and instead rendering the separate line that is not part of standard metadata with adjusted price right after. And the request here was that we do not have extra space between metadata and this separate offer pricing output.

I went with the simplest hacky way to do it by just specifying how many lines need to be suppressed for this Details component. Theoretically we can pass the number on lines as a property as well and base calculation on that but I figured it's  more clear to keep this number of lines as a constant (5) for now and very specifically pass the number of lines that should be hidden in specific cases.

This display still has a slight flicker on load but that is because of the way we are loading the data for those details. Limited offer into comes async there. We can try to fix this as well but that seems like a different issue.

Current view:
![current_staging](https://github.com/user-attachments/assets/b7892dab-16cc-4a3c-80aa-d676131c97f2)

Update view:
![updated_local](https://github.com/user-attachments/assets/0d759f74-5c89-40f9-aabf-631140664d52)


I can also DRY this calculating a new height code but wanted to get buy in on this approach first.
