### PR TITLE
fix: padding on partner works screen

### DIFF
--- a/src/Apps/Partner/PartnerApp.tsx
+++ b/src/Apps/Partner/PartnerApp.tsx
@@ -1,4 +1,4 @@
-import { FullBleed, Marquee, Separator } from "@artsy/palette"
+import { FullBleed, Marquee, Separator, Spacer } from "@artsy/palette"
 import { NavigationTabsFragmentContainer as NavigationTabs } from "Apps/Partner/Components/NavigationTabs"
 import { Analytics } from "System/Contexts/AnalyticsContext"
 import type { PartnerApp_partner$data } from "__generated__/PartnerApp_partner.graphql"
@@ -66,6 +66,8 @@ export const PartnerApp: React.FC<React.PropsWithChildren<PartnerAppProps>> = ({
         {(displayFullPartnerPage || partnerType === "Brand") && (
           <NavigationTabs partner={partner} />
         )}
+
+        <Spacer y={1} />
 
         {children}
       </PartnerArtistsLoadingContextProvider>


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Fixes a weird padding issue noticed on the works screen - the alignment didn't work because of the sticky filter in grid combined with the sticky tab bar, so this just makes it even. 

<img width="778" alt="Screenshot 2025-04-12 at 11 07 24 PM" src="https://github.com/user-attachments/assets/169fed7b-1994-4170-95f2-01fc9b079f76" />
