### PR TITLE
chore: Show pickup last, do less work to reset order on load

### DIFF
--- a/src/Apps/Order/Components/ExpressCheckout/ExpressCheckoutUI.tsx
+++ b/src/Apps/Order/Components/ExpressCheckout/ExpressCheckoutUI.tsx
@@ -137,7 +137,7 @@ export const ExpressCheckoutUI = ({ order }: ExpressCheckoutUIProps) => {
     try {
       const allowedShippingCountries =
         extractAllowedShippingCountries(orderData)
-      const shippingRates = extractShippingRates(orderData)
+      const shippingRates = [CALCULATING_SHIPPING_RATE]
 
       return updateOrderTotalAndResolve({
         buyerTotalMinor: itemsTotal?.minor,

--- a/src/Apps/Order/Components/ExpressCheckout/ExpressCheckoutUI.tsx
+++ b/src/Apps/Order/Components/ExpressCheckout/ExpressCheckoutUI.tsx
@@ -132,26 +132,20 @@ export const ExpressCheckoutUI = ({ order }: ExpressCheckoutUIProps) => {
       order: orderData,
       paymentMethod: expressPaymentType,
     })
+    const { itemsTotal } = orderData
 
     try {
-      const data = await resetOrder()
-      const validatedResult = validateAndExtractOrderResponse(data)
-
-      const allowedShippingCountries = extractAllowedShippingCountries(
-        validatedResult.order,
-      )
-      const shippingRates = extractShippingRates(validatedResult.order)
-      const lineItems = extractLineItems(validatedResult.order)
+      const allowedShippingCountries =
+        extractAllowedShippingCountries(orderData)
+      const shippingRates = extractShippingRates(orderData)
 
       return updateOrderTotalAndResolve({
-        buyerTotalMinor: validatedResult.order.buyerTotal?.minor,
-        timeout: 0,
+        buyerTotalMinor: itemsTotal?.minor,
         resolveDetails: () =>
           resolve({
             ...checkoutOptions,
             allowedShippingCountries,
             shippingRates,
-            lineItems,
           }),
       })
     } catch (error) {
@@ -460,7 +454,6 @@ const extractLineItems = (order: ParseableOrder): Array<LineItem> => {
     throw new Error("itemsTotal is required")
   }
 
-  // TODO: Change to let when we have shipping and tax lines
   let shippingLine: LineItem | null = null
   let taxLine: LineItem | null = null
 
@@ -553,15 +546,28 @@ const shippingRateForFulfillmentOption = option => {
   }
 }
 
+const sortPickupLast = (a: ShippingRate, b: ShippingRate) => {
+  // Sort pickup last
+  if (a.id === "PICKUP" && b.id !== "PICKUP") {
+    return 1
+  }
+  if (a.id !== "PICKUP" && b.id === "PICKUP") {
+    return -1
+  }
+  return 0
+}
+
 const extractShippingRates = (order: ParseableOrder): Array<ShippingRate> => {
   const rates = order.fulfillmentOptions
     .map(shippingRateForFulfillmentOption)
     .filter(Boolean) as ShippingRate[]
   const shippingRatesOnly = rates.filter(rate => rate.id !== "PICKUP")
-  if (shippingRatesOnly.length === 0) {
-    return rates.concat(CALCULATING_SHIPPING_RATE)
-  }
-  return rates
+  const finalRates =
+    shippingRatesOnly.length === 0
+      ? rates.concat(CALCULATING_SHIPPING_RATE)
+      : rates
+
+  return finalRates.sort(sortPickupLast)
 }
 
 // Only max-height can be animated

--- a/src/Apps/Order/Components/ExpressCheckout/index.tsx
+++ b/src/Apps/Order/Components/ExpressCheckout/index.tsx
@@ -19,15 +19,18 @@ interface Props {
 
 export const ExpressCheckout = ({ order }: Props) => {
   const orderData = useFragment(ORDER_FRAGMENT, order)
-  const { buyerTotal } = orderData
 
-  if (!(buyerTotal && orderData.availableShippingCountries.length)) {
+  // Use itemsTotal on load, but subsequent updates inside ExpressCheckoutUI
+  // will use the updated buyersTotal.
+  const { itemsTotal } = orderData
+
+  if (!(itemsTotal && orderData.availableShippingCountries.length)) {
     return null
   }
 
   const orderOptions: StripeElementsUpdateOptions = {
-    amount: buyerTotal.minor,
-    currency: buyerTotal.currencyCode.toLowerCase(),
+    amount: itemsTotal.minor,
+    currency: itemsTotal.currencyCode.toLowerCase(),
     setupFutureUsage: "off_session",
     captureMethod: "manual",
     // TODO: Add seller details to the order type


### PR DESCRIPTION
The type of this PR is: **chore**

### Description

This PR makes 2 optimizations to the express checkout flow:
- Don't fully reset the order on load - pass the initial line items total and rely on subsequent events like shipping address and shipping rate selection to update totals including line items.
- show pickup last in the shipping rates list.

<!-- Implementation description -->
