### PR TITLE
fix(artwork): switches to use correct feature flag

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkLightbox.tsx
+++ b/src/Apps/Artwork/Components/ArtworkLightbox.tsx
@@ -34,7 +34,7 @@ const ArtworkLightbox: React.FC<
   const images = compact(artwork.images)
   const hasGeometry = !!images[0]?.resized?.width
 
-  const isBlurhashEnabled = useFeatureFlag("diamond_blurhash-on-artist-pages")
+  const isBlurhashEnabled = useFeatureFlag("diamond_artwork-page-blurhash")
   const localImage = useLocalImage(images[activeIndex])
 
   const resizedLocalImage = localImage && {


### PR DESCRIPTION
I think we could probably remove this feature flag completely, but we might as well just see this through into production.