### PR TITLE
chore: load order summary lines from MP

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/Order2CollapsibleOrderSummary.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2CollapsibleOrderSummary.tsx
@@ -11,9 +11,6 @@ interface Order2CollapsibleOrderSummaryProps {
   order: Order2CollapsibleOrderSummary_order$key
 }
 
-const TAX_CALCULATION_ARTICLE =
-  "https://support.artsy.net/s/article/How-are-taxes-and-customs-fees-calculated"
-
 export const Order2CollapsibleOrderSummary: React.FC<
   Order2CollapsibleOrderSummaryProps
 > = ({ order }) => {
@@ -72,18 +69,6 @@ export const Order2CollapsibleOrderSummary: React.FC<
         <Spacer y={1} />
         <Box mb={2}>
           <Order2PricingBreakdown order={orderData} />
-          <Text variant="xs" color="mono60" textAlign="left" mt={2}>
-            *Additional duties and taxes{" "}
-            <RouterLink
-              inline
-              to={TAX_CALCULATION_ARTICLE}
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              may apply at import
-            </RouterLink>
-            .
-          </Text>
         </Box>
         <Spacer y={1} />
       </Box>

--- a/src/Apps/Order2/Routes/Checkout/Components/Order2CollapsibleOrderSummary.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2CollapsibleOrderSummary.tsx
@@ -1,5 +1,6 @@
 import ChevronDownIcon from "@artsy/icons/ChevronDownIcon"
 import { Box, Clickable, Flex, Image, Spacer, Text } from "@artsy/palette"
+import { Order2PricingBreakdown } from "Apps/Order2/Routes/Checkout/Components/Order2PricingBreakdown"
 import { RouterLink } from "System/Components/RouterLink"
 import type { Order2CollapsibleOrderSummary_order$key } from "__generated__/Order2CollapsibleOrderSummary_order.graphql"
 import type * as React from "react"
@@ -70,49 +71,7 @@ export const Order2CollapsibleOrderSummary: React.FC<
       >
         <Spacer y={1} />
         <Box mb={2}>
-          <Flex>
-            <Text flexGrow={1} variant="sm" color="mono60">
-              Price
-            </Text>
-            <Text flexGrow={0} variant="sm" color="mono60">
-              {orderData.itemsTotal?.display}
-            </Text>
-          </Flex>
-          <Flex>
-            <Text flexGrow={1} variant="sm" color="mono60">
-              Shipping
-            </Text>
-            <Text flexGrow={0} variant="sm" color="mono60">
-              {orderData.shippingTotal?.display || "Calculated in next steps"}
-            </Text>
-          </Flex>
-          <Flex>
-            <Text flexGrow={1} variant="sm" color="mono60">
-              Tax*
-            </Text>
-            <Text flexGrow={0} variant="sm" color="mono60">
-              {orderData.shippingTotal?.display || "Calculated in next steps"}
-            </Text>
-          </Flex>
-          <Spacer y={0.5} />
-          <Flex>
-            <Text
-              flexGrow={1}
-              variant="sm-display"
-              color="mono100"
-              fontWeight="medium"
-            >
-              Total
-            </Text>
-            <Text
-              flexGrow={0}
-              variant="sm-display"
-              color="mono100"
-              fontWeight="medium"
-            >
-              Waiting for final cost
-            </Text>
-          </Flex>
+          <Order2PricingBreakdown order={orderData} />
           <Text variant="xs" color="mono60" textAlign="left" mt={2}>
             *Additional duties and taxes{" "}
             <RouterLink
@@ -134,6 +93,7 @@ export const Order2CollapsibleOrderSummary: React.FC<
 
 const FRAGMENT = graphql`
   fragment Order2CollapsibleOrderSummary_order on Order {
+    ...Order2PricingBreakdown_order
     mode
     source
     buyerTotal {

--- a/src/Apps/Order2/Routes/Checkout/Components/Order2PricingBreakdown.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2PricingBreakdown.tsx
@@ -1,0 +1,133 @@
+import { Flex, Spacer, Text } from "@artsy/palette"
+import type {
+  Order2PricingBreakdown_order$data,
+  Order2PricingBreakdown_order$key,
+} from "__generated__/Order2PricingBreakdown_order.graphql"
+import { graphql, useFragment } from "react-relay"
+
+interface Order2PricingBreakdownProps {
+  order: Order2PricingBreakdown_order$key
+}
+
+const knownLineTypes = [
+  "ShippingLine",
+  "TaxLine",
+  "SubtotalLine",
+  "TotalLine",
+] as const
+
+type KnownLineType = Extract<
+  Order2PricingBreakdown_order$data["pricingBreakdownLines"][number],
+  { __typename: "ShippingLine" | "TaxLine" | "SubtotalLine" | "TotalLine" }
+>
+
+const isKnownLineType = (
+  line: Order2PricingBreakdown_order$data["pricingBreakdownLines"][number],
+): line is KnownLineType => {
+  return !!line && knownLineTypes.includes(line.__typename as any)
+}
+
+export const Order2PricingBreakdown: React.FC<Order2PricingBreakdownProps> = ({
+  order,
+}) => {
+  const { pricingBreakdownLines } = useFragment(FRAGMENT, order)
+  return (
+    <>
+      {pricingBreakdownLines.map((line, index) => {
+        if (!(line && isKnownLineType(line))) {
+          return null
+        }
+
+        const typename = line.__typename
+        let variant: "sm" | "sm-display" = "sm"
+        let fontWeight = "regular"
+        let color = "mono60"
+        let withAsterisk = false
+
+        let amountText: string
+        switch (typename) {
+          case "SubtotalLine":
+            amountText = line.amount
+              ? `${line.amount.currencySymbol} ${line.amount.amount}`
+              : ""
+            break
+          case "ShippingLine":
+            amountText = line.amount
+              ? `${line.amount.currencySymbol} ${line.amount.amount}`
+              : (line.amountFallbackText ?? "")
+            break
+          case "TaxLine":
+            amountText = line.amount
+              ? `${line.amount.currencySymbol} ${line.amount.amount}`
+              : (line.amountFallbackText ?? "")
+            withAsterisk = true
+            break
+          case "TotalLine":
+            variant = "sm-display"
+            fontWeight = "medium"
+            color = "mono100"
+            amountText = (line.amount?.display || line.amountFallbackText) ?? ""
+        }
+        if (typename === "TotalLine") {
+          amountText = (line.amount?.display || line.amountFallbackText) ?? ""
+        }
+
+        return (
+          <>
+            {typename !== "TotalLine" && <Spacer y={0.5} />}
+            <Flex key={typename} color={color}>
+              <Text flexGrow={1} variant={variant} fontWeight={fontWeight}>
+                {line.displayName}
+                {withAsterisk && "*"}
+              </Text>
+              <Text flexGrow={0} variant={variant} fontWeight={fontWeight}>
+                {amountText}
+              </Text>
+            </Flex>
+          </>
+        )
+      })}
+    </>
+  )
+}
+
+const FRAGMENT = graphql`
+  fragment Order2PricingBreakdown_order on Order {
+    pricingBreakdownLines {
+      __typename
+      ... on ShippingLine {
+        displayName
+        amountFallbackText
+        amount {
+          amount
+          currencySymbol
+        }
+      }
+
+      ... on TaxLine {
+        displayName
+        amountFallbackText
+        amount {
+          amount
+          currencySymbol
+        }
+      }
+
+      ... on SubtotalLine {
+        displayName
+        amount {
+          amount
+          currencySymbol
+        }
+      }
+
+      ... on TotalLine {
+        displayName
+        amountFallbackText
+        amount {
+          display
+        }
+      }
+    }
+  }
+`

--- a/src/Apps/Order2/Routes/Checkout/Components/Order2PricingBreakdown.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2PricingBreakdown.tsx
@@ -1,14 +1,17 @@
 import { Flex, Spacer, Text } from "@artsy/palette"
+import { RouterLink } from "System/Components/RouterLink"
 import type {
   Order2PricingBreakdown_order$data,
   Order2PricingBreakdown_order$key,
 } from "__generated__/Order2PricingBreakdown_order.graphql"
+import { Fragment } from "react"
 import { graphql, useFragment } from "react-relay"
 
 interface Order2PricingBreakdownProps {
   order: Order2PricingBreakdown_order$key
 }
-
+const TAX_CALCULATION_ARTICLE_URL =
+  "https://support.artsy.net/s/article/How-are-taxes-and-customs-fees-calculated"
 const knownLineTypes = [
   "ShippingLine",
   "TaxLine",
@@ -40,7 +43,7 @@ export const Order2PricingBreakdown: React.FC<Order2PricingBreakdownProps> = ({
 
         const typename = line.__typename
         let variant: "sm" | "sm-display" = "sm"
-        let fontWeight = "regular"
+        let fontWeight: 400 | 500 = 400
         let color = "mono60"
         let withAsterisk = false
 
@@ -48,23 +51,23 @@ export const Order2PricingBreakdown: React.FC<Order2PricingBreakdownProps> = ({
         switch (typename) {
           case "SubtotalLine":
             amountText = line.amount
-              ? `${line.amount.currencySymbol} ${line.amount.amount}`
+              ? `${line.amount.currencySymbol}${line.amount.amount}`
               : ""
             break
           case "ShippingLine":
             amountText = line.amount
-              ? `${line.amount.currencySymbol} ${line.amount.amount}`
+              ? `${line.amount.currencySymbol}${line.amount.amount}`
               : (line.amountFallbackText ?? "")
             break
           case "TaxLine":
             amountText = line.amount
-              ? `${line.amount.currencySymbol} ${line.amount.amount}`
+              ? `${line.amount.currencySymbol}${line.amount.amount}`
               : (line.amountFallbackText ?? "")
             withAsterisk = true
             break
           case "TotalLine":
             variant = "sm-display"
-            fontWeight = "medium"
+            fontWeight = 500
             color = "mono100"
             amountText = (line.amount?.display || line.amountFallbackText) ?? ""
         }
@@ -73,9 +76,9 @@ export const Order2PricingBreakdown: React.FC<Order2PricingBreakdownProps> = ({
         }
 
         return (
-          <>
-            {typename !== "TotalLine" && <Spacer y={0.5} />}
-            <Flex key={typename} color={color}>
+          <Fragment key={typename}>
+            {typename === "TotalLine" && <Spacer y={0.5} />}
+            <Flex color={color}>
               <Text flexGrow={1} variant={variant} fontWeight={fontWeight}>
                 {line.displayName}
                 {withAsterisk && "*"}
@@ -84,9 +87,21 @@ export const Order2PricingBreakdown: React.FC<Order2PricingBreakdownProps> = ({
                 {amountText}
               </Text>
             </Flex>
-          </>
+          </Fragment>
         )
       })}
+      <Text variant="xs" color="mono60" textAlign="left" mt={2}>
+        *Additional duties and taxes{" "}
+        <RouterLink
+          inline
+          to={TAX_CALCULATION_ARTICLE_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          may apply at import
+        </RouterLink>
+        .
+      </Text>
     </>
   )
 }

--- a/src/Apps/Order2/Routes/Checkout/Components/Order2PricingBreakdown.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2PricingBreakdown.tsx
@@ -12,6 +12,7 @@ interface Order2PricingBreakdownProps {
 }
 const TAX_CALCULATION_ARTICLE_URL =
   "https://support.artsy.net/s/article/How-are-taxes-and-customs-fees-calculated"
+
 const knownLineTypes = [
   "ShippingLine",
   "TaxLine",
@@ -21,7 +22,7 @@ const knownLineTypes = [
 
 type KnownLineType = Extract<
   Order2PricingBreakdown_order$data["pricingBreakdownLines"][number],
-  { __typename: "ShippingLine" | "TaxLine" | "SubtotalLine" | "TotalLine" }
+  { __typename: (typeof knownLineTypes)[number] }
 >
 
 const isKnownLineType = (
@@ -57,19 +58,20 @@ export const Order2PricingBreakdown: React.FC<Order2PricingBreakdownProps> = ({
           case "ShippingLine":
             amountText = line.amount
               ? `${line.amount.currencySymbol}${line.amount.amount}`
-              : (line.amountFallbackText ?? "")
+              : (line.amountFallbackText as string)
             break
           case "TaxLine":
             amountText = line.amount
               ? `${line.amount.currencySymbol}${line.amount.amount}`
-              : (line.amountFallbackText ?? "")
+              : (line.amountFallbackText as string)
             withAsterisk = true
             break
           case "TotalLine":
             variant = "sm-display"
             fontWeight = 500
             color = "mono100"
-            amountText = (line.amount?.display || line.amountFallbackText) ?? ""
+            amountText = (line.amount?.display ||
+              line.amountFallbackText) as string
         }
 
         return (

--- a/src/Apps/Order2/Routes/Checkout/Components/Order2PricingBreakdown.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2PricingBreakdown.tsx
@@ -71,9 +71,6 @@ export const Order2PricingBreakdown: React.FC<Order2PricingBreakdownProps> = ({
             color = "mono100"
             amountText = (line.amount?.display || line.amountFallbackText) ?? ""
         }
-        if (typename === "TotalLine") {
-          amountText = (line.amount?.display || line.amountFallbackText) ?? ""
-        }
 
         return (
           <Fragment key={typename}>

--- a/src/Apps/Order2/Routes/Checkout/Components/Order2ReviewStep.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2ReviewStep.tsx
@@ -1,5 +1,6 @@
 import ShieldIcon from "@artsy/icons/ShieldIcon"
 import { Box, Flex, Image, Message, Spacer, Text } from "@artsy/palette"
+import { Order2PricingBreakdown } from "Apps/Order2/Routes/Checkout/Components/Order2PricingBreakdown"
 import { RouterLink } from "System/Components/RouterLink"
 import type { Order2ReviewStep_order$key } from "__generated__/Order2ReviewStep_order.graphql"
 import { graphql, useFragment } from "react-relay"
@@ -52,49 +53,7 @@ export const Order2ReviewStep: React.FC<Order2ReviewStepProps> = ({
         </Box>
       </Flex>
       <Box mb={2}>
-        <Flex>
-          <Text flexGrow={1} variant="sm" color="mono60">
-            Price
-          </Text>
-          <Text flexGrow={0} variant="sm" color="mono60">
-            $15,000
-          </Text>
-        </Flex>
-        <Flex>
-          <Text flexGrow={1} variant="sm" color="mono60">
-            Shipping
-          </Text>
-          <Text flexGrow={0} variant="sm" color="mono60">
-            Calculated in next steps
-          </Text>
-        </Flex>
-        <Flex>
-          <Text flexGrow={1} variant="sm" color="mono60">
-            Tax*
-          </Text>
-          <Text flexGrow={0} variant="sm" color="mono60">
-            Calculated in next steps
-          </Text>
-        </Flex>
-        <Spacer y={0.5} />
-        <Flex>
-          <Text
-            flexGrow={1}
-            variant="sm-display"
-            color="mono100"
-            fontWeight="medium"
-          >
-            Total
-          </Text>
-          <Text
-            flexGrow={0}
-            variant="sm-display"
-            color="mono100"
-            fontWeight="medium"
-          >
-            Waiting for final cost
-          </Text>
-        </Flex>
+        <Order2PricingBreakdown order={orderData} />
         <Text variant="xs" color="mono60" textAlign="left" mt={2}>
           *Additional duties and taxes{" "}
           <RouterLink
@@ -123,6 +82,7 @@ export const Order2ReviewStep: React.FC<Order2ReviewStepProps> = ({
 
 const FRAGMENT = graphql`
   fragment Order2ReviewStep_order on Order {
+    ...Order2PricingBreakdown_order
     mode
     source
     buyerTotal {

--- a/src/Apps/Order2/Routes/Checkout/Components/Order2ReviewStep.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2ReviewStep.tsx
@@ -9,9 +9,6 @@ interface Order2ReviewStepProps {
   order: Order2ReviewStep_order$key
 }
 
-const TAX_CALCULATION_ARTICLE =
-  "https://support.artsy.net/s/article/How-are-taxes-and-customs-fees-calculated"
-
 export const Order2ReviewStep: React.FC<Order2ReviewStepProps> = ({
   order,
 }) => {
@@ -21,7 +18,7 @@ export const Order2ReviewStep: React.FC<Order2ReviewStepProps> = ({
 
   return (
     <Flex flexDirection="column" backgroundColor="mono0" p={2}>
-      <Text variant="sm-display" fontWeight="medium" color="mono100">
+      <Text variant="sm-display" fontWeight={500} color="mono100">
         Order summary
       </Text>
       <Flex py={1} justifyContent="space-between" alignItems="flex-start">
@@ -54,18 +51,6 @@ export const Order2ReviewStep: React.FC<Order2ReviewStepProps> = ({
       </Flex>
       <Box mb={2}>
         <Order2PricingBreakdown order={orderData} />
-        <Text variant="xs" color="mono60" textAlign="left" mt={2}>
-          *Additional duties and taxes{" "}
-          <RouterLink
-            inline
-            to={TAX_CALCULATION_ARTICLE}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            may apply at import
-          </RouterLink>
-          .
-        </Text>
       </Box>
       <Message variant="default">
         <Flex>

--- a/src/Apps/Order2/Routes/Checkout/Components/__tests__/Order2PricingBreakdown.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/__tests__/Order2PricingBreakdown.jest.tsx
@@ -1,0 +1,134 @@
+import { screen } from "@testing-library/react"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
+import type { Order2PricingBreakdownTestQuery } from "__generated__/Order2PricingBreakdownTestQuery.graphql"
+import { graphql } from "react-relay"
+import { Order2PricingBreakdown } from "../Order2PricingBreakdown"
+
+jest.unmock("react-relay")
+
+const { renderWithRelay } = setupTestWrapperTL<Order2PricingBreakdownTestQuery>(
+  {
+    Component: props => {
+      const order = props.me!.order!
+      return <Order2PricingBreakdown order={order} />
+    },
+    query: graphql`
+      query Order2PricingBreakdownTestQuery @relay_test_operation {
+        me {
+          order(id: "test-order") {
+            ...Order2PricingBreakdown_order
+          }
+        }
+      }
+    `,
+  },
+)
+
+describe("Order2PricingBreakdown", () => {
+  it("renders pricing breakdown lines with fallback text if amount is null", () => {
+    renderWithRelay({
+      Me: () => ({
+        order: {
+          pricingBreakdownLines: [
+            {
+              __typename: "SubtotalLine",
+              displayName: "Subtotal",
+              amount: { amount: 1000, currencySymbol: "$" },
+            },
+            {
+              __typename: "ShippingLine",
+              displayName: "Shipping",
+              amountFallbackText: "Calculated at checkout",
+              amount: null,
+            },
+            {
+              __typename: "TaxLine",
+              displayName: "Tax",
+              amountFallbackText: "Calculated at checkout",
+              amount: null,
+            },
+            {
+              __typename: "TotalLine",
+              displayName: "Total",
+              amountFallbackText: "Waiting for final totals",
+              amount: null,
+            },
+          ],
+        },
+      }),
+    })
+
+    // Subtotal
+    const subtotalRow = screen.getByText("Subtotal").parentElement
+    expect(subtotalRow).toHaveTextContent("$1000")
+
+    // Shipping
+    const shippingRow = screen.getByText("Shipping").parentElement
+    expect(shippingRow).toHaveTextContent("Calculated at checkout")
+
+    // Tax
+    const taxRow = screen.getByText("Tax*").parentElement
+    expect(taxRow).toHaveTextContent("Calculated at checkout")
+
+    // Total
+    const totalRow = screen.getByText("Total").parentElement
+    expect(totalRow).toHaveTextContent("Waiting for final totals")
+  })
+
+  it("renders pricing breakdown lines with prices", () => {
+    renderWithRelay({
+      Me: () => ({
+        order: {
+          pricingBreakdownLines: [
+            {
+              __typename: "SubtotalLine",
+              displayName: "Subtotal",
+              amount: {
+                amount: "1000",
+                currencySymbol: "$",
+              },
+            },
+            {
+              __typename: "ShippingLine",
+              displayName: "Shipping",
+              amount: {
+                amount: "42.99",
+                currencySymbol: "$",
+              },
+            },
+            {
+              __typename: "TaxLine",
+              displayName: "Tax",
+              amountFallbackText: null,
+
+              amount: { amount: "99.58", currencySymbol: "$" },
+            },
+            {
+              __typename: "TotalLine",
+              displayName: "Total",
+              amount: {
+                display: "$US 1052.57",
+              },
+            },
+          ],
+        },
+      }),
+    })
+
+    // Subtotal
+    const subtotalRow = screen.getByText("Subtotal").parentElement
+    expect(subtotalRow).toHaveTextContent("$1000")
+
+    // Shipping
+    const shippingRow = screen.getByText("Shipping").parentElement
+    expect(shippingRow).toHaveTextContent("$42.99")
+
+    // Tax
+    const taxRow = screen.getByText("Tax*").parentElement
+    expect(taxRow).toHaveTextContent("$99.58")
+
+    // Total
+    const totalRow = screen.getByText("Total").parentElement
+    expect(totalRow).toHaveTextContent("$US 1052.57")
+  })
+})

--- a/src/__generated__/Order2CollapsibleOrderSummary_order.graphql.ts
+++ b/src/__generated__/Order2CollapsibleOrderSummary_order.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<148e449511d187c93e362342b372b0e0>>
+ * @generated SignedSource<<6a0cc9da26f23b113e7f5ec8b2f9986a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -42,6 +42,7 @@ export type Order2CollapsibleOrderSummary_order$data = {
   readonly taxTotal: {
     readonly display: string | null | undefined;
   } | null | undefined;
+  readonly " $fragmentSpreads": FragmentRefs<"Order2PricingBreakdown_order">;
   readonly " $fragmentType": "Order2CollapsibleOrderSummary_order";
 };
 export type Order2CollapsibleOrderSummary_order$key = {
@@ -65,6 +66,11 @@ return {
   "metadata": null,
   "name": "Order2CollapsibleOrderSummary_order",
   "selections": [
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "Order2PricingBreakdown_order"
+    },
     {
       "alias": null,
       "args": null,
@@ -226,6 +232,6 @@ return {
 };
 })();
 
-(node as any).hash = "cea49933eed9fd4c478433353204a19b";
+(node as any).hash = "dd59dbc994537c54f548e84aa617b801";
 
 export default node;

--- a/src/__generated__/Order2PricingBreakdownTestQuery.graphql.ts
+++ b/src/__generated__/Order2PricingBreakdownTestQuery.graphql.ts
@@ -1,0 +1,287 @@
+/**
+ * @generated SignedSource<<ec7e759934d8b9ccfb0c2673220663f5>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type Order2PricingBreakdownTestQuery$variables = Record<PropertyKey, never>;
+export type Order2PricingBreakdownTestQuery$data = {
+  readonly me: {
+    readonly order: {
+      readonly " $fragmentSpreads": FragmentRefs<"Order2PricingBreakdown_order">;
+    } | null | undefined;
+  } | null | undefined;
+};
+export type Order2PricingBreakdownTestQuery = {
+  response: Order2PricingBreakdownTestQuery$data;
+  variables: Order2PricingBreakdownTestQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "test-order"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "displayName",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "amountFallbackText",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Money",
+  "kind": "LinkedField",
+  "name": "amount",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "amount",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "currencySymbol",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v4 = [
+  (v1/*: any*/),
+  (v2/*: any*/),
+  (v3/*: any*/)
+],
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v6 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v7 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "String"
+},
+v8 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "Order2PricingBreakdownTestQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": (v0/*: any*/),
+            "concreteType": "Order",
+            "kind": "LinkedField",
+            "name": "order",
+            "plural": false,
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "Order2PricingBreakdown_order"
+              }
+            ],
+            "storageKey": "order(id:\"test-order\")"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "Order2PricingBreakdownTestQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": (v0/*: any*/),
+            "concreteType": "Order",
+            "kind": "LinkedField",
+            "name": "order",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": null,
+                "kind": "LinkedField",
+                "name": "pricingBreakdownLines",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "__typename",
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": (v4/*: any*/),
+                    "type": "ShippingLine",
+                    "abstractKey": null
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": (v4/*: any*/),
+                    "type": "TaxLine",
+                    "abstractKey": null
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      (v1/*: any*/),
+                      (v3/*: any*/)
+                    ],
+                    "type": "SubtotalLine",
+                    "abstractKey": null
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      (v1/*: any*/),
+                      (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Money",
+                        "kind": "LinkedField",
+                        "name": "amount",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "display",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "type": "TotalLine",
+                    "abstractKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v5/*: any*/)
+            ],
+            "storageKey": "order(id:\"test-order\")"
+          },
+          (v5/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "347896f935428c47c26c3d4c687144cb",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "me": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Me"
+        },
+        "me.id": (v6/*: any*/),
+        "me.order": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Order"
+        },
+        "me.order.id": (v6/*: any*/),
+        "me.order.pricingBreakdownLines": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": true,
+          "type": "PricingBreakdownLineUnion"
+        },
+        "me.order.pricingBreakdownLines.__typename": (v7/*: any*/),
+        "me.order.pricingBreakdownLines.amount": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Money"
+        },
+        "me.order.pricingBreakdownLines.amount.amount": (v8/*: any*/),
+        "me.order.pricingBreakdownLines.amount.currencySymbol": (v8/*: any*/),
+        "me.order.pricingBreakdownLines.amount.display": (v8/*: any*/),
+        "me.order.pricingBreakdownLines.amountFallbackText": (v8/*: any*/),
+        "me.order.pricingBreakdownLines.displayName": (v7/*: any*/)
+      }
+    },
+    "name": "Order2PricingBreakdownTestQuery",
+    "operationKind": "query",
+    "text": "query Order2PricingBreakdownTestQuery {\n  me {\n    order(id: \"test-order\") {\n      ...Order2PricingBreakdown_order\n      id\n    }\n    id\n  }\n}\n\nfragment Order2PricingBreakdown_order on Order {\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "dbac9586b71148a8d18eeaa130661fcd";
+
+export default node;

--- a/src/__generated__/Order2PricingBreakdown_order.graphql.ts
+++ b/src/__generated__/Order2PricingBreakdown_order.graphql.ts
@@ -1,0 +1,181 @@
+/**
+ * @generated SignedSource<<12d244087c84150d6394dfbeebadbc49>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type Order2PricingBreakdown_order$data = {
+  readonly pricingBreakdownLines: ReadonlyArray<{
+    readonly __typename: "ShippingLine";
+    readonly amount: {
+      readonly amount: string | null | undefined;
+      readonly currencySymbol: string | null | undefined;
+    } | null | undefined;
+    readonly amountFallbackText: string | null | undefined;
+    readonly displayName: string;
+  } | {
+    readonly __typename: "SubtotalLine";
+    readonly amount: {
+      readonly amount: string | null | undefined;
+      readonly currencySymbol: string | null | undefined;
+    } | null | undefined;
+    readonly displayName: string;
+  } | {
+    readonly __typename: "TaxLine";
+    readonly amount: {
+      readonly amount: string | null | undefined;
+      readonly currencySymbol: string | null | undefined;
+    } | null | undefined;
+    readonly amountFallbackText: string | null | undefined;
+    readonly displayName: string;
+  } | {
+    readonly __typename: "TotalLine";
+    readonly amount: {
+      readonly display: string | null | undefined;
+    } | null | undefined;
+    readonly amountFallbackText: string | null | undefined;
+    readonly displayName: string;
+  } | {
+    // This will never be '%other', but we need some
+    // value in case none of the concrete values match.
+    readonly __typename: "%other";
+  } | null | undefined>;
+  readonly " $fragmentType": "Order2PricingBreakdown_order";
+};
+export type Order2PricingBreakdown_order$key = {
+  readonly " $data"?: Order2PricingBreakdown_order$data;
+  readonly " $fragmentSpreads": FragmentRefs<"Order2PricingBreakdown_order">;
+};
+
+const node: ReaderFragment = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "displayName",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "amountFallbackText",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Money",
+  "kind": "LinkedField",
+  "name": "amount",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "amount",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "currencySymbol",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v3 = [
+  (v0/*: any*/),
+  (v1/*: any*/),
+  (v2/*: any*/)
+];
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "Order2PricingBreakdown_order",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": null,
+      "kind": "LinkedField",
+      "name": "pricingBreakdownLines",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "__typename",
+          "storageKey": null
+        },
+        {
+          "kind": "InlineFragment",
+          "selections": (v3/*: any*/),
+          "type": "ShippingLine",
+          "abstractKey": null
+        },
+        {
+          "kind": "InlineFragment",
+          "selections": (v3/*: any*/),
+          "type": "TaxLine",
+          "abstractKey": null
+        },
+        {
+          "kind": "InlineFragment",
+          "selections": [
+            (v0/*: any*/),
+            (v2/*: any*/)
+          ],
+          "type": "SubtotalLine",
+          "abstractKey": null
+        },
+        {
+          "kind": "InlineFragment",
+          "selections": [
+            (v0/*: any*/),
+            (v1/*: any*/),
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Money",
+              "kind": "LinkedField",
+              "name": "amount",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "display",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "type": "TotalLine",
+          "abstractKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Order",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "3fa6f328fe15e31041983dd37748dcef";
+
+export default node;

--- a/src/__generated__/Order2ReviewStep_order.graphql.ts
+++ b/src/__generated__/Order2ReviewStep_order.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e5b839b3696463ca09beaaa7ed287b0f>>
+ * @generated SignedSource<<18dcb0596048b31c48bcac809a780b4d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -42,6 +42,7 @@ export type Order2ReviewStep_order$data = {
   readonly taxTotal: {
     readonly display: string | null | undefined;
   } | null | undefined;
+  readonly " $fragmentSpreads": FragmentRefs<"Order2PricingBreakdown_order">;
   readonly " $fragmentType": "Order2ReviewStep_order";
 };
 export type Order2ReviewStep_order$key = {
@@ -65,6 +66,11 @@ return {
   "metadata": null,
   "name": "Order2ReviewStep_order",
   "selections": [
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "Order2PricingBreakdown_order"
+    },
     {
       "alias": null,
       "args": null,
@@ -226,6 +232,6 @@ return {
 };
 })();
 
-(node as any).hash = "a9f92a55d87fcb6b5eb9061e17649762";
+(node as any).hash = "397ea176292b127da0b449199cd7ba97";
 
 export default node;

--- a/src/__generated__/order2Routes_CheckoutQuery.graphql.ts
+++ b/src/__generated__/order2Routes_CheckoutQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c1bf55fbe994d613fde5573aac367726>>
+ * @generated SignedSource<<2216789f39396cf000fa1e5324430ce6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -66,7 +66,51 @@ v4 = {
   "name": "id",
   "storageKey": null
 },
-v5 = [
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "displayName",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "amountFallbackText",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Money",
+  "kind": "LinkedField",
+  "name": "amount",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "amount",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "currencySymbol",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v8 = [
+  (v5/*: any*/),
+  (v6/*: any*/),
+  (v7/*: any*/)
+],
+v9 = [
   {
     "alias": null,
     "args": null,
@@ -168,6 +212,64 @@ return {
                   {
                     "alias": null,
                     "args": null,
+                    "concreteType": null,
+                    "kind": "LinkedField",
+                    "name": "pricingBreakdownLines",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "__typename",
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "InlineFragment",
+                        "selections": (v8/*: any*/),
+                        "type": "ShippingLine",
+                        "abstractKey": null
+                      },
+                      {
+                        "kind": "InlineFragment",
+                        "selections": (v8/*: any*/),
+                        "type": "TaxLine",
+                        "abstractKey": null
+                      },
+                      {
+                        "kind": "InlineFragment",
+                        "selections": [
+                          (v5/*: any*/),
+                          (v7/*: any*/)
+                        ],
+                        "type": "SubtotalLine",
+                        "abstractKey": null
+                      },
+                      {
+                        "kind": "InlineFragment",
+                        "selections": [
+                          (v5/*: any*/),
+                          (v6/*: any*/),
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Money",
+                            "kind": "LinkedField",
+                            "name": "amount",
+                            "plural": false,
+                            "selections": (v9/*: any*/),
+                            "storageKey": null
+                          }
+                        ],
+                        "type": "TotalLine",
+                        "abstractKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
                     "kind": "ScalarField",
                     "name": "source",
                     "storageKey": null
@@ -179,7 +281,7 @@ return {
                     "kind": "LinkedField",
                     "name": "buyerTotal",
                     "plural": false,
-                    "selections": (v5/*: any*/),
+                    "selections": (v9/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -189,7 +291,7 @@ return {
                     "kind": "LinkedField",
                     "name": "itemsTotal",
                     "plural": false,
-                    "selections": (v5/*: any*/),
+                    "selections": (v9/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -199,7 +301,7 @@ return {
                     "kind": "LinkedField",
                     "name": "shippingTotal",
                     "plural": false,
-                    "selections": (v5/*: any*/),
+                    "selections": (v9/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -209,7 +311,7 @@ return {
                     "kind": "LinkedField",
                     "name": "taxTotal",
                     "plural": false,
-                    "selections": (v5/*: any*/),
+                    "selections": (v9/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -370,12 +472,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "92cbdf0031e185b0fc43108626c561f7",
+    "cacheID": "1187652afedb9a8f324ff828f9ad5829",
     "id": null,
     "metadata": {},
     "name": "order2Routes_CheckoutQuery",
     "operationKind": "query",
-    "text": "query order2Routes_CheckoutQuery(\n  $orderID: String!\n) {\n  viewer {\n    me {\n      order(id: $orderID) {\n        internalID\n        mode\n        id\n      }\n      id\n    }\n    ...Order2CheckoutRoute_viewer_3HPek8\n  }\n}\n\nfragment Order2CheckoutRoute_viewer_3HPek8 on Viewer {\n  me {\n    order(id: $orderID) {\n      internalID\n      ...Order2CollapsibleOrderSummary_order\n      ...Order2ReviewStep_order\n      id\n    }\n    addressConnection(first: 10) {\n      edges {\n        node {\n          internalID\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Order2CollapsibleOrderSummary_order on Order {\n  mode\n  source\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      image {\n        resized(width: 185, height: 138) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment Order2ReviewStep_order on Order {\n  mode\n  source\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      image {\n        resized(width: 185, height: 138) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n}\n"
+    "text": "query order2Routes_CheckoutQuery(\n  $orderID: String!\n) {\n  viewer {\n    me {\n      order(id: $orderID) {\n        internalID\n        mode\n        id\n      }\n      id\n    }\n    ...Order2CheckoutRoute_viewer_3HPek8\n  }\n}\n\nfragment Order2CheckoutRoute_viewer_3HPek8 on Viewer {\n  me {\n    order(id: $orderID) {\n      internalID\n      ...Order2CollapsibleOrderSummary_order\n      ...Order2ReviewStep_order\n      id\n    }\n    addressConnection(first: 10) {\n      edges {\n        node {\n          internalID\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Order2CollapsibleOrderSummary_order on Order {\n  ...Order2PricingBreakdown_order\n  mode\n  source\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      image {\n        resized(width: 185, height: 138) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment Order2PricingBreakdown_order on Order {\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n}\n\nfragment Order2ReviewStep_order on Order {\n  ...Order2PricingBreakdown_order\n  mode\n  source\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      image {\n        resized(width: 185, height: 138) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **chore**

This PR improves the collapsible order summary and order review components in the new checkout flow with pricing breakdown data from metaphysics.

Completes [EMI-2466]
✅ Depends on artsy/metaphysics#6714 for new order pricing breakdown schema
### Description

Graphql Enum typenames are used to render the render the ordered lines with appropriate formatting. No user-facing changes except that we will get more specific names for shipping/pickup values than just "Shipping" once a user has selected an option.

[EMI-2466]: https://artsyproduct.atlassian.net/browse/EMI-2466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ