### PR TITLE
feat: allow NWFY works to be strictly gridded for easier evaluation

### DIFF
--- a/src/Apps/NewForYou/Components/NewForYouArtworksGrid.tsx
+++ b/src/Apps/NewForYou/Components/NewForYouArtworksGrid.tsx
@@ -1,5 +1,8 @@
 import { Text } from "@artsy/palette"
-import ArtworkGrid from "Components/ArtworkGrid/ArtworkGrid"
+import ArtworkGrid, {
+  ArtworkGridLayout,
+} from "Components/ArtworkGrid/ArtworkGrid"
+import { useRouter } from "System/Hooks/useRouter"
 import type { NewForYouArtworksGrid_viewer$data } from "__generated__/NewForYouArtworksGrid_viewer.graphql"
 import type { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -11,6 +14,12 @@ interface NewForYouArtworksGridProps {
 export const NewForYouArtworksGrid: FC<
   React.PropsWithChildren<NewForYouArtworksGridProps>
 > = ({ viewer }) => {
+  const { match } = useRouter()
+
+  const layout = (
+    match?.location?.query?.layout ?? "masonry"
+  ).toUpperCase() as ArtworkGridLayout
+
   return (
     <>
       {viewer.artworksForUser &&
@@ -18,6 +27,7 @@ export const NewForYouArtworksGrid: FC<
         <ArtworkGrid
           artworks={viewer.artworksForUser}
           columnCount={[2, 3, 4]}
+          layout={layout}
         />
       ) : (
         <Text variant="lg-display" mt={4} color="mono60">


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [ONYX-1748]

### Description

When discussing the process of evaluating NWFY recs, we noted that masonry layouts can make it difficult to understand the ordering of artworks.

Because ordering of artworks will be an important part of the next round of recs work (i.e. a/b test of re-ranking based on price affinity) I make a small change here to allow NWFY works to be presented in strict gridded order instead of masonry.

With this change, toggling between masonry and strict grids is accomplished with a simple query param:

- <code>/new-for-you?version=A</code>
-vs-
- <code>/new-for-you?version=A<b>&layout=grid</b></code>

Hopefully that smooths the qualitative QA step.

(We could also consider making the strict grid the default, so that users coming from the email would see this as well — similar to the other surfaces where we've deemed it important to have clear artwork ordering: partner shows and auctions.)

| Default (masonry, same as before) | With layout=grid |
|--------|--------|
| <img width="1199" alt="masonry" src="https://github.com/user-attachments/assets/63d76ab0-42fb-4429-b732-d956d1ba4fde" /> | <img width="1199" alt="grid" src="https://github.com/user-attachments/assets/6dbff5f3-b81f-41e2-a59a-fb118a436b13" /> | 


[ONYX-1748]: https://artsyproduct.atlassian.net/browse/ONYX-1748?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ