### PR TITLE
feat(EMI-2383): redirect to Status screen after applePay successful submission

### DIFF
--- a/src/Apps/Order/Components/ExpressCheckout/ExpressCheckoutUI.tsx
+++ b/src/Apps/Order/Components/ExpressCheckout/ExpressCheckoutUI.tsx
@@ -25,6 +25,7 @@ import {
 } from "Apps/Order/Components/ExpressCheckout/Util/mutationHandling"
 import { useOrderTracking } from "Apps/Order/Hooks/useOrderTracking"
 import { useShippingContext } from "Apps/Order/Routes/Shipping/Hooks/useShippingContext"
+import { useRouter } from "System/Hooks/useRouter"
 import createLogger from "Utils/logger"
 import type {
   ExpressCheckoutUI_order$data,
@@ -63,6 +64,7 @@ export const ExpressCheckoutUI = ({ order }: ExpressCheckoutUIProps) => {
   const orderTracking = useOrderTracking()
   const shippingContext = useShippingContext()
   const errorRef = useRef<string | null>(null)
+  const { router } = useRouter()
 
   if (!(stripe && elements)) {
     return null
@@ -352,6 +354,9 @@ export const ExpressCheckoutUI = ({ order }: ExpressCheckoutUIProps) => {
       validateAndExtractOrderResponse(
         submitOrderResult.submitOrder?.orderOrError,
       )
+
+      // Redirect to status page after successful order submission
+      router.push(`/orders/${orderData.internalID}/status`)
     } catch (error) {
       errorRef.current = error.message || "unknown_error"
       logger.error("Error confirming payment", error)

--- a/src/Apps/Order/Components/ExpressCheckout/__tests__/ExpressCheckoutUI.jest.tsx
+++ b/src/Apps/Order/Components/ExpressCheckout/__tests__/ExpressCheckoutUI.jest.tsx
@@ -9,7 +9,16 @@ import { graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import { ExpressCheckoutUI } from "../ExpressCheckoutUI"
 
+const mockRouterPush = jest.fn()
+
 jest.mock("react-tracking")
+jest.mock("System/Hooks/useRouter", () => ({
+  useRouter: () => ({
+    router: {
+      push: mockRouterPush,
+    },
+  }),
+}))
 
 jest.unmock("react-relay")
 
@@ -124,6 +133,7 @@ describe("ExpressCheckoutUI", () => {
     jest.clearAllMocks()
     mockTracking.mockImplementation(() => ({ trackEvent }))
     trackEvent.mockClear()
+    mockRouterPush.mockClear()
   })
 
   it("passes correct props to ExpressCheckoutElement", async () => {
@@ -323,6 +333,46 @@ describe("ExpressCheckoutUI", () => {
 
     await flushPromiseQueue()
     expect(env.mock.getAllOperations()).toHaveLength(0)
+  })
+
+  it("navigates to the status page after successful order submission", async () => {
+    const { mockResolveLastOperation } = renderWithRelay({
+      Order: () => ({
+        ...orderData,
+        fulfillmentOptions: [{ type: "SHIPPING_TBD", amount: null }],
+      }),
+    })
+
+    fireEvent.click(screen.getByTestId("express-checkout-confirm"))
+
+    // Resolve the update order mutation
+    await mockResolveLastOperation({
+      updateOrderPayload: () => ({
+        orderOrError: {
+          __typename: "OrderMutationSuccess",
+          order: orderData,
+        },
+      }),
+    })
+
+    await flushPromiseQueue()
+    expect(mockCreateConfirmationToken).toHaveBeenCalled()
+
+    // Resolve the submit order mutation
+    await mockResolveLastOperation({
+      submitOrderPayload: () => ({
+        orderOrError: {
+          __typename: "OrderMutationSuccess",
+          order: orderData,
+        },
+      }),
+    })
+
+    await flushPromiseQueue()
+
+    expect(mockRouterPush).toHaveBeenCalledWith(
+      `/orders/${orderData.internalID}/status`,
+    )
   })
 })
 


### PR DESCRIPTION
Just pushing a new url into the router seems to do the trick. There is a loading bar and redirect happens. It takes several seconds but looks ok to me.

Let me know if you think there is a better way to approach it.
