### PR TITLE
fix(artwork): loads a single version of image for all platforms

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkImageBrowserLarge.jest.enzyme.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkImageBrowserLarge.jest.enzyme.tsx
@@ -43,15 +43,13 @@ describe("ArtworkImageBrowserLarge", () => {
       }),
       Image: () => ({ isDefault: true }),
       ResizedImageUrl: () => ({
-        width: 800,
-        height: 600,
+        width: 1600,
+        height: 1200,
         src: "example.jpg",
-        srcSet: "example.jpg 1x",
       }),
     })
 
     expect(wrapper.html()).toContain("max-width: 800px")
     expect(wrapper.html()).toContain('src="example.jpg"')
-    expect(wrapper.html()).toContain('srcset="example.jpg 1x"')
   })
 })

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkImageBrowserSmall.jest.enzyme.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkImageBrowserSmall.jest.enzyme.tsx
@@ -41,15 +41,13 @@ describe("ArtworkImageBrowserSmall", () => {
       }),
       Image: () => ({ isDefault: true }),
       ResizedImageUrl: () => ({
-        width: 800,
-        height: 600,
+        width: 1600,
+        height: 1200,
         src: "example.jpg",
-        srcSet: "example.jpg 1x",
       }),
     })
 
     expect(wrapper.html()).toContain("max-width: 800px")
     expect(wrapper.html()).toContain('src="example.jpg"')
-    expect(wrapper.html()).toContain('srcset="example.jpg 1x"')
   })
 })

--- a/src/Apps/Artwork/Components/ArtworkLightbox.tsx
+++ b/src/Apps/Artwork/Components/ArtworkLightbox.tsx
@@ -6,7 +6,6 @@ import {
 } from "@artsy/palette"
 import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
 import { useSystemContext } from "System/Hooks/useSystemContext"
-import { getENV } from "Utils/getENV"
 import { useLocalImage } from "Utils/localImageHelpers"
 import { userIsTeam } from "Utils/user"
 import type { ArtworkLightbox_artwork$data } from "__generated__/ArtworkLightbox_artwork.graphql"
@@ -24,7 +23,7 @@ interface ArtworkLightboxProps extends ClickableProps {
   lazyLoad?: boolean
 }
 
-const MAX_SIZE = 800
+const MAX_SIZE = 1600
 
 const ArtworkLightbox: React.FC<
   React.PropsWithChildren<ArtworkLightboxProps>
@@ -39,7 +38,6 @@ const ArtworkLightbox: React.FC<
 
   const resizedLocalImage = localImage && {
     src: localImage.data,
-    srcSet: undefined,
     ...scale({ ...localImage, maxWidth: MAX_SIZE, maxHeight: MAX_SIZE }),
   }
 
@@ -51,7 +49,6 @@ const ArtworkLightbox: React.FC<
     isDefault,
     placeholder,
     resized,
-    mobileLightboxSource,
     blurhashDataURL,
   } = images[activeIndex]
 
@@ -59,25 +56,10 @@ const ArtworkLightbox: React.FC<
 
   if (!image) return null
 
-  let lightboxImage = image
-
-  if (getENV("IS_MOBILE") && mobileLightboxSource) {
-    lightboxImage = mobileLightboxSource
-  }
-
-  // Always preload the 2x image for mobile lightbox if available
-  const preloadImage = mobileLightboxSource?.srcSet?.match(/ ([^ ]+) 2x/)?.[1]
-
   return (
     <>
       {isDefault && (
-        <Link
-          rel="preload"
-          as="image"
-          href={preloadImage}
-          imageSrcSet={lightboxImage.srcSet}
-          fetchPriority="high"
-        />
+        <Link rel="preload" as="image" href={image.src} fetchPriority="high" />
       )}
 
       <Clickable
@@ -96,7 +78,7 @@ const ArtworkLightbox: React.FC<
           data-testid="artwork-lightbox-box"
           bg="black10"
           mx={[0, 2]}
-          maxWidth={image.width || ("100%" as any)}
+          maxWidth={image.width ? image.width / 2 : ("100%" as any)}
           aspectWidth={image.width || 1}
           aspectHeight={image.height || 1}
         >
@@ -138,8 +120,7 @@ const ArtworkLightbox: React.FC<
               : {})}
             width="100%"
             height="100%"
-            src={lightboxImage.src}
-            srcSet={lightboxImage.srcSet}
+            src={image.src}
             alt={artwork.formattedMetadata ?? ""}
             position="relative"
             preventRightClick={!isTeam}
@@ -169,36 +150,23 @@ export const ArtworkLightboxFragmentContainer = createFragmentContainer(
           blurhashDataURL(width: 801)
           fallback: cropped(
             quality: 80
-            width: 800
-            height: 800
+            width: 1600
+            height: 1600
             version: ["main", "normalized", "larger", "large"]
           ) {
             width
             height
             src
-            srcSet
           }
           resized(
             quality: 80
-            width: 800
-            height: 800
+            width: 1600
+            height: 1600
             version: ["main", "normalized", "larger", "large"]
           ) {
             width
             height
             src
-            srcSet
-          }
-          mobileLightboxSource: resized(
-            quality: 50
-            width: 800
-            height: 800
-            version: ["main", "normalized", "larger", "large"]
-          ) {
-            width
-            height
-            src
-            srcSet
           }
           versions
         }

--- a/src/__generated__/ArtworkAppTestQuery.graphql.ts
+++ b/src/__generated__/ArtworkAppTestQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fd9a40abe06be69aa46b11eab26196f7>>
+ * @generated SignedSource<<584dafb4b469e2c0e491f48210f318b6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -281,11 +281,6 @@ v33 = {
 },
 v34 = {
   "kind": "Literal",
-  "name": "height",
-  "value": 800
-},
-v35 = {
-  "kind": "Literal",
   "name": "version",
   "value": [
     "main",
@@ -294,74 +289,76 @@ v35 = {
     "large"
   ]
 },
-v36 = {
-  "kind": "Literal",
-  "name": "width",
-  "value": 800
-},
-v37 = [
-  (v34/*: any*/),
+v35 = [
+  {
+    "kind": "Literal",
+    "name": "height",
+    "value": 1600
+  },
   {
     "kind": "Literal",
     "name": "quality",
     "value": 80
   },
-  (v35/*: any*/),
-  (v36/*: any*/)
+  (v34/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "width",
+    "value": 1600
+  }
 ],
-v38 = [
+v36 = [
   (v9/*: any*/),
   (v10/*: any*/),
-  (v29/*: any*/),
-  (v30/*: any*/)
+  (v29/*: any*/)
 ],
-v39 = {
+v37 = {
   "alias": "type",
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v40 = {
+v38 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "details",
   "storageKey": null
 },
-v41 = {
+v39 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "label",
   "storageKey": null
 },
-v42 = {
+v40 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "editionOf",
   "storageKey": null
 },
-v43 = {
+v41 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "saleMessage",
   "storageKey": null
 },
-v44 = {
+v42 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "displayText",
   "storageKey": null
 },
-v45 = [
-  (v41/*: any*/),
-  (v40/*: any*/)
+v43 = [
+  (v39/*: any*/),
+  (v38/*: any*/)
 ],
-v46 = [
+v44 = [
   (v31/*: any*/)
 ];
 return {
@@ -1300,42 +1297,23 @@ return {
                   },
                   {
                     "alias": "fallback",
-                    "args": (v37/*: any*/),
+                    "args": (v35/*: any*/),
                     "concreteType": "CroppedImageUrl",
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": (v38/*: any*/),
-                    "storageKey": "cropped(height:800,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
+                    "selections": (v36/*: any*/),
+                    "storageKey": "cropped(height:1600,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:1600)"
                   },
                   {
                     "alias": null,
-                    "args": (v37/*: any*/),
+                    "args": (v35/*: any*/),
                     "concreteType": "ResizedImageUrl",
                     "kind": "LinkedField",
                     "name": "resized",
                     "plural": false,
-                    "selections": (v38/*: any*/),
-                    "storageKey": "resized(height:800,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
-                  },
-                  {
-                    "alias": "mobileLightboxSource",
-                    "args": [
-                      (v34/*: any*/),
-                      {
-                        "kind": "Literal",
-                        "name": "quality",
-                        "value": 50
-                      },
-                      (v35/*: any*/),
-                      (v36/*: any*/)
-                    ],
-                    "concreteType": "ResizedImageUrl",
-                    "kind": "LinkedField",
-                    "name": "resized",
-                    "plural": false,
-                    "selections": (v38/*: any*/),
-                    "storageKey": "resized(height:800,quality:50,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
+                    "selections": (v36/*: any*/),
+                    "storageKey": "resized(height:1600,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:1600)"
                   },
                   {
                     "alias": null,
@@ -1390,9 +1368,17 @@ return {
                   {
                     "alias": null,
                     "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 800
+                      },
                       (v34/*: any*/),
-                      (v35/*: any*/),
-                      (v36/*: any*/)
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 800
+                      }
                     ],
                     "concreteType": "ResizedImageUrl",
                     "kind": "LinkedField",
@@ -1464,7 +1450,7 @@ return {
                         "storageKey": null
                       },
                       (v15/*: any*/),
-                      (v39/*: any*/)
+                      (v37/*: any*/)
                     ],
                     "type": "Video",
                     "abstractKey": null
@@ -1562,7 +1548,7 @@ return {
                         "name": "isZoomable",
                         "storageKey": null
                       },
-                      (v39/*: any*/),
+                      (v37/*: any*/),
                       (v33/*: any*/),
                       (v9/*: any*/),
                       (v10/*: any*/)
@@ -1602,12 +1588,12 @@ return {
                 "name": "framed",
                 "plural": false,
                 "selections": [
-                  (v40/*: any*/),
-                  (v41/*: any*/)
+                  (v38/*: any*/),
+                  (v39/*: any*/)
                 ],
                 "storageKey": null
               },
-              (v42/*: any*/),
+              (v40/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1627,7 +1613,7 @@ return {
                   (v15/*: any*/),
                   (v22/*: any*/),
                   (v21/*: any*/),
-                  (v43/*: any*/),
+                  (v41/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -1644,7 +1630,7 @@ return {
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v42/*: any*/)
+                      (v40/*: any*/)
                     ],
                     "type": "Sellable",
                     "abstractKey": "__isSellable"
@@ -1694,7 +1680,7 @@ return {
                 "name": "isEligibleToCreateAlert",
                 "storageKey": null
               },
-              (v43/*: any*/),
+              (v41/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -1779,7 +1765,7 @@ return {
                 "name": "taxInfo",
                 "plural": false,
                 "selections": [
-                  (v44/*: any*/),
+                  (v42/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -1788,7 +1774,7 @@ return {
                     "name": "moreInfo",
                     "plural": false,
                     "selections": [
-                      (v44/*: any*/),
+                      (v42/*: any*/),
                       (v11/*: any*/)
                     ],
                     "storageKey": null
@@ -1981,7 +1967,7 @@ return {
                 "kind": "LinkedField",
                 "name": "signatureInfo",
                 "plural": false,
-                "selections": (v45/*: any*/),
+                "selections": (v43/*: any*/),
                 "storageKey": null
               },
               {
@@ -1991,7 +1977,7 @@ return {
                 "kind": "LinkedField",
                 "name": "conditionDescription",
                 "plural": false,
-                "selections": (v45/*: any*/),
+                "selections": (v43/*: any*/),
                 "storageKey": null
               },
               {
@@ -2001,7 +1987,7 @@ return {
                 "kind": "LinkedField",
                 "name": "certificateOfAuthenticity",
                 "plural": false,
-                "selections": (v45/*: any*/),
+                "selections": (v43/*: any*/),
                 "storageKey": null
               },
               {
@@ -2134,7 +2120,7 @@ return {
               },
               {
                 "alias": "additionalInformationHTML",
-                "args": (v46/*: any*/),
+                "args": (v44/*: any*/),
                 "kind": "ScalarField",
                 "name": "additionalInformation",
                 "storageKey": "additionalInformation(format:\"HTML\")"
@@ -2148,14 +2134,14 @@ return {
               },
               {
                 "alias": null,
-                "args": (v46/*: any*/),
+                "args": (v44/*: any*/),
                 "kind": "ScalarField",
                 "name": "provenance",
                 "storageKey": "provenance(format:\"HTML\")"
               },
               {
                 "alias": null,
-                "args": (v46/*: any*/),
+                "args": (v44/*: any*/),
                 "kind": "ScalarField",
                 "name": "exhibitionHistory",
                 "storageKey": "exhibitionHistory(format:\"HTML\")"
@@ -2343,12 +2329,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "7fde5700a4eb5e68ad0a348bf3665d47",
+    "cacheID": "3139ceffcef944aa2ef4021d1ce5771e",
     "id": null,
     "metadata": {},
     "name": "ArtworkAppTestQuery",
     "operationKind": "query",
-    "text": "query ArtworkAppTestQuery {\n  artworkResult(id: \"artwork-id\") {\n    __typename\n    ...ArtworkApp_artworkResult_3eglH\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  me {\n    ...ArtworkApp_me_1liwfq\n    id\n  }\n}\n\nfragment ArtsyShippingEstimate_artwork on Artwork {\n  depthCm\n  diameterCm\n  framedHeight\n  framedWidth\n  framedDepth\n  framedDiameter\n  framedMetric\n  heightCm\n  isFramed\n  listPrice {\n    __typename\n    ... on Money {\n      major\n    }\n    ... on PriceRange {\n      maxPrice {\n        major\n      }\n      minPrice {\n        major\n      }\n    }\n  }\n  mediumType {\n    name\n  }\n  priceCurrency\n  shippingOrigin\n  shippingWeight\n  shippingWeightMetric\n  widthCm\n}\n\nfragment ArtworkActionsSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isInAuction\n  isSavedToAnyList\n  sale {\n    isAuction\n    isClosed\n    id\n  }\n  collectorSignals {\n    auction {\n      lotWatcherCount\n    }\n  }\n  ...ArtworkActionsWatchLotButton_artwork\n}\n\nfragment ArtworkActionsWatchLotButton_artwork on Artwork {\n  sale {\n    isLiveOpen\n    isRegistrationClosed\n    liveStartAt\n    registrationStatus {\n      qualifiedForBidding\n      id\n    }\n    id\n  }\n  ...ArtworkAuctionRegistrationPanel_artwork\n}\n\nfragment ArtworkActions_artwork_FOvjt on Artwork {\n  ...ArtworkActionsSaveButton_artwork\n  ...ArtworkDownloadButton_artwork\n  ...ArtworkSharePanel_artwork_FOvjt\n  ...ViewInRoom_artwork\n  isUnlisted\n  slug\n  downloadableImageUrl\n  isDownloadable\n  isHangable\n  partner {\n    slug\n    id\n  }\n}\n\nfragment ArtworkApp_artworkResult_3eglH on ArtworkResult {\n  __isArtworkResult: __typename\n  __typename\n  ...ArtworkApp_artwork_3eglH\n  ...ArtworkErrorApp_artworkError\n}\n\nfragment ArtworkApp_artwork_3eglH on Artwork {\n  ...ArtworkMeta_artwork\n  ...ArtworkTopContextBar_artwork\n  ...ArtworkImageBrowser_artwork\n  ...ArtworkSidebar_artwork\n  ...ArtworkAuctionCreateAlertHeader_artwork\n  ...PrivateArtworkDetails_artwork\n  ...ArtworkPageBanner_artwork\n  attributionClass {\n    internalID\n    id\n  }\n  slug\n  internalID\n  isAcquireable\n  isOfferable\n  published\n  availability\n  mediumType {\n    filterGene {\n      slug\n      id\n    }\n  }\n  visibilityLevel\n  isUnlisted\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  partner {\n    __typename\n    id\n  }\n  isInAuction\n  sale {\n    internalID\n    slug\n    extendedBiddingIntervalMinutes\n    id\n  }\n  saleMessage\n  artists(shallow: true) {\n    id\n    internalID\n    slug\n  }\n}\n\nfragment ArtworkApp_me_1liwfq on Me {\n  ...ArtworkSidebar_me_39o6UP\n  ...ArtworkPageBanner_me_39o6UP\n}\n\nfragment ArtworkAuctionCreateAlertHeader_artwork on Artwork {\n  slug\n  internalID\n  title\n  isEligibleToCreateAlert\n  isInAuction\n  artistNames\n  artists(shallow: true) {\n    internalID\n    name\n    slug\n    id\n  }\n  sale {\n    startAt\n    isClosed\n    id\n  }\n  saleArtwork {\n    extendedBiddingEndAt\n    endAt\n    endedAt\n    id\n  }\n  attributionClass {\n    internalID\n    id\n  }\n  mediumType {\n    filterGene {\n      slug\n      name\n      id\n    }\n  }\n  myLotStandingManageAlerts: myLotStanding {\n    isHighestBidder\n  }\n}\n\nfragment ArtworkAuctionRegistrationPanel_artwork on Artwork {\n  sale {\n    slug\n    registrationEndsAt\n    isRegistrationClosed\n    id\n  }\n}\n\nfragment ArtworkChatBubble_artwork on Artwork {\n  isAcquireable\n  isInquireable\n  isOfferable\n  isInAuction\n  listPrice {\n    __typename\n    ... on Money {\n      currencyCode\n      major\n    }\n    ... on PriceRange {\n      maxPrice {\n        currencyCode\n        major\n      }\n    }\n  }\n  saleArtwork {\n    currency\n    openingBid {\n      cents\n    }\n    id\n  }\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  category\n  series\n  publisher\n  manufacturer\n  image_rights: imageRights\n  canRequestLotConditionsReport\n  internalID\n  isUnlisted\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n  mediumType {\n    __typename\n  }\n  dimensions {\n    in\n    cm\n  }\n  attributionClass {\n    name\n    id\n  }\n  medium\n  ...ArtworkDetailsMediumModal_artwork\n}\n\nfragment ArtworkDetailsMediumModal_artwork on Artwork {\n  mediumType {\n    name\n    longDescription\n  }\n}\n\nfragment ArtworkDownloadButton_artwork on Artwork {\n  title\n  date\n  downloadableImageUrl\n  artists(shallow: true) {\n    name\n    id\n  }\n}\n\nfragment ArtworkErrorApp_artworkError on ArtworkError {\n  artwork {\n    slug\n    id\n  }\n  requestError {\n    statusCode\n  }\n}\n\nfragment ArtworkImageBrowserLarge_artwork_FOvjt on Artwork {\n  ...ArtworkLightbox_artwork_FOvjt\n  ...ArtworkVideoPlayer_artwork_FOvjt\n  isSetVideoAsCover\n  figures(includeAll: false) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      __typename\n      internalID\n      isZoomable\n    }\n    ... on Video {\n      __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowserSmall_artwork_FOvjt on Artwork {\n  ...ArtworkLightbox_artwork_FOvjt\n  ...ArtworkVideoPlayer_artwork_FOvjt\n  isSetVideoAsCover\n  figures(includeAll: false) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      internalID\n      isZoomable\n      type: __typename\n    }\n    ... on Video {\n      type: __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowser_artwork on Artwork {\n  ...ArtworkActions_artwork_FOvjt\n  ...ArtworkImageBrowserSmall_artwork_FOvjt\n  ...ArtworkImageBrowserLarge_artwork_FOvjt\n  internalID\n  figures(includeAll: false) {\n    __typename\n    ... on Image {\n      isDefault\n      width\n      height\n    }\n    ... on Video {\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment ArtworkLightbox_artwork_FOvjt on Artwork {\n  formattedMetadata\n  images(includeAll: false) {\n    internalID\n    isDefault\n    placeholder: url(version: [\"small\", \"medium\"])\n    blurhashDataURL(width: 801)\n    fallback: cropped(quality: 80, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    resized(quality: 80, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    mobileLightboxSource: resized(quality: 50, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    versions\n  }\n}\n\nfragment ArtworkMeta_artwork on Artwork {\n  ...SeoDataForArtwork_artwork\n  ...ArtworkChatBubble_artwork\n  href\n  internalID\n  isShareable\n  isUnlisted\n  metaImage: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n    longDescription: description(limit: 200)\n  }\n}\n\nfragment ArtworkPageBanner_artwork on Artwork {\n  published\n  visibilityLevel\n  isPurchasable\n  sale {\n    __typename\n    ...CascadingEndTimesBanner_sale\n    id\n  }\n}\n\nfragment ArtworkPageBanner_me_39o6UP on Me {\n  partnerOffersConnection(artworkID: \"artwork-id\", first: 1) {\n    edges {\n      node {\n        internalID\n        isActive\n        id\n      }\n    }\n  }\n}\n\nfragment ArtworkSharePanel_artwork_FOvjt on Artwork {\n  href\n  images(includeAll: false) {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  culturalMaker\n  artists(shallow: true) {\n    slug\n    name\n    id\n  }\n}\n\nfragment ArtworkSidebarArtsyGuarantee_artwork on Artwork {\n  isUnlisted\n}\n\nfragment ArtworkSidebarArtworkTitle_artwork on Artwork {\n  date\n  title\n}\n\nfragment ArtworkSidebarAuctionInfoPolling_artwork on Artwork {\n  internalID\n  sale {\n    isClosed\n    id\n  }\n  saleArtwork {\n    currentBid {\n      display\n    }\n    id\n  }\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n}\n\nfragment ArtworkSidebarAuctionInfoPolling_me on Me {\n  ...ArtworkSidebarBidAction_me\n}\n\nfragment ArtworkSidebarAuctionTimer_artwork on Artwork {\n  internalID\n  sale {\n    cascadingEndTimeIntervalMinutes\n    isClosed\n    ...AuctionTimer_sale\n    startAt\n    id\n  }\n  saleArtwork {\n    ...LotTimer_saleArtwork\n    endAt\n    endedAt\n    id\n  }\n}\n\nfragment ArtworkSidebarAuthenticityCertificate_artwork on Artwork {\n  hasCertificateOfAuthenticity\n  isBiddable\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        cents\n      }\n      id\n    }\n  }\n  slug\n  internalID\n  sale {\n    slug\n    registrationStatus {\n      qualified_for_bidding: qualifiedForBidding\n      id\n    }\n    is_preview: isPreview\n    is_open: isOpen\n    is_live_open: isLiveOpen\n    is_closed: isClosed\n    is_registration_closed: isRegistrationClosed\n    requireIdentityVerification\n    id\n  }\n  sale_artwork: saleArtwork {\n    increments {\n      cents\n      display\n    }\n    endedAt\n    id\n  }\n  collectorSignals {\n    auction {\n      bidCount\n      lotWatcherCount\n    }\n  }\n}\n\nfragment ArtworkSidebarBidAction_me on Me {\n  isIdentityVerified\n  pendingIdentityVerification {\n    internalID\n    id\n  }\n}\n\nfragment ArtworkSidebarBiddingClosedMessage_artwork on Artwork {\n  isEligibleToCreateAlert\n  artists(shallow: true) {\n    internalID\n    id\n  }\n  attributionClass {\n    internalID\n    id\n  }\n  mediumType {\n    filterGene {\n      slug\n      id\n    }\n  }\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attributionClass {\n    shortArrayDescription\n    id\n  }\n}\n\nfragment ArtworkSidebarCollectorSignal_artwork on Artwork {\n  collectorSignals {\n    primaryLabel(ignore: [PARTNER_OFFER])\n    runningShow {\n      name\n      href\n      startAt\n      endAt\n      id\n    }\n  }\n}\n\nfragment ArtworkSidebarCommercialButtons_artwork on Artwork {\n  ...ArtworkSidebarEditionSets_artwork\n  isEligibleToCreateAlert\n  artists(shallow: true) {\n    internalID\n    id\n  }\n  attributionClass {\n    internalID\n    id\n  }\n  internalID\n  slug\n  saleMessage\n  isInquireable\n  isAcquireable\n  isOfferable\n  isSold\n  priceListedDisplay\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  mediumType {\n    filterGene {\n      slug\n      id\n    }\n  }\n  editionSets {\n    id\n    internalID\n    isAcquireable\n    isOfferable\n    saleMessage\n    dimensions {\n      in\n      cm\n    }\n  }\n  partner {\n    profile {\n      icon {\n        url(version: \"square140\")\n      }\n      id\n    }\n    id\n  }\n  collectorSignals {\n    partnerOffer {\n      endAt\n      id\n    }\n    increasedInterest\n    curatorsPick\n  }\n}\n\nfragment ArtworkSidebarCommercialButtons_me_39o6UP on Me {\n  partnerOffersConnection(artworkID: \"artwork-id\", first: 1) {\n    edges {\n      node {\n        endAt\n        internalID\n        isAvailable\n        note\n        priceWithDiscount {\n          display\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ArtworkSidebarCreateAlert_artwork on Artwork {\n  isEligibleToCreateAlert\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  sale {\n    is_closed: isClosed\n    is_live_open: isLiveOpen\n    internalID\n    is_with_buyers_premium: isWithBuyersPremium\n    id\n  }\n  sale_artwork: saleArtwork {\n    is_with_reserve: isWithReserve\n    reserve_message: reserveMessage\n    reserve_status: reserveStatus\n    endedAt\n    current_bid: currentBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n  myLotStanding(live: true) {\n    active_bid: activeBid {\n      is_winning: isWinning\n      id\n    }\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        display\n      }\n      id\n    }\n  }\n  collectorSignals {\n    auction {\n      lotWatcherCount\n    }\n  }\n  ...ArtworkSidebarBiddingClosedMessage_artwork\n}\n\nfragment ArtworkSidebarDetails_artwork on Artwork {\n  isUnlisted\n  medium\n  dimensions {\n    in\n    cm\n  }\n  framed {\n    details\n  }\n  editionOf\n  isEdition\n  editionSets {\n    internalID\n    id\n  }\n  ...ArtworkSidebarClassification_artwork\n  ...ArtworkSidebarAuthenticityCertificate_artwork\n  ...ArtworkSidebarCollectorSignal_artwork\n}\n\nfragment ArtworkSidebarEditionSets_artwork on Artwork {\n  isInquireable\n  isOfferable\n  isAcquireable\n  editionSets {\n    id\n    internalID\n    isOfferable\n    isAcquireable\n    saleMessage\n    dimensions {\n      cm\n      in\n    }\n    ...ArtworkSidebarSizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebarEstimatedValue_artwork on Artwork {\n  saleArtwork {\n    estimate\n    id\n  }\n  sale {\n    isClosed\n    id\n  }\n}\n\nfragment ArtworkSidebarLinks_artwork on Artwork {\n  isInAuction\n  isUnlisted\n  sale {\n    isClosed\n    id\n  }\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  internalID\n  slug\n  isInquireable\n  isUnlisted\n  partner {\n    name\n    href\n    cities\n    isInquireable\n    id\n  }\n  sale {\n    name\n    href\n    id\n  }\n  collectorSignals {\n    partnerOffer {\n      endAt\n      id\n    }\n    increasedInterest\n    curatorsPick\n  }\n}\n\nfragment ArtworkSidebarPrivateArtwork_artwork on Artwork {\n  partner {\n    name\n    slug\n    profile {\n      isPubliclyVisible\n      id\n    }\n    id\n  }\n  isUnlisted\n  additionalInformation\n}\n\nfragment ArtworkSidebarShippingInformation_artwork on Artwork {\n  isUnlisted\n  priceIncludesTaxDisplay\n  shippingOrigin\n  shippingInfo\n  pickupAvailable\n  taxInfo {\n    displayText\n    moreInfo {\n      displayText\n      url\n    }\n  }\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  __isSellable: __typename\n  dimensions {\n    in\n    cm\n  }\n  editionOf\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  ...ArtworkSidebarArtworkTitle_artwork\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarDetails_artwork\n  ...ArtworkSidebarCommercialButtons_artwork\n  ...ArtworkSidebarShippingInformation_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarCreateAlert_artwork\n  ...ArtworkSidebarLinks_artwork\n  ...ArtworkSidebarEstimatedValue_artwork\n  ...ArtworkSidebarBiddingClosedMessage_artwork\n  ...ArtworkSidebarAuctionTimer_artwork\n  ...ArtworkSidebarAuctionInfoPolling_artwork\n  ...ArtworkSidebarPrivateArtwork_artwork\n  ...ArtworkSidebarArtsyGuarantee_artwork\n  ...PrivateArtworkAdditionalInfo_artwork\n  ...ArtsyShippingEstimate_artwork\n  artists(shallow: true) {\n    internalID\n    id\n  }\n  artsyShippingDomestic\n  artsyShippingInternational\n  editionSets {\n    internalID\n    id\n  }\n  internationalShippingFee {\n    major\n  }\n  isAcquireable\n  isBiddable\n  isEdition\n  isEligibleForArtsyGuarantee\n  isEligibleToCreateAlert\n  isInAuction\n  isOfferable\n  isSold\n  isUnlisted\n  partner {\n    internalID\n    id\n  }\n  sale {\n    endAt\n    startAt\n    isClosed\n    isAuction\n    id\n  }\n  saleArtwork {\n    lotID\n    lotLabel\n    extendedBiddingEndAt\n    endAt\n    endedAt\n    id\n  }\n  saleMessage\n  shippingWeight\n  shippingWeightMetric\n  slug\n}\n\nfragment ArtworkSidebar_me_39o6UP on Me {\n  ...ArtworkSidebarAuctionInfoPolling_me\n  ...ArtworkSidebarCommercialButtons_me_39o6UP\n}\n\nfragment ArtworkTopContextBarBreadcrumb_artwork on Artwork {\n  internalID\n  href\n  title\n  artist {\n    name\n    href\n    id\n  }\n}\n\nfragment ArtworkTopContextBar_artwork on Artwork {\n  ...ArtworkTopContextBarBreadcrumb_artwork\n  internalID\n}\n\nfragment ArtworkVideoPlayer_artwork_FOvjt on Artwork {\n  internalID\n  slug\n  figures(includeAll: false) {\n    __typename\n    ... on Video {\n      __typename\n      playerUrl\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment AuctionTimer_sale on Sale {\n  liveStartAt\n  endAt\n}\n\nfragment CascadingEndTimesBanner_sale on Sale {\n  isClosed\n  cascadingEndTimeIntervalMinutes\n  extendedBiddingIntervalMinutes\n}\n\nfragment DeepZoom_image on Image {\n  deepZoom {\n    Image {\n      xmlns\n      Url\n      Format\n      TileSize\n      Overlap\n      Size {\n        Width\n        Height\n      }\n    }\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  slug\n  name\n  internalID\n  counts {\n    follows\n  }\n}\n\nfragment LotTimer_saleArtwork on SaleArtwork {\n  endAt\n  formattedStartDateTime\n  extendedBiddingEndAt\n  lotID\n  sale {\n    startAt\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    internalID\n    id\n  }\n}\n\nfragment PrivateArtworkAboutArtist_artwork on Artwork {\n  displayArtistBio\n  slug\n  artists(shallow: true) {\n    ...FollowArtistButton_artist\n    internalID\n    href\n    slug\n    name\n    initials\n    formattedNationalityAndBirthday\n    counts {\n      follows\n    }\n    coverArtwork {\n      image {\n        cropped(width: 145, height: 145) {\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    biographyBlurb(format: HTML, partnerBio: false) {\n      text\n    }\n    id\n  }\n}\n\nfragment PrivateArtworkAboutWork_artwork on Artwork {\n  additionalInformationHTML: additionalInformation(format: HTML)\n}\n\nfragment PrivateArtworkAdditionalInfo_artwork on Artwork {\n  category\n  series\n  publisher\n  manufacturer\n  image_rights: imageRights\n  canRequestLotConditionsReport\n  internalID\n  isUnlisted\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n  mediumType {\n    __typename\n  }\n  dimensions {\n    in\n    cm\n  }\n  attributionClass {\n    name\n    id\n  }\n  medium\n  ...ArtworkDetailsMediumModal_artwork\n}\n\nfragment PrivateArtworkDetails_artwork on Artwork {\n  ...PrivateArtworkAboutWork_artwork\n  ...PrivateArtworkAboutArtist_artwork\n  ...PrivateArtworkMetadata_artwork\n}\n\nfragment PrivateArtworkMetadata_artwork on Artwork {\n  ...ArtworkDetailsAdditionalInfo_artwork\n  conditionDescription {\n    details\n  }\n  provenance(format: HTML)\n  exhibitionHistory(format: HTML)\n}\n\nfragment SeoDataForArtwork_artwork on Artwork {\n  href\n  date\n  is_price_hidden: isPriceHidden\n  is_price_range: isPriceRange\n  listPrice {\n    __typename\n    ... on PriceRange {\n      minPrice {\n        major\n        currencyCode\n      }\n      maxPrice {\n        major\n      }\n    }\n    ... on Money {\n      major\n      currencyCode\n    }\n  }\n  meta_image: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n  }\n  partner {\n    name\n    type\n    profile {\n      image {\n        resized(width: 320, height: 320, version: [\"medium\"]) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n  artistNames\n  availability\n  category\n  dimensions {\n    in\n  }\n}\n\nfragment ViewInRoomArtwork_artwork on Artwork {\n  widthCm\n  heightCm\n  image {\n    resized(width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ViewInRoom_artwork on Artwork {\n  ...ViewInRoomArtwork_artwork\n}\n"
+    "text": "query ArtworkAppTestQuery {\n  artworkResult(id: \"artwork-id\") {\n    __typename\n    ...ArtworkApp_artworkResult_3eglH\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  me {\n    ...ArtworkApp_me_1liwfq\n    id\n  }\n}\n\nfragment ArtsyShippingEstimate_artwork on Artwork {\n  depthCm\n  diameterCm\n  framedHeight\n  framedWidth\n  framedDepth\n  framedDiameter\n  framedMetric\n  heightCm\n  isFramed\n  listPrice {\n    __typename\n    ... on Money {\n      major\n    }\n    ... on PriceRange {\n      maxPrice {\n        major\n      }\n      minPrice {\n        major\n      }\n    }\n  }\n  mediumType {\n    name\n  }\n  priceCurrency\n  shippingOrigin\n  shippingWeight\n  shippingWeightMetric\n  widthCm\n}\n\nfragment ArtworkActionsSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isInAuction\n  isSavedToAnyList\n  sale {\n    isAuction\n    isClosed\n    id\n  }\n  collectorSignals {\n    auction {\n      lotWatcherCount\n    }\n  }\n  ...ArtworkActionsWatchLotButton_artwork\n}\n\nfragment ArtworkActionsWatchLotButton_artwork on Artwork {\n  sale {\n    isLiveOpen\n    isRegistrationClosed\n    liveStartAt\n    registrationStatus {\n      qualifiedForBidding\n      id\n    }\n    id\n  }\n  ...ArtworkAuctionRegistrationPanel_artwork\n}\n\nfragment ArtworkActions_artwork_FOvjt on Artwork {\n  ...ArtworkActionsSaveButton_artwork\n  ...ArtworkDownloadButton_artwork\n  ...ArtworkSharePanel_artwork_FOvjt\n  ...ViewInRoom_artwork\n  isUnlisted\n  slug\n  downloadableImageUrl\n  isDownloadable\n  isHangable\n  partner {\n    slug\n    id\n  }\n}\n\nfragment ArtworkApp_artworkResult_3eglH on ArtworkResult {\n  __isArtworkResult: __typename\n  __typename\n  ...ArtworkApp_artwork_3eglH\n  ...ArtworkErrorApp_artworkError\n}\n\nfragment ArtworkApp_artwork_3eglH on Artwork {\n  ...ArtworkMeta_artwork\n  ...ArtworkTopContextBar_artwork\n  ...ArtworkImageBrowser_artwork\n  ...ArtworkSidebar_artwork\n  ...ArtworkAuctionCreateAlertHeader_artwork\n  ...PrivateArtworkDetails_artwork\n  ...ArtworkPageBanner_artwork\n  attributionClass {\n    internalID\n    id\n  }\n  slug\n  internalID\n  isAcquireable\n  isOfferable\n  published\n  availability\n  mediumType {\n    filterGene {\n      slug\n      id\n    }\n  }\n  visibilityLevel\n  isUnlisted\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  partner {\n    __typename\n    id\n  }\n  isInAuction\n  sale {\n    internalID\n    slug\n    extendedBiddingIntervalMinutes\n    id\n  }\n  saleMessage\n  artists(shallow: true) {\n    id\n    internalID\n    slug\n  }\n}\n\nfragment ArtworkApp_me_1liwfq on Me {\n  ...ArtworkSidebar_me_39o6UP\n  ...ArtworkPageBanner_me_39o6UP\n}\n\nfragment ArtworkAuctionCreateAlertHeader_artwork on Artwork {\n  slug\n  internalID\n  title\n  isEligibleToCreateAlert\n  isInAuction\n  artistNames\n  artists(shallow: true) {\n    internalID\n    name\n    slug\n    id\n  }\n  sale {\n    startAt\n    isClosed\n    id\n  }\n  saleArtwork {\n    extendedBiddingEndAt\n    endAt\n    endedAt\n    id\n  }\n  attributionClass {\n    internalID\n    id\n  }\n  mediumType {\n    filterGene {\n      slug\n      name\n      id\n    }\n  }\n  myLotStandingManageAlerts: myLotStanding {\n    isHighestBidder\n  }\n}\n\nfragment ArtworkAuctionRegistrationPanel_artwork on Artwork {\n  sale {\n    slug\n    registrationEndsAt\n    isRegistrationClosed\n    id\n  }\n}\n\nfragment ArtworkChatBubble_artwork on Artwork {\n  isAcquireable\n  isInquireable\n  isOfferable\n  isInAuction\n  listPrice {\n    __typename\n    ... on Money {\n      currencyCode\n      major\n    }\n    ... on PriceRange {\n      maxPrice {\n        currencyCode\n        major\n      }\n    }\n  }\n  saleArtwork {\n    currency\n    openingBid {\n      cents\n    }\n    id\n  }\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  category\n  series\n  publisher\n  manufacturer\n  image_rights: imageRights\n  canRequestLotConditionsReport\n  internalID\n  isUnlisted\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n  mediumType {\n    __typename\n  }\n  dimensions {\n    in\n    cm\n  }\n  attributionClass {\n    name\n    id\n  }\n  medium\n  ...ArtworkDetailsMediumModal_artwork\n}\n\nfragment ArtworkDetailsMediumModal_artwork on Artwork {\n  mediumType {\n    name\n    longDescription\n  }\n}\n\nfragment ArtworkDownloadButton_artwork on Artwork {\n  title\n  date\n  downloadableImageUrl\n  artists(shallow: true) {\n    name\n    id\n  }\n}\n\nfragment ArtworkErrorApp_artworkError on ArtworkError {\n  artwork {\n    slug\n    id\n  }\n  requestError {\n    statusCode\n  }\n}\n\nfragment ArtworkImageBrowserLarge_artwork_FOvjt on Artwork {\n  ...ArtworkLightbox_artwork_FOvjt\n  ...ArtworkVideoPlayer_artwork_FOvjt\n  isSetVideoAsCover\n  figures(includeAll: false) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      __typename\n      internalID\n      isZoomable\n    }\n    ... on Video {\n      __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowserSmall_artwork_FOvjt on Artwork {\n  ...ArtworkLightbox_artwork_FOvjt\n  ...ArtworkVideoPlayer_artwork_FOvjt\n  isSetVideoAsCover\n  figures(includeAll: false) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      internalID\n      isZoomable\n      type: __typename\n    }\n    ... on Video {\n      type: __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowser_artwork on Artwork {\n  ...ArtworkActions_artwork_FOvjt\n  ...ArtworkImageBrowserSmall_artwork_FOvjt\n  ...ArtworkImageBrowserLarge_artwork_FOvjt\n  internalID\n  figures(includeAll: false) {\n    __typename\n    ... on Image {\n      isDefault\n      width\n      height\n    }\n    ... on Video {\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment ArtworkLightbox_artwork_FOvjt on Artwork {\n  formattedMetadata\n  images(includeAll: false) {\n    internalID\n    isDefault\n    placeholder: url(version: [\"small\", \"medium\"])\n    blurhashDataURL(width: 801)\n    fallback: cropped(quality: 80, width: 1600, height: 1600, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n    }\n    resized(quality: 80, width: 1600, height: 1600, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n    }\n    versions\n  }\n}\n\nfragment ArtworkMeta_artwork on Artwork {\n  ...SeoDataForArtwork_artwork\n  ...ArtworkChatBubble_artwork\n  href\n  internalID\n  isShareable\n  isUnlisted\n  metaImage: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n    longDescription: description(limit: 200)\n  }\n}\n\nfragment ArtworkPageBanner_artwork on Artwork {\n  published\n  visibilityLevel\n  isPurchasable\n  sale {\n    __typename\n    ...CascadingEndTimesBanner_sale\n    id\n  }\n}\n\nfragment ArtworkPageBanner_me_39o6UP on Me {\n  partnerOffersConnection(artworkID: \"artwork-id\", first: 1) {\n    edges {\n      node {\n        internalID\n        isActive\n        id\n      }\n    }\n  }\n}\n\nfragment ArtworkSharePanel_artwork_FOvjt on Artwork {\n  href\n  images(includeAll: false) {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  culturalMaker\n  artists(shallow: true) {\n    slug\n    name\n    id\n  }\n}\n\nfragment ArtworkSidebarArtsyGuarantee_artwork on Artwork {\n  isUnlisted\n}\n\nfragment ArtworkSidebarArtworkTitle_artwork on Artwork {\n  date\n  title\n}\n\nfragment ArtworkSidebarAuctionInfoPolling_artwork on Artwork {\n  internalID\n  sale {\n    isClosed\n    id\n  }\n  saleArtwork {\n    currentBid {\n      display\n    }\n    id\n  }\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n}\n\nfragment ArtworkSidebarAuctionInfoPolling_me on Me {\n  ...ArtworkSidebarBidAction_me\n}\n\nfragment ArtworkSidebarAuctionTimer_artwork on Artwork {\n  internalID\n  sale {\n    cascadingEndTimeIntervalMinutes\n    isClosed\n    ...AuctionTimer_sale\n    startAt\n    id\n  }\n  saleArtwork {\n    ...LotTimer_saleArtwork\n    endAt\n    endedAt\n    id\n  }\n}\n\nfragment ArtworkSidebarAuthenticityCertificate_artwork on Artwork {\n  hasCertificateOfAuthenticity\n  isBiddable\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        cents\n      }\n      id\n    }\n  }\n  slug\n  internalID\n  sale {\n    slug\n    registrationStatus {\n      qualified_for_bidding: qualifiedForBidding\n      id\n    }\n    is_preview: isPreview\n    is_open: isOpen\n    is_live_open: isLiveOpen\n    is_closed: isClosed\n    is_registration_closed: isRegistrationClosed\n    requireIdentityVerification\n    id\n  }\n  sale_artwork: saleArtwork {\n    increments {\n      cents\n      display\n    }\n    endedAt\n    id\n  }\n  collectorSignals {\n    auction {\n      bidCount\n      lotWatcherCount\n    }\n  }\n}\n\nfragment ArtworkSidebarBidAction_me on Me {\n  isIdentityVerified\n  pendingIdentityVerification {\n    internalID\n    id\n  }\n}\n\nfragment ArtworkSidebarBiddingClosedMessage_artwork on Artwork {\n  isEligibleToCreateAlert\n  artists(shallow: true) {\n    internalID\n    id\n  }\n  attributionClass {\n    internalID\n    id\n  }\n  mediumType {\n    filterGene {\n      slug\n      id\n    }\n  }\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attributionClass {\n    shortArrayDescription\n    id\n  }\n}\n\nfragment ArtworkSidebarCollectorSignal_artwork on Artwork {\n  collectorSignals {\n    primaryLabel(ignore: [PARTNER_OFFER])\n    runningShow {\n      name\n      href\n      startAt\n      endAt\n      id\n    }\n  }\n}\n\nfragment ArtworkSidebarCommercialButtons_artwork on Artwork {\n  ...ArtworkSidebarEditionSets_artwork\n  isEligibleToCreateAlert\n  artists(shallow: true) {\n    internalID\n    id\n  }\n  attributionClass {\n    internalID\n    id\n  }\n  internalID\n  slug\n  saleMessage\n  isInquireable\n  isAcquireable\n  isOfferable\n  isSold\n  priceListedDisplay\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  mediumType {\n    filterGene {\n      slug\n      id\n    }\n  }\n  editionSets {\n    id\n    internalID\n    isAcquireable\n    isOfferable\n    saleMessage\n    dimensions {\n      in\n      cm\n    }\n  }\n  partner {\n    profile {\n      icon {\n        url(version: \"square140\")\n      }\n      id\n    }\n    id\n  }\n  collectorSignals {\n    partnerOffer {\n      endAt\n      id\n    }\n    increasedInterest\n    curatorsPick\n  }\n}\n\nfragment ArtworkSidebarCommercialButtons_me_39o6UP on Me {\n  partnerOffersConnection(artworkID: \"artwork-id\", first: 1) {\n    edges {\n      node {\n        endAt\n        internalID\n        isAvailable\n        note\n        priceWithDiscount {\n          display\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ArtworkSidebarCreateAlert_artwork on Artwork {\n  isEligibleToCreateAlert\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  sale {\n    is_closed: isClosed\n    is_live_open: isLiveOpen\n    internalID\n    is_with_buyers_premium: isWithBuyersPremium\n    id\n  }\n  sale_artwork: saleArtwork {\n    is_with_reserve: isWithReserve\n    reserve_message: reserveMessage\n    reserve_status: reserveStatus\n    endedAt\n    current_bid: currentBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n  myLotStanding(live: true) {\n    active_bid: activeBid {\n      is_winning: isWinning\n      id\n    }\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        display\n      }\n      id\n    }\n  }\n  collectorSignals {\n    auction {\n      lotWatcherCount\n    }\n  }\n  ...ArtworkSidebarBiddingClosedMessage_artwork\n}\n\nfragment ArtworkSidebarDetails_artwork on Artwork {\n  isUnlisted\n  medium\n  dimensions {\n    in\n    cm\n  }\n  framed {\n    details\n  }\n  editionOf\n  isEdition\n  editionSets {\n    internalID\n    id\n  }\n  ...ArtworkSidebarClassification_artwork\n  ...ArtworkSidebarAuthenticityCertificate_artwork\n  ...ArtworkSidebarCollectorSignal_artwork\n}\n\nfragment ArtworkSidebarEditionSets_artwork on Artwork {\n  isInquireable\n  isOfferable\n  isAcquireable\n  editionSets {\n    id\n    internalID\n    isOfferable\n    isAcquireable\n    saleMessage\n    dimensions {\n      cm\n      in\n    }\n    ...ArtworkSidebarSizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebarEstimatedValue_artwork on Artwork {\n  saleArtwork {\n    estimate\n    id\n  }\n  sale {\n    isClosed\n    id\n  }\n}\n\nfragment ArtworkSidebarLinks_artwork on Artwork {\n  isInAuction\n  isUnlisted\n  sale {\n    isClosed\n    id\n  }\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  internalID\n  slug\n  isInquireable\n  isUnlisted\n  partner {\n    name\n    href\n    cities\n    isInquireable\n    id\n  }\n  sale {\n    name\n    href\n    id\n  }\n  collectorSignals {\n    partnerOffer {\n      endAt\n      id\n    }\n    increasedInterest\n    curatorsPick\n  }\n}\n\nfragment ArtworkSidebarPrivateArtwork_artwork on Artwork {\n  partner {\n    name\n    slug\n    profile {\n      isPubliclyVisible\n      id\n    }\n    id\n  }\n  isUnlisted\n  additionalInformation\n}\n\nfragment ArtworkSidebarShippingInformation_artwork on Artwork {\n  isUnlisted\n  priceIncludesTaxDisplay\n  shippingOrigin\n  shippingInfo\n  pickupAvailable\n  taxInfo {\n    displayText\n    moreInfo {\n      displayText\n      url\n    }\n  }\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  __isSellable: __typename\n  dimensions {\n    in\n    cm\n  }\n  editionOf\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  ...ArtworkSidebarArtworkTitle_artwork\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarDetails_artwork\n  ...ArtworkSidebarCommercialButtons_artwork\n  ...ArtworkSidebarShippingInformation_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarCreateAlert_artwork\n  ...ArtworkSidebarLinks_artwork\n  ...ArtworkSidebarEstimatedValue_artwork\n  ...ArtworkSidebarBiddingClosedMessage_artwork\n  ...ArtworkSidebarAuctionTimer_artwork\n  ...ArtworkSidebarAuctionInfoPolling_artwork\n  ...ArtworkSidebarPrivateArtwork_artwork\n  ...ArtworkSidebarArtsyGuarantee_artwork\n  ...PrivateArtworkAdditionalInfo_artwork\n  ...ArtsyShippingEstimate_artwork\n  artists(shallow: true) {\n    internalID\n    id\n  }\n  artsyShippingDomestic\n  artsyShippingInternational\n  editionSets {\n    internalID\n    id\n  }\n  internationalShippingFee {\n    major\n  }\n  isAcquireable\n  isBiddable\n  isEdition\n  isEligibleForArtsyGuarantee\n  isEligibleToCreateAlert\n  isInAuction\n  isOfferable\n  isSold\n  isUnlisted\n  partner {\n    internalID\n    id\n  }\n  sale {\n    endAt\n    startAt\n    isClosed\n    isAuction\n    id\n  }\n  saleArtwork {\n    lotID\n    lotLabel\n    extendedBiddingEndAt\n    endAt\n    endedAt\n    id\n  }\n  saleMessage\n  shippingWeight\n  shippingWeightMetric\n  slug\n}\n\nfragment ArtworkSidebar_me_39o6UP on Me {\n  ...ArtworkSidebarAuctionInfoPolling_me\n  ...ArtworkSidebarCommercialButtons_me_39o6UP\n}\n\nfragment ArtworkTopContextBarBreadcrumb_artwork on Artwork {\n  internalID\n  href\n  title\n  artist {\n    name\n    href\n    id\n  }\n}\n\nfragment ArtworkTopContextBar_artwork on Artwork {\n  ...ArtworkTopContextBarBreadcrumb_artwork\n  internalID\n}\n\nfragment ArtworkVideoPlayer_artwork_FOvjt on Artwork {\n  internalID\n  slug\n  figures(includeAll: false) {\n    __typename\n    ... on Video {\n      __typename\n      playerUrl\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment AuctionTimer_sale on Sale {\n  liveStartAt\n  endAt\n}\n\nfragment CascadingEndTimesBanner_sale on Sale {\n  isClosed\n  cascadingEndTimeIntervalMinutes\n  extendedBiddingIntervalMinutes\n}\n\nfragment DeepZoom_image on Image {\n  deepZoom {\n    Image {\n      xmlns\n      Url\n      Format\n      TileSize\n      Overlap\n      Size {\n        Width\n        Height\n      }\n    }\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  slug\n  name\n  internalID\n  counts {\n    follows\n  }\n}\n\nfragment LotTimer_saleArtwork on SaleArtwork {\n  endAt\n  formattedStartDateTime\n  extendedBiddingEndAt\n  lotID\n  sale {\n    startAt\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    internalID\n    id\n  }\n}\n\nfragment PrivateArtworkAboutArtist_artwork on Artwork {\n  displayArtistBio\n  slug\n  artists(shallow: true) {\n    ...FollowArtistButton_artist\n    internalID\n    href\n    slug\n    name\n    initials\n    formattedNationalityAndBirthday\n    counts {\n      follows\n    }\n    coverArtwork {\n      image {\n        cropped(width: 145, height: 145) {\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    biographyBlurb(format: HTML, partnerBio: false) {\n      text\n    }\n    id\n  }\n}\n\nfragment PrivateArtworkAboutWork_artwork on Artwork {\n  additionalInformationHTML: additionalInformation(format: HTML)\n}\n\nfragment PrivateArtworkAdditionalInfo_artwork on Artwork {\n  category\n  series\n  publisher\n  manufacturer\n  image_rights: imageRights\n  canRequestLotConditionsReport\n  internalID\n  isUnlisted\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n  mediumType {\n    __typename\n  }\n  dimensions {\n    in\n    cm\n  }\n  attributionClass {\n    name\n    id\n  }\n  medium\n  ...ArtworkDetailsMediumModal_artwork\n}\n\nfragment PrivateArtworkDetails_artwork on Artwork {\n  ...PrivateArtworkAboutWork_artwork\n  ...PrivateArtworkAboutArtist_artwork\n  ...PrivateArtworkMetadata_artwork\n}\n\nfragment PrivateArtworkMetadata_artwork on Artwork {\n  ...ArtworkDetailsAdditionalInfo_artwork\n  conditionDescription {\n    details\n  }\n  provenance(format: HTML)\n  exhibitionHistory(format: HTML)\n}\n\nfragment SeoDataForArtwork_artwork on Artwork {\n  href\n  date\n  is_price_hidden: isPriceHidden\n  is_price_range: isPriceRange\n  listPrice {\n    __typename\n    ... on PriceRange {\n      minPrice {\n        major\n        currencyCode\n      }\n      maxPrice {\n        major\n      }\n    }\n    ... on Money {\n      major\n      currencyCode\n    }\n  }\n  meta_image: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n  }\n  partner {\n    name\n    type\n    profile {\n      image {\n        resized(width: 320, height: 320, version: [\"medium\"]) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n  artistNames\n  availability\n  category\n  dimensions {\n    in\n  }\n}\n\nfragment ViewInRoomArtwork_artwork on Artwork {\n  widthCm\n  heightCm\n  image {\n    resized(width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ViewInRoom_artwork on Artwork {\n  ...ViewInRoomArtwork_artwork\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtworkImageBrowserLarge_Test_Query.graphql.ts
+++ b/src/__generated__/ArtworkImageBrowserLarge_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d7a177e0efafa387a3900166c6af07b4>>
+ * @generated SignedSource<<409e587af1a6f17fbaee842b9ca1ca22>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -43,37 +43,34 @@ v2 = {
   "name": "internalID",
   "storageKey": null
 },
-v3 = {
-  "kind": "Literal",
-  "name": "height",
-  "value": 800
-},
-v4 = {
-  "kind": "Literal",
-  "name": "version",
-  "value": [
-    "main",
-    "normalized",
-    "larger",
-    "large"
-  ]
-},
-v5 = {
-  "kind": "Literal",
-  "name": "width",
-  "value": 800
-},
-v6 = [
-  (v3/*: any*/),
+v3 = [
+  {
+    "kind": "Literal",
+    "name": "height",
+    "value": 1600
+  },
   {
     "kind": "Literal",
     "name": "quality",
     "value": 80
   },
-  (v4/*: any*/),
-  (v5/*: any*/)
+  {
+    "kind": "Literal",
+    "name": "version",
+    "value": [
+      "main",
+      "normalized",
+      "larger",
+      "large"
+    ]
+  },
+  {
+    "kind": "Literal",
+    "name": "width",
+    "value": 1600
+  }
 ],
-v7 = [
+v4 = [
   {
     "alias": null,
     "args": null,
@@ -94,69 +91,56 @@ v7 = [
     "kind": "ScalarField",
     "name": "src",
     "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "srcSet",
-    "storageKey": null
   }
 ],
-v8 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v9 = {
+v6 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
+},
+v7 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v8 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Int"
+},
+v9 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
 },
 v10 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "String"
+  "type": "ID"
 },
 v11 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Int"
+  "type": "Boolean"
 },
 v12 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
-  "type": "ID"
-},
-v13 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "ID"
-},
-v14 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Boolean"
-},
-v15 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
   "type": "Int"
-},
-v16 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "ResizedImageUrl"
 };
 return {
   "fragment": {
@@ -253,42 +237,23 @@ return {
               },
               {
                 "alias": "fallback",
-                "args": (v6/*: any*/),
+                "args": (v3/*: any*/),
                 "concreteType": "CroppedImageUrl",
                 "kind": "LinkedField",
                 "name": "cropped",
                 "plural": false,
-                "selections": (v7/*: any*/),
-                "storageKey": "cropped(height:800,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
+                "selections": (v4/*: any*/),
+                "storageKey": "cropped(height:1600,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:1600)"
               },
               {
                 "alias": null,
-                "args": (v6/*: any*/),
+                "args": (v3/*: any*/),
                 "concreteType": "ResizedImageUrl",
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v7/*: any*/),
-                "storageKey": "resized(height:800,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
-              },
-              {
-                "alias": "mobileLightboxSource",
-                "args": [
-                  (v3/*: any*/),
-                  {
-                    "kind": "Literal",
-                    "name": "quality",
-                    "value": 50
-                  },
-                  (v4/*: any*/),
-                  (v5/*: any*/)
-                ],
-                "concreteType": "ResizedImageUrl",
-                "kind": "LinkedField",
-                "name": "resized",
-                "plural": false,
-                "selections": (v7/*: any*/),
-                "storageKey": "resized(height:800,quality:50,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
+                "selections": (v4/*: any*/),
+                "storageKey": "resized(height:1600,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:1600)"
               },
               {
                 "alias": null,
@@ -347,7 +312,7 @@ return {
                     "name": "height",
                     "storageKey": null
                   },
-                  (v8/*: any*/)
+                  (v5/*: any*/)
                 ],
                 "type": "Video",
                 "abstractKey": null
@@ -459,14 +424,14 @@ return {
             "name": "isSetVideoAsCover",
             "storageKey": null
           },
-          (v8/*: any*/)
+          (v5/*: any*/)
         ],
         "storageKey": "artwork(id:\"example\")"
       }
     ]
   },
   "params": {
-    "cacheID": "11c76444859af1ae8b31857558f9dd41",
+    "cacheID": "ae0b3e8f86030270361fb1d7deefdf67",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -482,7 +447,7 @@ return {
           "plural": true,
           "type": "ArtworkFigures"
         },
-        "artwork.figures.__typename": (v9/*: any*/),
+        "artwork.figures.__typename": (v6/*: any*/),
         "artwork.figures.deepZoom": {
           "enumValues": null,
           "nullable": true,
@@ -495,71 +460,69 @@ return {
           "plural": false,
           "type": "DeepZoomImage"
         },
-        "artwork.figures.deepZoom.Image.Format": (v10/*: any*/),
-        "artwork.figures.deepZoom.Image.Overlap": (v11/*: any*/),
+        "artwork.figures.deepZoom.Image.Format": (v7/*: any*/),
+        "artwork.figures.deepZoom.Image.Overlap": (v8/*: any*/),
         "artwork.figures.deepZoom.Image.Size": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "DeepZoomImageSize"
         },
-        "artwork.figures.deepZoom.Image.Size.Height": (v11/*: any*/),
-        "artwork.figures.deepZoom.Image.Size.Width": (v11/*: any*/),
-        "artwork.figures.deepZoom.Image.TileSize": (v11/*: any*/),
-        "artwork.figures.deepZoom.Image.Url": (v10/*: any*/),
-        "artwork.figures.deepZoom.Image.xmlns": (v10/*: any*/),
-        "artwork.figures.id": (v12/*: any*/),
-        "artwork.figures.internalID": (v13/*: any*/),
-        "artwork.figures.isZoomable": (v14/*: any*/),
-        "artwork.figures.playerUrl": (v9/*: any*/),
-        "artwork.figures.videoHeight": (v15/*: any*/),
-        "artwork.figures.videoWidth": (v15/*: any*/),
-        "artwork.formattedMetadata": (v10/*: any*/),
-        "artwork.id": (v12/*: any*/),
+        "artwork.figures.deepZoom.Image.Size.Height": (v8/*: any*/),
+        "artwork.figures.deepZoom.Image.Size.Width": (v8/*: any*/),
+        "artwork.figures.deepZoom.Image.TileSize": (v8/*: any*/),
+        "artwork.figures.deepZoom.Image.Url": (v7/*: any*/),
+        "artwork.figures.deepZoom.Image.xmlns": (v7/*: any*/),
+        "artwork.figures.id": (v9/*: any*/),
+        "artwork.figures.internalID": (v10/*: any*/),
+        "artwork.figures.isZoomable": (v11/*: any*/),
+        "artwork.figures.playerUrl": (v6/*: any*/),
+        "artwork.figures.videoHeight": (v12/*: any*/),
+        "artwork.figures.videoWidth": (v12/*: any*/),
+        "artwork.formattedMetadata": (v7/*: any*/),
+        "artwork.id": (v9/*: any*/),
         "artwork.images": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Image"
         },
-        "artwork.images.blurhashDataURL": (v10/*: any*/),
+        "artwork.images.blurhashDataURL": (v7/*: any*/),
         "artwork.images.fallback": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "CroppedImageUrl"
         },
-        "artwork.images.fallback.height": (v15/*: any*/),
-        "artwork.images.fallback.src": (v9/*: any*/),
-        "artwork.images.fallback.srcSet": (v9/*: any*/),
-        "artwork.images.fallback.width": (v15/*: any*/),
-        "artwork.images.internalID": (v13/*: any*/),
-        "artwork.images.isDefault": (v14/*: any*/),
-        "artwork.images.mobileLightboxSource": (v16/*: any*/),
-        "artwork.images.mobileLightboxSource.height": (v11/*: any*/),
-        "artwork.images.mobileLightboxSource.src": (v9/*: any*/),
-        "artwork.images.mobileLightboxSource.srcSet": (v9/*: any*/),
-        "artwork.images.mobileLightboxSource.width": (v11/*: any*/),
-        "artwork.images.placeholder": (v10/*: any*/),
-        "artwork.images.resized": (v16/*: any*/),
-        "artwork.images.resized.height": (v11/*: any*/),
-        "artwork.images.resized.src": (v9/*: any*/),
-        "artwork.images.resized.srcSet": (v9/*: any*/),
-        "artwork.images.resized.width": (v11/*: any*/),
+        "artwork.images.fallback.height": (v12/*: any*/),
+        "artwork.images.fallback.src": (v6/*: any*/),
+        "artwork.images.fallback.width": (v12/*: any*/),
+        "artwork.images.internalID": (v10/*: any*/),
+        "artwork.images.isDefault": (v11/*: any*/),
+        "artwork.images.placeholder": (v7/*: any*/),
+        "artwork.images.resized": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ResizedImageUrl"
+        },
+        "artwork.images.resized.height": (v8/*: any*/),
+        "artwork.images.resized.src": (v6/*: any*/),
+        "artwork.images.resized.width": (v8/*: any*/),
         "artwork.images.versions": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "String"
         },
-        "artwork.internalID": (v12/*: any*/),
-        "artwork.isSetVideoAsCover": (v14/*: any*/),
-        "artwork.slug": (v12/*: any*/)
+        "artwork.internalID": (v9/*: any*/),
+        "artwork.isSetVideoAsCover": (v11/*: any*/),
+        "artwork.slug": (v9/*: any*/)
       }
     },
     "name": "ArtworkImageBrowserLarge_Test_Query",
     "operationKind": "query",
-    "text": "query ArtworkImageBrowserLarge_Test_Query {\n  artwork(id: \"example\") {\n    ...ArtworkImageBrowserLarge_artwork\n    id\n  }\n}\n\nfragment ArtworkImageBrowserLarge_artwork on Artwork {\n  ...ArtworkLightbox_artwork_FOvjt\n  ...ArtworkVideoPlayer_artwork_FOvjt\n  isSetVideoAsCover\n  figures(includeAll: false) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      __typename\n      internalID\n      isZoomable\n    }\n    ... on Video {\n      __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkLightbox_artwork_FOvjt on Artwork {\n  formattedMetadata\n  images(includeAll: false) {\n    internalID\n    isDefault\n    placeholder: url(version: [\"small\", \"medium\"])\n    blurhashDataURL(width: 801)\n    fallback: cropped(quality: 80, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    resized(quality: 80, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    mobileLightboxSource: resized(quality: 50, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    versions\n  }\n}\n\nfragment ArtworkVideoPlayer_artwork_FOvjt on Artwork {\n  internalID\n  slug\n  figures(includeAll: false) {\n    __typename\n    ... on Video {\n      __typename\n      playerUrl\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment DeepZoom_image on Image {\n  deepZoom {\n    Image {\n      xmlns\n      Url\n      Format\n      TileSize\n      Overlap\n      Size {\n        Width\n        Height\n      }\n    }\n  }\n}\n"
+    "text": "query ArtworkImageBrowserLarge_Test_Query {\n  artwork(id: \"example\") {\n    ...ArtworkImageBrowserLarge_artwork\n    id\n  }\n}\n\nfragment ArtworkImageBrowserLarge_artwork on Artwork {\n  ...ArtworkLightbox_artwork_FOvjt\n  ...ArtworkVideoPlayer_artwork_FOvjt\n  isSetVideoAsCover\n  figures(includeAll: false) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      __typename\n      internalID\n      isZoomable\n    }\n    ... on Video {\n      __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkLightbox_artwork_FOvjt on Artwork {\n  formattedMetadata\n  images(includeAll: false) {\n    internalID\n    isDefault\n    placeholder: url(version: [\"small\", \"medium\"])\n    blurhashDataURL(width: 801)\n    fallback: cropped(quality: 80, width: 1600, height: 1600, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n    }\n    resized(quality: 80, width: 1600, height: 1600, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n    }\n    versions\n  }\n}\n\nfragment ArtworkVideoPlayer_artwork_FOvjt on Artwork {\n  internalID\n  slug\n  figures(includeAll: false) {\n    __typename\n    ... on Video {\n      __typename\n      playerUrl\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment DeepZoom_image on Image {\n  deepZoom {\n    Image {\n      xmlns\n      Url\n      Format\n      TileSize\n      Overlap\n      Size {\n        Width\n        Height\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtworkImageBrowserSmall_Test_Query.graphql.ts
+++ b/src/__generated__/ArtworkImageBrowserSmall_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6c1d21a117207e883bb92471f5f04ef2>>
+ * @generated SignedSource<<b1a30bf8e4f1c607c6e7d6fbcb740f6b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -43,37 +43,34 @@ v2 = {
   "name": "internalID",
   "storageKey": null
 },
-v3 = {
-  "kind": "Literal",
-  "name": "height",
-  "value": 800
-},
-v4 = {
-  "kind": "Literal",
-  "name": "version",
-  "value": [
-    "main",
-    "normalized",
-    "larger",
-    "large"
-  ]
-},
-v5 = {
-  "kind": "Literal",
-  "name": "width",
-  "value": 800
-},
-v6 = [
-  (v3/*: any*/),
+v3 = [
+  {
+    "kind": "Literal",
+    "name": "height",
+    "value": 1600
+  },
   {
     "kind": "Literal",
     "name": "quality",
     "value": 80
   },
-  (v4/*: any*/),
-  (v5/*: any*/)
+  {
+    "kind": "Literal",
+    "name": "version",
+    "value": [
+      "main",
+      "normalized",
+      "larger",
+      "large"
+    ]
+  },
+  {
+    "kind": "Literal",
+    "name": "width",
+    "value": 1600
+  }
 ],
-v7 = [
+v4 = [
   {
     "alias": null,
     "args": null,
@@ -94,76 +91,63 @@ v7 = [
     "kind": "ScalarField",
     "name": "src",
     "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "srcSet",
-    "storageKey": null
   }
 ],
-v8 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v9 = {
+v6 = {
   "alias": "type",
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v10 = {
+v7 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
+},
+v8 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v9 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Int"
+},
+v10 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
 },
 v11 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "String"
+  "type": "ID"
 },
 v12 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Int"
+  "type": "Boolean"
 },
 v13 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
-  "type": "ID"
-},
-v14 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "ID"
-},
-v15 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Boolean"
-},
-v16 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
   "type": "Int"
-},
-v17 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "ResizedImageUrl"
 };
 return {
   "fragment": {
@@ -260,42 +244,23 @@ return {
               },
               {
                 "alias": "fallback",
-                "args": (v6/*: any*/),
+                "args": (v3/*: any*/),
                 "concreteType": "CroppedImageUrl",
                 "kind": "LinkedField",
                 "name": "cropped",
                 "plural": false,
-                "selections": (v7/*: any*/),
-                "storageKey": "cropped(height:800,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
+                "selections": (v4/*: any*/),
+                "storageKey": "cropped(height:1600,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:1600)"
               },
               {
                 "alias": null,
-                "args": (v6/*: any*/),
+                "args": (v3/*: any*/),
                 "concreteType": "ResizedImageUrl",
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v7/*: any*/),
-                "storageKey": "resized(height:800,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
-              },
-              {
-                "alias": "mobileLightboxSource",
-                "args": [
-                  (v3/*: any*/),
-                  {
-                    "kind": "Literal",
-                    "name": "quality",
-                    "value": 50
-                  },
-                  (v4/*: any*/),
-                  (v5/*: any*/)
-                ],
-                "concreteType": "ResizedImageUrl",
-                "kind": "LinkedField",
-                "name": "resized",
-                "plural": false,
-                "selections": (v7/*: any*/),
-                "storageKey": "resized(height:800,quality:50,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
+                "selections": (v4/*: any*/),
+                "storageKey": "resized(height:1600,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:1600)"
               },
               {
                 "alias": null,
@@ -354,8 +319,8 @@ return {
                     "name": "height",
                     "storageKey": null
                   },
-                  (v8/*: any*/),
-                  (v9/*: any*/)
+                  (v5/*: any*/),
+                  (v6/*: any*/)
                 ],
                 "type": "Video",
                 "abstractKey": null
@@ -453,7 +418,7 @@ return {
                     "name": "isZoomable",
                     "storageKey": null
                   },
-                  (v9/*: any*/)
+                  (v6/*: any*/)
                 ],
                 "type": "Image",
                 "abstractKey": null
@@ -468,14 +433,14 @@ return {
             "name": "isSetVideoAsCover",
             "storageKey": null
           },
-          (v8/*: any*/)
+          (v5/*: any*/)
         ],
         "storageKey": "artwork(id:\"example\")"
       }
     ]
   },
   "params": {
-    "cacheID": "648da78163546b513a7d10a4277410ed",
+    "cacheID": "8f8d39986cf3cec479d903e496aacfd1",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -491,7 +456,7 @@ return {
           "plural": true,
           "type": "ArtworkFigures"
         },
-        "artwork.figures.__typename": (v10/*: any*/),
+        "artwork.figures.__typename": (v7/*: any*/),
         "artwork.figures.deepZoom": {
           "enumValues": null,
           "nullable": true,
@@ -504,72 +469,70 @@ return {
           "plural": false,
           "type": "DeepZoomImage"
         },
-        "artwork.figures.deepZoom.Image.Format": (v11/*: any*/),
-        "artwork.figures.deepZoom.Image.Overlap": (v12/*: any*/),
+        "artwork.figures.deepZoom.Image.Format": (v8/*: any*/),
+        "artwork.figures.deepZoom.Image.Overlap": (v9/*: any*/),
         "artwork.figures.deepZoom.Image.Size": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "DeepZoomImageSize"
         },
-        "artwork.figures.deepZoom.Image.Size.Height": (v12/*: any*/),
-        "artwork.figures.deepZoom.Image.Size.Width": (v12/*: any*/),
-        "artwork.figures.deepZoom.Image.TileSize": (v12/*: any*/),
-        "artwork.figures.deepZoom.Image.Url": (v11/*: any*/),
-        "artwork.figures.deepZoom.Image.xmlns": (v11/*: any*/),
-        "artwork.figures.id": (v13/*: any*/),
-        "artwork.figures.internalID": (v14/*: any*/),
-        "artwork.figures.isZoomable": (v15/*: any*/),
-        "artwork.figures.playerUrl": (v10/*: any*/),
-        "artwork.figures.type": (v10/*: any*/),
-        "artwork.figures.videoHeight": (v16/*: any*/),
-        "artwork.figures.videoWidth": (v16/*: any*/),
-        "artwork.formattedMetadata": (v11/*: any*/),
-        "artwork.id": (v13/*: any*/),
+        "artwork.figures.deepZoom.Image.Size.Height": (v9/*: any*/),
+        "artwork.figures.deepZoom.Image.Size.Width": (v9/*: any*/),
+        "artwork.figures.deepZoom.Image.TileSize": (v9/*: any*/),
+        "artwork.figures.deepZoom.Image.Url": (v8/*: any*/),
+        "artwork.figures.deepZoom.Image.xmlns": (v8/*: any*/),
+        "artwork.figures.id": (v10/*: any*/),
+        "artwork.figures.internalID": (v11/*: any*/),
+        "artwork.figures.isZoomable": (v12/*: any*/),
+        "artwork.figures.playerUrl": (v7/*: any*/),
+        "artwork.figures.type": (v7/*: any*/),
+        "artwork.figures.videoHeight": (v13/*: any*/),
+        "artwork.figures.videoWidth": (v13/*: any*/),
+        "artwork.formattedMetadata": (v8/*: any*/),
+        "artwork.id": (v10/*: any*/),
         "artwork.images": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Image"
         },
-        "artwork.images.blurhashDataURL": (v11/*: any*/),
+        "artwork.images.blurhashDataURL": (v8/*: any*/),
         "artwork.images.fallback": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "CroppedImageUrl"
         },
-        "artwork.images.fallback.height": (v16/*: any*/),
-        "artwork.images.fallback.src": (v10/*: any*/),
-        "artwork.images.fallback.srcSet": (v10/*: any*/),
-        "artwork.images.fallback.width": (v16/*: any*/),
-        "artwork.images.internalID": (v14/*: any*/),
-        "artwork.images.isDefault": (v15/*: any*/),
-        "artwork.images.mobileLightboxSource": (v17/*: any*/),
-        "artwork.images.mobileLightboxSource.height": (v12/*: any*/),
-        "artwork.images.mobileLightboxSource.src": (v10/*: any*/),
-        "artwork.images.mobileLightboxSource.srcSet": (v10/*: any*/),
-        "artwork.images.mobileLightboxSource.width": (v12/*: any*/),
-        "artwork.images.placeholder": (v11/*: any*/),
-        "artwork.images.resized": (v17/*: any*/),
-        "artwork.images.resized.height": (v12/*: any*/),
-        "artwork.images.resized.src": (v10/*: any*/),
-        "artwork.images.resized.srcSet": (v10/*: any*/),
-        "artwork.images.resized.width": (v12/*: any*/),
+        "artwork.images.fallback.height": (v13/*: any*/),
+        "artwork.images.fallback.src": (v7/*: any*/),
+        "artwork.images.fallback.width": (v13/*: any*/),
+        "artwork.images.internalID": (v11/*: any*/),
+        "artwork.images.isDefault": (v12/*: any*/),
+        "artwork.images.placeholder": (v8/*: any*/),
+        "artwork.images.resized": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ResizedImageUrl"
+        },
+        "artwork.images.resized.height": (v9/*: any*/),
+        "artwork.images.resized.src": (v7/*: any*/),
+        "artwork.images.resized.width": (v9/*: any*/),
         "artwork.images.versions": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "String"
         },
-        "artwork.internalID": (v13/*: any*/),
-        "artwork.isSetVideoAsCover": (v15/*: any*/),
-        "artwork.slug": (v13/*: any*/)
+        "artwork.internalID": (v10/*: any*/),
+        "artwork.isSetVideoAsCover": (v12/*: any*/),
+        "artwork.slug": (v10/*: any*/)
       }
     },
     "name": "ArtworkImageBrowserSmall_Test_Query",
     "operationKind": "query",
-    "text": "query ArtworkImageBrowserSmall_Test_Query {\n  artwork(id: \"example\") {\n    ...ArtworkImageBrowserSmall_artwork\n    id\n  }\n}\n\nfragment ArtworkImageBrowserSmall_artwork on Artwork {\n  ...ArtworkLightbox_artwork_FOvjt\n  ...ArtworkVideoPlayer_artwork_FOvjt\n  isSetVideoAsCover\n  figures(includeAll: false) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      internalID\n      isZoomable\n      type: __typename\n    }\n    ... on Video {\n      type: __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkLightbox_artwork_FOvjt on Artwork {\n  formattedMetadata\n  images(includeAll: false) {\n    internalID\n    isDefault\n    placeholder: url(version: [\"small\", \"medium\"])\n    blurhashDataURL(width: 801)\n    fallback: cropped(quality: 80, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    resized(quality: 80, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    mobileLightboxSource: resized(quality: 50, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    versions\n  }\n}\n\nfragment ArtworkVideoPlayer_artwork_FOvjt on Artwork {\n  internalID\n  slug\n  figures(includeAll: false) {\n    __typename\n    ... on Video {\n      __typename\n      playerUrl\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment DeepZoom_image on Image {\n  deepZoom {\n    Image {\n      xmlns\n      Url\n      Format\n      TileSize\n      Overlap\n      Size {\n        Width\n        Height\n      }\n    }\n  }\n}\n"
+    "text": "query ArtworkImageBrowserSmall_Test_Query {\n  artwork(id: \"example\") {\n    ...ArtworkImageBrowserSmall_artwork\n    id\n  }\n}\n\nfragment ArtworkImageBrowserSmall_artwork on Artwork {\n  ...ArtworkLightbox_artwork_FOvjt\n  ...ArtworkVideoPlayer_artwork_FOvjt\n  isSetVideoAsCover\n  figures(includeAll: false) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      internalID\n      isZoomable\n      type: __typename\n    }\n    ... on Video {\n      type: __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkLightbox_artwork_FOvjt on Artwork {\n  formattedMetadata\n  images(includeAll: false) {\n    internalID\n    isDefault\n    placeholder: url(version: [\"small\", \"medium\"])\n    blurhashDataURL(width: 801)\n    fallback: cropped(quality: 80, width: 1600, height: 1600, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n    }\n    resized(quality: 80, width: 1600, height: 1600, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n    }\n    versions\n  }\n}\n\nfragment ArtworkVideoPlayer_artwork_FOvjt on Artwork {\n  internalID\n  slug\n  figures(includeAll: false) {\n    __typename\n    ... on Video {\n      __typename\n      playerUrl\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment DeepZoom_image on Image {\n  deepZoom {\n    Image {\n      xmlns\n      Url\n      Format\n      TileSize\n      Overlap\n      Size {\n        Width\n        Height\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtworkLightboxTestQuery.graphql.ts
+++ b/src/__generated__/ArtworkLightboxTestQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<485923c15296da0acaf8ec5517eeec0a>>
+ * @generated SignedSource<<04c3ebd6467ee97055962e4428e61d90>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -29,37 +29,34 @@ var v0 = [
     "value": "foo"
   }
 ],
-v1 = {
-  "kind": "Literal",
-  "name": "height",
-  "value": 800
-},
-v2 = {
-  "kind": "Literal",
-  "name": "version",
-  "value": [
-    "main",
-    "normalized",
-    "larger",
-    "large"
-  ]
-},
-v3 = {
-  "kind": "Literal",
-  "name": "width",
-  "value": 800
-},
-v4 = [
-  (v1/*: any*/),
+v1 = [
+  {
+    "kind": "Literal",
+    "name": "height",
+    "value": 1600
+  },
   {
     "kind": "Literal",
     "name": "quality",
     "value": 80
   },
-  (v2/*: any*/),
-  (v3/*: any*/)
+  {
+    "kind": "Literal",
+    "name": "version",
+    "value": [
+      "main",
+      "normalized",
+      "larger",
+      "large"
+    ]
+  },
+  {
+    "kind": "Literal",
+    "name": "width",
+    "value": 1600
+  }
 ],
-v5 = [
+v2 = [
   {
     "alias": null,
     "args": null,
@@ -79,13 +76,6 @@ v5 = [
     "args": null,
     "kind": "ScalarField",
     "name": "src",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "srcSet",
     "storageKey": null
   }
 ];
@@ -196,42 +186,23 @@ return {
               },
               {
                 "alias": "fallback",
-                "args": (v4/*: any*/),
+                "args": (v1/*: any*/),
                 "concreteType": "CroppedImageUrl",
                 "kind": "LinkedField",
                 "name": "cropped",
                 "plural": false,
-                "selections": (v5/*: any*/),
-                "storageKey": "cropped(height:800,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
+                "selections": (v2/*: any*/),
+                "storageKey": "cropped(height:1600,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:1600)"
               },
               {
                 "alias": null,
-                "args": (v4/*: any*/),
+                "args": (v1/*: any*/),
                 "concreteType": "ResizedImageUrl",
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v5/*: any*/),
-                "storageKey": "resized(height:800,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
-              },
-              {
-                "alias": "mobileLightboxSource",
-                "args": [
-                  (v1/*: any*/),
-                  {
-                    "kind": "Literal",
-                    "name": "quality",
-                    "value": 50
-                  },
-                  (v2/*: any*/),
-                  (v3/*: any*/)
-                ],
-                "concreteType": "ResizedImageUrl",
-                "kind": "LinkedField",
-                "name": "resized",
-                "plural": false,
-                "selections": (v5/*: any*/),
-                "storageKey": "resized(height:800,quality:50,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
+                "selections": (v2/*: any*/),
+                "storageKey": "resized(height:1600,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:1600)"
               },
               {
                 "alias": null,
@@ -256,12 +227,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "b46fba0315d9ec8ccca65648ebf2114b",
+    "cacheID": "036c4f4d186ae16d98b8c5e35a1a84aa",
     "id": null,
     "metadata": {},
     "name": "ArtworkLightboxTestQuery",
     "operationKind": "query",
-    "text": "query ArtworkLightboxTestQuery {\n  artwork(id: \"foo\") {\n    ...ArtworkLightbox_artwork\n    id\n  }\n}\n\nfragment ArtworkLightbox_artwork on Artwork {\n  formattedMetadata\n  images(includeAll: false) {\n    internalID\n    isDefault\n    placeholder: url(version: [\"small\", \"medium\"])\n    blurhashDataURL(width: 801)\n    fallback: cropped(quality: 80, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    resized(quality: 80, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    mobileLightboxSource: resized(quality: 50, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    versions\n  }\n}\n"
+    "text": "query ArtworkLightboxTestQuery {\n  artwork(id: \"foo\") {\n    ...ArtworkLightbox_artwork\n    id\n  }\n}\n\nfragment ArtworkLightbox_artwork on Artwork {\n  formattedMetadata\n  images(includeAll: false) {\n    internalID\n    isDefault\n    placeholder: url(version: [\"small\", \"medium\"])\n    blurhashDataURL(width: 801)\n    fallback: cropped(quality: 80, width: 1600, height: 1600, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n    }\n    resized(quality: 80, width: 1600, height: 1600, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n    }\n    versions\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtworkLightbox_artwork.graphql.ts
+++ b/src/__generated__/ArtworkLightbox_artwork.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8a47012558a69abbce70c4f7a906484c>>
+ * @generated SignedSource<<dba69c34324298792a1d178bdb6c1899>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -17,22 +17,14 @@ export type ArtworkLightbox_artwork$data = {
     readonly fallback: {
       readonly height: number;
       readonly src: string;
-      readonly srcSet: string;
       readonly width: number;
     } | null | undefined;
     readonly internalID: string | null | undefined;
     readonly isDefault: boolean | null | undefined;
-    readonly mobileLightboxSource: {
-      readonly height: number | null | undefined;
-      readonly src: string;
-      readonly srcSet: string;
-      readonly width: number | null | undefined;
-    } | null | undefined;
     readonly placeholder: string | null | undefined;
     readonly resized: {
       readonly height: number | null | undefined;
       readonly src: string;
-      readonly srcSet: string;
       readonly width: number | null | undefined;
     } | null | undefined;
     readonly versions: ReadonlyArray<string | null | undefined> | null | undefined;
@@ -45,37 +37,34 @@ export type ArtworkLightbox_artwork$key = {
 };
 
 const node: ReaderFragment = (function(){
-var v0 = {
-  "kind": "Literal",
-  "name": "height",
-  "value": 800
-},
-v1 = {
-  "kind": "Literal",
-  "name": "version",
-  "value": [
-    "main",
-    "normalized",
-    "larger",
-    "large"
-  ]
-},
-v2 = {
-  "kind": "Literal",
-  "name": "width",
-  "value": 800
-},
-v3 = [
-  (v0/*: any*/),
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "height",
+    "value": 1600
+  },
   {
     "kind": "Literal",
     "name": "quality",
     "value": 80
   },
-  (v1/*: any*/),
-  (v2/*: any*/)
+  {
+    "kind": "Literal",
+    "name": "version",
+    "value": [
+      "main",
+      "normalized",
+      "larger",
+      "large"
+    ]
+  },
+  {
+    "kind": "Literal",
+    "name": "width",
+    "value": 1600
+  }
 ],
-v4 = [
+v1 = [
   {
     "alias": null,
     "args": null,
@@ -95,13 +84,6 @@ v4 = [
     "args": null,
     "kind": "ScalarField",
     "name": "src",
-    "storageKey": null
-  },
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "srcSet",
     "storageKey": null
   }
 ];
@@ -183,42 +165,23 @@ return {
         },
         {
           "alias": "fallback",
-          "args": (v3/*: any*/),
+          "args": (v0/*: any*/),
           "concreteType": "CroppedImageUrl",
           "kind": "LinkedField",
           "name": "cropped",
           "plural": false,
-          "selections": (v4/*: any*/),
-          "storageKey": "cropped(height:800,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
+          "selections": (v1/*: any*/),
+          "storageKey": "cropped(height:1600,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:1600)"
         },
         {
           "alias": null,
-          "args": (v3/*: any*/),
+          "args": (v0/*: any*/),
           "concreteType": "ResizedImageUrl",
           "kind": "LinkedField",
           "name": "resized",
           "plural": false,
-          "selections": (v4/*: any*/),
-          "storageKey": "resized(height:800,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
-        },
-        {
-          "alias": "mobileLightboxSource",
-          "args": [
-            (v0/*: any*/),
-            {
-              "kind": "Literal",
-              "name": "quality",
-              "value": 50
-            },
-            (v1/*: any*/),
-            (v2/*: any*/)
-          ],
-          "concreteType": "ResizedImageUrl",
-          "kind": "LinkedField",
-          "name": "resized",
-          "plural": false,
-          "selections": (v4/*: any*/),
-          "storageKey": "resized(height:800,quality:50,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
+          "selections": (v1/*: any*/),
+          "storageKey": "resized(height:1600,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:1600)"
         },
         {
           "alias": null,
@@ -236,6 +199,6 @@ return {
 };
 })();
 
-(node as any).hash = "74ab1795e99fb44777d238220d7acf9d";
+(node as any).hash = "7e3192f3e15bd2d6cd9a376e78cc936f";
 
 export default node;

--- a/src/__generated__/MyCollectionArtworkImageBrowserTestQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkImageBrowserTestQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<db16a8afebe6caea30f739d1e52ed7eb>>
+ * @generated SignedSource<<91e29df227765c0d15d785ffa4748357>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -66,11 +66,6 @@ v5 = {
 },
 v6 = {
   "kind": "Literal",
-  "name": "height",
-  "value": 800
-},
-v7 = {
-  "kind": "Literal",
   "name": "version",
   "value": [
     "main",
@@ -79,123 +74,118 @@ v7 = {
     "large"
   ]
 },
-v8 = {
-  "kind": "Literal",
-  "name": "width",
-  "value": 800
-},
-v9 = [
-  (v6/*: any*/),
+v7 = [
+  {
+    "kind": "Literal",
+    "name": "height",
+    "value": 1600
+  },
   {
     "kind": "Literal",
     "name": "quality",
     "value": 80
   },
-  (v7/*: any*/),
-  (v8/*: any*/)
+  (v6/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "width",
+    "value": 1600
+  }
 ],
-v10 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "width",
   "storageKey": null
 },
-v11 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "height",
   "storageKey": null
 },
-v12 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "src",
   "storageKey": null
 },
-v13 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "srcSet",
-  "storageKey": null
-},
-v14 = [
-  (v10/*: any*/),
-  (v11/*: any*/),
-  (v12/*: any*/),
-  (v13/*: any*/)
+v11 = [
+  (v8/*: any*/),
+  (v9/*: any*/),
+  (v10/*: any*/)
 ],
-v15 = {
+v12 = {
   "alias": "type",
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v16 = {
+v13 = {
   "enumValues": null,
   "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v14 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v15 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "Int"
+},
+v16 = {
+  "enumValues": null,
+  "nullable": false,
   "plural": false,
   "type": "String"
 },
 v17 = {
   "enumValues": null,
-  "nullable": false,
+  "nullable": true,
   "plural": false,
-  "type": "ID"
+  "type": "Int"
 },
 v18 = {
   "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "Int"
-},
-v19 = {
-  "enumValues": null,
-  "nullable": false,
-  "plural": false,
-  "type": "String"
-},
-v20 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Int"
-},
-v21 = {
-  "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "ID"
 },
-v22 = {
+v19 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Boolean"
 },
-v23 = {
+v20 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Float"
 },
-v24 = {
+v21 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Image"
 },
-v25 = {
+v22 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "ResizedImageUrl"
 },
-v26 = {
+v23 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
@@ -494,42 +484,23 @@ return {
               },
               {
                 "alias": "fallback",
-                "args": (v9/*: any*/),
+                "args": (v7/*: any*/),
                 "concreteType": "CroppedImageUrl",
                 "kind": "LinkedField",
                 "name": "cropped",
                 "plural": false,
-                "selections": (v14/*: any*/),
-                "storageKey": "cropped(height:800,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
+                "selections": (v11/*: any*/),
+                "storageKey": "cropped(height:1600,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:1600)"
               },
               {
                 "alias": null,
-                "args": (v9/*: any*/),
+                "args": (v7/*: any*/),
                 "concreteType": "ResizedImageUrl",
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v14/*: any*/),
-                "storageKey": "resized(height:800,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
-              },
-              {
-                "alias": "mobileLightboxSource",
-                "args": [
-                  (v6/*: any*/),
-                  {
-                    "kind": "Literal",
-                    "name": "quality",
-                    "value": 50
-                  },
-                  (v7/*: any*/),
-                  (v8/*: any*/)
-                ],
-                "concreteType": "ResizedImageUrl",
-                "kind": "LinkedField",
-                "name": "resized",
-                "plural": false,
-                "selections": (v14/*: any*/),
-                "storageKey": "resized(height:800,quality:50,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
+                "selections": (v11/*: any*/),
+                "storageKey": "resized(height:1600,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:1600)"
               },
               {
                 "alias": null,
@@ -584,19 +555,33 @@ return {
               {
                 "alias": null,
                 "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 800
+                  },
                   (v6/*: any*/),
-                  (v7/*: any*/),
-                  (v8/*: any*/)
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 800
+                  }
                 ],
                 "concreteType": "ResizedImageUrl",
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
                 "selections": [
-                  (v12/*: any*/),
-                  (v13/*: any*/),
                   (v10/*: any*/),
-                  (v11/*: any*/)
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "srcSet",
+                    "storageKey": null
+                  },
+                  (v8/*: any*/),
+                  (v9/*: any*/)
                 ],
                 "storageKey": "resized(height:800,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
               }
@@ -684,7 +669,7 @@ return {
                     "storageKey": null
                   },
                   (v1/*: any*/),
-                  (v15/*: any*/)
+                  (v12/*: any*/)
                 ],
                 "type": "Video",
                 "abstractKey": null
@@ -782,10 +767,10 @@ return {
                     "name": "isZoomable",
                     "storageKey": null
                   },
-                  (v15/*: any*/),
+                  (v12/*: any*/),
                   (v5/*: any*/),
-                  (v10/*: any*/),
-                  (v11/*: any*/)
+                  (v8/*: any*/),
+                  (v9/*: any*/)
                 ],
                 "type": "Image",
                 "abstractKey": null
@@ -806,7 +791,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "76b57950b846f36eddfb68e62269c95d",
+    "cacheID": "ebac7a8779aeb0d9b1803b3d9dbb2c3a",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -816,22 +801,22 @@ return {
           "plural": false,
           "type": "Artwork"
         },
-        "artwork.artistNames": (v16/*: any*/),
+        "artwork.artistNames": (v13/*: any*/),
         "artwork.artists": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Artist"
         },
-        "artwork.artists.id": (v17/*: any*/),
-        "artwork.artists.name": (v16/*: any*/),
+        "artwork.artists.id": (v14/*: any*/),
+        "artwork.artists.name": (v13/*: any*/),
         "artwork.artworkMeta": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtworkMeta"
         },
-        "artwork.artworkMeta.share": (v16/*: any*/),
+        "artwork.artworkMeta.share": (v13/*: any*/),
         "artwork.collectorSignals": {
           "enumValues": null,
           "nullable": true,
@@ -844,16 +829,16 @@ return {
           "plural": false,
           "type": "AuctionCollectorSignals"
         },
-        "artwork.collectorSignals.auction.lotWatcherCount": (v18/*: any*/),
-        "artwork.date": (v16/*: any*/),
-        "artwork.downloadableImageUrl": (v16/*: any*/),
+        "artwork.collectorSignals.auction.lotWatcherCount": (v15/*: any*/),
+        "artwork.date": (v13/*: any*/),
+        "artwork.downloadableImageUrl": (v13/*: any*/),
         "artwork.figures": {
           "enumValues": null,
           "nullable": false,
           "plural": true,
           "type": "ArtworkFigures"
         },
-        "artwork.figures.__typename": (v19/*: any*/),
+        "artwork.figures.__typename": (v16/*: any*/),
         "artwork.figures.deepZoom": {
           "enumValues": null,
           "nullable": true,
@@ -866,123 +851,116 @@ return {
           "plural": false,
           "type": "DeepZoomImage"
         },
-        "artwork.figures.deepZoom.Image.Format": (v16/*: any*/),
-        "artwork.figures.deepZoom.Image.Overlap": (v20/*: any*/),
+        "artwork.figures.deepZoom.Image.Format": (v13/*: any*/),
+        "artwork.figures.deepZoom.Image.Overlap": (v17/*: any*/),
         "artwork.figures.deepZoom.Image.Size": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "DeepZoomImageSize"
         },
-        "artwork.figures.deepZoom.Image.Size.Height": (v20/*: any*/),
-        "artwork.figures.deepZoom.Image.Size.Width": (v20/*: any*/),
-        "artwork.figures.deepZoom.Image.TileSize": (v20/*: any*/),
-        "artwork.figures.deepZoom.Image.Url": (v16/*: any*/),
-        "artwork.figures.deepZoom.Image.xmlns": (v16/*: any*/),
-        "artwork.figures.height": (v20/*: any*/),
-        "artwork.figures.id": (v17/*: any*/),
-        "artwork.figures.internalID": (v21/*: any*/),
-        "artwork.figures.isDefault": (v22/*: any*/),
-        "artwork.figures.isZoomable": (v22/*: any*/),
-        "artwork.figures.playerUrl": (v19/*: any*/),
-        "artwork.figures.type": (v19/*: any*/),
-        "artwork.figures.videoHeight": (v18/*: any*/),
-        "artwork.figures.videoWidth": (v18/*: any*/),
-        "artwork.figures.width": (v20/*: any*/),
-        "artwork.formattedMetadata": (v16/*: any*/),
-        "artwork.heightCm": (v23/*: any*/),
-        "artwork.href": (v16/*: any*/),
-        "artwork.id": (v17/*: any*/),
-        "artwork.image": (v24/*: any*/),
-        "artwork.image.resized": (v25/*: any*/),
-        "artwork.image.resized.height": (v20/*: any*/),
-        "artwork.image.resized.src": (v19/*: any*/),
-        "artwork.image.resized.srcSet": (v19/*: any*/),
-        "artwork.image.resized.width": (v20/*: any*/),
+        "artwork.figures.deepZoom.Image.Size.Height": (v17/*: any*/),
+        "artwork.figures.deepZoom.Image.Size.Width": (v17/*: any*/),
+        "artwork.figures.deepZoom.Image.TileSize": (v17/*: any*/),
+        "artwork.figures.deepZoom.Image.Url": (v13/*: any*/),
+        "artwork.figures.deepZoom.Image.xmlns": (v13/*: any*/),
+        "artwork.figures.height": (v17/*: any*/),
+        "artwork.figures.id": (v14/*: any*/),
+        "artwork.figures.internalID": (v18/*: any*/),
+        "artwork.figures.isDefault": (v19/*: any*/),
+        "artwork.figures.isZoomable": (v19/*: any*/),
+        "artwork.figures.playerUrl": (v16/*: any*/),
+        "artwork.figures.type": (v16/*: any*/),
+        "artwork.figures.videoHeight": (v15/*: any*/),
+        "artwork.figures.videoWidth": (v15/*: any*/),
+        "artwork.figures.width": (v17/*: any*/),
+        "artwork.formattedMetadata": (v13/*: any*/),
+        "artwork.heightCm": (v20/*: any*/),
+        "artwork.href": (v13/*: any*/),
+        "artwork.id": (v14/*: any*/),
+        "artwork.image": (v21/*: any*/),
+        "artwork.image.resized": (v22/*: any*/),
+        "artwork.image.resized.height": (v17/*: any*/),
+        "artwork.image.resized.src": (v16/*: any*/),
+        "artwork.image.resized.srcSet": (v16/*: any*/),
+        "artwork.image.resized.width": (v17/*: any*/),
         "artwork.images": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Image"
         },
-        "artwork.images.blurhashDataURL": (v16/*: any*/),
+        "artwork.images.blurhashDataURL": (v13/*: any*/),
         "artwork.images.fallback": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "CroppedImageUrl"
         },
-        "artwork.images.fallback.height": (v18/*: any*/),
-        "artwork.images.fallback.src": (v19/*: any*/),
-        "artwork.images.fallback.srcSet": (v19/*: any*/),
-        "artwork.images.fallback.width": (v18/*: any*/),
-        "artwork.images.internalID": (v21/*: any*/),
-        "artwork.images.isDefault": (v22/*: any*/),
-        "artwork.images.mobileLightboxSource": (v25/*: any*/),
-        "artwork.images.mobileLightboxSource.height": (v20/*: any*/),
-        "artwork.images.mobileLightboxSource.src": (v19/*: any*/),
-        "artwork.images.mobileLightboxSource.srcSet": (v19/*: any*/),
-        "artwork.images.mobileLightboxSource.width": (v20/*: any*/),
-        "artwork.images.placeholder": (v16/*: any*/),
-        "artwork.images.resized": (v25/*: any*/),
-        "artwork.images.resized.height": (v20/*: any*/),
-        "artwork.images.resized.src": (v19/*: any*/),
-        "artwork.images.resized.srcSet": (v19/*: any*/),
-        "artwork.images.resized.width": (v20/*: any*/),
-        "artwork.images.url": (v16/*: any*/),
+        "artwork.images.fallback.height": (v15/*: any*/),
+        "artwork.images.fallback.src": (v16/*: any*/),
+        "artwork.images.fallback.width": (v15/*: any*/),
+        "artwork.images.internalID": (v18/*: any*/),
+        "artwork.images.isDefault": (v19/*: any*/),
+        "artwork.images.placeholder": (v13/*: any*/),
+        "artwork.images.resized": (v22/*: any*/),
+        "artwork.images.resized.height": (v17/*: any*/),
+        "artwork.images.resized.src": (v16/*: any*/),
+        "artwork.images.resized.width": (v17/*: any*/),
+        "artwork.images.url": (v13/*: any*/),
         "artwork.images.versions": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "String"
         },
-        "artwork.internalID": (v17/*: any*/),
-        "artwork.isDownloadable": (v22/*: any*/),
-        "artwork.isHangable": (v22/*: any*/),
-        "artwork.isInAuction": (v22/*: any*/),
-        "artwork.isSavedToAnyList": (v26/*: any*/),
-        "artwork.isSetVideoAsCover": (v22/*: any*/),
-        "artwork.isUnlisted": (v26/*: any*/),
+        "artwork.internalID": (v14/*: any*/),
+        "artwork.isDownloadable": (v19/*: any*/),
+        "artwork.isHangable": (v19/*: any*/),
+        "artwork.isInAuction": (v19/*: any*/),
+        "artwork.isSavedToAnyList": (v23/*: any*/),
+        "artwork.isSetVideoAsCover": (v19/*: any*/),
+        "artwork.isUnlisted": (v23/*: any*/),
         "artwork.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "artwork.partner.id": (v17/*: any*/),
-        "artwork.partner.slug": (v17/*: any*/),
-        "artwork.preview": (v24/*: any*/),
-        "artwork.preview.url": (v16/*: any*/),
+        "artwork.partner.id": (v14/*: any*/),
+        "artwork.partner.slug": (v14/*: any*/),
+        "artwork.preview": (v21/*: any*/),
+        "artwork.preview.url": (v13/*: any*/),
         "artwork.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "artwork.sale.id": (v17/*: any*/),
-        "artwork.sale.isAuction": (v22/*: any*/),
-        "artwork.sale.isClosed": (v22/*: any*/),
-        "artwork.sale.isLiveOpen": (v22/*: any*/),
-        "artwork.sale.isRegistrationClosed": (v22/*: any*/),
-        "artwork.sale.liveStartAt": (v16/*: any*/),
-        "artwork.sale.registrationEndsAt": (v16/*: any*/),
+        "artwork.sale.id": (v14/*: any*/),
+        "artwork.sale.isAuction": (v19/*: any*/),
+        "artwork.sale.isClosed": (v19/*: any*/),
+        "artwork.sale.isLiveOpen": (v19/*: any*/),
+        "artwork.sale.isRegistrationClosed": (v19/*: any*/),
+        "artwork.sale.liveStartAt": (v13/*: any*/),
+        "artwork.sale.registrationEndsAt": (v13/*: any*/),
         "artwork.sale.registrationStatus": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Bidder"
         },
-        "artwork.sale.registrationStatus.id": (v17/*: any*/),
-        "artwork.sale.registrationStatus.qualifiedForBidding": (v22/*: any*/),
-        "artwork.sale.slug": (v17/*: any*/),
-        "artwork.slug": (v17/*: any*/),
-        "artwork.title": (v16/*: any*/),
-        "artwork.widthCm": (v23/*: any*/)
+        "artwork.sale.registrationStatus.id": (v14/*: any*/),
+        "artwork.sale.registrationStatus.qualifiedForBidding": (v19/*: any*/),
+        "artwork.sale.slug": (v14/*: any*/),
+        "artwork.slug": (v14/*: any*/),
+        "artwork.title": (v13/*: any*/),
+        "artwork.widthCm": (v20/*: any*/)
       }
     },
     "name": "MyCollectionArtworkImageBrowserTestQuery",
     "operationKind": "query",
-    "text": "query MyCollectionArtworkImageBrowserTestQuery {\n  artwork(id: \"artwork-id\") {\n    ...MyCollectionArtworkImageBrowser_artwork\n    id\n  }\n}\n\nfragment ArtworkActionsSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isInAuction\n  isSavedToAnyList\n  sale {\n    isAuction\n    isClosed\n    id\n  }\n  collectorSignals {\n    auction {\n      lotWatcherCount\n    }\n  }\n  ...ArtworkActionsWatchLotButton_artwork\n}\n\nfragment ArtworkActionsWatchLotButton_artwork on Artwork {\n  sale {\n    isLiveOpen\n    isRegistrationClosed\n    liveStartAt\n    registrationStatus {\n      qualifiedForBidding\n      id\n    }\n    id\n  }\n  ...ArtworkAuctionRegistrationPanel_artwork\n}\n\nfragment ArtworkActions_artwork_yvCPB on Artwork {\n  ...ArtworkActionsSaveButton_artwork\n  ...ArtworkDownloadButton_artwork\n  ...ArtworkSharePanel_artwork_yvCPB\n  ...ViewInRoom_artwork\n  isUnlisted\n  slug\n  downloadableImageUrl\n  isDownloadable\n  isHangable\n  partner {\n    slug\n    id\n  }\n}\n\nfragment ArtworkAuctionRegistrationPanel_artwork on Artwork {\n  sale {\n    slug\n    registrationEndsAt\n    isRegistrationClosed\n    id\n  }\n}\n\nfragment ArtworkDownloadButton_artwork on Artwork {\n  title\n  date\n  downloadableImageUrl\n  artists(shallow: true) {\n    name\n    id\n  }\n}\n\nfragment ArtworkImageBrowserLarge_artwork_yvCPB on Artwork {\n  ...ArtworkLightbox_artwork_yvCPB\n  ...ArtworkVideoPlayer_artwork_yvCPB\n  isSetVideoAsCover\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      __typename\n      internalID\n      isZoomable\n    }\n    ... on Video {\n      __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowserSmall_artwork_yvCPB on Artwork {\n  ...ArtworkLightbox_artwork_yvCPB\n  ...ArtworkVideoPlayer_artwork_yvCPB\n  isSetVideoAsCover\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      internalID\n      isZoomable\n      type: __typename\n    }\n    ... on Video {\n      type: __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowser_artwork_yvCPB on Artwork {\n  ...ArtworkActions_artwork_yvCPB\n  ...ArtworkImageBrowserSmall_artwork_yvCPB\n  ...ArtworkImageBrowserLarge_artwork_yvCPB\n  internalID\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      isDefault\n      width\n      height\n    }\n    ... on Video {\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment ArtworkLightbox_artwork_yvCPB on Artwork {\n  formattedMetadata\n  images(includeAll: true) {\n    internalID\n    isDefault\n    placeholder: url(version: [\"small\", \"medium\"])\n    blurhashDataURL(width: 801)\n    fallback: cropped(quality: 80, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    resized(quality: 80, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    mobileLightboxSource: resized(quality: 50, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    versions\n  }\n}\n\nfragment ArtworkSharePanel_artwork_yvCPB on Artwork {\n  href\n  images(includeAll: true) {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n\nfragment ArtworkVideoPlayer_artwork_yvCPB on Artwork {\n  internalID\n  slug\n  figures(includeAll: true) {\n    __typename\n    ... on Video {\n      __typename\n      playerUrl\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment DeepZoom_image on Image {\n  deepZoom {\n    Image {\n      xmlns\n      Url\n      Format\n      TileSize\n      Overlap\n      Size {\n        Width\n        Height\n      }\n    }\n  }\n}\n\nfragment MyCollectionArtworkImageBrowser_artwork on Artwork {\n  ...ArtworkImageBrowser_artwork_yvCPB\n  internalID\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      width\n      height\n    }\n    ... on Video {\n      id\n    }\n  }\n}\n\nfragment ViewInRoomArtwork_artwork on Artwork {\n  widthCm\n  heightCm\n  image {\n    resized(width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ViewInRoom_artwork on Artwork {\n  ...ViewInRoomArtwork_artwork\n}\n"
+    "text": "query MyCollectionArtworkImageBrowserTestQuery {\n  artwork(id: \"artwork-id\") {\n    ...MyCollectionArtworkImageBrowser_artwork\n    id\n  }\n}\n\nfragment ArtworkActionsSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isInAuction\n  isSavedToAnyList\n  sale {\n    isAuction\n    isClosed\n    id\n  }\n  collectorSignals {\n    auction {\n      lotWatcherCount\n    }\n  }\n  ...ArtworkActionsWatchLotButton_artwork\n}\n\nfragment ArtworkActionsWatchLotButton_artwork on Artwork {\n  sale {\n    isLiveOpen\n    isRegistrationClosed\n    liveStartAt\n    registrationStatus {\n      qualifiedForBidding\n      id\n    }\n    id\n  }\n  ...ArtworkAuctionRegistrationPanel_artwork\n}\n\nfragment ArtworkActions_artwork_yvCPB on Artwork {\n  ...ArtworkActionsSaveButton_artwork\n  ...ArtworkDownloadButton_artwork\n  ...ArtworkSharePanel_artwork_yvCPB\n  ...ViewInRoom_artwork\n  isUnlisted\n  slug\n  downloadableImageUrl\n  isDownloadable\n  isHangable\n  partner {\n    slug\n    id\n  }\n}\n\nfragment ArtworkAuctionRegistrationPanel_artwork on Artwork {\n  sale {\n    slug\n    registrationEndsAt\n    isRegistrationClosed\n    id\n  }\n}\n\nfragment ArtworkDownloadButton_artwork on Artwork {\n  title\n  date\n  downloadableImageUrl\n  artists(shallow: true) {\n    name\n    id\n  }\n}\n\nfragment ArtworkImageBrowserLarge_artwork_yvCPB on Artwork {\n  ...ArtworkLightbox_artwork_yvCPB\n  ...ArtworkVideoPlayer_artwork_yvCPB\n  isSetVideoAsCover\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      __typename\n      internalID\n      isZoomable\n    }\n    ... on Video {\n      __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowserSmall_artwork_yvCPB on Artwork {\n  ...ArtworkLightbox_artwork_yvCPB\n  ...ArtworkVideoPlayer_artwork_yvCPB\n  isSetVideoAsCover\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      internalID\n      isZoomable\n      type: __typename\n    }\n    ... on Video {\n      type: __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowser_artwork_yvCPB on Artwork {\n  ...ArtworkActions_artwork_yvCPB\n  ...ArtworkImageBrowserSmall_artwork_yvCPB\n  ...ArtworkImageBrowserLarge_artwork_yvCPB\n  internalID\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      isDefault\n      width\n      height\n    }\n    ... on Video {\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment ArtworkLightbox_artwork_yvCPB on Artwork {\n  formattedMetadata\n  images(includeAll: true) {\n    internalID\n    isDefault\n    placeholder: url(version: [\"small\", \"medium\"])\n    blurhashDataURL(width: 801)\n    fallback: cropped(quality: 80, width: 1600, height: 1600, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n    }\n    resized(quality: 80, width: 1600, height: 1600, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n    }\n    versions\n  }\n}\n\nfragment ArtworkSharePanel_artwork_yvCPB on Artwork {\n  href\n  images(includeAll: true) {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n\nfragment ArtworkVideoPlayer_artwork_yvCPB on Artwork {\n  internalID\n  slug\n  figures(includeAll: true) {\n    __typename\n    ... on Video {\n      __typename\n      playerUrl\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment DeepZoom_image on Image {\n  deepZoom {\n    Image {\n      xmlns\n      Url\n      Format\n      TileSize\n      Overlap\n      Size {\n        Width\n        Height\n      }\n    }\n  }\n}\n\nfragment MyCollectionArtworkImageBrowser_artwork on Artwork {\n  ...ArtworkImageBrowser_artwork_yvCPB\n  internalID\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      width\n      height\n    }\n    ... on Video {\n      id\n    }\n  }\n}\n\nfragment ViewInRoomArtwork_artwork on Artwork {\n  widthCm\n  heightCm\n  image {\n    resized(width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ViewInRoom_artwork on Artwork {\n  ...ViewInRoomArtwork_artwork\n}\n"
   }
 };
 })();

--- a/src/__generated__/MyCollectionArtworkTestQuery.graphql.ts
+++ b/src/__generated__/MyCollectionArtworkTestQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bed319d261459bf62322acb5ef0ed3d6>>
+ * @generated SignedSource<<d562450284f7b8296a6fd59e1c4b0491>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -166,30 +166,29 @@ v20 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "srcSet",
+  "name": "width",
   "storageKey": null
 },
 v21 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "width",
-  "storageKey": null
-},
-v22 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "height",
   "storageKey": null
 },
-v23 = [
+v22 = [
   (v19/*: any*/),
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "srcSet",
+    "storageKey": null
+  },
   (v20/*: any*/),
-  (v21/*: any*/),
-  (v22/*: any*/)
+  (v21/*: any*/)
 ],
-v24 = {
+v23 = {
   "alias": null,
   "args": null,
   "concreteType": "AuctionLotImages",
@@ -230,7 +229,7 @@ v24 = {
           "kind": "LinkedField",
           "name": "cropped",
           "plural": false,
-          "selections": (v23/*: any*/),
+          "selections": (v22/*: any*/),
           "storageKey": "cropped(height:130,version:[\"square140\"],width:130)"
         }
       ],
@@ -239,56 +238,56 @@ v24 = {
   ],
   "storageKey": null
 },
-v25 = {
+v24 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "mediumText",
   "storageKey": null
 },
-v26 = {
+v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "categoryText",
   "storageKey": null
 },
-v27 = {
+v26 = {
   "alias": "date_text",
   "args": null,
   "kind": "ScalarField",
   "name": "dateText",
   "storageKey": null
 },
-v28 = {
+v27 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "saleDate",
   "storageKey": null
 },
-v29 = {
+v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "boughtIn",
   "storageKey": null
 },
-v30 = {
+v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "currency",
   "storageKey": null
 },
-v31 = {
+v30 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "display",
   "storageKey": null
 },
-v32 = {
+v31 = {
   "alias": "price_realized",
   "args": null,
   "concreteType": "AuctionResultPriceRealized",
@@ -296,7 +295,7 @@ v32 = {
   "name": "priceRealized",
   "plural": false,
   "selections": [
-    (v31/*: any*/),
+    (v30/*: any*/),
     {
       "alias": "display_usd",
       "args": null,
@@ -314,7 +313,7 @@ v32 = {
   ],
   "storageKey": null
 },
-v33 = {
+v32 = {
   "alias": null,
   "args": null,
   "concreteType": "AuctionLotPerformance",
@@ -332,74 +331,69 @@ v33 = {
   ],
   "storageKey": null
 },
-v34 = [
-  (v31/*: any*/)
+v33 = [
+  (v30/*: any*/)
 ],
-v35 = {
+v34 = {
   "alias": null,
   "args": null,
   "concreteType": "AuctionLotEstimate",
   "kind": "LinkedField",
   "name": "estimate",
   "plural": false,
-  "selections": (v34/*: any*/),
+  "selections": (v33/*: any*/),
   "storageKey": null
 },
-v36 = {
+v35 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "location",
   "storageKey": null
 },
-v37 = {
+v36 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotNumber",
   "storageKey": null
 },
-v38 = {
+v37 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "saleTitle",
   "storageKey": null
 },
-v39 = {
+v38 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isUpcoming",
   "storageKey": null
 },
-v40 = {
+v39 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "state",
   "storageKey": null
 },
-v41 = [
+v40 = [
   {
     "kind": "Literal",
     "name": "includeAll",
     "value": true
   }
 ],
-v42 = {
+v41 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isDefault",
   "storageKey": null
 },
-v43 = {
-  "kind": "Literal",
-  "name": "height",
-  "value": 800
-},
-v44 = {
+v42 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -409,155 +403,157 @@ v44 = {
     "large"
   ]
 },
-v45 = {
-  "kind": "Literal",
-  "name": "width",
-  "value": 800
-},
-v46 = [
-  (v43/*: any*/),
+v43 = [
+  {
+    "kind": "Literal",
+    "name": "height",
+    "value": 1600
+  },
   {
     "kind": "Literal",
     "name": "quality",
     "value": 80
   },
-  (v44/*: any*/),
-  (v45/*: any*/)
+  (v42/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "width",
+    "value": 1600
+  }
 ],
-v47 = [
+v44 = [
+  (v20/*: any*/),
   (v21/*: any*/),
-  (v22/*: any*/),
-  (v19/*: any*/),
-  (v20/*: any*/)
+  (v19/*: any*/)
 ],
-v48 = {
+v45 = {
   "alias": "type",
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v49 = {
+v46 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Artist"
 },
-v50 = {
+v47 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "AuctionResultConnection"
 },
-v51 = {
+v48 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v52 = {
+v49 = {
   "enumValues": null,
   "nullable": true,
   "plural": true,
   "type": "AuctionResultEdge"
 },
-v53 = {
+v50 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "AuctionResult"
 },
-v54 = {
+v51 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v55 = {
+v52 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v56 = {
+v53 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Boolean"
 },
-v57 = {
+v54 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "AuctionLotEstimate"
 },
-v58 = {
+v55 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "AuctionLotImages"
 },
-v59 = {
+v56 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Image"
 },
-v60 = {
+v57 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "CroppedImageUrl"
 },
-v61 = {
+v58 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Int"
 },
-v62 = {
+v59 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v63 = {
+v60 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "AuctionLotPerformance"
 },
-v64 = {
+v61 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "AuctionResultPriceRealized"
 },
-v65 = {
+v62 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Float"
 },
-v66 = {
+v63 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Boolean"
 },
-v67 = {
+v64 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "PageCursor"
 },
-v68 = {
+v65 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "ID"
 },
-v69 = {
+v66 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
@@ -771,20 +767,20 @@ return {
                           (v15/*: any*/),
                           (v16/*: any*/),
                           (v18/*: any*/),
+                          (v23/*: any*/),
                           (v24/*: any*/),
                           (v25/*: any*/),
                           (v26/*: any*/),
                           (v27/*: any*/),
                           (v28/*: any*/),
                           (v29/*: any*/),
-                          (v30/*: any*/),
+                          (v31/*: any*/),
                           (v32/*: any*/),
-                          (v33/*: any*/),
+                          (v34/*: any*/),
                           (v35/*: any*/),
                           (v36/*: any*/),
                           (v37/*: any*/),
                           (v38/*: any*/),
-                          (v39/*: any*/),
                           (v6/*: any*/)
                         ],
                         "storageKey": null
@@ -906,7 +902,7 @@ return {
             "kind": "LinkedField",
             "name": "pricePaid",
             "plural": false,
-            "selections": (v34/*: any*/),
+            "selections": (v33/*: any*/),
             "storageKey": null
           },
           {
@@ -924,7 +920,7 @@ return {
                 "name": "city",
                 "storageKey": null
               },
-              (v40/*: any*/),
+              (v39/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -997,20 +993,20 @@ return {
                       (v15/*: any*/),
                       (v16/*: any*/),
                       (v18/*: any*/),
+                      (v23/*: any*/),
                       (v24/*: any*/),
                       (v25/*: any*/),
                       (v26/*: any*/),
                       (v27/*: any*/),
                       (v28/*: any*/),
                       (v29/*: any*/),
-                      (v30/*: any*/),
+                      (v31/*: any*/),
                       (v32/*: any*/),
-                      (v33/*: any*/),
+                      (v34/*: any*/),
                       (v35/*: any*/),
                       (v36/*: any*/),
                       (v37/*: any*/),
                       (v38/*: any*/),
-                      (v39/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1250,7 +1246,7 @@ return {
           (v5/*: any*/),
           {
             "alias": null,
-            "args": (v41/*: any*/),
+            "args": (v40/*: any*/),
             "concreteType": "Image",
             "kind": "LinkedField",
             "name": "images",
@@ -1264,7 +1260,7 @@ return {
                 "storageKey": null
               },
               (v1/*: any*/),
-              (v42/*: any*/),
+              (v41/*: any*/),
               {
                 "alias": "placeholder",
                 "args": [
@@ -1296,42 +1292,23 @@ return {
               },
               {
                 "alias": "fallback",
-                "args": (v46/*: any*/),
+                "args": (v43/*: any*/),
                 "concreteType": "CroppedImageUrl",
                 "kind": "LinkedField",
                 "name": "cropped",
                 "plural": false,
-                "selections": (v47/*: any*/),
-                "storageKey": "cropped(height:800,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
+                "selections": (v44/*: any*/),
+                "storageKey": "cropped(height:1600,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:1600)"
               },
               {
                 "alias": null,
-                "args": (v46/*: any*/),
+                "args": (v43/*: any*/),
                 "concreteType": "ResizedImageUrl",
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v47/*: any*/),
-                "storageKey": "resized(height:800,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
-              },
-              {
-                "alias": "mobileLightboxSource",
-                "args": [
-                  (v43/*: any*/),
-                  {
-                    "kind": "Literal",
-                    "name": "quality",
-                    "value": 50
-                  },
-                  (v44/*: any*/),
-                  (v45/*: any*/)
-                ],
-                "concreteType": "ResizedImageUrl",
-                "kind": "LinkedField",
-                "name": "resized",
-                "plural": false,
-                "selections": (v47/*: any*/),
-                "storageKey": "resized(height:800,quality:50,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
+                "selections": (v44/*: any*/),
+                "storageKey": "resized(height:1600,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:1600)"
               },
               {
                 "alias": null,
@@ -1386,15 +1363,23 @@ return {
               {
                 "alias": null,
                 "args": [
-                  (v43/*: any*/),
-                  (v44/*: any*/),
-                  (v45/*: any*/)
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 800
+                  },
+                  (v42/*: any*/),
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 800
+                  }
                 ],
                 "concreteType": "ResizedImageUrl",
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v23/*: any*/),
+                "selections": (v22/*: any*/),
                 "storageKey": "resized(height:800,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
               }
             ],
@@ -1443,7 +1428,7 @@ return {
           },
           {
             "alias": null,
-            "args": (v41/*: any*/),
+            "args": (v40/*: any*/),
             "concreteType": null,
             "kind": "LinkedField",
             "name": "figures",
@@ -1481,7 +1466,7 @@ return {
                     "storageKey": null
                   },
                   (v6/*: any*/),
-                  (v48/*: any*/)
+                  (v45/*: any*/)
                 ],
                 "type": "Video",
                 "abstractKey": null
@@ -1579,10 +1564,10 @@ return {
                     "name": "isZoomable",
                     "storageKey": null
                   },
-                  (v48/*: any*/),
-                  (v42/*: any*/),
-                  (v21/*: any*/),
-                  (v22/*: any*/)
+                  (v45/*: any*/),
+                  (v41/*: any*/),
+                  (v20/*: any*/),
+                  (v21/*: any*/)
                 ],
                 "type": "Image",
                 "abstractKey": null
@@ -1606,7 +1591,7 @@ return {
             "plural": false,
             "selections": [
               (v1/*: any*/),
-              (v40/*: any*/)
+              (v39/*: any*/)
             ],
             "storageKey": null
           },
@@ -1640,7 +1625,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "2020384a617752c5b3d8565d7c1b2204",
+    "cacheID": "da16ca565f6926bae78f5b891fbdd783",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -1650,45 +1635,45 @@ return {
           "plural": false,
           "type": "Artwork"
         },
-        "artwork.artist": (v49/*: any*/),
-        "artwork.artist.auctionResults": (v50/*: any*/),
-        "artwork.artist.auctionResults.totalCount": (v51/*: any*/),
-        "artwork.artist.auctionResultsConnection": (v50/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges": (v52/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node": (v53/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.artist": (v49/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.artist.id": (v54/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.artist.name": (v55/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.boughtIn": (v56/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.categoryText": (v55/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.currency": (v55/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.date_text": (v55/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.dimension_text": (v55/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.estimate": (v57/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.estimate.display": (v55/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.id": (v54/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.images": (v58/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.images.thumbnail": (v59/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.images.thumbnail.cropped": (v60/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.images.thumbnail.cropped.height": (v61/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.images.thumbnail.cropped.src": (v62/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.images.thumbnail.cropped.srcSet": (v62/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.images.thumbnail.cropped.width": (v61/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.internalID": (v54/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.isUpcoming": (v56/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.location": (v55/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.lotNumber": (v55/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.mediumText": (v55/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.organization": (v55/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.performance": (v63/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.performance.mid": (v55/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.price_realized": (v64/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.price_realized.cents_usd": (v65/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.price_realized.display": (v55/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.price_realized.display_usd": (v55/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.saleDate": (v55/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.saleTitle": (v55/*: any*/),
-        "artwork.artist.auctionResultsConnection.edges.node.title": (v55/*: any*/),
+        "artwork.artist": (v46/*: any*/),
+        "artwork.artist.auctionResults": (v47/*: any*/),
+        "artwork.artist.auctionResults.totalCount": (v48/*: any*/),
+        "artwork.artist.auctionResultsConnection": (v47/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges": (v49/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node": (v50/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.artist": (v46/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.artist.id": (v51/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.artist.name": (v52/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.boughtIn": (v53/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.categoryText": (v52/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.currency": (v52/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.date_text": (v52/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.dimension_text": (v52/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.estimate": (v54/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.estimate.display": (v52/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.id": (v51/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.images": (v55/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.images.thumbnail": (v56/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.images.thumbnail.cropped": (v57/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.images.thumbnail.cropped.height": (v58/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.images.thumbnail.cropped.src": (v59/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.images.thumbnail.cropped.srcSet": (v59/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.images.thumbnail.cropped.width": (v58/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.internalID": (v51/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.isUpcoming": (v53/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.location": (v52/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.lotNumber": (v52/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.mediumText": (v52/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.organization": (v52/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.performance": (v60/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.performance.mid": (v52/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.price_realized": (v61/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.price_realized.cents_usd": (v62/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.price_realized.display": (v52/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.price_realized.display_usd": (v52/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.saleDate": (v52/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.saleTitle": (v52/*: any*/),
+        "artwork.artist.auctionResultsConnection.edges.node.title": (v52/*: any*/),
         "artwork.artist.auctionResultsConnection.pageCursors": {
           "enumValues": null,
           "nullable": false,
@@ -1701,36 +1686,36 @@ return {
           "plural": true,
           "type": "PageCursor"
         },
-        "artwork.artist.auctionResultsConnection.pageCursors.around.cursor": (v62/*: any*/),
-        "artwork.artist.auctionResultsConnection.pageCursors.around.isCurrent": (v66/*: any*/),
-        "artwork.artist.auctionResultsConnection.pageCursors.around.page": (v61/*: any*/),
-        "artwork.artist.auctionResultsConnection.pageCursors.first": (v67/*: any*/),
-        "artwork.artist.auctionResultsConnection.pageCursors.first.cursor": (v62/*: any*/),
-        "artwork.artist.auctionResultsConnection.pageCursors.first.isCurrent": (v66/*: any*/),
-        "artwork.artist.auctionResultsConnection.pageCursors.first.page": (v61/*: any*/),
-        "artwork.artist.auctionResultsConnection.pageCursors.last": (v67/*: any*/),
-        "artwork.artist.auctionResultsConnection.pageCursors.last.cursor": (v62/*: any*/),
-        "artwork.artist.auctionResultsConnection.pageCursors.last.isCurrent": (v66/*: any*/),
-        "artwork.artist.auctionResultsConnection.pageCursors.last.page": (v61/*: any*/),
-        "artwork.artist.auctionResultsConnection.pageCursors.previous": (v67/*: any*/),
-        "artwork.artist.auctionResultsConnection.pageCursors.previous.cursor": (v62/*: any*/),
-        "artwork.artist.auctionResultsConnection.pageCursors.previous.page": (v61/*: any*/),
+        "artwork.artist.auctionResultsConnection.pageCursors.around.cursor": (v59/*: any*/),
+        "artwork.artist.auctionResultsConnection.pageCursors.around.isCurrent": (v63/*: any*/),
+        "artwork.artist.auctionResultsConnection.pageCursors.around.page": (v58/*: any*/),
+        "artwork.artist.auctionResultsConnection.pageCursors.first": (v64/*: any*/),
+        "artwork.artist.auctionResultsConnection.pageCursors.first.cursor": (v59/*: any*/),
+        "artwork.artist.auctionResultsConnection.pageCursors.first.isCurrent": (v63/*: any*/),
+        "artwork.artist.auctionResultsConnection.pageCursors.first.page": (v58/*: any*/),
+        "artwork.artist.auctionResultsConnection.pageCursors.last": (v64/*: any*/),
+        "artwork.artist.auctionResultsConnection.pageCursors.last.cursor": (v59/*: any*/),
+        "artwork.artist.auctionResultsConnection.pageCursors.last.isCurrent": (v63/*: any*/),
+        "artwork.artist.auctionResultsConnection.pageCursors.last.page": (v58/*: any*/),
+        "artwork.artist.auctionResultsConnection.pageCursors.previous": (v64/*: any*/),
+        "artwork.artist.auctionResultsConnection.pageCursors.previous.cursor": (v59/*: any*/),
+        "artwork.artist.auctionResultsConnection.pageCursors.previous.page": (v58/*: any*/),
         "artwork.artist.auctionResultsConnection.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "artwork.artist.auctionResultsConnection.pageInfo.hasNextPage": (v66/*: any*/),
-        "artwork.artist.auctionResultsConnection.totalCount": (v51/*: any*/),
-        "artwork.artist.auctionResultsCount": (v50/*: any*/),
-        "artwork.artist.auctionResultsCount.totalCount": (v51/*: any*/),
-        "artwork.artist.href": (v55/*: any*/),
-        "artwork.artist.id": (v54/*: any*/),
-        "artwork.artist.internalID": (v54/*: any*/),
-        "artwork.artist.isPersonalArtist": (v56/*: any*/),
-        "artwork.artist.name": (v55/*: any*/),
-        "artwork.artist.slug": (v54/*: any*/),
+        "artwork.artist.auctionResultsConnection.pageInfo.hasNextPage": (v63/*: any*/),
+        "artwork.artist.auctionResultsConnection.totalCount": (v48/*: any*/),
+        "artwork.artist.auctionResultsCount": (v47/*: any*/),
+        "artwork.artist.auctionResultsCount.totalCount": (v48/*: any*/),
+        "artwork.artist.href": (v52/*: any*/),
+        "artwork.artist.id": (v51/*: any*/),
+        "artwork.artist.internalID": (v51/*: any*/),
+        "artwork.artist.isPersonalArtist": (v53/*: any*/),
+        "artwork.artist.name": (v52/*: any*/),
+        "artwork.artist.slug": (v51/*: any*/),
         "artwork.artist.targetSupply": {
           "enumValues": null,
           "nullable": false,
@@ -1746,81 +1731,81 @@ return {
           "plural": false,
           "type": "ArtistTargetSupplyPriority"
         },
-        "artwork.artistNames": (v55/*: any*/),
+        "artwork.artistNames": (v52/*: any*/),
         "artwork.artists": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Artist"
         },
-        "artwork.artists.id": (v54/*: any*/),
-        "artwork.artists.name": (v55/*: any*/),
+        "artwork.artists.id": (v51/*: any*/),
+        "artwork.artists.name": (v52/*: any*/),
         "artwork.artworkMeta": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtworkMeta"
         },
-        "artwork.artworkMeta.share": (v55/*: any*/),
+        "artwork.artworkMeta.share": (v52/*: any*/),
         "artwork.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "artwork.attributionClass.id": (v54/*: any*/),
-        "artwork.attributionClass.shortDescription": (v55/*: any*/),
-        "artwork.auctionResult": (v50/*: any*/),
-        "artwork.auctionResult.edges": (v52/*: any*/),
-        "artwork.auctionResult.edges.cursor": (v62/*: any*/),
-        "artwork.auctionResult.edges.node": (v53/*: any*/),
-        "artwork.auctionResult.edges.node.artist": (v49/*: any*/),
-        "artwork.auctionResult.edges.node.artist.id": (v54/*: any*/),
-        "artwork.auctionResult.edges.node.artist.name": (v55/*: any*/),
-        "artwork.auctionResult.edges.node.artistID": (v62/*: any*/),
-        "artwork.auctionResult.edges.node.boughtIn": (v56/*: any*/),
-        "artwork.auctionResult.edges.node.categoryText": (v55/*: any*/),
-        "artwork.auctionResult.edges.node.currency": (v55/*: any*/),
-        "artwork.auctionResult.edges.node.date_text": (v55/*: any*/),
-        "artwork.auctionResult.edges.node.dimension_text": (v55/*: any*/),
-        "artwork.auctionResult.edges.node.estimate": (v57/*: any*/),
-        "artwork.auctionResult.edges.node.estimate.display": (v55/*: any*/),
-        "artwork.auctionResult.edges.node.id": (v54/*: any*/),
-        "artwork.auctionResult.edges.node.images": (v58/*: any*/),
-        "artwork.auctionResult.edges.node.images.thumbnail": (v59/*: any*/),
-        "artwork.auctionResult.edges.node.images.thumbnail.cropped": (v60/*: any*/),
-        "artwork.auctionResult.edges.node.images.thumbnail.cropped.height": (v61/*: any*/),
-        "artwork.auctionResult.edges.node.images.thumbnail.cropped.src": (v62/*: any*/),
-        "artwork.auctionResult.edges.node.images.thumbnail.cropped.srcSet": (v62/*: any*/),
-        "artwork.auctionResult.edges.node.images.thumbnail.cropped.width": (v61/*: any*/),
-        "artwork.auctionResult.edges.node.internalID": (v54/*: any*/),
-        "artwork.auctionResult.edges.node.isUpcoming": (v56/*: any*/),
-        "artwork.auctionResult.edges.node.location": (v55/*: any*/),
-        "artwork.auctionResult.edges.node.lotNumber": (v55/*: any*/),
-        "artwork.auctionResult.edges.node.mediumText": (v55/*: any*/),
-        "artwork.auctionResult.edges.node.organization": (v55/*: any*/),
-        "artwork.auctionResult.edges.node.performance": (v63/*: any*/),
-        "artwork.auctionResult.edges.node.performance.mid": (v55/*: any*/),
-        "artwork.auctionResult.edges.node.price_realized": (v64/*: any*/),
-        "artwork.auctionResult.edges.node.price_realized.cents_usd": (v65/*: any*/),
-        "artwork.auctionResult.edges.node.price_realized.display": (v55/*: any*/),
-        "artwork.auctionResult.edges.node.price_realized.display_usd": (v55/*: any*/),
-        "artwork.auctionResult.edges.node.saleDate": (v55/*: any*/),
-        "artwork.auctionResult.edges.node.saleTitle": (v55/*: any*/),
-        "artwork.auctionResult.edges.node.title": (v55/*: any*/),
-        "artwork.auctionResults": (v50/*: any*/),
-        "artwork.auctionResults.totalCount": (v51/*: any*/),
+        "artwork.attributionClass.id": (v51/*: any*/),
+        "artwork.attributionClass.shortDescription": (v52/*: any*/),
+        "artwork.auctionResult": (v47/*: any*/),
+        "artwork.auctionResult.edges": (v49/*: any*/),
+        "artwork.auctionResult.edges.cursor": (v59/*: any*/),
+        "artwork.auctionResult.edges.node": (v50/*: any*/),
+        "artwork.auctionResult.edges.node.artist": (v46/*: any*/),
+        "artwork.auctionResult.edges.node.artist.id": (v51/*: any*/),
+        "artwork.auctionResult.edges.node.artist.name": (v52/*: any*/),
+        "artwork.auctionResult.edges.node.artistID": (v59/*: any*/),
+        "artwork.auctionResult.edges.node.boughtIn": (v53/*: any*/),
+        "artwork.auctionResult.edges.node.categoryText": (v52/*: any*/),
+        "artwork.auctionResult.edges.node.currency": (v52/*: any*/),
+        "artwork.auctionResult.edges.node.date_text": (v52/*: any*/),
+        "artwork.auctionResult.edges.node.dimension_text": (v52/*: any*/),
+        "artwork.auctionResult.edges.node.estimate": (v54/*: any*/),
+        "artwork.auctionResult.edges.node.estimate.display": (v52/*: any*/),
+        "artwork.auctionResult.edges.node.id": (v51/*: any*/),
+        "artwork.auctionResult.edges.node.images": (v55/*: any*/),
+        "artwork.auctionResult.edges.node.images.thumbnail": (v56/*: any*/),
+        "artwork.auctionResult.edges.node.images.thumbnail.cropped": (v57/*: any*/),
+        "artwork.auctionResult.edges.node.images.thumbnail.cropped.height": (v58/*: any*/),
+        "artwork.auctionResult.edges.node.images.thumbnail.cropped.src": (v59/*: any*/),
+        "artwork.auctionResult.edges.node.images.thumbnail.cropped.srcSet": (v59/*: any*/),
+        "artwork.auctionResult.edges.node.images.thumbnail.cropped.width": (v58/*: any*/),
+        "artwork.auctionResult.edges.node.internalID": (v51/*: any*/),
+        "artwork.auctionResult.edges.node.isUpcoming": (v53/*: any*/),
+        "artwork.auctionResult.edges.node.location": (v52/*: any*/),
+        "artwork.auctionResult.edges.node.lotNumber": (v52/*: any*/),
+        "artwork.auctionResult.edges.node.mediumText": (v52/*: any*/),
+        "artwork.auctionResult.edges.node.organization": (v52/*: any*/),
+        "artwork.auctionResult.edges.node.performance": (v60/*: any*/),
+        "artwork.auctionResult.edges.node.performance.mid": (v52/*: any*/),
+        "artwork.auctionResult.edges.node.price_realized": (v61/*: any*/),
+        "artwork.auctionResult.edges.node.price_realized.cents_usd": (v62/*: any*/),
+        "artwork.auctionResult.edges.node.price_realized.display": (v52/*: any*/),
+        "artwork.auctionResult.edges.node.price_realized.display_usd": (v52/*: any*/),
+        "artwork.auctionResult.edges.node.saleDate": (v52/*: any*/),
+        "artwork.auctionResult.edges.node.saleTitle": (v52/*: any*/),
+        "artwork.auctionResult.edges.node.title": (v52/*: any*/),
+        "artwork.auctionResults": (v47/*: any*/),
+        "artwork.auctionResults.totalCount": (v48/*: any*/),
         "artwork.collectorLocation": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "MyLocation"
         },
-        "artwork.collectorLocation.city": (v55/*: any*/),
-        "artwork.collectorLocation.country": (v55/*: any*/),
-        "artwork.collectorLocation.countryCode": (v55/*: any*/),
-        "artwork.collectorLocation.id": (v54/*: any*/),
-        "artwork.collectorLocation.state": (v55/*: any*/),
+        "artwork.collectorLocation.city": (v52/*: any*/),
+        "artwork.collectorLocation.country": (v52/*: any*/),
+        "artwork.collectorLocation.countryCode": (v52/*: any*/),
+        "artwork.collectorLocation.id": (v51/*: any*/),
+        "artwork.collectorLocation.state": (v52/*: any*/),
         "artwork.collectorSignals": {
           "enumValues": null,
           "nullable": true,
@@ -1833,17 +1818,17 @@ return {
           "plural": false,
           "type": "AuctionCollectorSignals"
         },
-        "artwork.collectorSignals.auction.lotWatcherCount": (v61/*: any*/),
-        "artwork.comparables": (v50/*: any*/),
-        "artwork.comparables.totalCount": (v51/*: any*/),
-        "artwork.confidentialNotes": (v55/*: any*/),
+        "artwork.collectorSignals.auction.lotWatcherCount": (v58/*: any*/),
+        "artwork.comparables": (v47/*: any*/),
+        "artwork.comparables.totalCount": (v48/*: any*/),
+        "artwork.confidentialNotes": (v52/*: any*/),
         "artwork.consignmentSubmission": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtworkConsignmentSubmission"
         },
-        "artwork.consignmentSubmission.internalID": (v55/*: any*/),
+        "artwork.consignmentSubmission.internalID": (v52/*: any*/),
         "artwork.consignmentSubmission.state": {
           "enumValues": [
             "APPROVED",
@@ -1859,24 +1844,24 @@ return {
           "plural": false,
           "type": "ArtworkConsignmentSubmissionState"
         },
-        "artwork.date": (v55/*: any*/),
+        "artwork.date": (v52/*: any*/),
         "artwork.dimensions": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "dimensions"
         },
-        "artwork.dimensions.cm": (v55/*: any*/),
-        "artwork.dimensions.in": (v55/*: any*/),
-        "artwork.downloadableImageUrl": (v55/*: any*/),
-        "artwork.editionOf": (v55/*: any*/),
+        "artwork.dimensions.cm": (v52/*: any*/),
+        "artwork.dimensions.in": (v52/*: any*/),
+        "artwork.downloadableImageUrl": (v52/*: any*/),
+        "artwork.editionOf": (v52/*: any*/),
         "artwork.figures": {
           "enumValues": null,
           "nullable": false,
           "plural": true,
           "type": "ArtworkFigures"
         },
-        "artwork.figures.__typename": (v62/*: any*/),
+        "artwork.figures.__typename": (v59/*: any*/),
         "artwork.figures.deepZoom": {
           "enumValues": null,
           "nullable": true,
@@ -1889,152 +1874,145 @@ return {
           "plural": false,
           "type": "DeepZoomImage"
         },
-        "artwork.figures.deepZoom.Image.Format": (v55/*: any*/),
-        "artwork.figures.deepZoom.Image.Overlap": (v51/*: any*/),
+        "artwork.figures.deepZoom.Image.Format": (v52/*: any*/),
+        "artwork.figures.deepZoom.Image.Overlap": (v48/*: any*/),
         "artwork.figures.deepZoom.Image.Size": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "DeepZoomImageSize"
         },
-        "artwork.figures.deepZoom.Image.Size.Height": (v51/*: any*/),
-        "artwork.figures.deepZoom.Image.Size.Width": (v51/*: any*/),
-        "artwork.figures.deepZoom.Image.TileSize": (v51/*: any*/),
-        "artwork.figures.deepZoom.Image.Url": (v55/*: any*/),
-        "artwork.figures.deepZoom.Image.xmlns": (v55/*: any*/),
-        "artwork.figures.height": (v51/*: any*/),
-        "artwork.figures.id": (v54/*: any*/),
-        "artwork.figures.internalID": (v68/*: any*/),
-        "artwork.figures.isDefault": (v56/*: any*/),
-        "artwork.figures.isZoomable": (v56/*: any*/),
-        "artwork.figures.playerUrl": (v62/*: any*/),
-        "artwork.figures.type": (v62/*: any*/),
-        "artwork.figures.videoHeight": (v61/*: any*/),
-        "artwork.figures.videoWidth": (v61/*: any*/),
-        "artwork.figures.width": (v51/*: any*/),
-        "artwork.formattedMetadata": (v55/*: any*/),
-        "artwork.hasMarketPriceInsights": (v56/*: any*/),
-        "artwork.hasPriceEstimateRequest": (v56/*: any*/),
-        "artwork.heightCm": (v65/*: any*/),
-        "artwork.href": (v55/*: any*/),
-        "artwork.id": (v54/*: any*/),
-        "artwork.image": (v59/*: any*/),
-        "artwork.image.resized": (v69/*: any*/),
-        "artwork.image.resized.height": (v51/*: any*/),
-        "artwork.image.resized.src": (v62/*: any*/),
-        "artwork.image.resized.srcSet": (v62/*: any*/),
-        "artwork.image.resized.width": (v51/*: any*/),
+        "artwork.figures.deepZoom.Image.Size.Height": (v48/*: any*/),
+        "artwork.figures.deepZoom.Image.Size.Width": (v48/*: any*/),
+        "artwork.figures.deepZoom.Image.TileSize": (v48/*: any*/),
+        "artwork.figures.deepZoom.Image.Url": (v52/*: any*/),
+        "artwork.figures.deepZoom.Image.xmlns": (v52/*: any*/),
+        "artwork.figures.height": (v48/*: any*/),
+        "artwork.figures.id": (v51/*: any*/),
+        "artwork.figures.internalID": (v65/*: any*/),
+        "artwork.figures.isDefault": (v53/*: any*/),
+        "artwork.figures.isZoomable": (v53/*: any*/),
+        "artwork.figures.playerUrl": (v59/*: any*/),
+        "artwork.figures.type": (v59/*: any*/),
+        "artwork.figures.videoHeight": (v58/*: any*/),
+        "artwork.figures.videoWidth": (v58/*: any*/),
+        "artwork.figures.width": (v48/*: any*/),
+        "artwork.formattedMetadata": (v52/*: any*/),
+        "artwork.hasMarketPriceInsights": (v53/*: any*/),
+        "artwork.hasPriceEstimateRequest": (v53/*: any*/),
+        "artwork.heightCm": (v62/*: any*/),
+        "artwork.href": (v52/*: any*/),
+        "artwork.id": (v51/*: any*/),
+        "artwork.image": (v56/*: any*/),
+        "artwork.image.resized": (v66/*: any*/),
+        "artwork.image.resized.height": (v48/*: any*/),
+        "artwork.image.resized.src": (v59/*: any*/),
+        "artwork.image.resized.srcSet": (v59/*: any*/),
+        "artwork.image.resized.width": (v48/*: any*/),
         "artwork.images": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Image"
         },
-        "artwork.images.blurhashDataURL": (v55/*: any*/),
-        "artwork.images.fallback": (v60/*: any*/),
-        "artwork.images.fallback.height": (v61/*: any*/),
-        "artwork.images.fallback.src": (v62/*: any*/),
-        "artwork.images.fallback.srcSet": (v62/*: any*/),
-        "artwork.images.fallback.width": (v61/*: any*/),
-        "artwork.images.internalID": (v68/*: any*/),
-        "artwork.images.isDefault": (v56/*: any*/),
-        "artwork.images.mobileLightboxSource": (v69/*: any*/),
-        "artwork.images.mobileLightboxSource.height": (v51/*: any*/),
-        "artwork.images.mobileLightboxSource.src": (v62/*: any*/),
-        "artwork.images.mobileLightboxSource.srcSet": (v62/*: any*/),
-        "artwork.images.mobileLightboxSource.width": (v51/*: any*/),
-        "artwork.images.placeholder": (v55/*: any*/),
-        "artwork.images.resized": (v69/*: any*/),
-        "artwork.images.resized.height": (v51/*: any*/),
-        "artwork.images.resized.src": (v62/*: any*/),
-        "artwork.images.resized.srcSet": (v62/*: any*/),
-        "artwork.images.resized.width": (v51/*: any*/),
-        "artwork.images.url": (v55/*: any*/),
+        "artwork.images.blurhashDataURL": (v52/*: any*/),
+        "artwork.images.fallback": (v57/*: any*/),
+        "artwork.images.fallback.height": (v58/*: any*/),
+        "artwork.images.fallback.src": (v59/*: any*/),
+        "artwork.images.fallback.width": (v58/*: any*/),
+        "artwork.images.internalID": (v65/*: any*/),
+        "artwork.images.isDefault": (v53/*: any*/),
+        "artwork.images.placeholder": (v52/*: any*/),
+        "artwork.images.resized": (v66/*: any*/),
+        "artwork.images.resized.height": (v48/*: any*/),
+        "artwork.images.resized.src": (v59/*: any*/),
+        "artwork.images.resized.width": (v48/*: any*/),
+        "artwork.images.url": (v52/*: any*/),
         "artwork.images.versions": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "String"
         },
-        "artwork.internalID": (v54/*: any*/),
-        "artwork.isDownloadable": (v56/*: any*/),
-        "artwork.isHangable": (v56/*: any*/),
-        "artwork.isInAuction": (v56/*: any*/),
-        "artwork.isPriceEstimateRequestable": (v56/*: any*/),
-        "artwork.isSavedToAnyList": (v66/*: any*/),
-        "artwork.isSetVideoAsCover": (v56/*: any*/),
-        "artwork.isUnlisted": (v66/*: any*/),
+        "artwork.internalID": (v51/*: any*/),
+        "artwork.isDownloadable": (v53/*: any*/),
+        "artwork.isHangable": (v53/*: any*/),
+        "artwork.isInAuction": (v53/*: any*/),
+        "artwork.isPriceEstimateRequestable": (v53/*: any*/),
+        "artwork.isSavedToAnyList": (v63/*: any*/),
+        "artwork.isSetVideoAsCover": (v53/*: any*/),
+        "artwork.isUnlisted": (v63/*: any*/),
         "artwork.marketPriceInsights": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtworkPriceInsights"
         },
-        "artwork.marketPriceInsights.annualLotsSold": (v51/*: any*/),
-        "artwork.marketPriceInsights.annualValueSoldDisplayText": (v55/*: any*/),
-        "artwork.marketPriceInsights.demandRank": (v65/*: any*/),
-        "artwork.marketPriceInsights.demandRankDisplayText": (v55/*: any*/),
-        "artwork.marketPriceInsights.liquidityRankDisplayText": (v55/*: any*/),
-        "artwork.marketPriceInsights.medianSaleOverEstimatePercentage": (v65/*: any*/),
-        "artwork.marketPriceInsights.sellThroughRate": (v65/*: any*/),
-        "artwork.medium": (v55/*: any*/),
+        "artwork.marketPriceInsights.annualLotsSold": (v48/*: any*/),
+        "artwork.marketPriceInsights.annualValueSoldDisplayText": (v52/*: any*/),
+        "artwork.marketPriceInsights.demandRank": (v62/*: any*/),
+        "artwork.marketPriceInsights.demandRankDisplayText": (v52/*: any*/),
+        "artwork.marketPriceInsights.liquidityRankDisplayText": (v52/*: any*/),
+        "artwork.marketPriceInsights.medianSaleOverEstimatePercentage": (v62/*: any*/),
+        "artwork.marketPriceInsights.sellThroughRate": (v62/*: any*/),
+        "artwork.medium": (v52/*: any*/),
         "artwork.mediumType": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtworkMedium"
         },
-        "artwork.mediumType.name": (v55/*: any*/),
-        "artwork.metric": (v55/*: any*/),
+        "artwork.mediumType.name": (v52/*: any*/),
+        "artwork.metric": (v52/*: any*/),
         "artwork.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "artwork.partner.id": (v54/*: any*/),
-        "artwork.partner.slug": (v54/*: any*/),
-        "artwork.preview": (v59/*: any*/),
-        "artwork.preview.url": (v55/*: any*/),
+        "artwork.partner.id": (v51/*: any*/),
+        "artwork.partner.slug": (v51/*: any*/),
+        "artwork.preview": (v56/*: any*/),
+        "artwork.preview.url": (v52/*: any*/),
         "artwork.pricePaid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Money"
         },
-        "artwork.pricePaid.display": (v55/*: any*/),
-        "artwork.provenance": (v55/*: any*/),
+        "artwork.pricePaid.display": (v52/*: any*/),
+        "artwork.provenance": (v52/*: any*/),
         "artwork.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "artwork.sale.id": (v54/*: any*/),
-        "artwork.sale.isAuction": (v56/*: any*/),
-        "artwork.sale.isClosed": (v56/*: any*/),
-        "artwork.sale.isLiveOpen": (v56/*: any*/),
-        "artwork.sale.isRegistrationClosed": (v56/*: any*/),
-        "artwork.sale.liveStartAt": (v55/*: any*/),
-        "artwork.sale.registrationEndsAt": (v55/*: any*/),
+        "artwork.sale.id": (v51/*: any*/),
+        "artwork.sale.isAuction": (v53/*: any*/),
+        "artwork.sale.isClosed": (v53/*: any*/),
+        "artwork.sale.isLiveOpen": (v53/*: any*/),
+        "artwork.sale.isRegistrationClosed": (v53/*: any*/),
+        "artwork.sale.liveStartAt": (v52/*: any*/),
+        "artwork.sale.registrationEndsAt": (v52/*: any*/),
         "artwork.sale.registrationStatus": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Bidder"
         },
-        "artwork.sale.registrationStatus.id": (v54/*: any*/),
-        "artwork.sale.registrationStatus.qualifiedForBidding": (v56/*: any*/),
-        "artwork.sale.slug": (v54/*: any*/),
-        "artwork.slug": (v54/*: any*/),
-        "artwork.submissionId": (v55/*: any*/),
-        "artwork.title": (v55/*: any*/),
-        "artwork.widthCm": (v65/*: any*/)
+        "artwork.sale.registrationStatus.id": (v51/*: any*/),
+        "artwork.sale.registrationStatus.qualifiedForBidding": (v53/*: any*/),
+        "artwork.sale.slug": (v51/*: any*/),
+        "artwork.slug": (v51/*: any*/),
+        "artwork.submissionId": (v52/*: any*/),
+        "artwork.title": (v52/*: any*/),
+        "artwork.widthCm": (v62/*: any*/)
       }
     },
     "name": "MyCollectionArtworkTestQuery",
     "operationKind": "query",
-    "text": "query MyCollectionArtworkTestQuery {\n  artwork(id: \"foo\") {\n    ...MyCollectionArtwork_artwork\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  internalID\n  title\n  dimension_text: dimensionText\n  organization\n  artist {\n    name\n    id\n  }\n  images {\n    thumbnail {\n      cropped(width: 130, height: 130, version: [\"square140\"]) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n  }\n  mediumText\n  categoryText\n  date_text: dateText\n  saleDate\n  boughtIn\n  currency\n  price_realized: priceRealized {\n    display\n    display_usd: displayUSD\n    cents_usd: centsUSD\n  }\n  performance {\n    mid\n  }\n  estimate {\n    display\n  }\n  location\n  lotNumber\n  saleTitle\n  isUpcoming\n}\n\nfragment ArtworkActionsSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isInAuction\n  isSavedToAnyList\n  sale {\n    isAuction\n    isClosed\n    id\n  }\n  collectorSignals {\n    auction {\n      lotWatcherCount\n    }\n  }\n  ...ArtworkActionsWatchLotButton_artwork\n}\n\nfragment ArtworkActionsWatchLotButton_artwork on Artwork {\n  sale {\n    isLiveOpen\n    isRegistrationClosed\n    liveStartAt\n    registrationStatus {\n      qualifiedForBidding\n      id\n    }\n    id\n  }\n  ...ArtworkAuctionRegistrationPanel_artwork\n}\n\nfragment ArtworkActions_artwork_yvCPB on Artwork {\n  ...ArtworkActionsSaveButton_artwork\n  ...ArtworkDownloadButton_artwork\n  ...ArtworkSharePanel_artwork_yvCPB\n  ...ViewInRoom_artwork\n  isUnlisted\n  slug\n  downloadableImageUrl\n  isDownloadable\n  isHangable\n  partner {\n    slug\n    id\n  }\n}\n\nfragment ArtworkAuctionRegistrationPanel_artwork on Artwork {\n  sale {\n    slug\n    registrationEndsAt\n    isRegistrationClosed\n    id\n  }\n}\n\nfragment ArtworkDownloadButton_artwork on Artwork {\n  title\n  date\n  downloadableImageUrl\n  artists(shallow: true) {\n    name\n    id\n  }\n}\n\nfragment ArtworkImageBrowserLarge_artwork_yvCPB on Artwork {\n  ...ArtworkLightbox_artwork_yvCPB\n  ...ArtworkVideoPlayer_artwork_yvCPB\n  isSetVideoAsCover\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      __typename\n      internalID\n      isZoomable\n    }\n    ... on Video {\n      __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowserSmall_artwork_yvCPB on Artwork {\n  ...ArtworkLightbox_artwork_yvCPB\n  ...ArtworkVideoPlayer_artwork_yvCPB\n  isSetVideoAsCover\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      internalID\n      isZoomable\n      type: __typename\n    }\n    ... on Video {\n      type: __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowser_artwork_yvCPB on Artwork {\n  ...ArtworkActions_artwork_yvCPB\n  ...ArtworkImageBrowserSmall_artwork_yvCPB\n  ...ArtworkImageBrowserLarge_artwork_yvCPB\n  internalID\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      isDefault\n      width\n      height\n    }\n    ... on Video {\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment ArtworkLightbox_artwork_yvCPB on Artwork {\n  formattedMetadata\n  images(includeAll: true) {\n    internalID\n    isDefault\n    placeholder: url(version: [\"small\", \"medium\"])\n    blurhashDataURL(width: 801)\n    fallback: cropped(quality: 80, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    resized(quality: 80, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    mobileLightboxSource: resized(quality: 50, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    versions\n  }\n}\n\nfragment ArtworkSharePanel_artwork_yvCPB on Artwork {\n  href\n  images(includeAll: true) {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n\nfragment ArtworkVideoPlayer_artwork_yvCPB on Artwork {\n  internalID\n  slug\n  figures(includeAll: true) {\n    __typename\n    ... on Video {\n      __typename\n      playerUrl\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment DeepZoom_image on Image {\n  deepZoom {\n    Image {\n      xmlns\n      Url\n      Format\n      TileSize\n      Overlap\n      Size {\n        Width\n        Height\n      }\n    }\n  }\n}\n\nfragment MyCollectionArtworkAboutTab_artwork on Artwork {\n  ...MyCollectionArtworkDetails_artwork\n  artist(shallow: true) {\n    slug\n    targetSupply {\n      priority\n    }\n    id\n  }\n  consignmentSubmission {\n    internalID\n  }\n  hasPriceEstimateRequest\n  internalID\n}\n\nfragment MyCollectionArtworkArtistMarket_marketPriceInsights on ArtworkPriceInsights {\n  annualLotsSold\n  annualValueSoldDisplayText\n  medianSaleOverEstimatePercentage\n  liquidityRankDisplayText\n  sellThroughRate\n}\n\nfragment MyCollectionArtworkAuctionResults_artist on Artist {\n  slug\n  internalID\n  auctionResultsConnection(first: 6) {\n    totalCount\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        id\n      }\n    }\n  }\n}\n\nfragment MyCollectionArtworkComparables_artwork on Artwork {\n  auctionResult: comparableAuctionResults(first: 6) @optionalField {\n    edges {\n      cursor\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        artistID\n        internalID\n        id\n      }\n    }\n  }\n  artist(shallow: true) {\n    name\n    id\n  }\n}\n\nfragment MyCollectionArtworkDemandIndex_marketPriceInsights on ArtworkPriceInsights {\n  demandRank\n  demandRankDisplayText\n}\n\nfragment MyCollectionArtworkDetails_artwork on Artwork {\n  mediumType {\n    name\n  }\n  confidentialNotes\n  medium\n  metric\n  dimensions {\n    in\n    cm\n  }\n  provenance\n  attributionClass {\n    shortDescription\n    id\n  }\n  editionOf\n  pricePaid {\n    display\n  }\n  collectorLocation {\n    city\n    state\n    country\n    countryCode\n    id\n  }\n}\n\nfragment MyCollectionArtworkHeader_artwork on Artwork {\n  internalID\n  slug\n}\n\nfragment MyCollectionArtworkImageBrowser_artwork on Artwork {\n  ...ArtworkImageBrowser_artwork_yvCPB\n  internalID\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      width\n      height\n    }\n    ... on Video {\n      id\n    }\n  }\n}\n\nfragment MyCollectionArtworkInsights_artwork on Artwork {\n  hasPriceEstimateRequest\n  isPriceEstimateRequestable\n  internalID\n  auctionResults: comparableAuctionResults(first: 1) @optionalField {\n    totalCount\n  }\n  ...MyCollectionArtworkComparables_artwork\n  artist(shallow: true) {\n    slug\n    auctionResultsCount: auctionResultsConnection(first: 1) {\n      totalCount\n    }\n    targetSupply {\n      priority\n    }\n    ...MyCollectionArtworkAuctionResults_artist\n    id\n  }\n  marketPriceInsights {\n    ...MyCollectionArtworkArtistMarket_marketPriceInsights\n    ...MyCollectionArtworkDemandIndex_marketPriceInsights\n  }\n}\n\nfragment MyCollectionArtworkMeta_artwork on Artwork {\n  artistNames\n  title\n}\n\nfragment MyCollectionArtworkTitle_artwork on Artwork {\n  artistNames\n  title\n  date\n  artist(shallow: true) {\n    href\n    isPersonalArtist\n    id\n  }\n}\n\nfragment MyCollectionArtwork_artwork on Artwork {\n  ...MyCollectionArtworkHeader_artwork\n  ...MyCollectionArtworkTitle_artwork\n  ...MyCollectionArtworkDetails_artwork\n  ...MyCollectionArtworkMeta_artwork\n  ...MyCollectionArtworkInsights_artwork\n  ...MyCollectionArtworkImageBrowser_artwork\n  ...MyCollectionArtworkComparables_artwork\n  ...MyCollectionArtworkAboutTab_artwork\n  comparables: comparableAuctionResults {\n    totalCount\n  }\n  hasPriceEstimateRequest\n  hasMarketPriceInsights\n  submissionId\n  internalID\n  slug\n  consignmentSubmission {\n    state\n    internalID\n  }\n  artist(shallow: true) {\n    slug\n    targetSupply {\n      priority\n    }\n    auctionResults: auctionResultsConnection {\n      totalCount\n    }\n    ...MyCollectionArtworkAuctionResults_artist\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ViewInRoomArtwork_artwork on Artwork {\n  widthCm\n  heightCm\n  image {\n    resized(width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ViewInRoom_artwork on Artwork {\n  ...ViewInRoomArtwork_artwork\n}\n"
+    "text": "query MyCollectionArtworkTestQuery {\n  artwork(id: \"foo\") {\n    ...MyCollectionArtwork_artwork\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  internalID\n  title\n  dimension_text: dimensionText\n  organization\n  artist {\n    name\n    id\n  }\n  images {\n    thumbnail {\n      cropped(width: 130, height: 130, version: [\"square140\"]) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n  }\n  mediumText\n  categoryText\n  date_text: dateText\n  saleDate\n  boughtIn\n  currency\n  price_realized: priceRealized {\n    display\n    display_usd: displayUSD\n    cents_usd: centsUSD\n  }\n  performance {\n    mid\n  }\n  estimate {\n    display\n  }\n  location\n  lotNumber\n  saleTitle\n  isUpcoming\n}\n\nfragment ArtworkActionsSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isInAuction\n  isSavedToAnyList\n  sale {\n    isAuction\n    isClosed\n    id\n  }\n  collectorSignals {\n    auction {\n      lotWatcherCount\n    }\n  }\n  ...ArtworkActionsWatchLotButton_artwork\n}\n\nfragment ArtworkActionsWatchLotButton_artwork on Artwork {\n  sale {\n    isLiveOpen\n    isRegistrationClosed\n    liveStartAt\n    registrationStatus {\n      qualifiedForBidding\n      id\n    }\n    id\n  }\n  ...ArtworkAuctionRegistrationPanel_artwork\n}\n\nfragment ArtworkActions_artwork_yvCPB on Artwork {\n  ...ArtworkActionsSaveButton_artwork\n  ...ArtworkDownloadButton_artwork\n  ...ArtworkSharePanel_artwork_yvCPB\n  ...ViewInRoom_artwork\n  isUnlisted\n  slug\n  downloadableImageUrl\n  isDownloadable\n  isHangable\n  partner {\n    slug\n    id\n  }\n}\n\nfragment ArtworkAuctionRegistrationPanel_artwork on Artwork {\n  sale {\n    slug\n    registrationEndsAt\n    isRegistrationClosed\n    id\n  }\n}\n\nfragment ArtworkDownloadButton_artwork on Artwork {\n  title\n  date\n  downloadableImageUrl\n  artists(shallow: true) {\n    name\n    id\n  }\n}\n\nfragment ArtworkImageBrowserLarge_artwork_yvCPB on Artwork {\n  ...ArtworkLightbox_artwork_yvCPB\n  ...ArtworkVideoPlayer_artwork_yvCPB\n  isSetVideoAsCover\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      __typename\n      internalID\n      isZoomable\n    }\n    ... on Video {\n      __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowserSmall_artwork_yvCPB on Artwork {\n  ...ArtworkLightbox_artwork_yvCPB\n  ...ArtworkVideoPlayer_artwork_yvCPB\n  isSetVideoAsCover\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      internalID\n      isZoomable\n      type: __typename\n    }\n    ... on Video {\n      type: __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowser_artwork_yvCPB on Artwork {\n  ...ArtworkActions_artwork_yvCPB\n  ...ArtworkImageBrowserSmall_artwork_yvCPB\n  ...ArtworkImageBrowserLarge_artwork_yvCPB\n  internalID\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      isDefault\n      width\n      height\n    }\n    ... on Video {\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment ArtworkLightbox_artwork_yvCPB on Artwork {\n  formattedMetadata\n  images(includeAll: true) {\n    internalID\n    isDefault\n    placeholder: url(version: [\"small\", \"medium\"])\n    blurhashDataURL(width: 801)\n    fallback: cropped(quality: 80, width: 1600, height: 1600, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n    }\n    resized(quality: 80, width: 1600, height: 1600, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n    }\n    versions\n  }\n}\n\nfragment ArtworkSharePanel_artwork_yvCPB on Artwork {\n  href\n  images(includeAll: true) {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n\nfragment ArtworkVideoPlayer_artwork_yvCPB on Artwork {\n  internalID\n  slug\n  figures(includeAll: true) {\n    __typename\n    ... on Video {\n      __typename\n      playerUrl\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment DeepZoom_image on Image {\n  deepZoom {\n    Image {\n      xmlns\n      Url\n      Format\n      TileSize\n      Overlap\n      Size {\n        Width\n        Height\n      }\n    }\n  }\n}\n\nfragment MyCollectionArtworkAboutTab_artwork on Artwork {\n  ...MyCollectionArtworkDetails_artwork\n  artist(shallow: true) {\n    slug\n    targetSupply {\n      priority\n    }\n    id\n  }\n  consignmentSubmission {\n    internalID\n  }\n  hasPriceEstimateRequest\n  internalID\n}\n\nfragment MyCollectionArtworkArtistMarket_marketPriceInsights on ArtworkPriceInsights {\n  annualLotsSold\n  annualValueSoldDisplayText\n  medianSaleOverEstimatePercentage\n  liquidityRankDisplayText\n  sellThroughRate\n}\n\nfragment MyCollectionArtworkAuctionResults_artist on Artist {\n  slug\n  internalID\n  auctionResultsConnection(first: 6) {\n    totalCount\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        id\n      }\n    }\n  }\n}\n\nfragment MyCollectionArtworkComparables_artwork on Artwork {\n  auctionResult: comparableAuctionResults(first: 6) @optionalField {\n    edges {\n      cursor\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        artistID\n        internalID\n        id\n      }\n    }\n  }\n  artist(shallow: true) {\n    name\n    id\n  }\n}\n\nfragment MyCollectionArtworkDemandIndex_marketPriceInsights on ArtworkPriceInsights {\n  demandRank\n  demandRankDisplayText\n}\n\nfragment MyCollectionArtworkDetails_artwork on Artwork {\n  mediumType {\n    name\n  }\n  confidentialNotes\n  medium\n  metric\n  dimensions {\n    in\n    cm\n  }\n  provenance\n  attributionClass {\n    shortDescription\n    id\n  }\n  editionOf\n  pricePaid {\n    display\n  }\n  collectorLocation {\n    city\n    state\n    country\n    countryCode\n    id\n  }\n}\n\nfragment MyCollectionArtworkHeader_artwork on Artwork {\n  internalID\n  slug\n}\n\nfragment MyCollectionArtworkImageBrowser_artwork on Artwork {\n  ...ArtworkImageBrowser_artwork_yvCPB\n  internalID\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      width\n      height\n    }\n    ... on Video {\n      id\n    }\n  }\n}\n\nfragment MyCollectionArtworkInsights_artwork on Artwork {\n  hasPriceEstimateRequest\n  isPriceEstimateRequestable\n  internalID\n  auctionResults: comparableAuctionResults(first: 1) @optionalField {\n    totalCount\n  }\n  ...MyCollectionArtworkComparables_artwork\n  artist(shallow: true) {\n    slug\n    auctionResultsCount: auctionResultsConnection(first: 1) {\n      totalCount\n    }\n    targetSupply {\n      priority\n    }\n    ...MyCollectionArtworkAuctionResults_artist\n    id\n  }\n  marketPriceInsights {\n    ...MyCollectionArtworkArtistMarket_marketPriceInsights\n    ...MyCollectionArtworkDemandIndex_marketPriceInsights\n  }\n}\n\nfragment MyCollectionArtworkMeta_artwork on Artwork {\n  artistNames\n  title\n}\n\nfragment MyCollectionArtworkTitle_artwork on Artwork {\n  artistNames\n  title\n  date\n  artist(shallow: true) {\n    href\n    isPersonalArtist\n    id\n  }\n}\n\nfragment MyCollectionArtwork_artwork on Artwork {\n  ...MyCollectionArtworkHeader_artwork\n  ...MyCollectionArtworkTitle_artwork\n  ...MyCollectionArtworkDetails_artwork\n  ...MyCollectionArtworkMeta_artwork\n  ...MyCollectionArtworkInsights_artwork\n  ...MyCollectionArtworkImageBrowser_artwork\n  ...MyCollectionArtworkComparables_artwork\n  ...MyCollectionArtworkAboutTab_artwork\n  comparables: comparableAuctionResults {\n    totalCount\n  }\n  hasPriceEstimateRequest\n  hasMarketPriceInsights\n  submissionId\n  internalID\n  slug\n  consignmentSubmission {\n    state\n    internalID\n  }\n  artist(shallow: true) {\n    slug\n    targetSupply {\n      priority\n    }\n    auctionResults: auctionResultsConnection {\n      totalCount\n    }\n    ...MyCollectionArtworkAuctionResults_artist\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ViewInRoomArtwork_artwork on Artwork {\n  widthCm\n  heightCm\n  image {\n    resized(width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ViewInRoom_artwork on Artwork {\n  ...ViewInRoomArtwork_artwork\n}\n"
   }
 };
 })();

--- a/src/__generated__/artworkRoutes_ArtworkQuery.graphql.ts
+++ b/src/__generated__/artworkRoutes_ArtworkQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a6b1a68206c5b28318a9571908fbf955>>
+ * @generated SignedSource<<a4db1a4985d8c56c9d58b602c39ac9bc>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -314,11 +314,6 @@ v34 = {
 },
 v35 = {
   "kind": "Literal",
-  "name": "height",
-  "value": 800
-},
-v36 = {
-  "kind": "Literal",
   "name": "version",
   "value": [
     "main",
@@ -327,38 +322,40 @@ v36 = {
     "large"
   ]
 },
-v37 = {
-  "kind": "Literal",
-  "name": "width",
-  "value": 800
-},
-v38 = [
-  (v35/*: any*/),
+v36 = [
+  {
+    "kind": "Literal",
+    "name": "height",
+    "value": 1600
+  },
   {
     "kind": "Literal",
     "name": "quality",
     "value": 80
   },
-  (v36/*: any*/),
-  (v37/*: any*/)
+  (v35/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "width",
+    "value": 1600
+  }
 ],
-v39 = [
+v37 = [
   (v11/*: any*/),
   (v12/*: any*/),
-  (v30/*: any*/),
-  (v31/*: any*/)
+  (v30/*: any*/)
 ],
-v40 = {
+v38 = {
   "alias": "type",
   "args": null,
   "kind": "ScalarField",
   "name": "__typename",
   "storageKey": null
 },
-v41 = [
+v39 = [
   (v32/*: any*/)
 ],
-v42 = [
+v40 = [
   {
     "alias": null,
     "args": null,
@@ -374,31 +371,31 @@ v42 = [
     "storageKey": null
   }
 ],
-v43 = {
+v41 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "saleMessage",
   "storageKey": null
 },
-v44 = {
+v42 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "editionOf",
   "storageKey": null
 },
-v45 = {
+v43 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "displayText",
   "storageKey": null
 },
-v46 = [
+v44 = [
   (v10/*: any*/)
 ],
-v47 = [
+v45 = [
   (v4/*: any*/),
   {
     "kind": "Literal",
@@ -1125,42 +1122,23 @@ return {
                   },
                   {
                     "alias": "fallback",
-                    "args": (v38/*: any*/),
+                    "args": (v36/*: any*/),
                     "concreteType": "CroppedImageUrl",
                     "kind": "LinkedField",
                     "name": "cropped",
                     "plural": false,
-                    "selections": (v39/*: any*/),
-                    "storageKey": "cropped(height:800,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
+                    "selections": (v37/*: any*/),
+                    "storageKey": "cropped(height:1600,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:1600)"
                   },
                   {
                     "alias": null,
-                    "args": (v38/*: any*/),
+                    "args": (v36/*: any*/),
                     "concreteType": "ResizedImageUrl",
                     "kind": "LinkedField",
                     "name": "resized",
                     "plural": false,
-                    "selections": (v39/*: any*/),
-                    "storageKey": "resized(height:800,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
-                  },
-                  {
-                    "alias": "mobileLightboxSource",
-                    "args": [
-                      (v35/*: any*/),
-                      {
-                        "kind": "Literal",
-                        "name": "quality",
-                        "value": 50
-                      },
-                      (v36/*: any*/),
-                      (v37/*: any*/)
-                    ],
-                    "concreteType": "ResizedImageUrl",
-                    "kind": "LinkedField",
-                    "name": "resized",
-                    "plural": false,
-                    "selections": (v39/*: any*/),
-                    "storageKey": "resized(height:800,quality:50,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
+                    "selections": (v37/*: any*/),
+                    "storageKey": "resized(height:1600,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:1600)"
                   },
                   {
                     "alias": null,
@@ -1215,9 +1193,17 @@ return {
                   {
                     "alias": null,
                     "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 800
+                      },
                       (v35/*: any*/),
-                      (v36/*: any*/),
-                      (v37/*: any*/)
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 800
+                      }
                     ],
                     "concreteType": "ResizedImageUrl",
                     "kind": "LinkedField",
@@ -1289,7 +1275,7 @@ return {
                         "storageKey": null
                       },
                       (v17/*: any*/),
-                      (v40/*: any*/)
+                      (v38/*: any*/)
                     ],
                     "type": "Video",
                     "abstractKey": null
@@ -1387,7 +1373,7 @@ return {
                         "name": "isZoomable",
                         "storageKey": null
                       },
-                      (v40/*: any*/),
+                      (v38/*: any*/),
                       (v34/*: any*/),
                       (v11/*: any*/),
                       (v12/*: any*/)
@@ -1480,7 +1466,7 @@ return {
               },
               {
                 "alias": "additionalInformationHTML",
-                "args": (v41/*: any*/),
+                "args": (v39/*: any*/),
                 "kind": "ScalarField",
                 "name": "additionalInformation",
                 "storageKey": "additionalInformation(format:\"HTML\")"
@@ -1534,7 +1520,7 @@ return {
                 "kind": "LinkedField",
                 "name": "framed",
                 "plural": false,
-                "selections": (v42/*: any*/),
+                "selections": (v40/*: any*/),
                 "storageKey": null
               },
               {
@@ -1544,7 +1530,7 @@ return {
                 "kind": "LinkedField",
                 "name": "signatureInfo",
                 "plural": false,
-                "selections": (v42/*: any*/),
+                "selections": (v40/*: any*/),
                 "storageKey": null
               },
               {
@@ -1554,7 +1540,7 @@ return {
                 "kind": "LinkedField",
                 "name": "conditionDescription",
                 "plural": false,
-                "selections": (v42/*: any*/),
+                "selections": (v40/*: any*/),
                 "storageKey": null
               },
               {
@@ -1564,7 +1550,7 @@ return {
                 "kind": "LinkedField",
                 "name": "certificateOfAuthenticity",
                 "plural": false,
-                "selections": (v42/*: any*/),
+                "selections": (v40/*: any*/),
                 "storageKey": null
               },
               {
@@ -1576,14 +1562,14 @@ return {
               },
               {
                 "alias": null,
-                "args": (v41/*: any*/),
+                "args": (v39/*: any*/),
                 "kind": "ScalarField",
                 "name": "provenance",
                 "storageKey": "provenance(format:\"HTML\")"
               },
               {
                 "alias": null,
-                "args": (v41/*: any*/),
+                "args": (v39/*: any*/),
                 "kind": "ScalarField",
                 "name": "exhibitionHistory",
                 "storageKey": "exhibitionHistory(format:\"HTML\")"
@@ -1609,7 +1595,7 @@ return {
                 "name": "isPurchasable",
                 "storageKey": null
               },
-              (v43/*: any*/),
+              (v41/*: any*/),
               {
                 "condition": "loadSidebar",
                 "kind": "Condition",
@@ -1622,7 +1608,7 @@ return {
                     "name": "culturalMaker",
                     "storageKey": null
                   },
-                  (v44/*: any*/),
+                  (v42/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -1642,7 +1628,7 @@ return {
                       (v17/*: any*/),
                       (v23/*: any*/),
                       (v21/*: any*/),
-                      (v43/*: any*/),
+                      (v41/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1659,7 +1645,7 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v44/*: any*/)
+                          (v42/*: any*/)
                         ],
                         "type": "Sellable",
                         "abstractKey": "__isSellable"
@@ -1899,7 +1885,7 @@ return {
                     "name": "taxInfo",
                     "plural": false,
                     "selections": [
-                      (v45/*: any*/),
+                      (v43/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1908,7 +1894,7 @@ return {
                         "name": "moreInfo",
                         "plural": false,
                         "selections": [
-                          (v45/*: any*/),
+                          (v43/*: any*/),
                           (v13/*: any*/)
                         ],
                         "storageKey": null
@@ -2055,7 +2041,7 @@ return {
                         "kind": "LinkedField",
                         "name": "currentBid",
                         "plural": false,
-                        "selections": (v46/*: any*/),
+                        "selections": (v44/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -2105,7 +2091,7 @@ return {
                         "kind": "LinkedField",
                         "name": "currentBid",
                         "plural": false,
-                        "selections": (v46/*: any*/),
+                        "selections": (v44/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -2369,7 +2355,7 @@ return {
         "selections": [
           {
             "alias": null,
-            "args": (v47/*: any*/),
+            "args": (v45/*: any*/),
             "concreteType": "PartnerOfferToCollectorConnection",
             "kind": "LinkedField",
             "name": "partnerOffersConnection",
@@ -2437,7 +2423,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v47/*: any*/),
+                "args": (v45/*: any*/),
                 "concreteType": "PartnerOfferToCollectorConnection",
                 "kind": "LinkedField",
                 "name": "partnerOffersConnection",
@@ -2481,7 +2467,7 @@ return {
                             "kind": "LinkedField",
                             "name": "priceWithDiscount",
                             "plural": false,
-                            "selections": (v46/*: any*/),
+                            "selections": (v44/*: any*/),
                             "storageKey": null
                           }
                         ],
@@ -2501,12 +2487,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4ae51a7da8ace27263f690f669e5b4aa",
+    "cacheID": "3c3faacc8c38d8d1a76dec403e1cfe4b",
     "id": null,
     "metadata": {},
     "name": "artworkRoutes_ArtworkQuery",
     "operationKind": "query",
-    "text": "query artworkRoutes_ArtworkQuery(\n  $artworkID: String!\n  $loadSidebar: Boolean!\n) {\n  artworkResult(id: $artworkID) {\n    __typename\n    ...ArtworkApp_artworkResult_45HfMx\n    ... on ArtworkError {\n      requestError {\n        statusCode\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  me {\n    ...ArtworkApp_me_3Rs6v7\n    id\n  }\n}\n\nfragment ArtsyShippingEstimate_artwork on Artwork {\n  depthCm\n  diameterCm\n  framedHeight\n  framedWidth\n  framedDepth\n  framedDiameter\n  framedMetric\n  heightCm\n  isFramed\n  listPrice {\n    __typename\n    ... on Money {\n      major\n    }\n    ... on PriceRange {\n      maxPrice {\n        major\n      }\n      minPrice {\n        major\n      }\n    }\n  }\n  mediumType {\n    name\n  }\n  priceCurrency\n  shippingOrigin\n  shippingWeight\n  shippingWeightMetric\n  widthCm\n}\n\nfragment ArtworkActionsSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isInAuction\n  isSavedToAnyList\n  sale {\n    isAuction\n    isClosed\n    id\n  }\n  collectorSignals {\n    auction {\n      lotWatcherCount\n    }\n  }\n  ...ArtworkActionsWatchLotButton_artwork\n}\n\nfragment ArtworkActionsWatchLotButton_artwork on Artwork {\n  sale {\n    isLiveOpen\n    isRegistrationClosed\n    liveStartAt\n    registrationStatus {\n      qualifiedForBidding\n      id\n    }\n    id\n  }\n  ...ArtworkAuctionRegistrationPanel_artwork\n}\n\nfragment ArtworkActions_artwork_FOvjt on Artwork {\n  ...ArtworkActionsSaveButton_artwork\n  ...ArtworkDownloadButton_artwork\n  ...ArtworkSharePanel_artwork_FOvjt\n  ...ViewInRoom_artwork\n  isUnlisted\n  slug\n  downloadableImageUrl\n  isDownloadable\n  isHangable\n  partner {\n    slug\n    id\n  }\n}\n\nfragment ArtworkApp_artworkResult_45HfMx on ArtworkResult {\n  __isArtworkResult: __typename\n  __typename\n  ...ArtworkApp_artwork_45HfMx\n  ...ArtworkErrorApp_artworkError\n}\n\nfragment ArtworkApp_artwork_45HfMx on Artwork {\n  ...ArtworkMeta_artwork\n  ...ArtworkTopContextBar_artwork\n  ...ArtworkImageBrowser_artwork\n  ...ArtworkSidebar_artwork @include(if: $loadSidebar)\n  ...ArtworkAuctionCreateAlertHeader_artwork\n  ...PrivateArtworkDetails_artwork\n  ...ArtworkPageBanner_artwork\n  attributionClass {\n    internalID\n    id\n  }\n  slug\n  internalID\n  isAcquireable\n  isOfferable\n  published\n  availability\n  mediumType {\n    filterGene {\n      slug\n      id\n    }\n  }\n  visibilityLevel\n  isUnlisted\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  partner {\n    __typename\n    id\n  }\n  isInAuction\n  sale {\n    internalID\n    slug\n    extendedBiddingIntervalMinutes\n    id\n  }\n  saleMessage\n  artists(shallow: true) {\n    id\n    internalID\n    slug\n  }\n}\n\nfragment ArtworkApp_me_3Rs6v7 on Me {\n  ...ArtworkSidebar_me_2R6IMa @include(if: $loadSidebar)\n  ...ArtworkPageBanner_me_2R6IMa\n}\n\nfragment ArtworkAuctionCreateAlertHeader_artwork on Artwork {\n  slug\n  internalID\n  title\n  isEligibleToCreateAlert\n  isInAuction\n  artistNames\n  artists(shallow: true) {\n    internalID\n    name\n    slug\n    id\n  }\n  sale {\n    startAt\n    isClosed\n    id\n  }\n  saleArtwork {\n    extendedBiddingEndAt\n    endAt\n    endedAt\n    id\n  }\n  attributionClass {\n    internalID\n    id\n  }\n  mediumType {\n    filterGene {\n      slug\n      name\n      id\n    }\n  }\n  myLotStandingManageAlerts: myLotStanding {\n    isHighestBidder\n  }\n}\n\nfragment ArtworkAuctionRegistrationPanel_artwork on Artwork {\n  sale {\n    slug\n    registrationEndsAt\n    isRegistrationClosed\n    id\n  }\n}\n\nfragment ArtworkChatBubble_artwork on Artwork {\n  isAcquireable\n  isInquireable\n  isOfferable\n  isInAuction\n  listPrice {\n    __typename\n    ... on Money {\n      currencyCode\n      major\n    }\n    ... on PriceRange {\n      maxPrice {\n        currencyCode\n        major\n      }\n    }\n  }\n  saleArtwork {\n    currency\n    openingBid {\n      cents\n    }\n    id\n  }\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  category\n  series\n  publisher\n  manufacturer\n  image_rights: imageRights\n  canRequestLotConditionsReport\n  internalID\n  isUnlisted\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n  mediumType {\n    __typename\n  }\n  dimensions {\n    in\n    cm\n  }\n  attributionClass {\n    name\n    id\n  }\n  medium\n  ...ArtworkDetailsMediumModal_artwork\n}\n\nfragment ArtworkDetailsMediumModal_artwork on Artwork {\n  mediumType {\n    name\n    longDescription\n  }\n}\n\nfragment ArtworkDownloadButton_artwork on Artwork {\n  title\n  date\n  downloadableImageUrl\n  artists(shallow: true) {\n    name\n    id\n  }\n}\n\nfragment ArtworkErrorApp_artworkError on ArtworkError {\n  artwork {\n    slug\n    id\n  }\n  requestError {\n    statusCode\n  }\n}\n\nfragment ArtworkImageBrowserLarge_artwork_FOvjt on Artwork {\n  ...ArtworkLightbox_artwork_FOvjt\n  ...ArtworkVideoPlayer_artwork_FOvjt\n  isSetVideoAsCover\n  figures(includeAll: false) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      __typename\n      internalID\n      isZoomable\n    }\n    ... on Video {\n      __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowserSmall_artwork_FOvjt on Artwork {\n  ...ArtworkLightbox_artwork_FOvjt\n  ...ArtworkVideoPlayer_artwork_FOvjt\n  isSetVideoAsCover\n  figures(includeAll: false) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      internalID\n      isZoomable\n      type: __typename\n    }\n    ... on Video {\n      type: __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowser_artwork on Artwork {\n  ...ArtworkActions_artwork_FOvjt\n  ...ArtworkImageBrowserSmall_artwork_FOvjt\n  ...ArtworkImageBrowserLarge_artwork_FOvjt\n  internalID\n  figures(includeAll: false) {\n    __typename\n    ... on Image {\n      isDefault\n      width\n      height\n    }\n    ... on Video {\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment ArtworkLightbox_artwork_FOvjt on Artwork {\n  formattedMetadata\n  images(includeAll: false) {\n    internalID\n    isDefault\n    placeholder: url(version: [\"small\", \"medium\"])\n    blurhashDataURL(width: 801)\n    fallback: cropped(quality: 80, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    resized(quality: 80, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    mobileLightboxSource: resized(quality: 50, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    versions\n  }\n}\n\nfragment ArtworkMeta_artwork on Artwork {\n  ...SeoDataForArtwork_artwork\n  ...ArtworkChatBubble_artwork\n  href\n  internalID\n  isShareable\n  isUnlisted\n  metaImage: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n    longDescription: description(limit: 200)\n  }\n}\n\nfragment ArtworkPageBanner_artwork on Artwork {\n  published\n  visibilityLevel\n  isPurchasable\n  sale {\n    __typename\n    ...CascadingEndTimesBanner_sale\n    id\n  }\n}\n\nfragment ArtworkPageBanner_me_2R6IMa on Me {\n  partnerOffersConnection(artworkID: $artworkID, first: 1) {\n    edges {\n      node {\n        internalID\n        isActive\n        id\n      }\n    }\n  }\n}\n\nfragment ArtworkSharePanel_artwork_FOvjt on Artwork {\n  href\n  images(includeAll: false) {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  culturalMaker\n  artists(shallow: true) {\n    slug\n    name\n    id\n  }\n}\n\nfragment ArtworkSidebarArtsyGuarantee_artwork on Artwork {\n  isUnlisted\n}\n\nfragment ArtworkSidebarArtworkTitle_artwork on Artwork {\n  date\n  title\n}\n\nfragment ArtworkSidebarAuctionInfoPolling_artwork on Artwork {\n  internalID\n  sale {\n    isClosed\n    id\n  }\n  saleArtwork {\n    currentBid {\n      display\n    }\n    id\n  }\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n}\n\nfragment ArtworkSidebarAuctionInfoPolling_me on Me {\n  ...ArtworkSidebarBidAction_me\n}\n\nfragment ArtworkSidebarAuctionTimer_artwork on Artwork {\n  internalID\n  sale {\n    cascadingEndTimeIntervalMinutes\n    isClosed\n    ...AuctionTimer_sale\n    startAt\n    id\n  }\n  saleArtwork {\n    ...LotTimer_saleArtwork\n    endAt\n    endedAt\n    id\n  }\n}\n\nfragment ArtworkSidebarAuthenticityCertificate_artwork on Artwork {\n  hasCertificateOfAuthenticity\n  isBiddable\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        cents\n      }\n      id\n    }\n  }\n  slug\n  internalID\n  sale {\n    slug\n    registrationStatus {\n      qualified_for_bidding: qualifiedForBidding\n      id\n    }\n    is_preview: isPreview\n    is_open: isOpen\n    is_live_open: isLiveOpen\n    is_closed: isClosed\n    is_registration_closed: isRegistrationClosed\n    requireIdentityVerification\n    id\n  }\n  sale_artwork: saleArtwork {\n    increments {\n      cents\n      display\n    }\n    endedAt\n    id\n  }\n  collectorSignals {\n    auction {\n      bidCount\n      lotWatcherCount\n    }\n  }\n}\n\nfragment ArtworkSidebarBidAction_me on Me {\n  isIdentityVerified\n  pendingIdentityVerification {\n    internalID\n    id\n  }\n}\n\nfragment ArtworkSidebarBiddingClosedMessage_artwork on Artwork {\n  isEligibleToCreateAlert\n  artists(shallow: true) {\n    internalID\n    id\n  }\n  attributionClass {\n    internalID\n    id\n  }\n  mediumType {\n    filterGene {\n      slug\n      id\n    }\n  }\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attributionClass {\n    shortArrayDescription\n    id\n  }\n}\n\nfragment ArtworkSidebarCollectorSignal_artwork on Artwork {\n  collectorSignals {\n    primaryLabel(ignore: [PARTNER_OFFER])\n    runningShow {\n      name\n      href\n      startAt\n      endAt\n      id\n    }\n  }\n}\n\nfragment ArtworkSidebarCommercialButtons_artwork on Artwork {\n  ...ArtworkSidebarEditionSets_artwork\n  isEligibleToCreateAlert\n  artists(shallow: true) {\n    internalID\n    id\n  }\n  attributionClass {\n    internalID\n    id\n  }\n  internalID\n  slug\n  saleMessage\n  isInquireable\n  isAcquireable\n  isOfferable\n  isSold\n  priceListedDisplay\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  mediumType {\n    filterGene {\n      slug\n      id\n    }\n  }\n  editionSets {\n    id\n    internalID\n    isAcquireable\n    isOfferable\n    saleMessage\n    dimensions {\n      in\n      cm\n    }\n  }\n  partner {\n    profile {\n      icon {\n        url(version: \"square140\")\n      }\n      id\n    }\n    id\n  }\n  collectorSignals {\n    partnerOffer {\n      endAt\n      id\n    }\n    increasedInterest\n    curatorsPick\n  }\n}\n\nfragment ArtworkSidebarCommercialButtons_me_2R6IMa on Me {\n  partnerOffersConnection(artworkID: $artworkID, first: 1) {\n    edges {\n      node {\n        endAt\n        internalID\n        isAvailable\n        note\n        priceWithDiscount {\n          display\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ArtworkSidebarCreateAlert_artwork on Artwork {\n  isEligibleToCreateAlert\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  sale {\n    is_closed: isClosed\n    is_live_open: isLiveOpen\n    internalID\n    is_with_buyers_premium: isWithBuyersPremium\n    id\n  }\n  sale_artwork: saleArtwork {\n    is_with_reserve: isWithReserve\n    reserve_message: reserveMessage\n    reserve_status: reserveStatus\n    endedAt\n    current_bid: currentBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n  myLotStanding(live: true) {\n    active_bid: activeBid {\n      is_winning: isWinning\n      id\n    }\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        display\n      }\n      id\n    }\n  }\n  collectorSignals {\n    auction {\n      lotWatcherCount\n    }\n  }\n  ...ArtworkSidebarBiddingClosedMessage_artwork\n}\n\nfragment ArtworkSidebarDetails_artwork on Artwork {\n  isUnlisted\n  medium\n  dimensions {\n    in\n    cm\n  }\n  framed {\n    details\n  }\n  editionOf\n  isEdition\n  editionSets {\n    internalID\n    id\n  }\n  ...ArtworkSidebarClassification_artwork\n  ...ArtworkSidebarAuthenticityCertificate_artwork\n  ...ArtworkSidebarCollectorSignal_artwork\n}\n\nfragment ArtworkSidebarEditionSets_artwork on Artwork {\n  isInquireable\n  isOfferable\n  isAcquireable\n  editionSets {\n    id\n    internalID\n    isOfferable\n    isAcquireable\n    saleMessage\n    dimensions {\n      cm\n      in\n    }\n    ...ArtworkSidebarSizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebarEstimatedValue_artwork on Artwork {\n  saleArtwork {\n    estimate\n    id\n  }\n  sale {\n    isClosed\n    id\n  }\n}\n\nfragment ArtworkSidebarLinks_artwork on Artwork {\n  isInAuction\n  isUnlisted\n  sale {\n    isClosed\n    id\n  }\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  internalID\n  slug\n  isInquireable\n  isUnlisted\n  partner {\n    name\n    href\n    cities\n    isInquireable\n    id\n  }\n  sale {\n    name\n    href\n    id\n  }\n  collectorSignals {\n    partnerOffer {\n      endAt\n      id\n    }\n    increasedInterest\n    curatorsPick\n  }\n}\n\nfragment ArtworkSidebarPrivateArtwork_artwork on Artwork {\n  partner {\n    name\n    slug\n    profile {\n      isPubliclyVisible\n      id\n    }\n    id\n  }\n  isUnlisted\n  additionalInformation\n}\n\nfragment ArtworkSidebarShippingInformation_artwork on Artwork {\n  isUnlisted\n  priceIncludesTaxDisplay\n  shippingOrigin\n  shippingInfo\n  pickupAvailable\n  taxInfo {\n    displayText\n    moreInfo {\n      displayText\n      url\n    }\n  }\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  __isSellable: __typename\n  dimensions {\n    in\n    cm\n  }\n  editionOf\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  ...ArtworkSidebarArtworkTitle_artwork\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarDetails_artwork\n  ...ArtworkSidebarCommercialButtons_artwork\n  ...ArtworkSidebarShippingInformation_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarCreateAlert_artwork\n  ...ArtworkSidebarLinks_artwork\n  ...ArtworkSidebarEstimatedValue_artwork\n  ...ArtworkSidebarBiddingClosedMessage_artwork\n  ...ArtworkSidebarAuctionTimer_artwork\n  ...ArtworkSidebarAuctionInfoPolling_artwork\n  ...ArtworkSidebarPrivateArtwork_artwork\n  ...ArtworkSidebarArtsyGuarantee_artwork\n  ...PrivateArtworkAdditionalInfo_artwork\n  ...ArtsyShippingEstimate_artwork\n  artists(shallow: true) {\n    internalID\n    id\n  }\n  artsyShippingDomestic\n  artsyShippingInternational\n  editionSets {\n    internalID\n    id\n  }\n  internationalShippingFee {\n    major\n  }\n  isAcquireable\n  isBiddable\n  isEdition\n  isEligibleForArtsyGuarantee\n  isEligibleToCreateAlert\n  isInAuction\n  isOfferable\n  isSold\n  isUnlisted\n  partner {\n    internalID\n    id\n  }\n  sale {\n    endAt\n    startAt\n    isClosed\n    isAuction\n    id\n  }\n  saleArtwork {\n    lotID\n    lotLabel\n    extendedBiddingEndAt\n    endAt\n    endedAt\n    id\n  }\n  saleMessage\n  shippingWeight\n  shippingWeightMetric\n  slug\n}\n\nfragment ArtworkSidebar_me_2R6IMa on Me {\n  ...ArtworkSidebarAuctionInfoPolling_me\n  ...ArtworkSidebarCommercialButtons_me_2R6IMa\n}\n\nfragment ArtworkTopContextBarBreadcrumb_artwork on Artwork {\n  internalID\n  href\n  title\n  artist {\n    name\n    href\n    id\n  }\n}\n\nfragment ArtworkTopContextBar_artwork on Artwork {\n  ...ArtworkTopContextBarBreadcrumb_artwork\n  internalID\n}\n\nfragment ArtworkVideoPlayer_artwork_FOvjt on Artwork {\n  internalID\n  slug\n  figures(includeAll: false) {\n    __typename\n    ... on Video {\n      __typename\n      playerUrl\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment AuctionTimer_sale on Sale {\n  liveStartAt\n  endAt\n}\n\nfragment CascadingEndTimesBanner_sale on Sale {\n  isClosed\n  cascadingEndTimeIntervalMinutes\n  extendedBiddingIntervalMinutes\n}\n\nfragment DeepZoom_image on Image {\n  deepZoom {\n    Image {\n      xmlns\n      Url\n      Format\n      TileSize\n      Overlap\n      Size {\n        Width\n        Height\n      }\n    }\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  slug\n  name\n  internalID\n  counts {\n    follows\n  }\n}\n\nfragment LotTimer_saleArtwork on SaleArtwork {\n  endAt\n  formattedStartDateTime\n  extendedBiddingEndAt\n  lotID\n  sale {\n    startAt\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    internalID\n    id\n  }\n}\n\nfragment PrivateArtworkAboutArtist_artwork on Artwork {\n  displayArtistBio\n  slug\n  artists(shallow: true) {\n    ...FollowArtistButton_artist\n    internalID\n    href\n    slug\n    name\n    initials\n    formattedNationalityAndBirthday\n    counts {\n      follows\n    }\n    coverArtwork {\n      image {\n        cropped(width: 145, height: 145) {\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    biographyBlurb(format: HTML, partnerBio: false) {\n      text\n    }\n    id\n  }\n}\n\nfragment PrivateArtworkAboutWork_artwork on Artwork {\n  additionalInformationHTML: additionalInformation(format: HTML)\n}\n\nfragment PrivateArtworkAdditionalInfo_artwork on Artwork {\n  category\n  series\n  publisher\n  manufacturer\n  image_rights: imageRights\n  canRequestLotConditionsReport\n  internalID\n  isUnlisted\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n  mediumType {\n    __typename\n  }\n  dimensions {\n    in\n    cm\n  }\n  attributionClass {\n    name\n    id\n  }\n  medium\n  ...ArtworkDetailsMediumModal_artwork\n}\n\nfragment PrivateArtworkDetails_artwork on Artwork {\n  ...PrivateArtworkAboutWork_artwork\n  ...PrivateArtworkAboutArtist_artwork\n  ...PrivateArtworkMetadata_artwork\n}\n\nfragment PrivateArtworkMetadata_artwork on Artwork {\n  ...ArtworkDetailsAdditionalInfo_artwork\n  conditionDescription {\n    details\n  }\n  provenance(format: HTML)\n  exhibitionHistory(format: HTML)\n}\n\nfragment SeoDataForArtwork_artwork on Artwork {\n  href\n  date\n  is_price_hidden: isPriceHidden\n  is_price_range: isPriceRange\n  listPrice {\n    __typename\n    ... on PriceRange {\n      minPrice {\n        major\n        currencyCode\n      }\n      maxPrice {\n        major\n      }\n    }\n    ... on Money {\n      major\n      currencyCode\n    }\n  }\n  meta_image: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n  }\n  partner {\n    name\n    type\n    profile {\n      image {\n        resized(width: 320, height: 320, version: [\"medium\"]) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n  artistNames\n  availability\n  category\n  dimensions {\n    in\n  }\n}\n\nfragment ViewInRoomArtwork_artwork on Artwork {\n  widthCm\n  heightCm\n  image {\n    resized(width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ViewInRoom_artwork on Artwork {\n  ...ViewInRoomArtwork_artwork\n}\n"
+    "text": "query artworkRoutes_ArtworkQuery(\n  $artworkID: String!\n  $loadSidebar: Boolean!\n) {\n  artworkResult(id: $artworkID) {\n    __typename\n    ...ArtworkApp_artworkResult_45HfMx\n    ... on ArtworkError {\n      requestError {\n        statusCode\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  me {\n    ...ArtworkApp_me_3Rs6v7\n    id\n  }\n}\n\nfragment ArtsyShippingEstimate_artwork on Artwork {\n  depthCm\n  diameterCm\n  framedHeight\n  framedWidth\n  framedDepth\n  framedDiameter\n  framedMetric\n  heightCm\n  isFramed\n  listPrice {\n    __typename\n    ... on Money {\n      major\n    }\n    ... on PriceRange {\n      maxPrice {\n        major\n      }\n      minPrice {\n        major\n      }\n    }\n  }\n  mediumType {\n    name\n  }\n  priceCurrency\n  shippingOrigin\n  shippingWeight\n  shippingWeightMetric\n  widthCm\n}\n\nfragment ArtworkActionsSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isInAuction\n  isSavedToAnyList\n  sale {\n    isAuction\n    isClosed\n    id\n  }\n  collectorSignals {\n    auction {\n      lotWatcherCount\n    }\n  }\n  ...ArtworkActionsWatchLotButton_artwork\n}\n\nfragment ArtworkActionsWatchLotButton_artwork on Artwork {\n  sale {\n    isLiveOpen\n    isRegistrationClosed\n    liveStartAt\n    registrationStatus {\n      qualifiedForBidding\n      id\n    }\n    id\n  }\n  ...ArtworkAuctionRegistrationPanel_artwork\n}\n\nfragment ArtworkActions_artwork_FOvjt on Artwork {\n  ...ArtworkActionsSaveButton_artwork\n  ...ArtworkDownloadButton_artwork\n  ...ArtworkSharePanel_artwork_FOvjt\n  ...ViewInRoom_artwork\n  isUnlisted\n  slug\n  downloadableImageUrl\n  isDownloadable\n  isHangable\n  partner {\n    slug\n    id\n  }\n}\n\nfragment ArtworkApp_artworkResult_45HfMx on ArtworkResult {\n  __isArtworkResult: __typename\n  __typename\n  ...ArtworkApp_artwork_45HfMx\n  ...ArtworkErrorApp_artworkError\n}\n\nfragment ArtworkApp_artwork_45HfMx on Artwork {\n  ...ArtworkMeta_artwork\n  ...ArtworkTopContextBar_artwork\n  ...ArtworkImageBrowser_artwork\n  ...ArtworkSidebar_artwork @include(if: $loadSidebar)\n  ...ArtworkAuctionCreateAlertHeader_artwork\n  ...PrivateArtworkDetails_artwork\n  ...ArtworkPageBanner_artwork\n  attributionClass {\n    internalID\n    id\n  }\n  slug\n  internalID\n  isAcquireable\n  isOfferable\n  published\n  availability\n  mediumType {\n    filterGene {\n      slug\n      id\n    }\n  }\n  visibilityLevel\n  isUnlisted\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  partner {\n    __typename\n    id\n  }\n  isInAuction\n  sale {\n    internalID\n    slug\n    extendedBiddingIntervalMinutes\n    id\n  }\n  saleMessage\n  artists(shallow: true) {\n    id\n    internalID\n    slug\n  }\n}\n\nfragment ArtworkApp_me_3Rs6v7 on Me {\n  ...ArtworkSidebar_me_2R6IMa @include(if: $loadSidebar)\n  ...ArtworkPageBanner_me_2R6IMa\n}\n\nfragment ArtworkAuctionCreateAlertHeader_artwork on Artwork {\n  slug\n  internalID\n  title\n  isEligibleToCreateAlert\n  isInAuction\n  artistNames\n  artists(shallow: true) {\n    internalID\n    name\n    slug\n    id\n  }\n  sale {\n    startAt\n    isClosed\n    id\n  }\n  saleArtwork {\n    extendedBiddingEndAt\n    endAt\n    endedAt\n    id\n  }\n  attributionClass {\n    internalID\n    id\n  }\n  mediumType {\n    filterGene {\n      slug\n      name\n      id\n    }\n  }\n  myLotStandingManageAlerts: myLotStanding {\n    isHighestBidder\n  }\n}\n\nfragment ArtworkAuctionRegistrationPanel_artwork on Artwork {\n  sale {\n    slug\n    registrationEndsAt\n    isRegistrationClosed\n    id\n  }\n}\n\nfragment ArtworkChatBubble_artwork on Artwork {\n  isAcquireable\n  isInquireable\n  isOfferable\n  isInAuction\n  listPrice {\n    __typename\n    ... on Money {\n      currencyCode\n      major\n    }\n    ... on PriceRange {\n      maxPrice {\n        currencyCode\n        major\n      }\n    }\n  }\n  saleArtwork {\n    currency\n    openingBid {\n      cents\n    }\n    id\n  }\n}\n\nfragment ArtworkDetailsAdditionalInfo_artwork on Artwork {\n  category\n  series\n  publisher\n  manufacturer\n  image_rights: imageRights\n  canRequestLotConditionsReport\n  internalID\n  isUnlisted\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n  mediumType {\n    __typename\n  }\n  dimensions {\n    in\n    cm\n  }\n  attributionClass {\n    name\n    id\n  }\n  medium\n  ...ArtworkDetailsMediumModal_artwork\n}\n\nfragment ArtworkDetailsMediumModal_artwork on Artwork {\n  mediumType {\n    name\n    longDescription\n  }\n}\n\nfragment ArtworkDownloadButton_artwork on Artwork {\n  title\n  date\n  downloadableImageUrl\n  artists(shallow: true) {\n    name\n    id\n  }\n}\n\nfragment ArtworkErrorApp_artworkError on ArtworkError {\n  artwork {\n    slug\n    id\n  }\n  requestError {\n    statusCode\n  }\n}\n\nfragment ArtworkImageBrowserLarge_artwork_FOvjt on Artwork {\n  ...ArtworkLightbox_artwork_FOvjt\n  ...ArtworkVideoPlayer_artwork_FOvjt\n  isSetVideoAsCover\n  figures(includeAll: false) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      __typename\n      internalID\n      isZoomable\n    }\n    ... on Video {\n      __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowserSmall_artwork_FOvjt on Artwork {\n  ...ArtworkLightbox_artwork_FOvjt\n  ...ArtworkVideoPlayer_artwork_FOvjt\n  isSetVideoAsCover\n  figures(includeAll: false) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      internalID\n      isZoomable\n      type: __typename\n    }\n    ... on Video {\n      type: __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowser_artwork on Artwork {\n  ...ArtworkActions_artwork_FOvjt\n  ...ArtworkImageBrowserSmall_artwork_FOvjt\n  ...ArtworkImageBrowserLarge_artwork_FOvjt\n  internalID\n  figures(includeAll: false) {\n    __typename\n    ... on Image {\n      isDefault\n      width\n      height\n    }\n    ... on Video {\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment ArtworkLightbox_artwork_FOvjt on Artwork {\n  formattedMetadata\n  images(includeAll: false) {\n    internalID\n    isDefault\n    placeholder: url(version: [\"small\", \"medium\"])\n    blurhashDataURL(width: 801)\n    fallback: cropped(quality: 80, width: 1600, height: 1600, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n    }\n    resized(quality: 80, width: 1600, height: 1600, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n    }\n    versions\n  }\n}\n\nfragment ArtworkMeta_artwork on Artwork {\n  ...SeoDataForArtwork_artwork\n  ...ArtworkChatBubble_artwork\n  href\n  internalID\n  isShareable\n  isUnlisted\n  metaImage: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n    longDescription: description(limit: 200)\n  }\n}\n\nfragment ArtworkPageBanner_artwork on Artwork {\n  published\n  visibilityLevel\n  isPurchasable\n  sale {\n    __typename\n    ...CascadingEndTimesBanner_sale\n    id\n  }\n}\n\nfragment ArtworkPageBanner_me_2R6IMa on Me {\n  partnerOffersConnection(artworkID: $artworkID, first: 1) {\n    edges {\n      node {\n        internalID\n        isActive\n        id\n      }\n    }\n  }\n}\n\nfragment ArtworkSharePanel_artwork_FOvjt on Artwork {\n  href\n  images(includeAll: false) {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n\nfragment ArtworkSidebarArtists_artwork on Artwork {\n  culturalMaker\n  artists(shallow: true) {\n    slug\n    name\n    id\n  }\n}\n\nfragment ArtworkSidebarArtsyGuarantee_artwork on Artwork {\n  isUnlisted\n}\n\nfragment ArtworkSidebarArtworkTitle_artwork on Artwork {\n  date\n  title\n}\n\nfragment ArtworkSidebarAuctionInfoPolling_artwork on Artwork {\n  internalID\n  sale {\n    isClosed\n    id\n  }\n  saleArtwork {\n    currentBid {\n      display\n    }\n    id\n  }\n  ...ArtworkSidebarCurrentBidInfo_artwork\n  ...ArtworkSidebarBidAction_artwork\n}\n\nfragment ArtworkSidebarAuctionInfoPolling_me on Me {\n  ...ArtworkSidebarBidAction_me\n}\n\nfragment ArtworkSidebarAuctionTimer_artwork on Artwork {\n  internalID\n  sale {\n    cascadingEndTimeIntervalMinutes\n    isClosed\n    ...AuctionTimer_sale\n    startAt\n    id\n  }\n  saleArtwork {\n    ...LotTimer_saleArtwork\n    endAt\n    endedAt\n    id\n  }\n}\n\nfragment ArtworkSidebarAuthenticityCertificate_artwork on Artwork {\n  hasCertificateOfAuthenticity\n  isBiddable\n}\n\nfragment ArtworkSidebarBidAction_artwork on Artwork {\n  myLotStanding(live: true) {\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        cents\n      }\n      id\n    }\n  }\n  slug\n  internalID\n  sale {\n    slug\n    registrationStatus {\n      qualified_for_bidding: qualifiedForBidding\n      id\n    }\n    is_preview: isPreview\n    is_open: isOpen\n    is_live_open: isLiveOpen\n    is_closed: isClosed\n    is_registration_closed: isRegistrationClosed\n    requireIdentityVerification\n    id\n  }\n  sale_artwork: saleArtwork {\n    increments {\n      cents\n      display\n    }\n    endedAt\n    id\n  }\n  collectorSignals {\n    auction {\n      bidCount\n      lotWatcherCount\n    }\n  }\n}\n\nfragment ArtworkSidebarBidAction_me on Me {\n  isIdentityVerified\n  pendingIdentityVerification {\n    internalID\n    id\n  }\n}\n\nfragment ArtworkSidebarBiddingClosedMessage_artwork on Artwork {\n  isEligibleToCreateAlert\n  artists(shallow: true) {\n    internalID\n    id\n  }\n  attributionClass {\n    internalID\n    id\n  }\n  mediumType {\n    filterGene {\n      slug\n      id\n    }\n  }\n}\n\nfragment ArtworkSidebarClassification_artwork on Artwork {\n  attributionClass {\n    shortArrayDescription\n    id\n  }\n}\n\nfragment ArtworkSidebarCollectorSignal_artwork on Artwork {\n  collectorSignals {\n    primaryLabel(ignore: [PARTNER_OFFER])\n    runningShow {\n      name\n      href\n      startAt\n      endAt\n      id\n    }\n  }\n}\n\nfragment ArtworkSidebarCommercialButtons_artwork on Artwork {\n  ...ArtworkSidebarEditionSets_artwork\n  isEligibleToCreateAlert\n  artists(shallow: true) {\n    internalID\n    id\n  }\n  attributionClass {\n    internalID\n    id\n  }\n  internalID\n  slug\n  saleMessage\n  isInquireable\n  isAcquireable\n  isOfferable\n  isSold\n  priceListedDisplay\n  listPrice {\n    __typename\n    ... on PriceRange {\n      display\n    }\n    ... on Money {\n      display\n    }\n  }\n  mediumType {\n    filterGene {\n      slug\n      id\n    }\n  }\n  editionSets {\n    id\n    internalID\n    isAcquireable\n    isOfferable\n    saleMessage\n    dimensions {\n      in\n      cm\n    }\n  }\n  partner {\n    profile {\n      icon {\n        url(version: \"square140\")\n      }\n      id\n    }\n    id\n  }\n  collectorSignals {\n    partnerOffer {\n      endAt\n      id\n    }\n    increasedInterest\n    curatorsPick\n  }\n}\n\nfragment ArtworkSidebarCommercialButtons_me_2R6IMa on Me {\n  partnerOffersConnection(artworkID: $artworkID, first: 1) {\n    edges {\n      node {\n        endAt\n        internalID\n        isAvailable\n        note\n        priceWithDiscount {\n          display\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment ArtworkSidebarCreateAlert_artwork on Artwork {\n  isEligibleToCreateAlert\n}\n\nfragment ArtworkSidebarCurrentBidInfo_artwork on Artwork {\n  sale {\n    is_closed: isClosed\n    is_live_open: isLiveOpen\n    internalID\n    is_with_buyers_premium: isWithBuyersPremium\n    id\n  }\n  sale_artwork: saleArtwork {\n    is_with_reserve: isWithReserve\n    reserve_message: reserveMessage\n    reserve_status: reserveStatus\n    endedAt\n    current_bid: currentBid {\n      display\n    }\n    counts {\n      bidder_positions: bidderPositions\n    }\n    id\n  }\n  myLotStanding(live: true) {\n    active_bid: activeBid {\n      is_winning: isWinning\n      id\n    }\n    most_recent_bid: mostRecentBid {\n      max_bid: maxBid {\n        display\n      }\n      id\n    }\n  }\n  collectorSignals {\n    auction {\n      lotWatcherCount\n    }\n  }\n  ...ArtworkSidebarBiddingClosedMessage_artwork\n}\n\nfragment ArtworkSidebarDetails_artwork on Artwork {\n  isUnlisted\n  medium\n  dimensions {\n    in\n    cm\n  }\n  framed {\n    details\n  }\n  editionOf\n  isEdition\n  editionSets {\n    internalID\n    id\n  }\n  ...ArtworkSidebarClassification_artwork\n  ...ArtworkSidebarAuthenticityCertificate_artwork\n  ...ArtworkSidebarCollectorSignal_artwork\n}\n\nfragment ArtworkSidebarEditionSets_artwork on Artwork {\n  isInquireable\n  isOfferable\n  isAcquireable\n  editionSets {\n    id\n    internalID\n    isOfferable\n    isAcquireable\n    saleMessage\n    dimensions {\n      cm\n      in\n    }\n    ...ArtworkSidebarSizeInfo_piece\n  }\n}\n\nfragment ArtworkSidebarEstimatedValue_artwork on Artwork {\n  saleArtwork {\n    estimate\n    id\n  }\n  sale {\n    isClosed\n    id\n  }\n}\n\nfragment ArtworkSidebarLinks_artwork on Artwork {\n  isInAuction\n  isUnlisted\n  sale {\n    isClosed\n    id\n  }\n}\n\nfragment ArtworkSidebarPartnerInfo_artwork on Artwork {\n  internalID\n  slug\n  isInquireable\n  isUnlisted\n  partner {\n    name\n    href\n    cities\n    isInquireable\n    id\n  }\n  sale {\n    name\n    href\n    id\n  }\n  collectorSignals {\n    partnerOffer {\n      endAt\n      id\n    }\n    increasedInterest\n    curatorsPick\n  }\n}\n\nfragment ArtworkSidebarPrivateArtwork_artwork on Artwork {\n  partner {\n    name\n    slug\n    profile {\n      isPubliclyVisible\n      id\n    }\n    id\n  }\n  isUnlisted\n  additionalInformation\n}\n\nfragment ArtworkSidebarShippingInformation_artwork on Artwork {\n  isUnlisted\n  priceIncludesTaxDisplay\n  shippingOrigin\n  shippingInfo\n  pickupAvailable\n  taxInfo {\n    displayText\n    moreInfo {\n      displayText\n      url\n    }\n  }\n}\n\nfragment ArtworkSidebarSizeInfo_piece on Sellable {\n  __isSellable: __typename\n  dimensions {\n    in\n    cm\n  }\n  editionOf\n}\n\nfragment ArtworkSidebar_artwork on Artwork {\n  ...ArtworkSidebarArtworkTitle_artwork\n  ...ArtworkSidebarArtists_artwork\n  ...ArtworkSidebarDetails_artwork\n  ...ArtworkSidebarCommercialButtons_artwork\n  ...ArtworkSidebarShippingInformation_artwork\n  ...ArtworkSidebarPartnerInfo_artwork\n  ...ArtworkSidebarCreateAlert_artwork\n  ...ArtworkSidebarLinks_artwork\n  ...ArtworkSidebarEstimatedValue_artwork\n  ...ArtworkSidebarBiddingClosedMessage_artwork\n  ...ArtworkSidebarAuctionTimer_artwork\n  ...ArtworkSidebarAuctionInfoPolling_artwork\n  ...ArtworkSidebarPrivateArtwork_artwork\n  ...ArtworkSidebarArtsyGuarantee_artwork\n  ...PrivateArtworkAdditionalInfo_artwork\n  ...ArtsyShippingEstimate_artwork\n  artists(shallow: true) {\n    internalID\n    id\n  }\n  artsyShippingDomestic\n  artsyShippingInternational\n  editionSets {\n    internalID\n    id\n  }\n  internationalShippingFee {\n    major\n  }\n  isAcquireable\n  isBiddable\n  isEdition\n  isEligibleForArtsyGuarantee\n  isEligibleToCreateAlert\n  isInAuction\n  isOfferable\n  isSold\n  isUnlisted\n  partner {\n    internalID\n    id\n  }\n  sale {\n    endAt\n    startAt\n    isClosed\n    isAuction\n    id\n  }\n  saleArtwork {\n    lotID\n    lotLabel\n    extendedBiddingEndAt\n    endAt\n    endedAt\n    id\n  }\n  saleMessage\n  shippingWeight\n  shippingWeightMetric\n  slug\n}\n\nfragment ArtworkSidebar_me_2R6IMa on Me {\n  ...ArtworkSidebarAuctionInfoPolling_me\n  ...ArtworkSidebarCommercialButtons_me_2R6IMa\n}\n\nfragment ArtworkTopContextBarBreadcrumb_artwork on Artwork {\n  internalID\n  href\n  title\n  artist {\n    name\n    href\n    id\n  }\n}\n\nfragment ArtworkTopContextBar_artwork on Artwork {\n  ...ArtworkTopContextBarBreadcrumb_artwork\n  internalID\n}\n\nfragment ArtworkVideoPlayer_artwork_FOvjt on Artwork {\n  internalID\n  slug\n  figures(includeAll: false) {\n    __typename\n    ... on Video {\n      __typename\n      playerUrl\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment AuctionTimer_sale on Sale {\n  liveStartAt\n  endAt\n}\n\nfragment CascadingEndTimesBanner_sale on Sale {\n  isClosed\n  cascadingEndTimeIntervalMinutes\n  extendedBiddingIntervalMinutes\n}\n\nfragment DeepZoom_image on Image {\n  deepZoom {\n    Image {\n      xmlns\n      Url\n      Format\n      TileSize\n      Overlap\n      Size {\n        Width\n        Height\n      }\n    }\n  }\n}\n\nfragment FollowArtistButton_artist on Artist {\n  id\n  slug\n  name\n  internalID\n  counts {\n    follows\n  }\n}\n\nfragment LotTimer_saleArtwork on SaleArtwork {\n  endAt\n  formattedStartDateTime\n  extendedBiddingEndAt\n  lotID\n  sale {\n    startAt\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    internalID\n    id\n  }\n}\n\nfragment PrivateArtworkAboutArtist_artwork on Artwork {\n  displayArtistBio\n  slug\n  artists(shallow: true) {\n    ...FollowArtistButton_artist\n    internalID\n    href\n    slug\n    name\n    initials\n    formattedNationalityAndBirthday\n    counts {\n      follows\n    }\n    coverArtwork {\n      image {\n        cropped(width: 145, height: 145) {\n          src\n          srcSet\n        }\n      }\n      id\n    }\n    biographyBlurb(format: HTML, partnerBio: false) {\n      text\n    }\n    id\n  }\n}\n\nfragment PrivateArtworkAboutWork_artwork on Artwork {\n  additionalInformationHTML: additionalInformation(format: HTML)\n}\n\nfragment PrivateArtworkAdditionalInfo_artwork on Artwork {\n  category\n  series\n  publisher\n  manufacturer\n  image_rights: imageRights\n  canRequestLotConditionsReport\n  internalID\n  isUnlisted\n  framed {\n    label\n    details\n  }\n  signatureInfo {\n    label\n    details\n  }\n  conditionDescription {\n    label\n    details\n  }\n  certificateOfAuthenticity {\n    label\n    details\n  }\n  mediumType {\n    __typename\n  }\n  dimensions {\n    in\n    cm\n  }\n  attributionClass {\n    name\n    id\n  }\n  medium\n  ...ArtworkDetailsMediumModal_artwork\n}\n\nfragment PrivateArtworkDetails_artwork on Artwork {\n  ...PrivateArtworkAboutWork_artwork\n  ...PrivateArtworkAboutArtist_artwork\n  ...PrivateArtworkMetadata_artwork\n}\n\nfragment PrivateArtworkMetadata_artwork on Artwork {\n  ...ArtworkDetailsAdditionalInfo_artwork\n  conditionDescription {\n    details\n  }\n  provenance(format: HTML)\n  exhibitionHistory(format: HTML)\n}\n\nfragment SeoDataForArtwork_artwork on Artwork {\n  href\n  date\n  is_price_hidden: isPriceHidden\n  is_price_range: isPriceRange\n  listPrice {\n    __typename\n    ... on PriceRange {\n      minPrice {\n        major\n        currencyCode\n      }\n      maxPrice {\n        major\n      }\n    }\n    ... on Money {\n      major\n      currencyCode\n    }\n  }\n  meta_image: image {\n    resized(width: 640, height: 640, version: [\"large\", \"medium\", \"tall\"]) {\n      width\n      height\n      url\n    }\n  }\n  meta {\n    title\n    description(limit: 155)\n  }\n  partner {\n    name\n    type\n    profile {\n      image {\n        resized(width: 320, height: 320, version: [\"medium\"]) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n  artistNames\n  availability\n  category\n  dimensions {\n    in\n  }\n}\n\nfragment ViewInRoomArtwork_artwork on Artwork {\n  widthCm\n  heightCm\n  image {\n    resized(width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ViewInRoom_artwork on Artwork {\n  ...ViewInRoomArtwork_artwork\n}\n"
   }
 };
 })();

--- a/src/__generated__/collectorProfileRoutes_ArtworkQuery.graphql.ts
+++ b/src/__generated__/collectorProfileRoutes_ArtworkQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<cbb921a1af69f6518ce1806a7a7628ea>>
+ * @generated SignedSource<<8b902ba6897fe802b8071ec472daedb9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -175,30 +175,29 @@ v21 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "srcSet",
+  "name": "width",
   "storageKey": null
 },
 v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "width",
-  "storageKey": null
-},
-v23 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "height",
   "storageKey": null
 },
-v24 = [
+v23 = [
   (v20/*: any*/),
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "srcSet",
+    "storageKey": null
+  },
   (v21/*: any*/),
-  (v22/*: any*/),
-  (v23/*: any*/)
+  (v22/*: any*/)
 ],
-v25 = {
+v24 = {
   "alias": null,
   "args": null,
   "concreteType": "AuctionLotImages",
@@ -239,7 +238,7 @@ v25 = {
           "kind": "LinkedField",
           "name": "cropped",
           "plural": false,
-          "selections": (v24/*: any*/),
+          "selections": (v23/*: any*/),
           "storageKey": "cropped(height:130,version:[\"square140\"],width:130)"
         }
       ],
@@ -248,56 +247,56 @@ v25 = {
   ],
   "storageKey": null
 },
-v26 = {
+v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "mediumText",
   "storageKey": null
 },
-v27 = {
+v26 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "categoryText",
   "storageKey": null
 },
-v28 = {
+v27 = {
   "alias": "date_text",
   "args": null,
   "kind": "ScalarField",
   "name": "dateText",
   "storageKey": null
 },
-v29 = {
+v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "saleDate",
   "storageKey": null
 },
-v30 = {
+v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "boughtIn",
   "storageKey": null
 },
-v31 = {
+v30 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "currency",
   "storageKey": null
 },
-v32 = {
+v31 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "display",
   "storageKey": null
 },
-v33 = {
+v32 = {
   "alias": "price_realized",
   "args": null,
   "concreteType": "AuctionResultPriceRealized",
@@ -305,7 +304,7 @@ v33 = {
   "name": "priceRealized",
   "plural": false,
   "selections": [
-    (v32/*: any*/),
+    (v31/*: any*/),
     {
       "alias": "display_usd",
       "args": null,
@@ -323,7 +322,7 @@ v33 = {
   ],
   "storageKey": null
 },
-v34 = {
+v33 = {
   "alias": null,
   "args": null,
   "concreteType": "AuctionLotPerformance",
@@ -341,74 +340,69 @@ v34 = {
   ],
   "storageKey": null
 },
-v35 = [
-  (v32/*: any*/)
+v34 = [
+  (v31/*: any*/)
 ],
-v36 = {
+v35 = {
   "alias": null,
   "args": null,
   "concreteType": "AuctionLotEstimate",
   "kind": "LinkedField",
   "name": "estimate",
   "plural": false,
-  "selections": (v35/*: any*/),
+  "selections": (v34/*: any*/),
   "storageKey": null
 },
-v37 = {
+v36 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "location",
   "storageKey": null
 },
-v38 = {
+v37 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotNumber",
   "storageKey": null
 },
-v39 = {
+v38 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "saleTitle",
   "storageKey": null
 },
-v40 = {
+v39 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isUpcoming",
   "storageKey": null
 },
-v41 = {
+v40 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "state",
   "storageKey": null
 },
-v42 = [
+v41 = [
   {
     "kind": "Literal",
     "name": "includeAll",
     "value": true
   }
 ],
-v43 = {
+v42 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isDefault",
   "storageKey": null
 },
-v44 = {
-  "kind": "Literal",
-  "name": "height",
-  "value": 800
-},
-v45 = {
+v43 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -418,28 +412,30 @@ v45 = {
     "large"
   ]
 },
-v46 = {
-  "kind": "Literal",
-  "name": "width",
-  "value": 800
-},
-v47 = [
-  (v44/*: any*/),
+v44 = [
+  {
+    "kind": "Literal",
+    "name": "height",
+    "value": 1600
+  },
   {
     "kind": "Literal",
     "name": "quality",
     "value": 80
   },
-  (v45/*: any*/),
-  (v46/*: any*/)
+  (v43/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "width",
+    "value": 1600
+  }
 ],
-v48 = [
+v45 = [
+  (v21/*: any*/),
   (v22/*: any*/),
-  (v23/*: any*/),
-  (v20/*: any*/),
-  (v21/*: any*/)
+  (v20/*: any*/)
 ],
-v49 = {
+v46 = {
   "alias": "type",
   "args": null,
   "kind": "ScalarField",
@@ -654,20 +650,20 @@ return {
                           (v16/*: any*/),
                           (v17/*: any*/),
                           (v19/*: any*/),
+                          (v24/*: any*/),
                           (v25/*: any*/),
                           (v26/*: any*/),
                           (v27/*: any*/),
                           (v28/*: any*/),
                           (v29/*: any*/),
                           (v30/*: any*/),
-                          (v31/*: any*/),
+                          (v32/*: any*/),
                           (v33/*: any*/),
-                          (v34/*: any*/),
+                          (v35/*: any*/),
                           (v36/*: any*/),
                           (v37/*: any*/),
                           (v38/*: any*/),
                           (v39/*: any*/),
-                          (v40/*: any*/),
                           (v7/*: any*/)
                         ],
                         "storageKey": null
@@ -789,7 +785,7 @@ return {
             "kind": "LinkedField",
             "name": "pricePaid",
             "plural": false,
-            "selections": (v35/*: any*/),
+            "selections": (v34/*: any*/),
             "storageKey": null
           },
           {
@@ -807,7 +803,7 @@ return {
                 "name": "city",
                 "storageKey": null
               },
-              (v41/*: any*/),
+              (v40/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -880,20 +876,20 @@ return {
                       (v16/*: any*/),
                       (v17/*: any*/),
                       (v19/*: any*/),
+                      (v24/*: any*/),
                       (v25/*: any*/),
                       (v26/*: any*/),
                       (v27/*: any*/),
                       (v28/*: any*/),
                       (v29/*: any*/),
                       (v30/*: any*/),
-                      (v31/*: any*/),
+                      (v32/*: any*/),
                       (v33/*: any*/),
-                      (v34/*: any*/),
+                      (v35/*: any*/),
                       (v36/*: any*/),
                       (v37/*: any*/),
                       (v38/*: any*/),
                       (v39/*: any*/),
-                      (v40/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1133,7 +1129,7 @@ return {
           (v6/*: any*/),
           {
             "alias": null,
-            "args": (v42/*: any*/),
+            "args": (v41/*: any*/),
             "concreteType": "Image",
             "kind": "LinkedField",
             "name": "images",
@@ -1147,7 +1143,7 @@ return {
                 "storageKey": null
               },
               (v2/*: any*/),
-              (v43/*: any*/),
+              (v42/*: any*/),
               {
                 "alias": "placeholder",
                 "args": [
@@ -1179,42 +1175,23 @@ return {
               },
               {
                 "alias": "fallback",
-                "args": (v47/*: any*/),
+                "args": (v44/*: any*/),
                 "concreteType": "CroppedImageUrl",
                 "kind": "LinkedField",
                 "name": "cropped",
                 "plural": false,
-                "selections": (v48/*: any*/),
-                "storageKey": "cropped(height:800,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
+                "selections": (v45/*: any*/),
+                "storageKey": "cropped(height:1600,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:1600)"
               },
               {
                 "alias": null,
-                "args": (v47/*: any*/),
+                "args": (v44/*: any*/),
                 "concreteType": "ResizedImageUrl",
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v48/*: any*/),
-                "storageKey": "resized(height:800,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
-              },
-              {
-                "alias": "mobileLightboxSource",
-                "args": [
-                  (v44/*: any*/),
-                  {
-                    "kind": "Literal",
-                    "name": "quality",
-                    "value": 50
-                  },
-                  (v45/*: any*/),
-                  (v46/*: any*/)
-                ],
-                "concreteType": "ResizedImageUrl",
-                "kind": "LinkedField",
-                "name": "resized",
-                "plural": false,
-                "selections": (v48/*: any*/),
-                "storageKey": "resized(height:800,quality:50,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
+                "selections": (v45/*: any*/),
+                "storageKey": "resized(height:1600,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:1600)"
               },
               {
                 "alias": null,
@@ -1269,15 +1246,23 @@ return {
               {
                 "alias": null,
                 "args": [
-                  (v44/*: any*/),
-                  (v45/*: any*/),
-                  (v46/*: any*/)
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 800
+                  },
+                  (v43/*: any*/),
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 800
+                  }
                 ],
                 "concreteType": "ResizedImageUrl",
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v24/*: any*/),
+                "selections": (v23/*: any*/),
                 "storageKey": "resized(height:800,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
               }
             ],
@@ -1326,7 +1311,7 @@ return {
           },
           {
             "alias": null,
-            "args": (v42/*: any*/),
+            "args": (v41/*: any*/),
             "concreteType": null,
             "kind": "LinkedField",
             "name": "figures",
@@ -1364,7 +1349,7 @@ return {
                     "storageKey": null
                   },
                   (v7/*: any*/),
-                  (v49/*: any*/)
+                  (v46/*: any*/)
                 ],
                 "type": "Video",
                 "abstractKey": null
@@ -1462,10 +1447,10 @@ return {
                     "name": "isZoomable",
                     "storageKey": null
                   },
-                  (v49/*: any*/),
-                  (v43/*: any*/),
-                  (v22/*: any*/),
-                  (v23/*: any*/)
+                  (v46/*: any*/),
+                  (v42/*: any*/),
+                  (v21/*: any*/),
+                  (v22/*: any*/)
                 ],
                 "type": "Image",
                 "abstractKey": null
@@ -1489,7 +1474,7 @@ return {
             "plural": false,
             "selections": [
               (v2/*: any*/),
-              (v41/*: any*/)
+              (v40/*: any*/)
             ],
             "storageKey": null
           },
@@ -1523,12 +1508,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c71a55f994c4995346e4ad2e3f84c7b6",
+    "cacheID": "3ac5b1785a8754b14009669f3fb00067",
     "id": null,
     "metadata": {},
     "name": "collectorProfileRoutes_ArtworkQuery",
     "operationKind": "query",
-    "text": "query collectorProfileRoutes_ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) @principalField {\n    ...MyCollectionArtwork_artwork\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  internalID\n  title\n  dimension_text: dimensionText\n  organization\n  artist {\n    name\n    id\n  }\n  images {\n    thumbnail {\n      cropped(width: 130, height: 130, version: [\"square140\"]) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n  }\n  mediumText\n  categoryText\n  date_text: dateText\n  saleDate\n  boughtIn\n  currency\n  price_realized: priceRealized {\n    display\n    display_usd: displayUSD\n    cents_usd: centsUSD\n  }\n  performance {\n    mid\n  }\n  estimate {\n    display\n  }\n  location\n  lotNumber\n  saleTitle\n  isUpcoming\n}\n\nfragment ArtworkActionsSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isInAuction\n  isSavedToAnyList\n  sale {\n    isAuction\n    isClosed\n    id\n  }\n  collectorSignals {\n    auction {\n      lotWatcherCount\n    }\n  }\n  ...ArtworkActionsWatchLotButton_artwork\n}\n\nfragment ArtworkActionsWatchLotButton_artwork on Artwork {\n  sale {\n    isLiveOpen\n    isRegistrationClosed\n    liveStartAt\n    registrationStatus {\n      qualifiedForBidding\n      id\n    }\n    id\n  }\n  ...ArtworkAuctionRegistrationPanel_artwork\n}\n\nfragment ArtworkActions_artwork_yvCPB on Artwork {\n  ...ArtworkActionsSaveButton_artwork\n  ...ArtworkDownloadButton_artwork\n  ...ArtworkSharePanel_artwork_yvCPB\n  ...ViewInRoom_artwork\n  isUnlisted\n  slug\n  downloadableImageUrl\n  isDownloadable\n  isHangable\n  partner {\n    slug\n    id\n  }\n}\n\nfragment ArtworkAuctionRegistrationPanel_artwork on Artwork {\n  sale {\n    slug\n    registrationEndsAt\n    isRegistrationClosed\n    id\n  }\n}\n\nfragment ArtworkDownloadButton_artwork on Artwork {\n  title\n  date\n  downloadableImageUrl\n  artists(shallow: true) {\n    name\n    id\n  }\n}\n\nfragment ArtworkImageBrowserLarge_artwork_yvCPB on Artwork {\n  ...ArtworkLightbox_artwork_yvCPB\n  ...ArtworkVideoPlayer_artwork_yvCPB\n  isSetVideoAsCover\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      __typename\n      internalID\n      isZoomable\n    }\n    ... on Video {\n      __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowserSmall_artwork_yvCPB on Artwork {\n  ...ArtworkLightbox_artwork_yvCPB\n  ...ArtworkVideoPlayer_artwork_yvCPB\n  isSetVideoAsCover\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      internalID\n      isZoomable\n      type: __typename\n    }\n    ... on Video {\n      type: __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowser_artwork_yvCPB on Artwork {\n  ...ArtworkActions_artwork_yvCPB\n  ...ArtworkImageBrowserSmall_artwork_yvCPB\n  ...ArtworkImageBrowserLarge_artwork_yvCPB\n  internalID\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      isDefault\n      width\n      height\n    }\n    ... on Video {\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment ArtworkLightbox_artwork_yvCPB on Artwork {\n  formattedMetadata\n  images(includeAll: true) {\n    internalID\n    isDefault\n    placeholder: url(version: [\"small\", \"medium\"])\n    blurhashDataURL(width: 801)\n    fallback: cropped(quality: 80, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    resized(quality: 80, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    mobileLightboxSource: resized(quality: 50, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    versions\n  }\n}\n\nfragment ArtworkSharePanel_artwork_yvCPB on Artwork {\n  href\n  images(includeAll: true) {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n\nfragment ArtworkVideoPlayer_artwork_yvCPB on Artwork {\n  internalID\n  slug\n  figures(includeAll: true) {\n    __typename\n    ... on Video {\n      __typename\n      playerUrl\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment DeepZoom_image on Image {\n  deepZoom {\n    Image {\n      xmlns\n      Url\n      Format\n      TileSize\n      Overlap\n      Size {\n        Width\n        Height\n      }\n    }\n  }\n}\n\nfragment MyCollectionArtworkAboutTab_artwork on Artwork {\n  ...MyCollectionArtworkDetails_artwork\n  artist(shallow: true) {\n    slug\n    targetSupply {\n      priority\n    }\n    id\n  }\n  consignmentSubmission {\n    internalID\n  }\n  hasPriceEstimateRequest\n  internalID\n}\n\nfragment MyCollectionArtworkArtistMarket_marketPriceInsights on ArtworkPriceInsights {\n  annualLotsSold\n  annualValueSoldDisplayText\n  medianSaleOverEstimatePercentage\n  liquidityRankDisplayText\n  sellThroughRate\n}\n\nfragment MyCollectionArtworkAuctionResults_artist on Artist {\n  slug\n  internalID\n  auctionResultsConnection(first: 6) {\n    totalCount\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        id\n      }\n    }\n  }\n}\n\nfragment MyCollectionArtworkComparables_artwork on Artwork {\n  auctionResult: comparableAuctionResults(first: 6) @optionalField {\n    edges {\n      cursor\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        artistID\n        internalID\n        id\n      }\n    }\n  }\n  artist(shallow: true) {\n    name\n    id\n  }\n}\n\nfragment MyCollectionArtworkDemandIndex_marketPriceInsights on ArtworkPriceInsights {\n  demandRank\n  demandRankDisplayText\n}\n\nfragment MyCollectionArtworkDetails_artwork on Artwork {\n  mediumType {\n    name\n  }\n  confidentialNotes\n  medium\n  metric\n  dimensions {\n    in\n    cm\n  }\n  provenance\n  attributionClass {\n    shortDescription\n    id\n  }\n  editionOf\n  pricePaid {\n    display\n  }\n  collectorLocation {\n    city\n    state\n    country\n    countryCode\n    id\n  }\n}\n\nfragment MyCollectionArtworkHeader_artwork on Artwork {\n  internalID\n  slug\n}\n\nfragment MyCollectionArtworkImageBrowser_artwork on Artwork {\n  ...ArtworkImageBrowser_artwork_yvCPB\n  internalID\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      width\n      height\n    }\n    ... on Video {\n      id\n    }\n  }\n}\n\nfragment MyCollectionArtworkInsights_artwork on Artwork {\n  hasPriceEstimateRequest\n  isPriceEstimateRequestable\n  internalID\n  auctionResults: comparableAuctionResults(first: 1) @optionalField {\n    totalCount\n  }\n  ...MyCollectionArtworkComparables_artwork\n  artist(shallow: true) {\n    slug\n    auctionResultsCount: auctionResultsConnection(first: 1) {\n      totalCount\n    }\n    targetSupply {\n      priority\n    }\n    ...MyCollectionArtworkAuctionResults_artist\n    id\n  }\n  marketPriceInsights {\n    ...MyCollectionArtworkArtistMarket_marketPriceInsights\n    ...MyCollectionArtworkDemandIndex_marketPriceInsights\n  }\n}\n\nfragment MyCollectionArtworkMeta_artwork on Artwork {\n  artistNames\n  title\n}\n\nfragment MyCollectionArtworkTitle_artwork on Artwork {\n  artistNames\n  title\n  date\n  artist(shallow: true) {\n    href\n    isPersonalArtist\n    id\n  }\n}\n\nfragment MyCollectionArtwork_artwork on Artwork {\n  ...MyCollectionArtworkHeader_artwork\n  ...MyCollectionArtworkTitle_artwork\n  ...MyCollectionArtworkDetails_artwork\n  ...MyCollectionArtworkMeta_artwork\n  ...MyCollectionArtworkInsights_artwork\n  ...MyCollectionArtworkImageBrowser_artwork\n  ...MyCollectionArtworkComparables_artwork\n  ...MyCollectionArtworkAboutTab_artwork\n  comparables: comparableAuctionResults {\n    totalCount\n  }\n  hasPriceEstimateRequest\n  hasMarketPriceInsights\n  submissionId\n  internalID\n  slug\n  consignmentSubmission {\n    state\n    internalID\n  }\n  artist(shallow: true) {\n    slug\n    targetSupply {\n      priority\n    }\n    auctionResults: auctionResultsConnection {\n      totalCount\n    }\n    ...MyCollectionArtworkAuctionResults_artist\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ViewInRoomArtwork_artwork on Artwork {\n  widthCm\n  heightCm\n  image {\n    resized(width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ViewInRoom_artwork on Artwork {\n  ...ViewInRoomArtwork_artwork\n}\n"
+    "text": "query collectorProfileRoutes_ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) @principalField {\n    ...MyCollectionArtwork_artwork\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  internalID\n  title\n  dimension_text: dimensionText\n  organization\n  artist {\n    name\n    id\n  }\n  images {\n    thumbnail {\n      cropped(width: 130, height: 130, version: [\"square140\"]) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n  }\n  mediumText\n  categoryText\n  date_text: dateText\n  saleDate\n  boughtIn\n  currency\n  price_realized: priceRealized {\n    display\n    display_usd: displayUSD\n    cents_usd: centsUSD\n  }\n  performance {\n    mid\n  }\n  estimate {\n    display\n  }\n  location\n  lotNumber\n  saleTitle\n  isUpcoming\n}\n\nfragment ArtworkActionsSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isInAuction\n  isSavedToAnyList\n  sale {\n    isAuction\n    isClosed\n    id\n  }\n  collectorSignals {\n    auction {\n      lotWatcherCount\n    }\n  }\n  ...ArtworkActionsWatchLotButton_artwork\n}\n\nfragment ArtworkActionsWatchLotButton_artwork on Artwork {\n  sale {\n    isLiveOpen\n    isRegistrationClosed\n    liveStartAt\n    registrationStatus {\n      qualifiedForBidding\n      id\n    }\n    id\n  }\n  ...ArtworkAuctionRegistrationPanel_artwork\n}\n\nfragment ArtworkActions_artwork_yvCPB on Artwork {\n  ...ArtworkActionsSaveButton_artwork\n  ...ArtworkDownloadButton_artwork\n  ...ArtworkSharePanel_artwork_yvCPB\n  ...ViewInRoom_artwork\n  isUnlisted\n  slug\n  downloadableImageUrl\n  isDownloadable\n  isHangable\n  partner {\n    slug\n    id\n  }\n}\n\nfragment ArtworkAuctionRegistrationPanel_artwork on Artwork {\n  sale {\n    slug\n    registrationEndsAt\n    isRegistrationClosed\n    id\n  }\n}\n\nfragment ArtworkDownloadButton_artwork on Artwork {\n  title\n  date\n  downloadableImageUrl\n  artists(shallow: true) {\n    name\n    id\n  }\n}\n\nfragment ArtworkImageBrowserLarge_artwork_yvCPB on Artwork {\n  ...ArtworkLightbox_artwork_yvCPB\n  ...ArtworkVideoPlayer_artwork_yvCPB\n  isSetVideoAsCover\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      __typename\n      internalID\n      isZoomable\n    }\n    ... on Video {\n      __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowserSmall_artwork_yvCPB on Artwork {\n  ...ArtworkLightbox_artwork_yvCPB\n  ...ArtworkVideoPlayer_artwork_yvCPB\n  isSetVideoAsCover\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      internalID\n      isZoomable\n      type: __typename\n    }\n    ... on Video {\n      type: __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowser_artwork_yvCPB on Artwork {\n  ...ArtworkActions_artwork_yvCPB\n  ...ArtworkImageBrowserSmall_artwork_yvCPB\n  ...ArtworkImageBrowserLarge_artwork_yvCPB\n  internalID\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      isDefault\n      width\n      height\n    }\n    ... on Video {\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment ArtworkLightbox_artwork_yvCPB on Artwork {\n  formattedMetadata\n  images(includeAll: true) {\n    internalID\n    isDefault\n    placeholder: url(version: [\"small\", \"medium\"])\n    blurhashDataURL(width: 801)\n    fallback: cropped(quality: 80, width: 1600, height: 1600, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n    }\n    resized(quality: 80, width: 1600, height: 1600, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n    }\n    versions\n  }\n}\n\nfragment ArtworkSharePanel_artwork_yvCPB on Artwork {\n  href\n  images(includeAll: true) {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n\nfragment ArtworkVideoPlayer_artwork_yvCPB on Artwork {\n  internalID\n  slug\n  figures(includeAll: true) {\n    __typename\n    ... on Video {\n      __typename\n      playerUrl\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment DeepZoom_image on Image {\n  deepZoom {\n    Image {\n      xmlns\n      Url\n      Format\n      TileSize\n      Overlap\n      Size {\n        Width\n        Height\n      }\n    }\n  }\n}\n\nfragment MyCollectionArtworkAboutTab_artwork on Artwork {\n  ...MyCollectionArtworkDetails_artwork\n  artist(shallow: true) {\n    slug\n    targetSupply {\n      priority\n    }\n    id\n  }\n  consignmentSubmission {\n    internalID\n  }\n  hasPriceEstimateRequest\n  internalID\n}\n\nfragment MyCollectionArtworkArtistMarket_marketPriceInsights on ArtworkPriceInsights {\n  annualLotsSold\n  annualValueSoldDisplayText\n  medianSaleOverEstimatePercentage\n  liquidityRankDisplayText\n  sellThroughRate\n}\n\nfragment MyCollectionArtworkAuctionResults_artist on Artist {\n  slug\n  internalID\n  auctionResultsConnection(first: 6) {\n    totalCount\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        id\n      }\n    }\n  }\n}\n\nfragment MyCollectionArtworkComparables_artwork on Artwork {\n  auctionResult: comparableAuctionResults(first: 6) @optionalField {\n    edges {\n      cursor\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        artistID\n        internalID\n        id\n      }\n    }\n  }\n  artist(shallow: true) {\n    name\n    id\n  }\n}\n\nfragment MyCollectionArtworkDemandIndex_marketPriceInsights on ArtworkPriceInsights {\n  demandRank\n  demandRankDisplayText\n}\n\nfragment MyCollectionArtworkDetails_artwork on Artwork {\n  mediumType {\n    name\n  }\n  confidentialNotes\n  medium\n  metric\n  dimensions {\n    in\n    cm\n  }\n  provenance\n  attributionClass {\n    shortDescription\n    id\n  }\n  editionOf\n  pricePaid {\n    display\n  }\n  collectorLocation {\n    city\n    state\n    country\n    countryCode\n    id\n  }\n}\n\nfragment MyCollectionArtworkHeader_artwork on Artwork {\n  internalID\n  slug\n}\n\nfragment MyCollectionArtworkImageBrowser_artwork on Artwork {\n  ...ArtworkImageBrowser_artwork_yvCPB\n  internalID\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      width\n      height\n    }\n    ... on Video {\n      id\n    }\n  }\n}\n\nfragment MyCollectionArtworkInsights_artwork on Artwork {\n  hasPriceEstimateRequest\n  isPriceEstimateRequestable\n  internalID\n  auctionResults: comparableAuctionResults(first: 1) @optionalField {\n    totalCount\n  }\n  ...MyCollectionArtworkComparables_artwork\n  artist(shallow: true) {\n    slug\n    auctionResultsCount: auctionResultsConnection(first: 1) {\n      totalCount\n    }\n    targetSupply {\n      priority\n    }\n    ...MyCollectionArtworkAuctionResults_artist\n    id\n  }\n  marketPriceInsights {\n    ...MyCollectionArtworkArtistMarket_marketPriceInsights\n    ...MyCollectionArtworkDemandIndex_marketPriceInsights\n  }\n}\n\nfragment MyCollectionArtworkMeta_artwork on Artwork {\n  artistNames\n  title\n}\n\nfragment MyCollectionArtworkTitle_artwork on Artwork {\n  artistNames\n  title\n  date\n  artist(shallow: true) {\n    href\n    isPersonalArtist\n    id\n  }\n}\n\nfragment MyCollectionArtwork_artwork on Artwork {\n  ...MyCollectionArtworkHeader_artwork\n  ...MyCollectionArtworkTitle_artwork\n  ...MyCollectionArtworkDetails_artwork\n  ...MyCollectionArtworkMeta_artwork\n  ...MyCollectionArtworkInsights_artwork\n  ...MyCollectionArtworkImageBrowser_artwork\n  ...MyCollectionArtworkComparables_artwork\n  ...MyCollectionArtworkAboutTab_artwork\n  comparables: comparableAuctionResults {\n    totalCount\n  }\n  hasPriceEstimateRequest\n  hasMarketPriceInsights\n  submissionId\n  internalID\n  slug\n  consignmentSubmission {\n    state\n    internalID\n  }\n  artist(shallow: true) {\n    slug\n    targetSupply {\n      priority\n    }\n    auctionResults: auctionResultsConnection {\n      totalCount\n    }\n    ...MyCollectionArtworkAuctionResults_artist\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ViewInRoomArtwork_artwork on Artwork {\n  widthCm\n  heightCm\n  image {\n    resized(width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ViewInRoom_artwork on Artwork {\n  ...ViewInRoomArtwork_artwork\n}\n"
   }
 };
 })();

--- a/src/__generated__/myCollectionRoutes_ArtworkQuery.graphql.ts
+++ b/src/__generated__/myCollectionRoutes_ArtworkQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a0acfd8c8158f96f31873c97a20a8b32>>
+ * @generated SignedSource<<1c8719d075156ca5f89b47820dbe1e77>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -175,30 +175,29 @@ v21 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "srcSet",
+  "name": "width",
   "storageKey": null
 },
 v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "width",
-  "storageKey": null
-},
-v23 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
   "name": "height",
   "storageKey": null
 },
-v24 = [
+v23 = [
   (v20/*: any*/),
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "srcSet",
+    "storageKey": null
+  },
   (v21/*: any*/),
-  (v22/*: any*/),
-  (v23/*: any*/)
+  (v22/*: any*/)
 ],
-v25 = {
+v24 = {
   "alias": null,
   "args": null,
   "concreteType": "AuctionLotImages",
@@ -239,7 +238,7 @@ v25 = {
           "kind": "LinkedField",
           "name": "cropped",
           "plural": false,
-          "selections": (v24/*: any*/),
+          "selections": (v23/*: any*/),
           "storageKey": "cropped(height:130,version:[\"square140\"],width:130)"
         }
       ],
@@ -248,56 +247,56 @@ v25 = {
   ],
   "storageKey": null
 },
-v26 = {
+v25 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "mediumText",
   "storageKey": null
 },
-v27 = {
+v26 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "categoryText",
   "storageKey": null
 },
-v28 = {
+v27 = {
   "alias": "date_text",
   "args": null,
   "kind": "ScalarField",
   "name": "dateText",
   "storageKey": null
 },
-v29 = {
+v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "saleDate",
   "storageKey": null
 },
-v30 = {
+v29 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "boughtIn",
   "storageKey": null
 },
-v31 = {
+v30 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "currency",
   "storageKey": null
 },
-v32 = {
+v31 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "display",
   "storageKey": null
 },
-v33 = {
+v32 = {
   "alias": "price_realized",
   "args": null,
   "concreteType": "AuctionResultPriceRealized",
@@ -305,7 +304,7 @@ v33 = {
   "name": "priceRealized",
   "plural": false,
   "selections": [
-    (v32/*: any*/),
+    (v31/*: any*/),
     {
       "alias": "display_usd",
       "args": null,
@@ -323,7 +322,7 @@ v33 = {
   ],
   "storageKey": null
 },
-v34 = {
+v33 = {
   "alias": null,
   "args": null,
   "concreteType": "AuctionLotPerformance",
@@ -341,74 +340,69 @@ v34 = {
   ],
   "storageKey": null
 },
-v35 = [
-  (v32/*: any*/)
+v34 = [
+  (v31/*: any*/)
 ],
-v36 = {
+v35 = {
   "alias": null,
   "args": null,
   "concreteType": "AuctionLotEstimate",
   "kind": "LinkedField",
   "name": "estimate",
   "plural": false,
-  "selections": (v35/*: any*/),
+  "selections": (v34/*: any*/),
   "storageKey": null
 },
-v37 = {
+v36 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "location",
   "storageKey": null
 },
-v38 = {
+v37 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotNumber",
   "storageKey": null
 },
-v39 = {
+v38 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "saleTitle",
   "storageKey": null
 },
-v40 = {
+v39 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isUpcoming",
   "storageKey": null
 },
-v41 = {
+v40 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "state",
   "storageKey": null
 },
-v42 = [
+v41 = [
   {
     "kind": "Literal",
     "name": "includeAll",
     "value": true
   }
 ],
-v43 = {
+v42 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "isDefault",
   "storageKey": null
 },
-v44 = {
-  "kind": "Literal",
-  "name": "height",
-  "value": 800
-},
-v45 = {
+v43 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -418,28 +412,30 @@ v45 = {
     "large"
   ]
 },
-v46 = {
-  "kind": "Literal",
-  "name": "width",
-  "value": 800
-},
-v47 = [
-  (v44/*: any*/),
+v44 = [
+  {
+    "kind": "Literal",
+    "name": "height",
+    "value": 1600
+  },
   {
     "kind": "Literal",
     "name": "quality",
     "value": 80
   },
-  (v45/*: any*/),
-  (v46/*: any*/)
+  (v43/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "width",
+    "value": 1600
+  }
 ],
-v48 = [
+v45 = [
+  (v21/*: any*/),
   (v22/*: any*/),
-  (v23/*: any*/),
-  (v20/*: any*/),
-  (v21/*: any*/)
+  (v20/*: any*/)
 ],
-v49 = {
+v46 = {
   "alias": "type",
   "args": null,
   "kind": "ScalarField",
@@ -654,20 +650,20 @@ return {
                           (v16/*: any*/),
                           (v17/*: any*/),
                           (v19/*: any*/),
+                          (v24/*: any*/),
                           (v25/*: any*/),
                           (v26/*: any*/),
                           (v27/*: any*/),
                           (v28/*: any*/),
                           (v29/*: any*/),
                           (v30/*: any*/),
-                          (v31/*: any*/),
+                          (v32/*: any*/),
                           (v33/*: any*/),
-                          (v34/*: any*/),
+                          (v35/*: any*/),
                           (v36/*: any*/),
                           (v37/*: any*/),
                           (v38/*: any*/),
                           (v39/*: any*/),
-                          (v40/*: any*/),
                           (v7/*: any*/)
                         ],
                         "storageKey": null
@@ -789,7 +785,7 @@ return {
             "kind": "LinkedField",
             "name": "pricePaid",
             "plural": false,
-            "selections": (v35/*: any*/),
+            "selections": (v34/*: any*/),
             "storageKey": null
           },
           {
@@ -807,7 +803,7 @@ return {
                 "name": "city",
                 "storageKey": null
               },
-              (v41/*: any*/),
+              (v40/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -880,20 +876,20 @@ return {
                       (v16/*: any*/),
                       (v17/*: any*/),
                       (v19/*: any*/),
+                      (v24/*: any*/),
                       (v25/*: any*/),
                       (v26/*: any*/),
                       (v27/*: any*/),
                       (v28/*: any*/),
                       (v29/*: any*/),
                       (v30/*: any*/),
-                      (v31/*: any*/),
+                      (v32/*: any*/),
                       (v33/*: any*/),
-                      (v34/*: any*/),
+                      (v35/*: any*/),
                       (v36/*: any*/),
                       (v37/*: any*/),
                       (v38/*: any*/),
                       (v39/*: any*/),
-                      (v40/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1133,7 +1129,7 @@ return {
           (v6/*: any*/),
           {
             "alias": null,
-            "args": (v42/*: any*/),
+            "args": (v41/*: any*/),
             "concreteType": "Image",
             "kind": "LinkedField",
             "name": "images",
@@ -1147,7 +1143,7 @@ return {
                 "storageKey": null
               },
               (v2/*: any*/),
-              (v43/*: any*/),
+              (v42/*: any*/),
               {
                 "alias": "placeholder",
                 "args": [
@@ -1179,42 +1175,23 @@ return {
               },
               {
                 "alias": "fallback",
-                "args": (v47/*: any*/),
+                "args": (v44/*: any*/),
                 "concreteType": "CroppedImageUrl",
                 "kind": "LinkedField",
                 "name": "cropped",
                 "plural": false,
-                "selections": (v48/*: any*/),
-                "storageKey": "cropped(height:800,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
+                "selections": (v45/*: any*/),
+                "storageKey": "cropped(height:1600,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:1600)"
               },
               {
                 "alias": null,
-                "args": (v47/*: any*/),
+                "args": (v44/*: any*/),
                 "concreteType": "ResizedImageUrl",
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v48/*: any*/),
-                "storageKey": "resized(height:800,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
-              },
-              {
-                "alias": "mobileLightboxSource",
-                "args": [
-                  (v44/*: any*/),
-                  {
-                    "kind": "Literal",
-                    "name": "quality",
-                    "value": 50
-                  },
-                  (v45/*: any*/),
-                  (v46/*: any*/)
-                ],
-                "concreteType": "ResizedImageUrl",
-                "kind": "LinkedField",
-                "name": "resized",
-                "plural": false,
-                "selections": (v48/*: any*/),
-                "storageKey": "resized(height:800,quality:50,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
+                "selections": (v45/*: any*/),
+                "storageKey": "resized(height:1600,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:1600)"
               },
               {
                 "alias": null,
@@ -1269,15 +1246,23 @@ return {
               {
                 "alias": null,
                 "args": [
-                  (v44/*: any*/),
-                  (v45/*: any*/),
-                  (v46/*: any*/)
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 800
+                  },
+                  (v43/*: any*/),
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 800
+                  }
                 ],
                 "concreteType": "ResizedImageUrl",
                 "kind": "LinkedField",
                 "name": "resized",
                 "plural": false,
-                "selections": (v24/*: any*/),
+                "selections": (v23/*: any*/),
                 "storageKey": "resized(height:800,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
               }
             ],
@@ -1326,7 +1311,7 @@ return {
           },
           {
             "alias": null,
-            "args": (v42/*: any*/),
+            "args": (v41/*: any*/),
             "concreteType": null,
             "kind": "LinkedField",
             "name": "figures",
@@ -1364,7 +1349,7 @@ return {
                     "storageKey": null
                   },
                   (v7/*: any*/),
-                  (v49/*: any*/)
+                  (v46/*: any*/)
                 ],
                 "type": "Video",
                 "abstractKey": null
@@ -1462,10 +1447,10 @@ return {
                     "name": "isZoomable",
                     "storageKey": null
                   },
-                  (v49/*: any*/),
-                  (v43/*: any*/),
-                  (v22/*: any*/),
-                  (v23/*: any*/)
+                  (v46/*: any*/),
+                  (v42/*: any*/),
+                  (v21/*: any*/),
+                  (v22/*: any*/)
                 ],
                 "type": "Image",
                 "abstractKey": null
@@ -1489,7 +1474,7 @@ return {
             "plural": false,
             "selections": [
               (v2/*: any*/),
-              (v41/*: any*/)
+              (v40/*: any*/)
             ],
             "storageKey": null
           },
@@ -1523,12 +1508,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "afb9c8e238a8731b1cb4c36afb298625",
+    "cacheID": "4482fc00b299d9bad1aecdd9c2214678",
     "id": null,
     "metadata": {},
     "name": "myCollectionRoutes_ArtworkQuery",
     "operationKind": "query",
-    "text": "query myCollectionRoutes_ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) @principalField {\n    ...MyCollectionArtwork_artwork\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  internalID\n  title\n  dimension_text: dimensionText\n  organization\n  artist {\n    name\n    id\n  }\n  images {\n    thumbnail {\n      cropped(width: 130, height: 130, version: [\"square140\"]) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n  }\n  mediumText\n  categoryText\n  date_text: dateText\n  saleDate\n  boughtIn\n  currency\n  price_realized: priceRealized {\n    display\n    display_usd: displayUSD\n    cents_usd: centsUSD\n  }\n  performance {\n    mid\n  }\n  estimate {\n    display\n  }\n  location\n  lotNumber\n  saleTitle\n  isUpcoming\n}\n\nfragment ArtworkActionsSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isInAuction\n  isSavedToAnyList\n  sale {\n    isAuction\n    isClosed\n    id\n  }\n  collectorSignals {\n    auction {\n      lotWatcherCount\n    }\n  }\n  ...ArtworkActionsWatchLotButton_artwork\n}\n\nfragment ArtworkActionsWatchLotButton_artwork on Artwork {\n  sale {\n    isLiveOpen\n    isRegistrationClosed\n    liveStartAt\n    registrationStatus {\n      qualifiedForBidding\n      id\n    }\n    id\n  }\n  ...ArtworkAuctionRegistrationPanel_artwork\n}\n\nfragment ArtworkActions_artwork_yvCPB on Artwork {\n  ...ArtworkActionsSaveButton_artwork\n  ...ArtworkDownloadButton_artwork\n  ...ArtworkSharePanel_artwork_yvCPB\n  ...ViewInRoom_artwork\n  isUnlisted\n  slug\n  downloadableImageUrl\n  isDownloadable\n  isHangable\n  partner {\n    slug\n    id\n  }\n}\n\nfragment ArtworkAuctionRegistrationPanel_artwork on Artwork {\n  sale {\n    slug\n    registrationEndsAt\n    isRegistrationClosed\n    id\n  }\n}\n\nfragment ArtworkDownloadButton_artwork on Artwork {\n  title\n  date\n  downloadableImageUrl\n  artists(shallow: true) {\n    name\n    id\n  }\n}\n\nfragment ArtworkImageBrowserLarge_artwork_yvCPB on Artwork {\n  ...ArtworkLightbox_artwork_yvCPB\n  ...ArtworkVideoPlayer_artwork_yvCPB\n  isSetVideoAsCover\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      __typename\n      internalID\n      isZoomable\n    }\n    ... on Video {\n      __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowserSmall_artwork_yvCPB on Artwork {\n  ...ArtworkLightbox_artwork_yvCPB\n  ...ArtworkVideoPlayer_artwork_yvCPB\n  isSetVideoAsCover\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      internalID\n      isZoomable\n      type: __typename\n    }\n    ... on Video {\n      type: __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowser_artwork_yvCPB on Artwork {\n  ...ArtworkActions_artwork_yvCPB\n  ...ArtworkImageBrowserSmall_artwork_yvCPB\n  ...ArtworkImageBrowserLarge_artwork_yvCPB\n  internalID\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      isDefault\n      width\n      height\n    }\n    ... on Video {\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment ArtworkLightbox_artwork_yvCPB on Artwork {\n  formattedMetadata\n  images(includeAll: true) {\n    internalID\n    isDefault\n    placeholder: url(version: [\"small\", \"medium\"])\n    blurhashDataURL(width: 801)\n    fallback: cropped(quality: 80, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    resized(quality: 80, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    mobileLightboxSource: resized(quality: 50, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    versions\n  }\n}\n\nfragment ArtworkSharePanel_artwork_yvCPB on Artwork {\n  href\n  images(includeAll: true) {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n\nfragment ArtworkVideoPlayer_artwork_yvCPB on Artwork {\n  internalID\n  slug\n  figures(includeAll: true) {\n    __typename\n    ... on Video {\n      __typename\n      playerUrl\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment DeepZoom_image on Image {\n  deepZoom {\n    Image {\n      xmlns\n      Url\n      Format\n      TileSize\n      Overlap\n      Size {\n        Width\n        Height\n      }\n    }\n  }\n}\n\nfragment MyCollectionArtworkAboutTab_artwork on Artwork {\n  ...MyCollectionArtworkDetails_artwork\n  artist(shallow: true) {\n    slug\n    targetSupply {\n      priority\n    }\n    id\n  }\n  consignmentSubmission {\n    internalID\n  }\n  hasPriceEstimateRequest\n  internalID\n}\n\nfragment MyCollectionArtworkArtistMarket_marketPriceInsights on ArtworkPriceInsights {\n  annualLotsSold\n  annualValueSoldDisplayText\n  medianSaleOverEstimatePercentage\n  liquidityRankDisplayText\n  sellThroughRate\n}\n\nfragment MyCollectionArtworkAuctionResults_artist on Artist {\n  slug\n  internalID\n  auctionResultsConnection(first: 6) {\n    totalCount\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        id\n      }\n    }\n  }\n}\n\nfragment MyCollectionArtworkComparables_artwork on Artwork {\n  auctionResult: comparableAuctionResults(first: 6) @optionalField {\n    edges {\n      cursor\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        artistID\n        internalID\n        id\n      }\n    }\n  }\n  artist(shallow: true) {\n    name\n    id\n  }\n}\n\nfragment MyCollectionArtworkDemandIndex_marketPriceInsights on ArtworkPriceInsights {\n  demandRank\n  demandRankDisplayText\n}\n\nfragment MyCollectionArtworkDetails_artwork on Artwork {\n  mediumType {\n    name\n  }\n  confidentialNotes\n  medium\n  metric\n  dimensions {\n    in\n    cm\n  }\n  provenance\n  attributionClass {\n    shortDescription\n    id\n  }\n  editionOf\n  pricePaid {\n    display\n  }\n  collectorLocation {\n    city\n    state\n    country\n    countryCode\n    id\n  }\n}\n\nfragment MyCollectionArtworkHeader_artwork on Artwork {\n  internalID\n  slug\n}\n\nfragment MyCollectionArtworkImageBrowser_artwork on Artwork {\n  ...ArtworkImageBrowser_artwork_yvCPB\n  internalID\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      width\n      height\n    }\n    ... on Video {\n      id\n    }\n  }\n}\n\nfragment MyCollectionArtworkInsights_artwork on Artwork {\n  hasPriceEstimateRequest\n  isPriceEstimateRequestable\n  internalID\n  auctionResults: comparableAuctionResults(first: 1) @optionalField {\n    totalCount\n  }\n  ...MyCollectionArtworkComparables_artwork\n  artist(shallow: true) {\n    slug\n    auctionResultsCount: auctionResultsConnection(first: 1) {\n      totalCount\n    }\n    targetSupply {\n      priority\n    }\n    ...MyCollectionArtworkAuctionResults_artist\n    id\n  }\n  marketPriceInsights {\n    ...MyCollectionArtworkArtistMarket_marketPriceInsights\n    ...MyCollectionArtworkDemandIndex_marketPriceInsights\n  }\n}\n\nfragment MyCollectionArtworkMeta_artwork on Artwork {\n  artistNames\n  title\n}\n\nfragment MyCollectionArtworkTitle_artwork on Artwork {\n  artistNames\n  title\n  date\n  artist(shallow: true) {\n    href\n    isPersonalArtist\n    id\n  }\n}\n\nfragment MyCollectionArtwork_artwork on Artwork {\n  ...MyCollectionArtworkHeader_artwork\n  ...MyCollectionArtworkTitle_artwork\n  ...MyCollectionArtworkDetails_artwork\n  ...MyCollectionArtworkMeta_artwork\n  ...MyCollectionArtworkInsights_artwork\n  ...MyCollectionArtworkImageBrowser_artwork\n  ...MyCollectionArtworkComparables_artwork\n  ...MyCollectionArtworkAboutTab_artwork\n  comparables: comparableAuctionResults {\n    totalCount\n  }\n  hasPriceEstimateRequest\n  hasMarketPriceInsights\n  submissionId\n  internalID\n  slug\n  consignmentSubmission {\n    state\n    internalID\n  }\n  artist(shallow: true) {\n    slug\n    targetSupply {\n      priority\n    }\n    auctionResults: auctionResultsConnection {\n      totalCount\n    }\n    ...MyCollectionArtworkAuctionResults_artist\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ViewInRoomArtwork_artwork on Artwork {\n  widthCm\n  heightCm\n  image {\n    resized(width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ViewInRoom_artwork on Artwork {\n  ...ViewInRoomArtwork_artwork\n}\n"
+    "text": "query myCollectionRoutes_ArtworkQuery(\n  $artworkID: String!\n) {\n  artwork(id: $artworkID) @principalField {\n    ...MyCollectionArtwork_artwork\n    id\n  }\n}\n\nfragment ArtistAuctionResultItem_auctionResult on AuctionResult {\n  internalID\n  title\n  dimension_text: dimensionText\n  organization\n  artist {\n    name\n    id\n  }\n  images {\n    thumbnail {\n      cropped(width: 130, height: 130, version: [\"square140\"]) {\n        src\n        srcSet\n        width\n        height\n      }\n    }\n  }\n  mediumText\n  categoryText\n  date_text: dateText\n  saleDate\n  boughtIn\n  currency\n  price_realized: priceRealized {\n    display\n    display_usd: displayUSD\n    cents_usd: centsUSD\n  }\n  performance {\n    mid\n  }\n  estimate {\n    display\n  }\n  location\n  lotNumber\n  saleTitle\n  isUpcoming\n}\n\nfragment ArtworkActionsSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isInAuction\n  isSavedToAnyList\n  sale {\n    isAuction\n    isClosed\n    id\n  }\n  collectorSignals {\n    auction {\n      lotWatcherCount\n    }\n  }\n  ...ArtworkActionsWatchLotButton_artwork\n}\n\nfragment ArtworkActionsWatchLotButton_artwork on Artwork {\n  sale {\n    isLiveOpen\n    isRegistrationClosed\n    liveStartAt\n    registrationStatus {\n      qualifiedForBidding\n      id\n    }\n    id\n  }\n  ...ArtworkAuctionRegistrationPanel_artwork\n}\n\nfragment ArtworkActions_artwork_yvCPB on Artwork {\n  ...ArtworkActionsSaveButton_artwork\n  ...ArtworkDownloadButton_artwork\n  ...ArtworkSharePanel_artwork_yvCPB\n  ...ViewInRoom_artwork\n  isUnlisted\n  slug\n  downloadableImageUrl\n  isDownloadable\n  isHangable\n  partner {\n    slug\n    id\n  }\n}\n\nfragment ArtworkAuctionRegistrationPanel_artwork on Artwork {\n  sale {\n    slug\n    registrationEndsAt\n    isRegistrationClosed\n    id\n  }\n}\n\nfragment ArtworkDownloadButton_artwork on Artwork {\n  title\n  date\n  downloadableImageUrl\n  artists(shallow: true) {\n    name\n    id\n  }\n}\n\nfragment ArtworkImageBrowserLarge_artwork_yvCPB on Artwork {\n  ...ArtworkLightbox_artwork_yvCPB\n  ...ArtworkVideoPlayer_artwork_yvCPB\n  isSetVideoAsCover\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      __typename\n      internalID\n      isZoomable\n    }\n    ... on Video {\n      __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowserSmall_artwork_yvCPB on Artwork {\n  ...ArtworkLightbox_artwork_yvCPB\n  ...ArtworkVideoPlayer_artwork_yvCPB\n  isSetVideoAsCover\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      internalID\n      isZoomable\n      type: __typename\n    }\n    ... on Video {\n      type: __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowser_artwork_yvCPB on Artwork {\n  ...ArtworkActions_artwork_yvCPB\n  ...ArtworkImageBrowserSmall_artwork_yvCPB\n  ...ArtworkImageBrowserLarge_artwork_yvCPB\n  internalID\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      isDefault\n      width\n      height\n    }\n    ... on Video {\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment ArtworkLightbox_artwork_yvCPB on Artwork {\n  formattedMetadata\n  images(includeAll: true) {\n    internalID\n    isDefault\n    placeholder: url(version: [\"small\", \"medium\"])\n    blurhashDataURL(width: 801)\n    fallback: cropped(quality: 80, width: 1600, height: 1600, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n    }\n    resized(quality: 80, width: 1600, height: 1600, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n    }\n    versions\n  }\n}\n\nfragment ArtworkSharePanel_artwork_yvCPB on Artwork {\n  href\n  images(includeAll: true) {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n\nfragment ArtworkVideoPlayer_artwork_yvCPB on Artwork {\n  internalID\n  slug\n  figures(includeAll: true) {\n    __typename\n    ... on Video {\n      __typename\n      playerUrl\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment DeepZoom_image on Image {\n  deepZoom {\n    Image {\n      xmlns\n      Url\n      Format\n      TileSize\n      Overlap\n      Size {\n        Width\n        Height\n      }\n    }\n  }\n}\n\nfragment MyCollectionArtworkAboutTab_artwork on Artwork {\n  ...MyCollectionArtworkDetails_artwork\n  artist(shallow: true) {\n    slug\n    targetSupply {\n      priority\n    }\n    id\n  }\n  consignmentSubmission {\n    internalID\n  }\n  hasPriceEstimateRequest\n  internalID\n}\n\nfragment MyCollectionArtworkArtistMarket_marketPriceInsights on ArtworkPriceInsights {\n  annualLotsSold\n  annualValueSoldDisplayText\n  medianSaleOverEstimatePercentage\n  liquidityRankDisplayText\n  sellThroughRate\n}\n\nfragment MyCollectionArtworkAuctionResults_artist on Artist {\n  slug\n  internalID\n  auctionResultsConnection(first: 6) {\n    totalCount\n    pageInfo {\n      hasNextPage\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    edges {\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        id\n      }\n    }\n  }\n}\n\nfragment MyCollectionArtworkComparables_artwork on Artwork {\n  auctionResult: comparableAuctionResults(first: 6) @optionalField {\n    edges {\n      cursor\n      node {\n        ...ArtistAuctionResultItem_auctionResult\n        artistID\n        internalID\n        id\n      }\n    }\n  }\n  artist(shallow: true) {\n    name\n    id\n  }\n}\n\nfragment MyCollectionArtworkDemandIndex_marketPriceInsights on ArtworkPriceInsights {\n  demandRank\n  demandRankDisplayText\n}\n\nfragment MyCollectionArtworkDetails_artwork on Artwork {\n  mediumType {\n    name\n  }\n  confidentialNotes\n  medium\n  metric\n  dimensions {\n    in\n    cm\n  }\n  provenance\n  attributionClass {\n    shortDescription\n    id\n  }\n  editionOf\n  pricePaid {\n    display\n  }\n  collectorLocation {\n    city\n    state\n    country\n    countryCode\n    id\n  }\n}\n\nfragment MyCollectionArtworkHeader_artwork on Artwork {\n  internalID\n  slug\n}\n\nfragment MyCollectionArtworkImageBrowser_artwork on Artwork {\n  ...ArtworkImageBrowser_artwork_yvCPB\n  internalID\n  figures(includeAll: true) {\n    __typename\n    ... on Image {\n      width\n      height\n    }\n    ... on Video {\n      id\n    }\n  }\n}\n\nfragment MyCollectionArtworkInsights_artwork on Artwork {\n  hasPriceEstimateRequest\n  isPriceEstimateRequestable\n  internalID\n  auctionResults: comparableAuctionResults(first: 1) @optionalField {\n    totalCount\n  }\n  ...MyCollectionArtworkComparables_artwork\n  artist(shallow: true) {\n    slug\n    auctionResultsCount: auctionResultsConnection(first: 1) {\n      totalCount\n    }\n    targetSupply {\n      priority\n    }\n    ...MyCollectionArtworkAuctionResults_artist\n    id\n  }\n  marketPriceInsights {\n    ...MyCollectionArtworkArtistMarket_marketPriceInsights\n    ...MyCollectionArtworkDemandIndex_marketPriceInsights\n  }\n}\n\nfragment MyCollectionArtworkMeta_artwork on Artwork {\n  artistNames\n  title\n}\n\nfragment MyCollectionArtworkTitle_artwork on Artwork {\n  artistNames\n  title\n  date\n  artist(shallow: true) {\n    href\n    isPersonalArtist\n    id\n  }\n}\n\nfragment MyCollectionArtwork_artwork on Artwork {\n  ...MyCollectionArtworkHeader_artwork\n  ...MyCollectionArtworkTitle_artwork\n  ...MyCollectionArtworkDetails_artwork\n  ...MyCollectionArtworkMeta_artwork\n  ...MyCollectionArtworkInsights_artwork\n  ...MyCollectionArtworkImageBrowser_artwork\n  ...MyCollectionArtworkComparables_artwork\n  ...MyCollectionArtworkAboutTab_artwork\n  comparables: comparableAuctionResults {\n    totalCount\n  }\n  hasPriceEstimateRequest\n  hasMarketPriceInsights\n  submissionId\n  internalID\n  slug\n  consignmentSubmission {\n    state\n    internalID\n  }\n  artist(shallow: true) {\n    slug\n    targetSupply {\n      priority\n    }\n    auctionResults: auctionResultsConnection {\n      totalCount\n    }\n    ...MyCollectionArtworkAuctionResults_artist\n    id\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n\nfragment ViewInRoomArtwork_artwork on Artwork {\n  widthCm\n  heightCm\n  image {\n    resized(width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ViewInRoom_artwork on Artwork {\n  ...ViewInRoomArtwork_artwork\n}\n"
   }
 };
 })();


### PR DESCRIPTION
This PR simplifies image loading by using a 2x version across all platforms. Previously, we loaded both 1x and 2x versions, plus a lower-quality mobile version that was inadvertently being served on desktop. By consolidating to a single image version in cache instead of 3-4 variants, we should see improved latency despite the slight increase in bandwidth usage.