### PR TITLE
fix(dia-1219): notifications item may overflow

### DIFF
--- a/src/Components/Notifications/NotificationItem.tsx
+++ b/src/Components/Notifications/NotificationItem.tsx
@@ -90,6 +90,7 @@ const NotificationItem: FC<React.PropsWithChildren<NotificationItemProps>> = ({
                       src={image.resized.src}
                       srcSet={image.resized.srcSet}
                       width={image.resized.width}
+                      placeHolderURL={image.blurhashDataURL ?? undefined}
                       height="100%"
                       lazyLoad
                       alt=""
@@ -101,6 +102,7 @@ const NotificationItem: FC<React.PropsWithChildren<NotificationItemProps>> = ({
               {shouldDisplayCounts && (
                 <>
                   <Spacer x={1} />
+
                   <Text
                     variant="xs"
                     color="black60"
@@ -176,6 +178,7 @@ export const NotificationItemFragmentContainer = createFragmentContainer(
         }
         previewImages(size: 4) {
           internalID
+          blurhashDataURL
           resized(
             height: 58
             version: ["main", "normalized", "larger", "large"]

--- a/src/Components/Notifications/NotificationItem.tsx
+++ b/src/Components/Notifications/NotificationItem.tsx
@@ -1,4 +1,11 @@
-import { Flex, Image, Join, Spacer, Text } from "@artsy/palette"
+import {
+  Flex,
+  HorizontalOverflow,
+  Image,
+  Spacer,
+  Stack,
+  Text,
+} from "@artsy/palette"
 import { themeGet } from "@styled-system/theme-get"
 import { ExpiresInTimer } from "Components/Notifications/ExpiresInTimer"
 import { useNotificationsContext } from "Components/Notifications/Hooks/useNotificationsContext"
@@ -11,7 +18,7 @@ import { RouterLink } from "System/Components/RouterLink"
 import { Media } from "Utils/Responsive"
 import createLogger from "Utils/logger"
 import type { NotificationItem_notification$data } from "__generated__/NotificationItem_notification.graphql"
-import { type FC, useCallback } from "react"
+import { type FC, useCallback, useMemo } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import styled from "styled-components"
 import { NotificationTypeLabel } from "./NotificationTypeLabel"
@@ -49,6 +56,14 @@ const NotificationItem: FC<React.PropsWithChildren<NotificationItemProps>> = ({
 
   const subTitle = getNotificationSubTitle(notification)
 
+  const images = useMemo(
+    () =>
+      notification.previewImages.filter(
+        image => image.resized?.width && image.resized?.height,
+      ),
+    [notification.previewImages],
+  )
+
   return (
     <NotificationItemWrapper
       item={notification}
@@ -57,45 +72,48 @@ const NotificationItem: FC<React.PropsWithChildren<NotificationItemProps>> = ({
     >
       <Flex
         flex={1}
-        flexDirection={
-          notification.notificationType === "PARTNER_OFFER_CREATED"
-            ? "row"
-            : "column"
-        }
+        minWidth={0}
+        {...(notification.notificationType === "PARTNER_OFFER_CREATED"
+          ? { flexDirection: "row", gap: 1 }
+          : { flexDirection: "column" })}
       >
-        {!!notification.previewImages.length && (
-          <Flex flexDirection="row" alignItems="center" mb={0.5}>
-            <Flex flex={1}>
-              <Join separator={<Spacer x={1} />}>
-                {notification.previewImages.map((image, index) => {
+        {images.length > 0 && (
+          <Stack flexDirection="row" alignItems="center" mb={0.5} gap={1}>
+            <HorizontalOverflow height={58} width="100%">
+              <Stack gap={1} flexDirection="row">
+                {images.map((image, index) => {
                   if (!image.resized) return null
 
                   return (
                     <Image
                       key={index}
+                      src={image.resized.src}
                       srcSet={image.resized.srcSet}
-                      alt=""
-                      height={image.resized.height}
                       width={image.resized.width}
+                      height="100%"
                       lazyLoad
+                      alt=""
                     />
                   )
                 })}
-              </Join>
-              <Spacer x={1} />
-            </Flex>
+              </Stack>
 
-            {shouldDisplayCounts && (
-              <Text
-                variant="xs"
-                color="black60"
-                aria-label="Remaining artworks count"
-                ml={1}
-              >
-                + {remainingArtworksCount}
-              </Text>
-            )}
-          </Flex>
+              {shouldDisplayCounts && (
+                <>
+                  <Spacer x={1} />
+                  <Text
+                    variant="xs"
+                    color="black60"
+                    aria-label="Remaining artworks count"
+                    display="flex"
+                    alignItems="center"
+                  >
+                    + {remainingArtworksCount}
+                  </Text>
+                </>
+              )}
+            </HorizontalOverflow>
+          </Stack>
         )}
 
         <Flex flexDirection="column">
@@ -118,6 +136,7 @@ const NotificationItem: FC<React.PropsWithChildren<NotificationItemProps>> = ({
 
           <Flex flexDirection="row" gap={0.5}>
             <NotificationTypeLabel notification={notification} />
+
             {notification.item?.__typename ===
               "PartnerOfferCreatedNotificationItem" &&
               notification.item.expiresAt && (
@@ -161,6 +180,7 @@ export const NotificationItemFragmentContainer = createFragmentContainer(
             height: 58
             version: ["main", "normalized", "larger", "large"]
           ) {
+            src
             srcSet
             height
             width
@@ -225,6 +245,7 @@ const NotificationItemLink = styled(RouterLink)`
   display: flex;
   align-items: center;
   text-decoration: none;
+  overflow: hidden;
 
   &:hover {
     background-color: ${themeGet("colors.black5")};

--- a/src/__generated__/NotificationItem_notification.graphql.ts
+++ b/src/__generated__/NotificationItem_notification.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8a13ef14233cd481117018d2d60deec6>>
+ * @generated SignedSource<<9bd52347ac15c7fc282f032c0edc65dc>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -32,6 +32,7 @@ export type NotificationItem_notification$data = {
     readonly internalID: string | null | undefined;
     readonly resized: {
       readonly height: number | null | undefined;
+      readonly src: string;
       readonly srcSet: string;
       readonly width: number | null | undefined;
     } | null | undefined;
@@ -192,6 +193,13 @@ return {
               "alias": null,
               "args": null,
               "kind": "ScalarField",
+              "name": "src",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
               "name": "srcSet",
               "storageKey": null
             },
@@ -233,6 +241,6 @@ return {
 };
 })();
 
-(node as any).hash = "1eabaa94d01dcae518982787f854a346";
+(node as any).hash = "476ccbaebfb4eef0b9cb1e4938593379";
 
 export default node;

--- a/src/__generated__/NotificationItem_notification.graphql.ts
+++ b/src/__generated__/NotificationItem_notification.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9bd52347ac15c7fc282f032c0edc65dc>>
+ * @generated SignedSource<<07f6c9b3d62c5db5f1004aa6c2a3fa04>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -29,6 +29,7 @@ export type NotificationItem_notification$data = {
   readonly notificationType: NotificationTypesEnum;
   readonly objectsCount: number;
   readonly previewImages: ReadonlyArray<{
+    readonly blurhashDataURL: string | null | undefined;
     readonly internalID: string | null | undefined;
     readonly resized: {
       readonly height: number | null | undefined;
@@ -167,6 +168,13 @@ return {
         (v0/*: any*/),
         {
           "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "blurhashDataURL",
+          "storageKey": null
+        },
+        {
+          "alias": null,
           "args": [
             {
               "kind": "Literal",
@@ -241,6 +249,6 @@ return {
 };
 })();
 
-(node as any).hash = "476ccbaebfb4eef0b9cb1e4938593379";
+(node as any).hash = "e7cd8fcb3735227e7d2d4e04879f64f2";
 
 export default node;

--- a/src/__generated__/NotificationItem_test_Query.graphql.ts
+++ b/src/__generated__/NotificationItem_test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f254c71b26fe8c3e3ede3166c156cdb1>>
+ * @generated SignedSource<<0fcfc412e2e31c79e245afd5b80f5267>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -269,6 +269,13 @@ return {
                             "alias": null,
                             "args": null,
                             "kind": "ScalarField",
+                            "name": "src",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
                             "name": "srcSet",
                             "storageKey": null
                           },
@@ -324,7 +331,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "91ec9f1f793b5a20592908983248ec8b",
+    "cacheID": "64a34888c5a93945d910203004698349",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -414,6 +421,7 @@ return {
           "type": "ResizedImageUrl"
         },
         "notificationsConnection.edges.node.previewImages.resized.height": (v4/*: any*/),
+        "notificationsConnection.edges.node.previewImages.resized.src": (v2/*: any*/),
         "notificationsConnection.edges.node.previewImages.resized.srcSet": (v2/*: any*/),
         "notificationsConnection.edges.node.previewImages.resized.width": (v4/*: any*/),
         "notificationsConnection.edges.node.publishedAt": (v2/*: any*/),
@@ -423,7 +431,7 @@ return {
     },
     "name": "NotificationItem_test_Query",
     "operationKind": "query",
-    "text": "query NotificationItem_test_Query {\n  notificationsConnection(first: 1) {\n    edges {\n      node {\n        ...NotificationItem_notification\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationItem_notification on Notification {\n  id\n  internalID\n  headline\n  message\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  item {\n    __typename\n    ... on PartnerOfferCreatedNotificationItem {\n      available\n      expiresAt\n    }\n  }\n  previewImages(size: 4) {\n    internalID\n    resized(height: 58, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      srcSet\n      height\n      width\n    }\n  }\n  title\n  ...NotificationTypeLabel_notification\n}\n\nfragment NotificationTypeLabel_notification on Notification {\n  notificationType\n  publishedAt(format: \"RELATIVE\")\n}\n"
+    "text": "query NotificationItem_test_Query {\n  notificationsConnection(first: 1) {\n    edges {\n      node {\n        ...NotificationItem_notification\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationItem_notification on Notification {\n  id\n  internalID\n  headline\n  message\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  item {\n    __typename\n    ... on PartnerOfferCreatedNotificationItem {\n      available\n      expiresAt\n    }\n  }\n  previewImages(size: 4) {\n    internalID\n    resized(height: 58, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      height\n      width\n    }\n  }\n  title\n  ...NotificationTypeLabel_notification\n}\n\nfragment NotificationTypeLabel_notification on Notification {\n  notificationType\n  publishedAt(format: \"RELATIVE\")\n}\n"
   }
 };
 })();

--- a/src/__generated__/NotificationItem_test_Query.graphql.ts
+++ b/src/__generated__/NotificationItem_test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0fcfc412e2e31c79e245afd5b80f5267>>
+ * @generated SignedSource<<21f4090a2e8a38c3171d852e3f41b79e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -53,6 +53,12 @@ v3 = {
   "type": "ID"
 },
 v4 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v5 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -243,6 +249,13 @@ return {
                       (v1/*: any*/),
                       {
                         "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "blurhashDataURL",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
                         "args": [
                           {
                             "kind": "Literal",
@@ -331,7 +344,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "64a34888c5a93945d910203004698349",
+    "cacheID": "c7c3f80ed48cf3accc1284674cf34d03",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -375,12 +388,7 @@ return {
           "plural": false,
           "type": "Boolean"
         },
-        "notificationsConnection.edges.node.item.expiresAt": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "String"
-        },
+        "notificationsConnection.edges.node.item.expiresAt": (v4/*: any*/),
         "notificationsConnection.edges.node.message": (v2/*: any*/),
         "notificationsConnection.edges.node.notificationType": {
           "enumValues": [
@@ -408,6 +416,7 @@ return {
           "plural": true,
           "type": "Image"
         },
+        "notificationsConnection.edges.node.previewImages.blurhashDataURL": (v4/*: any*/),
         "notificationsConnection.edges.node.previewImages.internalID": {
           "enumValues": null,
           "nullable": true,
@@ -420,10 +429,10 @@ return {
           "plural": false,
           "type": "ResizedImageUrl"
         },
-        "notificationsConnection.edges.node.previewImages.resized.height": (v4/*: any*/),
+        "notificationsConnection.edges.node.previewImages.resized.height": (v5/*: any*/),
         "notificationsConnection.edges.node.previewImages.resized.src": (v2/*: any*/),
         "notificationsConnection.edges.node.previewImages.resized.srcSet": (v2/*: any*/),
-        "notificationsConnection.edges.node.previewImages.resized.width": (v4/*: any*/),
+        "notificationsConnection.edges.node.previewImages.resized.width": (v5/*: any*/),
         "notificationsConnection.edges.node.publishedAt": (v2/*: any*/),
         "notificationsConnection.edges.node.targetHref": (v2/*: any*/),
         "notificationsConnection.edges.node.title": (v2/*: any*/)
@@ -431,7 +440,7 @@ return {
     },
     "name": "NotificationItem_test_Query",
     "operationKind": "query",
-    "text": "query NotificationItem_test_Query {\n  notificationsConnection(first: 1) {\n    edges {\n      node {\n        ...NotificationItem_notification\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationItem_notification on Notification {\n  id\n  internalID\n  headline\n  message\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  item {\n    __typename\n    ... on PartnerOfferCreatedNotificationItem {\n      available\n      expiresAt\n    }\n  }\n  previewImages(size: 4) {\n    internalID\n    resized(height: 58, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      height\n      width\n    }\n  }\n  title\n  ...NotificationTypeLabel_notification\n}\n\nfragment NotificationTypeLabel_notification on Notification {\n  notificationType\n  publishedAt(format: \"RELATIVE\")\n}\n"
+    "text": "query NotificationItem_test_Query {\n  notificationsConnection(first: 1) {\n    edges {\n      node {\n        ...NotificationItem_notification\n        id\n      }\n    }\n  }\n}\n\nfragment NotificationItem_notification on Notification {\n  id\n  internalID\n  headline\n  message\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  item {\n    __typename\n    ... on PartnerOfferCreatedNotificationItem {\n      available\n      expiresAt\n    }\n  }\n  previewImages(size: 4) {\n    internalID\n    blurhashDataURL\n    resized(height: 58, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      height\n      width\n    }\n  }\n  title\n  ...NotificationTypeLabel_notification\n}\n\nfragment NotificationTypeLabel_notification on Notification {\n  notificationType\n  publishedAt(format: \"RELATIVE\")\n}\n"
   }
 };
 })();

--- a/src/__generated__/NotificationsListNextQuery.graphql.ts
+++ b/src/__generated__/NotificationsListNextQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8d20179b3706b9c8e03d497a31aa343b>>
+ * @generated SignedSource<<baca095e412fa629b188f97931608d1c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -345,6 +345,13 @@ return {
                                 "alias": null,
                                 "args": null,
                                 "kind": "ScalarField",
+                                "name": "src",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
                                 "name": "srcSet",
                                 "storageKey": null
                               },
@@ -445,12 +452,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "2926c56050ee4ad00cc241f5c423771e",
+    "cacheID": "de36faf461a4ff16b20f0d3f07fe34ff",
     "id": null,
     "metadata": {},
     "name": "NotificationsListNextQuery",
     "operationKind": "query",
-    "text": "query NotificationsListNextQuery(\n  $count: Int!\n  $cursor: String\n  $types: [NotificationTypesEnum]\n) {\n  viewer {\n    ...NotificationsList_viewer_2TJroH\n  }\n}\n\nfragment NotificationItem_notification on Notification {\n  id\n  internalID\n  headline\n  message\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  item {\n    __typename\n    ... on PartnerOfferCreatedNotificationItem {\n      available\n      expiresAt\n    }\n  }\n  previewImages(size: 4) {\n    internalID\n    resized(height: 58, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      srcSet\n      height\n      width\n    }\n  }\n  title\n  ...NotificationTypeLabel_notification\n}\n\nfragment NotificationTypeLabel_notification on Notification {\n  notificationType\n  publishedAt(format: \"RELATIVE\")\n}\n\nfragment NotificationsList_viewer_2TJroH on Viewer {\n  notifications: notificationsConnection(first: $count, after: $cursor, notificationTypes: $types) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_notification\n        item {\n          __typename\n          ... on ViewingRoomPublishedNotificationItem {\n            viewingRoomsConnection(first: 1) {\n              totalCount\n            }\n          }\n          ... on ArticleFeaturedArtistNotificationItem {\n            article {\n              internalID\n              id\n            }\n          }\n        }\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query NotificationsListNextQuery(\n  $count: Int!\n  $cursor: String\n  $types: [NotificationTypesEnum]\n) {\n  viewer {\n    ...NotificationsList_viewer_2TJroH\n  }\n}\n\nfragment NotificationItem_notification on Notification {\n  id\n  internalID\n  headline\n  message\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  item {\n    __typename\n    ... on PartnerOfferCreatedNotificationItem {\n      available\n      expiresAt\n    }\n  }\n  previewImages(size: 4) {\n    internalID\n    resized(height: 58, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      height\n      width\n    }\n  }\n  title\n  ...NotificationTypeLabel_notification\n}\n\nfragment NotificationTypeLabel_notification on Notification {\n  notificationType\n  publishedAt(format: \"RELATIVE\")\n}\n\nfragment NotificationsList_viewer_2TJroH on Viewer {\n  notifications: notificationsConnection(first: $count, after: $cursor, notificationTypes: $types) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_notification\n        item {\n          __typename\n          ... on ViewingRoomPublishedNotificationItem {\n            viewingRoomsConnection(first: 1) {\n              totalCount\n            }\n          }\n          ... on ArticleFeaturedArtistNotificationItem {\n            article {\n              internalID\n              id\n            }\n          }\n        }\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/NotificationsListNextQuery.graphql.ts
+++ b/src/__generated__/NotificationsListNextQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<baca095e412fa629b188f97931608d1c>>
+ * @generated SignedSource<<b37ce0c376cb17e2690edbaa4a731fc7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -319,6 +319,13 @@ return {
                           (v2/*: any*/),
                           {
                             "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "blurhashDataURL",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
                             "args": [
                               {
                                 "kind": "Literal",
@@ -452,12 +459,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "de36faf461a4ff16b20f0d3f07fe34ff",
+    "cacheID": "d79e0b00e5af5d90e648f5910701c317",
     "id": null,
     "metadata": {},
     "name": "NotificationsListNextQuery",
     "operationKind": "query",
-    "text": "query NotificationsListNextQuery(\n  $count: Int!\n  $cursor: String\n  $types: [NotificationTypesEnum]\n) {\n  viewer {\n    ...NotificationsList_viewer_2TJroH\n  }\n}\n\nfragment NotificationItem_notification on Notification {\n  id\n  internalID\n  headline\n  message\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  item {\n    __typename\n    ... on PartnerOfferCreatedNotificationItem {\n      available\n      expiresAt\n    }\n  }\n  previewImages(size: 4) {\n    internalID\n    resized(height: 58, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      height\n      width\n    }\n  }\n  title\n  ...NotificationTypeLabel_notification\n}\n\nfragment NotificationTypeLabel_notification on Notification {\n  notificationType\n  publishedAt(format: \"RELATIVE\")\n}\n\nfragment NotificationsList_viewer_2TJroH on Viewer {\n  notifications: notificationsConnection(first: $count, after: $cursor, notificationTypes: $types) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_notification\n        item {\n          __typename\n          ... on ViewingRoomPublishedNotificationItem {\n            viewingRoomsConnection(first: 1) {\n              totalCount\n            }\n          }\n          ... on ArticleFeaturedArtistNotificationItem {\n            article {\n              internalID\n              id\n            }\n          }\n        }\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query NotificationsListNextQuery(\n  $count: Int!\n  $cursor: String\n  $types: [NotificationTypesEnum]\n) {\n  viewer {\n    ...NotificationsList_viewer_2TJroH\n  }\n}\n\nfragment NotificationItem_notification on Notification {\n  id\n  internalID\n  headline\n  message\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  item {\n    __typename\n    ... on PartnerOfferCreatedNotificationItem {\n      available\n      expiresAt\n    }\n  }\n  previewImages(size: 4) {\n    internalID\n    blurhashDataURL\n    resized(height: 58, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      height\n      width\n    }\n  }\n  title\n  ...NotificationTypeLabel_notification\n}\n\nfragment NotificationTypeLabel_notification on Notification {\n  notificationType\n  publishedAt(format: \"RELATIVE\")\n}\n\nfragment NotificationsList_viewer_2TJroH on Viewer {\n  notifications: notificationsConnection(first: $count, after: $cursor, notificationTypes: $types) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_notification\n        item {\n          __typename\n          ... on ViewingRoomPublishedNotificationItem {\n            viewingRoomsConnection(first: 1) {\n              totalCount\n            }\n          }\n          ... on ArticleFeaturedArtistNotificationItem {\n            article {\n              internalID\n              id\n            }\n          }\n        }\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/NotificationsListQuery.graphql.ts
+++ b/src/__generated__/NotificationsListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ce0070055d6fbbd70e81e95b2757ad51>>
+ * @generated SignedSource<<1c5e5a31e75ca845731201778fbdbc44>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -318,6 +318,13 @@ return {
                                 "alias": null,
                                 "args": null,
                                 "kind": "ScalarField",
+                                "name": "src",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
                                 "name": "srcSet",
                                 "storageKey": null
                               },
@@ -418,12 +425,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "8f80e3399ecca3c30b3c2b4f635fc8f0",
+    "cacheID": "36531baa328ddce9c7d90214b052d73d",
     "id": null,
     "metadata": {},
     "name": "NotificationsListQuery",
     "operationKind": "query",
-    "text": "query NotificationsListQuery(\n  $types: [NotificationTypesEnum]\n) {\n  viewer {\n    ...NotificationsList_viewer_1OKkmt\n  }\n}\n\nfragment NotificationItem_notification on Notification {\n  id\n  internalID\n  headline\n  message\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  item {\n    __typename\n    ... on PartnerOfferCreatedNotificationItem {\n      available\n      expiresAt\n    }\n  }\n  previewImages(size: 4) {\n    internalID\n    resized(height: 58, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      srcSet\n      height\n      width\n    }\n  }\n  title\n  ...NotificationTypeLabel_notification\n}\n\nfragment NotificationTypeLabel_notification on Notification {\n  notificationType\n  publishedAt(format: \"RELATIVE\")\n}\n\nfragment NotificationsList_viewer_1OKkmt on Viewer {\n  notifications: notificationsConnection(first: 10, notificationTypes: $types) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_notification\n        item {\n          __typename\n          ... on ViewingRoomPublishedNotificationItem {\n            viewingRoomsConnection(first: 1) {\n              totalCount\n            }\n          }\n          ... on ArticleFeaturedArtistNotificationItem {\n            article {\n              internalID\n              id\n            }\n          }\n        }\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query NotificationsListQuery(\n  $types: [NotificationTypesEnum]\n) {\n  viewer {\n    ...NotificationsList_viewer_1OKkmt\n  }\n}\n\nfragment NotificationItem_notification on Notification {\n  id\n  internalID\n  headline\n  message\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  item {\n    __typename\n    ... on PartnerOfferCreatedNotificationItem {\n      available\n      expiresAt\n    }\n  }\n  previewImages(size: 4) {\n    internalID\n    resized(height: 58, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      height\n      width\n    }\n  }\n  title\n  ...NotificationTypeLabel_notification\n}\n\nfragment NotificationTypeLabel_notification on Notification {\n  notificationType\n  publishedAt(format: \"RELATIVE\")\n}\n\nfragment NotificationsList_viewer_1OKkmt on Viewer {\n  notifications: notificationsConnection(first: 10, notificationTypes: $types) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_notification\n        item {\n          __typename\n          ... on ViewingRoomPublishedNotificationItem {\n            viewingRoomsConnection(first: 1) {\n              totalCount\n            }\n          }\n          ... on ArticleFeaturedArtistNotificationItem {\n            article {\n              internalID\n              id\n            }\n          }\n        }\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/NotificationsListQuery.graphql.ts
+++ b/src/__generated__/NotificationsListQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1c5e5a31e75ca845731201778fbdbc44>>
+ * @generated SignedSource<<d033de894f541cf606f515a2de5c723a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -292,6 +292,13 @@ return {
                           (v2/*: any*/),
                           {
                             "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "blurhashDataURL",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
                             "args": [
                               {
                                 "kind": "Literal",
@@ -425,12 +432,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "36531baa328ddce9c7d90214b052d73d",
+    "cacheID": "458f4795b7f2e80b288e1e7319d0c05c",
     "id": null,
     "metadata": {},
     "name": "NotificationsListQuery",
     "operationKind": "query",
-    "text": "query NotificationsListQuery(\n  $types: [NotificationTypesEnum]\n) {\n  viewer {\n    ...NotificationsList_viewer_1OKkmt\n  }\n}\n\nfragment NotificationItem_notification on Notification {\n  id\n  internalID\n  headline\n  message\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  item {\n    __typename\n    ... on PartnerOfferCreatedNotificationItem {\n      available\n      expiresAt\n    }\n  }\n  previewImages(size: 4) {\n    internalID\n    resized(height: 58, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      height\n      width\n    }\n  }\n  title\n  ...NotificationTypeLabel_notification\n}\n\nfragment NotificationTypeLabel_notification on Notification {\n  notificationType\n  publishedAt(format: \"RELATIVE\")\n}\n\nfragment NotificationsList_viewer_1OKkmt on Viewer {\n  notifications: notificationsConnection(first: 10, notificationTypes: $types) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_notification\n        item {\n          __typename\n          ... on ViewingRoomPublishedNotificationItem {\n            viewingRoomsConnection(first: 1) {\n              totalCount\n            }\n          }\n          ... on ArticleFeaturedArtistNotificationItem {\n            article {\n              internalID\n              id\n            }\n          }\n        }\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query NotificationsListQuery(\n  $types: [NotificationTypesEnum]\n) {\n  viewer {\n    ...NotificationsList_viewer_1OKkmt\n  }\n}\n\nfragment NotificationItem_notification on Notification {\n  id\n  internalID\n  headline\n  message\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  item {\n    __typename\n    ... on PartnerOfferCreatedNotificationItem {\n      available\n      expiresAt\n    }\n  }\n  previewImages(size: 4) {\n    internalID\n    blurhashDataURL\n    resized(height: 58, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      height\n      width\n    }\n  }\n  title\n  ...NotificationTypeLabel_notification\n}\n\nfragment NotificationTypeLabel_notification on Notification {\n  notificationType\n  publishedAt(format: \"RELATIVE\")\n}\n\nfragment NotificationsList_viewer_1OKkmt on Viewer {\n  notifications: notificationsConnection(first: 10, notificationTypes: $types) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_notification\n        item {\n          __typename\n          ... on ViewingRoomPublishedNotificationItem {\n            viewingRoomsConnection(first: 1) {\n              totalCount\n            }\n          }\n          ... on ArticleFeaturedArtistNotificationItem {\n            article {\n              internalID\n              id\n            }\n          }\n        }\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/NotificationsList_test_Query.graphql.ts
+++ b/src/__generated__/NotificationsList_test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<78dbf93848b55652d6ddee32df18f68d>>
+ * @generated SignedSource<<b8746853771865f120b65a19a51bdac0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -301,6 +301,13 @@ return {
                           (v1/*: any*/),
                           {
                             "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "blurhashDataURL",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
                             "args": [
                               {
                                 "kind": "Literal",
@@ -434,7 +441,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "961521f8eef69ffde33207c04bbd5441",
+    "cacheID": "0defd1b9b1131832709f04fc35e23e90",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -531,6 +538,7 @@ return {
           "plural": true,
           "type": "Image"
         },
+        "viewer.notifications.edges.node.previewImages.blurhashDataURL": (v9/*: any*/),
         "viewer.notifications.edges.node.previewImages.internalID": {
           "enumValues": null,
           "nullable": true,
@@ -562,7 +570,7 @@ return {
     },
     "name": "NotificationsList_test_Query",
     "operationKind": "query",
-    "text": "query NotificationsList_test_Query {\n  viewer {\n    ...NotificationsList_viewer\n  }\n}\n\nfragment NotificationItem_notification on Notification {\n  id\n  internalID\n  headline\n  message\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  item {\n    __typename\n    ... on PartnerOfferCreatedNotificationItem {\n      available\n      expiresAt\n    }\n  }\n  previewImages(size: 4) {\n    internalID\n    resized(height: 58, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      height\n      width\n    }\n  }\n  title\n  ...NotificationTypeLabel_notification\n}\n\nfragment NotificationTypeLabel_notification on Notification {\n  notificationType\n  publishedAt(format: \"RELATIVE\")\n}\n\nfragment NotificationsList_viewer on Viewer {\n  notifications: notificationsConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_notification\n        item {\n          __typename\n          ... on ViewingRoomPublishedNotificationItem {\n            viewingRoomsConnection(first: 1) {\n              totalCount\n            }\n          }\n          ... on ArticleFeaturedArtistNotificationItem {\n            article {\n              internalID\n              id\n            }\n          }\n        }\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query NotificationsList_test_Query {\n  viewer {\n    ...NotificationsList_viewer\n  }\n}\n\nfragment NotificationItem_notification on Notification {\n  id\n  internalID\n  headline\n  message\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  item {\n    __typename\n    ... on PartnerOfferCreatedNotificationItem {\n      available\n      expiresAt\n    }\n  }\n  previewImages(size: 4) {\n    internalID\n    blurhashDataURL\n    resized(height: 58, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      height\n      width\n    }\n  }\n  title\n  ...NotificationTypeLabel_notification\n}\n\nfragment NotificationTypeLabel_notification on Notification {\n  notificationType\n  publishedAt(format: \"RELATIVE\")\n}\n\nfragment NotificationsList_viewer on Viewer {\n  notifications: notificationsConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_notification\n        item {\n          __typename\n          ... on ViewingRoomPublishedNotificationItem {\n            viewingRoomsConnection(first: 1) {\n              totalCount\n            }\n          }\n          ... on ArticleFeaturedArtistNotificationItem {\n            article {\n              internalID\n              id\n            }\n          }\n        }\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/NotificationsList_test_Query.graphql.ts
+++ b/src/__generated__/NotificationsList_test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<39b2ea0da8fd0a686d8166689e55821e>>
+ * @generated SignedSource<<78dbf93848b55652d6ddee32df18f68d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -327,6 +327,13 @@ return {
                                 "alias": null,
                                 "args": null,
                                 "kind": "ScalarField",
+                                "name": "src",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
                                 "name": "srcSet",
                                 "storageKey": null
                               },
@@ -427,7 +434,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "5d0ef5fbd68e526e8f8b1d4922836144",
+    "cacheID": "961521f8eef69ffde33207c04bbd5441",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -537,6 +544,7 @@ return {
           "type": "ResizedImageUrl"
         },
         "viewer.notifications.edges.node.previewImages.resized.height": (v6/*: any*/),
+        "viewer.notifications.edges.node.previewImages.resized.src": (v5/*: any*/),
         "viewer.notifications.edges.node.previewImages.resized.srcSet": (v5/*: any*/),
         "viewer.notifications.edges.node.previewImages.resized.width": (v6/*: any*/),
         "viewer.notifications.edges.node.publishedAt": (v5/*: any*/),
@@ -554,7 +562,7 @@ return {
     },
     "name": "NotificationsList_test_Query",
     "operationKind": "query",
-    "text": "query NotificationsList_test_Query {\n  viewer {\n    ...NotificationsList_viewer\n  }\n}\n\nfragment NotificationItem_notification on Notification {\n  id\n  internalID\n  headline\n  message\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  item {\n    __typename\n    ... on PartnerOfferCreatedNotificationItem {\n      available\n      expiresAt\n    }\n  }\n  previewImages(size: 4) {\n    internalID\n    resized(height: 58, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      srcSet\n      height\n      width\n    }\n  }\n  title\n  ...NotificationTypeLabel_notification\n}\n\nfragment NotificationTypeLabel_notification on Notification {\n  notificationType\n  publishedAt(format: \"RELATIVE\")\n}\n\nfragment NotificationsList_viewer on Viewer {\n  notifications: notificationsConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_notification\n        item {\n          __typename\n          ... on ViewingRoomPublishedNotificationItem {\n            viewingRoomsConnection(first: 1) {\n              totalCount\n            }\n          }\n          ... on ArticleFeaturedArtistNotificationItem {\n            article {\n              internalID\n              id\n            }\n          }\n        }\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
+    "text": "query NotificationsList_test_Query {\n  viewer {\n    ...NotificationsList_viewer\n  }\n}\n\nfragment NotificationItem_notification on Notification {\n  id\n  internalID\n  headline\n  message\n  targetHref\n  isUnread\n  notificationType\n  objectsCount\n  item {\n    __typename\n    ... on PartnerOfferCreatedNotificationItem {\n      available\n      expiresAt\n    }\n  }\n  previewImages(size: 4) {\n    internalID\n    resized(height: 58, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      height\n      width\n    }\n  }\n  title\n  ...NotificationTypeLabel_notification\n}\n\nfragment NotificationTypeLabel_notification on Notification {\n  notificationType\n  publishedAt(format: \"RELATIVE\")\n}\n\nfragment NotificationsList_viewer on Viewer {\n  notifications: notificationsConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        notificationType\n        artworks: artworksConnection {\n          totalCount\n        }\n        ...NotificationItem_notification\n        item {\n          __typename\n          ... on ViewingRoomPublishedNotificationItem {\n            viewingRoomsConnection(first: 1) {\n              totalCount\n            }\n          }\n          ... on ArticleFeaturedArtistNotificationItem {\n            article {\n              internalID\n              id\n            }\n          }\n        }\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Previously, images would occasionally break the notifications dropdown layout, causing overflow issues and an unwanted horizontal scroll bar. I've implemented our horizontal overflow component with a gradient fade-out, which maintains the layout while still allowing users to peek at overflowing content via scroll if needed.

Additionally, I've integrated blur hashes for these images - an ideal use case for that feature as the component is client-side and contains images which are much less likely to be cached.

| Before | After |
| --- | --- |
<img src="https://capture.static.damonzucconi.com/Screen-Shot-2025-03-18-08-57-42.91-Xr3iaO10z8TS02rL6hy73ksd992BFEWmY6iFrSyPjepjoerdah5A2RwQTOLXNP6TjAgegCdHCajT1qyHkc3GIXzq3xTyToqBzWTs.png"> | <img src="https://capture.static.damonzucconi.com/Screen-Shot-2025-03-18-08-58-03.35-p0jSneRLwaYgBO9uZ3Y0ep2OUfKrEAkp5geqVgMhTCQRn4stiQa17djl8SC8B7zrORGuWwiQmgokIUgtvwXOVJxryUCnreowGX6W.png"> |