### PR TITLE
fix(EMI-2351): Add postal code to payload when selecting apple pay shipping address

### DIFF
--- a/src/Apps/Order/Components/ExpressCheckout/ExpressCheckoutUI.tsx
+++ b/src/Apps/Order/Components/ExpressCheckout/ExpressCheckoutUI.tsx
@@ -170,7 +170,7 @@ export const ExpressCheckoutUI = ({ order }: ExpressCheckoutUIProps) => {
     logger.warn("Express checkout element address change", address)
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { city, state, country } = address
+    const { city, state, country, postal_code } = address
 
     try {
       const updateOrderResult = await updateOrderMutation.submitMutation({
@@ -180,6 +180,7 @@ export const ExpressCheckoutUI = ({ order }: ExpressCheckoutUIProps) => {
             shippingCity: city,
             shippingRegion: state,
             shippingCountry: country,
+            shippingPostalCode: postal_code,
           },
         },
       })


### PR DESCRIPTION
The type of this PR is: **fix**

#minor

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2351]

### Description

For some reason we aren't setting postal code when the user selects a shipping address in express checkout. This PR fixes it.

[EMI-2351]: https://artsyproduct.atlassian.net/browse/EMI-2351?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ