### PR TITLE
fix(artist): fixes image collapse

### DIFF
--- a/src/Apps/Artist/Routes/Overview/Components/ArtistEditorialNewsGrid.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtistEditorialNewsGrid.tsx
@@ -115,7 +115,8 @@ const ArtistEditorialNewsGrid: FC<
               <Image
                 src={firstImage.src}
                 srcSet={firstImage.srcSet}
-                style={{ display: "block" }}
+                width="100%"
+                height="100%"
                 lazyLoad
               />
             </ResponsiveBox>


### PR DESCRIPTION
When `lazyLoad` is enabled the wrapper component needs a width/height. IMO width/height should be required on the component type but this is merely my opinion. Doing that with a canary would at least expose remaining bugs.

https://artsyproduct.atlassian.net/browse/DIA-1316