### PR TITLE
chore(DIA-1310): Add new follow CTAs for artist and partner headings in Editorial

### DIFF
--- a/src/Apps/Article/Components/ArticleHTML.tsx
+++ b/src/Apps/Article/Components/ArticleHTML.tsx
@@ -2,6 +2,7 @@ import { ContextModule } from "@artsy/cohesion"
 import { Box, type BoxProps, Flex, THEME } from "@artsy/palette"
 import { themeGet } from "@styled-system/theme-get"
 import { FollowArtistButtonQueryRenderer } from "Components/FollowButton/FollowArtistButton"
+import { FollowProfileButtonQueryRenderer } from "Components/FollowButton/FollowProfileButton"
 import { toStyle } from "Utils/toStyle"
 import { type FC, useEffect, useState } from "react"
 import styled from "styled-components"
@@ -36,8 +37,15 @@ export const ArticleHTML: FC<React.PropsWithChildren<ArticleHTMLProps>> = ({
         "a[href^='https://www.artsy.net/artist/']",
       )
 
+      const partnerLinks = heading?.querySelectorAll(
+        "a[href^='https://www.artsy.net/partner/']",
+      )
+
       const isArtistHeading =
         entity === "artist" && heading && artistLinks?.length === 1
+
+      const isPartnerHeading =
+        entity === "partner" && heading && partnerLinks?.length === 1
 
       if (isArtistHeading) {
         return (
@@ -49,6 +57,21 @@ export const ArticleHTML: FC<React.PropsWithChildren<ArticleHTMLProps>> = ({
               id={id}
               size={["large", "small"]}
               contextModule={ContextModule.artistHeader}
+            />
+          </Flex>
+        )
+      }
+
+      if (isPartnerHeading) {
+        return (
+          <Flex alignItems="center" gap={1} key={[i, id].join("-")}>
+            <ArticleTooltip entity={entity} id={id} href={href}>
+              {node.textContent}
+            </ArticleTooltip>
+            <FollowProfileButtonQueryRenderer
+              id={id}
+              size={["large", "small"]}
+              contextModule={ContextModule.partnerHeader}
             />
           </Flex>
         )

--- a/src/Apps/Article/Components/ArticleHTML.tsx
+++ b/src/Apps/Article/Components/ArticleHTML.tsx
@@ -1,5 +1,7 @@
-import { Box, type BoxProps, THEME } from "@artsy/palette"
+import { ContextModule } from "@artsy/cohesion"
+import { Box, type BoxProps, Flex, THEME } from "@artsy/palette"
 import { themeGet } from "@styled-system/theme-get"
+import { FollowArtistButtonQueryRenderer } from "Components/FollowButton/FollowArtistButton"
 import { toStyle } from "Utils/toStyle"
 import { type FC, useEffect, useState } from "react"
 import styled from "styled-components"
@@ -28,6 +30,29 @@ export const ArticleHTML: FC<React.PropsWithChildren<ArticleHTMLProps>> = ({
       const [_, entity, id] = uri.pathname.split("/")
 
       if (!isSupportedArticleTooltip(entity)) return
+
+      const heading = node.closest("h2")
+      const artistLinks = heading?.querySelectorAll(
+        "a[href^='https://www.artsy.net/artist/']",
+      )
+
+      const isArtistHeading =
+        entity === "artist" && heading && artistLinks?.length === 1
+
+      if (isArtistHeading) {
+        return (
+          <Flex alignItems="center" gap={1} key={[i, id].join("-")}>
+            <ArticleTooltip entity={entity} id={id} href={href}>
+              {node.textContent}
+            </ArticleTooltip>
+            <FollowArtistButtonQueryRenderer
+              id={id}
+              size={["large", "small"]}
+              contextModule={ContextModule.artistHeader}
+            />
+          </Flex>
+        )
+      }
 
       return (
         <ArticleTooltip


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [DIA-1310]

### Description

<!-- Implementation description -->
For SEO improvements, we've added additional Follow CTAs (in addition to current article tooltips) for individual artists and partners that appear in article headers. This is currently only in place for artists/partners contained within h2 headers - we may expand this after seo/design feedback. 

<img width="624" alt="Screenshot 2025-06-01 at 1 50 26 PM" src="https://github.com/user-attachments/assets/76b07b46-2613-4a66-85ae-fcb54b7c9f8e" />

