### PR TITLE
feat(onyx-1570): tracking share saves

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves/Components/SavesArtworksHeader.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves/Components/SavesArtworksHeader.tsx
@@ -1,3 +1,4 @@
+import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
 import HideIcon from "@artsy/icons/HideIcon"
 import ShareIcon from "@artsy/icons/ShareIcon"
 import {
@@ -11,9 +12,13 @@ import {
 import { ArtworkListContextualMenu } from "Apps/CollectorProfile/Routes/Saves/Components/Actions/ArtworkListContextualMenu"
 import { ClientSuspense } from "Components/ClientSuspense"
 import { ShareCollectionDialog } from "Components/ShareCollectionDialog"
-import type { SavesArtworksHeaderQuery } from "__generated__/SavesArtworksHeaderQuery.graphql"
+import type {
+  SavesArtworksHeaderQuery,
+  SavesArtworksHeaderQuery$data,
+} from "__generated__/SavesArtworksHeaderQuery.graphql"
 import { type FC, useState } from "react"
 import { graphql, useLazyLoadQuery } from "react-relay"
+import { useTracking } from "react-tracking"
 
 interface SavesArtworksHeaderProps {
   id: string
@@ -25,12 +30,15 @@ const SavesArtworksHeader: FC<
   const { me } = useLazyLoadQuery<SavesArtworksHeaderQuery>(QUERY, {
     id,
   })
+  const { trackEvent } = useTracking()
 
   const collection = me?.collection
 
   const [mode, setMode] = useState<"Idle" | "Share">("Idle")
 
   const handleShare = () => {
+    trackEvent(tracks.clickedShareButton(collection))
+
     setMode("Share")
   }
 
@@ -124,3 +132,15 @@ const QUERY = graphql`
     }
   }
 `
+
+const tracks = {
+  clickedShareButton: (
+    collection: NonNullable<SavesArtworksHeaderQuery$data["me"]>["collection"],
+  ) => ({
+    action: ActionType.clickedShareButton,
+    context_module: ContextModule.saves,
+    context_owner_type: OwnerType.saves,
+    context_owner_id: collection?.internalID,
+    context_owner_slug: collection?.slug,
+  }),
+}

--- a/src/Apps/User/Routes/UserCollectionRoute.tsx
+++ b/src/Apps/User/Routes/UserCollectionRoute.tsx
@@ -1,3 +1,4 @@
+import { ActionType, OwnerType } from "@artsy/cohesion"
 import { Spacer, Stack, Text } from "@artsy/palette"
 import { UserCollectionArtworks } from "Apps/User/Components/UserCollectionArtworks"
 import { ArtworkGridPlaceholder } from "Components/ArtworkGrid/ArtworkGrid"
@@ -6,7 +7,9 @@ import { MetaTags } from "Components/MetaTags"
 import { useRouter } from "System/Hooks/useRouter"
 import { Jump } from "Utils/Hooks/useJump"
 import type { UserCollectionRoute_collection$data } from "__generated__/UserCollectionRoute_collection.graphql"
+import { useEffect } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
+import { useTracking } from "react-tracking"
 
 interface UserCollectionRouteProps {
   collection: UserCollectionRoute_collection$data
@@ -16,6 +19,12 @@ const UserCollectionRoute = ({ collection }: UserCollectionRouteProps) => {
   const {
     match: { params },
   } = useRouter()
+
+  const { trackEvent } = useTracking()
+
+  useEffect(() => {
+    trackEvent(tracks.openedPage(collection))
+  }, [collection, trackEvent])
 
   return (
     <>
@@ -65,3 +74,11 @@ export const UserCollectionRouteFragmentContainer = createFragmentContainer(
     `,
   },
 )
+
+const tracks = {
+  openedPage: (collection: UserCollectionRoute_collection$data) => ({
+    action: ActionType.viewedSharedArtworkList,
+    context_owner_type: OwnerType.saves,
+    owner_id: collection.internalID,
+  }),
+}


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [ONYX-1570]

### Description

Tracking events for the “Share” Saves Collection feature:

- Click Share Button – When a user clicks the “Share” button.
- Copy URL – When a user clicks the “Copy URL” button.
- Open in New Tab – When a user clicks the “Open in New Tab” button.
- Shared Page View – When someone opens a shared saves page.

[ONYX-1570]: https://artsyproduct.atlassian.net/browse/ONYX-1570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ