### PR TITLE
fix: update my profile link to match new link on Eigen

### DIFF
--- a/src/Apps/Order/Components/TransactionDetailsSummaryItem.tsx
+++ b/src/Apps/Order/Components/TransactionDetailsSummaryItem.tsx
@@ -311,7 +311,7 @@ export const TransactionDetailsSummaryItem: FC<
             {isEigen ? (
               <>
                 View and manage all artworks in your Collection through your{" "}
-                <RouterLink inline to={"/my-profile"}>
+                <RouterLink inline to={"/my-collection"}>
                   profile.
                 </RouterLink>
               </>

--- a/src/Apps/Order/Components/TransactionDetailsSummaryItem.tsx
+++ b/src/Apps/Order/Components/TransactionDetailsSummaryItem.tsx
@@ -9,6 +9,7 @@ import {
 } from "Components/StepSummaryItem"
 import { RouterLink } from "System/Components/RouterLink"
 import { withSystemContext } from "System/Contexts/SystemContext"
+import { Device, useDeviceDetection } from "Utils/Hooks/useDeviceDetection"
 import { extractNodes } from "Utils/extractNodes"
 import type { TransactionDetailsSummaryItem_order$data } from "__generated__/TransactionDetailsSummaryItem_order.graphql"
 import type { Omit } from "lodash"
@@ -41,6 +42,8 @@ export const TransactionDetailsSummaryItem: FC<
   useLastSubmittedOffer,
   ...others
 }) => {
+  const { device } = useDeviceDetection()
+
   const renderPriceEntry = () => {
     const currency = order.currencyCode
 
@@ -311,9 +314,13 @@ export const TransactionDetailsSummaryItem: FC<
             {isEigen ? (
               <>
                 View and manage all artworks in your Collection through your{" "}
-                <RouterLink inline to={"/my-collection"}>
-                  profile.
-                </RouterLink>
+                {device === Device.iPhone ? (
+                  <RouterLink inline to={"/my-collection"}>
+                    profile.
+                  </RouterLink>
+                ) : (
+                  "profile."
+                )}
               </>
             ) : (
               <Stack gap={1}>


### PR DESCRIPTION
The type of this PR is: **fix**


This PR solves [PBRW-836]

### Description

This PR makes two changes:
- Update the link of my collection to match the new one on Eigen
- Hide the link on Android until `react-native-webview` successfully intercepts js.

_This is the new link working on Eigen_

https://github.com/user-attachments/assets/488c202a-33fd-41c4-be03-ffd08b687009


<!-- Implementation description -->


[PBRW-836]: https://artsyproduct.atlassian.net/browse/PBRW-836?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ