### PR TITLE
fix: unlink partner sharing from public list sharing

### DIFF
--- a/src/Components/ShareCollectionDialog.tsx
+++ b/src/Components/ShareCollectionDialog.tsx
@@ -68,7 +68,6 @@ export const ShareCollectionDialog: React.FC<
             id: collectionId,
             name: collectionName, // TODO: Shouldn't be required
             private: false,
-            shareableWithPartners: true,
           },
         },
         rejectIf: res => {


### PR DESCRIPTION
The type of this PR is: **Fix**

Makes the change [discussed here](https://github.com/artsy/force/pull/15110/files#r1994348426), in order to prevent unintended sharing with partners of the user's saved artwork lists.

This PR solves [ONYX-1612]






[ONYX-1612]: https://artsyproduct.atlassian.net/browse/ONYX-1612?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ