### PR TITLE
feat(EMI-2452): conditionally render pickup if available

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/Order2DeliveryForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2DeliveryForm.tsx
@@ -1,0 +1,59 @@
+import { Button, Checkbox, Flex, Spacer, Text } from "@artsy/palette"
+import {
+  AddressFormFields,
+  addressFormFieldsValidator,
+} from "Components/Address/AddressFormFields"
+import { Formik, type FormikHelpers, type FormikValues } from "formik"
+import type * as React from "react"
+import * as yup from "yup"
+
+interface Order2DeliveryFormProps {
+  initialValues: FormikValues
+  onSubmit: (
+    values: FormikValues,
+    formikHelpers: FormikHelpers<FormikValues>,
+  ) => void
+}
+
+const validationSchema = yup.object().shape({
+  ...addressFormFieldsValidator({ withPhoneNumber: true }),
+  saveAddress: yup.boolean(),
+})
+
+export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
+  initialValues,
+  onSubmit,
+}) => {
+  return (
+    <>
+      <Text fontWeight="medium" color="mono100" variant="sm-display">
+        Delivery address
+      </Text>
+      <Spacer y={2} />
+      <Formik
+        initialValues={initialValues}
+        validationSchema={validationSchema}
+        onSubmit={onSubmit}
+      >
+        {formikContext => (
+          <Flex flexDirection={"column"} mb={2}>
+            <AddressFormFields withPhoneNumber />
+            <Spacer y={2} />
+            <Checkbox
+              onSelect={selected => {
+                formikContext.setFieldValue("saveAddress", selected)
+              }}
+              selected={formikContext.values.saveAddress}
+            >
+              <Text variant="xs">Save shipping address for later use</Text>
+            </Checkbox>
+            <Spacer y={4} />
+            <Button type="submit" onClick={() => formikContext.handleSubmit()}>
+              See Shipping Methods
+            </Button>
+          </Flex>
+        )}
+      </Formik>
+    </>
+  )
+}

--- a/src/Apps/Order2/Routes/Checkout/Order2CheckoutRoute.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Order2CheckoutRoute.tsx
@@ -59,19 +59,9 @@ export const Order2CheckoutRoute: React.FC<Order2CheckoutRouteProps> = ({
             {/* Fulfillment details Step */}
             <Flex flexDirection="column" backgroundColor="mono0" py={2}>
               {fulfillmentOptions?.some(option => option.type === "PICKUP") ? (
-                <Tabs
-                  justifyContent="space-between"
-                  initialTabIndex={0}
-                  onChange={tabInfo => {
-                    // Required because the tabInfo.name is a customized text element
-                    const selected =
-                      tabInfo?.tabIndex === 0 ? "delivery" : "pickup"
-                    console.log("Tab change", selected)
-                  }}
-                >
+                <Tabs justifyContent="space-between" initialTabIndex={0}>
                   <Tab
                     name={
-                      // margins here come pretty close to making the tabs fill the full width
                       <Text mx={50} variant="xs">
                         Delivery
                       </Text>
@@ -95,12 +85,7 @@ export const Order2CheckoutRoute: React.FC<Order2CheckoutRouteProps> = ({
                         onSubmit={(
                           values: FormikValues,
                           formikHelpers: FormikHelpers<FormikValues>,
-                        ) => {
-                          console.warn(
-                            "Delivery address values submitted:",
-                            values,
-                          )
-                        }}
+                        ) => {}}
                       />
                     </Box>
                   </Tab>
@@ -129,12 +114,7 @@ export const Order2CheckoutRoute: React.FC<Order2CheckoutRouteProps> = ({
                           pickupPhoneNumberCountryCode: "",
                         }}
                         validationSchema={{}}
-                        onSubmit={(
-                          values: FormikValues,
-                          // formikHelpers: FormikHelpers<FormikValues>,
-                        ) => {
-                          console.warn("Pickup values submitted:", values)
-                        }}
+                        onSubmit={(values: FormikValues) => {}}
                       >
                         {formikContext => (
                           <GridColumns data-testid={"PickupDetailsForm"}>
@@ -208,9 +188,7 @@ export const Order2CheckoutRoute: React.FC<Order2CheckoutRouteProps> = ({
                       phoneNumber: "",
                       phoneNumberCountryCode: "",
                     }}
-                    onSubmit={(values: FormikValues) => {
-                      console.warn("Delivery address values submitted:", values)
-                    }}
+                    onSubmit={(values: FormikValues) => {}}
                   />
                 </Box>
               )}

--- a/src/Apps/Order2/Routes/Checkout/Order2CheckoutRoute.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Order2CheckoutRoute.tsx
@@ -37,6 +37,7 @@ export const Order2CheckoutRoute: React.FC<Order2CheckoutRouteProps> = ({
 
   const data = useFragment(FRAGMENT, viewer)
   const order = data.me?.order
+  const fulfillmentOptions = order?.fulfillmentOptions
 
   const validationSchema = yup.object().shape({
     ...addressFormFieldsValidator({ withPhoneNumber: true }),
@@ -146,93 +147,97 @@ export const Order2CheckoutRoute: React.FC<Order2CheckoutRouteProps> = ({
                     </Formik>
                   </Box>
                 </Tab>
-                <Tab
-                  name={
-                    <Text mx={50} variant="xs">
-                      Pickup
-                    </Text>
-                  }
-                >
-                  <Box px={2}>
-                    <Text
-                      fontWeight="medium"
-                      color="mono100"
-                      variant="sm-display"
-                    >
-                      Free pickup
-                    </Text>
-                    <Text variant="xs" color="mono60" my={1}>
-                      After your order is confirmed, a specialist will contact
-                      you with details on how to pick up the work.
-                    </Text>
-                    <Formik
-                      initialValues={{
-                        pickupPhoneNumber: "",
-                        pickupPhoneNumberCountryCode: "",
-                      }}
-                      validationSchema={{}}
-                      onSubmit={(
-                        values: FormikValues,
-                        // formikHelpers: FormikHelpers<FormikValues>,
-                      ) => {
-                        console.warn("Pickup values submitted:", values)
-                      }}
-                    >
-                      {formikContext => (
-                        <GridColumns data-testid={"PickupDetailsForm"}>
-                          <Column span={12}>
-                            <PhoneInput
-                              mt={1}
-                              name="pickupPhoneNumber"
-                              onChange={formikContext.handleChange}
-                              onBlur={formikContext.handleBlur}
-                              data-testid={"PickupPhoneNumberInput"}
-                              options={phoneCountryOptions}
-                              onSelect={(
-                                option: (typeof phoneCountryOptions)[number],
-                              ): void => {
-                                formikContext.setFieldValue(
-                                  "pickupPhoneNumberCountryCode",
-                                  option.value,
-                                )
-                              }}
-                              dropdownValue={
-                                formikContext.values
-                                  .pickupPhoneNumberCountryCode
-                              }
-                              inputValue={
-                                formikContext.values.pickupPhoneNumber
-                              }
-                              placeholder="(000) 000 0000"
-                              error={
-                                (formikContext.touched
-                                  .pickupPhoneNumberCountryCode &&
-                                  (formikContext.errors
-                                    .pickupPhoneNumberCountryCode as
-                                    | string
-                                    | undefined)) ||
-                                (formikContext.touched.pickupPhoneNumber &&
-                                  (formikContext.errors.pickupPhoneNumber as
-                                    | string
-                                    | undefined))
-                              }
-                              required
-                            />
-                            <Spacer y={4} />
-                            <Button
-                              variant={"primaryBlack"}
-                              width="100%"
-                              type="submit"
-                              onClick={() => formikContext.handleSubmit()}
-                            >
-                              Continue to Payment
-                            </Button>
-                          </Column>
-                        </GridColumns>
-                      )}
-                    </Formik>
-                  </Box>
-                </Tab>
+                {fulfillmentOptions?.some(
+                  option => option.type === "PICKUP",
+                ) && (
+                  <Tab
+                    name={
+                      <Text mx={50} variant="xs">
+                        Pickup
+                      </Text>
+                    }
+                  >
+                    <Box px={2}>
+                      <Text
+                        fontWeight="medium"
+                        color="mono100"
+                        variant="sm-display"
+                      >
+                        Free pickup
+                      </Text>
+                      <Text variant="xs" color="mono60" my={1}>
+                        After your order is confirmed, a specialist will contact
+                        you with details on how to pick up the work.
+                      </Text>
+                      <Formik
+                        initialValues={{
+                          pickupPhoneNumber: "",
+                          pickupPhoneNumberCountryCode: "",
+                        }}
+                        validationSchema={{}}
+                        onSubmit={(
+                          values: FormikValues,
+                          // formikHelpers: FormikHelpers<FormikValues>,
+                        ) => {
+                          console.warn("Pickup values submitted:", values)
+                        }}
+                      >
+                        {formikContext => (
+                          <GridColumns data-testid={"PickupDetailsForm"}>
+                            <Column span={12}>
+                              <PhoneInput
+                                mt={1}
+                                name="pickupPhoneNumber"
+                                onChange={formikContext.handleChange}
+                                onBlur={formikContext.handleBlur}
+                                data-testid={"PickupPhoneNumberInput"}
+                                options={phoneCountryOptions}
+                                onSelect={(
+                                  option: (typeof phoneCountryOptions)[number],
+                                ): void => {
+                                  formikContext.setFieldValue(
+                                    "pickupPhoneNumberCountryCode",
+                                    option.value,
+                                  )
+                                }}
+                                dropdownValue={
+                                  formikContext.values
+                                    .pickupPhoneNumberCountryCode
+                                }
+                                inputValue={
+                                  formikContext.values.pickupPhoneNumber
+                                }
+                                placeholder="(000) 000 0000"
+                                error={
+                                  (formikContext.touched
+                                    .pickupPhoneNumberCountryCode &&
+                                    (formikContext.errors
+                                      .pickupPhoneNumberCountryCode as
+                                      | string
+                                      | undefined)) ||
+                                  (formikContext.touched.pickupPhoneNumber &&
+                                    (formikContext.errors.pickupPhoneNumber as
+                                      | string
+                                      | undefined))
+                                }
+                                required
+                              />
+                              <Spacer y={4} />
+                              <Button
+                                variant={"primaryBlack"}
+                                width="100%"
+                                type="submit"
+                                onClick={() => formikContext.handleSubmit()}
+                              >
+                                Continue to Payment
+                              </Button>
+                            </Column>
+                          </GridColumns>
+                        )}
+                      </Formik>
+                    </Box>
+                  </Tab>
+                )}
               </Tabs>
             </Flex>
 
@@ -271,6 +276,9 @@ const FRAGMENT = graphql`
     me {
       order(id: $orderID) {
         internalID
+        fulfillmentOptions {
+          type
+        }
         ...Order2CollapsibleOrderSummary_order
         ...Order2ReviewStep_order
       }

--- a/src/__generated__/Order2CheckoutRoute_viewer.graphql.ts
+++ b/src/__generated__/Order2CheckoutRoute_viewer.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<007f7e0bddc49204773b7dc205cc8694>>
+ * @generated SignedSource<<469069589a78cb3d9f5a51b50f7ad6f0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,6 +9,7 @@
 // @ts-nocheck
 
 import { ReaderFragment } from 'relay-runtime';
+export type FulfillmentOptionTypeEnum = "DOMESTIC_FLAT" | "INTERNATIONAL_FLAT" | "PICKUP" | "SHIPPING_TBD" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type Order2CheckoutRoute_viewer$data = {
   readonly me: {
@@ -20,6 +21,9 @@ export type Order2CheckoutRoute_viewer$data = {
       } | null | undefined> | null | undefined;
     } | null | undefined;
     readonly order: {
+      readonly fulfillmentOptions: ReadonlyArray<{
+        readonly type: FulfillmentOptionTypeEnum;
+      }>;
       readonly internalID: string;
       readonly " $fragmentSpreads": FragmentRefs<"Order2CollapsibleOrderSummary_order" | "Order2ReviewStep_order">;
     } | null | undefined;
@@ -74,6 +78,24 @@ return {
           "plural": false,
           "selections": [
             (v0/*: any*/),
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "FulfillmentOption",
+              "kind": "LinkedField",
+              "name": "fulfillmentOptions",
+              "plural": true,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "type",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            },
             {
               "args": null,
               "kind": "FragmentSpread",
@@ -136,6 +158,6 @@ return {
 };
 })();
 
-(node as any).hash = "2814aadf5ca462f20584667bed830b98";
+(node as any).hash = "865300edf458ce1be5fc386503ab70e4";
 
 export default node;

--- a/src/__generated__/order2Routes_CheckoutQuery.graphql.ts
+++ b/src/__generated__/order2Routes_CheckoutQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2216789f39396cf000fa1e5324430ce6>>
+ * @generated SignedSource<<e6ad964b2cef676b89d26e8bf7a2a4f1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -209,6 +209,24 @@ return {
                   (v2/*: any*/),
                   (v3/*: any*/),
                   (v4/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "FulfillmentOption",
+                    "kind": "LinkedField",
+                    "name": "fulfillmentOptions",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "type",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
                   {
                     "alias": null,
                     "args": null,
@@ -472,12 +490,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1187652afedb9a8f324ff828f9ad5829",
+    "cacheID": "c447310e9bcf07dc07fb7b1831f70944",
     "id": null,
     "metadata": {},
     "name": "order2Routes_CheckoutQuery",
     "operationKind": "query",
-    "text": "query order2Routes_CheckoutQuery(\n  $orderID: String!\n) {\n  viewer {\n    me {\n      order(id: $orderID) {\n        internalID\n        mode\n        id\n      }\n      id\n    }\n    ...Order2CheckoutRoute_viewer_3HPek8\n  }\n}\n\nfragment Order2CheckoutRoute_viewer_3HPek8 on Viewer {\n  me {\n    order(id: $orderID) {\n      internalID\n      ...Order2CollapsibleOrderSummary_order\n      ...Order2ReviewStep_order\n      id\n    }\n    addressConnection(first: 10) {\n      edges {\n        node {\n          internalID\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Order2CollapsibleOrderSummary_order on Order {\n  ...Order2PricingBreakdown_order\n  mode\n  source\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      image {\n        resized(width: 185, height: 138) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment Order2PricingBreakdown_order on Order {\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n}\n\nfragment Order2ReviewStep_order on Order {\n  ...Order2PricingBreakdown_order\n  mode\n  source\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      image {\n        resized(width: 185, height: 138) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n}\n"
+    "text": "query order2Routes_CheckoutQuery(\n  $orderID: String!\n) {\n  viewer {\n    me {\n      order(id: $orderID) {\n        internalID\n        mode\n        id\n      }\n      id\n    }\n    ...Order2CheckoutRoute_viewer_3HPek8\n  }\n}\n\nfragment Order2CheckoutRoute_viewer_3HPek8 on Viewer {\n  me {\n    order(id: $orderID) {\n      internalID\n      fulfillmentOptions {\n        type\n      }\n      ...Order2CollapsibleOrderSummary_order\n      ...Order2ReviewStep_order\n      id\n    }\n    addressConnection(first: 10) {\n      edges {\n        node {\n          internalID\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Order2CollapsibleOrderSummary_order on Order {\n  ...Order2PricingBreakdown_order\n  mode\n  source\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      image {\n        resized(width: 185, height: 138) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment Order2PricingBreakdown_order on Order {\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n}\n\nfragment Order2ReviewStep_order on Order {\n  ...Order2PricingBreakdown_order\n  mode\n  source\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      image {\n        resized(width: 185, height: 138) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2452]

### Description

- Implement the ship/pickup switcher if the order has pickup available (checking `fulfillmentOptions` for a pickup option).
- Need to check if it's simple to persist input values when switching tabs - not included in this PR

<img width="1387" alt="Screenshot 2025-05-13 at 13 33 26" src="https://github.com/user-attachments/assets/cb2a9428-5aa4-4de1-acb9-4befb558fa26" />




[EMI-2452]: https://artsyproduct.atlassian.net/browse/EMI-2452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ