### PR TITLE
feat: continue implementation for Summary component on order details page

### DIFF
--- a/src/Apps/Order/__tests__/OrderApp.jest.enzyme.tsx
+++ b/src/Apps/Order/__tests__/OrderApp.jest.enzyme.tsx
@@ -159,25 +159,18 @@ describe("OrderApp routing redirects", () => {
       expect(res.redirect.url).toBe("/orders2/2939023/details")
     })
 
-    it("does not redirect from the legacy status page to the new details page for a submitted order if the order is OFFER mode", async () => {
+    it("redirects from the legacy status page to the new details page for a submitted order if the order is OFFER mode", async () => {
       featureFlags.isEnabled.mockReturnValue(true)
-      let threw = false
-      try {
-        await render(
-          "/orders/2939023/status",
-          mockResolver({
-            ...BuyOrderPickup,
-            mode: "OFFER",
-            state: "SUBMITTED",
-            displayState: "SUBMITTED",
-          }),
-        )
-      } catch (error) {
-        threw = true
-        // eslint-disable-next-line jest/no-conditional-expect, jest/no-try-expect
-        expect(error.message).toBe("No redirect found for order")
-      }
-      expect(threw).toBe(true)
+      const res = await render(
+        "/orders/2939023/status",
+        mockResolver({
+          ...BuyOrderPickup,
+          mode: "OFFER",
+          state: "SUBMITTED",
+          displayState: "SUBMITTED",
+        }),
+      )
+      expect(res.redirect.url).toBe("/orders2/2939023/details")
     })
   })
 

--- a/src/Apps/Order/redirects.tsx
+++ b/src/Apps/Order/redirects.tsx
@@ -219,7 +219,7 @@ export const newDetailsEnabled = ({
   featureFlags,
 }: Order2RedirectArgs): boolean => {
   return !!(
-    order.mode === "BUY" &&
+    (order.mode === "BUY" || order.mode === "OFFER") &&
     featureFlags?.isEnabled?.("emerald_order-details-page")
   )
 }

--- a/src/Apps/Order2/Routes/Details/Components/Order2DetailsHeader.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/Order2DetailsHeader.tsx
@@ -12,7 +12,7 @@ export const Order2DetailsHeader = ({ order }: Order2DetailsHeaderProps) => {
   return (
     <>
       {/* Title */}
-      <Text variant="lg">{orderData.displayTexts.titleText}</Text>
+      <Text variant="lg">{orderData.displayTexts.title}</Text>
       {/* Order # */}
       <Text variant="xs">Order #{orderData.code} </Text>
     </>
@@ -23,7 +23,7 @@ const FRAGMENT = graphql`
   fragment Order2DetailsHeader_order on Order {
     code
     displayTexts {
-      titleText
+      title
     }
   }
 `

--- a/src/Apps/Order2/Routes/Details/Components/Order2DetailsMessage.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/Order2DetailsMessage.tsx
@@ -1,0 +1,40 @@
+import { Stack, Text } from "@artsy/palette"
+import type { Order2DetailsMessage_order$key } from "__generated__/Order2DetailsMessage_order.graphql"
+import { graphql, useFragment } from "react-relay"
+
+interface Order2DetailsMessageProps {
+  order: Order2DetailsMessage_order$key
+}
+
+export const Order2DetailsMessage = ({ order }: Order2DetailsMessageProps) => {
+  const orderData = useFragment(FRAGMENT, order)
+
+  return (
+    <Stack gap={1}>
+      {orderData.displayTexts.message && (
+        <Text
+          variant="sm"
+          dangerouslySetInnerHTML={{
+            __html: orderData.displayTexts.message,
+          }}
+        />
+      )}
+
+      <Text variant="sm">
+        You will be notified when the work has shipped, typically within 5-7
+        business days.
+      </Text>
+      <Text variant="sm">
+        You can contact the gallery with any questions about your order.
+      </Text>
+    </Stack>
+  )
+}
+
+const FRAGMENT = graphql`
+  fragment Order2DetailsMessage_order on Order {
+    displayTexts {
+      message
+    }
+  }
+`

--- a/src/Apps/Order2/Routes/Details/Components/Order2DetailsMessage.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/Order2DetailsMessage.tsx
@@ -19,14 +19,6 @@ export const Order2DetailsMessage = ({ order }: Order2DetailsMessageProps) => {
           }}
         />
       )}
-
-      <Text variant="sm">
-        You will be notified when the work has shipped, typically within 5-7
-        business days.
-      </Text>
-      <Text variant="sm">
-        You can contact the gallery with any questions about your order.
-      </Text>
     </Stack>
   )
 }

--- a/src/Apps/Order2/Routes/Details/Components/Order2DetailsPage.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/Order2DetailsPage.tsx
@@ -17,6 +17,7 @@ import { type Brand, BrandCreditCardIcon } from "Components/BrandCreditCardIcon"
 import type { Order2DetailsPage_order$key } from "__generated__/Order2DetailsPage_order.graphql"
 import { graphql, useFragment } from "react-relay"
 import { Order2DetailsHeader } from "./Order2DetailsHeader"
+import { Order2DetailsMessage } from "./Order2DetailsMessage"
 
 interface Order2DetailsPageProps {
   order: Order2DetailsPage_order$key
@@ -33,18 +34,9 @@ export const Order2DetailsPage = ({ order }: Order2DetailsPageProps) => {
         </Box>
 
         {/* Message */}
-        <Stack gap={1} m={2}>
-          <Text variant="sm">
-            Your order has been confirmed. Thank you for your purchase.
-          </Text>
-          <Text variant="sm">
-            You will be notified when the work has shipped, typically within 5-7
-            business days.
-          </Text>
-          <Text variant="sm">
-            You can contact the gallery with any questions about your order.
-          </Text>
-        </Stack>
+        <Box m={2}>
+          <Order2DetailsMessage order={orderData} />
+        </Box>
 
         {/* Full Order Summary */}
         <Box m={2}>
@@ -204,6 +196,7 @@ export const Order2DetailsPage = ({ order }: Order2DetailsPageProps) => {
 const FRAGMENT = graphql`
   fragment Order2DetailsPage_order on Order {
     ...Order2DetailsHeader_order
+    ...Order2DetailsMessage_order
   }
 `
 

--- a/src/Apps/Order2/Routes/Details/Components/__tests__/Order2DetailsPage.jest.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/__tests__/Order2DetailsPage.jest.tsx
@@ -36,6 +36,6 @@ const orderData = {
   internalID: "a5aaa8b0-93ff-4f2a-8bb3-9589f378d229",
   code: "123",
   displayTexts: {
-    titleText: "Test Order Title",
+    title: "Test Order Title",
   },
 }

--- a/src/__generated__/Order2DetailsHeader_order.graphql.ts
+++ b/src/__generated__/Order2DetailsHeader_order.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<68ea1902f9d517af2184de87eff8f4c8>>
+ * @generated SignedSource<<d425c4481da5ae52ce148675aabf2a91>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -58,6 +58,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "cd083827d41bc82288815e03e8096e50";
+(node as any).hash = "5fd40254975455c949309bf42c5ada19";
 
 export default node;

--- a/src/__generated__/Order2DetailsMessage_order.graphql.ts
+++ b/src/__generated__/Order2DetailsMessage_order.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<68ea1902f9d517af2184de87eff8f4c8>>
+ * @generated SignedSource<<8f5540c8e6e0049f9e08b805375dd1b0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,31 +10,23 @@
 
 import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type Order2DetailsHeader_order$data = {
-  readonly code: string;
+export type Order2DetailsMessage_order$data = {
   readonly displayTexts: {
-    readonly title: string;
+    readonly message: string | null | undefined;
   };
-  readonly " $fragmentType": "Order2DetailsHeader_order";
+  readonly " $fragmentType": "Order2DetailsMessage_order";
 };
-export type Order2DetailsHeader_order$key = {
-  readonly " $data"?: Order2DetailsHeader_order$data;
-  readonly " $fragmentSpreads": FragmentRefs<"Order2DetailsHeader_order">;
+export type Order2DetailsMessage_order$key = {
+  readonly " $data"?: Order2DetailsMessage_order$data;
+  readonly " $fragmentSpreads": FragmentRefs<"Order2DetailsMessage_order">;
 };
 
 const node: ReaderFragment = {
   "argumentDefinitions": [],
   "kind": "Fragment",
   "metadata": null,
-  "name": "Order2DetailsHeader_order",
+  "name": "Order2DetailsMessage_order",
   "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "code",
-      "storageKey": null
-    },
     {
       "alias": null,
       "args": null,
@@ -47,7 +39,7 @@ const node: ReaderFragment = {
           "alias": null,
           "args": null,
           "kind": "ScalarField",
-          "name": "title",
+          "name": "message",
           "storageKey": null
         }
       ],
@@ -58,6 +50,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "cd083827d41bc82288815e03e8096e50";
+(node as any).hash = "51a67c6c6a3523b5139720fd28bc1e24";
 
 export default node;

--- a/src/__generated__/Order2DetailsMessage_order.graphql.ts
+++ b/src/__generated__/Order2DetailsMessage_order.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8f5540c8e6e0049f9e08b805375dd1b0>>
+ * @generated SignedSource<<22a9c059468c774ce3eaa25af5958743>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -50,6 +50,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "51a67c6c6a3523b5139720fd28bc1e24";
+(node as any).hash = "23cc3c4ca3141ad617629b0acc31e381";
 
 export default node;

--- a/src/__generated__/Order2DetailsPage_Test_Query.graphql.ts
+++ b/src/__generated__/Order2DetailsPage_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<833854ddb0f7358595a4a923c5dc465a>>
+ * @generated SignedSource<<b50ba5a94821f4f84208a5e6492d7486>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -24,7 +24,8 @@ export type Order2DetailsPage_Test_Query$rawResponse = {
     readonly order: {
       readonly code: string;
       readonly displayTexts: {
-        readonly titleText: string;
+        readonly message: string | null | undefined;
+        readonly title: string;
       };
       readonly id: string;
     } | null | undefined;
@@ -130,7 +131,14 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
-                    "name": "titleText",
+                    "name": "title",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "message",
                     "storageKey": null
                   }
                 ],
@@ -147,12 +155,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e600145f28d495bb25e408340926acb7",
+    "cacheID": "741b5426c47869afe81a3a3ce0f0091f",
     "id": null,
     "metadata": {},
     "name": "Order2DetailsPage_Test_Query",
     "operationKind": "query",
-    "text": "query Order2DetailsPage_Test_Query {\n  me {\n    order(id: \"123\") {\n      ...Order2DetailsPage_order\n      id\n    }\n    id\n  }\n}\n\nfragment Order2DetailsHeader_order on Order {\n  code\n  displayTexts {\n    titleText\n  }\n}\n\nfragment Order2DetailsPage_order on Order {\n  ...Order2DetailsHeader_order\n}\n"
+    "text": "query Order2DetailsPage_Test_Query {\n  me {\n    order(id: \"123\") {\n      ...Order2DetailsPage_order\n      id\n    }\n    id\n  }\n}\n\nfragment Order2DetailsHeader_order on Order {\n  code\n  displayTexts {\n    title\n  }\n}\n\nfragment Order2DetailsMessage_order on Order {\n  displayTexts {\n    message\n  }\n}\n\nfragment Order2DetailsPage_order on Order {\n  ...Order2DetailsHeader_order\n  ...Order2DetailsMessage_order\n}\n"
   }
 };
 })();

--- a/src/__generated__/Order2DetailsPage_Test_Query.graphql.ts
+++ b/src/__generated__/Order2DetailsPage_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b50ba5a94821f4f84208a5e6492d7486>>
+ * @generated SignedSource<<5547f08ccbad9c710f3ddf3ca5d14760>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -155,7 +155,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "741b5426c47869afe81a3a3ce0f0091f",
+    "cacheID": "ffc71040de61e36fb3cc2d6e595a613c",
     "id": null,
     "metadata": {},
     "name": "Order2DetailsPage_Test_Query",

--- a/src/__generated__/Order2DetailsPage_order.graphql.ts
+++ b/src/__generated__/Order2DetailsPage_order.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5755b15aa06f3ddf93c927a8e68bf32d>>
+ * @generated SignedSource<<2e40f0b9d5cb9c1c2b868ada4a1c7a7a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,7 +11,7 @@
 import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type Order2DetailsPage_order$data = {
-  readonly " $fragmentSpreads": FragmentRefs<"Order2DetailsHeader_order">;
+  readonly " $fragmentSpreads": FragmentRefs<"Order2DetailsHeader_order" | "Order2DetailsMessage_order">;
   readonly " $fragmentType": "Order2DetailsPage_order";
 };
 export type Order2DetailsPage_order$key = {
@@ -29,12 +29,17 @@ const node: ReaderFragment = {
       "args": null,
       "kind": "FragmentSpread",
       "name": "Order2DetailsHeader_order"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "Order2DetailsMessage_order"
     }
   ],
   "type": "Order",
   "abstractKey": null
 };
 
-(node as any).hash = "9e784a949b20bce2d7f81e5fe3ea3f50";
+(node as any).hash = "9421ef50cceec1037a7e14edd8a587d2";
 
 export default node;

--- a/src/__generated__/order2Routes_DetailsQuery.graphql.ts
+++ b/src/__generated__/order2Routes_DetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4a8903628f480f7369a09868405e3b8d>>
+ * @generated SignedSource<<d6690110b2a88a141fd48a415097e1ae>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -172,7 +172,14 @@ return {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
-                        "name": "titleText",
+                        "name": "titleT",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "message",
                         "storageKey": null
                       }
                     ],
@@ -194,12 +201,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "752951689219d899229f8b4eac41d612",
+    "cacheID": "a4a72747bea290ae64ead81c29d11b2d",
     "id": null,
     "metadata": {},
     "name": "order2Routes_DetailsQuery",
     "operationKind": "query",
-    "text": "query order2Routes_DetailsQuery(\n  $orderID: String!\n) {\n  viewer {\n    ...Order2DetailsRoute_viewer_3HPek8\n    me {\n      order(id: $orderID) {\n        internalID\n        mode\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment Order2DetailsHeader_order on Order {\n  code\n  displayTexts {\n    titleText\n  }\n}\n\nfragment Order2DetailsPage_order on Order {\n  ...Order2DetailsHeader_order\n}\n\nfragment Order2DetailsRoute_viewer_3HPek8 on Viewer {\n  me {\n    order(id: $orderID) {\n      ...Order2DetailsPage_order\n      internalID\n      id\n    }\n    id\n  }\n}\n"
+    "text": "query order2Routes_DetailsQuery(\n  $orderID: String!\n) {\n  viewer {\n    ...Order2DetailsRoute_viewer_3HPek8\n    me {\n      order(id: $orderID) {\n        internalID\n        mode\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment Order2DetailsHeader_order on Order {\n  code\n  displayTexts {\n    title\n  }\n}\n\nfragment Order2DetailsMessage_order on Order {\n  displayTexts {\n    message\n  }\n}\n\nfragment Order2DetailsPage_order on Order {\n  ...Order2DetailsHeader_order\n  ...Order2DetailsMessage_order\n}\n\nfragment Order2DetailsRoute_viewer_3HPek8 on Viewer {\n  me {\n    order(id: $orderID) {\n      ...Order2DetailsPage_order\n      internalID\n      id\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/order2Routes_DetailsQuery.graphql.ts
+++ b/src/__generated__/order2Routes_DetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d6690110b2a88a141fd48a415097e1ae>>
+ * @generated SignedSource<<bd42a90da64d2b1af275d0497a8a0772>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -172,7 +172,7 @@ return {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
-                        "name": "titleT",
+                        "name": "title",
                         "storageKey": null
                       },
                       {
@@ -201,7 +201,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a4a72747bea290ae64ead81c29d11b2d",
+    "cacheID": "12ea1257a0d04fdaa567bb12affe47ac",
     "id": null,
     "metadata": {},
     "name": "order2Routes_DetailsQuery",


### PR DESCRIPTION
This is mainly to bring the strings that we've created in MP for this summary.

I'm also relaxing the requirement for redirect to happen only for BuyNow orders as we would need to test the messaging for offers as well (the plan is to release those together).
