### PR TITLE
fix(a11y): add alt text to artist cover image

### DIFF
--- a/src/Apps/Artist/Components/ArtistHeader/ArtistHeader.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/ArtistHeader.tsx
@@ -45,6 +45,8 @@ const ArtistHeader: React.FC<React.PropsWithChildren<ArtistHeaderProps>> = ({
 
   const image = artist.coverArtwork?.image
   const hasImage = isValidImage(image)
+  const altText =
+    artist.coverArtwork?.imageTitle ?? `Artwork by ${artist.name!}`
   const hasPartnerSuppliedBio = !!artist.biographyBlurb?.credit
   const hasBio = artist.biographyBlurb?.text && !hasPartnerSuppliedBio
   const hasVerifiedRepresentatives = artist?.verifiedRepresentatives?.length > 0
@@ -62,7 +64,7 @@ const ArtistHeader: React.FC<React.PropsWithChildren<ArtistHeaderProps>> = ({
           alignItems="center"
         >
           <RouterLink to={artist.coverArtwork.href} display="block">
-            <ArtistHeaderImage image={image} />
+            <ArtistHeaderImage image={image} alt={altText} />
           </RouterLink>
         </Column>
       )}
@@ -277,6 +279,7 @@ export const ArtistHeaderFragmentContainer = createFragmentContainer(
         }
         coverArtwork {
           title
+          imageTitle
           href
           image {
             src: url(version: ["larger", "larger"])

--- a/src/Apps/Artist/Components/ArtistHeader/ArtistHeaderImage.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/ArtistHeaderImage.tsx
@@ -12,11 +12,12 @@ const MOBILE_SIZE = {
 interface ArtistHeaderImageProps
   extends Omit<BoxProps, "maxHeight" | "maxWidth"> {
   image: ValidImage
+  alt: string
 }
 
 export const ArtistHeaderImage: FC<
   React.PropsWithChildren<ArtistHeaderImageProps>
-> = ({ image, ...rest }) => {
+> = ({ image, alt, ...rest }) => {
   const max = maxDimensionsByArea({
     width: image.width,
     height: image.height,
@@ -58,6 +59,7 @@ export const ArtistHeaderImage: FC<
                 height="100%"
                 src={mobile.src}
                 srcSet={mobile.srcSet}
+                alt={alt}
                 fetchPriority="high"
                 // LCP optimization
                 lazyLoad={false}
@@ -83,6 +85,7 @@ export const ArtistHeaderImage: FC<
               key={desktop.src}
               src={desktop.src}
               srcSet={desktop.srcSet}
+              alt={alt}
               width="100%"
               height="100%"
               style={{ objectFit: "cover" }}

--- a/src/__generated__/ArtistApp_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistApp_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<62eefdf3bd8db869b0d04c6f073391de>>
+ * @generated SignedSource<<3a9ba1ba2b86c532ad26448db80b140b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -369,6 +369,13 @@ return {
               },
               (v6/*: any*/),
               (v4/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "imageTitle",
+                "storageKey": null
+              },
               (v2/*: any*/)
             ],
             "storageKey": null
@@ -747,7 +754,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "af31eb1fe393e09eb315279792a5f2e5",
+    "cacheID": "acd1bad0f6e2d655ca6c973c5afca861",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -841,6 +848,7 @@ return {
         "artist.coverArtwork.image.large": (v14/*: any*/),
         "artist.coverArtwork.image.src": (v14/*: any*/),
         "artist.coverArtwork.image.width": (v22/*: any*/),
+        "artist.coverArtwork.imageTitle": (v14/*: any*/),
         "artist.coverArtwork.title": (v14/*: any*/),
         "artist.deathday": (v14/*: any*/),
         "artist.formattedNationalityAndBirthday": (v14/*: any*/),
@@ -931,7 +939,7 @@ return {
     },
     "name": "ArtistApp_Test_Query",
     "operationKind": "query",
-    "text": "query ArtistApp_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistApp_artist\n    id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  internalID\n  slug\n  name\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n  biographyBlurb(format: HTML, partnerBio: false) {\n    text\n    credit\n  }\n  insights {\n    kind\n    ...ArtistCareerHighlight_insight\n  }\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          src1x: cropped(width: 30, height: 30) {\n            src\n          }\n          src2x: cropped(width: 60, height: 60) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n  coverArtwork {\n    title\n    href\n    image {\n      src: url(version: [\"larger\", \"larger\"])\n      width\n      height\n    }\n    id\n  }\n}\n\nfragment ArtistMeta_artist on Artist {\n  slug\n  name\n  nationality\n  birthday\n  deathday\n  gender\n  href\n  isInSeoExperiment\n  meta(page: ABOUT) {\n    description\n    title\n  }\n  alternateNames\n  coverArtwork {\n    image {\n      large: url(version: \"large\")\n    }\n    id\n  }\n  counts {\n    artworks\n  }\n  blurb\n  artworks_connection: artworksConnection(first: 10, filter: IS_FOR_SALE, published: true) {\n    edges {\n      node {\n        title\n        date\n        description\n        category\n        price_currency: priceCurrency\n        listPrice {\n          __typename\n          ... on PriceRange {\n            minPrice {\n              major\n              currencyCode\n            }\n            maxPrice {\n              major\n            }\n          }\n          ... on Money {\n            major\n            currencyCode\n          }\n        }\n        availability\n        href\n        image {\n          small: url(version: \"small\")\n          large: url(version: \"large\")\n        }\n        partner {\n          name\n          href\n          profile {\n            image {\n              small: url(version: \"small\")\n              large: url(version: \"large\")\n            }\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query ArtistApp_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistApp_artist\n    id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  internalID\n  slug\n  name\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n  biographyBlurb(format: HTML, partnerBio: false) {\n    text\n    credit\n  }\n  insights {\n    kind\n    ...ArtistCareerHighlight_insight\n  }\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          src1x: cropped(width: 30, height: 30) {\n            src\n          }\n          src2x: cropped(width: 60, height: 60) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n  coverArtwork {\n    title\n    imageTitle\n    href\n    image {\n      src: url(version: [\"larger\", \"larger\"])\n      width\n      height\n    }\n    id\n  }\n}\n\nfragment ArtistMeta_artist on Artist {\n  slug\n  name\n  nationality\n  birthday\n  deathday\n  gender\n  href\n  isInSeoExperiment\n  meta(page: ABOUT) {\n    description\n    title\n  }\n  alternateNames\n  coverArtwork {\n    image {\n      large: url(version: \"large\")\n    }\n    id\n  }\n  counts {\n    artworks\n  }\n  blurb\n  artworks_connection: artworksConnection(first: 10, filter: IS_FOR_SALE, published: true) {\n    edges {\n      node {\n        title\n        date\n        description\n        category\n        price_currency: priceCurrency\n        listPrice {\n          __typename\n          ... on PriceRange {\n            minPrice {\n              major\n              currencyCode\n            }\n            maxPrice {\n              major\n            }\n          }\n          ... on Money {\n            major\n            currencyCode\n          }\n        }\n        availability\n        href\n        image {\n          small: url(version: \"small\")\n          large: url(version: \"large\")\n        }\n        partner {\n          name\n          href\n          profile {\n            image {\n              small: url(version: \"small\")\n              large: url(version: \"large\")\n            }\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistHeader_artist.graphql.ts
+++ b/src/__generated__/ArtistHeader_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<460155b22f1bb9b95bd09fc7e33e10d4>>
+ * @generated SignedSource<<f988faffb52c6045ff20168dce578556>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,6 +26,7 @@ export type ArtistHeader_artist$data = {
       readonly src: string | null | undefined;
       readonly width: number | null | undefined;
     } | null | undefined;
+    readonly imageTitle: string | null | undefined;
     readonly title: string | null | undefined;
   } | null | undefined;
   readonly formattedNationalityAndBirthday: string | null | undefined;
@@ -294,6 +295,13 @@ return {
           "name": "title",
           "storageKey": null
         },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "imageTitle",
+          "storageKey": null
+        },
         (v2/*: any*/),
         {
           "alias": null,
@@ -345,6 +353,6 @@ return {
 };
 })();
 
-(node as any).hash = "966307beb64f1a2a1d34d53688a526e4";
+(node as any).hash = "e52c47ac3fe6c7aad115ef19f7f3218d";
 
 export default node;

--- a/src/__generated__/artistRoutes_ArtistAppQuery.graphql.ts
+++ b/src/__generated__/artistRoutes_ArtistAppQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6f16594870b8fb3f3e5569e368e34bba>>
+ * @generated SignedSource<<9e90480ff73650aff7d4118ea3242cf0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -312,6 +312,13 @@ return {
               },
               (v7/*: any*/),
               (v5/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "imageTitle",
+                "storageKey": null
+              },
               (v3/*: any*/)
             ],
             "storageKey": null
@@ -690,12 +697,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "be70aac744078ab581ed4d6e31e8c968",
+    "cacheID": "df81b1c06519b6a15253e09270555bf7",
     "id": null,
     "metadata": {},
     "name": "artistRoutes_ArtistAppQuery",
     "operationKind": "query",
-    "text": "query artistRoutes_ArtistAppQuery(\n  $artistID: String!\n) @cacheable {\n  artist(id: $artistID) @principalField {\n    ...ArtistApp_artist\n    id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  internalID\n  slug\n  name\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n  biographyBlurb(format: HTML, partnerBio: false) {\n    text\n    credit\n  }\n  insights {\n    kind\n    ...ArtistCareerHighlight_insight\n  }\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          src1x: cropped(width: 30, height: 30) {\n            src\n          }\n          src2x: cropped(width: 60, height: 60) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n  coverArtwork {\n    title\n    href\n    image {\n      src: url(version: [\"larger\", \"larger\"])\n      width\n      height\n    }\n    id\n  }\n}\n\nfragment ArtistMeta_artist on Artist {\n  slug\n  name\n  nationality\n  birthday\n  deathday\n  gender\n  href\n  isInSeoExperiment\n  meta(page: ABOUT) {\n    description\n    title\n  }\n  alternateNames\n  coverArtwork {\n    image {\n      large: url(version: \"large\")\n    }\n    id\n  }\n  counts {\n    artworks\n  }\n  blurb\n  artworks_connection: artworksConnection(first: 10, filter: IS_FOR_SALE, published: true) {\n    edges {\n      node {\n        title\n        date\n        description\n        category\n        price_currency: priceCurrency\n        listPrice {\n          __typename\n          ... on PriceRange {\n            minPrice {\n              major\n              currencyCode\n            }\n            maxPrice {\n              major\n            }\n          }\n          ... on Money {\n            major\n            currencyCode\n          }\n        }\n        availability\n        href\n        image {\n          small: url(version: \"small\")\n          large: url(version: \"large\")\n        }\n        partner {\n          name\n          href\n          profile {\n            image {\n              small: url(version: \"small\")\n              large: url(version: \"large\")\n            }\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n"
+    "text": "query artistRoutes_ArtistAppQuery(\n  $artistID: String!\n) @cacheable {\n  artist(id: $artistID) @principalField {\n    ...ArtistApp_artist\n    id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  internalID\n  slug\n  name\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n  biographyBlurb(format: HTML, partnerBio: false) {\n    text\n    credit\n  }\n  insights {\n    kind\n    ...ArtistCareerHighlight_insight\n  }\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          src1x: cropped(width: 30, height: 30) {\n            src\n          }\n          src2x: cropped(width: 60, height: 60) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n  coverArtwork {\n    title\n    imageTitle\n    href\n    image {\n      src: url(version: [\"larger\", \"larger\"])\n      width\n      height\n    }\n    id\n  }\n}\n\nfragment ArtistMeta_artist on Artist {\n  slug\n  name\n  nationality\n  birthday\n  deathday\n  gender\n  href\n  isInSeoExperiment\n  meta(page: ABOUT) {\n    description\n    title\n  }\n  alternateNames\n  coverArtwork {\n    image {\n      large: url(version: \"large\")\n    }\n    id\n  }\n  counts {\n    artworks\n  }\n  blurb\n  artworks_connection: artworksConnection(first: 10, filter: IS_FOR_SALE, published: true) {\n    edges {\n      node {\n        title\n        date\n        description\n        category\n        price_currency: priceCurrency\n        listPrice {\n          __typename\n          ... on PriceRange {\n            minPrice {\n              major\n              currencyCode\n            }\n            maxPrice {\n              major\n            }\n          }\n          ... on Money {\n            major\n            currencyCode\n          }\n        }\n        availability\n        href\n        image {\n          small: url(version: \"small\")\n          large: url(version: \"large\")\n        }\n        partner {\n          name\n          href\n          profile {\n            image {\n              small: url(version: \"small\")\n              large: url(version: \"large\")\n            }\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Belated follow-up on the recent [accessibility mob](https://artsy.slack.com/archives/C2TQ4PT8R/p1745246843599959)

This simply adds an `alt` attribute for the artist page cover image.

Amazingly TIL about the `artwork.imageTitle` attribute that's been around for years and was [concocted for this purpose](https://github.com/artsy/metaphysics/pull/523/files). I wonder if we use that everywhere we should.

There were some other findings in that session but they will have to be dealt with in Palette.

<img width="500" alt="Screenshot 2025-05-02 at 3 42 20 PM" src="https://github.com/user-attachments/assets/daea6560-5f16-4c13-91e5-c94625cc879c" />