### PR TITLE
fix: fixes content from sitting behind gradient overlay

### DIFF
--- a/src/Apps/BuyerGuarantee/Routes/BuyerGuaranteeIndex.tsx
+++ b/src/Apps/BuyerGuarantee/Routes/BuyerGuaranteeIndex.tsx
@@ -5,6 +5,7 @@ import MessageIcon from "@artsy/icons/MessageIcon"
 import MoneyBackIcon from "@artsy/icons/MoneyBackIcon"
 import VerifiedIcon from "@artsy/icons/VerifiedIcon"
 import {
+  Box,
   Button,
   Column,
   Flex,
@@ -21,10 +22,7 @@ import {
 } from "Apps/BuyerGuarantee/Components/BuyerGuaranteeTables"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
-import {
-  FullBleedHeader,
-  FullBleedHeaderOverlay,
-} from "Components/FullBleedHeader/FullBleedHeader"
+import { FullBleedHeader } from "Components/FullBleedHeader/FullBleedHeader"
 import { MetaTags } from "Components/MetaTags"
 import { Jump, useJump } from "Utils/Hooks/useJump"
 import { __internal__useMatchMedia } from "Utils/Hooks/useMatchMedia"
@@ -51,10 +49,17 @@ export const BuyerGuaranteeIndex: FC<React.PropsWithChildren<unknown>> = () => {
         src="https://files.artsy.net/images/normalizedheaderimage.jpeg"
         caption="Sophie Treppendahl, Swimming Hole, 2019. Courtesy of the artist and Kenise Barnes Fine Art."
       >
-        <FullBleedHeaderOverlay
+        <Box
+          position="absolute"
+          top={0}
+          left={0}
+          width="100%"
+          height="100%"
+          display="flex"
           alignItems="center"
           justifyContent={["center", "flex-start"]}
           p={4}
+          zIndex={1}
         >
           <Text
             variant={["xl", "xxl"]}
@@ -64,7 +69,7 @@ export const BuyerGuaranteeIndex: FC<React.PropsWithChildren<unknown>> = () => {
           >
             The Artsy Guarantee
           </Text>
-        </FullBleedHeaderOverlay>
+        </Box>
       </FullBleedHeader>
 
       <Spacer y={6} />

--- a/src/Apps/InstitutionPartnerships/Components/InstitutionPartnershipsHero.tsx
+++ b/src/Apps/InstitutionPartnerships/Components/InstitutionPartnershipsHero.tsx
@@ -1,6 +1,7 @@
-import { Box, Button, Column, GridColumns, Spacer, Text } from "@artsy/palette"
+import { Button, Column, GridColumns, Spacer, Text } from "@artsy/palette"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
+import { FullBleedHeaderOverlay } from "Components/FullBleedHeader/FullBleedHeader"
 import { FullBleedHeaderFader } from "Components/FullBleedHeader/FullBleedHeaderFader"
 import type { FC } from "react"
 
@@ -9,7 +10,7 @@ export const InstitutionPartnershipsHero: FC<
 > = () => {
   return (
     <FullBleedHeaderFader figures={FIGURES}>
-      <Box position="absolute" top={0} left={0} width="100%" height="100%">
+      <FullBleedHeaderOverlay zIndex={1}>
         <AppContainer height="100%">
           <HorizontalPadding
             display="flex"
@@ -31,7 +32,7 @@ export const InstitutionPartnershipsHero: FC<
                   and over 700 major museums and institutions worldwide.
                 </Text>
 
-                <Spacer y={[4, 6]} />
+                <Spacer y={4} />
 
                 <Button
                   size={["small", "large"]}
@@ -47,7 +48,7 @@ export const InstitutionPartnershipsHero: FC<
             </GridColumns>
           </HorizontalPadding>
         </AppContainer>
-      </Box>
+      </FullBleedHeaderOverlay>
     </FullBleedHeaderFader>
   )
 }


### PR DESCRIPTION
Noticed that content was sitting behind an overlay gradient in a few places. These headers were never really designed to have significant content in them. In the case of https://www.artsy.net/institution-partnerships the "Apply to Join" link wasn't even clickable. I think that also might be linking to a dead page (raised in Slack).