### PR TITLE
fix(price filter): alignment of histogram and sliders

### DIFF
--- a/src/Components/PriceRange/Histogram.tsx
+++ b/src/Components/PriceRange/Histogram.tsx
@@ -1,7 +1,8 @@
-import { Box, Flex, type FlexProps } from "@artsy/palette"
+import { Box, Flex, RANGE_HANDLE_SIZE, type FlexProps } from "@artsy/palette"
 
 const BAR_WIDTH = 2
 const BAR_ROUNDNESS = 10
+const HISTOGRAM_MARGIN = RANGE_HANDLE_SIZE / 2 + "px"
 
 type Range = [number, number]
 
@@ -37,6 +38,7 @@ export const Histogram: React.FC<React.PropsWithChildren<HistogramProps>> = ({
 
   return (
     <Flex
+      px={HISTOGRAM_MARGIN}
       height={110}
       justifyContent="space-between"
       alignItems="flex-end"


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [ONYX-1512]

### Description

Fixes a small visual regression that crept in sometime over the past few years:

<img width="1274" alt="Screenshot 2025-04-02 at 6 55 35 PM" src="https://github.com/user-attachments/assets/84946182-b09a-4c3d-be3f-d48fd3d48327" />

While it's relatively minor visually it does have an impact on the interaction between slider and histogram, since the slider range handles were no longer toggling the bars directly above them, but rather bars that were slightly off to the side.

This restores the original alignment.

| Before | After |
|--------|--------|
| <img src="https://github.com/user-attachments/assets/103a281c-64cd-4804-92e4-8b2e585d7f59" /> | <img src="https://github.com/user-attachments/assets/e106a47e-e570-434c-bce1-6428622793f5" /> | 







[ONYX-1512]: https://artsyproduct.atlassian.net/browse/ONYX-1512?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ