### PR TITLE
feat(EMI-2426): Add payment method in new Order details

### DIFF
--- a/data/schema.graphql
+++ b/data/schema.graphql
@@ -16491,6 +16491,9 @@ type Order {
   # Order code
   code: String!
 
+  # Express Checkout wallet type
+  creditCardWalletType: OrderCreditCardWalletTypeEnum
+
   # Currency code
   currencyCode: String!
 
@@ -16511,6 +16514,10 @@ type Order {
   itemsTotal: Money
   lineItems: [LineItem]!
   mode: OrderModeEnum!
+
+  # Payment method used for the order
+  paymentMethod: OrderPaymentMethodEnum
+  paymentMethodDetails: PaymentMethodUnion
 
   # Order pricing breakdown lines
   pricingBreakdownLines: [PricingBreakdownLineUnion]!
@@ -16553,6 +16560,9 @@ union OrderParty = Partner | User
 
 enum OrderPaymentMethodEnum {
   CREDIT_CARD
+  SEPA_DEBIT
+  US_BANK_ACCOUNT
+  WIRE_TRANSFER
 }
 
 enum OrderSourceEnum {

--- a/src/Apps/Order2/Routes/Details/Components/Order2DetailsPage.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/Order2DetailsPage.tsx
@@ -13,11 +13,11 @@ import {
   Stack,
   Text,
 } from "@artsy/palette"
-import { type Brand, BrandCreditCardIcon } from "Components/BrandCreditCardIcon"
 import type { Order2DetailsPage_order$key } from "__generated__/Order2DetailsPage_order.graphql"
 import { graphql, useFragment } from "react-relay"
 import { Order2DetailsHeader } from "./Order2DetailsHeader"
 import { Order2DetailsMessage } from "./Order2DetailsMessage"
+import { Order2DetailsPaymentInfo } from "Apps/Order2/Routes/Details/Components/Order2DetailsPaymentInfo"
 
 interface Order2DetailsPageProps {
   order: Order2DetailsPage_order$key
@@ -134,24 +134,7 @@ export const Order2DetailsPage = ({ order }: Order2DetailsPageProps) => {
 
         <Spacer y={1} />
 
-        {/* Payment method */}
-        <Box p={2} backgroundColor="mono0">
-          <Text variant="sm" fontWeight={500} color="mono100">
-            Payment method
-          </Text>
-          <Spacer y={1} />
-          <Flex>
-            <BrandCreditCardIcon
-              mr={1}
-              type={"Visa" as Brand}
-              width="26px"
-              height="26px"
-            />
-            <Text variant="xs" color="mono100">
-              •••• 4242 Exp 12/29
-            </Text>
-          </Flex>
-        </Box>
+        <Order2DetailsPaymentInfo order={orderData} />
 
         {/* Help section */}
         <Box p={2}>
@@ -192,6 +175,7 @@ const FRAGMENT = graphql`
   fragment Order2DetailsPage_order on Order {
     ...Order2DetailsHeader_order
     ...Order2DetailsMessage_order
+    ...Order2DetailsPaymentInfo_order
   }
 `
 

--- a/src/Apps/Order2/Routes/Details/Components/Order2DetailsPaymentInfo.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/Order2DetailsPaymentInfo.tsx
@@ -1,0 +1,111 @@
+import ApplePayMarkIcon from "@artsy/icons/ApplePayMarkIcon"
+import GooglePayIcon from "@artsy/icons/GooglePayIcon"
+import HomeIcon from "@artsy/icons/HomeIcon"
+import { Box, Flex, Spacer, Text } from "@artsy/palette"
+import type {
+  Order2DetailsPaymentInfo_order$data,
+  Order2DetailsPaymentInfo_order$key,
+} from "__generated__/Order2DetailsPaymentInfo_order.graphql"
+import { Brand, BrandCreditCardIcon } from "Components/BrandCreditCardIcon"
+import React from "react"
+import { useFragment } from "react-relay"
+import { graphql } from "relay-runtime"
+
+interface Props {
+  order: Order2DetailsPaymentInfo_order$key
+}
+
+export const Order2DetailsPaymentInfo: React.FC<Props> = ({ order }) => {
+  const orderData = useFragment(fragment, order)
+
+  const { Icon, text } = getPaymentMethodContent(orderData)
+
+  if (!Icon) {
+    return null
+  }
+
+  return (
+    <Box p={2} backgroundColor="mono0">
+      <Text variant="sm" fontWeight={500} color="mono100">
+        Payment method
+      </Text>
+
+      <Spacer y={1} />
+
+      <Flex alignItems="center">
+        <Icon mr={1} width={18} height={18} />
+
+        <Text variant="xs" color="mono100">
+          {text}
+        </Text>
+      </Flex>
+    </Box>
+  )
+}
+
+const getPaymentMethodContent = (
+  order: NonNullable<Order2DetailsPaymentInfo_order$data>,
+) => {
+  const { creditCardWalletType, paymentMethodDetails } = order
+
+  if (!!creditCardWalletType) {
+    switch (creditCardWalletType) {
+      case "APPLE_PAY":
+        return { Icon: ApplePayMarkIcon, text: "Apple Pay" }
+      case "GOOGLE_PAY":
+        return { Icon: GooglePayIcon, text: "Google Pay" }
+      default:
+        return { Icon: null }
+    }
+  }
+
+  switch (paymentMethodDetails?.__typename) {
+    case "CreditCard":
+      const { brand, expirationMonth, expirationYear, lastDigits } =
+        paymentMethodDetails
+      const formattedExpDate = `${expirationMonth.toString().padStart(2, "0")}/${expirationYear.toString().slice(-2)}`
+
+      return {
+        Icon: props => <BrandCreditCardIcon type={brand as Brand} {...props} />,
+        text: `•••• ${lastDigits}  Exp ${formattedExpDate}`,
+      }
+
+    case "BankAccount":
+      return {
+        Icon: HomeIcon,
+        text: "Bank transfer",
+      }
+
+    case "WireTransfer":
+      return {
+        Icon: HomeIcon,
+        text: "Wire transfer",
+      }
+
+    default:
+      return {
+        Icon: null,
+      }
+  }
+}
+
+const fragment = graphql`
+  fragment Order2DetailsPaymentInfo_order on Order {
+    creditCardWalletType
+    paymentMethodDetails {
+      __typename
+      ... on CreditCard {
+        brand
+        lastDigits
+        expirationYear
+        expirationMonth
+      }
+      ... on BankAccount {
+        last4
+      }
+      ... on WireTransfer {
+        isManualPayment
+      }
+    }
+  }
+`

--- a/src/Apps/Order2/Routes/Details/Components/__tests__/Order2DetailsPaymentInfo.jest.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/__tests__/Order2DetailsPaymentInfo.jest.tsx
@@ -1,0 +1,90 @@
+import { screen } from "@testing-library/react"
+import { Order2DetailsPaymentInfo } from "Apps/Order2/Routes/Details/Components/Order2DetailsPaymentInfo"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
+import { graphql } from "relay-runtime"
+
+import type { Order2DetailsPaymentInfo_TestQuery } from "__generated__/Order2DetailsPaymentInfo_TestQuery.graphql"
+
+jest.unmock("react-relay")
+
+describe("Order2DetailsPaymentInfo", () => {
+  const { renderWithRelay } =
+    setupTestWrapperTL<Order2DetailsPaymentInfo_TestQuery>({
+      Component: ({ me }) => <Order2DetailsPaymentInfo order={me!.order!} />,
+      query: graphql`
+        query Order2DetailsPaymentInfo_TestQuery @relay_test_operation {
+          me {
+            order(id: "order-id") {
+              ...Order2DetailsPaymentInfo_order
+            }
+          }
+        }
+      `,
+    })
+
+  it("renders Apple Pay payment details", () => {
+    renderWithRelay({ Order: () => ({ creditCardWalletType: "APPLE_PAY" }) })
+
+    expect(screen.getByText("Apple Pay")).toBeInTheDocument()
+  })
+
+  it("renders Google Pay payment details", () => {
+    renderWithRelay({ Order: () => ({ creditCardWalletType: "GOOGLE_PAY" }) })
+
+    expect(screen.getByText("Google Pay")).toBeInTheDocument()
+  })
+
+  it("renders credit card order payment details", () => {
+    renderWithRelay({
+      Order: () => ({
+        creditCardWalletType: null,
+        paymentMethodDetails: {
+          __typename: "CreditCard",
+          lastDigits: "1234",
+          brand: "Visa",
+          expirationYear: "2029",
+          expirationMonth: "2",
+        },
+      }),
+    })
+
+    expect(screen.getByText(/1234/)).toBeInTheDocument()
+    expect(screen.getByText(/Exp 02\/29/)).toBeInTheDocument()
+  })
+
+  it("renders bank transfer order payment details", () => {
+    renderWithRelay({
+      Order: () => ({
+        creditCardWalletType: null,
+        paymentMethodDetails: { __typename: "BankAccount" },
+      }),
+    })
+
+    expect(screen.getByText("Bank transfer")).toBeInTheDocument()
+  })
+
+  it("renders wire transfer order payment details", () => {
+    renderWithRelay({
+      Order: () => ({
+        creditCardWalletType: null,
+        paymentMethodDetails: { __typename: "WireTransfer" },
+      }),
+    })
+
+    expect(screen.getByText("Wire transfer")).toBeInTheDocument()
+  })
+
+  it("does not render anything when there is no data", () => {
+    renderWithRelay({
+      Order: () => ({
+        creditCardWalletType: null,
+        paymentMethodDetails: null,
+      }),
+    })
+
+    expect(screen.queryByText(/Pay/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/Exp/)).not.toBeInTheDocument()
+    expect(screen.queryByText("Bank transfer")).not.toBeInTheDocument()
+    expect(screen.queryByText("Wire transfer")).not.toBeInTheDocument()
+  })
+})

--- a/src/__generated__/Order2DetailsPage_order.graphql.ts
+++ b/src/__generated__/Order2DetailsPage_order.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<2e40f0b9d5cb9c1c2b868ada4a1c7a7a>>
+ * @generated SignedSource<<bc25f5bcae283f880fba8e8fb76d1b55>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,7 +11,7 @@
 import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type Order2DetailsPage_order$data = {
-  readonly " $fragmentSpreads": FragmentRefs<"Order2DetailsHeader_order" | "Order2DetailsMessage_order">;
+  readonly " $fragmentSpreads": FragmentRefs<"Order2DetailsHeader_order" | "Order2DetailsMessage_order" | "Order2DetailsPaymentInfo_order">;
   readonly " $fragmentType": "Order2DetailsPage_order";
 };
 export type Order2DetailsPage_order$key = {
@@ -34,12 +34,17 @@ const node: ReaderFragment = {
       "args": null,
       "kind": "FragmentSpread",
       "name": "Order2DetailsMessage_order"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "Order2DetailsPaymentInfo_order"
     }
   ],
   "type": "Order",
   "abstractKey": null
 };
 
-(node as any).hash = "9421ef50cceec1037a7e14edd8a587d2";
+(node as any).hash = "f90725a0495618dd5ca262ed965c5cd4";
 
 export default node;

--- a/src/__generated__/Order2DetailsPaymentInfo_TestQuery.graphql.ts
+++ b/src/__generated__/Order2DetailsPaymentInfo_TestQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ff0b7bce71e7ac01415012d7de05363f>>
+ * @generated SignedSource<<3bb6d8df62fbfd54bf5a7e5c60cda2a4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -10,53 +10,17 @@
 
 import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
-export type DisplayTextsMessageTypeEnum = "APPROVED_PICKUP" | "APPROVED_SHIP" | "APPROVED_SHIP_EXPRESS" | "APPROVED_SHIP_STANDARD" | "APPROVED_SHIP_WHITE_GLOVE" | "CANCELLED_ORDER" | "COMPLETED_PICKUP" | "COMPLETED_SHIP" | "PAYMENT_FAILED" | "PROCESSING_PAYMENT_PICKUP" | "PROCESSING_PAYMENT_SHIP" | "PROCESSING_WIRE" | "SHIPPED" | "SUBMITTED_OFFER" | "SUBMITTED_ORDER" | "UNKNOWN" | "%future added value";
-export type OrderCreditCardWalletTypeEnum = "APPLE_PAY" | "GOOGLE_PAY" | "%future added value";
-export type Order2DetailsPage_Test_Query$variables = Record<PropertyKey, never>;
-export type Order2DetailsPage_Test_Query$data = {
+export type Order2DetailsPaymentInfo_TestQuery$variables = Record<PropertyKey, never>;
+export type Order2DetailsPaymentInfo_TestQuery$data = {
   readonly me: {
     readonly order: {
-      readonly " $fragmentSpreads": FragmentRefs<"Order2DetailsPage_order">;
+      readonly " $fragmentSpreads": FragmentRefs<"Order2DetailsPaymentInfo_order">;
     } | null | undefined;
   } | null | undefined;
 };
-export type Order2DetailsPage_Test_Query$rawResponse = {
-  readonly me: {
-    readonly id: string;
-    readonly order: {
-      readonly buyerStateExpiresAt: string | null | undefined;
-      readonly code: string;
-      readonly creditCardWalletType: OrderCreditCardWalletTypeEnum | null | undefined;
-      readonly displayTexts: {
-        readonly messageType: DisplayTextsMessageTypeEnum;
-        readonly title: string;
-      };
-      readonly id: string;
-      readonly internalID: string;
-      readonly paymentMethodDetails: {
-        readonly __typename: "BankAccount";
-        readonly id: string;
-        readonly last4: string;
-      } | {
-        readonly __typename: "CreditCard";
-        readonly brand: string;
-        readonly expirationMonth: number;
-        readonly expirationYear: number;
-        readonly id: string;
-        readonly lastDigits: string;
-      } | {
-        readonly __typename: "WireTransfer";
-        readonly isManualPayment: boolean;
-      } | {
-        readonly __typename: string;
-      } | null | undefined;
-    } | null | undefined;
-  } | null | undefined;
-};
-export type Order2DetailsPage_Test_Query = {
-  rawResponse: Order2DetailsPage_Test_Query$rawResponse;
-  response: Order2DetailsPage_Test_Query$data;
-  variables: Order2DetailsPage_Test_Query$variables;
+export type Order2DetailsPaymentInfo_TestQuery = {
+  response: Order2DetailsPaymentInfo_TestQuery$data;
+  variables: Order2DetailsPaymentInfo_TestQuery$variables;
 };
 
 const node: ConcreteRequest = (function(){
@@ -64,7 +28,7 @@ var v0 = [
   {
     "kind": "Literal",
     "name": "id",
-    "value": "123"
+    "value": "order-id"
   }
 ],
 v1 = {
@@ -73,13 +37,31 @@ v1 = {
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
+},
+v2 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v3 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "String"
+},
+v4 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "Int"
 };
 return {
   "fragment": {
     "argumentDefinitions": [],
     "kind": "Fragment",
     "metadata": null,
-    "name": "Order2DetailsPage_Test_Query",
+    "name": "Order2DetailsPaymentInfo_TestQuery",
     "selections": [
       {
         "alias": null,
@@ -100,10 +82,10 @@ return {
               {
                 "args": null,
                 "kind": "FragmentSpread",
-                "name": "Order2DetailsPage_order"
+                "name": "Order2DetailsPaymentInfo_order"
               }
             ],
-            "storageKey": "order(id:\"123\")"
+            "storageKey": "order(id:\"order-id\")"
           }
         ],
         "storageKey": null
@@ -116,7 +98,7 @@ return {
   "operation": {
     "argumentDefinitions": [],
     "kind": "Operation",
-    "name": "Order2DetailsPage_Test_Query",
+    "name": "Order2DetailsPaymentInfo_TestQuery",
     "selections": [
       {
         "alias": null,
@@ -134,52 +116,6 @@ return {
             "name": "order",
             "plural": false,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "code",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "concreteType": "DisplayTexts",
-                "kind": "LinkedField",
-                "name": "displayTexts",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "title",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "messageType",
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "buyerStateExpiresAt",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "internalID",
-                "storageKey": null
-              },
               {
                 "alias": null,
                 "args": null,
@@ -272,7 +208,7 @@ return {
               },
               (v1/*: any*/)
             ],
-            "storageKey": "order(id:\"123\")"
+            "storageKey": "order(id:\"order-id\")"
           },
           (v1/*: any*/)
         ],
@@ -281,16 +217,61 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a0b353e2c36fe4f49d65978bd7271bcf",
+    "cacheID": "0345bdd6ee6bb51bd0c31383e7ba688a",
     "id": null,
-    "metadata": {},
-    "name": "Order2DetailsPage_Test_Query",
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "me": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Me"
+        },
+        "me.id": (v2/*: any*/),
+        "me.order": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Order"
+        },
+        "me.order.creditCardWalletType": {
+          "enumValues": [
+            "APPLE_PAY",
+            "GOOGLE_PAY"
+          ],
+          "nullable": true,
+          "plural": false,
+          "type": "OrderCreditCardWalletTypeEnum"
+        },
+        "me.order.id": (v2/*: any*/),
+        "me.order.paymentMethodDetails": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "PaymentMethodUnion"
+        },
+        "me.order.paymentMethodDetails.__typename": (v3/*: any*/),
+        "me.order.paymentMethodDetails.brand": (v3/*: any*/),
+        "me.order.paymentMethodDetails.expirationMonth": (v4/*: any*/),
+        "me.order.paymentMethodDetails.expirationYear": (v4/*: any*/),
+        "me.order.paymentMethodDetails.id": (v2/*: any*/),
+        "me.order.paymentMethodDetails.isManualPayment": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "Boolean"
+        },
+        "me.order.paymentMethodDetails.last4": (v3/*: any*/),
+        "me.order.paymentMethodDetails.lastDigits": (v3/*: any*/)
+      }
+    },
+    "name": "Order2DetailsPaymentInfo_TestQuery",
     "operationKind": "query",
-    "text": "query Order2DetailsPage_Test_Query {\n  me {\n    order(id: \"123\") {\n      ...Order2DetailsPage_order\n      id\n    }\n    id\n  }\n}\n\nfragment Order2DetailsHeader_order on Order {\n  code\n  displayTexts {\n    title\n  }\n}\n\nfragment Order2DetailsMessage_order on Order {\n  buyerStateExpiresAt\n  code\n  internalID\n  displayTexts {\n    messageType\n  }\n}\n\nfragment Order2DetailsPage_order on Order {\n  ...Order2DetailsHeader_order\n  ...Order2DetailsMessage_order\n  ...Order2DetailsPaymentInfo_order\n}\n\nfragment Order2DetailsPaymentInfo_order on Order {\n  creditCardWalletType\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      brand\n      lastDigits\n      expirationYear\n      expirationMonth\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n}\n"
+    "text": "query Order2DetailsPaymentInfo_TestQuery {\n  me {\n    order(id: \"order-id\") {\n      ...Order2DetailsPaymentInfo_order\n      id\n    }\n    id\n  }\n}\n\nfragment Order2DetailsPaymentInfo_order on Order {\n  creditCardWalletType\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      brand\n      lastDigits\n      expirationYear\n      expirationMonth\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "b68af50676405f31177c883fe9ef437a";
+(node as any).hash = "79b45db67396f4cc84e259c2122479ce";
 
 export default node;

--- a/src/__generated__/Order2DetailsPaymentInfo_order.graphql.ts
+++ b/src/__generated__/Order2DetailsPaymentInfo_order.graphql.ts
@@ -1,0 +1,141 @@
+/**
+ * @generated SignedSource<<47991e78c504ff12deb65b74e885e273>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type OrderCreditCardWalletTypeEnum = "APPLE_PAY" | "GOOGLE_PAY" | "%future added value";
+import { FragmentRefs } from "relay-runtime";
+export type Order2DetailsPaymentInfo_order$data = {
+  readonly creditCardWalletType: OrderCreditCardWalletTypeEnum | null | undefined;
+  readonly paymentMethodDetails: {
+    readonly __typename: "BankAccount";
+    readonly last4: string;
+  } | {
+    readonly __typename: "CreditCard";
+    readonly brand: string;
+    readonly expirationMonth: number;
+    readonly expirationYear: number;
+    readonly lastDigits: string;
+  } | {
+    readonly __typename: "WireTransfer";
+    readonly isManualPayment: boolean;
+  } | {
+    // This will never be '%other', but we need some
+    // value in case none of the concrete values match.
+    readonly __typename: "%other";
+  } | null | undefined;
+  readonly " $fragmentType": "Order2DetailsPaymentInfo_order";
+};
+export type Order2DetailsPaymentInfo_order$key = {
+  readonly " $data"?: Order2DetailsPaymentInfo_order$data;
+  readonly " $fragmentSpreads": FragmentRefs<"Order2DetailsPaymentInfo_order">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "Order2DetailsPaymentInfo_order",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "creditCardWalletType",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": null,
+      "kind": "LinkedField",
+      "name": "paymentMethodDetails",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "__typename",
+          "storageKey": null
+        },
+        {
+          "kind": "InlineFragment",
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "brand",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "lastDigits",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "expirationYear",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "expirationMonth",
+              "storageKey": null
+            }
+          ],
+          "type": "CreditCard",
+          "abstractKey": null
+        },
+        {
+          "kind": "InlineFragment",
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "last4",
+              "storageKey": null
+            }
+          ],
+          "type": "BankAccount",
+          "abstractKey": null
+        },
+        {
+          "kind": "InlineFragment",
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "isManualPayment",
+              "storageKey": null
+            }
+          ],
+          "type": "WireTransfer",
+          "abstractKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Order",
+  "abstractKey": null
+};
+
+(node as any).hash = "1a1e905d657b71539cf3035a7e302b2d";
+
+export default node;

--- a/src/__generated__/order2Routes_DetailsQuery.graphql.ts
+++ b/src/__generated__/order2Routes_DetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<956c9fb7b32b906699401fb9ad235bc6>>
+ * @generated SignedSource<<6013120c02c46d62cd2fc2607f73ca26>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -193,6 +193,96 @@ return {
                     "storageKey": null
                   },
                   (v2/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "creditCardWalletType",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": null,
+                    "kind": "LinkedField",
+                    "name": "paymentMethodDetails",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "__typename",
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "InlineFragment",
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "brand",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "lastDigits",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "expirationYear",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "expirationMonth",
+                            "storageKey": null
+                          },
+                          (v4/*: any*/)
+                        ],
+                        "type": "CreditCard",
+                        "abstractKey": null
+                      },
+                      {
+                        "kind": "InlineFragment",
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "last4",
+                            "storageKey": null
+                          },
+                          (v4/*: any*/)
+                        ],
+                        "type": "BankAccount",
+                        "abstractKey": null
+                      },
+                      {
+                        "kind": "InlineFragment",
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isManualPayment",
+                            "storageKey": null
+                          }
+                        ],
+                        "type": "WireTransfer",
+                        "abstractKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
                   (v4/*: any*/),
                   (v3/*: any*/)
                 ],
@@ -208,12 +298,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "bdec2d1ebb12cd6b86640375a38b172d",
+    "cacheID": "70eac993de9125cf403f2f46d55b7ada",
     "id": null,
     "metadata": {},
     "name": "order2Routes_DetailsQuery",
     "operationKind": "query",
-    "text": "query order2Routes_DetailsQuery(\n  $orderID: ID!\n) {\n  viewer {\n    ...Order2DetailsRoute_viewer_3HPek8\n    me {\n      order(id: $orderID) {\n        internalID\n        mode\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment Order2DetailsHeader_order on Order {\n  code\n  displayTexts {\n    title\n  }\n}\n\nfragment Order2DetailsMessage_order on Order {\n  buyerStateExpiresAt\n  code\n  internalID\n  displayTexts {\n    messageType\n  }\n}\n\nfragment Order2DetailsPage_order on Order {\n  ...Order2DetailsHeader_order\n  ...Order2DetailsMessage_order\n}\n\nfragment Order2DetailsRoute_viewer_3HPek8 on Viewer {\n  me {\n    order(id: $orderID) {\n      ...Order2DetailsPage_order\n      internalID\n      id\n    }\n    id\n  }\n}\n"
+    "text": "query order2Routes_DetailsQuery(\n  $orderID: ID!\n) {\n  viewer {\n    ...Order2DetailsRoute_viewer_3HPek8\n    me {\n      order(id: $orderID) {\n        internalID\n        mode\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment Order2DetailsHeader_order on Order {\n  code\n  displayTexts {\n    title\n  }\n}\n\nfragment Order2DetailsMessage_order on Order {\n  buyerStateExpiresAt\n  code\n  internalID\n  displayTexts {\n    messageType\n  }\n}\n\nfragment Order2DetailsPage_order on Order {\n  ...Order2DetailsHeader_order\n  ...Order2DetailsMessage_order\n  ...Order2DetailsPaymentInfo_order\n}\n\nfragment Order2DetailsPaymentInfo_order on Order {\n  creditCardWalletType\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      brand\n      lastDigits\n      expirationYear\n      expirationMonth\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n}\n\nfragment Order2DetailsRoute_viewer_3HPek8 on Viewer {\n  me {\n    order(id: $orderID) {\n      ...Order2DetailsPage_order\n      internalID\n      id\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/useUpdateOrderMutation.graphql.ts
+++ b/src/__generated__/useUpdateOrderMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<132e07f99046808f33bbef06718aa1e7>>
+ * @generated SignedSource<<8afe2f16e9e83a1aea3d445679aefe30>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,7 +12,7 @@ import { ConcreteRequest } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type FulfillmentOptionTypeEnum = "DOMESTIC_FLAT" | "INTERNATIONAL_FLAT" | "PICKUP" | "SHIPPING_TBD" | "%future added value";
 export type OrderCreditCardWalletTypeEnum = "APPLE_PAY" | "GOOGLE_PAY" | "%future added value";
-export type OrderPaymentMethodEnum = "CREDIT_CARD" | "%future added value";
+export type OrderPaymentMethodEnum = "CREDIT_CARD" | "SEPA_DEBIT" | "US_BANK_ACCOUNT" | "WIRE_TRANSFER" | "%future added value";
 export type updateOrderInput = {
   clientMutationId?: string | null | undefined;
   creditCardWalletType?: OrderCreditCardWalletTypeEnum | null | undefined;


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2426]

### Description
This PR requires merging artsy/metaphysics#6768

This PR links the data to the payment method section in the new Order Details screen

### Screenshots
| State | Screenshot |
|---|---|
| Apple Pay | ![image](https://github.com/user-attachments/assets/cdd901d1-ebb3-43d0-a1e0-424416cf17c5) |
| Google Pay | ![image](https://github.com/user-attachments/assets/a4b6dd60-a086-4b38-84e4-e96cc2dad3db) |
| Credit Card | ![image](https://github.com/user-attachments/assets/135d13a1-5b74-4aaf-b50e-c39fab4c5f2f) |
| ACH | ![image](https://github.com/user-attachments/assets/a2382761-3db6-4b52-bfab-7729398683a2) |
| SEPA | ![image](https://github.com/user-attachments/assets/d018f39c-b38b-4c0b-8da3-a8af7b1474e9) |
| Wire transfer | ![image](https://github.com/user-attachments/assets/6a5972ea-1383-47da-b3fb-831a7e69a6fc) |


<!-- Implementation description -->
