### PR TITLE
fix(EMI-2451): do not send address for pickup mode

### DIFF
--- a/src/Apps/Order/Components/ExpressCheckout/ExpressCheckoutUI.tsx
+++ b/src/Apps/Order/Components/ExpressCheckout/ExpressCheckoutUI.tsx
@@ -343,13 +343,16 @@ export const ExpressCheckoutUI = ({ order }: ExpressCheckoutUIProps) => {
               id: orderData.internalID,
               buyerPhoneNumber: phone,
               buyerPhoneNumberCountryCode: null,
-              shippingName: name,
-              shippingAddressLine1: line1,
-              shippingAddressLine2: line2,
-              shippingPostalCode: postal_code,
-              shippingCity: city,
-              shippingRegion: state,
-              shippingCountry: country,
+              shippingName: shippingRate?.id === "PICKUP" ? null : name,
+              shippingAddressLine1:
+                shippingRate?.id === "PICKUP" ? null : line1,
+              shippingAddressLine2:
+                shippingRate?.id === "PICKUP" ? null : line2,
+              shippingPostalCode:
+                shippingRate?.id === "PICKUP" ? null : postal_code,
+              shippingCity: shippingRate?.id === "PICKUP" ? null : city,
+              shippingRegion: shippingRate?.id === "PICKUP" ? null : state,
+              shippingCountry: shippingRate?.id === "PICKUP" ? null : country,
             },
           },
         })

--- a/src/Apps/Order/Components/ExpressCheckout/__tests__/ExpressCheckoutUI.jest.tsx
+++ b/src/Apps/Order/Components/ExpressCheckout/__tests__/ExpressCheckoutUI.jest.tsx
@@ -22,6 +22,7 @@ jest.mock("System/Hooks/useAnalyticsContext", () => ({
   })),
 }))
 
+let shippingRateId = "DOMESTIC_FLAT"
 const mockExpressCheckoutElement = ExpressCheckoutElement as jest.Mock
 const mockResolveOnClick = jest.fn()
 const mockElementsUpdate = jest.fn()
@@ -89,9 +90,8 @@ jest.mock("@stripe/react-stripe-js", () => {
                     phone: "1234567890",
                   },
                   shippingRate: {
-                    id: "PICKUP",
-                    amount: 123,
-                    displayName: "Pickup",
+                    id: shippingRateId,
+                    amount: 4200,
                   },
                 })
               }
@@ -250,6 +250,7 @@ describe("ExpressCheckoutUI", () => {
   })
 
   it("omits shipping data when order is pickup", async () => {
+    shippingRateId = "PICKUP"
     const { mockResolveLastOperation, env } = renderWithRelay({
       Order: () => ({
         ...orderData,
@@ -299,13 +300,13 @@ describe("ExpressCheckoutUI", () => {
       id: "a5aaa8b0-93ff-4f2a-8bb3-9589f378d229",
       buyerPhoneNumber: "1234567890",
       buyerPhoneNumberCountryCode: null,
-      shippingAddressLine1: "401 Broadway",
+      shippingAddressLine1: null,
       shippingAddressLine2: null,
-      shippingCity: "New York",
-      shippingCountry: "US",
-      shippingName: "Buyer Name",
-      shippingPostalCode: "10013",
-      shippingRegion: "NY",
+      shippingCity: null,
+      shippingCountry: null,
+      shippingName: null,
+      shippingPostalCode: null,
+      shippingRegion: null,
     })
 
     await flushPromiseQueue()


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2451]

### Description

We only want to set shipping address when it’s really a shipping order


[EMI-2451]: https://artsyproduct.atlassian.net/browse/EMI-2451?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ