### PR TITLE
feat(EMI-2394): pickup orders should not have shipping address set in Payment Intent

### DIFF
--- a/src/Apps/Order/Components/ExpressCheckout/ExpressCheckoutUI.tsx
+++ b/src/Apps/Order/Components/ExpressCheckout/ExpressCheckoutUI.tsx
@@ -329,6 +329,22 @@ export const ExpressCheckoutUI = ({ order }: ExpressCheckoutUIProps) => {
       const { error, confirmationToken } = await stripe.createConfirmationToken(
         {
           elements,
+          params:
+            shippingRate?.id === "PICKUP"
+              ? {
+                  shipping: {
+                    address: {
+                      line1: null,
+                      line2: null,
+                      city: null,
+                      postal_code: null,
+                      state: null,
+                      country: null,
+                    },
+                    name: null,
+                  },
+                }
+              : undefined,
         },
       )
 


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2394]

### Description
When we create the confirmation token, the shipping address is being serialized and sent to stripe, even though we don't need it for pickup orders.

Followup from https://github.com/artsy/exchange/pull/2512
See slack for more context https://artsy.slack.com/archives/C02JHHHKP5K/p1744127890207159




<!-- Implementation description -->
