### PR TITLE
feat(collection sharing): update UI and allow un-sharing

### DIFF
--- a/src/Apps/CollectorProfile/Routes/Saves/Components/SavesArtworksHeader.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves/Components/SavesArtworksHeader.tsx
@@ -92,11 +92,10 @@ const SavesArtworksHeader: FC<
         )}
       </Stack>
 
-      {mode === "Share" && (
+      {mode === "Share" && collection && (
         <ShareCollectionDialog
           onClose={() => setMode("Idle")}
-          collectionId={collection.slug || collection.internalID}
-          collectionName={collection.name}
+          collection={collection}
         />
       )}
     </>
@@ -126,6 +125,7 @@ const QUERY = graphql`
         internalID
         name
         default
+        private
         shareableWithPartners
         slug
       }

--- a/src/Apps/CollectorProfile/Routes/Saves/Components/SavesArtworksHeader.tsx
+++ b/src/Apps/CollectorProfile/Routes/Saves/Components/SavesArtworksHeader.tsx
@@ -83,7 +83,7 @@ const SavesArtworksHeader: FC<
             onClick={handleShare}
             Icon={ShareIcon}
           >
-            Share
+            {collection.private ? "Share" : "Shared"}
           </Button>
         </Stack>
 

--- a/src/Apps/Settings/Routes/MyCollection/MyCollectionRoute.tsx
+++ b/src/Apps/Settings/Routes/MyCollection/MyCollectionRoute.tsx
@@ -136,6 +136,7 @@ export const MyCollectionRoutePaginationContainer = createPaginationContainer(
         myCollection: collection(id: "my-collection") {
           internalID
           slug
+          name
           private
         }
         myCollectionConnection(

--- a/src/Apps/Settings/Routes/MyCollection/MyCollectionRoute.tsx
+++ b/src/Apps/Settings/Routes/MyCollection/MyCollectionRoute.tsx
@@ -37,7 +37,7 @@ const MyCollectionRoute: FC<
     cleanLocalImages()
   }, [])
 
-  const { myCollectionConnection } = me
+  const { myCollection, myCollectionConnection } = me
 
   const [mode, setMode] = useState<"Idle" | "Share">("Idle")
 
@@ -114,11 +114,10 @@ const MyCollectionRoute: FC<
         <EmptyMyCollectionPage />
       )}
 
-      {mode === "Share" && (
+      {mode === "Share" && myCollection && (
         <ShareCollectionDialog
           onClose={() => setMode("Idle")}
-          collectionId="my-collection"
-          collectionName="My Collection"
+          collection={myCollection}
         />
       )}
     </>
@@ -134,6 +133,11 @@ export const MyCollectionRoutePaginationContainer = createPaginationContainer(
         count: { type: "Int", defaultValue: 25 }
         cursor: { type: "String" }
       ) {
+        myCollection: collection(id: "my-collection") {
+          internalID
+          slug
+          private
+        }
         myCollectionConnection(
           first: $count
           after: $cursor

--- a/src/Apps/User/Components/UserCollectionArtworks.tsx
+++ b/src/Apps/User/Components/UserCollectionArtworks.tsx
@@ -52,7 +52,7 @@ export const UserCollectionArtworks: FC<
           })}
         </Masonry>
       ) : (
-        <Message>There aren‘t any works in this collection yet.</Message>
+        <Message>There aren’t any works in this list yet.</Message>
       )}
 
       <PaginationFragmentContainer

--- a/src/Components/ShareCollectionDialog.tsx
+++ b/src/Components/ShareCollectionDialog.tsx
@@ -34,6 +34,7 @@ export const ShareCollectionDialog: React.FC<
   const [isShared, setIsShared] = useState(!collection.private)
   const [isUpdating, setIsUpdating] = useState(false)
   const [copyMode, setCopyMode] = useState<"Idle" | "Copied">("Idle")
+  const [slug, setSlug] = useState<string | undefined>(collection.slug)
 
   const handleClick = () => {
     navigator?.clipboard.writeText(url)
@@ -61,6 +62,13 @@ export const ShareCollectionDialog: React.FC<
                 message
               }
             }
+            ... on UpdateCollectionSuccess {
+              collection {
+                internalID
+                slug
+                private
+              }
+            }
           }
         }
       }
@@ -72,7 +80,7 @@ export const ShareCollectionDialog: React.FC<
   const handleToggle = async toggleValue => {
     try {
       setIsUpdating(true)
-      await submitMutation({
+      const result = await submitMutation({
         variables: {
           input: {
             id: collection.internalID,
@@ -83,6 +91,7 @@ export const ShareCollectionDialog: React.FC<
           return !!res.updateCollection?.responseOrError?.mutationError
         },
       })
+      setSlug(result.updateCollection?.responseOrError?.collection?.slug)
       setIsShared(toggleValue)
       setIsUpdating(false)
     } catch (error) {
@@ -96,7 +105,7 @@ export const ShareCollectionDialog: React.FC<
 
   if (!user) return null
 
-  const url = `${getENV("APP_URL")}/user/${user.id}/collection/${collection.slug ?? collection.internalID}`
+  const url = `${getENV("APP_URL")}/user/${user.id}/collection/${slug ?? collection.internalID}`
 
   return (
     <ModalDialog onClose={onClose} title="Share List">

--- a/src/Components/ShareCollectionDialog.tsx
+++ b/src/Components/ShareCollectionDialog.tsx
@@ -22,7 +22,7 @@ export interface ShareCollectionDialogProps {
   onClose: () => void
   collection: {
     internalID: string
-    slug: string
+    slug: string | null | undefined
     private: boolean
   }
 }
@@ -35,7 +35,7 @@ export const ShareCollectionDialog: React.FC<
   const [isShared, setIsShared] = useState(!collection.private)
   const [isUpdating, setIsUpdating] = useState(false)
   const [copyMode, setCopyMode] = useState<"Idle" | "Copied">("Idle")
-  const [slug, setSlug] = useState<string | undefined>(collection.slug)
+  const [slug, setSlug] = useState<string | null | undefined>(collection.slug)
 
   const handleClick = () => {
     navigator?.clipboard.writeText(url)

--- a/src/Components/ShareCollectionDialog.tsx
+++ b/src/Components/ShareCollectionDialog.tsx
@@ -4,9 +4,11 @@ import {
   Button,
   Input,
   ModalDialog,
-  Skeleton,
+  Text,
   Stack,
   useToasts,
+  Flex,
+  Toggle,
 } from "@artsy/palette"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import { useMutation } from "Utils/Hooks/useMutation"
@@ -27,6 +29,7 @@ export const ShareCollectionDialog: React.FC<
 > = ({ onClose, collectionId, collectionName }) => {
   const { user } = useSystemContext()
   const { trackEvent } = useTracking()
+  const [isShared, setIsShared] = useState(false)
 
   const [mode, setMode] = useState<"Idle" | "Copied">("Idle")
 
@@ -64,31 +67,34 @@ export const ShareCollectionDialog: React.FC<
 
   const { sendToast } = useToasts()
 
+  const handleToggle = x => {
+    alert(JSON.stringify(x))
+  }
+
   if (!user) return null
 
   const url = `${getENV("APP_URL")}/user/${user.id}/collection/${collectionId}`
 
   return (
     <ModalDialog onClose={onClose} title="Share List">
-      {mode === "Updating" ? (
-        <Skeleton>
-          <Stack gap={1}>
-            <Input value={url} readOnly disabled />
+      <Stack gap={1}>
+        <Flex flexDirection="row" gap={2} mb={1}>
+          <Text>Create a shareable link to allow others to view this list</Text>
+          <Toggle
+            selected={isShared}
+            disabled={false}
+            aria-label={
+              isShared ? "Disable shareable link" : "Enable shareable link"
+            }
+            onSelect={handleToggle}
+          />
+        </Flex>
 
-            <Button variant="secondaryBlack" disabled>
-              Copy URL
-            </Button>
+        <Input value={url} readOnly />
 
-            <Button variant="primaryBlack" disabled>
-              Open in new tab
-            </Button>
-          </Stack>
-        </Skeleton>
-      ) : (
-        <Stack gap={1}>
-          <Input value={url} readOnly />
-
+        <Flex my={1} gap={1}>
           <Button
+            width={1}
             variant="secondaryBlack"
             onClick={handleClick}
             disabled={mode === "Copied"}
@@ -97,7 +103,8 @@ export const ShareCollectionDialog: React.FC<
           </Button>
 
           <Button
-            variant="primaryBlack"
+            width={1}
+            variant="secondaryBlack"
             Icon={ShareIcon}
             // @ts-ignore
             as="a"
@@ -107,8 +114,9 @@ export const ShareCollectionDialog: React.FC<
           >
             Open in new tab
           </Button>
-        </Stack>
-      )}
+        </Flex>
+        <Button onClick={onClose}>Done</Button>
+      </Stack>
     </ModalDialog>
   )
 }

--- a/src/Components/ShareCollectionDialog.tsx
+++ b/src/Components/ShareCollectionDialog.tsx
@@ -99,7 +99,7 @@ export const ShareCollectionDialog: React.FC<
   const url = `${getENV("APP_URL")}/user/${user.id}/collection/${collectionId}`
 
   return (
-    <ModalDialog onClose={onClose} title="Share Collection">
+    <ModalDialog onClose={onClose} title="Share List">
       {mode === "Updating" ? (
         <Skeleton>
           <Stack gap={1}>

--- a/src/Components/ShareCollectionDialog.tsx
+++ b/src/Components/ShareCollectionDialog.tsx
@@ -33,17 +33,16 @@ export const ShareCollectionDialog: React.FC<
   const { trackEvent } = useTracking()
   const [isShared, setIsShared] = useState(!collection.private)
   const [isUpdating, setIsUpdating] = useState(false)
-
-  const [mode, setMode] = useState<"Idle" | "Copied">("Idle")
+  const [copyMode, setCopyMode] = useState<"Idle" | "Copied">("Idle")
 
   const handleClick = () => {
     navigator?.clipboard.writeText(url)
-    setMode("Copied")
+    setCopyMode("Copied")
 
     trackEvent(tracks.clickedCopyButton(collection.internalID))
 
     setTimeout(() => {
-      setMode("Idle")
+      setCopyMode("Idle")
     }, 2000)
   }
 
@@ -121,9 +120,9 @@ export const ShareCollectionDialog: React.FC<
             width={1}
             variant="secondaryBlack"
             onClick={handleClick}
-            disabled={!isShared || mode === "Copied"}
+            disabled={!isShared}
           >
-            {mode === "Copied" ? "Copied to clipboard" : "Copy URL"}
+            {copyMode === "Copied" ? "Copied to clipboard" : "Copy link"}
           </Button>
 
           <Button

--- a/src/Components/ShareCollectionDialog.tsx
+++ b/src/Components/ShareCollectionDialog.tsx
@@ -13,7 +13,6 @@ import {
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import { useMutation } from "Utils/Hooks/useMutation"
 import { getENV } from "Utils/getENV"
-import { SavesArtworksHeaderQuery$data } from "__generated__/SavesArtworksHeaderQuery.graphql"
 import type { ShareCollectionDialogMutation } from "__generated__/ShareCollectionDialogMutation.graphql"
 import { useState } from "react"
 import { graphql } from "react-relay"
@@ -21,9 +20,11 @@ import { useTracking } from "react-tracking"
 
 export interface ShareCollectionDialogProps {
   onClose: () => void
-  collection: NonNullable<
-    NonNullable<SavesArtworksHeaderQuery$data["me"]>["collection"]
-  >
+  collection: {
+    internalID: string
+    slug: string
+    private: boolean
+  }
 }
 
 export const ShareCollectionDialog: React.FC<

--- a/src/Components/ShareCollectionDialog.tsx
+++ b/src/Components/ShareCollectionDialog.tsx
@@ -31,7 +31,7 @@ export const ShareCollectionDialog: React.FC<
 > = ({ onClose, collection }) => {
   const { user } = useSystemContext()
   const { trackEvent } = useTracking()
-  const [isShared, setIsShared] = useState(false)
+  const [isShared, setIsShared] = useState(!collection.private)
   const [isUpdating, setIsUpdating] = useState(false)
 
   const [mode, setMode] = useState<"Idle" | "Copied">("Idle")

--- a/src/Components/ShareCollectionDialog.tsx
+++ b/src/Components/ShareCollectionDialog.tsx
@@ -10,7 +10,6 @@ import {
 } from "@artsy/palette"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import { useMutation } from "Utils/Hooks/useMutation"
-import { useOnce } from "Utils/Hooks/useOnce"
 import { getENV } from "Utils/getENV"
 import type { ShareCollectionDialogMutation } from "__generated__/ShareCollectionDialogMutation.graphql"
 import { useState } from "react"
@@ -29,9 +28,7 @@ export const ShareCollectionDialog: React.FC<
   const { user } = useSystemContext()
   const { trackEvent } = useTracking()
 
-  const [mode, setMode] = useState<"Idle" | "Updating" | "Ready" | "Copied">(
-    "Idle",
-  )
+  const [mode, setMode] = useState<"Idle" | "Copied">("Idle")
 
   const handleClick = () => {
     navigator?.clipboard.writeText(url)
@@ -66,33 +63,6 @@ export const ShareCollectionDialog: React.FC<
   })
 
   const { sendToast } = useToasts()
-
-  useOnce(async () => {
-    setMode("Updating")
-
-    try {
-      await submitMutation({
-        variables: {
-          input: {
-            id: collectionId,
-            name: collectionName, // TODO: Shouldn't be required
-            private: false,
-          },
-        },
-        rejectIf: res => {
-          return !!res.updateCollection?.responseOrError?.mutationError
-        },
-      })
-
-      setMode("Ready")
-    } catch (error) {
-      onClose()
-      sendToast({
-        message: "Failed to share collection",
-        variant: "error",
-      })
-    }
-  })
 
   if (!user) return null
 

--- a/src/Components/ShareCollectionDialog.tsx
+++ b/src/Components/ShareCollectionDialog.tsx
@@ -94,13 +94,14 @@ export const ShareCollectionDialog: React.FC<
       })
       setSlug(result.updateCollection?.responseOrError?.collection?.slug)
       setIsShared(toggleValue)
-      setIsUpdating(false)
     } catch (error) {
       onClose()
       sendToast({
         message: "Failed to enable sharing",
         variant: "error",
       })
+    } finally {
+      setIsUpdating(false)
     }
   }
 

--- a/src/Components/ShareCollectionDialog.tsx
+++ b/src/Components/ShareCollectionDialog.tsx
@@ -23,6 +23,7 @@ export interface ShareCollectionDialogProps {
   collection: {
     internalID: string
     slug: string | null | undefined
+    name: string
     private: boolean
   }
 }
@@ -110,7 +111,7 @@ export const ShareCollectionDialog: React.FC<
   const url = `${getENV("APP_URL")}/user/${user.id}/collection/${slug ?? collection.internalID}`
 
   return (
-    <ModalDialog onClose={onClose} title="Share List">
+    <ModalDialog onClose={onClose} title={`Share “${collection.name}”`}>
       <Stack gap={1}>
         <Flex flexDirection="row" gap={2} mb={1}>
           <Text>Create a shareable link to allow others to view this list</Text>

--- a/src/Components/__tests__/ShareCollectionDialog.jest.tsx
+++ b/src/Components/__tests__/ShareCollectionDialog.jest.tsx
@@ -46,6 +46,7 @@ describe("ShareCollectionDialog", () => {
   const mockCollection = {
     internalID: "collection-id-1",
     slug: "test-collection-slug",
+    name: "Test Collection",
     private: true, // initially private
   } as ShareCollectionDialogProps["collection"]
 
@@ -61,7 +62,7 @@ describe("ShareCollectionDialog", () => {
       />,
     )
 
-    expect(screen.getByText("Share List")).toBeInTheDocument()
+    expect(screen.getByText("Share “Test Collection”")).toBeInTheDocument()
 
     const toggle = screen.getByRole("toggle")
     const inputField = screen.getByRole("textbox")
@@ -85,7 +86,7 @@ describe("ShareCollectionDialog", () => {
       />,
     )
 
-    expect(screen.getByText("Share List")).toBeInTheDocument()
+    expect(screen.getByText("Share “Test Collection”")).toBeInTheDocument()
 
     const toggle = screen.getByRole("toggle")
     const inputField = screen.getByRole("textbox")

--- a/src/Components/__tests__/ShareCollectionDialog.jest.tsx
+++ b/src/Components/__tests__/ShareCollectionDialog.jest.tsx
@@ -1,0 +1,195 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react"
+import {
+  ShareCollectionDialog,
+  ShareCollectionDialogProps,
+} from "Components/ShareCollectionDialog"
+
+jest.mock("System/Hooks/useSystemContext", () => ({
+  useSystemContext: () => ({
+    user: { id: "user-id-1" },
+  }),
+}))
+
+jest.mock("Utils/getENV", () => ({
+  getENV: () => "https://artsy.biz",
+}))
+
+Object.defineProperty(navigator, "clipboard", {
+  value: {
+    writeText: jest.fn(),
+  },
+  configurable: true,
+})
+
+const mockSubmitMutation = jest.fn()
+jest.mock("Utils/Hooks/useMutation", () => ({
+  useMutation: () => ({
+    submitMutation: mockSubmitMutation,
+  }),
+}))
+
+const mockSendToast = jest.fn()
+jest.mock("@artsy/palette", () => {
+  const originalModule = jest.requireActual("@artsy/palette")
+  return {
+    ...originalModule,
+    useToasts: () => ({
+      sendToast: mockSendToast,
+    }),
+  }
+})
+
+jest.useFakeTimers()
+
+describe("ShareCollectionDialog", () => {
+  const mockOnClose = jest.fn()
+  const mockCollection = {
+    internalID: "collection-id-1",
+    slug: "test-collection-slug",
+    private: true, // initially private
+  } as ShareCollectionDialogProps["collection"]
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("renders correctly with initial state (private collection)", () => {
+    render(
+      <ShareCollectionDialog
+        onClose={mockOnClose}
+        collection={mockCollection}
+      />,
+    )
+
+    expect(screen.getByText("Share List")).toBeInTheDocument()
+
+    const toggle = screen.getByRole("toggle")
+    const inputField = screen.getByRole("textbox")
+    const copyButton = screen.getByRole("button", { name: /Copy link/ })
+    const openLinkButton = screen.getByRole("link", { name: /Open in new tab/ })
+
+    expect(toggle).toBeEnabled()
+    expect(inputField).toBeDisabled()
+    expect(copyButton).toBeDisabled()
+    expect(openLinkButton).toHaveAttribute("disabled")
+  })
+
+  it("renders correctly with a shared collection", () => {
+    render(
+      <ShareCollectionDialog
+        onClose={mockOnClose}
+        collection={{
+          ...mockCollection,
+          private: false, // not private = shared
+        }}
+      />,
+    )
+
+    expect(screen.getByText("Share List")).toBeInTheDocument()
+
+    const toggle = screen.getByRole("toggle")
+    const inputField = screen.getByRole("textbox")
+    const copyButton = screen.getByRole("button", { name: /Copy link/ })
+    const openLinkButton = screen.getByRole("link", { name: /Open in new tab/ })
+
+    expect(toggle).toBeEnabled()
+    expect(inputField).toBeEnabled()
+    expect(copyButton).toBeEnabled()
+    expect(openLinkButton).not.toHaveAttribute("disabled")
+  })
+
+  it("copies the link to clipboard when clicked", () => {
+    render(
+      <ShareCollectionDialog
+        onClose={mockOnClose}
+        collection={{
+          ...mockCollection,
+          private: false, // not private = shared
+        }}
+      />,
+    )
+
+    const copyButton = screen.getByRole("button", { name: /Copy link/ })
+    fireEvent.click(copyButton)
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      "https://artsy.biz/user/user-id-1/collection/test-collection-slug",
+    )
+  })
+
+  it("closes the dialog when Done button is clicked", () => {
+    render(
+      <ShareCollectionDialog
+        onClose={mockOnClose}
+        collection={mockCollection}
+      />,
+    )
+
+    fireEvent.click(screen.getByText("Done"))
+    expect(mockOnClose).toHaveBeenCalled()
+  })
+
+  it("toggles collection visibility when toggle is clicked", async () => {
+    mockSubmitMutation.mockResolvedValue({
+      updateCollection: {
+        responseOrError: {
+          collection: {
+            internalID: "collection-id-1",
+            slug: "test-collection-slug",
+            private: false,
+          },
+        },
+      },
+    })
+
+    render(
+      <ShareCollectionDialog
+        onClose={mockOnClose}
+        collection={mockCollection}
+      />,
+    )
+
+    const toggle = screen.getByRole("toggle")
+    fireEvent.click(toggle)
+
+    expect(mockSubmitMutation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: {
+          input: {
+            id: "collection-id-1",
+            private: false, // toggle from private to public
+          },
+        },
+      }),
+    )
+
+    // After the mutation resolves, the inputs should be enabled
+    await waitFor(() => {
+      const inputField = screen.getByRole("textbox")
+      expect(inputField).not.toBeDisabled()
+    })
+  })
+
+  it("handles error when toggling collection visibility", async () => {
+    // Set up mock mutation to reject
+    mockSubmitMutation.mockRejectedValue(new Error("Mutation failed"))
+
+    render(
+      <ShareCollectionDialog
+        onClose={mockOnClose}
+        collection={mockCollection}
+      />,
+    )
+
+    const toggle = screen.getByRole("toggle")
+    fireEvent.click(toggle)
+
+    await waitFor(() => {
+      expect(mockOnClose).toHaveBeenCalled()
+      expect(mockSendToast).toHaveBeenCalledWith({
+        message: "Failed to enable sharing",
+        variant: "error",
+      })
+    })
+  })
+})

--- a/src/__generated__/MyCollectionRouteQuery.graphql.ts
+++ b/src/__generated__/MyCollectionRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<bf94ddd23a515453a59ffd1eeb770a0e>>
+ * @generated SignedSource<<9355fe7ba67c4f1306340675ed7ca42e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -55,10 +55,17 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v4 = [
+v5 = [
   {
     "kind": "Variable",
     "name": "after",
@@ -75,14 +82,14 @@ v4 = [
     "value": "CREATED_AT_DESC"
   }
 ],
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v6 = {
+v7 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -90,21 +97,21 @@ v6 = {
     "large"
   ]
 },
-v7 = [
+v8 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v9 = [
+v10 = [
   {
     "alias": null,
     "args": null,
@@ -113,13 +120,6 @@ v9 = [
     "storageKey": null
   }
 ],
-v10 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-},
 v11 = {
   "alias": null,
   "args": null,
@@ -135,8 +135,8 @@ v12 = {
   "storageKey": null
 },
 v13 = [
-  (v10/*: any*/),
-  (v3/*: any*/)
+  (v3/*: any*/),
+  (v4/*: any*/)
 ];
 return {
   "fragment": {
@@ -206,6 +206,7 @@ return {
             "selections": [
               (v1/*: any*/),
               (v2/*: any*/),
+              (v3/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -213,13 +214,13 @@ return {
                 "name": "private",
                 "storageKey": null
               },
-              (v3/*: any*/)
+              (v4/*: any*/)
             ],
             "storageKey": "collection(id:\"my-collection\")"
           },
           {
             "alias": null,
-            "args": (v4/*: any*/),
+            "args": (v5/*: any*/),
             "concreteType": "MyCollectionConnection",
             "kind": "LinkedField",
             "name": "myCollectionConnection",
@@ -241,9 +242,9 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v3/*: any*/),
+                      (v4/*: any*/),
                       (v2/*: any*/),
-                      (v5/*: any*/),
+                      (v6/*: any*/),
                       (v1/*: any*/),
                       {
                         "alias": null,
@@ -277,7 +278,7 @@ return {
                           {
                             "alias": null,
                             "args": [
-                              (v6/*: any*/)
+                              (v7/*: any*/)
                             ],
                             "kind": "ScalarField",
                             "name": "url",
@@ -293,7 +294,7 @@ return {
                           {
                             "alias": null,
                             "args": [
-                              (v6/*: any*/),
+                              (v7/*: any*/),
                               {
                                 "kind": "Literal",
                                 "name": "width",
@@ -341,7 +342,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v7/*: any*/),
+                        "args": (v8/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artist",
@@ -372,7 +373,7 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v4/*: any*/)
                         ],
                         "storageKey": "artist(shallow:true)"
                       },
@@ -491,7 +492,7 @@ return {
                             "name": "partnerOffer",
                             "plural": false,
                             "selections": [
-                              (v8/*: any*/),
+                              (v9/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -499,10 +500,10 @@ return {
                                 "kind": "LinkedField",
                                 "name": "priceWithDiscount",
                                 "plural": false,
-                                "selections": (v9/*: any*/),
+                                "selections": (v10/*: any*/),
                                 "storageKey": null
                               },
-                              (v3/*: any*/)
+                              (v4/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -543,15 +544,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v7/*: any*/),
+                        "args": (v8/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v3/*: any*/),
-                          (v5/*: any*/),
-                          (v10/*: any*/)
+                          (v4/*: any*/),
+                          (v6/*: any*/),
+                          (v3/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -564,15 +565,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v7/*: any*/),
+                        "args": (v8/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v10/*: any*/),
-                          (v5/*: any*/),
-                          (v3/*: any*/)
+                          (v3/*: any*/),
+                          (v6/*: any*/),
+                          (v4/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
                       },
@@ -584,7 +585,7 @@ return {
                         "name": "sale",
                         "plural": false,
                         "selections": [
-                          (v8/*: any*/),
+                          (v9/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -620,7 +621,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v3/*: any*/),
+                          (v4/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -654,7 +655,7 @@ return {
                             "name": "lotLabel",
                             "storageKey": null
                           },
-                          (v8/*: any*/),
+                          (v9/*: any*/),
                           (v12/*: any*/),
                           {
                             "alias": null,
@@ -688,7 +689,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v9/*: any*/),
+                            "selections": (v10/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -698,10 +699,10 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v9/*: any*/),
+                            "selections": (v10/*: any*/),
                             "storageKey": null
                           },
-                          (v3/*: any*/)
+                          (v4/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -714,8 +715,8 @@ return {
                         "plural": false,
                         "selections": [
                           (v11/*: any*/),
-                          (v3/*: any*/),
-                          (v8/*: any*/),
+                          (v4/*: any*/),
+                          (v9/*: any*/),
                           (v12/*: any*/)
                         ],
                         "storageKey": null
@@ -822,26 +823,26 @@ return {
           },
           {
             "alias": null,
-            "args": (v4/*: any*/),
+            "args": (v5/*: any*/),
             "filters": [],
             "handle": "connection",
             "key": "MyCollectionRoute_myCollectionConnection",
             "kind": "LinkedHandle",
             "name": "myCollectionConnection"
           },
-          (v3/*: any*/)
+          (v4/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "88629382f77555c07f859615c5f429d2",
+    "cacheID": "fbfbccf8055461ce0729114b7c800661",
     "id": null,
     "metadata": {},
     "name": "MyCollectionRouteQuery",
     "operationKind": "query",
-    "text": "query MyCollectionRouteQuery(\n  $count: Int!\n  $cursor: String\n) {\n  me {\n    ...MyCollectionRoute_me_1G22uz\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_yvCPB on Artwork {\n  ...Metadata_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: true) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_yvCPB on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: true) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment MyCollectionArtworkGrid_artworks on MyCollectionConnection {\n  edges {\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: true) {\n        aspectRatio\n      }\n      artist(shallow: true) {\n        targetSupply {\n          priority\n        }\n        id\n      }\n      consignmentSubmission {\n        state\n      }\n      ...GridItem_artwork_yvCPB\n      ...FlatGridItem_artwork_yvCPB\n    }\n  }\n}\n\nfragment MyCollectionRoute_me_1G22uz on Me {\n  myCollection: collection(id: \"my-collection\") {\n    internalID\n    slug\n    private\n    id\n  }\n  myCollectionConnection(first: $count, after: $cursor, sort: CREATED_AT_DESC) {\n    ...MyCollectionArtworkGrid_artworks\n    totalCount\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  internalID\n  collectorSignals {\n    primaryLabel\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n}\n"
+    "text": "query MyCollectionRouteQuery(\n  $count: Int!\n  $cursor: String\n) {\n  me {\n    ...MyCollectionRoute_me_1G22uz\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_yvCPB on Artwork {\n  ...Metadata_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: true) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_yvCPB on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: true) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment MyCollectionArtworkGrid_artworks on MyCollectionConnection {\n  edges {\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: true) {\n        aspectRatio\n      }\n      artist(shallow: true) {\n        targetSupply {\n          priority\n        }\n        id\n      }\n      consignmentSubmission {\n        state\n      }\n      ...GridItem_artwork_yvCPB\n      ...FlatGridItem_artwork_yvCPB\n    }\n  }\n}\n\nfragment MyCollectionRoute_me_1G22uz on Me {\n  myCollection: collection(id: \"my-collection\") {\n    internalID\n    slug\n    name\n    private\n    id\n  }\n  myCollectionConnection(first: $count, after: $cursor, sort: CREATED_AT_DESC) {\n    ...MyCollectionArtworkGrid_artworks\n    totalCount\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  internalID\n  collectorSignals {\n    primaryLabel\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/MyCollectionRouteQuery.graphql.ts
+++ b/src/__generated__/MyCollectionRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4d93e32d36654c071102bc150edb755f>>
+ * @generated SignedSource<<bf94ddd23a515453a59ffd1eeb770a0e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -37,7 +37,28 @@ var v0 = [
     "name": "cursor"
   }
 ],
-v1 = [
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = [
   {
     "kind": "Variable",
     "name": "after",
@@ -54,28 +75,14 @@ v1 = [
     "value": "CREATED_AT_DESC"
   }
 ],
-v2 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v3 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v4 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v5 = {
+v6 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -83,21 +90,21 @@ v5 = {
     "large"
   ]
 },
-v6 = [
+v7 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v8 = [
+v9 = [
   {
     "alias": null,
     "args": null,
@@ -106,30 +113,30 @@ v8 = [
     "storageKey": null
   }
 ],
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v12 = [
-  (v9/*: any*/),
-  (v2/*: any*/)
+v13 = [
+  (v10/*: any*/),
+  (v3/*: any*/)
 ];
 return {
   "fragment": {
@@ -184,8 +191,35 @@ return {
         "plural": false,
         "selections": [
           {
+            "alias": "myCollection",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "id",
+                "value": "my-collection"
+              }
+            ],
+            "concreteType": "Collection",
+            "kind": "LinkedField",
+            "name": "collection",
+            "plural": false,
+            "selections": [
+              (v1/*: any*/),
+              (v2/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "private",
+                "storageKey": null
+              },
+              (v3/*: any*/)
+            ],
+            "storageKey": "collection(id:\"my-collection\")"
+          },
+          {
             "alias": null,
-            "args": (v1/*: any*/),
+            "args": (v4/*: any*/),
             "concreteType": "MyCollectionConnection",
             "kind": "LinkedField",
             "name": "myCollectionConnection",
@@ -207,16 +241,10 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v2/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "slug",
-                        "storageKey": null
-                      },
                       (v3/*: any*/),
-                      (v4/*: any*/),
+                      (v2/*: any*/),
+                      (v5/*: any*/),
+                      (v1/*: any*/),
                       {
                         "alias": null,
                         "args": [
@@ -238,7 +266,7 @@ return {
                             "name": "aspectRatio",
                             "storageKey": null
                           },
-                          (v4/*: any*/),
+                          (v1/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -249,7 +277,7 @@ return {
                           {
                             "alias": null,
                             "args": [
-                              (v5/*: any*/)
+                              (v6/*: any*/)
                             ],
                             "kind": "ScalarField",
                             "name": "url",
@@ -265,7 +293,7 @@ return {
                           {
                             "alias": null,
                             "args": [
-                              (v5/*: any*/),
+                              (v6/*: any*/),
                               {
                                 "kind": "Literal",
                                 "name": "width",
@@ -313,7 +341,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v6/*: any*/),
+                        "args": (v7/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artist",
@@ -344,7 +372,7 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v2/*: any*/)
+                          (v3/*: any*/)
                         ],
                         "storageKey": "artist(shallow:true)"
                       },
@@ -463,7 +491,7 @@ return {
                             "name": "partnerOffer",
                             "plural": false,
                             "selections": [
-                              (v7/*: any*/),
+                              (v8/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -471,10 +499,10 @@ return {
                                 "kind": "LinkedField",
                                 "name": "priceWithDiscount",
                                 "plural": false,
-                                "selections": (v8/*: any*/),
+                                "selections": (v9/*: any*/),
                                 "storageKey": null
                               },
-                              (v2/*: any*/)
+                              (v3/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -515,15 +543,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v6/*: any*/),
+                        "args": (v7/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v2/*: any*/),
                           (v3/*: any*/),
-                          (v9/*: any*/)
+                          (v5/*: any*/),
+                          (v10/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -536,15 +564,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v6/*: any*/),
+                        "args": (v7/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v9/*: any*/),
-                          (v3/*: any*/),
-                          (v2/*: any*/)
+                          (v10/*: any*/),
+                          (v5/*: any*/),
+                          (v3/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
                       },
@@ -556,7 +584,7 @@ return {
                         "name": "sale",
                         "plural": false,
                         "selections": [
-                          (v7/*: any*/),
+                          (v8/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -592,7 +620,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v2/*: any*/),
+                          (v3/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -618,7 +646,7 @@ return {
                         "name": "saleArtwork",
                         "plural": false,
                         "selections": [
-                          (v10/*: any*/),
+                          (v11/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -626,8 +654,8 @@ return {
                             "name": "lotLabel",
                             "storageKey": null
                           },
-                          (v7/*: any*/),
-                          (v11/*: any*/),
+                          (v8/*: any*/),
+                          (v12/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -660,7 +688,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v8/*: any*/),
+                            "selections": (v9/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -670,10 +698,10 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v8/*: any*/),
+                            "selections": (v9/*: any*/),
                             "storageKey": null
                           },
-                          (v2/*: any*/)
+                          (v3/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -685,10 +713,10 @@ return {
                         "name": "saleArtwork",
                         "plural": false,
                         "selections": [
-                          (v10/*: any*/),
-                          (v2/*: any*/),
-                          (v7/*: any*/),
-                          (v11/*: any*/)
+                          (v11/*: any*/),
+                          (v3/*: any*/),
+                          (v8/*: any*/),
+                          (v12/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -699,7 +727,7 @@ return {
                         "kind": "LinkedField",
                         "name": "attributionClass",
                         "plural": false,
-                        "selections": (v12/*: any*/),
+                        "selections": (v13/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -717,7 +745,7 @@ return {
                             "kind": "LinkedField",
                             "name": "filterGene",
                             "plural": false,
-                            "selections": (v12/*: any*/),
+                            "selections": (v13/*: any*/),
                             "storageKey": null
                           }
                         ],
@@ -794,26 +822,26 @@ return {
           },
           {
             "alias": null,
-            "args": (v1/*: any*/),
+            "args": (v4/*: any*/),
             "filters": [],
             "handle": "connection",
             "key": "MyCollectionRoute_myCollectionConnection",
             "kind": "LinkedHandle",
             "name": "myCollectionConnection"
           },
-          (v2/*: any*/)
+          (v3/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "cd0f547cdf41ac4513d87f0b94e220c5",
+    "cacheID": "88629382f77555c07f859615c5f429d2",
     "id": null,
     "metadata": {},
     "name": "MyCollectionRouteQuery",
     "operationKind": "query",
-    "text": "query MyCollectionRouteQuery(\n  $count: Int!\n  $cursor: String\n) {\n  me {\n    ...MyCollectionRoute_me_1G22uz\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_yvCPB on Artwork {\n  ...Metadata_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: true) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_yvCPB on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: true) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment MyCollectionArtworkGrid_artworks on MyCollectionConnection {\n  edges {\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: true) {\n        aspectRatio\n      }\n      artist(shallow: true) {\n        targetSupply {\n          priority\n        }\n        id\n      }\n      consignmentSubmission {\n        state\n      }\n      ...GridItem_artwork_yvCPB\n      ...FlatGridItem_artwork_yvCPB\n    }\n  }\n}\n\nfragment MyCollectionRoute_me_1G22uz on Me {\n  myCollectionConnection(first: $count, after: $cursor, sort: CREATED_AT_DESC) {\n    ...MyCollectionArtworkGrid_artworks\n    totalCount\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  internalID\n  collectorSignals {\n    primaryLabel\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n}\n"
+    "text": "query MyCollectionRouteQuery(\n  $count: Int!\n  $cursor: String\n) {\n  me {\n    ...MyCollectionRoute_me_1G22uz\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_yvCPB on Artwork {\n  ...Metadata_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: true) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_yvCPB on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: true) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment MyCollectionArtworkGrid_artworks on MyCollectionConnection {\n  edges {\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: true) {\n        aspectRatio\n      }\n      artist(shallow: true) {\n        targetSupply {\n          priority\n        }\n        id\n      }\n      consignmentSubmission {\n        state\n      }\n      ...GridItem_artwork_yvCPB\n      ...FlatGridItem_artwork_yvCPB\n    }\n  }\n}\n\nfragment MyCollectionRoute_me_1G22uz on Me {\n  myCollection: collection(id: \"my-collection\") {\n    internalID\n    slug\n    private\n    id\n  }\n  myCollectionConnection(first: $count, after: $cursor, sort: CREATED_AT_DESC) {\n    ...MyCollectionArtworkGrid_artworks\n    totalCount\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  internalID\n  collectorSignals {\n    primaryLabel\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/MyCollectionRoute_me.graphql.ts
+++ b/src/__generated__/MyCollectionRoute_me.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b9b84a771fc4b4940fccad069d720809>>
+ * @generated SignedSource<<813cbff8a59edca5115d3afced9a5409>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,6 +13,7 @@ import { FragmentRefs } from "relay-runtime";
 export type MyCollectionRoute_me$data = {
   readonly myCollection: {
     readonly internalID: string;
+    readonly name: string;
     readonly private: boolean;
     readonly slug: string | null | undefined;
   } | null | undefined;
@@ -86,6 +87,13 @@ const node: ReaderFragment = {
           "args": null,
           "kind": "ScalarField",
           "name": "slug",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
           "storageKey": null
         },
         {
@@ -194,6 +202,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "f157c676f90174ca1740af1d57d46825";
+(node as any).hash = "9fb061ddf0a0f613172f15caffb87640";
 
 export default node;

--- a/src/__generated__/MyCollectionRoute_me.graphql.ts
+++ b/src/__generated__/MyCollectionRoute_me.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<42e14207222bcbb036371dec9db5687e>>
+ * @generated SignedSource<<d927d125845aaa858e1c18e25a30e9e3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,6 +11,11 @@
 import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type MyCollectionRoute_me$data = {
+  readonly myCollection: {
+    readonly internalID: string;
+    readonly private: boolean;
+    readonly slug: string;
+  } | null | undefined;
   readonly myCollectionConnection: {
     readonly edges: ReadonlyArray<{
       readonly node: {
@@ -55,6 +60,44 @@ const node: ReaderFragment = {
   },
   "name": "MyCollectionRoute_me",
   "selections": [
+    {
+      "alias": "myCollection",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "id",
+          "value": "my-collection"
+        }
+      ],
+      "concreteType": "Collection",
+      "kind": "LinkedField",
+      "name": "collection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "internalID",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "slug",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "private",
+          "storageKey": null
+        }
+      ],
+      "storageKey": "collection(id:\"my-collection\")"
+    },
     {
       "alias": "myCollectionConnection",
       "args": null,
@@ -151,6 +194,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "90bf02c929b1358c41e9cef821762f5d";
+(node as any).hash = "f157c676f90174ca1740af1d57d46825";
 
 export default node;

--- a/src/__generated__/MyCollectionRoute_me.graphql.ts
+++ b/src/__generated__/MyCollectionRoute_me.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d927d125845aaa858e1c18e25a30e9e3>>
+ * @generated SignedSource<<b9b84a771fc4b4940fccad069d720809>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -14,7 +14,7 @@ export type MyCollectionRoute_me$data = {
   readonly myCollection: {
     readonly internalID: string;
     readonly private: boolean;
-    readonly slug: string;
+    readonly slug: string | null | undefined;
   } | null | undefined;
   readonly myCollectionConnection: {
     readonly edges: ReadonlyArray<{

--- a/src/__generated__/SavesArtworksHeaderQuery.graphql.ts
+++ b/src/__generated__/SavesArtworksHeaderQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e446a8a2d0805101426d27280be3c4d2>>
+ * @generated SignedSource<<0be54371b615b303d9dd57086e5c3f86>>
  * @lightSyntaxTransform
  * @nogrep
  */

--- a/src/__generated__/SavesArtworksHeaderQuery.graphql.ts
+++ b/src/__generated__/SavesArtworksHeaderQuery.graphql.ts
@@ -18,6 +18,7 @@ export type SavesArtworksHeaderQuery$data = {
       readonly default: boolean;
       readonly internalID: string;
       readonly name: string;
+      readonly private: boolean;
       readonly shareableWithPartners: boolean;
       readonly slug: string | null | undefined;
     } | null | undefined;
@@ -68,17 +69,24 @@ v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "shareableWithPartners",
+  "name": "private",
   "storageKey": null
 },
 v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "slug",
+  "name": "shareableWithPartners",
   "storageKey": null
 },
 v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -112,7 +120,8 @@ return {
               (v3/*: any*/),
               (v4/*: any*/),
               (v5/*: any*/),
-              (v6/*: any*/)
+              (v6/*: any*/),
+              (v7/*: any*/)
             ],
             "storageKey": null
           }
@@ -150,27 +159,28 @@ return {
               (v4/*: any*/),
               (v5/*: any*/),
               (v6/*: any*/),
-              (v7/*: any*/)
+              (v7/*: any*/),
+              (v8/*: any*/)
             ],
             "storageKey": null
           },
-          (v7/*: any*/)
+          (v8/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "5d886fb930e896709b8510eb764fc5c0",
+    "cacheID": "905c11a783a4592ba2f56d2226bf3041",
     "id": null,
     "metadata": {},
     "name": "SavesArtworksHeaderQuery",
     "operationKind": "query",
-    "text": "query SavesArtworksHeaderQuery(\n  $id: String!\n) {\n  me {\n    collection(id: $id) {\n      internalID\n      name\n      default\n      shareableWithPartners\n      slug\n      id\n    }\n    id\n  }\n}\n"
+    "text": "query SavesArtworksHeaderQuery(\n  $id: String!\n) {\n  me {\n    collection(id: $id) {\n      internalID\n      name\n      default\n      private\n      shareableWithPartners\n      slug\n      id\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "c3357788f75b58fdfcc8c7d65f638149";
+(node as any).hash = "ea48e8a6764d1e2e856015f132df33dd";
 
 export default node;

--- a/src/__generated__/ShareCollectionDialogMutation.graphql.ts
+++ b/src/__generated__/ShareCollectionDialogMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b213615c3d45f1fa7c91425300f34adb>>
+ * @generated SignedSource<<2592b17e2fb078bea96304326d42a760>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,7 +26,7 @@ export type ShareCollectionDialogMutation$data = {
       readonly collection?: {
         readonly internalID: string;
         readonly private: boolean;
-        readonly slug: string;
+        readonly slug: string | null | undefined;
       } | null | undefined;
       readonly mutationError?: {
         readonly message: string;

--- a/src/__generated__/ShareCollectionDialogMutation.graphql.ts
+++ b/src/__generated__/ShareCollectionDialogMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<523c38756e9dd7a0d29bcfa70b68fa3b>>
+ * @generated SignedSource<<b213615c3d45f1fa7c91425300f34adb>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -23,6 +23,11 @@ export type ShareCollectionDialogMutation$data = {
   readonly updateCollection: {
     readonly clientMutationId: string | null | undefined;
     readonly responseOrError: {
+      readonly collection?: {
+        readonly internalID: string;
+        readonly private: boolean;
+        readonly slug: string;
+      } | null | undefined;
       readonly mutationError?: {
         readonly message: string;
       } | null | undefined;
@@ -80,6 +85,27 @@ v3 = {
   ],
   "type": "UpdateCollectionFailure",
   "abstractKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "private",
+  "storageKey": null
 };
 return {
   "fragment": {
@@ -105,7 +131,28 @@ return {
             "name": "responseOrError",
             "plural": false,
             "selections": [
-              (v3/*: any*/)
+              (v3/*: any*/),
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Collection",
+                    "kind": "LinkedField",
+                    "name": "collection",
+                    "plural": false,
+                    "selections": [
+                      (v4/*: any*/),
+                      (v5/*: any*/),
+                      (v6/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "UpdateCollectionSuccess",
+                "abstractKey": null
+              }
             ],
             "storageKey": null
           }
@@ -146,7 +193,35 @@ return {
                 "name": "__typename",
                 "storageKey": null
               },
-              (v3/*: any*/)
+              (v3/*: any*/),
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Collection",
+                    "kind": "LinkedField",
+                    "name": "collection",
+                    "plural": false,
+                    "selections": [
+                      (v4/*: any*/),
+                      (v5/*: any*/),
+                      (v6/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "id",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "UpdateCollectionSuccess",
+                "abstractKey": null
+              }
             ],
             "storageKey": null
           }
@@ -156,16 +231,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "642735d07b225659e2cdf1a376f04557",
+    "cacheID": "86f5ab6abab4a1da07d2ee28b7040557",
     "id": null,
     "metadata": {},
     "name": "ShareCollectionDialogMutation",
     "operationKind": "mutation",
-    "text": "mutation ShareCollectionDialogMutation(\n  $input: updateCollectionInput!\n) {\n  updateCollection(input: $input) {\n    clientMutationId\n    responseOrError {\n      __typename\n      ... on UpdateCollectionFailure {\n        mutationError {\n          message\n        }\n      }\n    }\n  }\n}\n"
+    "text": "mutation ShareCollectionDialogMutation(\n  $input: updateCollectionInput!\n) {\n  updateCollection(input: $input) {\n    clientMutationId\n    responseOrError {\n      __typename\n      ... on UpdateCollectionFailure {\n        mutationError {\n          message\n        }\n      }\n      ... on UpdateCollectionSuccess {\n        collection {\n          internalID\n          slug\n          private\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "664c315dcb821405f46fb10b7998dcf1";
+(node as any).hash = "b8d4e0f939e02625a86bc1764bd7e948";
 
 export default node;

--- a/src/__generated__/collectorProfileRoutes_MyCollectionRouteQuery.graphql.ts
+++ b/src/__generated__/collectorProfileRoutes_MyCollectionRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<59b6f2322a0f8de9a530542540edd4ec>>
+ * @generated SignedSource<<879e13648a5dcd5ffd510dabd8780b17>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -40,10 +40,17 @@ v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v3 = [
+v4 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -55,14 +62,14 @@ v3 = [
     "value": "CREATED_AT_DESC"
   }
 ],
-v4 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v5 = {
+v6 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -70,21 +77,21 @@ v5 = {
     "large"
   ]
 },
-v6 = [
+v7 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v8 = [
+v9 = [
   {
     "alias": null,
     "args": null,
@@ -93,13 +100,6 @@ v8 = [
     "storageKey": null
   }
 ],
-v9 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "name",
-  "storageKey": null
-},
 v10 = {
   "alias": null,
   "args": null,
@@ -115,8 +115,8 @@ v11 = {
   "storageKey": null
 },
 v12 = [
-  (v9/*: any*/),
-  (v2/*: any*/)
+  (v2/*: any*/),
+  (v3/*: any*/)
 ];
 return {
   "fragment": {
@@ -175,6 +175,7 @@ return {
             "selections": [
               (v0/*: any*/),
               (v1/*: any*/),
+              (v2/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -182,13 +183,13 @@ return {
                 "name": "private",
                 "storageKey": null
               },
-              (v2/*: any*/)
+              (v3/*: any*/)
             ],
             "storageKey": "collection(id:\"my-collection\")"
           },
           {
             "alias": null,
-            "args": (v3/*: any*/),
+            "args": (v4/*: any*/),
             "concreteType": "MyCollectionConnection",
             "kind": "LinkedField",
             "name": "myCollectionConnection",
@@ -210,9 +211,9 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v2/*: any*/),
+                      (v3/*: any*/),
                       (v1/*: any*/),
-                      (v4/*: any*/),
+                      (v5/*: any*/),
                       (v0/*: any*/),
                       {
                         "alias": null,
@@ -246,7 +247,7 @@ return {
                           {
                             "alias": null,
                             "args": [
-                              (v5/*: any*/)
+                              (v6/*: any*/)
                             ],
                             "kind": "ScalarField",
                             "name": "url",
@@ -262,7 +263,7 @@ return {
                           {
                             "alias": null,
                             "args": [
-                              (v5/*: any*/),
+                              (v6/*: any*/),
                               {
                                 "kind": "Literal",
                                 "name": "width",
@@ -310,7 +311,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v6/*: any*/),
+                        "args": (v7/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artist",
@@ -341,7 +342,7 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v2/*: any*/)
+                          (v3/*: any*/)
                         ],
                         "storageKey": "artist(shallow:true)"
                       },
@@ -460,7 +461,7 @@ return {
                             "name": "partnerOffer",
                             "plural": false,
                             "selections": [
-                              (v7/*: any*/),
+                              (v8/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -468,10 +469,10 @@ return {
                                 "kind": "LinkedField",
                                 "name": "priceWithDiscount",
                                 "plural": false,
-                                "selections": (v8/*: any*/),
+                                "selections": (v9/*: any*/),
                                 "storageKey": null
                               },
-                              (v2/*: any*/)
+                              (v3/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -512,15 +513,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v6/*: any*/),
+                        "args": (v7/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v2/*: any*/),
-                          (v4/*: any*/),
-                          (v9/*: any*/)
+                          (v3/*: any*/),
+                          (v5/*: any*/),
+                          (v2/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -533,15 +534,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v6/*: any*/),
+                        "args": (v7/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v9/*: any*/),
-                          (v4/*: any*/),
-                          (v2/*: any*/)
+                          (v2/*: any*/),
+                          (v5/*: any*/),
+                          (v3/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
                       },
@@ -553,7 +554,7 @@ return {
                         "name": "sale",
                         "plural": false,
                         "selections": [
-                          (v7/*: any*/),
+                          (v8/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -589,7 +590,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v2/*: any*/),
+                          (v3/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -623,7 +624,7 @@ return {
                             "name": "lotLabel",
                             "storageKey": null
                           },
-                          (v7/*: any*/),
+                          (v8/*: any*/),
                           (v11/*: any*/),
                           {
                             "alias": null,
@@ -657,7 +658,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v8/*: any*/),
+                            "selections": (v9/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -667,10 +668,10 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v8/*: any*/),
+                            "selections": (v9/*: any*/),
                             "storageKey": null
                           },
-                          (v2/*: any*/)
+                          (v3/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -683,8 +684,8 @@ return {
                         "plural": false,
                         "selections": [
                           (v10/*: any*/),
-                          (v2/*: any*/),
-                          (v7/*: any*/),
+                          (v3/*: any*/),
+                          (v8/*: any*/),
                           (v11/*: any*/)
                         ],
                         "storageKey": null
@@ -791,26 +792,26 @@ return {
           },
           {
             "alias": null,
-            "args": (v3/*: any*/),
+            "args": (v4/*: any*/),
             "filters": [],
             "handle": "connection",
             "key": "MyCollectionRoute_myCollectionConnection",
             "kind": "LinkedHandle",
             "name": "myCollectionConnection"
           },
-          (v2/*: any*/)
+          (v3/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "1b33953c150bba3144bb5450c91e473a",
+    "cacheID": "bb5d929ee4e751eb33460fafbe438be7",
     "id": null,
     "metadata": {},
     "name": "collectorProfileRoutes_MyCollectionRouteQuery",
     "operationKind": "query",
-    "text": "query collectorProfileRoutes_MyCollectionRouteQuery {\n  me {\n    ...MyCollectionRoute_me\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_yvCPB on Artwork {\n  ...Metadata_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: true) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_yvCPB on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: true) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment MyCollectionArtworkGrid_artworks on MyCollectionConnection {\n  edges {\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: true) {\n        aspectRatio\n      }\n      artist(shallow: true) {\n        targetSupply {\n          priority\n        }\n        id\n      }\n      consignmentSubmission {\n        state\n      }\n      ...GridItem_artwork_yvCPB\n      ...FlatGridItem_artwork_yvCPB\n    }\n  }\n}\n\nfragment MyCollectionRoute_me on Me {\n  myCollection: collection(id: \"my-collection\") {\n    internalID\n    slug\n    private\n    id\n  }\n  myCollectionConnection(first: 25, sort: CREATED_AT_DESC) {\n    ...MyCollectionArtworkGrid_artworks\n    totalCount\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  internalID\n  collectorSignals {\n    primaryLabel\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n}\n"
+    "text": "query collectorProfileRoutes_MyCollectionRouteQuery {\n  me {\n    ...MyCollectionRoute_me\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_yvCPB on Artwork {\n  ...Metadata_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: true) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_yvCPB on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: true) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment MyCollectionArtworkGrid_artworks on MyCollectionConnection {\n  edges {\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: true) {\n        aspectRatio\n      }\n      artist(shallow: true) {\n        targetSupply {\n          priority\n        }\n        id\n      }\n      consignmentSubmission {\n        state\n      }\n      ...GridItem_artwork_yvCPB\n      ...FlatGridItem_artwork_yvCPB\n    }\n  }\n}\n\nfragment MyCollectionRoute_me on Me {\n  myCollection: collection(id: \"my-collection\") {\n    internalID\n    slug\n    name\n    private\n    id\n  }\n  myCollectionConnection(first: 25, sort: CREATED_AT_DESC) {\n    ...MyCollectionArtworkGrid_artworks\n    totalCount\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  internalID\n  collectorSignals {\n    primaryLabel\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/collectorProfileRoutes_MyCollectionRouteQuery.graphql.ts
+++ b/src/__generated__/collectorProfileRoutes_MyCollectionRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<488b89682d29a871143ec1fe9f14254c>>
+ * @generated SignedSource<<59b6f2322a0f8de9a530542540edd4ec>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -22,7 +22,28 @@ export type collectorProfileRoutes_MyCollectionRouteQuery = {
 };
 
 const node: ConcreteRequest = (function(){
-var v0 = [
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = [
   {
     "kind": "Literal",
     "name": "first",
@@ -34,28 +55,14 @@ var v0 = [
     "value": "CREATED_AT_DESC"
   }
 ],
-v1 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "id",
-  "storageKey": null
-},
-v2 = {
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "href",
   "storageKey": null
 },
-v3 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "internalID",
-  "storageKey": null
-},
-v4 = {
+v5 = {
   "kind": "Literal",
   "name": "version",
   "value": [
@@ -63,21 +70,21 @@ v4 = {
     "large"
   ]
 },
-v5 = [
+v6 = [
   {
     "kind": "Literal",
     "name": "shallow",
     "value": true
   }
 ],
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "endAt",
   "storageKey": null
 },
-v7 = [
+v8 = [
   {
     "alias": null,
     "args": null,
@@ -86,30 +93,30 @@ v7 = [
     "storageKey": null
   }
 ],
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v9 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "lotID",
   "storageKey": null
 },
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "extendedBiddingEndAt",
   "storageKey": null
 },
-v11 = [
-  (v8/*: any*/),
-  (v1/*: any*/)
+v12 = [
+  (v9/*: any*/),
+  (v2/*: any*/)
 ];
 return {
   "fragment": {
@@ -153,8 +160,35 @@ return {
         "plural": false,
         "selections": [
           {
+            "alias": "myCollection",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "id",
+                "value": "my-collection"
+              }
+            ],
+            "concreteType": "Collection",
+            "kind": "LinkedField",
+            "name": "collection",
+            "plural": false,
+            "selections": [
+              (v0/*: any*/),
+              (v1/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "private",
+                "storageKey": null
+              },
+              (v2/*: any*/)
+            ],
+            "storageKey": "collection(id:\"my-collection\")"
+          },
+          {
             "alias": null,
-            "args": (v0/*: any*/),
+            "args": (v3/*: any*/),
             "concreteType": "MyCollectionConnection",
             "kind": "LinkedField",
             "name": "myCollectionConnection",
@@ -176,16 +210,10 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v1/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "slug",
-                        "storageKey": null
-                      },
                       (v2/*: any*/),
-                      (v3/*: any*/),
+                      (v1/*: any*/),
+                      (v4/*: any*/),
+                      (v0/*: any*/),
                       {
                         "alias": null,
                         "args": [
@@ -207,7 +235,7 @@ return {
                             "name": "aspectRatio",
                             "storageKey": null
                           },
-                          (v3/*: any*/),
+                          (v0/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -218,7 +246,7 @@ return {
                           {
                             "alias": null,
                             "args": [
-                              (v4/*: any*/)
+                              (v5/*: any*/)
                             ],
                             "kind": "ScalarField",
                             "name": "url",
@@ -234,7 +262,7 @@ return {
                           {
                             "alias": null,
                             "args": [
-                              (v4/*: any*/),
+                              (v5/*: any*/),
                               {
                                 "kind": "Literal",
                                 "name": "width",
@@ -282,7 +310,7 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v5/*: any*/),
+                        "args": (v6/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artist",
@@ -313,7 +341,7 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v1/*: any*/)
+                          (v2/*: any*/)
                         ],
                         "storageKey": "artist(shallow:true)"
                       },
@@ -432,7 +460,7 @@ return {
                             "name": "partnerOffer",
                             "plural": false,
                             "selections": [
-                              (v6/*: any*/),
+                              (v7/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -440,10 +468,10 @@ return {
                                 "kind": "LinkedField",
                                 "name": "priceWithDiscount",
                                 "plural": false,
-                                "selections": (v7/*: any*/),
+                                "selections": (v8/*: any*/),
                                 "storageKey": null
                               },
-                              (v1/*: any*/)
+                              (v2/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -484,15 +512,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v5/*: any*/),
+                        "args": (v6/*: any*/),
                         "concreteType": "Artist",
                         "kind": "LinkedField",
                         "name": "artists",
                         "plural": true,
                         "selections": [
-                          (v1/*: any*/),
                           (v2/*: any*/),
-                          (v8/*: any*/)
+                          (v4/*: any*/),
+                          (v9/*: any*/)
                         ],
                         "storageKey": "artists(shallow:true)"
                       },
@@ -505,15 +533,15 @@ return {
                       },
                       {
                         "alias": null,
-                        "args": (v5/*: any*/),
+                        "args": (v6/*: any*/),
                         "concreteType": "Partner",
                         "kind": "LinkedField",
                         "name": "partner",
                         "plural": false,
                         "selections": [
-                          (v8/*: any*/),
-                          (v2/*: any*/),
-                          (v1/*: any*/)
+                          (v9/*: any*/),
+                          (v4/*: any*/),
+                          (v2/*: any*/)
                         ],
                         "storageKey": "partner(shallow:true)"
                       },
@@ -525,7 +553,7 @@ return {
                         "name": "sale",
                         "plural": false,
                         "selections": [
-                          (v6/*: any*/),
+                          (v7/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -561,7 +589,7 @@ return {
                             "name": "isClosed",
                             "storageKey": null
                           },
-                          (v1/*: any*/),
+                          (v2/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -587,7 +615,7 @@ return {
                         "name": "saleArtwork",
                         "plural": false,
                         "selections": [
-                          (v9/*: any*/),
+                          (v10/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -595,8 +623,8 @@ return {
                             "name": "lotLabel",
                             "storageKey": null
                           },
-                          (v6/*: any*/),
-                          (v10/*: any*/),
+                          (v7/*: any*/),
+                          (v11/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -629,7 +657,7 @@ return {
                             "kind": "LinkedField",
                             "name": "highestBid",
                             "plural": false,
-                            "selections": (v7/*: any*/),
+                            "selections": (v8/*: any*/),
                             "storageKey": null
                           },
                           {
@@ -639,10 +667,10 @@ return {
                             "kind": "LinkedField",
                             "name": "openingBid",
                             "plural": false,
-                            "selections": (v7/*: any*/),
+                            "selections": (v8/*: any*/),
                             "storageKey": null
                           },
-                          (v1/*: any*/)
+                          (v2/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -654,10 +682,10 @@ return {
                         "name": "saleArtwork",
                         "plural": false,
                         "selections": [
-                          (v9/*: any*/),
-                          (v1/*: any*/),
-                          (v6/*: any*/),
-                          (v10/*: any*/)
+                          (v10/*: any*/),
+                          (v2/*: any*/),
+                          (v7/*: any*/),
+                          (v11/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -668,7 +696,7 @@ return {
                         "kind": "LinkedField",
                         "name": "attributionClass",
                         "plural": false,
-                        "selections": (v11/*: any*/),
+                        "selections": (v12/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -686,7 +714,7 @@ return {
                             "kind": "LinkedField",
                             "name": "filterGene",
                             "plural": false,
-                            "selections": (v11/*: any*/),
+                            "selections": (v12/*: any*/),
                             "storageKey": null
                           }
                         ],
@@ -763,26 +791,26 @@ return {
           },
           {
             "alias": null,
-            "args": (v0/*: any*/),
+            "args": (v3/*: any*/),
             "filters": [],
             "handle": "connection",
             "key": "MyCollectionRoute_myCollectionConnection",
             "kind": "LinkedHandle",
             "name": "myCollectionConnection"
           },
-          (v1/*: any*/)
+          (v2/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "95aa3c51e7f4b4c632a2ab8e3a69d506",
+    "cacheID": "1b33953c150bba3144bb5450c91e473a",
     "id": null,
     "metadata": {},
     "name": "collectorProfileRoutes_MyCollectionRouteQuery",
     "operationKind": "query",
-    "text": "query collectorProfileRoutes_MyCollectionRouteQuery {\n  me {\n    ...MyCollectionRoute_me\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_yvCPB on Artwork {\n  ...Metadata_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: true) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_yvCPB on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: true) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment MyCollectionArtworkGrid_artworks on MyCollectionConnection {\n  edges {\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: true) {\n        aspectRatio\n      }\n      artist(shallow: true) {\n        targetSupply {\n          priority\n        }\n        id\n      }\n      consignmentSubmission {\n        state\n      }\n      ...GridItem_artwork_yvCPB\n      ...FlatGridItem_artwork_yvCPB\n    }\n  }\n}\n\nfragment MyCollectionRoute_me on Me {\n  myCollectionConnection(first: 25, sort: CREATED_AT_DESC) {\n    ...MyCollectionArtworkGrid_artworks\n    totalCount\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  internalID\n  collectorSignals {\n    primaryLabel\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n}\n"
+    "text": "query collectorProfileRoutes_MyCollectionRouteQuery {\n  me {\n    ...MyCollectionRoute_me\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork_yvCPB on Artwork {\n  ...Metadata_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: true) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork_yvCPB on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: true) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment MyCollectionArtworkGrid_artworks on MyCollectionConnection {\n  edges {\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: true) {\n        aspectRatio\n      }\n      artist(shallow: true) {\n        targetSupply {\n          priority\n        }\n        id\n      }\n      consignmentSubmission {\n        state\n      }\n      ...GridItem_artwork_yvCPB\n      ...FlatGridItem_artwork_yvCPB\n    }\n  }\n}\n\nfragment MyCollectionRoute_me on Me {\n  myCollection: collection(id: \"my-collection\") {\n    internalID\n    slug\n    private\n    id\n  }\n  myCollectionConnection(first: 25, sort: CREATED_AT_DESC) {\n    ...MyCollectionArtworkGrid_artworks\n    totalCount\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  internalID\n  collectorSignals {\n    primaryLabel\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [ONYX-1627]

### Description

Updates the recent Hackathon project for sharing artwork lists. 

Highlights:

- Changes the UX to a toggle (rather than sharing upon mount) so that **un-sharing is permitted**. This is analogous to the existing toggle for sharing lists for partner offers.
- Ensures that the collection **slug is available in the url**, even on the initial share
- Updates copy to be consistent with the public-facing **language** for existing feature ("list" instead of "collection")
- Adds **test coverage** (based on somewhat iffy Claude results which I had to touch up)

Not in scope:

- Trying to reconcile the copy or the UX between this feature and the Partner Offer sharing. Punting on that based on today's office hours discussion.

cc @mzikherman @dzucconi 

| Before | After |
|--------|--------|
| <img width="501" alt="before" src="https://github.com/user-attachments/assets/c6e636dc-de51-4219-9cc7-4e58b640070e" /> | <img width="501" alt="afterr" src="https://github.com/user-attachments/assets/f95876bc-c768-4fb3-8875-08117d96f4f7" /> |

<!--
| <video src="https://github.com/user-attachments/assets/4e45071f-e243-4707-b36d-716509f921f4" /> | <video src="https://github.com/user-attachments/assets/6805e57d-5c37-45f1-8cb5-011ed5c51ec5" /> | 
-->



[ONYX-1627]: https://artsyproduct.atlassian.net/browse/ONYX-1627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ