### PR TITLE
chore(EMI-2410): remove dot from checkout links

### DIFF
--- a/src/Apps/Order/Components/BuyerGuarantee.tsx
+++ b/src/Apps/Order/Components/BuyerGuarantee.tsx
@@ -93,8 +93,9 @@ export const BuyerGuarantee: React.FC<
               to={BUYER_GUARANTEE_URL}
               onClick={handleClick}
             >
-              Artsy’s buyer protection.
+              Artsy’s buyer protection
             </RouterLink>
+            .
           </Text>
         </Flex>
       </Flex>

--- a/src/Apps/Order/Components/ExpressCheckout/ExpressCheckoutUI.tsx
+++ b/src/Apps/Order/Components/ExpressCheckout/ExpressCheckoutUI.tsx
@@ -406,8 +406,9 @@ export const ExpressCheckoutUI = ({ order }: ExpressCheckoutUIProps) => {
           target="_blank"
           rel="noopener noreferrer"
         >
-          General Terms and Conditions of Sale.
+          General Terms and Conditions of Sale
         </RouterLink>
+        .
       </Text>
       <Spacer y={4} />
     </UncollapsingBox>

--- a/src/Apps/Order/Components/TransactionDetailsSummaryItem.tsx
+++ b/src/Apps/Order/Components/TransactionDetailsSummaryItem.tsx
@@ -294,8 +294,9 @@ export const TransactionDetailsSummaryItem: FC<
           target="_blank"
           rel="noopener noreferrer"
         >
-          may apply at import.
+          may apply at import
         </RouterLink>
+        .
       </Text>
       {showOfferNote && order.mode === "OFFER" && renderNoteEntry()}
       {showCongratulationMessage && (

--- a/src/Apps/Order/Components/__tests__/BuyerGuarantee.jest.tsx
+++ b/src/Apps/Order/Components/__tests__/BuyerGuarantee.jest.tsx
@@ -27,7 +27,7 @@ describe("BuyerGuarantee", () => {
           />,
         )
 
-        userEvent.click(screen.getByText("Artsy’s buyer protection."))
+        userEvent.click(screen.getByText("Artsy’s buyer protection"))
 
         expect(trackEvent).toHaveBeenCalledTimes(1)
         expect(trackEvent.mock.calls[0]).toMatchInlineSnapshot(`
@@ -51,7 +51,7 @@ describe("BuyerGuarantee", () => {
           />,
         )
 
-        userEvent.click(screen.getByText("Artsy’s buyer protection."))
+        userEvent.click(screen.getByText("Artsy’s buyer protection"))
 
         expect(trackEvent).not.toHaveBeenCalled()
       })


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2410]

### Description
<img width="1492" alt="SCR-20250414-suzd" src="https://github.com/user-attachments/assets/98f22e84-a78b-41d5-bfab-ad132c0926d3" />

@artsy/emerald-devs 

<!-- Implementation description -->


[EMI-2410]: https://artsyproduct.atlassian.net/browse/EMI-2410?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ