### PR TITLE
chore(EMI-2364): Redirects for new order checkout/details routes

### DIFF
--- a/src/Apps/Order/__tests__/OrderApp.jest.enzyme.tsx
+++ b/src/Apps/Order/__tests__/OrderApp.jest.enzyme.tsx
@@ -32,7 +32,9 @@ jest.mock("Utils/getENV", () => ({
 }))
 
 jest.mock("System/Hooks/useSystemContext", () => ({
-  useSystemContext: jest.fn().mockReturnValue({ isEigen: false }),
+  useSystemContext: jest.fn().mockReturnValue({
+    isEigen: false,
+  }),
 }))
 
 jest.mock(
@@ -43,6 +45,10 @@ jest.mock(
     return jest.requireActual("../Components/__mocks__/BankDebitProvider")
   },
 )
+
+const unleashClient = {
+  isEnabled: jest.fn(() => false),
+}
 
 describe("OrderApp routing redirects", () => {
   // FIXME: move to DevTools folder
@@ -60,6 +66,9 @@ describe("OrderApp routing redirects", () => {
       resolver: new Resolver(environment),
       routeConfig: orderRoutes,
       url,
+      matchContext: {
+        unleashClient,
+      },
     })
 
     return result as FarceRedirectResult
@@ -78,6 +87,97 @@ describe("OrderApp routing redirects", () => {
         ...data,
       },
     }),
+  })
+  describe("new checkout flow redirects", () => {
+    it("redirects from the legacy shipping step to the new checkout flow if feature flag is enabled and order is BUY mode", async () => {
+      unleashClient.isEnabled.mockReturnValue(true)
+      const res = await render(
+        "/orders/2939023/shipping",
+        mockResolver({
+          ...BuyOrderPickup,
+          state: "PENDING",
+          mode: "BUY",
+        }),
+      )
+      expect(res.redirect.url).toBe("/orders2/2939023/checkout")
+    })
+    it("redirects from the legacy payment step to the new checkout flow if feature flag is enabled and order is BUY mode", async () => {
+      unleashClient.isEnabled.mockReturnValue(true)
+      const res = await render(
+        "/orders/2939023/payment",
+        mockResolver({
+          ...BuyOrderPickup,
+          state: "PENDING",
+          mode: "BUY",
+        }),
+      )
+      expect(res.redirect.url).toBe("/orders2/2939023/checkout")
+    })
+    it("redirects from the legacy review step to the new checkout flow if feature flag is enabled and order is BUY mode", async () => {
+      unleashClient.isEnabled.mockReturnValue(true)
+      const res = await render(
+        "/orders/2939023/review",
+        mockResolver({
+          ...BuyOrderPickup,
+          state: "PENDING",
+          mode: "BUY",
+        }),
+      )
+      expect(res.redirect.url).toBe("/orders2/2939023/checkout")
+    })
+
+    it("does not redirect to the new checkout flow if feature flag is enabled and order is OFFER mode", async () => {
+      unleashClient.isEnabled.mockReturnValue(true)
+      let threw = false
+      try {
+        await render(
+          "/orders/2939023/offer",
+          mockResolver({
+            ...BuyOrderPickup,
+            state: "PENDING",
+            mode: "OFFER",
+          }),
+        )
+      } catch (error) {
+        threw = true
+        // eslint-disable-next-line jest/no-conditional-expect, jest/no-try-expect
+        expect(error.message).toBe("No redirect found for order")
+      }
+      expect(threw).toBe(true)
+    })
+
+    it("redirects from the legacy status page to the new details page for a submitted order if the order is BUY mode", async () => {
+      unleashClient.isEnabled.mockReturnValue(true)
+      const res = await render(
+        "/orders/2939023/status",
+        mockResolver({
+          ...BuyOrderPickup,
+          state: "SUBMITTED",
+        }),
+      )
+      expect(res.redirect.url).toBe("/orders2/2939023/details")
+    })
+
+    it("does not redirect from the legacy status page to the new details page for a submitted order if the order is OFFER mode", async () => {
+      unleashClient.isEnabled.mockReturnValue(true)
+      let threw = false
+      try {
+        await render(
+          "/orders/2939023/status",
+          mockResolver({
+            ...BuyOrderPickup,
+            mode: "OFFER",
+            state: "SUBMITTED",
+            displayState: "SUBMITTED",
+          }),
+        )
+      } catch (error) {
+        threw = true
+        // eslint-disable-next-line jest/no-conditional-expect, jest/no-try-expect
+        expect(error.message).toBe("No redirect found for order")
+      }
+      expect(threw).toBe(true)
+    })
   })
 
   it("does not redirect to the status route if the order is pending", async () => {

--- a/src/Apps/Order/orderRoutes.tsx
+++ b/src/Apps/Order/orderRoutes.tsx
@@ -2,6 +2,7 @@ import loadable from "@loadable/component"
 import { getRedirect } from "Apps/Order/getRedirect"
 import { redirects } from "Apps/Order/redirects"
 import { ErrorPage } from "Components/ErrorPage"
+import type { SystemContextProps } from "System/Contexts/SystemContext"
 import type { RouteProps } from "System/Router/Route"
 import { Redirect, RedirectException } from "found"
 import { graphql } from "react-relay"
@@ -117,12 +118,13 @@ export const orderRoutes: RouteProps[] = [
       // found-relay
       if (resolving) {
         const { match, order } = props as any
+        const { unleashClient } = match.context as SystemContextProps
 
         if (order) {
           const redirect = getRedirect(
             redirects,
-            match.location.pathname.replace(/order(2|s)\/[^\/]+/, ""),
-            { order },
+            match.location.pathname.replace(/order(s)\/[^\/]+/, ""),
+            { order, unleashClient },
           )
 
           if (redirect === null) {

--- a/src/Apps/Order/redirects.tsx
+++ b/src/Apps/Order/redirects.tsx
@@ -3,11 +3,13 @@ import { DateTime } from "luxon"
 import { graphql } from "react-relay"
 import type { RedirectPredicate, RedirectRecord } from "./getRedirect"
 
+import type { SystemContextProps } from "System/Contexts/SystemContext"
 import { extractNodes } from "Utils/extractNodes"
 import type { redirects_order$data } from "__generated__/redirects_order.graphql"
 
 interface OrderQuery {
   order: redirects_order$data
+  unleashClient: SystemContextProps["unleashClient"]
 }
 
 type OrderPredicate = RedirectPredicate<OrderQuery>
@@ -174,6 +176,55 @@ const goToRespondIfAwaitingBuyerResponse: OrderPredicate = ({ order }) => {
   }
 }
 
+const goToOrder2DetailsIfEnabled: OrderPredicate = ({
+  order,
+  unleashClient,
+}) => {
+  if (newDetailsEnabled({ order, unleashClient })) {
+    return {
+      path: `/orders2/${order.internalID}/details`,
+      reason: "Order2 is enabled for this order",
+    }
+  }
+}
+
+const goToOrder2CheckoutIfEnabled: OrderPredicate = ({
+  order,
+  unleashClient,
+}) => {
+  if (newCheckoutEnabled({ order, unleashClient })) {
+    return {
+      path: `/orders2/${order.internalID}/checkout`,
+      reason: "Order2 is enabled for this order",
+    }
+  }
+}
+
+// Temporary type to allow orders queried for the new checkout page to work here
+interface Order2RedirectArgs {
+  order: { mode?: string | null }
+  unleashClient: SystemContextProps["unleashClient"]
+}
+export const newCheckoutEnabled = ({
+  order,
+  unleashClient,
+}: Order2RedirectArgs): boolean => {
+  return !!(
+    order.mode === "BUY" &&
+    unleashClient?.isEnabled("emerald_checkout-redesign")
+  )
+}
+
+export const newDetailsEnabled = ({
+  order,
+  unleashClient,
+}: Order2RedirectArgs): boolean => {
+  return !!(
+    order.mode === "BUY" &&
+    unleashClient?.isEnabled("emerald_order-details-page")
+  )
+}
+
 export const redirects: RedirectRecord<OrderQuery> = {
   path: "",
   rules: [goToArtworkIfOrderWasAbandoned],
@@ -200,6 +251,7 @@ export const redirects: RedirectRecord<OrderQuery> = {
         goToPaymentIfPrivateSaleOrder,
         goToStatusIfOrderIsNotPending,
         goToOfferIfNoOfferMade,
+        goToOrder2CheckoutIfEnabled,
       ],
     },
     {
@@ -207,6 +259,7 @@ export const redirects: RedirectRecord<OrderQuery> = {
       rules: [
         goToStatusIfOrderIsNotPending,
         goToShippingIfShippingIsNotCompleted,
+        goToOrder2CheckoutIfEnabled,
       ],
     },
     {
@@ -222,6 +275,7 @@ export const redirects: RedirectRecord<OrderQuery> = {
         goToStatusIfOrderIsNotPending,
         goToShippingIfShippingIsNotCompleted,
         goToPaymentIfPaymentIsNotCompleted,
+        goToOrder2CheckoutIfEnabled,
       ],
     },
     {
@@ -256,6 +310,7 @@ export const redirects: RedirectRecord<OrderQuery> = {
         goToShippingIfShippingIsNotCompleted,
         goToPaymentIfPaymentIsNotCompleted,
         goToRespondIfAwaitingBuyerResponse,
+        goToOrder2DetailsIfEnabled,
       ],
     },
   ],

--- a/src/Apps/Order2/Routes/Checkout/Order2CheckoutRoute.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Order2CheckoutRoute.tsx
@@ -13,7 +13,6 @@ import {
 import { useFlag } from "@unleash/proxy-client-react"
 import { addressFormFieldsValidator } from "Components/Address/AddressFormFields"
 import { AddressFormFields } from "Components/Address/AddressFormFields"
-import { ErrorPage } from "Components/ErrorPage"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import createLogger from "Utils/logger"
 import type { Order2CheckoutRoute_viewer$key } from "__generated__/Order2CheckoutRoute_viewer.graphql"
@@ -44,8 +43,6 @@ export const Order2CheckoutRoute: React.FC<Order2CheckoutRouteProps> = ({
       isCheckoutRedesignEnabled,
     })
   }, [isCheckoutRedesignEnabled])
-
-  if (!isCheckoutRedesignEnabled) return <ErrorPage code={404} />
 
   const validationSchema = yup.object().shape({
     ...addressFormFieldsValidator({ withPhoneNumber: true }),

--- a/src/Apps/Order2/Routes/Details/Order2DetailsRoute.tsx
+++ b/src/Apps/Order2/Routes/Details/Order2DetailsRoute.tsx
@@ -1,6 +1,5 @@
 import { useFlag } from "@unleash/proxy-client-react"
 import { Order2DetailsPage } from "Apps/Order2/Routes/Details/Components/Order2DetailsPage"
-import { ErrorPage } from "Components/ErrorPage"
 import createLogger from "Utils/logger"
 import type { Order2DetailsRoute_viewer$key } from "__generated__/Order2DetailsRoute_viewer.graphql"
 import type React from "react"
@@ -22,8 +21,6 @@ export const Order2DetailsRoute: React.FC<DetailsProps> = ({ viewer }) => {
   useEffect(() => {
     logger.warn("Order details page data:", data, isOrderDetailsFlagEnabled)
   }, [isOrderDetailsFlagEnabled])
-
-  if (!isOrderDetailsFlagEnabled) return <ErrorPage code={404} />
 
   return (
     <>

--- a/src/Apps/Order2/order2Routes.tsx
+++ b/src/Apps/Order2/order2Routes.tsx
@@ -1,9 +1,11 @@
 import loadable from "@loadable/component"
+import { newCheckoutEnabled, newDetailsEnabled } from "Apps/Order/redirects"
 import { ErrorPage } from "Components/ErrorPage"
+import type { SystemContextProps } from "System/Contexts/SystemContext"
 import type { RouteProps } from "System/Router/Route"
 import createLogger from "Utils/logger"
 import type { order2Routes_CheckoutQuery$data } from "__generated__/order2Routes_CheckoutQuery.graphql"
-import type { order2Routes_DetailsQuery$data } from "__generated__/order2Routes_DetailsQuery.graphql"
+import { type Match, RedirectException } from "found"
 import { graphql } from "react-relay"
 
 const logger = createLogger("order2Routes.tsx")
@@ -55,6 +57,7 @@ export const order2Routes: RouteProps[] = [
               me {
                 order(id: $orderID) {
                   internalID
+                  mode
                 }
               }
               ...Order2CheckoutRoute_viewer @arguments(orderID: $orderID)
@@ -66,12 +69,27 @@ export const order2Routes: RouteProps[] = [
           if (!(Component && props)) {
             return
           }
-          const viewer = (props as unknown as order2Routes_CheckoutQuery$data)
-            .viewer
+          const typedProps = props as unknown as {
+            viewer: order2Routes_CheckoutQuery$data["viewer"]
+            match: Match<SystemContextProps>
+          }
+          const { viewer, match } = typedProps
           const order = viewer?.me?.order
+          const unleashClient = match.context.unleashClient
+
           if (!order) {
             logger.warn("No order found - checkout page")
             return <ErrorPage code={404} />
+          }
+
+          if (!newCheckoutEnabled({ order, unleashClient })) {
+            const redirectUrl = `/orders/${order.internalID}/shipping`
+            if (process.env.NODE_ENV === "development") {
+              console.error(
+                `Redirecting from to ${redirectUrl} because Order2 checkout is not enabled for this order`,
+              )
+            }
+            throw new RedirectException(redirectUrl)
           }
 
           return <Component viewer={viewer} />
@@ -88,6 +106,7 @@ export const order2Routes: RouteProps[] = [
               me {
                 order(id: $orderID) {
                   internalID
+                  mode
                 }
               }
             }
@@ -98,13 +117,27 @@ export const order2Routes: RouteProps[] = [
           if (!(Component && props)) {
             return
           }
-          const viewer = (props as unknown as order2Routes_DetailsQuery$data)
-            .viewer
-
+          const typedProps = props as unknown as {
+            viewer: order2Routes_CheckoutQuery$data["viewer"]
+            match: Match<SystemContextProps>
+          }
+          const { viewer, match } = typedProps
           const order = viewer?.me?.order
+          const unleashClient = match.context.unleashClient
+
           if (!order) {
-            logger.warn("No order found - details page")
+            logger.warn("No order found - checkout page")
             return <ErrorPage code={404} />
+          }
+
+          if (!newDetailsEnabled({ order, unleashClient })) {
+            const redirectUrl = `/orders/${order.internalID}/status`
+            if (process.env.NODE_ENV === "development") {
+              console.error(
+                `Redirecting from to ${redirectUrl} because Order2 details page is not enabled for this order`,
+              )
+            }
+            throw new RedirectException(redirectUrl)
           }
 
           return <Component viewer={viewer} />

--- a/src/__generated__/order2Routes_CheckoutQuery.graphql.ts
+++ b/src/__generated__/order2Routes_CheckoutQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9a706480b88048bf26ca0ce2042d4ac1>>
+ * @generated SignedSource<<cd538682023afc54934a2d55de77b4aa>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,6 +10,7 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
+export type OrderModeEnum = "BUY" | "OFFER" | "%future added value";
 export type order2Routes_CheckoutQuery$variables = {
   orderID: string;
 };
@@ -18,6 +19,7 @@ export type order2Routes_CheckoutQuery$data = {
     readonly me: {
       readonly order: {
         readonly internalID: string;
+        readonly mode: OrderModeEnum;
       } | null | undefined;
     } | null | undefined;
     readonly " $fragmentSpreads": FragmentRefs<"Order2CheckoutRoute_viewer">;
@@ -54,13 +56,16 @@ v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "mode",
   "storageKey": null
 },
-v4 = [
-  (v2/*: any*/),
-  (v3/*: any*/)
-];
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -92,7 +97,8 @@ return {
                 "name": "order",
                 "plural": false,
                 "selections": [
-                  (v2/*: any*/)
+                  (v2/*: any*/),
+                  (v3/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -146,10 +152,14 @@ return {
                 "kind": "LinkedField",
                 "name": "order",
                 "plural": false,
-                "selections": (v4/*: any*/),
+                "selections": [
+                  (v2/*: any*/),
+                  (v3/*: any*/),
+                  (v4/*: any*/)
+                ],
                 "storageKey": null
               },
-              (v3/*: any*/),
+              (v4/*: any*/),
               {
                 "alias": null,
                 "args": [
@@ -179,7 +189,10 @@ return {
                         "kind": "LinkedField",
                         "name": "node",
                         "plural": false,
-                        "selections": (v4/*: any*/),
+                        "selections": [
+                          (v2/*: any*/),
+                          (v4/*: any*/)
+                        ],
                         "storageKey": null
                       }
                     ],
@@ -197,16 +210,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "225e17b3e464902e10e8834508f16063",
+    "cacheID": "10115b62aa6825bfc8badbb1ae5b440e",
     "id": null,
     "metadata": {},
     "name": "order2Routes_CheckoutQuery",
     "operationKind": "query",
-    "text": "query order2Routes_CheckoutQuery(\n  $orderID: String!\n) {\n  viewer {\n    me {\n      order(id: $orderID) {\n        internalID\n        id\n      }\n      id\n    }\n    ...Order2CheckoutRoute_viewer_3HPek8\n  }\n}\n\nfragment Order2CheckoutRoute_viewer_3HPek8 on Viewer {\n  me {\n    order(id: $orderID) {\n      internalID\n      id\n    }\n    addressConnection(first: 10) {\n      edges {\n        node {\n          internalID\n          id\n        }\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query order2Routes_CheckoutQuery(\n  $orderID: String!\n) {\n  viewer {\n    me {\n      order(id: $orderID) {\n        internalID\n        mode\n        id\n      }\n      id\n    }\n    ...Order2CheckoutRoute_viewer_3HPek8\n  }\n}\n\nfragment Order2CheckoutRoute_viewer_3HPek8 on Viewer {\n  me {\n    order(id: $orderID) {\n      internalID\n      id\n    }\n    addressConnection(first: 10) {\n      edges {\n        node {\n          internalID\n          id\n        }\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "32a0a878f853edd6cb78159b3639cc6f";
+(node as any).hash = "2c087ef48ce01679b2b82e689e6bf48f";
 
 export default node;

--- a/src/__generated__/order2Routes_DetailsQuery.graphql.ts
+++ b/src/__generated__/order2Routes_DetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<524feda0ab5e048704244893d63232da>>
+ * @generated SignedSource<<ea307fc3b179f36b3ba2586f24a59e9d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,6 +10,7 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
+export type OrderModeEnum = "BUY" | "OFFER" | "%future added value";
 export type order2Routes_DetailsQuery$variables = {
   orderID: string;
 };
@@ -18,6 +19,7 @@ export type order2Routes_DetailsQuery$data = {
     readonly me: {
       readonly order: {
         readonly internalID: string;
+        readonly mode: OrderModeEnum;
       } | null | undefined;
     } | null | undefined;
     readonly " $fragmentSpreads": FragmentRefs<"Order2DetailsRoute_viewer">;
@@ -51,6 +53,13 @@ v2 = {
   "storageKey": null
 },
 v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "mode",
+  "storageKey": null
+},
+v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -99,7 +108,8 @@ return {
                 "name": "order",
                 "plural": false,
                 "selections": [
-                  (v2/*: any*/)
+                  (v2/*: any*/),
+                  (v3/*: any*/)
                 ],
                 "storageKey": null
               }
@@ -144,11 +154,12 @@ return {
                 "plural": false,
                 "selections": [
                   (v2/*: any*/),
+                  (v4/*: any*/),
                   (v3/*: any*/)
                 ],
                 "storageKey": null
               },
-              (v3/*: any*/)
+              (v4/*: any*/)
             ],
             "storageKey": null
           }
@@ -158,16 +169,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "c6c27620635e0a9def3c19c815e0eae0",
+    "cacheID": "161800c5620413118385777f578500b0",
     "id": null,
     "metadata": {},
     "name": "order2Routes_DetailsQuery",
     "operationKind": "query",
-    "text": "query order2Routes_DetailsQuery(\n  $orderID: String!\n) {\n  viewer {\n    ...Order2DetailsRoute_viewer_3HPek8\n    me {\n      order(id: $orderID) {\n        internalID\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment Order2DetailsRoute_viewer_3HPek8 on Viewer {\n  me {\n    order(id: $orderID) {\n      internalID\n      id\n    }\n    id\n  }\n}\n"
+    "text": "query order2Routes_DetailsQuery(\n  $orderID: String!\n) {\n  viewer {\n    ...Order2DetailsRoute_viewer_3HPek8\n    me {\n      order(id: $orderID) {\n        internalID\n        mode\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment Order2DetailsRoute_viewer_3HPek8 on Viewer {\n  me {\n    order(id: $orderID) {\n      internalID\n      id\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "61af607a27764f716534fecfb7d7daef";
+(node as any).hash = "22bf40218da5d62cf30cd9ce83538d6b";
 
 export default node;


### PR DESCRIPTION
_Draft: Rebase after #15480 is merged: changes start with https://github.com/artsy/force/pull/15481_

The type of this PR is: **chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2364] and [EMI-2380]

### Description
This PR is one of the first uses of force's new server-side unleash feature flag checks. In short, for legacy checkout flow routes we redirect to `orders2/:id/checkout` and for the legacy status page we redirect to `orders2/:id/details`. Likewise from those routes we use the same criteria to direct you to the legacy pages.

The criteria for both is the same right now: A BUY order with the appropriate feature flag enabled.

Paired with @damassi and @oxaudo 
CC @artsy/emerald-devs 

[EMI-2364]: https://artsyproduct.atlassian.net/browse/EMI-2364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EMI-2380]: https://artsyproduct.atlassian.net/browse/EMI-2380?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ