### PR TITLE
chore: alternative approach to rendering messages on order details page

### DIFF
--- a/src/Apps/Order2/Routes/Details/Components/Order2DetailsMessage2.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/Order2DetailsMessage2.tsx
@@ -1,0 +1,325 @@
+import { Box, Flex, Link, Spacer, Text } from "@artsy/palette"
+import { RouterLink } from "System/Components/RouterLink"
+import type {
+  DisplayTextsMessageTypeEnum,
+  Order2DetailsMessage2_order$key,
+} from "__generated__/Order2DetailsMessage2_order.graphql"
+import { graphql, useFragment } from "react-relay"
+
+interface Order2DetailsMessage2Props {
+  order: Order2DetailsMessage2_order$key
+}
+
+export const Order2DetailsMessage2 = ({
+  order,
+}: Order2DetailsMessage2Props) => {
+  const orderData = useFragment(FRAGMENT, order)
+
+  return getMessageContent(orderData)
+}
+
+const NumberedListItem: React.FC<{
+  children: React.ReactNode
+  index: number
+}> = ({ children, index }) => (
+  <Flex flexDirection="row">
+    <Flex minWidth={20}>
+      <Text>{index}.</Text>
+    </Flex>
+    <Flex>{children}</Flex>
+  </Flex>
+)
+
+const getMessageContent = (order, logger?): React.ReactNode => {
+  const messageType: DisplayTextsMessageTypeEnum =
+    order.displayTexts.messageType
+
+  const formattedStateExpireTime =
+    order.buyerStateExpiresAt &&
+    new Date(order.buyerStateExpiresAt).toLocaleDateString("en-US", {
+      month: "short",
+      day: "numeric",
+      hour: "numeric",
+      minute: "numeric",
+      hour12: true,
+      timeZoneName: "short",
+    })
+
+  switch (messageType) {
+    case "SUBMITTED_ORDER":
+      return (
+        <>
+          <Text variant="sm">
+            Thank you! Your order is being processed. You will receive an email
+            shortly with all the details.
+          </Text>
+          <Spacer y={2} />
+          <Text variant="sm">
+            The gallery will confirm by {formattedStateExpireTime}.
+          </Text>
+          <Text variant="sm">
+            You can <Link>contact the gallery</Link> with any questions about
+            your order.
+          </Text>
+        </>
+      )
+    case "SUBMITTED_OFFER":
+      return (
+        <>
+          <Text variant="sm">
+            Thank you! Your offer has been submitted. You will receive an email
+            shortly with all the details. Please note making an offer doesn’t
+            guarantee you the work.
+          </Text>
+          <Spacer y={2} />
+          <Text variant="sm">
+            The gallery will confirm by {formattedStateExpireTime}.
+          </Text>
+          <Text variant="sm">
+            You can <Link>contact the gallery</Link> with any questions about
+            your order.
+          </Text>
+        </>
+      )
+    case "PAYMENT_FAILED":
+      return (
+        <>
+          <Text variant="sm">
+            To complete your purchase, please{" "}
+            <RouterLink to={`/orders/${order.internalID}/payment/new`}>
+              update your payment details
+            </RouterLink>{" "}
+            or provide an alternative payment method by{" "}
+            {formattedStateExpireTime}.
+          </Text>
+        </>
+      )
+    case "PROCESSING_PAYMENT_PICKUP":
+      return (
+        <Text variant="sm">
+          Thank you for your purchase. You will be notified when the work is
+          available for pickup.
+        </Text>
+      )
+    case "PROCESSING_PAYMENT_SHIP":
+      return (
+        <Text variant="sm">
+          Thank you for your purchase. You will be notified when the work has
+          shipped.
+        </Text>
+      )
+    case "PROCESSING_WIRE":
+      return (
+        <>
+          <Text variant="sm">
+            Your order has been confirmed. Thank you for your purchase.
+          </Text>
+          <Spacer y={2} />
+          <Text variant="sm" fontWeight="bold">
+            Please proceed with the wire transfer within 7 days to complete your
+            purchase.
+          </Text>
+          <Spacer y={1} />
+          <NumberedListItem index={1}>
+            Find the total amount due and Artsy's banking details below.
+          </NumberedListItem>
+          <NumberedListItem index={2}>
+            Please inform your bank that you are responsible for all wire
+            transfer fees.
+          </NumberedListItem>
+          <NumberedListItem index={3}>
+            <Text>
+              Please make the transfer in the currency displayed on the order
+              breakdown and then email proof of payment to{" "}
+              <RouterLink to="mailto:orders@artsy.net" display="inline">
+                orders@artsy.net
+              </RouterLink>
+              .
+            </Text>
+          </NumberedListItem>
+          <Spacer y={2} />
+          <Box border="1px solid" borderColor="mono15" p={2}>
+            <Text variant="sm" fontWeight="bold">
+              Send wire transfer to
+            </Text>
+            <Spacer y={1} />
+            <Text variant="sm">
+              Account name: Art.sy Inc.
+              <br />
+              Account number: 424385142
+              <br />
+              Routing number: 121000248
+              <br />
+              International SWIFT: WFBIUS6S
+            </Text>
+            <Spacer y={4} />
+            <Text variant="sm" fontWeight="bold">
+              Bank address
+            </Text>
+            <Spacer y={1} />
+            <Text variant="sm">
+              Wells Fargo Bank, N.A.
+              <br />
+              420 Montgomery Street
+              <br />
+              San Francisco, CA 9410
+            </Text>
+            <Spacer y={4} />
+            <Text variant="sm" fontWeight="bold">
+              Add order #{order.code} to the notes section in your wire
+              transfer.
+            </Text>
+            <Spacer y={1} />
+            <Text variant="sm">
+              If your bank account is not in USD, please reference Artsy’s
+              intermediary bank ING Brussels (Intermediary Bank BIC/SWIFT:
+              PNBPUS3NNYC) along with Artsy’s international SWIFT (WFBIUS6S)
+              when making payment. Ask your bank for further instructions.
+            </Text>
+          </Box>
+        </>
+      )
+    case "APPROVED_PICKUP":
+      return (
+        <>
+          <Text variant="sm">
+            Thank you for your purchase. A specialist will contact you within 2
+            business days to coordinate pickup.
+          </Text>
+          <Text variant="sm">
+            You can <Link>contact the gallery</Link> with any questions about
+            your order.
+          </Text>
+        </>
+      )
+    case "APPROVED_SHIP_EXPRESS":
+      return (
+        <>
+          <Text variant="sm">
+            Your order has been confirmed. Thank you for your purchase.
+          </Text>
+          <Spacer y={2} />
+          <Text variant="sm">
+            Your order will be processed and packaged, and you will be notified
+            once it ships.
+          </Text>
+          <Text variant="sm">
+            Once shipped, your order will be delivered in 2 business days.
+          </Text>
+        </>
+      )
+    case "APPROVED_SHIP_STANDARD":
+      return (
+        <>
+          <Text variant="sm">
+            Your order has been confirmed. Thank you for your purchase.
+          </Text>
+          <Spacer y={2} />
+          <Text variant="sm">
+            Your order will be processed and packaged, and you will be notified
+            once it ships.
+          </Text>
+          <Text variant="sm">
+            Once shipped, your order will be delivered in 3-5 business days.
+          </Text>
+        </>
+      )
+    case "APPROVED_SHIP_WHITE_GLOVE":
+      return (
+        <>
+          <Text variant="sm">
+            Your order has been confirmed. Thank you for your purchase.
+          </Text>
+          <Spacer y={2} />
+          <Text variant="sm">
+            Once shipped, you will receive a notification and further details.
+          </Text>
+          <Text variant="sm">
+            You can contact{" "}
+            <RouterLink to="mailto:orders@artsy.net" display="inline">
+              orders@artsy.net
+            </RouterLink>{" "}
+            with any questions.
+          </Text>
+        </>
+      )
+    case "APPROVED_SHIP":
+      return (
+        <>
+          <Text variant="sm">
+            Your order has been confirmed. Thank you for your purchase.
+          </Text>
+          <Spacer y={2} />
+          <Text variant="sm">
+            You will be notified when the work has shipped, typically within 5-7
+            business days.
+          </Text>
+          <Text variant="sm">
+            You can contact{" "}
+            <RouterLink to="mailto:orders@artsy.net" display="inline">
+              orders@artsy.net
+            </RouterLink>{" "}
+            with any questions.
+          </Text>
+        </>
+      )
+    case "SHIPPED":
+      return (
+        <>
+          <Text variant="sm">Your work is on its way.</Text>
+          {/* TODO: Add shipping tracking info when available */}
+          <Spacer y={2} />
+          <Text variant="sm">
+            This artwork will be added to your Collection on Artsy. You can view
+            and manage all your artworks on the Artsy app, available in the{" "}
+            <Link href="#">Apple App Store</Link> and{" "}
+            <Link href="#">Google Play Store</Link>.
+          </Text>
+        </>
+      )
+    case "COMPLETED_PICKUP":
+    case "COMPLETED_SHIP":
+      return (
+        <>
+          <Text variant="sm">We hope you love your purchase!</Text>
+          <Text variant="sm">
+            Your feedback is valuable—share any thoughts with us at
+            <RouterLink to="mailto:orders@artsy.net" display="inline">
+              orders@artsy.net
+            </RouterLink>{" "}
+            .
+          </Text>
+          <Spacer y={2} />
+          <Text variant="sm">
+            This artwork will be added to your Collection on Artsy. You can view
+            and manage all your artworks on the Artsy app, available in the{" "}
+            <Link href="#">Apple App Store</Link> and{" "}
+            <Link href="#">Google Play Store</Link>.
+          </Text>
+        </>
+      )
+    case "CANCELLED_ORDER":
+      return (
+        <Text variant="sm">
+          You can contact{" "}
+          <RouterLink to="mailto:orders@artsy.net" display="inline">
+            orders@artsy.net
+          </RouterLink>{" "}
+          with any questions.
+        </Text>
+      )
+    default:
+      return ""
+  }
+}
+
+const FRAGMENT = graphql`
+  fragment Order2DetailsMessage2_order on Order {
+    buyerStateExpiresAt
+    code
+    internalID
+    displayTexts {
+      messageType
+    }
+  }
+`

--- a/src/Apps/Order2/Routes/Details/Components/Order2DetailsPage.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/Order2DetailsPage.tsx
@@ -17,7 +17,7 @@ import { type Brand, BrandCreditCardIcon } from "Components/BrandCreditCardIcon"
 import type { Order2DetailsPage_order$key } from "__generated__/Order2DetailsPage_order.graphql"
 import { graphql, useFragment } from "react-relay"
 import { Order2DetailsHeader } from "./Order2DetailsHeader"
-import { Order2DetailsMessage } from "./Order2DetailsMessage"
+import { Order2DetailsMessage2 } from "./Order2DetailsMessage2"
 
 interface Order2DetailsPageProps {
   order: Order2DetailsPage_order$key
@@ -35,7 +35,7 @@ export const Order2DetailsPage = ({ order }: Order2DetailsPageProps) => {
 
         {/* Message */}
         <Box m={2}>
-          <Order2DetailsMessage order={orderData} />
+          <Order2DetailsMessage2 order={orderData} />
         </Box>
 
         {/* Full Order Summary */}
@@ -196,7 +196,7 @@ export const Order2DetailsPage = ({ order }: Order2DetailsPageProps) => {
 const FRAGMENT = graphql`
   fragment Order2DetailsPage_order on Order {
     ...Order2DetailsHeader_order
-    ...Order2DetailsMessage_order
+    ...Order2DetailsMessage2_order
   }
 `
 

--- a/src/__generated__/Order2DetailsMessage2_order.graphql.ts
+++ b/src/__generated__/Order2DetailsMessage2_order.graphql.ts
@@ -1,0 +1,80 @@
+/**
+ * @generated SignedSource<<dc12ed4140c37794acb30e0b975aec67>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type DisplayTextsMessageTypeEnum = "APPROVED_PICKUP" | "APPROVED_SHIP" | "APPROVED_SHIP_EXPRESS" | "APPROVED_SHIP_STANDARD" | "APPROVED_SHIP_WHITE_GLOVE" | "CANCELLED_ORDER" | "COMPLETED_PICKUP" | "COMPLETED_SHIP" | "PAYMENT_FAILED" | "PROCESSING_PAYMENT_PICKUP" | "PROCESSING_PAYMENT_SHIP" | "PROCESSING_WIRE" | "SHIPPED" | "SUBMITTED_OFFER" | "SUBMITTED_ORDER" | "UNKNOWN" | "%future added value";
+import { FragmentRefs } from "relay-runtime";
+export type Order2DetailsMessage2_order$data = {
+  readonly buyerStateExpiresAt: string | null | undefined;
+  readonly code: string;
+  readonly displayTexts: {
+    readonly messageType: DisplayTextsMessageTypeEnum;
+  };
+  readonly internalID: string;
+  readonly " $fragmentType": "Order2DetailsMessage2_order";
+};
+export type Order2DetailsMessage2_order$key = {
+  readonly " $data"?: Order2DetailsMessage2_order$data;
+  readonly " $fragmentSpreads": FragmentRefs<"Order2DetailsMessage2_order">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "Order2DetailsMessage2_order",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "buyerStateExpiresAt",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "code",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "internalID",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "DisplayTexts",
+      "kind": "LinkedField",
+      "name": "displayTexts",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "messageType",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Order",
+  "abstractKey": null
+};
+
+(node as any).hash = "bfd63713272f33de5e9c0f16028be438";
+
+export default node;

--- a/src/__generated__/Order2DetailsPage_Test_Query.graphql.ts
+++ b/src/__generated__/Order2DetailsPage_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5547f08ccbad9c710f3ddf3ca5d14760>>
+ * @generated SignedSource<<5442d94645a2fd17c42d7680e24cd276>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,6 +10,7 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
+export type DisplayTextsMessageTypeEnum = "APPROVED_PICKUP" | "APPROVED_SHIP" | "APPROVED_SHIP_EXPRESS" | "APPROVED_SHIP_STANDARD" | "APPROVED_SHIP_WHITE_GLOVE" | "CANCELLED_ORDER" | "COMPLETED_PICKUP" | "COMPLETED_SHIP" | "PAYMENT_FAILED" | "PROCESSING_PAYMENT_PICKUP" | "PROCESSING_PAYMENT_SHIP" | "PROCESSING_WIRE" | "SHIPPED" | "SUBMITTED_OFFER" | "SUBMITTED_ORDER" | "UNKNOWN" | "%future added value";
 export type Order2DetailsPage_Test_Query$variables = Record<PropertyKey, never>;
 export type Order2DetailsPage_Test_Query$data = {
   readonly me: {
@@ -22,12 +23,14 @@ export type Order2DetailsPage_Test_Query$rawResponse = {
   readonly me: {
     readonly id: string;
     readonly order: {
+      readonly buyerStateExpiresAt: string | null | undefined;
       readonly code: string;
       readonly displayTexts: {
-        readonly message: string | null | undefined;
+        readonly messageType: DisplayTextsMessageTypeEnum;
         readonly title: string;
       };
       readonly id: string;
+      readonly internalID: string;
     } | null | undefined;
   } | null | undefined;
 };
@@ -138,10 +141,24 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
-                    "name": "message",
+                    "name": "messageType",
                     "storageKey": null
                   }
                 ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "buyerStateExpiresAt",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "internalID",
                 "storageKey": null
               },
               (v1/*: any*/)
@@ -155,12 +172,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ffc71040de61e36fb3cc2d6e595a613c",
+    "cacheID": "a84eb443953df2930ee38d218e11c337",
     "id": null,
     "metadata": {},
     "name": "Order2DetailsPage_Test_Query",
     "operationKind": "query",
-    "text": "query Order2DetailsPage_Test_Query {\n  me {\n    order(id: \"123\") {\n      ...Order2DetailsPage_order\n      id\n    }\n    id\n  }\n}\n\nfragment Order2DetailsHeader_order on Order {\n  code\n  displayTexts {\n    title\n  }\n}\n\nfragment Order2DetailsMessage_order on Order {\n  displayTexts {\n    message\n  }\n}\n\nfragment Order2DetailsPage_order on Order {\n  ...Order2DetailsHeader_order\n  ...Order2DetailsMessage_order\n}\n"
+    "text": "query Order2DetailsPage_Test_Query {\n  me {\n    order(id: \"123\") {\n      ...Order2DetailsPage_order\n      id\n    }\n    id\n  }\n}\n\nfragment Order2DetailsHeader_order on Order {\n  code\n  displayTexts {\n    title\n  }\n}\n\nfragment Order2DetailsMessage2_order on Order {\n  buyerStateExpiresAt\n  code\n  internalID\n  displayTexts {\n    messageType\n  }\n}\n\nfragment Order2DetailsPage_order on Order {\n  ...Order2DetailsHeader_order\n  ...Order2DetailsMessage2_order\n}\n"
   }
 };
 })();

--- a/src/__generated__/Order2DetailsPage_order.graphql.ts
+++ b/src/__generated__/Order2DetailsPage_order.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2e40f0b9d5cb9c1c2b868ada4a1c7a7a>>
+ * @generated SignedSource<<c259dee1d57011cbb0281c9c2bf76797>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,7 +11,7 @@
 import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type Order2DetailsPage_order$data = {
-  readonly " $fragmentSpreads": FragmentRefs<"Order2DetailsHeader_order" | "Order2DetailsMessage_order">;
+  readonly " $fragmentSpreads": FragmentRefs<"Order2DetailsHeader_order" | "Order2DetailsMessage2_order">;
   readonly " $fragmentType": "Order2DetailsPage_order";
 };
 export type Order2DetailsPage_order$key = {
@@ -33,13 +33,13 @@ const node: ReaderFragment = {
     {
       "args": null,
       "kind": "FragmentSpread",
-      "name": "Order2DetailsMessage_order"
+      "name": "Order2DetailsMessage2_order"
     }
   ],
   "type": "Order",
   "abstractKey": null
 };
 
-(node as any).hash = "9421ef50cceec1037a7e14edd8a587d2";
+(node as any).hash = "34d1d712bfda73823ffee7652a6c3886";
 
 export default node;

--- a/src/__generated__/order2Routes_DetailsQuery.graphql.ts
+++ b/src/__generated__/order2Routes_DetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b1d1dfad86ec2dc6abb78468ad3657d1>>
+ * @generated SignedSource<<a56aabb437415b775ce83ff6db6f0ee9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -179,10 +179,17 @@ return {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
-                        "name": "message",
+                        "name": "messageType",
                         "storageKey": null
                       }
                     ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "buyerStateExpiresAt",
                     "storageKey": null
                   },
                   (v2/*: any*/),
@@ -201,12 +208,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e51f0e9a5703af4c10c7d2975fe9bd5e",
+    "cacheID": "3ec23cf2361a5becfafb80a2ba876ad7",
     "id": null,
     "metadata": {},
     "name": "order2Routes_DetailsQuery",
     "operationKind": "query",
-    "text": "query order2Routes_DetailsQuery(\n  $orderID: ID!\n) {\n  viewer {\n    ...Order2DetailsRoute_viewer_3HPek8\n    me {\n      order(id: $orderID) {\n        internalID\n        mode\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment Order2DetailsHeader_order on Order {\n  code\n  displayTexts {\n    title\n  }\n}\n\nfragment Order2DetailsMessage_order on Order {\n  displayTexts {\n    message\n  }\n}\n\nfragment Order2DetailsPage_order on Order {\n  ...Order2DetailsHeader_order\n  ...Order2DetailsMessage_order\n}\n\nfragment Order2DetailsRoute_viewer_3HPek8 on Viewer {\n  me {\n    order(id: $orderID) {\n      ...Order2DetailsPage_order\n      internalID\n      id\n    }\n    id\n  }\n}\n"
+    "text": "query order2Routes_DetailsQuery(\n  $orderID: ID!\n) {\n  viewer {\n    ...Order2DetailsRoute_viewer_3HPek8\n    me {\n      order(id: $orderID) {\n        internalID\n        mode\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment Order2DetailsHeader_order on Order {\n  code\n  displayTexts {\n    title\n  }\n}\n\nfragment Order2DetailsMessage2_order on Order {\n  buyerStateExpiresAt\n  code\n  internalID\n  displayTexts {\n    messageType\n  }\n}\n\nfragment Order2DetailsPage_order on Order {\n  ...Order2DetailsHeader_order\n  ...Order2DetailsMessage2_order\n}\n\nfragment Order2DetailsRoute_viewer_3HPek8 on Viewer {\n  me {\n    order(id: $orderID) {\n      ...Order2DetailsPage_order\n      internalID\n      id\n    }\n    id\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
This is an alternative approach to DetailsMessage where content is rendered completely on the client based on specific `message_type` that is coming from the server.

Once we settle on the approach - we'll need to DRY this code a bit and add some specs. But want to confirm what is the way to go forward first.
