### PR TITLE
feat(DIA-1246): Artsy for Galleries and Collecting 101 pages 

### DIFF
--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -79,6 +79,9 @@ export const NavBar: React.FC<React.PropsWithChildren<unknown>> = track(
 
   const shouldTransition = transitionCount <= 1
 
+  const GALLERY_PARTNERSHIPS_URL =
+    "https://partners.artsy.net/gallery-partnerships/?utm_medium=internal-banner&utm_source=artsy&utm_campaign=b2b-2025-gallery-partnerships-application-banner-link&utm_sfc=701Hu000001jeLjIAI"
+
   // Close mobile menu if dragging window from small size to desktop
   useEffect(() => {
     if (!isMobile) {
@@ -224,7 +227,7 @@ export const NavBar: React.FC<React.PropsWithChildren<unknown>> = track(
                   </Flex>
 
                   <NavBarItemLink
-                    href="https://partners.artsy.net/gallery-partnerships/?utm_medium=internal-banner&utm_source=artsy&utm_campaign=b2b-2025-gallery-partnerships-application-banner-link&utm_sfc=701Hu000001jeLjIAI"
+                    href={GALLERY_PARTNERSHIPS_URL}
                     textDecoration="none"
                     onClick={handleClick}
                     data-label="Artsy for Galleries"
@@ -489,6 +492,7 @@ export const NavBar: React.FC<React.PropsWithChildren<unknown>> = track(
 })
 
 // Hide these links earlier to ensure "Collecting 101" has space on smaller widths
+
 const NavBarItemFairsLink = styled(NavBarItemLink)`
   @media (max-width: 900px) {
     display: none;

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -224,6 +224,15 @@ export const NavBar: React.FC<React.PropsWithChildren<unknown>> = track(
                   </Flex>
 
                   <NavBarItemLink
+                    href="https://partners.artsy.net/gallery-partnerships/?utm_medium=internal-banner&utm_source=artsy&utm_campaign=b2b-2025-gallery-partnerships-application-banner-link&utm_sfc=701Hu000001jeLjIAI"
+                    textDecoration="none"
+                    onClick={handleClick}
+                    data-label="Artsy for Galleries"
+                  >
+                    Artsy for Galleries
+                  </NavBarItemLink>
+
+                  <NavBarItemLink
                     href="/price-database"
                     onMouseOver={() => prefetch("/price-database")}
                     textDecoration="none"
@@ -421,14 +430,14 @@ export const NavBar: React.FC<React.PropsWithChildren<unknown>> = track(
                   Galleries
                 </NavBarItemLink>
 
-                <NavBarItemLink
+                <NavBarItemFairsLink
                   href="/art-fairs"
                   onMouseOver={() => prefetch("/art-fairs")}
                   onClick={handleClick}
                   data-label="Fairs & Events"
                 >
                   Fairs & Events
-                </NavBarItemLink>
+                </NavBarItemFairsLink>
 
                 <NavBarItemLink
                   href="/shows"
@@ -447,6 +456,14 @@ export const NavBar: React.FC<React.PropsWithChildren<unknown>> = track(
                 >
                   Museums
                 </NavBarItemInstitutionsLink>
+                <NavBarItemLink
+                  href="/feature/how-to-collect-art"
+                  onMouseOver={() => prefetch("/feature/how-to-collect-art")}
+                  onClick={handleClick}
+                  data-label="Collecting 101"
+                >
+                  Collecting 101
+                </NavBarItemLink>
               </Flex>
             </Text>
           </HorizontalPadding>
@@ -471,6 +488,12 @@ export const NavBar: React.FC<React.PropsWithChildren<unknown>> = track(
   )
 })
 
+// Hide these links earlier to ensure "Collecting 101" has space on smaller widths
+const NavBarItemFairsLink = styled(NavBarItemLink)`
+  @media (max-width: 900px) {
+    display: none;
+  }
+`
 const NavBarItemInstitutionsLink = styled(NavBarItemLink)`
   // Can no longer fit on screen @ 900px
   @media (max-width: 900px) {

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -494,7 +494,7 @@ export const NavBar: React.FC<React.PropsWithChildren<unknown>> = track(
 // Hide these links earlier to ensure "Collecting 101" has space on smaller widths
 
 const NavBarItemFairsLink = styled(NavBarItemLink)`
-  @media (max-width: 900px) {
+  @media (max-width: 1000px) {
     display: none;
   }
 `


### PR DESCRIPTION
The type of this PR is: **feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [DIA-1246]

### Description

Added two new links to the nav: 
- Artsy for Galleries in the top navigation
- Collecting 101 in the bottom navigation 

Museums and Fairs & Events are both hidden at max-width: 900px so Collecting 101 stays visible for smaller screens.

<!-- Implementation description -->
Before:
![Screenshot 2025-03-31 at 11 19 02 PM](https://github.com/user-attachments/assets/9c88da62-2cac-4d51-935e-8477fb999fb5)

After:
![Screenshot 2025-03-31 at 11 17 43 PM](https://github.com/user-attachments/assets/664e2e33-7fb4-4e01-bf39-7cbc6377e702)



[DIA-1246]: https://artsyproduct.atlassian.net/browse/DIA-1246?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ