### PR TITLE
feat(dia-1331): ensure uniqueness of h1 tags on collect pages

### DIFF
--- a/cypress/e2e/collect.cy.js
+++ b/cypress/e2e/collect.cy.js
@@ -9,7 +9,7 @@ describe("/collect", () => {
       .should("have.attr", "content")
       .and(
         "eq",
-        "Find artworks by subject matter, style/technique, movement, price, and gallery/institution."
+        "Find artworks by subject matter, style/technique, movement, price, and gallery/institution.",
       )
     cy.get("h1").should("contain", "Collect art and design online")
   })
@@ -17,6 +17,6 @@ describe("/collect", () => {
   it("renders medium-specific content", () => {
     cy.visit("/collect/painting")
     cy.title().should("eq", "Paintings - For Sale on Artsy")
-    cy.get("h1").should("contain", "Collect art and design online")
+    cy.get("h1").should("contain", "Collect paintings online")
   })
 })

--- a/cypress/e2e/collections.cy.ts
+++ b/cypress/e2e/collections.cy.ts
@@ -10,7 +10,7 @@ describe.skip("/collections", () => {
       .should("have.attr", "content")
       .and(
         "eq",
-        "Discover collections of art curated by Artsy Specialists. From iconic artist series to trending design, shop collections on the world's largest online art marketplace."
+        "Discover collections of art curated by Artsy Specialists. From iconic artist series to trending design, shop collections on the world’s largest online art marketplace.",
       )
   })
 

--- a/src/Apps/Artwork/Utils/__tests__/createCollectUrl.jest.tsx
+++ b/src/Apps/Artwork/Utils/__tests__/createCollectUrl.jest.tsx
@@ -1,4 +1,7 @@
-import { createCollectUrl } from "Apps/Artwork/Utils/createCollectUrl"
+import {
+  type FilterCategory,
+  createCollectUrl,
+} from "Apps/Artwork/Utils/createCollectUrl"
 
 describe("createCollectUrl", () => {
   it("formats the collect page url correctly (large)", async () => {
@@ -51,7 +54,7 @@ describe("createCollectUrl", () => {
   it("doesn't specify category in some cases", () => {
     const result = createCollectUrl({
       dimension: "SMALL",
-      category: "Sound",
+      category: "Sound" as FilterCategory, // Intentionally not a valid category
       artistId: "banksy",
     })
 

--- a/src/Apps/Artwork/Utils/createCollectUrl.tsx
+++ b/src/Apps/Artwork/Utils/createCollectUrl.tsx
@@ -34,36 +34,37 @@ export const createCollectUrl = ({
     artist_id: artistId,
   })
 
-  const path = ["/collect", filterCategories[category]]
+  const path = ["/collect", FILTER_CATEGORIES[category]]
     .filter(Boolean)
     .join("/")
 
   return `${path}?${query}`
 }
 
-export type FilterCategory = keyof typeof filterCategories
+export type FilterCategory = keyof typeof FILTER_CATEGORIES
 
 // these come from MediumFilter.tsx
-const filterCategories = {
+export const FILTER_CATEGORIES = {
   Architecture: "architecture",
   "Books and Portfolios": "books-and-portfolios",
   "Design/Decorative Art": "design",
   "Digital Art": "digital-art",
   "Drawing, Collage or other Work on Paper": "work-on-paper",
+  Drawing: "drawing",
+  "Ephemera or Merchandise": "ephemera-or-merchandise",
   "Fashion Design and Wearable Art": "fashion-design-and-wearable-art",
   Installation: "installation",
   Jewelry: "jewelry",
   "Mixed Media": "mixed-media",
   NFT: "nft",
-  Other: "",
   Painting: "painting",
   "Performance Art": "performance-art",
   Photography: "photography",
   Posters: "poster",
   Print: "prints",
+  Reproduction: "reproduction",
   Sculpture: "sculpture",
-  Sound: "",
   "Textile Arts": "textiles",
   "Video/Film/Animation": "film-slash-video",
   "Work on Paper": "work-on-paper",
-}
+} as const

--- a/src/Apps/Collect/Routes/Collect/Utils/__tests__/getMetadata.jest.ts
+++ b/src/Apps/Collect/Routes/Collect/Utils/__tests__/getMetadata.jest.ts
@@ -10,7 +10,7 @@ describe("getMetadata", () => {
       expect(title).toBe("Paintings - For Sale on Artsy")
       expect(breadcrumbTitle).toBe("Paintings")
       expect(description).toBe(
-        "Buy, bid, and inquire on over 250,000 paintings on Artsy, the world’s largest online marketplace for art and design.",
+        "Buy, bid, and inquire on over 850,000+ paintings on Artsy, the world’s largest online marketplace for art and design.",
       )
     })
 
@@ -37,7 +37,7 @@ describe("getMetadata", () => {
       expect(title).toBe("Red Art - For Sale on Artsy")
       expect(breadcrumbTitle).toBe("Red Art")
       expect(description).toBe(
-        `Discover and buy red art by the world's leading artists on Artsy.`,
+        "Discover and buy red art by the world’s leading artists on Artsy.",
       )
     })
 

--- a/src/Apps/Collect/Routes/Collect/Utils/getMetadata.ts
+++ b/src/Apps/Collect/Routes/Collect/Utils/getMetadata.ts
@@ -1,144 +1,136 @@
-export type Medium =
-  | "painting"
-  | "photography"
-  | "sculpture"
-  | "prints"
-  | "work-on-paper"
-  | "drawing"
-  | "design"
-  | "installation"
-  | "film-slash-video"
-  | "jewelry"
-  | "performance-art"
-  | "reproduction"
-  | "ephemera-or-merchandise"
+import type { FILTER_CATEGORIES } from "Apps/Artwork/Utils/createCollectUrl"
+import type { COLOR_OPTIONS } from "Components/ArtworkFilter/ArtworkFilters/ColorFilter"
+import { FACTS_AND_FIGURES } from "Utils/factsAndFigures"
 
-export type Color =
-  | "black-and-white"
-  | "blue"
-  | "gray"
-  | "green"
-  | "orange"
-  | "pink"
-  | "purple"
-  | "red"
-  | "yellow"
+export type Medium = (typeof FILTER_CATEGORIES)[keyof typeof FILTER_CATEGORIES]
+export type Color = (typeof COLOR_OPTIONS)[number]["value"]
 
-interface Props {
-  medium: Medium | undefined
-  color: Color | undefined
+const COLOR_TITLES: Record<Color, string> = {
+  "black-and-white": "Black and White Art",
+  blue: "Blue Art",
+  brown: "Brown Art",
+  gray: "Gray Art",
+  green: "Green Art",
+  orange: "Orange Art",
+  pink: "Pink Art",
+  purple: "Purple Art",
+  red: "Red Art",
+  yellow: "Yellow Art",
 }
 
-export function getMetadata({ medium, color }: Props) {
-  let title = ""
-  let description = ""
+const MEDIUM_METADATA: Record<Medium, { title: string; description: string }> =
+  {
+    architecture: {
+      title: "Architecture",
+      description: `${FACTS_AND_FIGURES.categoriesCounts.architecture}+ architectural works`,
+    },
+    "books-and-portfolios": {
+      title: "Books and Portfolios",
+      description: `${FACTS_AND_FIGURES.categoriesCounts["books-and-portfolios"]}+ books and portfolios`,
+    },
+    design: {
+      title: "Design Works",
+      description: `${FACTS_AND_FIGURES.categoriesCounts.design}+ design works`,
+    },
+    "digital-art": {
+      title: "Digital Art",
+      description: `${FACTS_AND_FIGURES.categoriesCounts["digital-art"]}+ digital art works`,
+    },
+    drawing: {
+      title: "Drawings",
+      description: `${FACTS_AND_FIGURES.categoriesCounts.drawing}+ drawings`,
+    },
+    "ephemera-or-merchandise": {
+      title: "Ephemera or Merchandise",
+      description: `${FACTS_AND_FIGURES.categoriesCounts["ephemera-or-merchandise"]}+ ephemera or merchandise`,
+    },
+    "fashion-design-and-wearable-art": {
+      title: "Fashion Design and Wearable Art",
+      description: `${FACTS_AND_FIGURES.categoriesCounts["fashion-design-and-wearable-art"]}+ pieces of fashion design and wearable art`,
+    },
+    "film-slash-video": {
+      title: "Films & Videos",
+      description: `${FACTS_AND_FIGURES.categoriesCounts["film-slash-video"]}+ Films & Videos works`,
+    },
+    installation: {
+      title: "Installations",
+      description: `${FACTS_AND_FIGURES.categoriesCounts.installation}+ installations`,
+    },
+    jewelry: {
+      title: "Jewelry",
+      description: `${FACTS_AND_FIGURES.categoriesCounts.jewelry}+ pieces of jewelry`,
+    },
+    "mixed-media": {
+      title: "Mixed Media",
+      description: `${FACTS_AND_FIGURES.categoriesCounts["mixed-media"]}+ mixed media works`,
+    },
+    nft: {
+      title: "NFTs",
+      description: `${FACTS_AND_FIGURES.categoriesCounts.nft}+ NFTs`,
+    },
+    painting: {
+      title: "Paintings",
+      description: `${FACTS_AND_FIGURES.categoriesCounts.painting}+ paintings`,
+    },
+    "performance-art": {
+      title: "Performance Art Works",
+      description: `${FACTS_AND_FIGURES.categoriesCounts["performance-art"]}+ performance art works`,
+    },
+    photography: {
+      title: "Photography",
+      description: `${FACTS_AND_FIGURES.categoriesCounts.photography}+ photographs`,
+    },
+    poster: {
+      title: "Posters",
+      description: `${FACTS_AND_FIGURES.categoriesCounts.poster}+ posters`,
+    },
+    prints: {
+      title: "Prints",
+      description: `${FACTS_AND_FIGURES.categoriesCounts.prints}+ prints`,
+    },
+    reproduction: {
+      title: "Reproduction",
+      description: `${FACTS_AND_FIGURES.categoriesCounts.reproduction}+ reproductions`,
+    },
+    sculpture: {
+      title: "Sculptures",
+      description: `${FACTS_AND_FIGURES.categoriesCounts.sculpture}+ sculptures`,
+    },
+    textiles: {
+      title: "Textiles",
+      description: `${FACTS_AND_FIGURES.categoriesCounts.textiles}+ textiles`,
+    },
+    "work-on-paper": {
+      title: "Works on Paper",
+      description: `${FACTS_AND_FIGURES.categoriesCounts["work-on-paper"]}+ works on paper`,
+    },
+  }
 
-  if (medium) {
-    switch (medium) {
-      case "painting":
-        title = "Paintings"
-        description = "250,000 paintings"
-        break
-      case "photography":
-        title = "Photography"
-        description = "140,000 photographs"
-        break
-      case "sculpture":
-        title = "Sculptures"
-        description = "90,000 sculptures"
-        break
-      case "prints":
-        title = "Prints"
-        description = "75,000 prints"
-        break
-      case "work-on-paper":
-        title = "Works on Paper"
-        description = "80,000 works on paper"
-        break
-      case "drawing":
-        title = "Drawings"
-        description = "32,000 drawings"
-        break
-      case "design":
-        title = "Design Works"
-        description = "16,000 design works"
-        break
-      case "installation":
-        title = "Installations"
-        description = "13,000 installations"
-        break
-      case "film-slash-video":
-        title = "Films & Videos"
-        description = "4,000 Films & Videos works"
-        break
-      case "jewelry":
-        title = "Jewelry"
-        description = "3,000 pieces of jewelry"
-        break
-      case "performance-art":
-        title = "Performance Art Works"
-        description = "3,000 performance art works"
-        break
-      case "reproduction":
-        title = "Reproduction"
-        description = "3,000 reproductions"
-        break
-      case "ephemera-or-merchandise":
-        title = "Ephemera or Merchandise"
-        description = "5,000 ephemera or merchandise"
-        break
-      default:
-        null
-    }
+export const getMetadata = ({
+  medium,
+  color,
+}: {
+  medium?: Medium
+  color?: Color
+}) => {
+  if (medium && medium in MEDIUM_METADATA) {
+    const { title, description } = MEDIUM_METADATA[medium]
 
-    if (title && description) {
-      return {
-        title: `${title} - For Sale on Artsy`,
-        breadcrumbTitle: title,
-        description: `Buy, bid, and inquire on over ${description} on Artsy, the world’s largest online marketplace for art and design.`,
-      }
+    return {
+      title: `${title} - For Sale on Artsy`,
+      breadcrumbTitle: title,
+      description: `Buy, bid, and inquire on over ${description} on Artsy, the world’s largest online marketplace for art and design.`,
     }
   }
 
-  if (color) {
-    switch (color) {
-      case "black-and-white":
-        title = "Black and White Art"
-        break
-      case "green":
-        title = "Green Art"
-        break
-      case "gray":
-        title = "Gray Art"
-        break
-      case "blue":
-        title = "Blue Art"
-        break
-      case "orange":
-        title = "Orange Art"
-        break
-      case "pink":
-        title = "Pink Art"
-        break
-      case "red":
-        title = "Red Art"
-        break
-      case "purple":
-        title = "Purple Art"
-        break
-      case "yellow":
-        title = "Yellow Art"
-        break
-      default:
-        null
-    }
+  if (color && color in COLOR_TITLES) {
+    const title = COLOR_TITLES[color]
 
     if (title) {
-      const fullTitle = `${title} - For Sale on Artsy`
       return {
-        title: fullTitle,
+        title: `${title} - For Sale on Artsy`,
         breadcrumbTitle: title,
-        description: `Discover and buy ${title.toLowerCase()} by the world's leading artists on Artsy.`,
+        description: `Discover and buy ${title.toLowerCase()} by the world’s leading artists on Artsy.`,
       }
     }
   }

--- a/src/Apps/Collect/Routes/Collect/index.tsx
+++ b/src/Apps/Collect/Routes/Collect/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Separator, Spacer, Text, color } from "@artsy/palette"
+import { Box, Flex, Separator, Spacer, Text } from "@artsy/palette"
 import { buildUrlForCollectApp } from "Apps/Collect/Utils/urlBuilder"
 import { initializeVariablesWithFilterState } from "Apps/Collect/collectRoutes"
 import { ArtworkFilter } from "Components/ArtworkFilter"
@@ -66,7 +66,7 @@ export const CollectApp: React.FC<React.PropsWithChildren<CollectAppProps>> = ({
             <Text variant={["lg-display", "xl"]}>
               <h1>
                 Collect{" "}
-                {breadcrumbTitle
+                {breadcrumbTitle && breadcrumbTitle !== "Collect"
                   ? breadcrumbTitle.toLowerCase()
                   : "art and design"}{" "}
                 online

--- a/src/Apps/Collect/Routes/Collections/index.tsx
+++ b/src/Apps/Collect/Routes/Collections/index.tsx
@@ -72,4 +72,4 @@ export const CollectionsAppFragmentContainer = createFragmentContainer(
 
 const META_DESCRIPTION =
   "Discover collections of art curated by Artsy Specialists. From iconic artist series to trending design, shop " +
-  "collections on the world's largest online art marketplace."
+  "collections on the world’s largest online art marketplace."

--- a/src/Components/ArtworkFilter/ArtworkFilters/ColorFilter.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/ColorFilter.tsx
@@ -24,7 +24,7 @@ export const COLOR_OPTIONS = [
   { hex: "#7B5927", value: "brown", name: "Brown" },
   { hex: "#C2C2C2", value: "gray", name: "Gray" },
   { hex: "#E1ADCD", value: "pink", name: "Pink" },
-]
+] as const
 
 type ColorOption = (typeof COLOR_OPTIONS)[number]
 
@@ -122,7 +122,10 @@ export const ColorFilter: React.FC<
   )
   const hasBelowTheFoldColorFilter = intersected.length > 0
   const hasColorFilter = colors.length > 0
-  const resultsSorted = sortResults(colors, COLOR_OPTIONS)
+  const resultsSorted = sortResults(
+    colors,
+    COLOR_OPTIONS.map(({ name, value }) => ({ name, value })),
+  )
 
   return (
     <FilterExpandable label={label} expanded={hasColorFilter || expanded}>

--- a/src/Utils/factsAndFigures.ts
+++ b/src/Utils/factsAndFigures.ts
@@ -17,4 +17,27 @@ export const FACTS_AND_FIGURES = {
   artistsCount: "100,000",
   fairsCount: "80",
   auctionHouseCount: "25",
+  categoriesCounts: {
+    architecture: "55,000",
+    "books-and-portfolios": "7,500",
+    design: "60,000",
+    "digital-art": "2,000",
+    drawing: "70,000",
+    "ephemera-or-merchandise": "5,000", // FIXME: Unable to access count
+    "fashion-design-and-wearable-art": "2,500",
+    "film-slash-video": "8,000",
+    installation: "30,000",
+    jewelry: "3,500",
+    "mixed-media": "250,000",
+    nft: "100",
+    painting: "850,000",
+    "performance-art": "7,500",
+    photography: "300,000",
+    poster: "10,000",
+    prints: "350,000",
+    reproduction: "3,000", // FIXME: Unable to access count
+    sculpture: "225,000",
+    textiles: "20,000",
+    "work-on-paper": "210,000",
+  },
 } as const


### PR DESCRIPTION
So, this was one of a few places that came up where we have unique routes with duplicate h1 tags. Routes like `/collect/painting` and `collect/color/pink` — these are kinda weird in that they link to real paths instead of just URLs with query string params applied.

So this just tightens up the code surrounding them and ensures the h1 tags are unique. I've also gone ahead and extracted all the counts and updated them to be reflect more recent data.

Interestingly, I also noticed that the `reproduction` and the `ephemera-or-merchandise` medium filters no longer work. Trying to figure out why this is the case.

![](https://capture.static.damonzucconi.com/Screen-Shot-2025-05-28-07-39-30.18-v9sC1HTRztqZYYnqhNlBKQq16KXYLrKEZSPRnoUcDVpdIb92QLzFwSQeiAsBA5uf2ggv7jKr7fd5emM6Ll7hxWWi3Z1g15QyZfnM.png)

![](https://capture.static.damonzucconi.com/Screen-Shot-2025-05-28-07-39-54.43-D41Ute1ojs0Iz9l89jbxJ7jmriZUsSmgPbJb8uUNh5vgnhGN3g3tpkILDYebIap5wDXRo3bXjSFFzNBfnW34aqK6AFR7832m3ojT.png)