### PR TITLE
fix(EMI-2311): another attempt to deal with empty line in partner offer notification

### DIFF
--- a/src/Components/Artwork/Details/SaleMessage.tsx
+++ b/src/Components/Artwork/Details/SaleMessage.tsx
@@ -1,11 +1,11 @@
-import { FC, ReactElement } from "react"
-import { createFragmentContainer, graphql } from "react-relay"
 import { Flex, Text } from "@artsy/palette"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { useTimer } from "Utils/Hooks/useTimer"
-import { SaleMessageQuery } from "__generated__/SaleMessageQuery.graphql"
-import { SaleMessage_artwork$data } from "__generated__/SaleMessage_artwork.graphql"
-import { Details_artwork$data } from "__generated__/Details_artwork.graphql"
+import type { Details_artwork$data } from "__generated__/Details_artwork.graphql"
+import type { SaleMessageQuery } from "__generated__/SaleMessageQuery.graphql"
+import type { SaleMessage_artwork$data } from "__generated__/SaleMessage_artwork.graphql"
+import type { FC, ReactElement } from "react"
+import { createFragmentContainer, graphql } from "react-relay"
 
 interface PublicSaleMessageProps {
   artwork: Details_artwork$data

--- a/src/Components/Notifications/PartnerOfferArtwork.tsx
+++ b/src/Components/Notifications/PartnerOfferArtwork.tsx
@@ -1,5 +1,5 @@
 import { ContextModule } from "@artsy/cohesion"
-import { Box, Button, Flex, Image, Link, Text, useTheme } from "@artsy/palette"
+import { Box, Button, Image, Link, Text, useTheme } from "@artsy/palette"
 import { ManageArtworkForSavesProvider } from "Components/Artwork/ManageArtworkForSaves"
 import Metadata from "Components/Artwork/Metadata"
 import { useNotificationsTracking } from "Components/Notifications/Hooks/useNotificationsTracking"
@@ -102,26 +102,15 @@ export const PartnerOfferArtwork: FC<
           artwork={artwork}
           contextModule={ContextModule.activity}
           showSaveButton
-          hideSaleInfo
+          hideSaleInfo={!fullyAvailable}
           maxWidth="100%"
           to={fullyAvailable ? artworkListingHref : href}
         />
 
         {fullyAvailable && (
-          <Flex flexDirection="row">
-            <Text
-              variant="xs"
-              color="black100"
-              fontWeight="bold"
-              overflowEllipsis
-            >
-              {priceWithDiscount}
-              {" "}
-            </Text>
-            <Text variant="xs" color="black60" overflowEllipsis>
-              (List price: {priceListed})
-            </Text>
-          </Flex>
+          <Text variant="xs" color="black60" overflowEllipsis>
+            (List price: {priceListed})
+          </Text>
         )}
       </Box>
       <Box

--- a/src/Components/Notifications/PartnerOfferCreatedNotification.tsx
+++ b/src/Components/Notifications/PartnerOfferCreatedNotification.tsx
@@ -78,7 +78,7 @@ export const PartnerOfferCreatedNotification: FC<
           <Text
             variant="xs"
             fontWeight="bold"
-            aria-label={`Notification type: Offer`}
+            aria-label={"Notification type: Offer"}
           >
             Offer
           </Text>

--- a/src/Components/Notifications/__tests__/PartnerOfferCreatedNotification.jest.tsx
+++ b/src/Components/Notifications/__tests__/PartnerOfferCreatedNotification.jest.tsx
@@ -52,7 +52,6 @@ describe("PartnerOfferCreatedNotification", () => {
       "src",
       "undefined?quality=80&resize_to=width&src=artwork-image-one&width=600",
     )
-    expect(screen.getByText("$900")).toBeInTheDocument()
     expect(screen.getByText("(List price: $1,000)")).toBeInTheDocument()
 
     // Continue to purchase button


### PR DESCRIPTION

Another even simpler way to deal with issue in https://artsyproduct.atlassian.net/browse/EMI-2311

My proposal here is to render Metadata for the artwork as is, including pricing line that accounts for partner offer. And then the additional line that notification adds will only render price without discount.

This is alternative of a solution explored here: https://github.com/artsy/force/pull/15293

And the current view:
![422071401-b7892dab-16cc-4a3c-80aa-d676131c97f2](https://github.com/user-attachments/assets/33cb7e1b-4129-4b36-aac1-980adcd48fa8)


And updated view proposed on this pr:
![notifications](https://github.com/user-attachments/assets/d2ccd1f7-056a-4344-a147-69be44f4357b)
