### PR TITLE
feat: configure Apple Pay `onBehalfOf` the partner

### DIFF
--- a/src/Apps/Order/Components/ExpressCheckout/__tests__/ExpressCheckout.jest.tsx
+++ b/src/Apps/Order/Components/ExpressCheckout/__tests__/ExpressCheckout.jest.tsx
@@ -1,0 +1,103 @@
+import { Elements } from "@stripe/react-stripe-js"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
+import { graphql } from "react-relay"
+import { ExpressCheckout } from ".."
+import type { ExpressCheckout_Test_Query } from "__generated__/ExpressCheckout_Test_Query.graphql"
+
+jest.mock("react-tracking")
+
+jest.unmock("react-relay")
+
+const mockElements = Elements as jest.Mock
+
+const { renderWithRelay } = setupTestWrapperTL<ExpressCheckout_Test_Query>({
+  Component: ({ me }) => me?.order && <ExpressCheckout order={me.order!} />,
+  query: graphql`
+    query ExpressCheckout_Test_Query @raw_response_type {
+      me {
+        order(id: "123") {
+          ...ExpressCheckout_order
+        }
+      }
+    }
+  `,
+})
+
+jest.mock("@stripe/react-stripe-js", () => {
+  return {
+    Elements: jest.fn(() => {
+      return <button />
+    }),
+  }
+})
+
+describe("ExpressCheckout", () => {
+  it("passes correct props to Stripe Elements", async () => {
+    renderWithRelay({
+      Order: () => ({ ...orderData }),
+    })
+
+    const elementsProps = mockElements.mock.calls[0][0]
+
+    expect(elementsProps.options).toEqual({
+      amount: 100000,
+      appearance: {
+        variables: {
+          borderRadius: "50px",
+        },
+      },
+      captureMethod: "manual",
+      currency: "usd",
+      mode: "payment",
+      onBehalfOf: "acct_456",
+      setupFutureUsage: "off_session",
+    })
+  })
+})
+
+const orderData = {
+  internalID: "a5aaa8b0-93ff-4f2a-8bb3-9589f378d229",
+  buyerTotal: {
+    minor: 104300,
+    currencyCode: "USD",
+  },
+  itemsTotal: {
+    minor: 100000,
+    currencyCode: "USD",
+  },
+  shippingTotal: {
+    minor: 4200,
+    currencyCode: "USD",
+  },
+  taxTotal: {
+    minor: 100,
+    currencyCode: "USD",
+  },
+  source: "ARTWORK_PAGE",
+  mode: "BUY",
+  availableShippingCountries: ["US"],
+  fulfillmentOptions: [
+    {
+      type: "DOMESTIC_FLAT",
+      amount: {
+        minor: 4200,
+        currencyCode: "USD",
+      },
+      selected: null,
+    },
+  ],
+  lineItems: [
+    {
+      artwork: {
+        internalID: "artwork123",
+        slug: "artwork-slug",
+      },
+    },
+  ],
+  seller: {
+    __typeName: "Partner",
+    merchantAccount: {
+      externalId: "acct_456",
+    },
+  },
+}

--- a/src/Apps/Order/Components/ExpressCheckout/index.tsx
+++ b/src/Apps/Order/Components/ExpressCheckout/index.tsx
@@ -8,7 +8,10 @@ import { ExpressCheckoutUI } from "Apps/Order/Components/ExpressCheckout/Express
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { getENV } from "Utils/getENV"
 import type { ExpressCheckoutQuery } from "__generated__/ExpressCheckoutQuery.graphql"
-import type { ExpressCheckout_order$key } from "__generated__/ExpressCheckout_order.graphql"
+import type {
+  ExpressCheckout_order$key,
+  ExpressCheckout_order$data,
+} from "__generated__/ExpressCheckout_order.graphql"
 import { graphql, useFragment } from "react-relay"
 
 const stripePromise = loadStripe(getENV("STRIPE_PUBLISHABLE_KEY"))
@@ -17,12 +20,18 @@ interface Props {
   order: ExpressCheckout_order$key
 }
 
+type Seller = Exclude<
+  ExpressCheckout_order$data["seller"],
+  { __typename: "%other" }
+>
+
 export const ExpressCheckout = ({ order }: Props) => {
   const orderData = useFragment(ORDER_FRAGMENT, order)
 
   // Use itemsTotal on load, but subsequent updates inside ExpressCheckoutUI
   // will use the updated buyersTotal.
-  const { itemsTotal } = orderData
+  const { itemsTotal, seller } = orderData
+  const sellerStripeAccountId = (seller as Seller)?.merchantAccount?.externalId
 
   if (!(itemsTotal && orderData.availableShippingCountries.length)) {
     return null
@@ -33,8 +42,7 @@ export const ExpressCheckout = ({ order }: Props) => {
     currency: itemsTotal.currencyCode.toLowerCase(),
     setupFutureUsage: "off_session",
     captureMethod: "manual",
-    // TODO: Add seller details to the order type
-    onBehalfOf: "acct_14FIYS4fSw9JrcJy",
+    onBehalfOf: sellerStripeAccountId,
   }
 
   const options: StripeElementsOptions = {
@@ -68,6 +76,14 @@ const ORDER_FRAGMENT = graphql`
       minor
       currencyCode
     }
+    seller {
+      __typename
+      ... on Partner {
+        merchantAccount {
+          externalId
+        }
+      }
+    }
   }
 `
 
@@ -90,7 +106,7 @@ export const ExpressCheckoutQueryRenderer: React.FC<{ orderID: string }> = ({
       render={({ props }) => {
         console.log("****", props)
         if (props?.me?.order) {
-          return <ExpressCheckout order={props?.me?.order} />
+          return <ExpressCheckout order={props.me.order} />
         }
         return null
       }}

--- a/src/Apps/Order/Components/ExpressCheckout/index.tsx
+++ b/src/Apps/Order/Components/ExpressCheckout/index.tsx
@@ -31,11 +31,17 @@ export const ExpressCheckout = ({ order }: Props) => {
   // Use itemsTotal on load, but subsequent updates inside ExpressCheckoutUI
   // will use the updated buyersTotal.
   const { itemsTotal, seller } = orderData
-  const sellerStripeAccountId = (seller as Seller)?.merchantAccount?.externalId
 
   if (!(itemsTotal && orderData.availableShippingCountries.length)) {
     return null
   }
+
+  const sellerStripeAccountId = (seller as Seller)?.merchantAccount?.externalId
+  // TODO: Handle exceptional cases with no seller's Stripe account
+  //   - When passing `onBehalfOf: ""` below, a validation error is raised in the console and the Apple Pay button will
+  //     not render.
+  //   - When passing `onBehalfOf: null`, the Apple Pay button will render but Artsy's Stripe account will (incorrectly)
+  //     be used. When confirming the payment on the server, it might eventually fail due to mismatched `onBehalfOf`.
 
   const orderOptions: StripeElementsUpdateOptions = {
     amount: itemsTotal.minor,

--- a/src/__generated__/ExpressCheckout_Test_Query.graphql.ts
+++ b/src/__generated__/ExpressCheckout_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<274dd508fdae517268191afd7054d44d>>
+ * @generated SignedSource<<77aa88eba5059994e79d6528d7142b74>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,52 +10,112 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type ExpressCheckoutQuery$variables = {
-  orderID: string;
-};
-export type ExpressCheckoutQuery$data = {
+export type FulfillmentOptionTypeEnum = "DOMESTIC_FLAT" | "INTERNATIONAL_FLAT" | "PICKUP" | "SHIPPING_TBD" | "%future added value";
+export type OrderModeEnum = "BUY" | "OFFER" | "%future added value";
+export type OrderSourceEnum = "ARTWORK_PAGE" | "INQUIRY" | "PARTNER_OFFER" | "PRIVATE_SALE" | "%future added value";
+export type ExpressCheckout_Test_Query$variables = Record<PropertyKey, never>;
+export type ExpressCheckout_Test_Query$data = {
   readonly me: {
     readonly order: {
       readonly " $fragmentSpreads": FragmentRefs<"ExpressCheckout_order">;
     } | null | undefined;
   } | null | undefined;
 };
-export type ExpressCheckoutQuery = {
-  response: ExpressCheckoutQuery$data;
-  variables: ExpressCheckoutQuery$variables;
+export type ExpressCheckout_Test_Query$rawResponse = {
+  readonly me: {
+    readonly id: string;
+    readonly order: {
+      readonly availableShippingCountries: ReadonlyArray<string>;
+      readonly buyerTotal: {
+        readonly currencyCode: string;
+        readonly minor: any;
+      } | null | undefined;
+      readonly fulfillmentDetails: {
+        readonly addressLine1: string | null | undefined;
+        readonly addressLine2: string | null | undefined;
+        readonly city: string | null | undefined;
+        readonly country: string | null | undefined;
+        readonly name: string | null | undefined;
+        readonly phoneNumber: string | null | undefined;
+        readonly phoneNumberCountryCode: string | null | undefined;
+        readonly postalCode: string | null | undefined;
+        readonly region: string | null | undefined;
+      } | null | undefined;
+      readonly fulfillmentOptions: ReadonlyArray<{
+        readonly amount: {
+          readonly currencyCode: string;
+          readonly minor: any;
+        } | null | undefined;
+        readonly selected: boolean | null | undefined;
+        readonly type: FulfillmentOptionTypeEnum;
+      }>;
+      readonly id: string;
+      readonly internalID: string;
+      readonly itemsTotal: {
+        readonly currencyCode: string;
+        readonly minor: any;
+      } | null | undefined;
+      readonly lineItems: ReadonlyArray<{
+        readonly artwork: {
+          readonly id: string;
+          readonly internalID: string;
+          readonly slug: string;
+        } | null | undefined;
+        readonly id: string;
+      } | null | undefined>;
+      readonly mode: OrderModeEnum;
+      readonly seller: {
+        readonly __typename: "Partner";
+        readonly __isNode: "Partner";
+        readonly id: string;
+        readonly merchantAccount: {
+          readonly externalId: string;
+        } | null | undefined;
+      } | {
+        readonly __typename: string;
+        readonly __isNode: string;
+        readonly id: string;
+      } | null | undefined;
+      readonly shippingTotal: {
+        readonly minor: any;
+      } | null | undefined;
+      readonly source: OrderSourceEnum;
+      readonly taxTotal: {
+        readonly minor: any;
+      } | null | undefined;
+    } | null | undefined;
+  } | null | undefined;
+};
+export type ExpressCheckout_Test_Query = {
+  rawResponse: ExpressCheckout_Test_Query$rawResponse;
+  response: ExpressCheckout_Test_Query$data;
+  variables: ExpressCheckout_Test_Query$variables;
 };
 
 const node: ConcreteRequest = (function(){
 var v0 = [
   {
-    "defaultValue": null,
-    "kind": "LocalArgument",
-    "name": "orderID"
-  }
-],
-v1 = [
-  {
-    "kind": "Variable",
+    "kind": "Literal",
     "name": "id",
-    "variableName": "orderID"
+    "value": "123"
   }
 ],
-v2 = {
+v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v3 = {
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "minor",
   "storageKey": null
 },
-v4 = [
-  (v3/*: any*/),
+v3 = [
+  (v2/*: any*/),
   {
     "alias": null,
     "args": null,
@@ -64,10 +124,10 @@ v4 = [
     "storageKey": null
   }
 ],
-v5 = [
-  (v3/*: any*/)
+v4 = [
+  (v2/*: any*/)
 ],
-v6 = {
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -76,10 +136,10 @@ v6 = {
 };
 return {
   "fragment": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [],
     "kind": "Fragment",
     "metadata": null,
-    "name": "ExpressCheckoutQuery",
+    "name": "ExpressCheckout_Test_Query",
     "selections": [
       {
         "alias": null,
@@ -91,7 +151,7 @@ return {
         "selections": [
           {
             "alias": null,
-            "args": (v1/*: any*/),
+            "args": (v0/*: any*/),
             "concreteType": "Order",
             "kind": "LinkedField",
             "name": "order",
@@ -103,7 +163,7 @@ return {
                 "name": "ExpressCheckout_order"
               }
             ],
-            "storageKey": null
+            "storageKey": "order(id:\"123\")"
           }
         ],
         "storageKey": null
@@ -114,9 +174,9 @@ return {
   },
   "kind": "Request",
   "operation": {
-    "argumentDefinitions": (v0/*: any*/),
+    "argumentDefinitions": [],
     "kind": "Operation",
-    "name": "ExpressCheckoutQuery",
+    "name": "ExpressCheckout_Test_Query",
     "selections": [
       {
         "alias": null,
@@ -128,13 +188,13 @@ return {
         "selections": [
           {
             "alias": null,
-            "args": (v1/*: any*/),
+            "args": (v0/*: any*/),
             "concreteType": "Order",
             "kind": "LinkedField",
             "name": "order",
             "plural": false,
             "selections": [
-              (v2/*: any*/),
+              (v1/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -156,7 +216,7 @@ return {
                 "kind": "LinkedField",
                 "name": "buyerTotal",
                 "plural": false,
-                "selections": (v4/*: any*/),
+                "selections": (v3/*: any*/),
                 "storageKey": null
               },
               {
@@ -166,7 +226,7 @@ return {
                 "kind": "LinkedField",
                 "name": "itemsTotal",
                 "plural": false,
-                "selections": (v4/*: any*/),
+                "selections": (v3/*: any*/),
                 "storageKey": null
               },
               {
@@ -176,7 +236,7 @@ return {
                 "kind": "LinkedField",
                 "name": "shippingTotal",
                 "plural": false,
-                "selections": (v5/*: any*/),
+                "selections": (v4/*: any*/),
                 "storageKey": null
               },
               {
@@ -186,7 +246,7 @@ return {
                 "kind": "LinkedField",
                 "name": "taxTotal",
                 "plural": false,
-                "selections": (v5/*: any*/),
+                "selections": (v4/*: any*/),
                 "storageKey": null
               },
               {
@@ -218,7 +278,7 @@ return {
                     "kind": "LinkedField",
                     "name": "amount",
                     "plural": false,
-                    "selections": (v4/*: any*/),
+                    "selections": (v3/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -321,7 +381,7 @@ return {
                     "name": "artwork",
                     "plural": false,
                     "selections": [
-                      (v2/*: any*/),
+                      (v1/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -329,11 +389,11 @@ return {
                         "name": "slug",
                         "storageKey": null
                       },
-                      (v6/*: any*/)
+                      (v5/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v6/*: any*/)
+                  (v5/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -380,7 +440,7 @@ return {
                   {
                     "kind": "InlineFragment",
                     "selections": [
-                      (v6/*: any*/)
+                      (v5/*: any*/)
                     ],
                     "type": "Node",
                     "abstractKey": "__isNode"
@@ -388,27 +448,27 @@ return {
                 ],
                 "storageKey": null
               },
-              (v6/*: any*/)
+              (v5/*: any*/)
             ],
-            "storageKey": null
+            "storageKey": "order(id:\"123\")"
           },
-          (v6/*: any*/)
+          (v5/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "5f93c985cfb973484c38945a5e007247",
+    "cacheID": "5dff16314882b954d433b96ea7fbd6a3",
     "id": null,
     "metadata": {},
-    "name": "ExpressCheckoutQuery",
+    "name": "ExpressCheckout_Test_Query",
     "operationKind": "query",
-    "text": "query ExpressCheckoutQuery(\n  $orderID: String!\n) {\n  me {\n    order(id: $orderID) {\n      ...ExpressCheckout_order\n      id\n    }\n    id\n  }\n}\n\nfragment ExpressCheckoutUI_order on Order {\n  internalID\n  source\n  mode\n  buyerTotal {\n    minor\n    currencyCode\n  }\n  itemsTotal {\n    minor\n  }\n  shippingTotal {\n    minor\n  }\n  taxTotal {\n    minor\n  }\n  availableShippingCountries\n  fulfillmentOptions {\n    type\n    amount {\n      minor\n      currencyCode\n    }\n    selected\n  }\n  fulfillmentDetails {\n    addressLine1\n    addressLine2\n    city\n    postalCode\n    region\n    country\n    phoneNumber\n    phoneNumberCountryCode\n    name\n  }\n  lineItems {\n    artwork {\n      internalID\n      slug\n      id\n    }\n    id\n  }\n}\n\nfragment ExpressCheckout_order on Order {\n  ...ExpressCheckoutUI_order\n  availableShippingCountries\n  buyerTotal {\n    minor\n    currencyCode\n  }\n  itemsTotal {\n    minor\n    currencyCode\n  }\n  seller {\n    __typename\n    ... on Partner {\n      merchantAccount {\n        externalId\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n"
+    "text": "query ExpressCheckout_Test_Query {\n  me {\n    order(id: \"123\") {\n      ...ExpressCheckout_order\n      id\n    }\n    id\n  }\n}\n\nfragment ExpressCheckoutUI_order on Order {\n  internalID\n  source\n  mode\n  buyerTotal {\n    minor\n    currencyCode\n  }\n  itemsTotal {\n    minor\n  }\n  shippingTotal {\n    minor\n  }\n  taxTotal {\n    minor\n  }\n  availableShippingCountries\n  fulfillmentOptions {\n    type\n    amount {\n      minor\n      currencyCode\n    }\n    selected\n  }\n  fulfillmentDetails {\n    addressLine1\n    addressLine2\n    city\n    postalCode\n    region\n    country\n    phoneNumber\n    phoneNumberCountryCode\n    name\n  }\n  lineItems {\n    artwork {\n      internalID\n      slug\n      id\n    }\n    id\n  }\n}\n\nfragment ExpressCheckout_order on Order {\n  ...ExpressCheckoutUI_order\n  availableShippingCountries\n  buyerTotal {\n    minor\n    currencyCode\n  }\n  itemsTotal {\n    minor\n    currencyCode\n  }\n  seller {\n    __typename\n    ... on Partner {\n      merchantAccount {\n        externalId\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "1261f9ad42a8e1b9c782bca109ad6378";
+(node as any).hash = "2f4636e770d35aa703e9214a126673eb";
 
 export default node;

--- a/src/__generated__/ExpressCheckout_order.graphql.ts
+++ b/src/__generated__/ExpressCheckout_order.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<102fc5863e1b6cfbaabdd90212fb0f68>>
+ * @generated SignedSource<<dba6026f84dbe1fa7c16d6c309042103>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -19,6 +19,16 @@ export type ExpressCheckout_order$data = {
   readonly itemsTotal: {
     readonly currencyCode: string;
     readonly minor: any;
+  } | null | undefined;
+  readonly seller: {
+    readonly __typename: "Partner";
+    readonly merchantAccount: {
+      readonly externalId: string;
+    } | null | undefined;
+  } | {
+    // This will never be '%other', but we need some
+    // value in case none of the concrete values match.
+    readonly __typename: "%other";
   } | null | undefined;
   readonly " $fragmentSpreads": FragmentRefs<"ExpressCheckoutUI_order">;
   readonly " $fragmentType": "ExpressCheckout_order";
@@ -82,6 +92,49 @@ return {
       "plural": false,
       "selections": (v0/*: any*/),
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": null,
+      "kind": "LinkedField",
+      "name": "seller",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "__typename",
+          "storageKey": null
+        },
+        {
+          "kind": "InlineFragment",
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "PartnerMerchantAccount",
+              "kind": "LinkedField",
+              "name": "merchantAccount",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "externalId",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "type": "Partner",
+          "abstractKey": null
+        }
+      ],
+      "storageKey": null
     }
   ],
   "type": "Order",
@@ -89,6 +142,6 @@ return {
 };
 })();
 
-(node as any).hash = "cb19c16d234bae12a7d81e12fff38b81";
+(node as any).hash = "671a82ab464d85e9d972a98de2fa2c39";
 
 export default node;


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [EMI-2377]

### Description

Now that the seller info is [available from MP](https://github.com/artsy/metaphysics/pull/6581), we can configure the Stripe Elements provider with the proper `onBehalfOf` parameter.

Note that when the partner's stripe account id is missing in exceptional cases, depending on the value, the behavior would be different. I'll create a separate ticket to follow up and avoid silent failures or incorrect transactions. More details inline.

cc @artsy/emerald-devs 

[EMI-2377]: https://artsyproduct.atlassian.net/browse/EMI-2377?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ