### PR TITLE
feat(EMI-2469): Set pickup fulfillment type and details on new checkout flow

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/Order2FulfillmentDetailsStep/Order2DeliveryForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2FulfillmentDetailsStep/Order2DeliveryForm.tsx
@@ -1,4 +1,4 @@
-import { Button, Checkbox, Flex, Spacer, Text } from "@artsy/palette"
+import { Button, Flex, Spacer, Text } from "@artsy/palette"
 import {
   AddressFormFields,
   addressFormFieldsValidator,
@@ -11,10 +11,9 @@ interface Order2DeliveryFormProps {
   order: any
 }
 
-const validationSchema = yup.object().shape({
-  ...addressFormFieldsValidator({ withPhoneNumber: true }),
-  saveAddress: yup.boolean(),
-})
+const validationSchema = yup
+  .object()
+  .shape(addressFormFieldsValidator({ withPhoneNumber: true }))
 
 export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = () => {
   // Placeholders
@@ -49,15 +48,6 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = () => {
         {formikContext => (
           <Flex flexDirection={"column"} mb={2}>
             <AddressFormFields withPhoneNumber />
-            <Spacer y={2} />
-            <Checkbox
-              onSelect={selected => {
-                formikContext.setFieldValue("saveAddress", selected)
-              }}
-              selected={formikContext.values.saveAddress}
-            >
-              <Text variant="xs">Save shipping address for later use</Text>
-            </Checkbox>
             <Spacer y={4} />
             <Button type="submit" onClick={() => formikContext.handleSubmit()}>
               See Shipping Methods

--- a/src/Apps/Order2/Routes/Checkout/Components/Order2FulfillmentDetailsStep/Order2DeliveryForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2FulfillmentDetailsStep/Order2DeliveryForm.tsx
@@ -8,11 +8,7 @@ import type * as React from "react"
 import * as yup from "yup"
 
 interface Order2DeliveryFormProps {
-  initialValues: FormikValues
-  onSubmit: (
-    values: FormikValues,
-    formikHelpers: FormikHelpers<FormikValues>,
-  ) => void
+  order: any
 }
 
 const validationSchema = yup.object().shape({
@@ -20,10 +16,25 @@ const validationSchema = yup.object().shape({
   saveAddress: yup.boolean(),
 })
 
-export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
-  initialValues,
-  onSubmit,
-}) => {
+export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = () => {
+  // Placeholders
+  const initialValues = {
+    address: {
+      name: "",
+      country: "",
+      postalCode: "",
+      addressLine1: "",
+      addressLine2: "",
+      city: "",
+      region: "",
+    },
+    phoneNumber: "",
+    phoneNumberCountryCode: "",
+  }
+  const onSubmit = (
+    values: FormikValues,
+    formikHelpers: FormikHelpers<FormikValues>,
+  ) => {}
   return (
     <>
       <Text fontWeight="medium" color="mono100" variant="sm-display">

--- a/src/Apps/Order2/Routes/Checkout/Components/Order2FulfillmentDetailsStep/Order2FulfillmentDetailsCompletedView.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2FulfillmentDetailsStep/Order2FulfillmentDetailsCompletedView.tsx
@@ -40,6 +40,7 @@ export const Order2FulfillmentDetailsCompletedView = ({
       </Flex>
     )
   }
+
   return (
     <Flex>
       <CheckmarkIcon height={20} width={20} fill="mono100" />

--- a/src/Apps/Order2/Routes/Checkout/Components/Order2FulfillmentDetailsStep/Order2FulfillmentDetailsCompletedView.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2FulfillmentDetailsStep/Order2FulfillmentDetailsCompletedView.tsx
@@ -12,10 +12,15 @@ export const Order2FulfillmentDetailsCompletedView = ({
 }: Order2FulfillmentDetailsCompletedViewProps) => {
   if (fulfillmentOption.type === "PICKUP") {
     return (
-      <Flex>
-        <CheckmarkIcon height={20} width={20} fill="mono100" />
+      <Flex alignItems="flex-start">
+        <CheckmarkIcon
+          flexShrink={0}
+          height="20px"
+          width="20px"
+          fill="mono100"
+        />
         <Box flexGrow={1} mx={0.5}>
-          <Text variant="md" fontWeight="500" color="mono100">
+          <Text variant="sm-display" fontWeight="500" color="mono100">
             Pickup
           </Text>
           <Text variant="xs" fontWeight="400" color="mono100">
@@ -23,7 +28,15 @@ export const Order2FulfillmentDetailsCompletedView = ({
             2 business days to coordinate pickup.
           </Text>
         </Box>
-        <Clickable onClick={onClickEdit}>Edit</Clickable>
+        <Clickable
+          textDecoration="underline"
+          flexShrink={0}
+          onClick={onClickEdit}
+        >
+          <Text variant="xs" fontWeight="400" color="mono100">
+            Edit
+          </Text>
+        </Clickable>
       </Flex>
     )
   }

--- a/src/Apps/Order2/Routes/Checkout/Components/Order2FulfillmentDetailsStep/Order2FulfillmentDetailsCompletedView.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2FulfillmentDetailsStep/Order2FulfillmentDetailsCompletedView.tsx
@@ -1,0 +1,42 @@
+import CheckmarkIcon from "@artsy/icons/CheckmarkIcon"
+import { Box, Clickable, Flex, Text } from "@artsy/palette"
+
+interface Order2FulfillmentDetailsCompletedViewProps {
+  fulfillmentDetails: any
+  fulfillmentOption: any
+  onClickEdit: () => void
+}
+export const Order2FulfillmentDetailsCompletedView = ({
+  fulfillmentOption,
+  onClickEdit,
+}: Order2FulfillmentDetailsCompletedViewProps) => {
+  if (fulfillmentOption.type === "PICKUP") {
+    return (
+      <Flex>
+        <CheckmarkIcon height={20} width={20} fill="mono100" />
+        <Box flexGrow={1} mx={0.5}>
+          <Text variant="md" fontWeight="500" color="mono100">
+            Pickup
+          </Text>
+          <Text variant="xs" fontWeight="400" color="mono100">
+            After your order is confirmed, a specialist will contact you within
+            2 business days to coordinate pickup.
+          </Text>
+        </Box>
+        <Clickable onClick={onClickEdit}>Edit</Clickable>
+      </Flex>
+    )
+  }
+  return (
+    <Flex>
+      <CheckmarkIcon height={20} width={20} fill="mono100" />
+      <Box flexGrow={1} mx={0.5} />
+      <Text variant="md" fontWeight="500" color="mono100">
+        Delivery
+      </Text>
+      <Text variant="xs" fontWeight="400" color="mono100">
+        This is just some text to show the delivery details. It's not ready yet.
+      </Text>
+    </Flex>
+  )
+}

--- a/src/Apps/Order2/Routes/Checkout/Components/Order2FulfillmentDetailsStep/Order2FulfillmentDetailsStep.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2FulfillmentDetailsStep/Order2FulfillmentDetailsStep.tsx
@@ -1,0 +1,113 @@
+import { Box, Flex, Tab, Tabs, Text } from "@artsy/palette"
+import { Order2DeliveryForm } from "Apps/Order2/Routes/Checkout/Components/Order2FulfillmentDetailsStep/Order2DeliveryForm"
+import { Order2FulfillmentDetailsCompletedView } from "Apps/Order2/Routes/Checkout/Components/Order2FulfillmentDetailsStep/Order2FulfillmentDetailsCompletedView"
+import { Order2PickupForm } from "Apps/Order2/Routes/Checkout/Components/Order2FulfillmentDetailsStep/Order2PickupForm"
+import type { Order2FulfillmentDetailsStep_order$key } from "__generated__/Order2FulfillmentDetailsStep_order.graphql"
+import { useEffect, useState } from "react"
+import { graphql, useFragment } from "react-relay"
+
+interface Order2FulfillmentDetailsStepProps {
+  order: Order2FulfillmentDetailsStep_order$key
+}
+
+enum TempStepStatus {
+  ACTIVE = "ACTIVE",
+  COMPLETE = "COMPLETE",
+}
+
+export const Order2FulfillmentDetailsStep: React.FC<
+  Order2FulfillmentDetailsStepProps
+> = ({ order }) => {
+  const orderData = useFragment(ORDER_FRAGMENT, order)
+
+  // TODO: This is to see saved data coming through and will probably be
+  // promoted to some higher-level context/dispatch in the future
+  const savedFulfillmentDetails = orderData?.fulfillmentDetails
+  const selectedFulfillmentOption = orderData?.selectedFulfillmentOption
+
+  const [stepStatus, setStepStatus] = useState<TempStepStatus>(
+    TempStepStatus.ACTIVE,
+  )
+  useEffect(() => {
+    if (savedFulfillmentDetails && selectedFulfillmentOption) {
+      setStepStatus(TempStepStatus.COMPLETE)
+    }
+  }, [savedFulfillmentDetails, selectedFulfillmentOption])
+
+  const fulfillmentOptions = orderData?.fulfillmentOptions
+
+  return (
+    <Flex
+      data-testid="FulfillmentDetailsStep"
+      flexDirection="column"
+      backgroundColor="mono0"
+      py={2}
+    >
+      {stepStatus === TempStepStatus.COMPLETE ? (
+        <Box px={2}>
+          <Order2FulfillmentDetailsCompletedView
+            fulfillmentDetails={savedFulfillmentDetails}
+            onClickEdit={() => setStepStatus(TempStepStatus.ACTIVE)}
+            fulfillmentOption={orderData?.selectedFulfillmentOption}
+          />
+        </Box>
+      ) : fulfillmentOptions?.some(option => option.type === "PICKUP") ? (
+        <Tabs justifyContent="space-between" initialTabIndex={0}>
+          <Tab
+            name={
+              <Text mx={50} variant="xs">
+                Delivery
+              </Text>
+            }
+          >
+            <Box px={2}>
+              <Order2DeliveryForm order={orderData} />
+            </Box>
+          </Tab>
+          <Tab
+            name={
+              <Text mx={50} variant="xs">
+                Pickup
+              </Text>
+            }
+          >
+            <Box px={2}>
+              <Order2PickupForm order={orderData} />
+            </Box>
+          </Tab>
+        </Tabs>
+      ) : (
+        <Box px={2}>
+          <Order2DeliveryForm order={orderData} />
+        </Box>
+      )}
+    </Flex>
+  )
+}
+
+const ORDER_FRAGMENT = graphql`
+  fragment Order2FulfillmentDetailsStep_order on Order {
+    ...Order2PickupForm_order
+    id
+    fulfillmentDetails {
+      phoneNumber {
+        countryCode
+        regionCode
+        originalNumber
+      }
+      addressLine1
+      addressLine2
+      city
+      country
+      name
+      postalCode
+      region
+    }
+    selectedFulfillmentOption {
+      type
+    }
+    fulfillmentOptions {
+      type
+    }
+  }
+`

--- a/src/Apps/Order2/Routes/Checkout/Components/Order2FulfillmentDetailsStep/Order2FulfillmentDetailsStep.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2FulfillmentDetailsStep/Order2FulfillmentDetailsStep.tsx
@@ -28,6 +28,9 @@ export const Order2FulfillmentDetailsStep: React.FC<
   const [stepStatus, setStepStatus] = useState<TempStepStatus>(
     TempStepStatus.ACTIVE,
   )
+  // FIXME: If you edit your saved number but don't change it,
+  // it doesn't trigger the step back to complete.
+  // Solve this when we implement the real state system
   useEffect(() => {
     if (savedFulfillmentDetails && selectedFulfillmentOption) {
       setStepStatus(TempStepStatus.COMPLETE)

--- a/src/Apps/Order2/Routes/Checkout/Components/Order2FulfillmentDetailsStep/Order2PickupForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2FulfillmentDetailsStep/Order2PickupForm.tsx
@@ -84,8 +84,6 @@ export const Order2PickupForm: React.FC<Order2PickupFormProps> = ({
         validateAndExtractOrderResponse(
           setOrderPickupDetailsResult.updateOrderShippingAddress?.orderOrError,
         )
-
-        // TODO: Handle success
       } catch (error) {
         // TODO: Handle errors
         logger.error("Error while setting pickup details", error)

--- a/src/Apps/Order2/Routes/Checkout/Components/Order2FulfillmentDetailsStep/Order2PickupForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2FulfillmentDetailsStep/Order2PickupForm.tsx
@@ -1,0 +1,213 @@
+import {
+  Button,
+  Column,
+  GridColumns,
+  PhoneInput,
+  Spacer,
+  Text,
+} from "@artsy/palette"
+import { validateAndExtractOrderResponse } from "Apps/Order/Components/ExpressCheckout/Util/mutationHandling"
+import { useSetOrderFulfillmentOptionMutation } from "Apps/Order2/Routes/Checkout/Mutations/useSetOrderFulfillmentOptionMutation"
+import { useSetOrderPickupDetailsMutation } from "Apps/Order2/Routes/Checkout/Mutations/useSetOrderPickupDetailsMutation"
+import { richPhoneValidators } from "Components/Address/utils"
+import { countries as phoneCountryOptions } from "Utils/countries"
+import createLogger from "Utils/logger"
+import type { Order2PickupForm_order$key } from "__generated__/Order2PickupForm_order.graphql"
+import { Formik, type FormikHelpers, type FormikValues } from "formik"
+import { useCallback } from "react"
+import { graphql, useFragment } from "react-relay"
+import * as Yup from "yup"
+
+const logger = createLogger("Order2PickupForm.tsx")
+
+interface Order2PickupFormProps {
+  order: Order2PickupForm_order$key
+}
+
+interface PickupFormValues {
+  phoneNumber: string
+  phoneNumberCountryCode: string
+}
+
+export const Order2PickupForm: React.FC<Order2PickupFormProps> = ({
+  order,
+}) => {
+  const orderData = useFragment(FRAGMENT, order)
+  const fulfillmentOptions = orderData?.fulfillmentOptions
+  // By the time we get here, this option should be available
+  const pickupFulfillmentOption = fulfillmentOptions?.find(
+    option => option.type === "PICKUP",
+  )
+
+  const setOrderPickupDetails = useSetOrderPickupDetailsMutation()
+  const setOrderFulfillmentOption = useSetOrderFulfillmentOptionMutation()
+
+  const handleSubmit = useCallback(
+    async (
+      values: FormikValues,
+      formikHelpers: FormikHelpers<PickupFormValues>,
+    ): Promise<void> => {
+      if (!pickupFulfillmentOption) {
+        logger.error(
+          "No pickup fulfillment option available (should not happen)",
+        )
+        return
+      }
+
+      try {
+        const setOrderFulfillmentOptionResult =
+          await setOrderFulfillmentOption.submitMutation({
+            variables: {
+              input: {
+                id: orderData.internalID,
+                fulfillmentOption: pickupFulfillmentOption as {
+                  type: "PICKUP"
+                },
+              },
+            },
+          })
+        validateAndExtractOrderResponse(
+          setOrderFulfillmentOptionResult.setOrderFulfillmentOption
+            ?.orderOrError,
+        )
+
+        const setOrderPickupDetailsResult =
+          await setOrderPickupDetails.submitMutation({
+            variables: {
+              input: {
+                id: orderData.internalID,
+                buyerPhoneNumber: values.phoneNumber,
+                buyerPhoneNumberCountryCode: values.phoneNumberCountryCode,
+              },
+            },
+          })
+        validateAndExtractOrderResponse(
+          setOrderPickupDetailsResult.updateOrderShippingAddress?.orderOrError,
+        )
+
+        // TODO: Handle success
+      } catch (error) {
+        // TODO: Handle errors
+        logger.error("Error while setting pickup details", error)
+      }
+    },
+    [
+      setOrderFulfillmentOption,
+      setOrderPickupDetails,
+      orderData.internalID,
+      pickupFulfillmentOption,
+    ],
+  )
+
+  const existingPickupValues =
+    orderData?.selectedFulfillmentOption?.type === "PICKUP"
+      ? orderData.fulfillmentDetails
+      : null
+
+  const existingCountryCode = existingPickupValues?.phoneNumber?.countryCode
+  const initialCountryOptionFromExisting =
+    existingCountryCode &&
+    phoneCountryOptions.find(
+      option =>
+        option.value.toLowerCase() === existingCountryCode?.toLowerCase(),
+    )?.value
+
+  const initialValues = !!(
+    initialCountryOptionFromExisting &&
+    existingPickupValues?.phoneNumber?.originalNumber
+  )
+    ? {
+        phoneNumber: existingPickupValues?.phoneNumber?.originalNumber,
+        phoneNumberCountryCode: initialCountryOptionFromExisting,
+      }
+    : {
+        phoneNumber: "",
+        phoneNumberCountryCode: phoneCountryOptions[0].value,
+      }
+
+  return (
+    <>
+      <Text fontWeight="medium" color="mono100" variant="sm-display">
+        Free pickup
+      </Text>
+      <Text variant="xs" color="mono60" my={1}>
+        After your order is confirmed, a specialist will contact you with
+        details on how to pick up the work.
+      </Text>
+      <Formik<PickupFormValues>
+        initialValues={initialValues}
+        validationSchema={VALIDATION_SCHEMA}
+        onSubmit={handleSubmit}
+      >
+        {formikContext => (
+          <GridColumns data-testid={"PickupDetailsForm"}>
+            <Column span={12}>
+              <PhoneInput
+                mt={1}
+                name="phoneNumber"
+                onChange={formikContext.handleChange}
+                onBlur={formikContext.handleBlur}
+                data-testid={"PickupPhoneNumberInput"}
+                options={phoneCountryOptions}
+                onSelect={(
+                  option: (typeof phoneCountryOptions)[number],
+                ): void => {
+                  formikContext.setFieldValue(
+                    "phoneNumberCountryCode",
+                    option.value,
+                  )
+                }}
+                dropdownValue={formikContext.values.phoneNumberCountryCode}
+                inputValue={formikContext.values.phoneNumber}
+                placeholder="(000) 000 0000"
+                error={
+                  (formikContext.touched.phoneNumberCountryCode &&
+                    (formikContext.errors.phoneNumberCountryCode as
+                      | string
+                      | undefined)) ||
+                  (formikContext.touched.phoneNumber &&
+                    (formikContext.errors.phoneNumber as string | undefined))
+                }
+                required
+              />
+              <Spacer y={4} />
+              <Button
+                variant={"primaryBlack"}
+                width="100%"
+                type="submit"
+                onClick={() => formikContext.handleSubmit()}
+                loading={formikContext.isSubmitting}
+                disabled={!formikContext.isValid}
+              >
+                Continue to Payment
+              </Button>
+            </Column>
+          </GridColumns>
+        )}
+      </Formik>
+    </>
+  )
+}
+
+const VALIDATION_SCHEMA = Yup.object().shape({
+  ...richPhoneValidators,
+})
+
+const FRAGMENT = graphql`
+  fragment Order2PickupForm_order on Order {
+    internalID
+    fulfillmentOptions {
+      type
+    }
+    selectedFulfillmentOption {
+      type
+    }
+    fulfillmentDetails {
+      phoneNumber {
+        countryCode
+        regionCode
+        originalNumber
+      }
+    }
+  }
+`

--- a/src/Apps/Order2/Routes/Checkout/Mutations/useSetOrderFulfillmentOptionMutation.ts
+++ b/src/Apps/Order2/Routes/Checkout/Mutations/useSetOrderFulfillmentOptionMutation.ts
@@ -1,0 +1,44 @@
+import { useMutation } from "Utils/Hooks/useMutation"
+import type { useSetOrderFulfillmentOptionMutation as useSetOrderFulfillmentOptionMutationType } from "__generated__/useSetOrderFulfillmentOptionMutation.graphql"
+
+import { graphql } from "react-relay"
+
+export const useSetOrderFulfillmentOptionMutation = () => {
+  return useMutation<useSetOrderFulfillmentOptionMutationType>({
+    mutation: graphql`
+      mutation useSetOrderFulfillmentOptionMutation(
+        $input: setOrderFulfillmentOptionInput!
+      ) {
+        setOrderFulfillmentOption(input: $input) {
+          orderOrError {
+            __typename
+            ... on OrderMutationSuccess {
+              order {
+                id
+                selectedFulfillmentOption {
+                  type
+                }
+                # TODO: fetch/refresh the full checkout flow order
+                internalID
+
+                fulfillmentOptions {
+                  type
+                }
+                ...Order2CollapsibleOrderSummary_order
+                ...Order2FulfillmentDetailsStep_order
+                ...Order2ReviewStep_order
+                ...useLoadCheckout_order
+                ...Order2CheckoutLoadingSkeleton_order
+              }
+            }
+            ... on OrderMutationError {
+              mutationError {
+                message
+              }
+            }
+          }
+        }
+      }
+    `,
+  })
+}

--- a/src/Apps/Order2/Routes/Checkout/Mutations/useSetOrderPickupDetailsMutation.ts
+++ b/src/Apps/Order2/Routes/Checkout/Mutations/useSetOrderPickupDetailsMutation.ts
@@ -1,0 +1,48 @@
+import { useMutation } from "Utils/Hooks/useMutation"
+import type { useSetOrderPickupDetailsMutation as useSetOrderPickupDetailsMutationType } from "__generated__/useSetOrderPickupDetailsMutation.graphql"
+import { graphql } from "react-relay"
+
+export const useSetOrderPickupDetailsMutation = () => {
+  return useMutation<useSetOrderPickupDetailsMutationType>({
+    mutation: graphql`
+      mutation useSetOrderPickupDetailsMutation(
+        $input: updateOrderShippingAddressInput!
+      ) {
+        updateOrderShippingAddress(input: $input) {
+          orderOrError {
+            __typename
+            ... on OrderMutationSuccess {
+              order {
+                id
+                fulfillmentDetails {
+                  phoneNumber {
+                    originalNumber
+                  }
+                }
+                selectedFulfillmentOption {
+                  type
+                }
+
+                # TODO: fetch/refresh the full checkout flow order
+                internalID
+                fulfillmentOptions {
+                  type
+                }
+                ...Order2CollapsibleOrderSummary_order
+                ...Order2FulfillmentDetailsStep_order
+                ...Order2ReviewStep_order
+                ...useLoadCheckout_order
+                ...Order2CheckoutLoadingSkeleton_order
+              }
+            }
+            ... on OrderMutationError {
+              mutationError {
+                message
+              }
+            }
+          }
+        }
+      }
+    `,
+  })
+}

--- a/src/Apps/Order2/Routes/Checkout/Order2CheckoutRoute.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Order2CheckoutRoute.tsx
@@ -1,26 +1,12 @@
-import {
-  Box,
-  Button,
-  Column,
-  Flex,
-  GridColumns,
-  PhoneInput,
-  Spacer,
-  Stack,
-  Tab,
-  Tabs,
-  Text,
-} from "@artsy/palette"
+import { Column, Flex, GridColumns, Stack, Text } from "@artsy/palette"
 import { Order2CheckoutLoadingSkeleton } from "Apps/Order2/Routes/Checkout/Components/Order2CheckoutLoadingSkeleton"
 import { Order2CollapsibleOrderSummary } from "Apps/Order2/Routes/Checkout/Components/Order2CollapsibleOrderSummary"
-import { Order2DeliveryForm } from "Apps/Order2/Routes/Checkout/Components/Order2DeliveryForm"
+import { Order2FulfillmentDetailsStep } from "Apps/Order2/Routes/Checkout/Components/Order2FulfillmentDetailsStep/Order2FulfillmentDetailsStep"
 import { Order2ReviewStep } from "Apps/Order2/Routes/Checkout/Components/Order2ReviewStep"
 import { useLoadCheckout } from "Apps/Order2/Routes/Checkout/Hooks/useLoadCheckout"
 import { ErrorPage } from "Components/ErrorPage"
 import { useSystemContext } from "System/Hooks/useSystemContext"
-import { countries as phoneCountryOptions } from "Utils/countries"
 import type { Order2CheckoutRoute_viewer$key } from "__generated__/Order2CheckoutRoute_viewer.graphql"
-import { Formik, type FormikHelpers, type FormikValues } from "formik"
 import { Meta, Title } from "react-head"
 import { graphql, useFragment } from "react-relay"
 
@@ -35,7 +21,6 @@ export const Order2CheckoutRoute: React.FC<Order2CheckoutRouteProps> = ({
 
   const data = useFragment(FRAGMENT, viewer)
   const order = data.me?.order
-  const fulfillmentOptions = order?.fulfillmentOptions
   const { isLoading } = useLoadCheckout(order)
 
   if (!order) {
@@ -59,143 +44,9 @@ export const Order2CheckoutRoute: React.FC<Order2CheckoutRouteProps> = ({
           <Stack gap={1} bg="mono5">
             {/* Collapsible order summary */}
             <Order2CollapsibleOrderSummary order={order} />
+
             {/* Fulfillment details Step */}
-            <Flex flexDirection="column" backgroundColor="mono0" py={2}>
-              {fulfillmentOptions?.some(option => option.type === "PICKUP") ? (
-                <Tabs justifyContent="space-between" initialTabIndex={0}>
-                  <Tab
-                    name={
-                      <Text mx={50} variant="xs">
-                        Delivery
-                      </Text>
-                    }
-                  >
-                    <Box px={2}>
-                      <Order2DeliveryForm
-                        initialValues={{
-                          address: {
-                            name: "",
-                            country: "",
-                            postalCode: "",
-                            addressLine1: "",
-                            addressLine2: "",
-                            city: "",
-                            region: "",
-                          },
-                          phoneNumber: "",
-                          phoneNumberCountryCode: "",
-                        }}
-                        onSubmit={(
-                          values: FormikValues,
-                          formikHelpers: FormikHelpers<FormikValues>,
-                        ) => {}}
-                      />
-                    </Box>
-                  </Tab>
-                  <Tab
-                    name={
-                      <Text mx={50} variant="xs">
-                        Pickup
-                      </Text>
-                    }
-                  >
-                    <Box px={2}>
-                      <Text
-                        fontWeight="medium"
-                        color="mono100"
-                        variant="sm-display"
-                      >
-                        Free pickup
-                      </Text>
-                      <Text variant="xs" color="mono60" my={1}>
-                        After your order is confirmed, a specialist will contact
-                        you with details on how to pick up the work.
-                      </Text>
-                      <Formik
-                        initialValues={{
-                          pickupPhoneNumber: "",
-                          pickupPhoneNumberCountryCode: "",
-                        }}
-                        validationSchema={{}}
-                        onSubmit={(values: FormikValues) => {}}
-                      >
-                        {formikContext => (
-                          <GridColumns data-testid={"PickupDetailsForm"}>
-                            <Column span={12}>
-                              <PhoneInput
-                                mt={1}
-                                name="pickupPhoneNumber"
-                                onChange={formikContext.handleChange}
-                                onBlur={formikContext.handleBlur}
-                                data-testid={"PickupPhoneNumberInput"}
-                                options={phoneCountryOptions}
-                                onSelect={(
-                                  option: (typeof phoneCountryOptions)[number],
-                                ): void => {
-                                  formikContext.setFieldValue(
-                                    "pickupPhoneNumberCountryCode",
-                                    option.value,
-                                  )
-                                }}
-                                dropdownValue={
-                                  formikContext.values
-                                    .pickupPhoneNumberCountryCode
-                                }
-                                inputValue={
-                                  formikContext.values.pickupPhoneNumber
-                                }
-                                placeholder="(000) 000 0000"
-                                error={
-                                  (formikContext.touched
-                                    .pickupPhoneNumberCountryCode &&
-                                    (formikContext.errors
-                                      .pickupPhoneNumberCountryCode as
-                                      | string
-                                      | undefined)) ||
-                                  (formikContext.touched.pickupPhoneNumber &&
-                                    (formikContext.errors.pickupPhoneNumber as
-                                      | string
-                                      | undefined))
-                                }
-                                required
-                              />
-                              <Spacer y={4} />
-                              <Button
-                                variant={"primaryBlack"}
-                                width="100%"
-                                type="submit"
-                                onClick={() => formikContext.handleSubmit()}
-                              >
-                                Continue to Payment
-                              </Button>
-                            </Column>
-                          </GridColumns>
-                        )}
-                      </Formik>
-                    </Box>
-                  </Tab>
-                </Tabs>
-              ) : (
-                <Box px={2}>
-                  <Order2DeliveryForm
-                    initialValues={{
-                      address: {
-                        name: "",
-                        country: "",
-                        postalCode: "",
-                        addressLine1: "",
-                        addressLine2: "",
-                        city: "",
-                        region: "",
-                      },
-                      phoneNumber: "",
-                      phoneNumberCountryCode: "",
-                    }}
-                    onSubmit={(values: FormikValues) => {}}
-                  />
-                </Box>
-              )}
-            </Flex>
+            <Order2FulfillmentDetailsStep order={order} />
 
             {/* Shipping method Step */}
             <Flex flexDirection="column" backgroundColor="mono0" p={2}>
@@ -236,6 +87,7 @@ const FRAGMENT = graphql`
           type
         }
         ...Order2CollapsibleOrderSummary_order
+        ...Order2FulfillmentDetailsStep_order
         ...Order2ReviewStep_order
         ...useLoadCheckout_order
         ...Order2CheckoutLoadingSkeleton_order

--- a/src/__generated__/Order2CheckoutRouteTestQuery.graphql.ts
+++ b/src/__generated__/Order2CheckoutRouteTestQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d8d1a8f22af5e8fa229a3372359cb24d>>
+ * @generated SignedSource<<661195236117b93850c7d3fb196740b5>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -29,21 +29,30 @@ var v0 = {
   "name": "internalID",
   "storageKey": null
 },
-v1 = {
+v1 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "type",
+    "storageKey": null
+  }
+],
+v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "displayName",
   "storageKey": null
 },
-v2 = {
+v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "amountFallbackText",
   "storageKey": null
 },
-v3 = {
+v4 = {
   "alias": null,
   "args": null,
   "concreteType": "Money",
@@ -68,12 +77,12 @@ v3 = {
   ],
   "storageKey": null
 },
-v4 = [
-  (v1/*: any*/),
-  (v2/*: any*/),
-  (v3/*: any*/)
-],
 v5 = [
+  (v2/*: any*/),
+  (v3/*: any*/),
+  (v4/*: any*/)
+],
+v6 = [
   {
     "alias": null,
     "args": null,
@@ -82,32 +91,43 @@ v5 = [
     "storageKey": null
   }
 ],
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v7 = {
+v8 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v8 = {
+v9 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Money"
 },
-v9 = {
+v10 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v10 = {
+v11 = {
+  "enumValues": [
+    "DOMESTIC_FLAT",
+    "INTERNATIONAL_FLAT",
+    "PICKUP",
+    "SHIPPING_TBD"
+  ],
+  "nullable": false,
+  "plural": false,
+  "type": "FulfillmentOptionTypeEnum"
+},
+v12 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
@@ -190,15 +210,7 @@ return {
                     "kind": "LinkedField",
                     "name": "fulfillmentOptions",
                     "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "type",
-                        "storageKey": null
-                      }
-                    ],
+                    "selections": (v1/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -218,21 +230,21 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": (v4/*: any*/),
+                        "selections": (v5/*: any*/),
                         "type": "ShippingLine",
                         "abstractKey": null
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": (v4/*: any*/),
+                        "selections": (v5/*: any*/),
                         "type": "TaxLine",
                         "abstractKey": null
                       },
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v1/*: any*/),
-                          (v3/*: any*/)
+                          (v2/*: any*/),
+                          (v4/*: any*/)
                         ],
                         "type": "SubtotalLine",
                         "abstractKey": null
@@ -240,8 +252,8 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v1/*: any*/),
                           (v2/*: any*/),
+                          (v3/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -249,7 +261,7 @@ return {
                             "kind": "LinkedField",
                             "name": "amount",
                             "plural": false,
-                            "selections": (v5/*: any*/),
+                            "selections": (v6/*: any*/),
                             "storageKey": null
                           }
                         ],
@@ -273,7 +285,7 @@ return {
                     "kind": "LinkedField",
                     "name": "buyerTotal",
                     "plural": false,
-                    "selections": (v5/*: any*/),
+                    "selections": (v6/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -283,7 +295,7 @@ return {
                     "kind": "LinkedField",
                     "name": "itemsTotal",
                     "plural": false,
-                    "selections": (v5/*: any*/),
+                    "selections": (v6/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -293,7 +305,7 @@ return {
                     "kind": "LinkedField",
                     "name": "shippingTotal",
                     "plural": false,
-                    "selections": (v5/*: any*/),
+                    "selections": (v6/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -303,7 +315,7 @@ return {
                     "kind": "LinkedField",
                     "name": "taxTotal",
                     "plural": false,
-                    "selections": (v5/*: any*/),
+                    "selections": (v6/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -329,7 +341,7 @@ return {
                             "name": "slug",
                             "storageKey": null
                           },
-                          (v6/*: any*/)
+                          (v7/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -402,23 +414,125 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v6/*: any*/),
+                          (v7/*: any*/),
                           (v0/*: any*/)
                         ],
                         "storageKey": null
                       },
-                      (v6/*: any*/)
+                      (v7/*: any*/)
                     ],
                     "storageKey": null
                   },
                   {
                     "alias": null,
                     "args": null,
+                    "concreteType": "FulfillmentOption",
+                    "kind": "LinkedField",
+                    "name": "selectedFulfillmentOption",
+                    "plural": false,
+                    "selections": (v1/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "FulfillmentDetails",
+                    "kind": "LinkedField",
+                    "name": "fulfillmentDetails",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "PhoneNumberType",
+                        "kind": "LinkedField",
+                        "name": "phoneNumber",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "countryCode",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "regionCode",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "originalNumber",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "addressLine1",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "addressLine2",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "city",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "country",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "name",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "postalCode",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "region",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  (v7/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
                     "kind": "ScalarField",
                     "name": "mode",
                     "storageKey": null
-                  },
-                  (v6/*: any*/)
+                  }
                 ],
                 "storageKey": "order(id:\"order-id\")"
               },
@@ -453,7 +567,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v0/*: any*/),
-                          (v6/*: any*/)
+                          (v7/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -463,7 +577,7 @@ return {
                 ],
                 "storageKey": "addressConnection(first:10)"
               },
-              (v6/*: any*/)
+              (v7/*: any*/)
             ],
             "storageKey": null
           }
@@ -473,7 +587,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "33204b6f986d315a7ba70f61c5d3d124",
+    "cacheID": "f0b8e3881765332703ee6544fe78157c",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -507,38 +621,50 @@ return {
           "plural": false,
           "type": "UserAddress"
         },
-        "viewer.me.addressConnection.edges.node.id": (v7/*: any*/),
-        "viewer.me.addressConnection.edges.node.internalID": (v7/*: any*/),
-        "viewer.me.id": (v7/*: any*/),
+        "viewer.me.addressConnection.edges.node.id": (v8/*: any*/),
+        "viewer.me.addressConnection.edges.node.internalID": (v8/*: any*/),
+        "viewer.me.id": (v8/*: any*/),
         "viewer.me.order": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Order"
         },
-        "viewer.me.order.buyerTotal": (v8/*: any*/),
-        "viewer.me.order.buyerTotal.display": (v9/*: any*/),
+        "viewer.me.order.buyerTotal": (v9/*: any*/),
+        "viewer.me.order.buyerTotal.display": (v10/*: any*/),
+        "viewer.me.order.fulfillmentDetails": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "FulfillmentDetails"
+        },
+        "viewer.me.order.fulfillmentDetails.addressLine1": (v10/*: any*/),
+        "viewer.me.order.fulfillmentDetails.addressLine2": (v10/*: any*/),
+        "viewer.me.order.fulfillmentDetails.city": (v10/*: any*/),
+        "viewer.me.order.fulfillmentDetails.country": (v10/*: any*/),
+        "viewer.me.order.fulfillmentDetails.name": (v10/*: any*/),
+        "viewer.me.order.fulfillmentDetails.phoneNumber": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "PhoneNumberType"
+        },
+        "viewer.me.order.fulfillmentDetails.phoneNumber.countryCode": (v10/*: any*/),
+        "viewer.me.order.fulfillmentDetails.phoneNumber.originalNumber": (v10/*: any*/),
+        "viewer.me.order.fulfillmentDetails.phoneNumber.regionCode": (v10/*: any*/),
+        "viewer.me.order.fulfillmentDetails.postalCode": (v10/*: any*/),
+        "viewer.me.order.fulfillmentDetails.region": (v10/*: any*/),
         "viewer.me.order.fulfillmentOptions": {
           "enumValues": null,
           "nullable": false,
           "plural": true,
           "type": "FulfillmentOption"
         },
-        "viewer.me.order.fulfillmentOptions.type": {
-          "enumValues": [
-            "DOMESTIC_FLAT",
-            "INTERNATIONAL_FLAT",
-            "PICKUP",
-            "SHIPPING_TBD"
-          ],
-          "nullable": false,
-          "plural": false,
-          "type": "FulfillmentOptionTypeEnum"
-        },
-        "viewer.me.order.id": (v7/*: any*/),
-        "viewer.me.order.internalID": (v7/*: any*/),
-        "viewer.me.order.itemsTotal": (v8/*: any*/),
-        "viewer.me.order.itemsTotal.display": (v9/*: any*/),
+        "viewer.me.order.fulfillmentOptions.type": (v11/*: any*/),
+        "viewer.me.order.id": (v8/*: any*/),
+        "viewer.me.order.internalID": (v8/*: any*/),
+        "viewer.me.order.itemsTotal": (v9/*: any*/),
+        "viewer.me.order.itemsTotal.display": (v10/*: any*/),
         "viewer.me.order.lineItems": {
           "enumValues": null,
           "nullable": false,
@@ -551,17 +677,17 @@ return {
           "plural": false,
           "type": "Artwork"
         },
-        "viewer.me.order.lineItems.artwork.id": (v7/*: any*/),
-        "viewer.me.order.lineItems.artwork.slug": (v7/*: any*/),
+        "viewer.me.order.lineItems.artwork.id": (v8/*: any*/),
+        "viewer.me.order.lineItems.artwork.slug": (v8/*: any*/),
         "viewer.me.order.lineItems.artworkVersion": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtworkVersion"
         },
-        "viewer.me.order.lineItems.artworkVersion.artistNames": (v9/*: any*/),
-        "viewer.me.order.lineItems.artworkVersion.date": (v9/*: any*/),
-        "viewer.me.order.lineItems.artworkVersion.id": (v7/*: any*/),
+        "viewer.me.order.lineItems.artworkVersion.artistNames": (v10/*: any*/),
+        "viewer.me.order.lineItems.artworkVersion.date": (v10/*: any*/),
+        "viewer.me.order.lineItems.artworkVersion.id": (v8/*: any*/),
         "viewer.me.order.lineItems.artworkVersion.image": {
           "enumValues": null,
           "nullable": true,
@@ -574,10 +700,10 @@ return {
           "plural": false,
           "type": "ResizedImageUrl"
         },
-        "viewer.me.order.lineItems.artworkVersion.image.resized.url": (v10/*: any*/),
-        "viewer.me.order.lineItems.artworkVersion.internalID": (v7/*: any*/),
-        "viewer.me.order.lineItems.artworkVersion.title": (v9/*: any*/),
-        "viewer.me.order.lineItems.id": (v7/*: any*/),
+        "viewer.me.order.lineItems.artworkVersion.image.resized.url": (v12/*: any*/),
+        "viewer.me.order.lineItems.artworkVersion.internalID": (v8/*: any*/),
+        "viewer.me.order.lineItems.artworkVersion.title": (v10/*: any*/),
+        "viewer.me.order.lineItems.id": (v8/*: any*/),
         "viewer.me.order.mode": {
           "enumValues": [
             "BUY",
@@ -593,15 +719,22 @@ return {
           "plural": true,
           "type": "PricingBreakdownLineUnion"
         },
-        "viewer.me.order.pricingBreakdownLines.__typename": (v10/*: any*/),
-        "viewer.me.order.pricingBreakdownLines.amount": (v8/*: any*/),
-        "viewer.me.order.pricingBreakdownLines.amount.amount": (v9/*: any*/),
-        "viewer.me.order.pricingBreakdownLines.amount.currencySymbol": (v9/*: any*/),
-        "viewer.me.order.pricingBreakdownLines.amount.display": (v9/*: any*/),
-        "viewer.me.order.pricingBreakdownLines.amountFallbackText": (v9/*: any*/),
-        "viewer.me.order.pricingBreakdownLines.displayName": (v10/*: any*/),
-        "viewer.me.order.shippingTotal": (v8/*: any*/),
-        "viewer.me.order.shippingTotal.display": (v9/*: any*/),
+        "viewer.me.order.pricingBreakdownLines.__typename": (v12/*: any*/),
+        "viewer.me.order.pricingBreakdownLines.amount": (v9/*: any*/),
+        "viewer.me.order.pricingBreakdownLines.amount.amount": (v10/*: any*/),
+        "viewer.me.order.pricingBreakdownLines.amount.currencySymbol": (v10/*: any*/),
+        "viewer.me.order.pricingBreakdownLines.amount.display": (v10/*: any*/),
+        "viewer.me.order.pricingBreakdownLines.amountFallbackText": (v10/*: any*/),
+        "viewer.me.order.pricingBreakdownLines.displayName": (v12/*: any*/),
+        "viewer.me.order.selectedFulfillmentOption": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "FulfillmentOption"
+        },
+        "viewer.me.order.selectedFulfillmentOption.type": (v11/*: any*/),
+        "viewer.me.order.shippingTotal": (v9/*: any*/),
+        "viewer.me.order.shippingTotal.display": (v10/*: any*/),
         "viewer.me.order.source": {
           "enumValues": [
             "ARTWORK_PAGE",
@@ -613,13 +746,13 @@ return {
           "plural": false,
           "type": "OrderSourceEnum"
         },
-        "viewer.me.order.taxTotal": (v8/*: any*/),
-        "viewer.me.order.taxTotal.display": (v9/*: any*/)
+        "viewer.me.order.taxTotal": (v9/*: any*/),
+        "viewer.me.order.taxTotal.display": (v10/*: any*/)
       }
     },
     "name": "Order2CheckoutRouteTestQuery",
     "operationKind": "query",
-    "text": "query Order2CheckoutRouteTestQuery {\n  viewer {\n    ...Order2CheckoutRoute_viewer_oauVf\n  }\n}\n\nfragment Order2CheckoutLoadingSkeleton_order on Order {\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  lineItems {\n    artworkVersion {\n      title\n      artistNames\n      date\n      id\n    }\n    id\n  }\n}\n\nfragment Order2CheckoutRoute_viewer_oauVf on Viewer {\n  me {\n    order(id: \"order-id\") {\n      internalID\n      fulfillmentOptions {\n        type\n      }\n      ...Order2CollapsibleOrderSummary_order\n      ...Order2ReviewStep_order\n      ...useLoadCheckout_order\n      ...Order2CheckoutLoadingSkeleton_order\n      id\n    }\n    addressConnection(first: 10) {\n      edges {\n        node {\n          internalID\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Order2CollapsibleOrderSummary_order on Order {\n  ...Order2PricingBreakdown_order\n  source\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      image {\n        resized(width: 185, height: 138) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment Order2PricingBreakdown_order on Order {\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n}\n\nfragment Order2ReviewStep_order on Order {\n  ...Order2PricingBreakdown_order\n  mode\n  source\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      image {\n        resized(width: 185, height: 138) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment useLoadCheckout_order on Order {\n  lineItems {\n    artworkVersion {\n      internalID\n      id\n    }\n    id\n  }\n}\n"
+    "text": "query Order2CheckoutRouteTestQuery {\n  viewer {\n    ...Order2CheckoutRoute_viewer_oauVf\n  }\n}\n\nfragment Order2CheckoutLoadingSkeleton_order on Order {\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  lineItems {\n    artworkVersion {\n      title\n      artistNames\n      date\n      id\n    }\n    id\n  }\n}\n\nfragment Order2CheckoutRoute_viewer_oauVf on Viewer {\n  me {\n    order(id: \"order-id\") {\n      internalID\n      fulfillmentOptions {\n        type\n      }\n      ...Order2CollapsibleOrderSummary_order\n      ...Order2FulfillmentDetailsStep_order\n      ...Order2ReviewStep_order\n      ...useLoadCheckout_order\n      ...Order2CheckoutLoadingSkeleton_order\n      id\n    }\n    addressConnection(first: 10) {\n      edges {\n        node {\n          internalID\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Order2CollapsibleOrderSummary_order on Order {\n  ...Order2PricingBreakdown_order\n  source\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      image {\n        resized(width: 185, height: 138) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment Order2FulfillmentDetailsStep_order on Order {\n  ...Order2PickupForm_order\n  id\n  fulfillmentDetails {\n    phoneNumber {\n      countryCode\n      regionCode\n      originalNumber\n    }\n    addressLine1\n    addressLine2\n    city\n    country\n    name\n    postalCode\n    region\n  }\n  selectedFulfillmentOption {\n    type\n  }\n  fulfillmentOptions {\n    type\n  }\n}\n\nfragment Order2PickupForm_order on Order {\n  internalID\n  fulfillmentOptions {\n    type\n  }\n  selectedFulfillmentOption {\n    type\n  }\n  fulfillmentDetails {\n    phoneNumber {\n      countryCode\n      regionCode\n      originalNumber\n    }\n  }\n}\n\nfragment Order2PricingBreakdown_order on Order {\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n}\n\nfragment Order2ReviewStep_order on Order {\n  ...Order2PricingBreakdown_order\n  mode\n  source\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      image {\n        resized(width: 185, height: 138) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment useLoadCheckout_order on Order {\n  lineItems {\n    artworkVersion {\n      internalID\n      id\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/Order2CheckoutRoute_viewer.graphql.ts
+++ b/src/__generated__/Order2CheckoutRoute_viewer.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<aa104655989801e1c83adcd77d763d34>>
+ * @generated SignedSource<<6c0b93f485fadefab9ac48238c31d6bb>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -25,7 +25,7 @@ export type Order2CheckoutRoute_viewer$data = {
         readonly type: FulfillmentOptionTypeEnum;
       }>;
       readonly internalID: string;
-      readonly " $fragmentSpreads": FragmentRefs<"Order2CheckoutLoadingSkeleton_order" | "Order2CollapsibleOrderSummary_order" | "Order2ReviewStep_order" | "useLoadCheckout_order">;
+      readonly " $fragmentSpreads": FragmentRefs<"Order2CheckoutLoadingSkeleton_order" | "Order2CollapsibleOrderSummary_order" | "Order2FulfillmentDetailsStep_order" | "Order2ReviewStep_order" | "useLoadCheckout_order">;
     } | null | undefined;
   } | null | undefined;
   readonly " $fragmentType": "Order2CheckoutRoute_viewer";
@@ -104,6 +104,11 @@ return {
             {
               "args": null,
               "kind": "FragmentSpread",
+              "name": "Order2FulfillmentDetailsStep_order"
+            },
+            {
+              "args": null,
+              "kind": "FragmentSpread",
               "name": "Order2ReviewStep_order"
             },
             {
@@ -168,6 +173,6 @@ return {
 };
 })();
 
-(node as any).hash = "5d20df6260bf3f116e12c2c7b17ec40b";
+(node as any).hash = "f349de1d0264b6ab69f4656376ab8990";
 
 export default node;

--- a/src/__generated__/Order2FulfillmentDetailsStep_order.graphql.ts
+++ b/src/__generated__/Order2FulfillmentDetailsStep_order.graphql.ts
@@ -1,0 +1,192 @@
+/**
+ * @generated SignedSource<<17f99b8584ad2033779130c8a2331353>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type FulfillmentOptionTypeEnum = "DOMESTIC_FLAT" | "INTERNATIONAL_FLAT" | "PICKUP" | "SHIPPING_TBD" | "%future added value";
+import { FragmentRefs } from "relay-runtime";
+export type Order2FulfillmentDetailsStep_order$data = {
+  readonly fulfillmentDetails: {
+    readonly addressLine1: string | null | undefined;
+    readonly addressLine2: string | null | undefined;
+    readonly city: string | null | undefined;
+    readonly country: string | null | undefined;
+    readonly name: string | null | undefined;
+    readonly phoneNumber: {
+      readonly countryCode: string | null | undefined;
+      readonly originalNumber: string | null | undefined;
+      readonly regionCode: string | null | undefined;
+    } | null | undefined;
+    readonly postalCode: string | null | undefined;
+    readonly region: string | null | undefined;
+  } | null | undefined;
+  readonly fulfillmentOptions: ReadonlyArray<{
+    readonly type: FulfillmentOptionTypeEnum;
+  }>;
+  readonly id: string;
+  readonly selectedFulfillmentOption: {
+    readonly type: FulfillmentOptionTypeEnum;
+  } | null | undefined;
+  readonly " $fragmentSpreads": FragmentRefs<"Order2PickupForm_order">;
+  readonly " $fragmentType": "Order2FulfillmentDetailsStep_order";
+};
+export type Order2FulfillmentDetailsStep_order$key = {
+  readonly " $data"?: Order2FulfillmentDetailsStep_order$data;
+  readonly " $fragmentSpreads": FragmentRefs<"Order2FulfillmentDetailsStep_order">;
+};
+
+const node: ReaderFragment = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "type",
+    "storageKey": null
+  }
+];
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "Order2FulfillmentDetailsStep_order",
+  "selections": [
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "Order2PickupForm_order"
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "id",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "FulfillmentDetails",
+      "kind": "LinkedField",
+      "name": "fulfillmentDetails",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "PhoneNumberType",
+          "kind": "LinkedField",
+          "name": "phoneNumber",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "countryCode",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "regionCode",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "originalNumber",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "addressLine1",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "addressLine2",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "city",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "country",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "name",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "postalCode",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "region",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "FulfillmentOption",
+      "kind": "LinkedField",
+      "name": "selectedFulfillmentOption",
+      "plural": false,
+      "selections": (v0/*: any*/),
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "FulfillmentOption",
+      "kind": "LinkedField",
+      "name": "fulfillmentOptions",
+      "plural": true,
+      "selections": (v0/*: any*/),
+      "storageKey": null
+    }
+  ],
+  "type": "Order",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "69b148de994636f51d8854642c58bb60";
+
+export default node;

--- a/src/__generated__/Order2PickupForm_order.graphql.ts
+++ b/src/__generated__/Order2PickupForm_order.graphql.ts
@@ -1,0 +1,130 @@
+/**
+ * @generated SignedSource<<d688a43de4923ccc112458f572f31085>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type FulfillmentOptionTypeEnum = "DOMESTIC_FLAT" | "INTERNATIONAL_FLAT" | "PICKUP" | "SHIPPING_TBD" | "%future added value";
+import { FragmentRefs } from "relay-runtime";
+export type Order2PickupForm_order$data = {
+  readonly fulfillmentDetails: {
+    readonly phoneNumber: {
+      readonly countryCode: string | null | undefined;
+      readonly originalNumber: string | null | undefined;
+      readonly regionCode: string | null | undefined;
+    } | null | undefined;
+  } | null | undefined;
+  readonly fulfillmentOptions: ReadonlyArray<{
+    readonly type: FulfillmentOptionTypeEnum;
+  }>;
+  readonly internalID: string;
+  readonly selectedFulfillmentOption: {
+    readonly type: FulfillmentOptionTypeEnum;
+  } | null | undefined;
+  readonly " $fragmentType": "Order2PickupForm_order";
+};
+export type Order2PickupForm_order$key = {
+  readonly " $data"?: Order2PickupForm_order$data;
+  readonly " $fragmentSpreads": FragmentRefs<"Order2PickupForm_order">;
+};
+
+const node: ReaderFragment = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "type",
+    "storageKey": null
+  }
+];
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "Order2PickupForm_order",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "internalID",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "FulfillmentOption",
+      "kind": "LinkedField",
+      "name": "fulfillmentOptions",
+      "plural": true,
+      "selections": (v0/*: any*/),
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "FulfillmentOption",
+      "kind": "LinkedField",
+      "name": "selectedFulfillmentOption",
+      "plural": false,
+      "selections": (v0/*: any*/),
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "FulfillmentDetails",
+      "kind": "LinkedField",
+      "name": "fulfillmentDetails",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "PhoneNumberType",
+          "kind": "LinkedField",
+          "name": "phoneNumber",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "countryCode",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "regionCode",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "originalNumber",
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Order",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "109ddd6926945d2ec382e11c538b07af";
+
+export default node;

--- a/src/__generated__/order2Routes_CheckoutQuery.graphql.ts
+++ b/src/__generated__/order2Routes_CheckoutQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8206ec21292900da4bbc8cfe946ae6ec>>
+ * @generated SignedSource<<f46b4a67b763d4051285800241e2718d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -66,21 +66,30 @@ v4 = {
   "name": "id",
   "storageKey": null
 },
-v5 = {
+v5 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "type",
+    "storageKey": null
+  }
+],
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "displayName",
   "storageKey": null
 },
-v6 = {
+v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "amountFallbackText",
   "storageKey": null
 },
-v7 = {
+v8 = {
   "alias": null,
   "args": null,
   "concreteType": "Money",
@@ -105,12 +114,12 @@ v7 = {
   ],
   "storageKey": null
 },
-v8 = [
-  (v5/*: any*/),
-  (v6/*: any*/),
-  (v7/*: any*/)
-],
 v9 = [
+  (v6/*: any*/),
+  (v7/*: any*/),
+  (v8/*: any*/)
+],
+v10 = [
   {
     "alias": null,
     "args": null,
@@ -216,15 +225,7 @@ return {
                     "kind": "LinkedField",
                     "name": "fulfillmentOptions",
                     "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "type",
-                        "storageKey": null
-                      }
-                    ],
+                    "selections": (v5/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -244,21 +245,21 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": (v8/*: any*/),
+                        "selections": (v9/*: any*/),
                         "type": "ShippingLine",
                         "abstractKey": null
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": (v8/*: any*/),
+                        "selections": (v9/*: any*/),
                         "type": "TaxLine",
                         "abstractKey": null
                       },
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v5/*: any*/),
-                          (v7/*: any*/)
+                          (v6/*: any*/),
+                          (v8/*: any*/)
                         ],
                         "type": "SubtotalLine",
                         "abstractKey": null
@@ -266,8 +267,8 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v5/*: any*/),
                           (v6/*: any*/),
+                          (v7/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -275,7 +276,7 @@ return {
                             "kind": "LinkedField",
                             "name": "amount",
                             "plural": false,
-                            "selections": (v9/*: any*/),
+                            "selections": (v10/*: any*/),
                             "storageKey": null
                           }
                         ],
@@ -299,7 +300,7 @@ return {
                     "kind": "LinkedField",
                     "name": "buyerTotal",
                     "plural": false,
-                    "selections": (v9/*: any*/),
+                    "selections": (v10/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -309,7 +310,7 @@ return {
                     "kind": "LinkedField",
                     "name": "itemsTotal",
                     "plural": false,
-                    "selections": (v9/*: any*/),
+                    "selections": (v10/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -319,7 +320,7 @@ return {
                     "kind": "LinkedField",
                     "name": "shippingTotal",
                     "plural": false,
-                    "selections": (v9/*: any*/),
+                    "selections": (v10/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -329,7 +330,7 @@ return {
                     "kind": "LinkedField",
                     "name": "taxTotal",
                     "plural": false,
-                    "selections": (v9/*: any*/),
+                    "selections": (v10/*: any*/),
                     "storageKey": null
                   },
                   {
@@ -436,6 +437,108 @@ return {
                       (v4/*: any*/)
                     ],
                     "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "FulfillmentOption",
+                    "kind": "LinkedField",
+                    "name": "selectedFulfillmentOption",
+                    "plural": false,
+                    "selections": (v5/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "FulfillmentDetails",
+                    "kind": "LinkedField",
+                    "name": "fulfillmentDetails",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "PhoneNumberType",
+                        "kind": "LinkedField",
+                        "name": "phoneNumber",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "countryCode",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "regionCode",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "originalNumber",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "addressLine1",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "addressLine2",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "city",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "country",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "name",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "postalCode",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "region",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
                   }
                 ],
                 "storageKey": null
@@ -491,12 +594,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "8e187f71d8c777594a27feb92d990f8a",
+    "cacheID": "4956734b3997eec9d13aa47d8df7d008",
     "id": null,
     "metadata": {},
     "name": "order2Routes_CheckoutQuery",
     "operationKind": "query",
-    "text": "query order2Routes_CheckoutQuery(\n  $orderID: ID!\n) {\n  viewer {\n    me {\n      order(id: $orderID) {\n        internalID\n        mode\n        id\n      }\n      id\n    }\n    ...Order2CheckoutRoute_viewer_3HPek8\n  }\n}\n\nfragment Order2CheckoutLoadingSkeleton_order on Order {\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  lineItems {\n    artworkVersion {\n      title\n      artistNames\n      date\n      id\n    }\n    id\n  }\n}\n\nfragment Order2CheckoutRoute_viewer_3HPek8 on Viewer {\n  me {\n    order(id: $orderID) {\n      internalID\n      fulfillmentOptions {\n        type\n      }\n      ...Order2CollapsibleOrderSummary_order\n      ...Order2ReviewStep_order\n      ...useLoadCheckout_order\n      ...Order2CheckoutLoadingSkeleton_order\n      id\n    }\n    addressConnection(first: 10) {\n      edges {\n        node {\n          internalID\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Order2CollapsibleOrderSummary_order on Order {\n  ...Order2PricingBreakdown_order\n  source\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      image {\n        resized(width: 185, height: 138) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment Order2PricingBreakdown_order on Order {\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n}\n\nfragment Order2ReviewStep_order on Order {\n  ...Order2PricingBreakdown_order\n  mode\n  source\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      image {\n        resized(width: 185, height: 138) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment useLoadCheckout_order on Order {\n  lineItems {\n    artworkVersion {\n      internalID\n      id\n    }\n    id\n  }\n}\n"
+    "text": "query order2Routes_CheckoutQuery(\n  $orderID: ID!\n) {\n  viewer {\n    me {\n      order(id: $orderID) {\n        internalID\n        mode\n        id\n      }\n      id\n    }\n    ...Order2CheckoutRoute_viewer_3HPek8\n  }\n}\n\nfragment Order2CheckoutLoadingSkeleton_order on Order {\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  lineItems {\n    artworkVersion {\n      title\n      artistNames\n      date\n      id\n    }\n    id\n  }\n}\n\nfragment Order2CheckoutRoute_viewer_3HPek8 on Viewer {\n  me {\n    order(id: $orderID) {\n      internalID\n      fulfillmentOptions {\n        type\n      }\n      ...Order2CollapsibleOrderSummary_order\n      ...Order2FulfillmentDetailsStep_order\n      ...Order2ReviewStep_order\n      ...useLoadCheckout_order\n      ...Order2CheckoutLoadingSkeleton_order\n      id\n    }\n    addressConnection(first: 10) {\n      edges {\n        node {\n          internalID\n          id\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Order2CollapsibleOrderSummary_order on Order {\n  ...Order2PricingBreakdown_order\n  source\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      image {\n        resized(width: 185, height: 138) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment Order2FulfillmentDetailsStep_order on Order {\n  ...Order2PickupForm_order\n  id\n  fulfillmentDetails {\n    phoneNumber {\n      countryCode\n      regionCode\n      originalNumber\n    }\n    addressLine1\n    addressLine2\n    city\n    country\n    name\n    postalCode\n    region\n  }\n  selectedFulfillmentOption {\n    type\n  }\n  fulfillmentOptions {\n    type\n  }\n}\n\nfragment Order2PickupForm_order on Order {\n  internalID\n  fulfillmentOptions {\n    type\n  }\n  selectedFulfillmentOption {\n    type\n  }\n  fulfillmentDetails {\n    phoneNumber {\n      countryCode\n      regionCode\n      originalNumber\n    }\n  }\n}\n\nfragment Order2PricingBreakdown_order on Order {\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n}\n\nfragment Order2ReviewStep_order on Order {\n  ...Order2PricingBreakdown_order\n  mode\n  source\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      image {\n        resized(width: 185, height: 138) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment useLoadCheckout_order on Order {\n  lineItems {\n    artworkVersion {\n      internalID\n      id\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/useSetOrderFulfillmentOptionMutation.graphql.ts
+++ b/src/__generated__/useSetOrderFulfillmentOptionMutation.graphql.ts
@@ -1,0 +1,653 @@
+/**
+ * @generated SignedSource<<ef769d6407da5b1c7242243c10436edf>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type FulfillmentOptionInputEnum = "DOMESTIC_FLAT" | "INTERNATIONAL_FLAT" | "PICKUP" | "%future added value";
+export type FulfillmentOptionTypeEnum = "DOMESTIC_FLAT" | "INTERNATIONAL_FLAT" | "PICKUP" | "SHIPPING_TBD" | "%future added value";
+export type setOrderFulfillmentOptionInput = {
+  clientMutationId?: string | null | undefined;
+  fulfillmentOption: FulfillmentOptionInput;
+  id: string;
+};
+export type FulfillmentOptionInput = {
+  type: FulfillmentOptionInputEnum;
+};
+export type useSetOrderFulfillmentOptionMutation$variables = {
+  input: setOrderFulfillmentOptionInput;
+};
+export type useSetOrderFulfillmentOptionMutation$data = {
+  readonly setOrderFulfillmentOption: {
+    readonly orderOrError: {
+      readonly __typename: "OrderMutationError";
+      readonly mutationError: {
+        readonly message: string;
+      };
+    } | {
+      readonly __typename: "OrderMutationSuccess";
+      readonly order: {
+        readonly fulfillmentOptions: ReadonlyArray<{
+          readonly type: FulfillmentOptionTypeEnum;
+        }>;
+        readonly id: string;
+        readonly internalID: string;
+        readonly selectedFulfillmentOption: {
+          readonly type: FulfillmentOptionTypeEnum;
+        } | null | undefined;
+        readonly " $fragmentSpreads": FragmentRefs<"Order2CheckoutLoadingSkeleton_order" | "Order2CollapsibleOrderSummary_order" | "Order2FulfillmentDetailsStep_order" | "Order2ReviewStep_order" | "useLoadCheckout_order">;
+      };
+    } | {
+      // This will never be '%other', but we need some
+      // value in case none of the concrete values match.
+      readonly __typename: "%other";
+    } | null | undefined;
+  } | null | undefined;
+};
+export type useSetOrderFulfillmentOptionMutation = {
+  response: useSetOrderFulfillmentOptionMutation$data;
+  variables: useSetOrderFulfillmentOptionMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "type",
+    "storageKey": null
+  }
+],
+v5 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "FulfillmentOption",
+  "kind": "LinkedField",
+  "name": "selectedFulfillmentOption",
+  "plural": false,
+  "selections": (v4/*: any*/),
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "FulfillmentOption",
+  "kind": "LinkedField",
+  "name": "fulfillmentOptions",
+  "plural": true,
+  "selections": (v4/*: any*/),
+  "storageKey": null
+},
+v8 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "ExchangeError",
+      "kind": "LinkedField",
+      "name": "mutationError",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "message",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "OrderMutationError",
+  "abstractKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "displayName",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "amountFallbackText",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Money",
+  "kind": "LinkedField",
+  "name": "amount",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "amount",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "currencySymbol",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v12 = [
+  (v9/*: any*/),
+  (v10/*: any*/),
+  (v11/*: any*/)
+],
+v13 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "useSetOrderFulfillmentOptionMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "setOrderFulfillmentOptionPayload",
+        "kind": "LinkedField",
+        "name": "setOrderFulfillmentOption",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "orderOrError",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Order",
+                    "kind": "LinkedField",
+                    "name": "order",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      (v5/*: any*/),
+                      (v6/*: any*/),
+                      (v7/*: any*/),
+                      {
+                        "args": null,
+                        "kind": "FragmentSpread",
+                        "name": "Order2CollapsibleOrderSummary_order"
+                      },
+                      {
+                        "args": null,
+                        "kind": "FragmentSpread",
+                        "name": "Order2FulfillmentDetailsStep_order"
+                      },
+                      {
+                        "args": null,
+                        "kind": "FragmentSpread",
+                        "name": "Order2ReviewStep_order"
+                      },
+                      {
+                        "args": null,
+                        "kind": "FragmentSpread",
+                        "name": "useLoadCheckout_order"
+                      },
+                      {
+                        "args": null,
+                        "kind": "FragmentSpread",
+                        "name": "Order2CheckoutLoadingSkeleton_order"
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "OrderMutationSuccess",
+                "abstractKey": null
+              },
+              (v8/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "useSetOrderFulfillmentOptionMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "setOrderFulfillmentOptionPayload",
+        "kind": "LinkedField",
+        "name": "setOrderFulfillmentOption",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "orderOrError",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Order",
+                    "kind": "LinkedField",
+                    "name": "order",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      (v5/*: any*/),
+                      (v6/*: any*/),
+                      (v7/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "pricingBreakdownLines",
+                        "plural": true,
+                        "selections": [
+                          (v2/*: any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "selections": (v12/*: any*/),
+                            "type": "ShippingLine",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": (v12/*: any*/),
+                            "type": "TaxLine",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v9/*: any*/),
+                              (v11/*: any*/)
+                            ],
+                            "type": "SubtotalLine",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v9/*: any*/),
+                              (v10/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Money",
+                                "kind": "LinkedField",
+                                "name": "amount",
+                                "plural": false,
+                                "selections": (v13/*: any*/),
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "TotalLine",
+                            "abstractKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "source",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Money",
+                        "kind": "LinkedField",
+                        "name": "buyerTotal",
+                        "plural": false,
+                        "selections": (v13/*: any*/),
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Money",
+                        "kind": "LinkedField",
+                        "name": "itemsTotal",
+                        "plural": false,
+                        "selections": (v13/*: any*/),
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Money",
+                        "kind": "LinkedField",
+                        "name": "shippingTotal",
+                        "plural": false,
+                        "selections": (v13/*: any*/),
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Money",
+                        "kind": "LinkedField",
+                        "name": "taxTotal",
+                        "plural": false,
+                        "selections": (v13/*: any*/),
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "LineItem",
+                        "kind": "LinkedField",
+                        "name": "lineItems",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Artwork",
+                            "kind": "LinkedField",
+                            "name": "artwork",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "slug",
+                                "storageKey": null
+                              },
+                              (v3/*: any*/)
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ArtworkVersion",
+                            "kind": "LinkedField",
+                            "name": "artworkVersion",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "title",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "artistNames",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "date",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Image",
+                                "kind": "LinkedField",
+                                "name": "image",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "height",
+                                        "value": 138
+                                      },
+                                      {
+                                        "kind": "Literal",
+                                        "name": "width",
+                                        "value": 185
+                                      }
+                                    ],
+                                    "concreteType": "ResizedImageUrl",
+                                    "kind": "LinkedField",
+                                    "name": "resized",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "url",
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": "resized(height:138,width:185)"
+                                  }
+                                ],
+                                "storageKey": null
+                              },
+                              (v3/*: any*/),
+                              (v6/*: any*/)
+                            ],
+                            "storageKey": null
+                          },
+                          (v3/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "FulfillmentDetails",
+                        "kind": "LinkedField",
+                        "name": "fulfillmentDetails",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "PhoneNumberType",
+                            "kind": "LinkedField",
+                            "name": "phoneNumber",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "countryCode",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "regionCode",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "originalNumber",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "addressLine1",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "addressLine2",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "city",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "country",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "name",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "postalCode",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "region",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "mode",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "OrderMutationSuccess",
+                "abstractKey": null
+              },
+              (v8/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "54d116c3f8bc7fcda10b061a21de0b4f",
+    "id": null,
+    "metadata": {},
+    "name": "useSetOrderFulfillmentOptionMutation",
+    "operationKind": "mutation",
+    "text": "mutation useSetOrderFulfillmentOptionMutation(\n  $input: setOrderFulfillmentOptionInput!\n) {\n  setOrderFulfillmentOption(input: $input) {\n    orderOrError {\n      __typename\n      ... on OrderMutationSuccess {\n        order {\n          id\n          selectedFulfillmentOption {\n            type\n          }\n          internalID\n          fulfillmentOptions {\n            type\n          }\n          ...Order2CollapsibleOrderSummary_order\n          ...Order2FulfillmentDetailsStep_order\n          ...Order2ReviewStep_order\n          ...useLoadCheckout_order\n          ...Order2CheckoutLoadingSkeleton_order\n        }\n      }\n      ... on OrderMutationError {\n        mutationError {\n          message\n        }\n      }\n    }\n  }\n}\n\nfragment Order2CheckoutLoadingSkeleton_order on Order {\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  lineItems {\n    artworkVersion {\n      title\n      artistNames\n      date\n      id\n    }\n    id\n  }\n}\n\nfragment Order2CollapsibleOrderSummary_order on Order {\n  ...Order2PricingBreakdown_order\n  source\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      image {\n        resized(width: 185, height: 138) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment Order2FulfillmentDetailsStep_order on Order {\n  ...Order2PickupForm_order\n  id\n  fulfillmentDetails {\n    phoneNumber {\n      countryCode\n      regionCode\n      originalNumber\n    }\n    addressLine1\n    addressLine2\n    city\n    country\n    name\n    postalCode\n    region\n  }\n  selectedFulfillmentOption {\n    type\n  }\n  fulfillmentOptions {\n    type\n  }\n}\n\nfragment Order2PickupForm_order on Order {\n  internalID\n  fulfillmentOptions {\n    type\n  }\n  selectedFulfillmentOption {\n    type\n  }\n  fulfillmentDetails {\n    phoneNumber {\n      countryCode\n      regionCode\n      originalNumber\n    }\n  }\n}\n\nfragment Order2PricingBreakdown_order on Order {\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n}\n\nfragment Order2ReviewStep_order on Order {\n  ...Order2PricingBreakdown_order\n  mode\n  source\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      image {\n        resized(width: 185, height: 138) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment useLoadCheckout_order on Order {\n  lineItems {\n    artworkVersion {\n      internalID\n      id\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "1050ed4ecbf0d218726206dabca7224e";
+
+export default node;

--- a/src/__generated__/useSetOrderPickupDetailsMutation.graphql.ts
+++ b/src/__generated__/useSetOrderPickupDetailsMutation.graphql.ts
@@ -1,0 +1,686 @@
+/**
+ * @generated SignedSource<<e7660741d855a18a6175e11859446786>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type FulfillmentOptionTypeEnum = "DOMESTIC_FLAT" | "INTERNATIONAL_FLAT" | "PICKUP" | "SHIPPING_TBD" | "%future added value";
+export type updateOrderShippingAddressInput = {
+  buyerPhoneNumber?: string | null | undefined;
+  buyerPhoneNumberCountryCode?: string | null | undefined;
+  clientMutationId?: string | null | undefined;
+  id: string;
+  shippingAddressLine1?: string | null | undefined;
+  shippingAddressLine2?: string | null | undefined;
+  shippingCity?: string | null | undefined;
+  shippingCountry?: string | null | undefined;
+  shippingName?: string | null | undefined;
+  shippingPostalCode?: string | null | undefined;
+  shippingRegion?: string | null | undefined;
+};
+export type useSetOrderPickupDetailsMutation$variables = {
+  input: updateOrderShippingAddressInput;
+};
+export type useSetOrderPickupDetailsMutation$data = {
+  readonly updateOrderShippingAddress: {
+    readonly orderOrError: {
+      readonly __typename: "OrderMutationError";
+      readonly mutationError: {
+        readonly message: string;
+      };
+    } | {
+      readonly __typename: "OrderMutationSuccess";
+      readonly order: {
+        readonly fulfillmentDetails: {
+          readonly phoneNumber: {
+            readonly originalNumber: string | null | undefined;
+          } | null | undefined;
+        } | null | undefined;
+        readonly fulfillmentOptions: ReadonlyArray<{
+          readonly type: FulfillmentOptionTypeEnum;
+        }>;
+        readonly id: string;
+        readonly internalID: string;
+        readonly selectedFulfillmentOption: {
+          readonly type: FulfillmentOptionTypeEnum;
+        } | null | undefined;
+        readonly " $fragmentSpreads": FragmentRefs<"Order2CheckoutLoadingSkeleton_order" | "Order2CollapsibleOrderSummary_order" | "Order2FulfillmentDetailsStep_order" | "Order2ReviewStep_order" | "useLoadCheckout_order">;
+      };
+    } | {
+      // This will never be '%other', but we need some
+      // value in case none of the concrete values match.
+      readonly __typename: "%other";
+    } | null | undefined;
+  } | null | undefined;
+};
+export type useSetOrderPickupDetailsMutation = {
+  response: useSetOrderPickupDetailsMutation$data;
+  variables: useSetOrderPickupDetailsMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "originalNumber",
+  "storageKey": null
+},
+v5 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "type",
+    "storageKey": null
+  }
+],
+v6 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "FulfillmentOption",
+  "kind": "LinkedField",
+  "name": "selectedFulfillmentOption",
+  "plural": false,
+  "selections": (v5/*: any*/),
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "FulfillmentOption",
+  "kind": "LinkedField",
+  "name": "fulfillmentOptions",
+  "plural": true,
+  "selections": (v5/*: any*/),
+  "storageKey": null
+},
+v9 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "ExchangeError",
+      "kind": "LinkedField",
+      "name": "mutationError",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "message",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "OrderMutationError",
+  "abstractKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "displayName",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "amountFallbackText",
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Money",
+  "kind": "LinkedField",
+  "name": "amount",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "amount",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "currencySymbol",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v13 = [
+  (v10/*: any*/),
+  (v11/*: any*/),
+  (v12/*: any*/)
+],
+v14 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "useSetOrderPickupDetailsMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "updateOrderShippingAddressPayload",
+        "kind": "LinkedField",
+        "name": "updateOrderShippingAddress",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "orderOrError",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Order",
+                    "kind": "LinkedField",
+                    "name": "order",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "FulfillmentDetails",
+                        "kind": "LinkedField",
+                        "name": "fulfillmentDetails",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "PhoneNumberType",
+                            "kind": "LinkedField",
+                            "name": "phoneNumber",
+                            "plural": false,
+                            "selections": [
+                              (v4/*: any*/)
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      (v6/*: any*/),
+                      (v7/*: any*/),
+                      (v8/*: any*/),
+                      {
+                        "args": null,
+                        "kind": "FragmentSpread",
+                        "name": "Order2CollapsibleOrderSummary_order"
+                      },
+                      {
+                        "args": null,
+                        "kind": "FragmentSpread",
+                        "name": "Order2FulfillmentDetailsStep_order"
+                      },
+                      {
+                        "args": null,
+                        "kind": "FragmentSpread",
+                        "name": "Order2ReviewStep_order"
+                      },
+                      {
+                        "args": null,
+                        "kind": "FragmentSpread",
+                        "name": "useLoadCheckout_order"
+                      },
+                      {
+                        "args": null,
+                        "kind": "FragmentSpread",
+                        "name": "Order2CheckoutLoadingSkeleton_order"
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "OrderMutationSuccess",
+                "abstractKey": null
+              },
+              (v9/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "useSetOrderPickupDetailsMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "updateOrderShippingAddressPayload",
+        "kind": "LinkedField",
+        "name": "updateOrderShippingAddress",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "orderOrError",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Order",
+                    "kind": "LinkedField",
+                    "name": "order",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "FulfillmentDetails",
+                        "kind": "LinkedField",
+                        "name": "fulfillmentDetails",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "PhoneNumberType",
+                            "kind": "LinkedField",
+                            "name": "phoneNumber",
+                            "plural": false,
+                            "selections": [
+                              (v4/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "countryCode",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "regionCode",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "addressLine1",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "addressLine2",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "city",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "country",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "name",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "postalCode",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "region",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      (v6/*: any*/),
+                      (v7/*: any*/),
+                      (v8/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "pricingBreakdownLines",
+                        "plural": true,
+                        "selections": [
+                          (v2/*: any*/),
+                          {
+                            "kind": "InlineFragment",
+                            "selections": (v13/*: any*/),
+                            "type": "ShippingLine",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": (v13/*: any*/),
+                            "type": "TaxLine",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v10/*: any*/),
+                              (v12/*: any*/)
+                            ],
+                            "type": "SubtotalLine",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              (v10/*: any*/),
+                              (v11/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Money",
+                                "kind": "LinkedField",
+                                "name": "amount",
+                                "plural": false,
+                                "selections": (v14/*: any*/),
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "TotalLine",
+                            "abstractKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "source",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Money",
+                        "kind": "LinkedField",
+                        "name": "buyerTotal",
+                        "plural": false,
+                        "selections": (v14/*: any*/),
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Money",
+                        "kind": "LinkedField",
+                        "name": "itemsTotal",
+                        "plural": false,
+                        "selections": (v14/*: any*/),
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Money",
+                        "kind": "LinkedField",
+                        "name": "shippingTotal",
+                        "plural": false,
+                        "selections": (v14/*: any*/),
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Money",
+                        "kind": "LinkedField",
+                        "name": "taxTotal",
+                        "plural": false,
+                        "selections": (v14/*: any*/),
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "LineItem",
+                        "kind": "LinkedField",
+                        "name": "lineItems",
+                        "plural": true,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Artwork",
+                            "kind": "LinkedField",
+                            "name": "artwork",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "slug",
+                                "storageKey": null
+                              },
+                              (v3/*: any*/)
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ArtworkVersion",
+                            "kind": "LinkedField",
+                            "name": "artworkVersion",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "title",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "artistNames",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "date",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Image",
+                                "kind": "LinkedField",
+                                "name": "image",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": [
+                                      {
+                                        "kind": "Literal",
+                                        "name": "height",
+                                        "value": 138
+                                      },
+                                      {
+                                        "kind": "Literal",
+                                        "name": "width",
+                                        "value": 185
+                                      }
+                                    ],
+                                    "concreteType": "ResizedImageUrl",
+                                    "kind": "LinkedField",
+                                    "name": "resized",
+                                    "plural": false,
+                                    "selections": [
+                                      {
+                                        "alias": null,
+                                        "args": null,
+                                        "kind": "ScalarField",
+                                        "name": "url",
+                                        "storageKey": null
+                                      }
+                                    ],
+                                    "storageKey": "resized(height:138,width:185)"
+                                  }
+                                ],
+                                "storageKey": null
+                              },
+                              (v3/*: any*/),
+                              (v7/*: any*/)
+                            ],
+                            "storageKey": null
+                          },
+                          (v3/*: any*/)
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "mode",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "OrderMutationSuccess",
+                "abstractKey": null
+              },
+              (v9/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "bec529bd028fab3ff93658054fa3657b",
+    "id": null,
+    "metadata": {},
+    "name": "useSetOrderPickupDetailsMutation",
+    "operationKind": "mutation",
+    "text": "mutation useSetOrderPickupDetailsMutation(\n  $input: updateOrderShippingAddressInput!\n) {\n  updateOrderShippingAddress(input: $input) {\n    orderOrError {\n      __typename\n      ... on OrderMutationSuccess {\n        order {\n          id\n          fulfillmentDetails {\n            phoneNumber {\n              originalNumber\n            }\n          }\n          selectedFulfillmentOption {\n            type\n          }\n          internalID\n          fulfillmentOptions {\n            type\n          }\n          ...Order2CollapsibleOrderSummary_order\n          ...Order2FulfillmentDetailsStep_order\n          ...Order2ReviewStep_order\n          ...useLoadCheckout_order\n          ...Order2CheckoutLoadingSkeleton_order\n        }\n      }\n      ... on OrderMutationError {\n        mutationError {\n          message\n        }\n      }\n    }\n  }\n}\n\nfragment Order2CheckoutLoadingSkeleton_order on Order {\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  lineItems {\n    artworkVersion {\n      title\n      artistNames\n      date\n      id\n    }\n    id\n  }\n}\n\nfragment Order2CollapsibleOrderSummary_order on Order {\n  ...Order2PricingBreakdown_order\n  source\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      image {\n        resized(width: 185, height: 138) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment Order2FulfillmentDetailsStep_order on Order {\n  ...Order2PickupForm_order\n  id\n  fulfillmentDetails {\n    phoneNumber {\n      countryCode\n      regionCode\n      originalNumber\n    }\n    addressLine1\n    addressLine2\n    city\n    country\n    name\n    postalCode\n    region\n  }\n  selectedFulfillmentOption {\n    type\n  }\n  fulfillmentOptions {\n    type\n  }\n}\n\nfragment Order2PickupForm_order on Order {\n  internalID\n  fulfillmentOptions {\n    type\n  }\n  selectedFulfillmentOption {\n    type\n  }\n  fulfillmentDetails {\n    phoneNumber {\n      countryCode\n      regionCode\n      originalNumber\n    }\n  }\n}\n\nfragment Order2PricingBreakdown_order on Order {\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n}\n\nfragment Order2ReviewStep_order on Order {\n  ...Order2PricingBreakdown_order\n  mode\n  source\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      image {\n        resized(width: 185, height: 138) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment useLoadCheckout_order on Order {\n  lineItems {\n    artworkVersion {\n      internalID\n      id\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "6e9e8d660dda6722fc508bf79e0467aa";
+
+export default node;


### PR DESCRIPTION
The type of this PR is: **feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2469]

### Description

This PR allows a user to set a pickup fulfillment type and save the details (their phone number) to the order.

<!-- Implementation description -->
**Implementation details**
- We save the phone number country code value (like `us` or `de` in lower case) to the `order.buyer_phone_number_country_code`. Historically we haven't saved these very often. It's possible that express checkout does it (or does it but differently), and it's possible we want to save something else like the `+1` number. However, this is what we save to users in gravity.
- I implemented a bare minimum checkout state management system - when fulfillment details get set, transition to the completed view of the step. When clicking edit on that view, transition back to the active version of the step. This will evolve quickly.
- Tests are in place but mainly in the one big route test file. Migrating them shouldn't be hard.


[EMI-2469]: https://artsyproduct.atlassian.net/browse/EMI-2469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ