### PR TITLE
fix(artwork): corrects comma placement

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebar.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebar.tsx
@@ -7,7 +7,6 @@ import {
   SkeletonText,
   Spacer,
   Text,
-  VisuallyHidden,
 } from "@artsy/palette"
 import { ArtworkSidebarAuctionPollingRefetchContainer } from "Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarAuctionInfoPolling"
 import { ArtworkSidebarAuctionTimerFragmentContainer } from "Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarAuctionTimer"
@@ -143,8 +142,6 @@ export const ArtworkSidebar: React.FC<
 
       <h1>
         <ArtworkSidebarArtistsFragmentContainer artwork={artwork} />
-
-        <VisuallyHidden>, </VisuallyHidden>
 
         <ArtworkSidebarArtworkTitleFragmentContainer artwork={artwork} />
       </h1>

--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarArtists.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarArtists.tsx
@@ -1,4 +1,4 @@
-import { ShowMore, Text } from "@artsy/palette"
+import { ShowMore, Text, VisuallyHidden } from "@artsy/palette"
 import { themeGet } from "@styled-system/theme-get"
 import { RouterLink } from "System/Components/RouterLink"
 import type { ArtworkSidebarArtists_artwork$data } from "__generated__/ArtworkSidebarArtists_artwork.graphql"
@@ -59,6 +59,8 @@ export const ArtworkSidebarArtists: React.FC<
       {artists.length === 0 && culturalMaker && (
         <Text variant="lg-display">{culturalMaker}</Text>
       )}
+
+      <VisuallyHidden>, </VisuallyHidden>
     </div>
   )
 }


### PR DESCRIPTION
This fixes a long standing annoyance that never even occurred to me as something to fix. I recently added the visually hidden comma to improve the uniqueness of the h1 tags. And I noticed that, of course, now when I copy/paste that block of text it has the comma in it! I used to copy/paste the artist name-artwork title and then manually insert the comma. But there was just a space in the wrong place now. This gets rid of that extra space.