### PR TITLE
fix(nav): prevents submenus from taking over screen

### DIFF
--- a/src/Components/NavBar/Menus/NavBarSubMenu.tsx
+++ b/src/Components/NavBar/Menus/NavBarSubMenu.tsx
@@ -1,5 +1,12 @@
 import * as DeprecatedAnalyticsSchema from "@artsy/cohesion/dist/DeprecatedSchema"
-import { Box, Column, GridColumns, Spacer, Text } from "@artsy/palette"
+import {
+  Box,
+  type BoxProps,
+  Column,
+  GridColumns,
+  Spacer,
+  Text,
+} from "@artsy/palette"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
 import type { MenuData } from "Components/NavBar/menuData"
@@ -8,7 +15,7 @@ import type * as React from "react"
 import { useTracking } from "react-tracking"
 import { NavBarMenuItemLink } from "./NavBarMenuItem"
 
-interface NavBarSubMenuProps {
+interface NavBarSubMenuProps extends BoxProps {
   menu: MenuData
   contextModule: DeprecatedAnalyticsSchema.ContextModule
   /** Detect any click to possibly close the menu */
@@ -18,7 +25,7 @@ interface NavBarSubMenuProps {
 /** Component for full-width sub-menus (Artworks, Artists) */
 export const NavBarSubMenu: React.FC<
   React.PropsWithChildren<NavBarSubMenuProps>
-> = ({ menu, contextModule, onClick }) => {
+> = ({ menu, contextModule, onClick, ...rest }) => {
   const { trackEvent } = useTracking()
 
   const handleClick = (
@@ -47,7 +54,12 @@ export const NavBarSubMenu: React.FC<
     !("links" in lastMenuItem) && "href" in lastMenuItem ? lastMenuItem : null
 
   return (
-    <Text width="100vw" variant={["xs", "xs", "sm"]} onClick={onClick}>
+    <Text
+      width="100vw"
+      variant={["xs", "xs", "sm"]}
+      onClick={onClick}
+      {...rest}
+    >
       <AppContainer>
         <HorizontalPadding>
           <GridColumns py={6} gridColumnGap={0}>

--- a/src/Components/NavBar/NavBarDropdownPanel.tsx
+++ b/src/Components/NavBar/NavBarDropdownPanel.tsx
@@ -1,8 +1,12 @@
 import type * as DeprecatedAnalyticsSchema from "@artsy/cohesion/dist/DeprecatedSchema"
 import { Dropdown } from "@artsy/palette"
+import composeRefs from "@seznam/compose-react-refs"
 import { Z } from "Apps/Components/constants"
 import type { MenuData } from "Components/NavBar/menuData"
 import { usePrefetchRoute } from "System/Hooks/usePrefetchRoute"
+import { useWindowSize } from "Utils/Hooks/useWindowSize"
+import { useEffect, useRef } from "react"
+import { useState } from "react"
 import { NavBarSubMenu } from "./Menus"
 import { NavBarItemButton, NavBarItemUnfocusableAnchor } from "./NavBarItem"
 
@@ -27,6 +31,22 @@ export const NavBarDropdownPanel: React.FC<NavBarDropdownPanelProps> = ({
 }) => {
   const { prefetch } = usePrefetchRoute()
 
+  // Calculate max height based on the distance between anchor and bottom of viewport
+  const [maxHeight, setMaxHeight] = useState<number>(0)
+
+  const { height: viewportHeight } = useWindowSize()
+
+  const positionRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!positionRef.current) return
+
+    const { top, height } = positionRef.current.getBoundingClientRect()
+    const availableHeight = viewportHeight - top - height - 2 // 2px for border
+
+    setMaxHeight(availableHeight)
+  }, [viewportHeight])
+
   return (
     <Dropdown
       zIndex={Z.dropdown}
@@ -42,6 +62,7 @@ export const NavBarDropdownPanel: React.FC<NavBarDropdownPanelProps> = ({
             contextModule as DeprecatedAnalyticsSchema.ContextModule
           }
           onClick={() => setVisible(false)}
+          maxHeight={maxHeight}
         />
       )}
     >
@@ -50,7 +71,7 @@ export const NavBarDropdownPanel: React.FC<NavBarDropdownPanelProps> = ({
 
         return (
           <NavBarItemButton
-            ref={anchorRef as any}
+            ref={composeRefs(anchorRef, positionRef) as any}
             active={visible}
             onMouseEnter={e => {
               onMouseEnter?.(e)

--- a/src/Utils/Hooks/useWindowSize.ts
+++ b/src/Utils/Hooks/useWindowSize.ts
@@ -1,19 +1,20 @@
 import { getViewportDimensions } from "Utils/viewport"
 import { useEffect, useState } from "react"
+import { useDebouncedCallback } from "use-debounce"
 
 export const useWindowSize = () => {
   const [size, setSize] = useState({ width: 0, height: 0 })
 
-  useEffect(() => {
-    function resize() {
-      const { width, height } = getViewportDimensions()
+  const debouncedResize = useDebouncedCallback(() => {
+    const { width, height } = getViewportDimensions()
+    setSize({ width, height })
+  }, 100)
 
-      setSize({ width, height })
-    }
-    window.addEventListener("resize", resize)
-    resize()
-    return () => window.removeEventListener("resize", resize)
-  }, [])
+  useEffect(() => {
+    window.addEventListener("resize", debouncedResize)
+    debouncedResize()
+    return () => window.removeEventListener("resize", debouncedResize)
+  }, [debouncedResize])
 
   if (typeof window === "undefined") {
     return { width: 0, height: 0 }


### PR DESCRIPTION
This change ensures that the submenus never get large enough to exceed the bounds of the viewport. I do think that Palette should be doing this, but that change is a little trickier than it sounds. I'm going to take another crack at it before converting this off draft. 

https://github.com/user-attachments/assets/15acf308-cf04-4b9c-bbc1-ef5293babb2b

