### PR TITLE
refactor: use unleash useFlag for apple pay flag

### DIFF
--- a/src/Apps/Checkout/ApplePay.tsx
+++ b/src/Apps/Checkout/ApplePay.tsx
@@ -1,7 +1,7 @@
 import { ApplePay_order$key } from "__generated__/ApplePay_order.graphql"
 import { ExpressCheckoutQueryRenderer } from "Apps/Order/Components/ExpressCheckout"
 import { graphql, useFragment } from "react-relay"
-import { useFeatureFlag } from "System/Hooks/useFeatureFlag"
+import { useFlag } from "@unleash/proxy-client-react"
 import { extractNodes } from "Utils/extractNodes"
 
 interface ApplePayProps {
@@ -10,7 +10,7 @@ interface ApplePayProps {
 
 export const ApplePay: React.FC<ApplePayProps> = ({ order }) => {
   const data = useFragment(orderFragment, order)
-  const expressCheckoutPrototypeEnabled = useFeatureFlag(
+  const expressCheckoutPrototypeEnabled = useFlag(
     "emerald_stripe-express-checkout-prototype",
   )
 


### PR DESCRIPTION
The type of this PR is: **refactor**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

<!-- Implementation description -->

This new `useFeatureFlag` snuck in right before I merged #15263 . This updates the import to use the native unleash `useFlag` function.
