### PR TITLE
feat(EMI-2432): Add Google Pay icon to order history

### DIFF
--- a/src/Apps/Order/Components/GooglePayDetails.tsx
+++ b/src/Apps/Order/Components/GooglePayDetails.tsx
@@ -1,0 +1,20 @@
+import GooglePayIcon from "@artsy/icons/GooglePayIcon"
+import { Flex, Text } from "@artsy/palette"
+
+interface Props {
+  textColor?: string
+}
+
+export const GooglePayDetails = (props: Props) => {
+  const { textColor = "mono100" } = props
+
+  return (
+    <Flex alignItems="center">
+      <GooglePayIcon mr={1} width="26px" height="26px" />
+
+      <Text variant="sm-display" color={textColor}>
+        Google Pay
+      </Text>
+    </Flex>
+  )
+}

--- a/src/Apps/Order/Components/PaymentMethodSummaryItem.tsx
+++ b/src/Apps/Order/Components/PaymentMethodSummaryItem.tsx
@@ -8,6 +8,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 import { BankDebitDetails } from "./BankDebitDetails"
 import { CreditCardDetails } from "./CreditCardDetails"
 import { WireTransferDetails } from "./WireTransferDetails"
+import { GooglePayDetails } from "Apps/Order/Components/GooglePayDetails"
 
 export const PaymentMethodSummaryItem = ({
   order: { creditCardWalletType, source, paymentMethodDetails },
@@ -20,8 +21,15 @@ export const PaymentMethodSummaryItem = ({
   withDescription?: boolean
 } & StepSummaryItemProps) => {
   const renderPaymentMethodSummary = () => {
-    if (creditCardWalletType === "apple_pay") {
-      return <ApplePayDetails textColor={textColor} />
+    if (!!creditCardWalletType) {
+      switch (creditCardWalletType) {
+        case "apple_pay":
+          return <ApplePayDetails textColor={textColor} />
+        case "google_pay":
+          return <GooglePayDetails textColor={textColor} />
+        default:
+          break
+      }
     }
     switch (paymentMethodDetails?.__typename) {
       case "CreditCard":

--- a/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchasesRow.tsx
+++ b/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchasesRow.tsx
@@ -100,8 +100,15 @@ const getPaymentMethodText = (
   paymentMethodDetails: SettingsPurchasesRow_order$data["paymentMethodDetails"],
   creditCardWalletType: SettingsPurchasesRow_order$data["creditCardWalletType"],
 ) => {
-  if (creditCardWalletType === "apple_pay") {
-    return "Apple Pay"
+  if (!!creditCardWalletType) {
+    switch (creditCardWalletType) {
+      case "google_pay":
+        return "Google Pay"
+      case "apple_pay":
+        return "Apple Pay"
+      default:
+        break
+    }
   }
   switch (paymentMethodDetails?.__typename) {
     case "BankAccount":

--- a/src/Apps/Settings/Routes/Purchases/Components/__tests__/SettingsPurchases.jest.tsx
+++ b/src/Apps/Settings/Routes/Purchases/Components/__tests__/SettingsPurchases.jest.tsx
@@ -276,6 +276,18 @@ describe("SettingsPurchases", () => {
       expect(screen.getByText("Apple Pay")).toBeInTheDocument()
     })
 
+    it("renders Google Pay payment method", () => {
+      renderWithRelay({
+        CommerceOrder: () => ({
+          paymentMethodDetails: { __typename: "CreditCard" },
+          creditCardWalletType: "google_pay",
+        }),
+        CreditCard: () => ({ lastDigits: "1234" }),
+      })
+
+      expect(screen.getByText("Google Pay")).toBeInTheDocument()
+    })
+
     it("skips credit card wallet type if not recognized", () => {
       renderWithRelay({
         CommerceOrder: () => ({


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2432]

### Description
This PR adds Google Pay as a payment method in the order history and order details page


| View | Desktop | mWeb |
|---|---|---|
| Order History | ![image](https://github.com/user-attachments/assets/bb4cf649-fc64-4458-b4e6-ae43f2ee491f) | ![image](https://github.com/user-attachments/assets/4f3c03bd-d865-407f-9cc9-0b852ac6af4d) |
| Order Details | ![image](https://github.com/user-attachments/assets/21529705-51f5-4e51-808e-6caca513f2e8) | ![image](https://github.com/user-attachments/assets/83355bb9-8dc2-4478-b4ba-7ae1137a00ce) |

<!-- Implementation description -->


[EMI-2432]: https://artsyproduct.atlassian.net/browse/EMI-2432?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ