### PR TITLE
chore(dismissible): Make SSR safe @latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "@artsy/cohesion": "4.244.0",
     "@artsy/commerce_helpers": "artsy/commerce_helpers",
     "@artsy/detect-responsive-traits": "^0.1.0",
-    "@artsy/dismissible": "^0.4.0",
+    "@artsy/dismissible": "^0.4.1",
     "@artsy/express-reloadable": "^1.7.0",
     "@artsy/fresnel": "^8.1.0",
     "@artsy/icons": "3.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -38,7 +38,7 @@
   resolved "https://registry.yarnpkg.com/@artsy/detect-responsive-traits/-/detect-responsive-traits-0.1.0.tgz#f7ae5041893b859ff9f6bc305fd318d2f5132745"
   integrity sha512-cdHMDcGpYuItSBvelAWEWxWipVGw/8Yzk7YoMvO+qWjZsHJtIF2hACtL5QFQxcf9K3j/eTXNSFlPmfZAe9Byew==
 
-"@artsy/dismissible@^0.4.0":
+"@artsy/dismissible@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@artsy/dismissible/-/dismissible-0.4.1.tgz#9251033d6e1dc5b577a847f88c0dfd9de85ff6ee"
   integrity sha512-jYp3MEsxolw/8JFglaSAFGVBnjkaM3ZrRTCLmxWl6nGYlR2mxOKIHrxiOScmZNtCl7rFUmVuNhR1B1I3U8QeqA==


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

@dzucconi  caught an SSR error with the latest `@artsy/dismissible` changes. Fixed [there](https://github.com/artsy/dismissible/pull/9) and bumping here. 


<img width="1014" alt="Screenshot 2025-03-17 at 9 27 07 AM" src="https://github.com/user-attachments/assets/9c01948f-0a7d-415c-920a-6602144c94e7" />
