### PR TITLE
chore(EMI-2366): track express checkout viewed

### DIFF
--- a/src/Apps/Order/Components/ExpressCheckout/__tests__/ExpressCheckoutUI.jest.tsx
+++ b/src/Apps/Order/Components/ExpressCheckout/__tests__/ExpressCheckoutUI.jest.tsx
@@ -15,7 +15,7 @@ jest.unmock("react-relay")
 
 jest.mock("System/Hooks/useAnalyticsContext", () => ({
   useAnalyticsContext: jest.fn(() => ({
-    contextPageOwnerSlug: "artwork-slug",
+    contextPageOwnerSlug: "artwork-slug-from-context",
   })),
 }))
 
@@ -153,7 +153,7 @@ describe("ExpressCheckoutUI", () => {
     expect(trackEvent).toHaveBeenCalledWith({
       action: "expressCheckoutViewed",
       context_page_owner_id: "a5aaa8b0-93ff-4f2a-8bb3-9589f378d229",
-      context_page_owner_slug: "artwork-slug",
+      context_page_owner_slug: "artwork-slug-from-context",
       context_page_owner_type: "orders-shipping",
       flow: "Buy now",
       payment_methods: ["applePay"],
@@ -170,7 +170,7 @@ describe("ExpressCheckoutUI", () => {
     expect(trackEvent).toHaveBeenCalledWith({
       action: "clickedExpressCheckout",
       context_page_owner_id: "a5aaa8b0-93ff-4f2a-8bb3-9589f378d229",
-      context_page_owner_slug: "artwork-slug",
+      context_page_owner_slug: "artwork-slug-from-context",
       context_page_owner_type: "orders-shipping",
       flow: "Buy now",
       payment_method: "apple_pay",
@@ -200,7 +200,7 @@ describe("ExpressCheckoutUI", () => {
     expect(trackEvent).toHaveBeenCalledWith({
       action: "clickedCancelExpressCheckout",
       context_page_owner_id: "a5aaa8b0-93ff-4f2a-8bb3-9589f378d229",
-      context_page_owner_slug: "artwork-slug",
+      context_page_owner_slug: "artwork-slug-from-context",
       context_page_owner_type: "orders-shipping",
       flow: "Buy now",
       payment_method: "apple_pay",

--- a/src/Apps/Order/Hooks/useOrderTracking.tsx
+++ b/src/Apps/Order/Hooks/useOrderTracking.tsx
@@ -1,6 +1,8 @@
 import {
   ActionType,
   type ClickedAddNewShippingAddress,
+  type ClickedCancelExpressCheckout,
+  type ClickedExpressCheckout,
   type ClickedSelectShippingOption,
   type ClickedShippingAddress,
   ContextModule,
@@ -11,6 +13,7 @@ import {
 import * as DeprecatedSchema from "@artsy/cohesion/dist/DeprecatedSchema"
 import type { FulfillmentType } from "Apps/Order/Routes/Shipping/Utils/shippingUtils"
 import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
+import type { ExpressCheckoutUI_order$data } from "__generated__/ExpressCheckoutUI_order.graphql"
 import { useMemo } from "react"
 import { useTracking } from "react-tracking"
 
@@ -94,7 +97,13 @@ export const useOrderTracking = () => {
         trackEvent(payload)
       },
 
-      expressCheckoutViewed: ({ order, paymentMethods }) => {
+      expressCheckoutViewed: ({
+        order,
+        paymentMethods,
+      }: {
+        order: ExpressCheckoutUI_order$data
+        paymentMethods: string[]
+      }) => {
         const payload: ExpressCheckoutViewed = {
           action: ActionType.expressCheckoutViewed,
           context_page_owner_type: OwnerType.ordersShipping,
@@ -107,6 +116,54 @@ export const useOrderTracking = () => {
                 ? "Buy now"
                 : "Make offer",
           payment_methods: paymentMethods,
+        }
+
+        trackEvent(payload)
+      },
+
+      clickedExpressCheckout: ({
+        order,
+        paymentMethod,
+      }: {
+        order: ExpressCheckoutUI_order$data
+        paymentMethod: string
+      }) => {
+        const payload: ClickedExpressCheckout = {
+          action: ActionType.clickedExpressCheckout,
+          context_page_owner_type: OwnerType.ordersShipping,
+          context_page_owner_id: order.internalID ?? "",
+          context_page_owner_slug: contextPageOwnerSlug,
+          flow:
+            order.source === "PARTNER_OFFER"
+              ? "Partner offer"
+              : order.mode === "BUY"
+                ? "Buy now"
+                : "Make offer",
+          payment_method: paymentMethod,
+        }
+
+        trackEvent(payload)
+      },
+
+      clickedCancelExpressCheckout: ({
+        order,
+        paymentMethod,
+      }: {
+        order: ExpressCheckoutUI_order$data
+        paymentMethod: string
+      }) => {
+        const payload: ClickedCancelExpressCheckout = {
+          action: ActionType.clickedCancelExpressCheckout,
+          context_page_owner_type: OwnerType.ordersShipping,
+          context_page_owner_id: order.internalID ?? "",
+          context_page_owner_slug: contextPageOwnerSlug,
+          flow:
+            order.source === "PARTNER_OFFER"
+              ? "Partner offer"
+              : order.mode === "BUY"
+                ? "Buy now"
+                : "Make offer",
+          payment_method: paymentMethod,
         }
 
         trackEvent(payload)

--- a/src/Apps/Order/Hooks/useOrderTracking.tsx
+++ b/src/Apps/Order/Hooks/useOrderTracking.tsx
@@ -5,6 +5,7 @@ import {
   type ClickedShippingAddress,
   ContextModule,
   type ErrorMessageViewed,
+  type ExpressCheckoutViewed,
   OwnerType,
 } from "@artsy/cohesion"
 import * as DeprecatedSchema from "@artsy/cohesion/dist/DeprecatedSchema"
@@ -17,6 +18,7 @@ export const useOrderTracking = () => {
   const { trackEvent } = useTracking()
   const analytics = useAnalyticsContext()
   const contextPageOwnerId = analytics.contextPageOwnerId as string
+  const contextPageOwnerSlug = analytics.contextPageOwnerSlug as string
 
   const trackingCalls = useMemo(() => {
     return {
@@ -91,8 +93,26 @@ export const useOrderTracking = () => {
 
         trackEvent(payload)
       },
+
+      expressCheckoutViewed: ({ order, paymentMethods }) => {
+        const payload: ExpressCheckoutViewed = {
+          action: ActionType.expressCheckoutViewed,
+          context_page_owner_type: OwnerType.ordersShipping,
+          context_page_owner_id: order.internalID ?? "",
+          context_page_owner_slug: contextPageOwnerSlug,
+          flow:
+            order.source === "PARTNER_OFFER"
+              ? "Partner offer"
+              : order.mode === "BUY"
+                ? "Buy now"
+                : "Make offer",
+          payment_methods: paymentMethods,
+        }
+
+        trackEvent(payload)
+      },
     }
-  }, [trackEvent, contextPageOwnerId])
+  }, [trackEvent, contextPageOwnerId, contextPageOwnerSlug])
 
   return trackingCalls
 }


### PR DESCRIPTION
The type of this PR is: **Chore*

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2366]

### Description

This adds the `ExpressCheckoutViewed` event for express checkout as well as moves all express checkout tracking to `useOrderTracking`. 

<!-- Implementation description -->


[EMI-2366]: https://artsyproduct.atlassian.net/browse/EMI-2366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ