### PR TITLE
style: checkout app naming conventions

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/ExpressCheckout/Order2ExpressCheckout.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/ExpressCheckout/Order2ExpressCheckout.tsx
@@ -22,7 +22,7 @@ const logger = createLogger("Order2ExpressCheckout.tsx")
 
 const stripePromise = loadStripe(getENV("STRIPE_PUBLISHABLE_KEY"))
 
-interface Props {
+interface Order2ExpressCheckoutProps {
   order: Order2ExpressCheckout_order$key
 }
 
@@ -31,8 +31,10 @@ type Seller = Exclude<
   { __typename: "%other" }
 >
 
-export const Order2ExpressCheckout = ({ order }: Props) => {
-  const orderData = useFragment(ORDER_FRAGMENT, order)
+export const Order2ExpressCheckout: React.FC<Order2ExpressCheckoutProps> = ({
+  order,
+}) => {
+  const orderData = useFragment(FRAGMENT, order)
   const [isChrome, setIsChrome] = useState<boolean | null>(null)
   const { expressCheckoutPaymentMethods } = useCheckoutContext()
 
@@ -91,7 +93,7 @@ export const Order2ExpressCheckout = ({ order }: Props) => {
   )
 }
 
-const ORDER_FRAGMENT = graphql`
+const FRAGMENT = graphql`
   fragment Order2ExpressCheckout_order on Order {
     ...Order2ExpressCheckoutUI_order
     availableShippingCountries

--- a/src/Apps/Order2/Routes/Checkout/Components/ExpressCheckout/Order2ExpressCheckoutUI.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/ExpressCheckout/Order2ExpressCheckoutUI.tsx
@@ -44,6 +44,7 @@ import type {
   OrderCreditCardWalletTypeEnum,
   useUpdateOrderMutation$data,
 } from "__generated__/useUpdateOrderMutation.graphql"
+import type React from "react"
 import { useRef, useState } from "react"
 import { graphql, useFragment } from "react-relay"
 
@@ -59,11 +60,10 @@ type HandleCancelCallback = NonNullable<
   React.ComponentProps<typeof ExpressCheckoutElement>["onCancel"]
 >
 
-export const Order2ExpressCheckoutUI = ({
-  order,
-  isChrome,
-}: Order2ExpressCheckoutUIProps) => {
-  const orderData = useFragment(ORDER_FRAGMENT, order)
+export const Order2ExpressCheckoutUI: React.FC<
+  Order2ExpressCheckoutUIProps
+> = ({ order, isChrome }) => {
+  const orderData = useFragment(FRAGMENT, order)
 
   const elements = useElements()
   const stripe = useStripe()
@@ -531,7 +531,7 @@ export const Order2ExpressCheckoutUI = ({
   )
 }
 
-const ORDER_FRAGMENT = graphql`
+const FRAGMENT = graphql`
   fragment Order2ExpressCheckoutUI_order on Order {
     internalID
     source

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2FulfillmentDetailsCompletedView.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2FulfillmentDetailsCompletedView.tsx
@@ -6,10 +6,9 @@ interface Order2FulfillmentDetailsCompletedViewProps {
   fulfillmentOption: any
   onClickEdit: () => void
 }
-export const Order2FulfillmentDetailsCompletedView = ({
-  fulfillmentOption,
-  onClickEdit,
-}: Order2FulfillmentDetailsCompletedViewProps) => {
+export const Order2FulfillmentDetailsCompletedView: React.FC<
+  Order2FulfillmentDetailsCompletedViewProps
+> = ({ fulfillmentOption, onClickEdit }) => {
   if (fulfillmentOption?.type === "PICKUP") {
     return (
       <Flex alignItems="flex-start">

--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentCompletedView.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentCompletedView.tsx
@@ -6,10 +6,9 @@ interface Order2PaymentCompletedViewProps {
   confirmationToken: any
   onClickEdit: () => void
 }
-export const Order2PaymentCompletedView = ({
-  confirmationToken,
-  onClickEdit,
-}: Order2PaymentCompletedViewProps) => {
+export const Order2PaymentCompletedView: React.FC<
+  Order2PaymentCompletedViewProps
+> = ({ confirmationToken, onClickEdit }) => {
   return (
     <Flex flexDirection="column" backgroundColor="mono0" p={2}>
       <Flex justifyContent="space-between">

--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
@@ -1,5 +1,6 @@
-import { Box, Button, Flex, Spacer, Text } from "@artsy/palette"
+import LockIcon from "@artsy/icons/LockIcon"
 import ReceiptIcon from "@artsy/icons/ReceiptIcon"
+import { Box, Button, Flex, Spacer, Text } from "@artsy/palette"
 import {
   Elements,
   PaymentElement,
@@ -14,23 +15,26 @@ import {
 } from "@stripe/stripe-js"
 import { Collapse } from "Apps/Order/Components/Collapse"
 import { FadeInBox } from "Components/FadeInBox"
-import { getENV } from "Utils/getENV"
-import { useState } from "react"
-import LockIcon from "@artsy/icons/LockIcon"
 import { RouterLink } from "System/Components/RouterLink"
+import { getENV } from "Utils/getENV"
 import createLogger from "Utils/logger"
-import { graphql, useRelayEnvironment, fetchQuery } from "react-relay"
 import type { Order2PaymentFormConfirmationTokenQuery } from "__generated__/Order2PaymentFormConfirmationTokenQuery.graphql"
+import type React from "react"
+import { useState } from "react"
+import { fetchQuery, graphql, useRelayEnvironment } from "react-relay"
 
 const stripePromise = loadStripe(getENV("STRIPE_PUBLISHABLE_KEY"))
 const logger = createLogger("Order2PaymentForm")
 
-interface Props {
+interface Order2PaymentFormProps {
   order: any
   setConfirmationToken: (token: any) => void
 }
 
-export const Order2PaymentForm = ({ order, setConfirmationToken }: Props) => {
+export const Order2PaymentForm: React.FC<Order2PaymentFormProps> = ({
+  order,
+  setConfirmationToken,
+}) => {
   const { itemsTotal, seller } = order
 
   if (!itemsTotal) {

--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentStep.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentStep.tsx
@@ -16,7 +16,7 @@ interface Order2PaymentStepProps {
 export const Order2PaymentStep: React.FC<Order2PaymentStepProps> = ({
   order,
 }) => {
-  const orderData = useFragment(ORDER_FRAGMENT, order)
+  const orderData = useFragment(FRAGMENT, order)
 
   const { editPayment, confirmationToken, steps, setConfirmationToken } =
     useCheckoutContext()!
@@ -73,7 +73,7 @@ export const Order2PaymentStep: React.FC<Order2PaymentStepProps> = ({
   )
 }
 
-const ORDER_FRAGMENT = graphql`
+const FRAGMENT = graphql`
   fragment Order2PaymentStep_order on Order {
     internalID
     buyerTotal {


### PR DESCRIPTION
The type of this PR is: **Style**

#minor

### Description
This PR updates the checkout app to follow naming conventions for React FCs and their prop types as well as calling a single fragment `FRAGMENT` rather than `{OBJECT_NAME}_FRAGMENT`.

See https://github.com/artsy/force/pull/15632#discussion_r2112883352
<!-- Implementation description -->
