### PR TITLE
fix(smoke-test): Fix smoke-test-on-live-env job by bumping cypress docker image version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -214,7 +214,7 @@ jobs:
 
   smoke-test-on-live-env:
     docker:
-      - image: cypress/included:12.17.4
+      - image: cypress/included:14.4.0
         environment:
           TERM: xterm
     working_directory: /usr/src/app


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

With the Node 22 bump, smoke tests started failing due to the node version not being matched in the cypress docker container image. This fixes that. 
