### PR TITLE
feat(EMI-2450): Add loading screen for express checkout submissions

### DIFF
--- a/src/Apps/Order/Components/ExpressCheckout/ExpressCheckoutUI.tsx
+++ b/src/Apps/Order/Components/ExpressCheckout/ExpressCheckoutUI.tsx
@@ -427,6 +427,7 @@ export const ExpressCheckoutUI = ({
       )
 
       // Redirect to status page after successful order submission
+      setShowSpinner?.(false)
       window.location.reload()
     } catch (error) {
       logger.error("Error confirming payment", error)
@@ -447,6 +448,7 @@ export const ExpressCheckoutUI = ({
         }),
       )
 
+      setShowSpinner?.(false)
       resetOrder()
     }
   }

--- a/src/Apps/Order/Components/ExpressCheckout/ExpressCheckoutUI.tsx
+++ b/src/Apps/Order/Components/ExpressCheckout/ExpressCheckoutUI.tsx
@@ -427,7 +427,6 @@ export const ExpressCheckoutUI = ({
       )
 
       // Redirect to status page after successful order submission
-      setShowSpinner?.(false)
       window.location.reload()
     } catch (error) {
       logger.error("Error confirming payment", error)
@@ -448,7 +447,6 @@ export const ExpressCheckoutUI = ({
         }),
       )
 
-      setShowSpinner?.(false)
       resetOrder()
     }
   }

--- a/src/Apps/Order/Components/ExpressCheckout/ExpressCheckoutUI.tsx
+++ b/src/Apps/Order/Components/ExpressCheckout/ExpressCheckoutUI.tsx
@@ -50,11 +50,12 @@ import type {
   OrderCreditCardWalletTypeEnum,
   useUpdateOrderMutation$data,
 } from "__generated__/useUpdateOrderMutation.graphql"
-import { useRef, useState } from "react"
+import { Dispatch, SetStateAction, useRef, useState } from "react"
 import { graphql, useFragment } from "react-relay"
 
 interface ExpressCheckoutUIProps {
   order: ExpressCheckoutUI_order$key
+  setShowSpinner?: Dispatch<SetStateAction<boolean>>
 }
 
 const logger = createLogger("ExpressCheckoutUI")
@@ -64,7 +65,10 @@ type HandleCancelCallback = NonNullable<
   React.ComponentProps<typeof ExpressCheckoutElement>["onCancel"]
 >
 
-export const ExpressCheckoutUI = ({ order }: ExpressCheckoutUIProps) => {
+export const ExpressCheckoutUI = ({
+  order,
+  setShowSpinner,
+}: ExpressCheckoutUIProps) => {
   const orderData = useFragment(ORDER_FRAGMENT, order)
   const [visible, setVisible] = useState(false)
   const elements = useElements()
@@ -406,6 +410,8 @@ export const ExpressCheckoutUI = ({ order }: ExpressCheckoutUIProps) => {
         logger.error(error)
         return
       }
+
+      setShowSpinner?.(true)
 
       const submitOrderResult = await submitOrderMutation.submitMutation({
         variables: {

--- a/src/Apps/Order/Components/ExpressCheckout/__tests__/ExpressCheckoutUI.jest.tsx
+++ b/src/Apps/Order/Components/ExpressCheckout/__tests__/ExpressCheckoutUI.jest.tsx
@@ -39,6 +39,7 @@ jest.mock("Apps/Order/Routes/Shipping/Hooks/useShippingContext", () => ({
 const mockExpressCheckoutElement = ExpressCheckoutElement as jest.Mock
 const mockResolveOnClick = jest.fn()
 const mockElementsUpdate = jest.fn()
+const mockShowSpinner = jest.fn()
 const mockCreateConfirmationToken = jest.fn(() => {
   return {
     confirmationToken: {
@@ -126,7 +127,10 @@ jest.mock("@stripe/react-stripe-js", () => {
 })
 
 const { renderWithRelay } = setupTestWrapperTL<ExpressCheckoutUI_Test_Query>({
-  Component: ({ me }) => me?.order && <ExpressCheckoutUI order={me.order!} />,
+  Component: ({ me }) =>
+    me?.order && (
+      <ExpressCheckoutUI order={me.order!} setShowSpinner={mockShowSpinner} />
+    ),
   query: graphql`
     query ExpressCheckoutUI_Test_Query @raw_response_type {
       me {
@@ -242,6 +246,9 @@ describe("ExpressCheckoutUI", () => {
     await flushPromiseQueue()
     expect(mockCreateConfirmationToken).toHaveBeenCalled()
 
+    // show the spinner after token creation
+    expect(mockShowSpinner).toHaveBeenCalledWith(true)
+
     // Third, test the order submission
     const orderSubmission = await mockResolveLastOperation({
       submitOrder: () => ({
@@ -340,6 +347,7 @@ describe("ExpressCheckoutUI", () => {
         },
       }),
     )
+    expect(mockShowSpinner).toHaveBeenCalledWith(true)
 
     const mutation = await mockResolveLastOperation({
       submitOrderPayload: () => ({
@@ -522,6 +530,7 @@ describe("ExpressCheckoutUI", () => {
 
     await flushPromiseQueue()
     expect(mockCreateConfirmationToken).toHaveBeenCalled()
+    expect(mockShowSpinner).toHaveBeenCalledWith(true)
 
     // Resolve the submit order mutation
     await mockResolveLastOperation({

--- a/src/Apps/Order/Components/ExpressCheckout/index.tsx
+++ b/src/Apps/Order/Components/ExpressCheckout/index.tsx
@@ -12,12 +12,14 @@ import type {
   ExpressCheckout_order$data,
   ExpressCheckout_order$key,
 } from "__generated__/ExpressCheckout_order.graphql"
+import { Dispatch, SetStateAction } from "react"
 import { graphql, useFragment } from "react-relay"
 
 const stripePromise = loadStripe(getENV("STRIPE_PUBLISHABLE_KEY"))
 
 interface Props {
   order: ExpressCheckout_order$key
+  setShowSpinner?: Dispatch<SetStateAction<boolean>>
 }
 
 type Seller = Exclude<
@@ -25,7 +27,7 @@ type Seller = Exclude<
   { __typename: "%other" }
 >
 
-export const ExpressCheckout = ({ order }: Props) => {
+export const ExpressCheckout = ({ order, setShowSpinner }: Props) => {
   const orderData = useFragment(ORDER_FRAGMENT, order)
 
   // Use itemsTotal on load, but subsequent updates inside ExpressCheckoutUI
@@ -66,7 +68,7 @@ export const ExpressCheckout = ({ order }: Props) => {
   return (
     <>
       <Elements stripe={stripePromise} options={options}>
-        <ExpressCheckoutUI order={orderData} />
+        <ExpressCheckoutUI order={orderData} setShowSpinner={setShowSpinner} />
       </Elements>
     </>
   )
@@ -95,9 +97,14 @@ const ORDER_FRAGMENT = graphql`
   }
 `
 
-export const ExpressCheckoutQueryRenderer: React.FC<{ orderID: string }> = ({
-  orderID,
-}) => {
+interface ExpressCheckoutQueryRendererProps {
+  orderID: string
+  setShowSpinner?: Dispatch<SetStateAction<boolean>>
+}
+
+export const ExpressCheckoutQueryRenderer: React.FC<
+  ExpressCheckoutQueryRendererProps
+> = ({ orderID, setShowSpinner }) => {
   return (
     <SystemQueryRenderer<ExpressCheckoutQuery>
       // lazyLoad
@@ -113,7 +120,12 @@ export const ExpressCheckoutQueryRenderer: React.FC<{ orderID: string }> = ({
       variables={{ orderID }}
       render={({ props }) => {
         if (props?.me?.order) {
-          return <ExpressCheckout order={props.me.order} />
+          return (
+            <ExpressCheckout
+              order={props.me.order}
+              setShowSpinner={setShowSpinner}
+            />
+          )
         }
         return null
       }}

--- a/src/Apps/Order/Components/ProcessingPaymentSpinner.tsx
+++ b/src/Apps/Order/Components/ProcessingPaymentSpinner.tsx
@@ -1,0 +1,19 @@
+import { Box, Flex, Spinner, Text } from "@artsy/palette"
+
+export const ProcessingPaymentSpinner: React.FC = () => {
+  return (
+    <Flex alignItems="center" flexDirection="column">
+      <Box position="relative" height={100}>
+        <Spinner size="large" color="blue100" />
+      </Box>
+
+      <Text variant="md" color="blue100">
+        Processing payment
+      </Text>
+
+      <Text variant="sm" color="mono60">
+        Please do not close or refresg this window
+      </Text>
+    </Flex>
+  )
+}

--- a/src/Apps/Order/Components/ProcessingPaymentSpinner.tsx
+++ b/src/Apps/Order/Components/ProcessingPaymentSpinner.tsx
@@ -12,7 +12,7 @@ export const ProcessingPaymentSpinner: React.FC = () => {
       </Text>
 
       <Text variant="sm" color="mono60">
-        Please do not close or refresg this window
+        Please do not close or refresh this window
       </Text>
     </Flex>
   )

--- a/src/Apps/Order/Components/SubmittingOrderSpinner.tsx
+++ b/src/Apps/Order/Components/SubmittingOrderSpinner.tsx
@@ -1,6 +1,6 @@
 import { Box, Flex, Spinner, Text } from "@artsy/palette"
 
-export const ProcessingPaymentSpinner: React.FC = () => {
+export const SubmittingOrderSpinner: React.FC = () => {
   return (
     <Flex alignItems="center" flexDirection="column">
       <Box position="relative" height={100}>
@@ -8,7 +8,7 @@ export const ProcessingPaymentSpinner: React.FC = () => {
       </Box>
 
       <Text variant="md" color="blue100">
-        Processing payment
+        Submitting your order
       </Text>
 
       <Text variant="sm" color="mono60">

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -11,6 +11,7 @@ import {
   buyNowFlowSteps,
   offerFlowSteps,
 } from "Apps/Order/Components/OrderStepper"
+import { SubmittingOrderSpinner } from "Apps/Order/Components/SubmittingOrderSpinner"
 import { TransactionDetailsSummaryItemFragmentContainer as TransactionDetailsSummaryItem } from "Apps/Order/Components/TransactionDetailsSummaryItem"
 import { type Dialog, injectDialog } from "Apps/Order/Dialogs"
 import { FulfillmentDetails } from "Apps/Order/Routes/Shipping/Components/FulfillmentDetails"
@@ -31,7 +32,6 @@ import type {
 } from "__generated__/Shipping_order.graphql"
 import { type FC, useEffect, useState } from "react"
 import { graphql, useFragment } from "react-relay"
-import { ProcessingPaymentSpinner } from "Apps/Order/Components/ProcessingPaymentSpinner"
 
 export type ShippingStage =
   // User choosing fulfillment type
@@ -113,7 +113,8 @@ const ShippingRouteLayout: FC<
         }
         content={
           <>
-            {!!showSpinner && <ProcessingPaymentSpinner />}
+            {!!showSpinner && <SubmittingOrderSpinner />}
+
             <Flex
               display={showSpinner ? "none" : "flex"}
               flexDirection="column"

--- a/src/Apps/Order/Routes/Shipping/index.tsx
+++ b/src/Apps/Order/Routes/Shipping/index.tsx
@@ -29,8 +29,9 @@ import type {
   Shipping_order$data,
   Shipping_order$key,
 } from "__generated__/Shipping_order.graphql"
-import { type FC, useEffect } from "react"
+import { type FC, useEffect, useState } from "react"
 import { graphql, useFragment } from "react-relay"
+import { ProcessingPaymentSpinner } from "Apps/Order/Components/ProcessingPaymentSpinner"
 
 export type ShippingStage =
   // User choosing fulfillment type
@@ -73,6 +74,7 @@ const ShippingRouteLayout: FC<
   React.PropsWithChildren<Omit<ShippingProps, "dialog">>
 > = ({ me, order }) => {
   useShowStoredErrorDialog()
+  const [showSpinner, setShowSpinner] = useState(false)
 
   const shippingContext = useShippingContext()
 
@@ -110,30 +112,37 @@ const ShippingRouteLayout: FC<
           shippingContext.orderData.isOffer ? offerFlowSteps : buyNowFlowSteps
         }
         content={
-          <Flex
-            flexDirection="column"
-            style={
-              shippingContext.state.isPerformingOperation
-                ? { pointerEvents: "none" }
-                : {}
-            }
-          >
-            {isExpressCheckoutEligible && (
-              <>
-                {isExpressCheckoutLoading && EXPRESS_CHECKOUT_PLACEHOLDER}
-                <ExpressCheckoutQueryRenderer orderID={order.internalID} />
-              </>
-            )}
+          <>
+            {!!showSpinner && <ProcessingPaymentSpinner />}
+            <Flex
+              display={showSpinner ? "none" : "flex"}
+              flexDirection="column"
+              style={
+                shippingContext.state.isPerformingOperation
+                  ? { pointerEvents: "none" }
+                  : {}
+              }
+            >
+              {isExpressCheckoutEligible && (
+                <>
+                  {isExpressCheckoutLoading && EXPRESS_CHECKOUT_PLACEHOLDER}
+                  <ExpressCheckoutQueryRenderer
+                    orderID={order.internalID}
+                    setShowSpinner={setShowSpinner}
+                  />
+                </>
+              )}
 
-            <FulfillmentDetails me={me} order={order} />
+              <FulfillmentDetails me={me} order={order} />
 
-            <Jump id="shippingOptionsTop" />
-            <ShippingQuotes order={order} />
+              <Jump id="shippingOptionsTop" />
+              <ShippingQuotes order={order} />
 
-            <Media greaterThan="xs">
-              <SaveAndContinueButton width="50%" order={order} />
-            </Media>
-          </Flex>
+              <Media greaterThan="xs">
+                <SaveAndContinueButton width="50%" order={order} />
+              </Media>
+            </Flex>
+          </>
         }
         sidebar={
           <Flex flexDirection="column">


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2450]

### Description
This PR adds a spinner for order submission through the express checkout


### Updated Videos
| Apple Pay | Google Pay |
|---|---|
| <video src="https://github.com/user-attachments/assets/517d0e07-799e-440b-a022-71b713408e67" /> | <video src="https://github.com/user-attachments/assets/c7b4d32f-5b92-4a66-a4be-96c22ee83d2f" /> |


<!-- Implementation description -->


[EMI-2450]: https://artsyproduct.atlassian.net/browse/EMI-2450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ