### PR TITLE
fix: remove Apple Pay Mark Icon

### DIFF
--- a/src/Apps/Order/Components/ApplePayDetails.tsx
+++ b/src/Apps/Order/Components/ApplePayDetails.tsx
@@ -1,5 +1,4 @@
 import { Flex, Text } from "@artsy/palette"
-import ApplePayMarkIcon from "@artsy/icons/ApplePayMarkIcon"
 
 interface Props {
   textColor?: string
@@ -10,8 +9,6 @@ export const ApplePayDetails = (props: Props) => {
 
   return (
     <Flex alignItems="center">
-      <ApplePayMarkIcon mr={1} width="24px" height="24px" />
-
       <Text
         variant="sm-display"
         color={textColor}

--- a/src/Apps/Settings/Routes/Purchases/Components/__tests__/SettingsPurchases.jest.tsx
+++ b/src/Apps/Settings/Routes/Purchases/Components/__tests__/SettingsPurchases.jest.tsx
@@ -231,7 +231,7 @@ describe("SettingsPurchases", () => {
     })
   })
 
-  fdescribe("Payment Methods", () => {
+  describe("Payment Methods", () => {
     it("renders credit card payment method", () => {
       renderWithRelay({
         CommerceOrder: () => ({


### PR DESCRIPTION
The type of this PR is: **fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PROJECT-XX]

### Description
This PR removes the Apple Pay Mark icon

| | Desktop | mWeb |
|---|---|---|
| Before | ![image](https://github.com/user-attachments/assets/649af3d6-92bd-473a-93c5-b03c1120fbca) | ![image](https://github.com/user-attachments/assets/55a4797d-840c-4880-b744-f72b3567c214) |
| After | ![image](https://github.com/user-attachments/assets/05eb2af5-2e56-4d7e-9f35-2bdd205c64b6) | ![image](https://github.com/user-attachments/assets/7f2495b1-e555-4980-89b3-ceb2717a24da) |
	


<!-- Implementation description -->
