### PR TITLE
feat: Final wire details for the message section.

### DIFF
--- a/src/Apps/Order2/Routes/Details/Components/Order2DetailsMessage.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/Order2DetailsMessage.tsx
@@ -230,6 +230,7 @@ const getMessageContent = (order): React.ReactNode => {
       return (
         <>
           <Text variant="sm">Your work is on its way.</Text>
+          {/* TODO: Add shipping tracking info when available */}
           <Spacer y={2} />
           <YourCollectionNote />
         </>

--- a/src/Apps/Order2/Routes/Details/Components/Order2DetailsMessage.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/Order2DetailsMessage.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Link, Spacer, Text } from "@artsy/palette"
+import { Box, Flex, Spacer, Text } from "@artsy/palette"
 import { RouterLink } from "System/Components/RouterLink"
 import type { Order2DetailsMessage_order$key } from "__generated__/Order2DetailsMessage_order.graphql"
 import { graphql, useFragment } from "react-relay"

--- a/src/Apps/Order2/Routes/Details/Components/Order2DetailsMessage.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/Order2DetailsMessage.tsx
@@ -82,7 +82,7 @@ const getMessageContent = (order): React.ReactNode => {
         <>
           <Text variant="sm">
             Thank you! Your offer has been submitted. You will receive an email
-            shortly with all the details. Please note making an offer doesn't
+            shortly with all the details. Please note making an offer doesn’t
             guarantee you the work.
           </Text>
           <Spacer y={2} />

--- a/src/Apps/Order2/Routes/Details/Components/Order2DetailsMessage.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/Order2DetailsMessage.tsx
@@ -2,6 +2,7 @@ import { Box, Flex, Link, Spacer, Text } from "@artsy/palette"
 import { RouterLink } from "System/Components/RouterLink"
 import type { Order2DetailsMessage_order$key } from "__generated__/Order2DetailsMessage_order.graphql"
 import { graphql, useFragment } from "react-relay"
+import { WireTransferInfo } from "./WireTransferInfo"
 
 interface Order2DetailsMessageProps {
   order: Order2DetailsMessage_order$key
@@ -72,8 +73,7 @@ const getMessageContent = (order): React.ReactNode => {
             The gallery will confirm by {formattedStateExpireTime}.
           </Text>
           <Text variant="sm">
-            You can <Link>contact the gallery</Link> with any questions about
-            your order.
+            You can contact the gallery with any questions about your order.
           </Text>
         </>
       )
@@ -82,7 +82,7 @@ const getMessageContent = (order): React.ReactNode => {
         <>
           <Text variant="sm">
             Thank you! Your offer has been submitted. You will receive an email
-            shortly with all the details. Please note making an offer doesn’t
+            shortly with all the details. Please note making an offer doesn't
             guarantee you the work.
           </Text>
           <Spacer y={2} />
@@ -90,8 +90,7 @@ const getMessageContent = (order): React.ReactNode => {
             The gallery will confirm by {formattedStateExpireTime}.
           </Text>
           <Text variant="sm">
-            You can <Link>contact the gallery</Link> with any questions about
-            your order.
+            You can contact the gallery with any questions about your order.
           </Text>
         </>
       )
@@ -149,45 +148,7 @@ const getMessageContent = (order): React.ReactNode => {
             </Text>
           </NumberedListItem>
           <Spacer y={2} />
-          <Box border="1px solid" borderColor="mono15" p={2}>
-            <Text variant="sm" fontWeight="bold">
-              Send wire transfer to
-            </Text>
-            <Spacer y={1} />
-            <Text variant="sm">
-              Account name: Art.sy Inc.
-              <br />
-              Account number: 424385142
-              <br />
-              Routing number: 121000248
-              <br />
-              International SWIFT: WFBIUS6S
-            </Text>
-            <Spacer y={4} />
-            <Text variant="sm" fontWeight="bold">
-              Bank address
-            </Text>
-            <Spacer y={1} />
-            <Text variant="sm">
-              Wells Fargo Bank, N.A.
-              <br />
-              420 Montgomery Street
-              <br />
-              San Francisco, CA 9410
-            </Text>
-            <Spacer y={4} />
-            <Text variant="sm" fontWeight="bold">
-              Add order #{order.code} to the notes section in your wire
-              transfer.
-            </Text>
-            <Spacer y={1} />
-            <Text variant="sm">
-              If your bank account is not in USD, please reference Artsy’s
-              intermediary bank ING Brussels (Intermediary Bank BIC/SWIFT:
-              PNBPUS3NNYC) along with Artsy’s international SWIFT (WFBIUS6S)
-              when making payment. Ask your bank for further instructions.
-            </Text>
-          </Box>
+          <WireTransferInfo order={order} />
         </>
       )
     case "APPROVED_PICKUP":
@@ -198,8 +159,7 @@ const getMessageContent = (order): React.ReactNode => {
             business days to coordinate pickup.
           </Text>
           <Text variant="sm">
-            You can <Link>contact the gallery</Link> with any questions about
-            your order.
+            You can contact the gallery with any questions about your order.
           </Text>
         </>
       )
@@ -270,7 +230,6 @@ const getMessageContent = (order): React.ReactNode => {
       return (
         <>
           <Text variant="sm">Your work is on its way.</Text>
-          {/* TODO: Add shipping tracking info when available */}
           <Spacer y={2} />
           <YourCollectionNote />
         </>
@@ -303,6 +262,7 @@ const FRAGMENT = graphql`
   fragment Order2DetailsMessage_order on Order {
     buyerStateExpiresAt
     code
+    currencyCode
     internalID
     displayTexts {
       messageType

--- a/src/Apps/Order2/Routes/Details/Components/WireTransferInfo.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/WireTransferInfo.tsx
@@ -91,6 +91,7 @@ export const WireTransferInfo: React.FC<WireTransferInfoProps> = ({
       <Spacer y={1} />
       <Stack gap={0}>
         <Text variant="sm">Account name: Art.sy Inc.</Text>
+        <Text variant="sm">Account number: {details.accountNumber}</Text>
         {details.iban && <Text variant="sm">IBAN: {details.iban}</Text>}
         {details.routingNumber && (
           <Text variant="sm">Routing number: {details.routingNumber}</Text>
@@ -100,14 +101,6 @@ export const WireTransferInfo: React.FC<WireTransferInfoProps> = ({
           <Text variant="sm">Sort Code: {details.sortCode}</Text>
         )}
       </Stack>
-      <Text variant="sm">
-        {details.sortCode && (
-          <>
-            <br />
-            Sort Code: {details.sortCode}
-          </>
-        )}
-      </Text>
       <Spacer y={4} />
       <Text variant="sm" fontWeight="bold">
         Bank address

--- a/src/Apps/Order2/Routes/Details/Components/WireTransferInfo.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/WireTransferInfo.tsx
@@ -12,7 +12,7 @@ interface BankDetails {
 const BANK_DETAILS: Record<string, BankDetails> = {
   GBP: {
     transferInfo: [
-      "Account name: Art.sy Inc",
+      "Account name: Art.sy Inc.",
       "Account number: 88005417",
       "IBAN: GB30PNBP16567188005417",
       "International SWIFT: PNBPGB2L",
@@ -31,7 +31,7 @@ const BANK_DETAILS: Record<string, BankDetails> = {
   },
   EUR: {
     transferInfo: [
-      "Account name: Art.sy Inc",
+      "Account name: Art.sy Inc.",
       "Account number: 88005419",
       "IBAN: GB73PNBP16567188005419",
       "International SWIFT: PNBPGB2L",
@@ -49,7 +49,7 @@ const BANK_DETAILS: Record<string, BankDetails> = {
   },
   USD: {
     transferInfo: [
-      "Account name: Art.sy Inc",
+      "Account name: Art.sy Inc.",
       "Account number: 4243851425",
       "Routing number: 121000248",
       "International SWIFT: WFBIUS6S",

--- a/src/Apps/Order2/Routes/Details/Components/WireTransferInfo.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/WireTransferInfo.tsx
@@ -1,71 +1,68 @@
 import { Box, Spacer, Stack, Text } from "@artsy/palette"
 
 interface BankDetails {
-  accountNumber: string
-  iban?: string
-  routingNumber?: string
-  swift: string
-  sortCode?: string
-  bankAddress: {
-    name: string
-    street1: string
-    street2?: string
-    city: string
-    country: string
-  }
-  intermediaryBank?: {
-    name: string
-    swift: string
+  transferInfo: string[]
+  bankAddress: string[]
+  referenceInfo: {
+    intermediary: string
+    international: string
   }
 }
 
 const BANK_DETAILS: Record<string, BankDetails> = {
   GBP: {
-    accountNumber: "88005417",
-    iban: "GB30PNBP16567188005417",
-    swift: "PNBPGB2L",
-    sortCode: "16-56-7",
-    bankAddress: {
-      name: "Wells Fargo Bank, N.A. London Branch",
-      street1: "1 Plantation Place",
-      street2: "30 Fenchurch Street",
-      city: "London, United Kingdom, EC3M 3BD",
-      country: "United Kingdom",
-    },
-    intermediaryBank: {
-      name: "ING Brussels",
-      swift: "NWBKGB2LXXX",
+    transferInfo: [
+      "Account name: Art.sy Inc",
+      "Account number: 88005417",
+      "IBAN: GB30PNBP16567188005417",
+      "International SWIFT: PNBPGB2L",
+      "Sort Code: 16-56-7",
+    ],
+    bankAddress: [
+      "Wells Fargo Bank, N.A. London Branch",
+      "1 Plantation Place",
+      "30 Fenchurch Street",
+      "London, United Kingdom, EC3M 3BD",
+    ],
+    referenceInfo: {
+      intermediary: "NWBKGB2LXXX",
+      international: "PNBPGB2L",
     },
   },
   EUR: {
-    accountNumber: "88005419",
-    iban: "GB73PNBP16567188005419",
-    swift: "PNBPGB2L",
-    bankAddress: {
-      name: "Wells Fargo Bank, N.A. London Branch",
-      street1: "1 Plantation Place",
-      street2: "30 Fenchurch Street",
-      city: "London, United Kingdom, EC3M 3BD",
-      country: "United Kingdom",
-    },
-    intermediaryBank: {
-      name: "ING Brussels",
-      swift: "BBRUBEBB010",
+    transferInfo: [
+      "Account name: Art.sy Inc",
+      "Account number: 88005419",
+      "IBAN: GB73PNBP16567188005419",
+      "International SWIFT: PNBPGB2L",
+    ],
+    bankAddress: [
+      "Wells Fargo Bank, N.A. London Branch",
+      "1 Plantation Place",
+      "30 Fenchurch Street",
+      "London, United Kingdom, EC3M 3BD",
+    ],
+    referenceInfo: {
+      intermediary: "BBRUBEBB010",
+      international: "PNBPGB2L",
     },
   },
   USD: {
-    accountNumber: "4243851425",
-    routingNumber: "121000248",
-    swift: "WFBIUS6S",
-    bankAddress: {
-      name: "Wells Fargo Bank, N.A.",
-      street1: "420 Montgomery Street",
-      city: "San Francisco, CA 94104",
-      country: "United States",
-    },
-    intermediaryBank: {
-      name: "ING Brussels",
-      swift: "PNBPUS3NNYC",
+    transferInfo: [
+      "Account name: Art.sy Inc",
+      "Account number: 4243851425",
+      "Routing number: 121000248",
+      "International SWIFT: WFBIUS6S",
+    ],
+    bankAddress: [
+      "Wells Fargo Bank, N.A.",
+      "420 Montgomery Street",
+      "San Francisco, CA 94104",
+      "United States",
+    ],
+    referenceInfo: {
+      intermediary: "PNBPUS3NNYC",
+      international: "WFBIUS6S",
     },
   },
 }
@@ -81,6 +78,7 @@ export const WireTransferInfo: React.FC<WireTransferInfoProps> = ({
   order,
 }) => {
   const currencyCode = order.currencyCode || "USD"
+
   const details = BANK_DETAILS[currencyCode] || BANK_DETAILS.USD
 
   return (
@@ -88,44 +86,29 @@ export const WireTransferInfo: React.FC<WireTransferInfoProps> = ({
       <Text variant="sm" fontWeight="bold">
         Send wire transfer to
       </Text>
-      <Spacer y={1} />
-      <Stack gap={0}>
-        <Text variant="sm">Account name: Art.sy Inc.</Text>
-        <Text variant="sm">Account number: {details.accountNumber}</Text>
-        {details.iban && <Text variant="sm">IBAN: {details.iban}</Text>}
-        {details.routingNumber && (
-          <Text variant="sm">Routing number: {details.routingNumber}</Text>
-        )}
-        <Text variant="sm">International SWIFT: {details.swift}</Text>
-        {details.sortCode && (
-          <Text variant="sm">Sort Code: {details.sortCode}</Text>
-        )}
+      <Stack gap={0} mt={1} mb={4}>
+        {details.transferInfo.map(rowText => (
+          <Text variant="sm">{rowText}</Text>
+        ))}
       </Stack>
-      <Spacer y={4} />
       <Text variant="sm" fontWeight="bold">
         Bank address
       </Text>
-      <Spacer y={1} />
-      <Stack gap={0}>
-        <Text variant="sm">{details.bankAddress.name}</Text>
-        <Text variant="sm">{details.bankAddress.street1}</Text>
-        {details.bankAddress.street2 && (
-          <Text variant="sm">{details.bankAddress.street2}</Text>
-        )}
-        <Text variant="sm">{details.bankAddress.city}</Text>
+      <Stack gap={0} mt={1} mb={4}>
+        {details.bankAddress.map(rowText => (
+          <Text variant="sm">{rowText}</Text>
+        ))}
       </Stack>
-      <Spacer y={4} />
       <Text variant="sm" fontWeight="bold">
         Add order #{order.code} to the notes section in your wire transfer.
       </Text>
       <Spacer y={1} />
       <Text variant="sm">
         If your bank account is not in {currencyCode}, please reference Artsy's
-        intermediary bank {details.intermediaryBank?.name} (Intermediary Bank
-        BIC/SWIFT:
-        {details.intermediaryBank?.swift}) along with Artsy's international
-        SWIFT ({details.swift}) when making payment. Ask your bank for further
-        instructions.
+        intermediary bank ING Brussels (Intermediary Bank BIC/SWIFT:{" "}
+        {details.referenceInfo.intermediary}) along with Artsy's international
+        SWIFT ({details.referenceInfo.international}) when making payment. Ask
+        your bank for further instructions.
       </Text>
     </Box>
   )

--- a/src/Apps/Order2/Routes/Details/Components/WireTransferInfo.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/WireTransferInfo.tsx
@@ -1,0 +1,139 @@
+import { Box, Spacer, Stack, Text } from "@artsy/palette"
+
+interface BankDetails {
+  accountNumber: string
+  iban?: string
+  routingNumber?: string
+  swift: string
+  sortCode?: string
+  bankAddress: {
+    name: string
+    street1: string
+    street2?: string
+    city: string
+    country: string
+  }
+  intermediaryBank?: {
+    name: string
+    swift: string
+  }
+}
+
+const BANK_DETAILS: Record<string, BankDetails> = {
+  GBP: {
+    accountNumber: "88005417",
+    iban: "GB30PNBP16567188005417",
+    swift: "PNBPGB2L",
+    sortCode: "16-56-7",
+    bankAddress: {
+      name: "Wells Fargo Bank, N.A. London Branch",
+      street1: "1 Plantation Place",
+      street2: "30 Fenchurch Street",
+      city: "London, United Kingdom, EC3M 3BD",
+      country: "United Kingdom",
+    },
+    intermediaryBank: {
+      name: "ING Brussels",
+      swift: "NWBKGB2LXXX",
+    },
+  },
+  EUR: {
+    accountNumber: "88005419",
+    iban: "GB73PNBP16567188005419",
+    swift: "PNBPGB2L",
+    bankAddress: {
+      name: "Wells Fargo Bank, N.A. London Branch",
+      street1: "1 Plantation Place",
+      street2: "30 Fenchurch Street",
+      city: "London, United Kingdom, EC3M 3BD",
+      country: "United Kingdom",
+    },
+    intermediaryBank: {
+      name: "ING Brussels",
+      swift: "BBRUBEBB010",
+    },
+  },
+  USD: {
+    accountNumber: "4243851425",
+    routingNumber: "121000248",
+    swift: "WFBIUS6S",
+    bankAddress: {
+      name: "Wells Fargo Bank, N.A.",
+      street1: "420 Montgomery Street",
+      city: "San Francisco, CA 94104",
+      country: "United States",
+    },
+    intermediaryBank: {
+      name: "ING Brussels",
+      swift: "PNBPUS3NNYC",
+    },
+  },
+}
+
+interface WireTransferInfoProps {
+  order: {
+    currencyCode?: string
+    code: string
+  }
+}
+
+export const WireTransferInfo: React.FC<WireTransferInfoProps> = ({
+  order,
+}) => {
+  const currencyCode = order.currencyCode || "USD"
+  const details = BANK_DETAILS[currencyCode] || BANK_DETAILS.USD
+
+  return (
+    <Box border="1px solid" borderColor="mono15" p={2}>
+      <Text variant="sm" fontWeight="bold">
+        Send wire transfer to
+      </Text>
+      <Spacer y={1} />
+      <Stack gap={0}>
+        <Text variant="sm">Account name: Art.sy Inc.</Text>
+        {details.iban && <Text variant="sm">IBAN: {details.iban}</Text>}
+        {details.routingNumber && (
+          <Text variant="sm">Routing number: {details.routingNumber}</Text>
+        )}
+        <Text variant="sm">International SWIFT: {details.swift}</Text>
+        {details.sortCode && (
+          <Text variant="sm">Sort Code: {details.sortCode}</Text>
+        )}
+      </Stack>
+      <Text variant="sm">
+        {details.sortCode && (
+          <>
+            <br />
+            Sort Code: {details.sortCode}
+          </>
+        )}
+      </Text>
+      <Spacer y={4} />
+      <Text variant="sm" fontWeight="bold">
+        Bank address
+      </Text>
+      <Spacer y={1} />
+      <Stack gap={0}>
+        <Text variant="sm">{details.bankAddress.name}</Text>
+        <Text variant="sm">{details.bankAddress.street1}</Text>
+        {details.bankAddress.street2 && (
+          <Text variant="sm">{details.bankAddress.street2}</Text>
+        )}
+        <Text variant="sm">{details.bankAddress.city}</Text>
+      </Stack>
+      <Spacer y={4} />
+      <Text variant="sm" fontWeight="bold">
+        Add order #{order.code} to the notes section in your wire transfer.
+      </Text>
+      <Spacer y={1} />
+      <Text variant="sm">
+        If your bank account is not in {currencyCode}, please reference Artsy's
+        intermediary bank {details.intermediaryBank?.name} (Intermediary Bank
+        BIC/SWIFT:
+        {details.intermediaryBank?.swift}) along with Artsy's international
+        SWIFT ({details.swift}) when making payment. Ask your bank for further
+        instructions.
+      </Text>
+    </Box>
+  )
+}

--- a/src/Apps/Order2/Routes/Details/Components/__tests__/Order2DetailsMessage.jest.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/__tests__/Order2DetailsMessage.jest.tsx
@@ -70,7 +70,7 @@ describe("Order2DetailsMessage", () => {
     })
 
     expect(screen.getByText("Send wire transfer to")).toBeInTheDocument()
-    expect(screen.getByText(/Account name: Art\.sy Inc\./)).toBeInTheDocument()
+    expect(screen.getByText(/Account name: Art.sy Inc/)).toBeInTheDocument()
     expect(screen.getByText(/Account number: 4243851425/)).toBeInTheDocument()
     expect(screen.getByText(/Routing number: 121000248/)).toBeInTheDocument()
     expect(

--- a/src/Apps/Order2/Routes/Details/Components/__tests__/Order2DetailsMessage.jest.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/__tests__/Order2DetailsMessage.jest.tsx
@@ -61,6 +61,7 @@ describe("Order2DetailsMessage", () => {
       Order: () => ({
         buyerStateExpiresAt: mockDate,
         code: "123",
+        currencyCode: "USD",
         internalID: "test-id",
         displayTexts: {
           messageType: "PROCESSING_WIRE",
@@ -70,7 +71,7 @@ describe("Order2DetailsMessage", () => {
 
     expect(screen.getByText("Send wire transfer to")).toBeInTheDocument()
     expect(screen.getByText(/Account name: Art\.sy Inc\./)).toBeInTheDocument()
-    expect(screen.getByText(/Account number: 424385142/)).toBeInTheDocument()
+    expect(screen.getByText(/Account number: 4243851425/)).toBeInTheDocument()
     expect(screen.getByText(/Routing number: 121000248/)).toBeInTheDocument()
     expect(
       screen.getByText(/International SWIFT: WFBIUS6S/),

--- a/src/__generated__/Order2DetailsMessage_Test_Query.graphql.ts
+++ b/src/__generated__/Order2DetailsMessage_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<5b3a620d3a9122c22edd96794ff87218>>
+ * @generated SignedSource<<d1d8cf340ab10ca8154cbc5bc1c7ecdd>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -25,6 +25,7 @@ export type Order2DetailsMessage_Test_Query$rawResponse = {
     readonly order: {
       readonly buyerStateExpiresAt: string | null | undefined;
       readonly code: string;
+      readonly currencyCode: string;
       readonly displayTexts: {
         readonly messageType: DisplayTextsMessageTypeEnum;
       };
@@ -132,6 +133,13 @@ return {
                 "alias": null,
                 "args": null,
                 "kind": "ScalarField",
+                "name": "currencyCode",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
                 "name": "internalID",
                 "storageKey": null
               },
@@ -164,12 +172,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "026726dfaec107b3bf6992676e78181e",
+    "cacheID": "ad9d13880b5046dfddbc8c297366e6f9",
     "id": null,
     "metadata": {},
     "name": "Order2DetailsMessage_Test_Query",
     "operationKind": "query",
-    "text": "query Order2DetailsMessage_Test_Query {\n  me {\n    order(id: \"123\") {\n      ...Order2DetailsMessage_order\n      id\n    }\n    id\n  }\n}\n\nfragment Order2DetailsMessage_order on Order {\n  buyerStateExpiresAt\n  code\n  internalID\n  displayTexts {\n    messageType\n  }\n}\n"
+    "text": "query Order2DetailsMessage_Test_Query {\n  me {\n    order(id: \"123\") {\n      ...Order2DetailsMessage_order\n      id\n    }\n    id\n  }\n}\n\nfragment Order2DetailsMessage_order on Order {\n  buyerStateExpiresAt\n  code\n  currencyCode\n  internalID\n  displayTexts {\n    messageType\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/Order2DetailsMessage_order.graphql.ts
+++ b/src/__generated__/Order2DetailsMessage_order.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7f929f33f156661f87d51b52c66a5d36>>
+ * @generated SignedSource<<fdd4bd904ed4b60e7555cc7b22389581>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -14,6 +14,7 @@ import { FragmentRefs } from "relay-runtime";
 export type Order2DetailsMessage_order$data = {
   readonly buyerStateExpiresAt: string | null | undefined;
   readonly code: string;
+  readonly currencyCode: string;
   readonly displayTexts: {
     readonly messageType: DisplayTextsMessageTypeEnum;
   };
@@ -49,6 +50,13 @@ const node: ReaderFragment = {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
+      "name": "currencyCode",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
       "name": "internalID",
       "storageKey": null
     },
@@ -75,6 +83,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "ac63312303fcd0bfc71d10cd7c5fc070";
+(node as any).hash = "d4a3de784c48a5844b365765f8ecc8ee";
 
 export default node;

--- a/src/__generated__/Order2DetailsPage_Test_Query.graphql.ts
+++ b/src/__generated__/Order2DetailsPage_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c768ca0e9db6153d03d6da3397a000af>>
+ * @generated SignedSource<<e8cd55f9c4dc63f3c185130cd3819a71>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -25,6 +25,7 @@ export type Order2DetailsPage_Test_Query$rawResponse = {
     readonly order: {
       readonly buyerStateExpiresAt: string | null | undefined;
       readonly code: string;
+      readonly currencyCode: string;
       readonly displayTexts: {
         readonly messageType: DisplayTextsMessageTypeEnum;
         readonly title: string;
@@ -158,6 +159,13 @@ return {
                 "alias": null,
                 "args": null,
                 "kind": "ScalarField",
+                "name": "currencyCode",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
                 "name": "internalID",
                 "storageKey": null
               },
@@ -172,12 +180,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "61a32786e85f3e38827d7810119284b9",
+    "cacheID": "203c3298efbd326659a486ca2f4e07fb",
     "id": null,
     "metadata": {},
     "name": "Order2DetailsPage_Test_Query",
     "operationKind": "query",
-    "text": "query Order2DetailsPage_Test_Query {\n  me {\n    order(id: \"123\") {\n      ...Order2DetailsPage_order\n      id\n    }\n    id\n  }\n}\n\nfragment Order2DetailsHeader_order on Order {\n  code\n  displayTexts {\n    title\n  }\n}\n\nfragment Order2DetailsMessage_order on Order {\n  buyerStateExpiresAt\n  code\n  internalID\n  displayTexts {\n    messageType\n  }\n}\n\nfragment Order2DetailsPage_order on Order {\n  ...Order2DetailsHeader_order\n  ...Order2DetailsMessage_order\n}\n"
+    "text": "query Order2DetailsPage_Test_Query {\n  me {\n    order(id: \"123\") {\n      ...Order2DetailsPage_order\n      id\n    }\n    id\n  }\n}\n\nfragment Order2DetailsHeader_order on Order {\n  code\n  displayTexts {\n    title\n  }\n}\n\nfragment Order2DetailsMessage_order on Order {\n  buyerStateExpiresAt\n  code\n  currencyCode\n  internalID\n  displayTexts {\n    messageType\n  }\n}\n\nfragment Order2DetailsPage_order on Order {\n  ...Order2DetailsHeader_order\n  ...Order2DetailsMessage_order\n}\n"
   }
 };
 })();

--- a/src/__generated__/order2Routes_DetailsQuery.graphql.ts
+++ b/src/__generated__/order2Routes_DetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<956c9fb7b32b906699401fb9ad235bc6>>
+ * @generated SignedSource<<81bcc62989eb68d462725ba1923163f0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -192,6 +192,13 @@ return {
                     "name": "buyerStateExpiresAt",
                     "storageKey": null
                   },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "currencyCode",
+                    "storageKey": null
+                  },
                   (v2/*: any*/),
                   (v4/*: any*/),
                   (v3/*: any*/)
@@ -208,12 +215,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "bdec2d1ebb12cd6b86640375a38b172d",
+    "cacheID": "8b8b7e035b0ee2ec21b699c64bc5e516",
     "id": null,
     "metadata": {},
     "name": "order2Routes_DetailsQuery",
     "operationKind": "query",
-    "text": "query order2Routes_DetailsQuery(\n  $orderID: ID!\n) {\n  viewer {\n    ...Order2DetailsRoute_viewer_3HPek8\n    me {\n      order(id: $orderID) {\n        internalID\n        mode\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment Order2DetailsHeader_order on Order {\n  code\n  displayTexts {\n    title\n  }\n}\n\nfragment Order2DetailsMessage_order on Order {\n  buyerStateExpiresAt\n  code\n  internalID\n  displayTexts {\n    messageType\n  }\n}\n\nfragment Order2DetailsPage_order on Order {\n  ...Order2DetailsHeader_order\n  ...Order2DetailsMessage_order\n}\n\nfragment Order2DetailsRoute_viewer_3HPek8 on Viewer {\n  me {\n    order(id: $orderID) {\n      ...Order2DetailsPage_order\n      internalID\n      id\n    }\n    id\n  }\n}\n"
+    "text": "query order2Routes_DetailsQuery(\n  $orderID: ID!\n) {\n  viewer {\n    ...Order2DetailsRoute_viewer_3HPek8\n    me {\n      order(id: $orderID) {\n        internalID\n        mode\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment Order2DetailsHeader_order on Order {\n  code\n  displayTexts {\n    title\n  }\n}\n\nfragment Order2DetailsMessage_order on Order {\n  buyerStateExpiresAt\n  code\n  currencyCode\n  internalID\n  displayTexts {\n    messageType\n  }\n}\n\nfragment Order2DetailsPage_order on Order {\n  ...Order2DetailsHeader_order\n  ...Order2DetailsMessage_order\n}\n\nfragment Order2DetailsRoute_viewer_3HPek8 on Viewer {\n  me {\n    order(id: $orderID) {\n      ...Order2DetailsPage_order\n      internalID\n      id\n    }\n    id\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Finally! It's the last part of [EMI-2436](https://artsyproduct.atlassian.net/browse/EMI-2436)

Here we are adding wire details selection based on order currency. I refactored this Wire details info into separate component and think it's a bit easier to see the variations in this format. But that brings a question - is that intentional that both EUR and GBP bank address is in London [cami-w](https://github.com/cami-w)?

Also removing a link for 'contact gallery' for now. As we've discussed it'll be a follow up to link this properly based on presense of existing conversation.

Here is the look for USD:
<img width="1369" alt="Screenshot 2025-05-21 at 10 49 05 AM" src="https://github.com/user-attachments/assets/0df3e860-9621-4baa-ac5a-c60d410b389e" />


[EMI-2436]: https://artsyproduct.atlassian.net/browse/EMI-2436?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ