### PR TITLE
feat(performance): Add support for prefetching route sub queries via `prefetchSubQueries` on hover

### DIFF
--- a/docs/adding_new_app.md
+++ b/docs/adding_new_app.md
@@ -80,6 +80,7 @@ export const myNewAppRoutes: AppRouteConfig[] = [
         </div>
       )
     },
+    // Typically prefetched by default unless cacheConfig is set to true above
     query: graphql`
       query myNewAppRoutesQuery {
         artist(id: "andy-warhol") {
@@ -87,6 +88,11 @@ export const myNewAppRoutes: AppRouteConfig[] = [
         }
       }
     `,
+    // If there are lazy loaded components that you want to prefetch, pass the
+    // query in here. Takes the same arguments as returned from prepareVariables.
+    prefetchSubQueries: [
+      SOME_GRID_QUERY
+    ]
   },
 ]
 ```
@@ -105,7 +111,7 @@ Extending the example above, lets add a server-side redirect if the user isn't l
 export function myNewAppRedirect({ req, res, next }) {
   if (!res.locals.sd.CURRENT_USER) {
     return res.redirect(
-      `/login?redirectTo=${encodeURIComponent(req.originalUrl)}`
+      `/login?redirectTo=${encodeURIComponent(req.originalUrl)}`,
     )
   }
 }

--- a/docs/adding_new_app.md
+++ b/docs/adding_new_app.md
@@ -90,6 +90,8 @@ export const myNewAppRoutes: AppRouteConfig[] = [
     `,
     // If there are lazy loaded components that you want to prefetch, pass the
     // query in here. Takes the same arguments as returned from prepareVariables.
+    // Currently only supported when a user hovers over an item matching the
+    // path.
     prefetchSubQueries: [
       SOME_GRID_QUERY
     ]

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -85,6 +85,7 @@ const myRouter = [
       }
     `,
     // Takes the same arguments as returned from prepareVariables, or route params
+    // Note: Currently only enabled on hover
     prefetchSubQueries: [SOME_ARTWORK_GRID_QUERY],
   },
 ]

--- a/docs/caching.md
+++ b/docs/caching.md
@@ -69,6 +69,27 @@ const myRouter = [
 ]
 ```
 
+5. Prefetch specific route query sub-queries (useful for lazy-loaded grids and the like):
+
+```tsx
+import { SOME_ARTWORK_GRID_QUERY } from "path/to/SomeApp"
+
+const myRouter = [
+  {
+    path: "/some-app",
+    query: graphql`
+      query SomeAppQuery($artistID: String!) @cacheable {
+        artist(id: $artistID) @principalField {
+          slug
+        }
+      }
+    `,
+    // Takes the same arguments as returned from prepareVariables, or route params
+    prefetchSubQueries: [SOME_ARTWORK_GRID_QUERY],
+  },
+]
+```
+
 5. Never cache in a QueryRenderer or hook or other relay-centric component:
 
 ```tsx

--- a/src/Apps/Artist/Routes/WorksForSale/ArtistWorksForSaleRoute.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/ArtistWorksForSaleRoute.tsx
@@ -30,33 +30,7 @@ const ArtistWorksForSaleRoute: React.FC<
       />
       <Meta name="description" content={description} />
       <SystemQueryRenderer<ArtistWorksForSaleRouteArtworksQuery>
-        query={graphql`
-          query ArtistWorksForSaleRouteArtworksQuery(
-            $artistID: String!
-            $aggregations: [ArtworkAggregation]
-            $input: FilterArtworksInput!
-          ) @cacheable {
-            artist(id: $artistID) {
-              ...ArtistArtworkFilter_artist @arguments(input: $input)
-              sidebarAggregations: filterArtworksConnection(
-                aggregations: $aggregations
-                first: 1
-              ) {
-                counts {
-                  total
-                }
-                aggregations {
-                  slice
-                  counts {
-                    name
-                    value
-                    count
-                  }
-                }
-              }
-            }
-          }
-        `}
+        query={ARTIST_WORKS_FOR_SALE_QUERY}
         variables={{
           ...getWorksForSaleRouteVariables(
             match.params as { artistID: string },
@@ -98,6 +72,34 @@ const ArtistWorksForSaleRoute: React.FC<
     </>
   )
 }
+
+export const ARTIST_WORKS_FOR_SALE_QUERY = graphql`
+  query ArtistWorksForSaleRouteArtworksQuery(
+    $artistID: String!
+    $aggregations: [ArtworkAggregation]
+    $input: FilterArtworksInput!
+  ) @cacheable {
+    artist(id: $artistID) {
+      ...ArtistArtworkFilter_artist @arguments(input: $input)
+      sidebarAggregations: filterArtworksConnection(
+        aggregations: $aggregations
+        first: 1
+      ) {
+        counts {
+          total
+        }
+        aggregations {
+          slice
+          counts {
+            name
+            value
+            count
+          }
+        }
+      }
+    }
+  }
+`
 
 export const ArtistWorksForSaleRouteFragmentContainer = createFragmentContainer(
   ArtistWorksForSaleRoute,

--- a/src/Apps/Artist/artistRoutes.tsx
+++ b/src/Apps/Artist/artistRoutes.tsx
@@ -1,5 +1,6 @@
 import loadable from "@loadable/component"
 import { initialAuctionResultsFilterState } from "Apps/Artist/Routes/AuctionResults/initialAuctionResultsFilterState"
+import { ARTIST_WORKS_FOR_SALE_QUERY } from "Apps/Artist/Routes/WorksForSale/ArtistWorksForSaleRoute"
 import { serverCacheTTLs } from "Apps/serverCacheTTLs"
 import { paramsToCamelCase } from "Components/ArtworkFilter/Utils/paramsCasing"
 import type { RouteProps } from "System/Router/Route"
@@ -127,6 +128,7 @@ export const artistRoutes: RouteProps[] = [
         onPreloadJS: () => {
           WorksForSaleRoute.preload()
         },
+        prefetchSubQueries: [ARTIST_WORKS_FOR_SALE_QUERY],
         prepareVariables: getWorksForSaleRouteVariables,
         query: graphql`
           query artistRoutes_WorksForSaleQuery($artistID: String!) @cacheable {

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -92,7 +92,7 @@ export const NavBar: React.FC<React.PropsWithChildren<unknown>> = track(
   useEffect(() => {
     const PREFETCH_NAVBAR_LINKS = ["/artists", "/collect"]
 
-    PREFETCH_NAVBAR_LINKS.forEach(prefetch)
+    PREFETCH_NAVBAR_LINKS.forEach(path => prefetch({ path }))
   }, [])
 
   const handleMobileNavClick = (
@@ -214,7 +214,7 @@ export const NavBar: React.FC<React.PropsWithChildren<unknown>> = track(
                   <Flex alignItems="center" display={["none", "flex"]}>
                     <NavBarItemLink
                       href="/collect"
-                      onMouseOver={() => prefetch("/collect")}
+                      onMouseOver={() => prefetch({ path: "/collect" })}
                       textDecoration="none"
                       onClick={handleClick}
                       data-label="Buy"
@@ -225,7 +225,7 @@ export const NavBar: React.FC<React.PropsWithChildren<unknown>> = track(
 
                   <NavBarItemLink
                     href="/price-database"
-                    onMouseOver={() => prefetch("/price-database")}
+                    onMouseOver={() => prefetch({ path: "/price-database" })}
                     textDecoration="none"
                     onClick={handleClick}
                     data-label="Price Database"
@@ -236,7 +236,7 @@ export const NavBar: React.FC<React.PropsWithChildren<unknown>> = track(
                   <Flex alignItems="center" display={["none", "flex"]}>
                     <NavBarItemLink
                       href="/articles"
-                      onMouseOver={() => prefetch("/articles")}
+                      onMouseOver={() => prefetch({ path: "/articles" })}
                       textDecoration="none"
                       onClick={handleClick}
                       data-label="Articles"
@@ -396,7 +396,7 @@ export const NavBar: React.FC<React.PropsWithChildren<unknown>> = track(
 
                 <NavBarItemLink
                   href="/auctions"
-                  onMouseOver={() => prefetch("/auctions")}
+                  onMouseOver={() => prefetch({ path: "/auctions" })}
                   onClick={handleClick}
                   data-label="Auctions"
                 >
@@ -405,7 +405,7 @@ export const NavBar: React.FC<React.PropsWithChildren<unknown>> = track(
 
                 <NavBarItemLink
                   href="/viewing-rooms"
-                  onMouseOver={() => prefetch("/viewing-rooms")}
+                  onMouseOver={() => prefetch({ path: "/viewing-rooms" })}
                   onClick={handleClick}
                   data-label="Viewing Rooms"
                 >
@@ -414,7 +414,7 @@ export const NavBar: React.FC<React.PropsWithChildren<unknown>> = track(
 
                 <NavBarItemLink
                   href="/galleries"
-                  onMouseOver={() => prefetch("/galleries")}
+                  onMouseOver={() => prefetch({ path: "/galleries" })}
                   onClick={handleClick}
                   data-label="Galleries"
                 >
@@ -423,7 +423,7 @@ export const NavBar: React.FC<React.PropsWithChildren<unknown>> = track(
 
                 <NavBarItemLink
                   href="/art-fairs"
-                  onMouseOver={() => prefetch("/art-fairs")}
+                  onMouseOver={() => prefetch({ path: "/art-fairs" })}
                   onClick={handleClick}
                   data-label="Fairs & Events"
                 >
@@ -432,7 +432,7 @@ export const NavBar: React.FC<React.PropsWithChildren<unknown>> = track(
 
                 <NavBarItemLink
                   href="/shows"
-                  onMouseOver={() => prefetch("/shows")}
+                  onMouseOver={() => prefetch({ path: "/shows" })}
                   onClick={handleClick}
                   data-label="Shows"
                 >
@@ -441,7 +441,7 @@ export const NavBar: React.FC<React.PropsWithChildren<unknown>> = track(
 
                 <NavBarItemInstitutionsLink
                   href="/institutions"
-                  onMouseOver={() => prefetch("/institutions")}
+                  onMouseOver={() => prefetch({ path: "/institutions" })}
                   onClick={handleClick}
                   data-label="Institutions"
                 >

--- a/src/Components/NavBar/NavBarDropdownPanel.tsx
+++ b/src/Components/NavBar/NavBarDropdownPanel.tsx
@@ -60,7 +60,7 @@ export const NavBarDropdownPanel: React.FC<NavBarDropdownPanelProps> = ({
           >
             <NavBarItemUnfocusableAnchor
               href={href}
-              onMouseOver={() => prefetch(href)}
+              onMouseOver={() => prefetch({ path: href })}
               onClick={event => {
                 handleClick(event)
                 setTimeout(() => setVisible(false), 100)

--- a/src/System/Components/RouterLink.tsx
+++ b/src/System/Components/RouterLink.tsx
@@ -83,7 +83,7 @@ export const RouterLink: React.FC<
   })
 
   const handleMouseOver = () => {
-    if (enablePrefetch) {
+    if (enablePrefetch && !isPrefetched) {
       prefetch()
     }
   }

--- a/src/System/Components/RouterLink.tsx
+++ b/src/System/Components/RouterLink.tsx
@@ -83,8 +83,8 @@ export const RouterLink: React.FC<
   })
 
   const handleMouseOver = () => {
-    if (enablePrefetch && !isPrefetched) {
-      prefetch()
+    if (enablePrefetch) {
+      prefetch({ enableSubQueryPrefetchOnHover: true })
     }
   }
 

--- a/src/System/Hooks/__tests__/usePrefetchRoute.jest.tsx
+++ b/src/System/Hooks/__tests__/usePrefetchRoute.jest.tsx
@@ -141,7 +141,7 @@ describe("usePrefetchRoute", () => {
     result.current.prefetch()
 
     expect(console.error).toHaveBeenCalledWith(
-      "[usePrefetchRoute] Error prefetching:",
+      "[usePrefetchRoute] Error prefetching [primary-query]:",
       "/foo/bar",
     )
   })
@@ -175,11 +175,11 @@ describe("usePrefetchRoute", () => {
     result.current.prefetch()
 
     expect(console.log).toHaveBeenCalledWith(
-      "[usePrefetchRoute] Starting prefetch:",
+      "[usePrefetchRoute] Starting prefetch [primary-query]:",
       "/foo/bar",
     )
     expect(console.log).toHaveBeenCalledWith(
-      "[usePrefetchRoute] Completed:",
+      "[usePrefetchRoute] Completed [primary-query]:",
       "/foo/bar",
     )
   })
@@ -235,6 +235,53 @@ describe("usePrefetchRoute", () => {
         fetchPolicy: "store-or-network",
         networkCacheConfig: { force: false, metadata: { maxAge: 1000 } },
       },
+    )
+  })
+
+  it("should prefetch `prefetchSubQueries` if they exist", () => {
+    const mockRoute = {
+      match: { params: { id: "bar" } },
+      route: {
+        path: "/foo/:id",
+        query: ["TestQuery"],
+        prefetchSubQueries: ["TestSubQuery"],
+        prepareVariables: jest.fn().mockReturnValue({ id: "bar" }),
+      },
+    }
+    const mockSubscription = { unsubscribe: jest.fn() }
+
+    mockFindRoutesByPath.mockReturnValue([mockRoute])
+    mockTake.mockReturnValue([mockRoute])
+    mockFetchQuery.mockReturnValue({
+      subscribe: jest.fn(({ start, complete }) => {
+        start()
+        complete()
+        return mockSubscription
+      }),
+    })
+
+    console.log = jest.fn()
+
+    const { result } = renderHook(() =>
+      usePrefetchRoute({ initialPath: "/foo/bar" }),
+    )
+    result.current.prefetch()
+
+    expect(console.log).toHaveBeenCalledWith(
+      "[usePrefetchRoute] Starting prefetch [primary-query]:",
+      "/foo/bar",
+    )
+    expect(console.log).toHaveBeenCalledWith(
+      "[usePrefetchRoute] Completed [primary-query]:",
+      "/foo/bar",
+    )
+    expect(console.log).toHaveBeenCalledWith(
+      "[usePrefetchRoute] Starting prefetch [sub-query]:",
+      "/foo/bar",
+    )
+    expect(console.log).toHaveBeenCalledWith(
+      "[usePrefetchRoute] Completed [sub-query]:",
+      "/foo/bar",
     )
   })
 })

--- a/src/System/Hooks/__tests__/usePrefetchRoute.jest.tsx
+++ b/src/System/Hooks/__tests__/usePrefetchRoute.jest.tsx
@@ -105,7 +105,7 @@ describe("usePrefetchRoute", () => {
 
     const { result } = renderHook(() => usePrefetchRoute())
 
-    const subscriptions = result.current.prefetch("/foo/bar")
+    const subscriptions = result.current.prefetch({ path: "/foo/bar" })
     expect(subscriptions).toHaveLength(1)
     expect(subscriptions?.[0]).toEqual(mockSubscription)
     expect(mockFetchQuery).toHaveBeenCalledWith(
@@ -265,7 +265,7 @@ describe("usePrefetchRoute", () => {
     const { result } = renderHook(() =>
       usePrefetchRoute({ initialPath: "/foo/bar" }),
     )
-    result.current.prefetch()
+    result.current.prefetch({ enableSubQueryPrefetchOnHover: true })
 
     expect(console.log).toHaveBeenCalledWith(
       "[usePrefetchRoute] Starting prefetch [primary-query]:",

--- a/src/System/Hooks/usePrefetchRoute.tsx
+++ b/src/System/Hooks/usePrefetchRoute.tsx
@@ -24,6 +24,9 @@ export const usePrefetchRoute = ({
   const { match } = useRouter()
 
   const prefetchFeatureFlagEnabled = useFeatureFlag("diamond_prefetch-hover")
+  const prefetchSubqueriesFeatureFlagEnabled = useFeatureFlag(
+    "diamond_prefetch-subqueries",
+  )
 
   // If we're transitioning routes, we don't want to prefetch
   const prefetchDisabled = !prefetchFeatureFlagEnabled || !match?.elements
@@ -101,7 +104,10 @@ export const usePrefetchRoute = ({
         })
 
         // If there are prefetchSubQueries, fetch them as well
-        if (prefetchSubQueries?.length) {
+        if (
+          prefetchSubqueriesFeatureFlagEnabled &&
+          prefetchSubQueries?.length
+        ) {
           prefetchSubQueries.forEach(prefetchQuery => {
             fetchQueryData({
               query: prefetchQuery,

--- a/src/System/Hooks/usePrefetchRoute.tsx
+++ b/src/System/Hooks/usePrefetchRoute.tsx
@@ -52,7 +52,7 @@ export const usePrefetchRoute = ({
         } = foundRoute
 
         const {
-          route: { query, prepareVariables },
+          route: { query, prefetchSubQueries, prepareVariables },
         } = foundRoute
 
         const variables = (() => {
@@ -69,39 +69,66 @@ export const usePrefetchRoute = ({
           return null
         }
 
-        const subscription = fetchQuery(
-          relayEnvironment,
+        // Prefetch primary route query
+        const subscription = fetchQueryData({
           query,
-          { ...variables, isPrefetched: true }, // Inject a variable to indicate this is a prefetch
-          {
-            fetchPolicy: "store-or-network",
-            networkCacheConfig: {
-              force: false,
-              metadata: {
-                maxAge: serverCacheTTL,
-              },
-            },
-          },
-        ).subscribe({
-          start: () => {
+          variables,
+          serverCacheTTL,
+          onStart: () => {
             if (isDevelopment) {
-              console.log("[usePrefetchRoute] Starting prefetch:", path)
+              console.log(
+                "[usePrefetchRoute] Starting prefetch [primary-query]:",
+                path,
+              )
             }
 
             // Prefetch bundle split JS alongside data, if defined
             foundRoute.route.onPreloadJS?.()
           },
-          complete: () => {
+          onComplete: () => {
             if (isDevelopment) {
-              console.log("[usePrefetchRoute] Completed:", path)
+              console.log("[usePrefetchRoute] Completed [primary-query]:", path)
             }
 
             onComplete?.()
           },
-          error: () => {
-            console.error("[usePrefetchRoute] Error prefetching:", path)
+          onError: () => {
+            console.error(
+              "[usePrefetchRoute] Error prefetching [primary-query]:",
+              path,
+            )
           },
         })
+
+        // If there are prefetchSubQueries, fetch them as well
+        if (prefetchSubQueries?.length) {
+          prefetchSubQueries.forEach(prefetchQuery => {
+            fetchQueryData({
+              query: prefetchQuery,
+              variables,
+              serverCacheTTL,
+              onStart: () => {
+                if (isDevelopment) {
+                  console.log(
+                    "[usePrefetchRoute] Starting prefetch [sub-query]:",
+                    path,
+                  )
+                }
+              },
+              onComplete: () => {
+                if (isDevelopment) {
+                  console.log("[usePrefetchRoute] Completed [sub-query]:", path)
+                }
+              },
+              onError: () => {
+                console.error(
+                  "[usePrefetchRoute] Error prefetching [sub-query]:",
+                  path,
+                )
+              },
+            })
+          })
+        }
 
         return subscription
       })
@@ -110,6 +137,42 @@ export const usePrefetchRoute = ({
     },
     [initialPath, prefetchDisabled],
   )
+
+  const fetchQueryData = ({
+    query,
+    variables,
+    serverCacheTTL,
+    onStart,
+    onComplete,
+    onError,
+  }) => {
+    const subscription = fetchQuery(
+      relayEnvironment,
+      query,
+      { ...variables, isPrefetched: true }, // Inject a variable to indicate this is a prefetch
+      {
+        fetchPolicy: "store-or-network",
+        networkCacheConfig: {
+          force: false,
+          metadata: {
+            maxAge: serverCacheTTL,
+          },
+        },
+      },
+    ).subscribe({
+      start: () => {
+        onStart()
+      },
+      complete: () => {
+        onComplete()
+      },
+      error: () => {
+        onError()
+      },
+    })
+
+    return subscription
+  }
 
   return { prefetch }
 }

--- a/src/System/Hooks/usePrefetchRoute.tsx
+++ b/src/System/Hooks/usePrefetchRoute.tsx
@@ -13,11 +13,23 @@ interface UsePrefetchRouteProps {
   onComplete?: () => void
 }
 
+interface PrefetchProps {
+  path?: string
+  /**
+   * Enable to support query prefetching
+   * @see: RouterLink.tsx
+   *
+   * We're conservative here so that we don't overload ElasticSearch.
+   * @see: https://github.com/artsy/force/pull/15090#issue-2793798833
+   */
+  enableSubQueryPrefetchOnHover?: boolean
+}
+
 export const usePrefetchRoute = ({
   initialPath,
   onComplete,
 }: UsePrefetchRouteProps = {}): {
-  prefetch: (path?: string) => Array<Subscription | null> | null
+  prefetch: (props?: PrefetchProps) => Array<Subscription | null> | null
 } => {
   const { relayEnvironment } = useSystemContext()
 
@@ -33,7 +45,10 @@ export const usePrefetchRoute = ({
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   const prefetch = useCallback(
-    (path = initialPath) => {
+    (props: PrefetchProps) => {
+      const { path = initialPath, enableSubQueryPrefetchOnHover = false } =
+        props || {}
+
       if (prefetchDisabled) {
         return null
       }
@@ -106,6 +121,7 @@ export const usePrefetchRoute = ({
         // If there are prefetchSubQueries, fetch them as well
         if (
           prefetchSubqueriesFeatureFlagEnabled &&
+          enableSubQueryPrefetchOnHover &&
           prefetchSubQueries?.length
         ) {
           prefetchSubQueries.forEach(prefetchQuery => {

--- a/src/System/Router/Route.tsx
+++ b/src/System/Router/Route.tsx
@@ -18,6 +18,12 @@ interface Route extends RouteObjectBase {
 
   prepareVariables?: (params: any, props: any) => object
   query?: GraphQLTaggedNode
+  /**
+   * If there are any queries in the route we'd like to prefetch (in order to
+   * warm the cache), declare them here.
+   *
+   * Currently only supported on hover. See RouterLink.tsx for usage.
+  ) */
   prefetchSubQueries?: GraphQLTaggedNode[]
   scrollToTop?: boolean
   shouldWarnBeforeLeaving?: boolean

--- a/src/System/Router/Route.tsx
+++ b/src/System/Router/Route.tsx
@@ -18,6 +18,7 @@ interface Route extends RouteObjectBase {
 
   prepareVariables?: (params: any, props: any) => object
   query?: GraphQLTaggedNode
+  prefetchSubQueries?: GraphQLTaggedNode[]
   scrollToTop?: boolean
   shouldWarnBeforeLeaving?: boolean
 


### PR DESCRIPTION
The type of this PR is: **Feat**

### Description

This builds in support for declaratively prefetching route dependencies, when a user hovers over a RouterLink that matches the path. Currently only enabled on artist! But lets evaluate. 

Guarded behind feature flag: 
- `diamond_prefetch-subqueries`

See:
- [Previous implementation](https://github.com/artsy/force/pull/15090) that we needed to back out of due to ES issues, hopefully remedied by only triggering via hover

New API: 

```tsx
const myRoute = [
  {
    path: '/foo/:id',
    Component: FooApp,
    query: ...,
    // Automatically receives forwarded arguments from `prepareVariables` or  `params` 
    prefetchSubQueries: [
      SomeArtworkGridQuery
    ] 
  }
]
```

Opening PR for discussion, since this has the potential to impact some system dynamics by fetching grids up front, when the artist is prefetched. 

My internet is slow, and fussy, but check out the screen cap! Note how there's a bit of a cascade as stuff is being prefetched in the background. Artist pages that are done prefetching also have instantly available grids. (Vs stuff still loading - to see the before / after; stuff thats still loading or didn't complete before click has a slow artwork grid). 

All in all, much sturdier pages:

https://github.com/user-attachments/assets/3877056f-6746-4e48-a1ee-05ca81aca53a

Now just figure out how to start warming the image cache ahead of time so we don't see the lazy loaded image placeholders... but maybe that's too much 😅 
