### PR TITLE
feat(EMI-2399): decouple address and payment method updates from express checkout orders

### DIFF
--- a/src/Apps/Order/Components/ExpressCheckout/ExpressCheckoutUI.tsx
+++ b/src/Apps/Order/Components/ExpressCheckout/ExpressCheckoutUI.tsx
@@ -656,8 +656,17 @@ const extractShippingRates = (order: ParseableOrder): Array<ShippingRate> => {
     shippingRatesOnly.length === 0
       ? rates.concat(CALCULATING_SHIPPING_RATE)
       : rates
-
-  return finalRates.sort(sortPickupLast)
+  const selectedFulfillmentOption = order.fulfillmentOptions.find(
+    option => option.selected,
+  )
+  if (selectedFulfillmentOption!.type === "PICKUP") {
+    // if pickup is selected, it should be the first option since Stripe auto
+    // selects the first option
+    return finalRates
+  } else {
+    // on modal open, the first option should always be ship
+    return finalRates.sort(sortPickupLast)
+  }
 }
 
 // Only max-height can be animated

--- a/src/Apps/Order/Components/ExpressCheckout/Mutations/useUpdateOrderShippingAddressMutation.ts
+++ b/src/Apps/Order/Components/ExpressCheckout/Mutations/useUpdateOrderShippingAddressMutation.ts
@@ -1,0 +1,52 @@
+import { useMutation } from "Utils/Hooks/useMutation"
+import type { useUpdateOrderShippingAddressMutation as useUpdateOrderShippingAddressType } from "__generated__/useUpdateOrderShippingAddressMutation.graphql"
+import { graphql } from "react-relay"
+
+export const useUpdateOrderShippingAddressMutation = () => {
+  return useMutation<useUpdateOrderShippingAddressType>({
+    mutation: graphql`
+      mutation useUpdateOrderShippingAddressMutation(
+        $input: updateOrderShippingAddressInput!
+      ) {
+        updateOrderShippingAddress(input: $input) {
+          orderOrError {
+            __typename
+            ... on OrderMutationSuccess {
+              order {
+                internalID
+                ...ExpressCheckoutUI_order
+                fulfillmentOptions {
+                  type
+                  amount {
+                    minor
+                    currencyCode
+                  }
+                  selected
+                }
+                buyerTotal {
+                  minor
+                  currencyCode
+                }
+                itemsTotal {
+                  minor
+                }
+                shippingTotal {
+                  minor
+                }
+                taxTotal {
+                  minor
+                }
+                availableShippingCountries
+              }
+            }
+            ... on OrderMutationError {
+              mutationError {
+                message
+              }
+            }
+          }
+        }
+      }
+    `,
+  })
+}

--- a/src/Apps/Order/Components/ExpressCheckout/__tests__/ExpressCheckoutUI.jest.tsx
+++ b/src/Apps/Order/Components/ExpressCheckout/__tests__/ExpressCheckoutUI.jest.tsx
@@ -176,22 +176,40 @@ describe("ExpressCheckoutUI", () => {
 
     fireEvent.click(screen.getByTestId("express-checkout-confirm"))
 
-    const { operationName, operationVariables } =
-      await mockResolveLastOperation({
-        updateOrderPayload: () => ({
-          orderOrError: {
-            __typename: "OrderMutationSuccess",
-            order: orderData,
-          },
-        }),
-      })
-    expect(operationName).toBe("useUpdateOrderMutation")
-    expect(operationVariables.input).toEqual({
+    // First, test the payment method update
+    const paymentMethodUpdate = await mockResolveLastOperation({
+      updateOrder: () => ({
+        orderOrError: {
+          __typename: "OrderMutationSuccess",
+          order: orderData,
+        },
+      }),
+    })
+
+    expect(paymentMethodUpdate.operationName).toBe("useUpdateOrderMutation")
+    expect(paymentMethodUpdate.operationVariables.input).toEqual({
+      id: "a5aaa8b0-93ff-4f2a-8bb3-9589f378d229",
+      paymentMethod: "CREDIT_CARD",
+      creditCardWalletType: "APPLE_PAY",
+    })
+
+    // Second, test the shipping address update
+    const shippingAddressUpdate = await mockResolveLastOperation({
+      updateOrderShippingAddress: () => ({
+        orderOrError: {
+          __typename: "OrderMutationSuccess",
+          order: orderData,
+        },
+      }),
+    })
+
+    expect(shippingAddressUpdate.operationName).toBe(
+      "useUpdateOrderShippingAddressMutation",
+    )
+    expect(shippingAddressUpdate.operationVariables.input).toEqual({
       id: "a5aaa8b0-93ff-4f2a-8bb3-9589f378d229",
       buyerPhoneNumber: "1234567890",
       buyerPhoneNumberCountryCode: null,
-      creditCardWalletType: "APPLE_PAY",
-      paymentMethod: "CREDIT_CARD",
       shippingAddressLine1: "401 Broadway",
       shippingAddressLine2: null,
       shippingCity: "New York",
@@ -204,16 +222,18 @@ describe("ExpressCheckoutUI", () => {
     await flushPromiseQueue()
     expect(mockCreateConfirmationToken).toHaveBeenCalled()
 
-    const mutation = await mockResolveLastOperation({
-      submitOrderPayload: () => ({
+    // Third, test the order submission
+    const orderSubmission = await mockResolveLastOperation({
+      submitOrder: () => ({
         orderOrError: {
           __typename: "OrderMutationSuccess",
           order: orderData,
         },
       }),
     })
-    expect(mutation.operationName).toBe("useSubmitOrderMutation")
-    expect(mutation.operationVariables.input).toEqual({
+
+    expect(orderSubmission.operationName).toBe("useSubmitOrderMutation")
+    expect(orderSubmission.operationVariables.input).toEqual({
       id: "a5aaa8b0-93ff-4f2a-8bb3-9589f378d229",
       confirmationToken: "ctoken_123",
     })
@@ -241,22 +261,37 @@ describe("ExpressCheckoutUI", () => {
 
     fireEvent.click(screen.getByTestId("express-checkout-confirm"))
 
+    // First, test the payment method update
+    const paymentMethodUpdate = await mockResolveLastOperation({
+      updateOrder: () => ({
+        orderOrError: {
+          __typename: "OrderMutationSuccess",
+          order: orderData,
+        },
+      }),
+    })
+
+    expect(paymentMethodUpdate.operationName).toBe("useUpdateOrderMutation")
+    expect(paymentMethodUpdate.operationVariables.input).toEqual({
+      id: "a5aaa8b0-93ff-4f2a-8bb3-9589f378d229",
+      paymentMethod: "CREDIT_CARD",
+      creditCardWalletType: "APPLE_PAY",
+    })
+
     const { operationName, operationVariables } =
       await mockResolveLastOperation({
-        updateOrderPayload: () => ({
+        updateOrderShippingAddress: () => ({
           orderOrError: {
             __typename: "OrderMutationSuccess",
             order: orderData,
           },
         }),
       })
-    expect(operationName).toBe("useUpdateOrderMutation")
+    expect(operationName).toBe("useUpdateOrderShippingAddressMutation")
     expect(operationVariables.input).toEqual({
       id: "a5aaa8b0-93ff-4f2a-8bb3-9589f378d229",
       buyerPhoneNumber: "1234567890",
       buyerPhoneNumberCountryCode: null,
-      creditCardWalletType: "APPLE_PAY",
-      paymentMethod: "CREDIT_CARD",
       shippingAddressLine1: "401 Broadway",
       shippingAddressLine2: null,
       shippingCity: "New York",
@@ -389,9 +424,19 @@ describe("ExpressCheckoutUI", () => {
 
     fireEvent.click(screen.getByTestId("express-checkout-confirm"))
 
+    // Resolve the payment method update mutation
+    await mockResolveLastOperation({
+      updateOrder: () => ({
+        orderOrError: {
+          __typename: "OrderMutationSuccess",
+          order: orderData,
+        },
+      }),
+    })
+
     // Resolve the update order mutation
     await mockResolveLastOperation({
-      updateOrderPayload: () => ({
+      updateOrderShippingAddress: () => ({
         orderOrError: {
           __typename: "OrderMutationSuccess",
           order: orderData,

--- a/src/__generated__/useUpdateOrderShippingAddressMutation.graphql.ts
+++ b/src/__generated__/useUpdateOrderShippingAddressMutation.graphql.ts
@@ -1,0 +1,482 @@
+/**
+ * @generated SignedSource<<638b176f56aba189fd6d4ea94409c5f2>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type FulfillmentOptionTypeEnum = "DOMESTIC_FLAT" | "INTERNATIONAL_FLAT" | "PICKUP" | "SHIPPING_TBD" | "%future added value";
+export type updateOrderShippingAddressInput = {
+  buyerPhoneNumber?: string | null | undefined;
+  buyerPhoneNumberCountryCode?: string | null | undefined;
+  clientMutationId?: string | null | undefined;
+  id: string;
+  shippingAddressLine1?: string | null | undefined;
+  shippingAddressLine2?: string | null | undefined;
+  shippingCity?: string | null | undefined;
+  shippingCountry?: string | null | undefined;
+  shippingName?: string | null | undefined;
+  shippingPostalCode?: string | null | undefined;
+  shippingRegion?: string | null | undefined;
+};
+export type useUpdateOrderShippingAddressMutation$variables = {
+  input: updateOrderShippingAddressInput;
+};
+export type useUpdateOrderShippingAddressMutation$data = {
+  readonly updateOrderShippingAddress: {
+    readonly orderOrError: {
+      readonly __typename: "OrderMutationError";
+      readonly mutationError: {
+        readonly message: string;
+      };
+    } | {
+      readonly __typename: "OrderMutationSuccess";
+      readonly order: {
+        readonly availableShippingCountries: ReadonlyArray<string>;
+        readonly buyerTotal: {
+          readonly currencyCode: string;
+          readonly minor: any;
+        } | null | undefined;
+        readonly fulfillmentOptions: ReadonlyArray<{
+          readonly amount: {
+            readonly currencyCode: string;
+            readonly minor: any;
+          } | null | undefined;
+          readonly selected: boolean | null | undefined;
+          readonly type: FulfillmentOptionTypeEnum;
+        }>;
+        readonly internalID: string;
+        readonly itemsTotal: {
+          readonly minor: any;
+        } | null | undefined;
+        readonly shippingTotal: {
+          readonly minor: any;
+        } | null | undefined;
+        readonly taxTotal: {
+          readonly minor: any;
+        } | null | undefined;
+        readonly " $fragmentSpreads": FragmentRefs<"ExpressCheckoutUI_order">;
+      };
+    } | {
+      // This will never be '%other', but we need some
+      // value in case none of the concrete values match.
+      readonly __typename: "%other";
+    } | null | undefined;
+  } | null | undefined;
+};
+export type useUpdateOrderShippingAddressMutation = {
+  response: useUpdateOrderShippingAddressMutation$data;
+  variables: useUpdateOrderShippingAddressMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "minor",
+  "storageKey": null
+},
+v5 = [
+  (v4/*: any*/),
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "currencyCode",
+    "storageKey": null
+  }
+],
+v6 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "FulfillmentOption",
+  "kind": "LinkedField",
+  "name": "fulfillmentOptions",
+  "plural": true,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "type",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Money",
+      "kind": "LinkedField",
+      "name": "amount",
+      "plural": false,
+      "selections": (v5/*: any*/),
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "selected",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Money",
+  "kind": "LinkedField",
+  "name": "buyerTotal",
+  "plural": false,
+  "selections": (v5/*: any*/),
+  "storageKey": null
+},
+v8 = [
+  (v4/*: any*/)
+],
+v9 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Money",
+  "kind": "LinkedField",
+  "name": "itemsTotal",
+  "plural": false,
+  "selections": (v8/*: any*/),
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Money",
+  "kind": "LinkedField",
+  "name": "shippingTotal",
+  "plural": false,
+  "selections": (v8/*: any*/),
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Money",
+  "kind": "LinkedField",
+  "name": "taxTotal",
+  "plural": false,
+  "selections": (v8/*: any*/),
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "availableShippingCountries",
+  "storageKey": null
+},
+v13 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "ExchangeError",
+      "kind": "LinkedField",
+      "name": "mutationError",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "message",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "OrderMutationError",
+  "abstractKey": null
+},
+v14 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "useUpdateOrderShippingAddressMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "updateOrderShippingAddressPayload",
+        "kind": "LinkedField",
+        "name": "updateOrderShippingAddress",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "orderOrError",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Order",
+                    "kind": "LinkedField",
+                    "name": "order",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      {
+                        "args": null,
+                        "kind": "FragmentSpread",
+                        "name": "ExpressCheckoutUI_order"
+                      },
+                      (v6/*: any*/),
+                      (v7/*: any*/),
+                      (v9/*: any*/),
+                      (v10/*: any*/),
+                      (v11/*: any*/),
+                      (v12/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "OrderMutationSuccess",
+                "abstractKey": null
+              },
+              (v13/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "useUpdateOrderShippingAddressMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "updateOrderShippingAddressPayload",
+        "kind": "LinkedField",
+        "name": "updateOrderShippingAddress",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "orderOrError",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Order",
+                    "kind": "LinkedField",
+                    "name": "order",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "source",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "mode",
+                        "storageKey": null
+                      },
+                      (v7/*: any*/),
+                      (v9/*: any*/),
+                      (v10/*: any*/),
+                      (v11/*: any*/),
+                      (v12/*: any*/),
+                      (v6/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "FulfillmentDetails",
+                        "kind": "LinkedField",
+                        "name": "fulfillmentDetails",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "addressLine1",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "addressLine2",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "city",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "postalCode",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "region",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "country",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "name",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "LineItem",
+                        "kind": "LinkedField",
+                        "name": "lineItems",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Artwork",
+                            "kind": "LinkedField",
+                            "name": "artwork",
+                            "plural": false,
+                            "selections": [
+                              (v3/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "slug",
+                                "storageKey": null
+                              },
+                              (v14/*: any*/)
+                            ],
+                            "storageKey": null
+                          },
+                          (v14/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      (v14/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "OrderMutationSuccess",
+                "abstractKey": null
+              },
+              (v13/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "7bafa3d31714ef6e65a51e606b557f52",
+    "id": null,
+    "metadata": {},
+    "name": "useUpdateOrderShippingAddressMutation",
+    "operationKind": "mutation",
+    "text": "mutation useUpdateOrderShippingAddressMutation(\n  $input: updateOrderShippingAddressInput!\n) {\n  updateOrderShippingAddress(input: $input) {\n    orderOrError {\n      __typename\n      ... on OrderMutationSuccess {\n        order {\n          internalID\n          ...ExpressCheckoutUI_order\n          fulfillmentOptions {\n            type\n            amount {\n              minor\n              currencyCode\n            }\n            selected\n          }\n          buyerTotal {\n            minor\n            currencyCode\n          }\n          itemsTotal {\n            minor\n          }\n          shippingTotal {\n            minor\n          }\n          taxTotal {\n            minor\n          }\n          availableShippingCountries\n          id\n        }\n      }\n      ... on OrderMutationError {\n        mutationError {\n          message\n        }\n      }\n    }\n  }\n}\n\nfragment ExpressCheckoutUI_order on Order {\n  internalID\n  source\n  mode\n  buyerTotal {\n    minor\n    currencyCode\n  }\n  itemsTotal {\n    minor\n  }\n  shippingTotal {\n    minor\n  }\n  taxTotal {\n    minor\n  }\n  availableShippingCountries\n  fulfillmentOptions {\n    type\n    amount {\n      minor\n      currencyCode\n    }\n    selected\n  }\n  fulfillmentDetails {\n    addressLine1\n    addressLine2\n    city\n    postalCode\n    region\n    country\n    name\n  }\n  lineItems {\n    artwork {\n      internalID\n      slug\n      id\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "96b4be2ec21bbc86eb027b575a3ab442";
+
+export default node;


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2399]

### Description
Followup from https://github.com/artsy/metaphysics/pull/6682 and https://github.com/artsy/exchange/pull/2535

The main idea here is to use a more specific endpoint to update the Order shipping address values instead of the general `PUT /api/me/orders/:id`, since updating shipping address values will require an Order totals re-calculation and we want to avoid that in the more general purpose update.

@artsy/emerald-devs 

<!-- Implementation description -->


[EMI-2399]: https://artsyproduct.atlassian.net/browse/EMI-2399?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ