### PR TITLE
fix(artwork): fixes layout for auction artwork breadcrumb

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkTopContextBar/ArtworkTopContextBarSale.tsx
+++ b/src/Apps/Artwork/Components/ArtworkTopContextBar/ArtworkTopContextBarSale.tsx
@@ -54,6 +54,7 @@ export const ArtworkTopContextBarSale: React.FC<
       src={sale.coverImage?.url}
       displayBackArrow
       preferHistoryBack
+      rightContent={<RegistrationAuctionTimerFragmentContainer sale={sale} />}
     >
       <Stack gap={1} flexDirection="row">
         {sale.name}
@@ -61,7 +62,6 @@ export const ArtworkTopContextBarSale: React.FC<
           {sale.partner?.name ? `${title} by ${sale.partner.name}` : title}
         </Box>
       </Stack>
-      <RegistrationAuctionTimerFragmentContainer sale={sale} />
     </TopContextBar>
   )
 }

--- a/src/Apps/Artwork/Components/ArtworkTopContextBar/__tests__/ArtworkTopContextBarSale.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkTopContextBar/__tests__/ArtworkTopContextBarSale.jest.tsx
@@ -12,6 +12,7 @@ jest.mock("Components/TopContextBar", () => ({
     src,
     displayBackArrow,
     preferHistoryBack,
+    rightContent,
   }) => (
     <div
       data-testid="top-context-bar"
@@ -21,6 +22,7 @@ jest.mock("Components/TopContextBar", () => ({
       data-prefer-history-back={preferHistoryBack}
     >
       {children}
+      {rightContent}
     </div>
   ),
 }))


### PR DESCRIPTION
Corrects the layout of the auction artwork dynamic breadcrumb when there is a countdown.

### Before:

![](https://capture.static.damonzucconi.com/Screen-Shot-2025-03-31-08-53-19.71-jLkwTdInAagJVe9SiTkytzcJJ3QmjdpqFzTLLN9LyW8Eg5v5mkno2g0q2I8lwEIkTnPHMcHTN8j7csQ3WSuFBW7UWg5Z6YWAldLK.png)

### After:
![](https://capture.static.damonzucconi.com/Screen-Shot-2025-03-31-08-52-23.89-AjouZSYN1DOvETXFD6A6Sz4q1uynVZTXRugfT0FYCp7MF1Q3wrNpA3ho6RDXdpx2bK1paCmdzsghohFekRHSj5CN61vIe43KPwL7.png)