### PR TITLE
feat:(dia-1117): update grid on gallery curated sort for gallery shows

### DIFF
--- a/src/Apps/Auction/Components/AuctionArtworkFilter.tsx
+++ b/src/Apps/Auction/Components/AuctionArtworkFilter.tsx
@@ -49,6 +49,7 @@ const AuctionArtworkFilter: React.FC<
         aggregations={aggregations as Aggregations}
         filters={match && match.location.query}
         counts={counts as Counts}
+        layout="grid"
         relayRefetchInputVariables={{
           ...getArtworkFilterInputArgs(user),
           saleID: match.params.slug,

--- a/src/Apps/Auction/Components/AuctionArtworkFilter.tsx
+++ b/src/Apps/Auction/Components/AuctionArtworkFilter.tsx
@@ -49,7 +49,7 @@ const AuctionArtworkFilter: React.FC<
         aggregations={aggregations as Aggregations}
         filters={match && match.location.query}
         counts={counts as Counts}
-        layout="grid"
+        layout="GRID"
         relayRefetchInputVariables={{
           ...getArtworkFilterInputArgs(user),
           saleID: match.params.slug,

--- a/src/Apps/Show/Components/ShowArtworks.tsx
+++ b/src/Apps/Show/Components/ShowArtworks.tsx
@@ -75,7 +75,7 @@ const ShowArtworksFilter: React.FC<
         relayVariables={{
           aggregations: ["TOTAL"],
         }}
-        layout="grid"
+        layout="GRID"
         {...rest}
       />
     </ArtworkFilterContextProvider>

--- a/src/Apps/Show/Components/ShowArtworks.tsx
+++ b/src/Apps/Show/Components/ShowArtworks.tsx
@@ -75,6 +75,7 @@ const ShowArtworksFilter: React.FC<
         relayVariables={{
           aggregations: ["TOTAL"],
         }}
+        layout="grid"
         {...rest}
       />
     </ArtworkFilterContextProvider>

--- a/src/Apps/Show/__tests__/ShowArtworks.jest.enzyme.tsx
+++ b/src/Apps/Show/__tests__/ShowArtworks.jest.enzyme.tsx
@@ -52,7 +52,7 @@ describe("ShowArtworks", () => {
     const { wrapper } = getWrapper({ Show: () => ({ __typename: "Show" }) })
 
     expect(wrapper.find("ArtworkFilterArtworkGrid").length).toBe(1)
-    expect(wrapper.find("ArtworkGridItem").length).toBe(1)
+    expect(wrapper.find("FlatGridItem").length).toBe(1)
   })
 
   it("renders filters in correct order", () => {

--- a/src/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
@@ -23,6 +23,7 @@ interface ArtworkFilterArtworkGridProps {
   isLoading?: boolean
   offset?: number
   relay: RelayProp
+  layout?: "grid" | "masonry"
 }
 
 const ArtworkFilterArtworkGrid: React.FC<
@@ -69,6 +70,7 @@ const ArtworkFilterArtworkGrid: React.FC<
           contextModule={ContextModule.artworkGrid}
           itemMargin={40}
           user={user}
+          layout={props.layout}
           onClearFilters={context.resetFilters}
           emptyStateComponent={context.ZeroState && <context.ZeroState />}
           onBrickClick={(artwork, artworkIndex) => {

--- a/src/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilterArtworkGrid.tsx
@@ -4,7 +4,9 @@ import {
   ContextModule,
   OwnerType,
 } from "@artsy/cohesion"
-import ArtworkGrid from "Components/ArtworkGrid/ArtworkGrid"
+import ArtworkGrid, {
+  type ArtworkGridLayout,
+} from "Components/ArtworkGrid/ArtworkGrid"
 import { useArtworkGridContext } from "Components/ArtworkGrid/ArtworkGridContext"
 import { LoadingArea } from "Components/LoadingArea"
 import { PaginationFragmentContainer as Pagination } from "Components/Pagination"
@@ -23,7 +25,7 @@ interface ArtworkFilterArtworkGridProps {
   isLoading?: boolean
   offset?: number
   relay: RelayProp
-  layout?: "grid" | "masonry"
+  layout?: ArtworkGridLayout
 }
 
 const ArtworkFilterArtworkGrid: React.FC<

--- a/src/Components/ArtworkFilter/index.tsx
+++ b/src/Components/ArtworkFilter/index.tsx
@@ -46,7 +46,7 @@ import {
 } from "react-relay"
 import { useTracking } from "react-tracking"
 import useDeepCompareEffect from "use-deep-compare-effect"
-import { ArtworkFilterArtworkGridRefetchContainer as ArtworkFilterArtworkGrid } from "./ArtworkFilterArtworkGrid"
+import { ArtworkFilterArtworkGridRefetchContainer } from "./ArtworkFilterArtworkGrid"
 import {
   ArtworkFilterContextProvider,
   type SharedArtworkFilterContextProps,
@@ -67,6 +67,7 @@ interface ArtworkFilterProps extends SharedArtworkFilterContextProps, BoxProps {
   relayVariables?: object
   viewer
   featuredKeywords?: readonly string[] | null | undefined
+  layout?: "grid" | "masonry"
 }
 
 /**
@@ -121,6 +122,7 @@ export const BaseArtworkFilter: React.FC<
   relayVariables = {},
   viewer,
   featuredKeywords,
+  layout,
   ...rest
 }) => {
   const tracking = useTracking()
@@ -329,11 +331,12 @@ export const BaseArtworkFilter: React.FC<
 
         <Spacer y={2} />
 
-        <ArtworkFilterArtworkGrid
+        <ArtworkFilterArtworkGridRefetchContainer
           filtered_artworks={viewer.filtered_artworks}
           isLoading={isLoading}
           offset={offset}
           columnCount={[2, 3]}
+          layout={layout}
         />
       </Media>
 
@@ -427,11 +430,12 @@ export const BaseArtworkFilter: React.FC<
         <Spacer y={2} />
 
         {children || (
-          <ArtworkFilterArtworkGrid
+          <ArtworkFilterArtworkGridRefetchContainer
             filtered_artworks={viewer.filtered_artworks}
             isLoading={isLoading}
             offset={offset}
             columnCount={[2, 3, 4]}
+            layout={layout}
           />
         )}
       </Media>

--- a/src/Components/ArtworkFilter/index.tsx
+++ b/src/Components/ArtworkFilter/index.tsx
@@ -29,6 +29,7 @@ import {
   ARTWORK_FILTERS_QUICK_FIELDS,
   ArtworkFiltersQuick,
 } from "Components/ArtworkFilter/ArtworkFiltersQuick"
+import type { ArtworkGridLayout } from "Components/ArtworkGrid/ArtworkGrid"
 import { useArtworkGridContext } from "Components/ArtworkGrid/ArtworkGridContext"
 import { Sticky } from "Components/Sticky"
 import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
@@ -67,7 +68,7 @@ interface ArtworkFilterProps extends SharedArtworkFilterContextProps, BoxProps {
   relayVariables?: object
   viewer
   featuredKeywords?: readonly string[] | null | undefined
-  layout?: "grid" | "masonry"
+  layout?: ArtworkGridLayout
 }
 
 /**

--- a/src/Components/ArtworkGrid/ArtworkGrid.tsx
+++ b/src/Components/ArtworkGrid/ArtworkGrid.tsx
@@ -40,8 +40,8 @@ interface ArtworkGridProps {
   columnCount?: number | number[]
   hideSaleInfo?: boolean
   preloadImageCount?: number
-  isAuctionArtwork?: boolean
   itemMargin?: number
+  layout?: "grid" | "masonry"
   onBrickClick?: (artwork: Artwork, artworkIndex: number) => void
   onClearFilters?: () => any
   onLoadMore?: () => any
@@ -73,9 +73,9 @@ export class ArtworkGridContainer extends React.Component<
   static defaultProps = {
     columnCount: [3],
     sectionMargin: 20,
-    isAuctionArtwork: false,
     itemMargin: 20,
     preloadImageCount: 0,
+    layout: "masonry",
   }
 
   state = {
@@ -307,18 +307,13 @@ export class ArtworkGridContainer extends React.Component<
   }
 
   render() {
-    const {
-      artworks,
-      className,
-      isAuctionArtwork,
-      onClearFilters,
-      emptyStateComponent,
-    } = this.props
+    const { artworks, className, onClearFilters, emptyStateComponent } =
+      this.props
 
     const hasArtworks = !isEmpty(artworks?.edges)
     let artworkGrids
 
-    if (isAuctionArtwork) {
+    if (this.props.layout === "grid") {
       artworkGrids = this.renderArtworkGrid()
     } else {
       artworkGrids = this.renderMasonrySectionsForAllBreakpoints()

--- a/src/Components/ArtworkGrid/ArtworkGrid.tsx
+++ b/src/Components/ArtworkGrid/ArtworkGrid.tsx
@@ -34,6 +34,8 @@ type Artworks =
 type Artwork = ExtractNodeType<Artworks>
 type SectionedArtworks = Array<Array<Artwork>>
 
+export type ArtworkGridLayout = "GRID" | "MASONRY"
+
 interface ArtworkGridProps {
   artworks: Artworks
   contextModule?: AuthContextModule
@@ -41,7 +43,7 @@ interface ArtworkGridProps {
   hideSaleInfo?: boolean
   preloadImageCount?: number
   itemMargin?: number
-  layout?: "grid" | "masonry"
+  layout?: ArtworkGridLayout
   onBrickClick?: (artwork: Artwork, artworkIndex: number) => void
   onClearFilters?: () => any
   onLoadMore?: () => any
@@ -75,7 +77,7 @@ export class ArtworkGridContainer extends React.Component<
     sectionMargin: 20,
     itemMargin: 20,
     preloadImageCount: 0,
-    layout: "masonry",
+    layout: "MASONRY",
   }
 
   state = {
@@ -313,7 +315,7 @@ export class ArtworkGridContainer extends React.Component<
     const hasArtworks = !isEmpty(artworks?.edges)
     let artworkGrids
 
-    if (this.props.layout === "grid") {
+    if (this.props.layout === "GRID") {
       artworkGrids = this.renderArtworkGrid()
     } else {
       artworkGrids = this.renderMasonrySectionsForAllBreakpoints()


### PR DESCRIPTION
This PR enables flat grid layouts for artwork displays on show pages so that the curated sort is intuitively reflected. The artwork grid implementation has been refactored to decouple the layout logic from auction-specific checks, making it more flexible for use across different contexts and collection types.