### PR TITLE
feat(dia-1212) uses flat grid placeholder skeleton when layout is grid

### DIFF
--- a/src/Apps/Auction/Components/AuctionArtworkFilter.tsx
+++ b/src/Apps/Auction/Components/AuctionArtworkFilter.tsx
@@ -155,10 +155,10 @@ export const AuctionArtworkFilterQueryRenderer: React.FC<
         `}
         variables={initializeVariablesWithFilterState(match.params, match)}
         fetchPolicy="network-only"
-        placeholder={<ArtworkFilterPlaceholder />}
+        placeholder={<ArtworkFilterPlaceholder layout="GRID" />}
         render={({ error, props }) => {
           if (error || !props?.viewer) {
-            return <ArtworkFilterPlaceholder />
+            return <ArtworkFilterPlaceholder layout="GRID" />
           }
 
           return (

--- a/src/Apps/Show/Components/ShowArtworks.tsx
+++ b/src/Apps/Show/Components/ShowArtworks.tsx
@@ -156,10 +156,10 @@ export const ShowArtworkFilterQueryRenderer: React.FC<
         `}
         variables={initializeVariablesWithFilterState(match.params, match)}
         fetchPolicy="store-and-network"
-        placeholder={<ArtworkFilterPlaceholder />}
+        placeholder={<ArtworkFilterPlaceholder layout="GRID" />}
         render={({ error, props }) => {
           if (error || !props?.show) {
-            return <ArtworkFilterPlaceholder />
+            return <ArtworkFilterPlaceholder layout="GRID" />
           }
 
           return <ShowArtworksRefetchContainer show={props.show} {...rest} />

--- a/src/Components/Artwork/FlatGridItem.tsx
+++ b/src/Components/Artwork/FlatGridItem.tsx
@@ -11,7 +11,7 @@ import { userIsTeam } from "Utils/user"
 import type { FlatGridItem_artwork$data } from "__generated__/FlatGridItem_artwork.graphql"
 import { useState } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import Metadata from "./Metadata"
+import Metadata, { MetadataPlaceholder } from "./Metadata"
 import { useSaveButton } from "./SaveButton"
 
 interface FlatGridItemProps {
@@ -158,3 +158,30 @@ export const FlatGridItemFragmentContainer = createFragmentContainer(
     `,
   },
 )
+
+interface FlatGridItemPlaceholderProps {
+  width: number
+  height: number
+}
+
+export const FlatGridItemPlaceholder: React.FC<
+  React.PropsWithChildren<FlatGridItemPlaceholderProps>
+> = ({ width, height }) => {
+  return (
+    <Flex
+      flexDirection="column"
+      justifyContent="flex-end"
+      width="100%"
+      height="100%"
+    >
+      <ResponsiveBox
+        aspectWidth={width}
+        aspectHeight={height}
+        maxWidth="100%"
+        bg="black10"
+      />
+
+      <MetadataPlaceholder />
+    </Flex>
+  )
+}

--- a/src/Components/Artwork/GridItem.tsx
+++ b/src/Components/Artwork/GridItem.tsx
@@ -1,6 +1,6 @@
 import { type AuthContextModule, ContextModule } from "@artsy/cohesion"
 import NoArtIcon from "@artsy/icons/NoArtIcon"
-import { Box, Flex, Popover, ResponsiveBox } from "@artsy/palette"
+import { Box, Flex, Popover, ResponsiveBox, SkeletonBox } from "@artsy/palette"
 import { Z } from "Apps/Components/constants"
 import { ExclusiveAccessBadge } from "Components/Artwork/ExclusiveAccessBadge"
 import { ManageArtworkForSavesProvider } from "Components/Artwork/ManageArtworkForSaves"
@@ -13,7 +13,7 @@ import { userIsTeam } from "Utils/user"
 import type { GridItem_artwork$data } from "__generated__/GridItem_artwork.graphql"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
-import Metadata from "./Metadata"
+import Metadata, { MetadataPlaceholder } from "./Metadata"
 import { useHoverMetadata } from "./useHoverMetadata"
 
 export const DEFAULT_GRID_ITEM_ASPECT_RATIO = 4 / 3
@@ -322,3 +322,22 @@ export const ArtworkGridItemFragmentContainer = createFragmentContainer(
 )
 
 export default ArtworkGridItemFragmentContainer
+
+interface ArtworkGridItemPlaceholderProps {
+  width: number
+  height: number
+}
+
+export const ArtworkGridItemPlaceholder: React.FC<
+  React.PropsWithChildren<ArtworkGridItemPlaceholderProps>
+> = ({ width, height }) => {
+  return (
+    <>
+      <ResponsiveBox aspectWidth={width} aspectHeight={height} maxWidth="100%">
+        <SkeletonBox width="100%" height="100%" />
+      </ResponsiveBox>
+
+      <MetadataPlaceholder />
+    </>
+  )
+}

--- a/src/Components/ArtworkFilter/ArtworkFilterPlaceholder.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilterPlaceholder.tsx
@@ -15,17 +15,21 @@ import {
 import { AppContainer } from "Apps/Components/AppContainer"
 import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
 import { ArtworkFilterActiveFilters } from "Components/ArtworkFilter/ArtworkFilterActiveFilters"
-import { ArtworkGridPlaceholder } from "Components/ArtworkGrid/ArtworkGrid"
+import {
+  type ArtworkGridLayout,
+  ArtworkGridPlaceholder,
+} from "Components/ArtworkGrid/ArtworkGrid"
 import { Sticky } from "Components/Sticky"
 import { Media } from "Utils/Responsive"
 
 interface ArtworkFilterPlaceholderProps extends BoxProps {
   showCreateAlert?: boolean
+  layout?: ArtworkGridLayout
 }
 
 export const ArtworkFilterPlaceholder: React.FC<
   React.PropsWithChildren<ArtworkFilterPlaceholderProps>
-> = ({ showCreateAlert = false, ...rest }) => {
+> = ({ showCreateAlert = false, layout = "MASONRY", ...rest }) => {
   return (
     <Skeleton {...rest}>
       {/* Mobile Artwork Filter Placeholder */}
@@ -65,7 +69,7 @@ export const ArtworkFilterPlaceholder: React.FC<
 
         <Spacer y={2} />
 
-        <ArtworkGridPlaceholder columnCount={2} />
+        <ArtworkGridPlaceholder columnCount={2} layout={layout} />
       </Media>
 
       {/* Desktop Artwork Filter Placeholder */}
@@ -163,7 +167,7 @@ export const ArtworkFilterPlaceholder: React.FC<
 
         {/* FIXME: The breakpoints that the artwork grid uses are completely different from Palette's */}
         {/* So this placeholder does not accurately reflect column count at certain widths */}
-        <ArtworkGridPlaceholder columnCount={[2, 3, 4]} />
+        <ArtworkGridPlaceholder columnCount={[2, 3, 4]} layout={layout} />
       </Media>
     </Skeleton>
   )

--- a/src/Components/ArtworkGrid/ArtworkGrid.tsx
+++ b/src/Components/ArtworkGrid/ArtworkGrid.tsx
@@ -1,17 +1,13 @@
 import type { AuthContextModule } from "@artsy/cohesion"
+import { Column, Flex, GridColumns, Spacer } from "@artsy/palette"
 import {
-  Column,
-  Flex,
-  GridColumns,
-  ResponsiveBox,
-  SkeletonBox,
-  Spacer,
-} from "@artsy/palette"
-import { FlatGridItemFragmentContainer } from "Components/Artwork/FlatGridItem"
+  FlatGridItemFragmentContainer,
+  FlatGridItemPlaceholder,
+} from "Components/Artwork/FlatGridItem"
 import GridItem, {
+  ArtworkGridItemPlaceholder,
   DEFAULT_GRID_ITEM_ASPECT_RATIO,
 } from "Components/Artwork/GridItem"
-import { MetadataPlaceholder } from "Components/Artwork/Metadata"
 import { ArtworkGridEmptyState } from "Components/ArtworkGrid/ArtworkGridEmptyState"
 import { Masonry, type MasonryProps } from "Components/Masonry"
 import { Media, valuesWithBreakpointProps } from "Utils/Responsive"
@@ -22,7 +18,7 @@ import type { MyCollectionArtworkGrid_artworks$data } from "__generated__/MyColl
 import { isEmpty, isEqual } from "lodash"
 import memoizeOnce from "memoize-one"
 import * as React from "react"
-import type { ReactNode } from "react"
+import { type ReactNode, useMemo } from "react"
 import ReactDOM from "react-dom"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
@@ -449,28 +445,41 @@ const PLACEHOLDER_DIMENSIONS = [
 
 interface ArtworkGridPlaceholderProps extends MasonryProps {
   amount?: number
+  layout?: ArtworkGridLayout
 }
 
 export const ArtworkGridPlaceholder: React.FC<
   React.PropsWithChildren<ArtworkGridPlaceholderProps>
-> = ({ amount = 20, ...rest }) => {
+> = ({ amount = 20, layout = "MASONRY", ...rest }) => {
+  const nodes = useMemo(() => {
+    return [...new Array(amount)].map((_, i) => {
+      const [width, height] =
+        PLACEHOLDER_DIMENSIONS[i % PLACEHOLDER_DIMENSIONS.length]
+
+      return { width, height }
+    })
+  }, [amount])
+
+  if (layout === "GRID") {
+    return (
+      <GridColumns width="100%">
+        {nodes.map(({ width, height }, index) => {
+          return (
+            <Column span={[6, 3]} key={index} minWidth={0}>
+              <FlatGridItemPlaceholder width={width} height={height} />
+            </Column>
+          )
+        })}
+      </GridColumns>
+    )
+  }
+
   return (
     <Masonry {...rest}>
-      {[...new Array(amount)].map((_, i) => {
-        const [width, height] =
-          PLACEHOLDER_DIMENSIONS[i % PLACEHOLDER_DIMENSIONS.length]
-
+      {nodes.map(({ width, height }, i) => {
         return (
           <div key={i}>
-            <ResponsiveBox
-              aspectWidth={width}
-              aspectHeight={height}
-              maxWidth="100%"
-            >
-              <SkeletonBox width="100%" height="100%" />
-            </ResponsiveBox>
-
-            <MetadataPlaceholder />
+            <ArtworkGridItemPlaceholder width={width} height={height} />
 
             <Spacer y={4} />
           </div>


### PR DESCRIPTION
While implementing the flat grid on show pages, I discovered the placeholder was still using a masonry layout. This PR exposes a new placeholder skeleton that correctly matches the flat grid layout style, implementing it across both show and auction pages.