### PR TITLE
feat(partner): enhances partner json schema

### DIFF
--- a/src/Apps/Partner/Components/PartnerMeta/PartnerMetaStructuredData.tsx
+++ b/src/Apps/Partner/Components/PartnerMeta/PartnerMetaStructuredData.tsx
@@ -1,0 +1,162 @@
+import { StructuredData } from "Components/Seo/StructuredData"
+import { getENV } from "Utils/getENV"
+import type { PartnerMetaStructuredData_partner$key } from "__generated__/PartnerMetaStructuredData_partner.graphql"
+import { compact } from "lodash"
+import { useMemo } from "react"
+import { graphql, useFragment } from "react-relay"
+import type { ImageObject, PostalAddress } from "schema-dts"
+import { formatOpeningHours } from "./formatOpeningHours"
+
+interface PartnerMetaStructuredDataProps {
+  partner: PartnerMetaStructuredData_partner$key
+}
+
+export const PartnerMetaStructuredData: React.FC<
+  PartnerMetaStructuredDataProps
+> = ({ partner: _partner }) => {
+  const partner = useFragment(fragment, _partner)
+  const partnerUrl = `${getENV("APP_URL")}${partner.href}`
+
+  const logo: ImageObject | undefined = partner.profile?.icon?.cropped?.url
+    ? {
+        "@type": "ImageObject",
+        url: partner.profile.icon.cropped.url,
+        width: {
+          "@type": "QuantitativeValue",
+          value: partner.profile.icon.cropped.width,
+          unitCode: "E37",
+        },
+        height: {
+          "@type": "QuantitativeValue",
+          value: partner.profile.icon.cropped.height,
+          unitCode: "E37",
+        },
+      }
+    : undefined
+
+  const image: ImageObject | undefined = partner.profile?.image?.resized?.url
+    ? {
+        "@type": "ImageObject",
+        url: partner.profile.image.resized.url,
+        width: {
+          "@type": "QuantitativeValue",
+          value: partner.profile.image.resized.width ?? 0,
+          unitCode: "E37",
+        },
+        height: {
+          "@type": "QuantitativeValue",
+          value: partner.profile.image.resized.height ?? 0,
+          unitCode: "E37",
+        },
+      }
+    : undefined
+
+  const location = partner.locationsConnection?.edges?.[0]?.node
+
+  const address: PostalAddress | undefined = location
+    ? {
+        "@type": "PostalAddress",
+        streetAddress: location.address ?? undefined,
+        addressLocality: location.city ?? undefined,
+        addressRegion: location.state ?? undefined,
+        postalCode: location.postalCode ?? undefined,
+        addressCountry: location.country ?? undefined,
+      }
+    : undefined
+
+  const openingHours = useMemo(() => {
+    if (!location?.openingHours) return undefined
+
+    if ("text" in location.openingHours && location.openingHours.text) {
+      return location.openingHours.text
+    }
+
+    if (
+      "schedules" in location.openingHours &&
+      location.openingHours.schedules
+    ) {
+      const schedules = compact(location.openingHours.schedules).map(
+        schedule => ({
+          days: schedule.days ?? "",
+          hours: schedule.hours ?? "",
+        }),
+      )
+
+      return formatOpeningHours(schedules) || undefined
+    }
+
+    return undefined
+  }, [location])
+
+  return (
+    <StructuredData
+      schemaData={{
+        "@context": "https://schema.org",
+        "@type": "ArtGallery",
+        "@id": partnerUrl,
+        name: partner.name ?? undefined,
+        url: partnerUrl,
+        description: partner.profile?.bio ?? undefined,
+        image,
+        logo,
+        mainEntityOfPage: {
+          "@type": "WebPage",
+          "@id": partnerUrl,
+        },
+        address,
+        openingHours,
+      }}
+    />
+  )
+}
+
+const fragment = graphql`
+  fragment PartnerMetaStructuredData_partner on Partner {
+    slug
+    href
+    name
+    profile {
+      bio
+      image {
+        resized(width: 1920, height: 1920) {
+          url
+          width
+          height
+        }
+      }
+      icon {
+        cropped(
+          width: 250
+          height: 250
+          version: ["untouched-png", "large", "square"]
+        ) {
+          url
+          width
+          height
+        }
+      }
+    }
+    locationsConnection(first: 50) {
+      edges {
+        node {
+          address
+          city
+          country
+          postalCode
+          state
+          openingHours {
+            ... on OpeningHoursArray {
+              schedules {
+                days
+                hours
+              }
+            }
+            ... on OpeningHoursText {
+              text
+            }
+          }
+        }
+      }
+    }
+  }
+`

--- a/src/Apps/Partner/Components/PartnerMeta/__tests__/formatOpeningHours.jest.tsx
+++ b/src/Apps/Partner/Components/PartnerMeta/__tests__/formatOpeningHours.jest.tsx
@@ -1,0 +1,205 @@
+import { formatOpeningHours } from "../formatOpeningHours"
+
+describe("formatOpeningHours", () => {
+  describe("closed hours", () => {
+    it("should return empty string when hours indicate closed", () => {
+      expect(
+        formatOpeningHours([{ days: "Monday, Sunday", hours: "Closed" }]),
+      ).toBe("")
+      expect(formatOpeningHours([{ days: "Monday", hours: "closed" }])).toBe("")
+      expect(formatOpeningHours([{ days: "Monday", hours: "CLOSED" }])).toBe("")
+    })
+  })
+
+  describe("day range formatting", () => {
+    it("should format day ranges with em dash", () => {
+      const result = formatOpeningHours([
+        {
+          days: "Tuesday–Saturday",
+          hours: "10am–6pm",
+        },
+      ])
+      expect(result).toBe("Tu-Sa 10:00-18:00")
+    })
+
+    it("should format day ranges with hyphen", () => {
+      const result = formatOpeningHours([
+        {
+          days: "Monday-Friday",
+          hours: "9am-5pm",
+        },
+      ])
+      expect(result).toBe("Mo-Fr 09:00-17:00")
+    })
+
+    it("should format weekends", () => {
+      const result = formatOpeningHours([
+        {
+          days: "Saturday-Sunday",
+          hours: "11am-4pm",
+        },
+      ])
+      expect(result).toBe("Sa-Su 11:00-16:00")
+    })
+  })
+
+  describe("comma-separated days", () => {
+    it("should format comma-separated days", () => {
+      const result = formatOpeningHours([
+        {
+          days: "Monday, Wednesday, Friday",
+          hours: "9am-5pm",
+        },
+      ])
+      expect(result).toBe("Mo,We,Fr 09:00-17:00")
+    })
+
+    it("should format weekend days", () => {
+      const result = formatOpeningHours([
+        {
+          days: "Saturday, Sunday",
+          hours: "10am-2pm",
+        },
+      ])
+      expect(result).toBe("Sa,Su 10:00-14:00")
+    })
+  })
+
+  describe("time formatting", () => {
+    it("should convert 12-hour to 24-hour format", () => {
+      expect(formatOpeningHours([{ days: "Monday", hours: "9am-5pm" }])).toBe(
+        "Mo 09:00-17:00",
+      )
+      expect(formatOpeningHours([{ days: "Tuesday", hours: "10am-6pm" }])).toBe(
+        "Tu 10:00-18:00",
+      )
+      expect(
+        formatOpeningHours([{ days: "Wednesday", hours: "1pm-9pm" }]),
+      ).toBe("We 13:00-21:00")
+    })
+
+    it("should handle noon and midnight correctly", () => {
+      expect(formatOpeningHours([{ days: "Monday", hours: "12am-12pm" }])).toBe(
+        "Mo 00:00-12:00",
+      )
+      expect(
+        formatOpeningHours([{ days: "Tuesday", hours: "12pm-11pm" }]),
+      ).toBe("Tu 12:00-23:00")
+    })
+
+    it("should handle times with minutes", () => {
+      expect(
+        formatOpeningHours([{ days: "Monday", hours: "9:30am-5:30pm" }]),
+      ).toBe("Mo 09:30-17:30")
+      expect(
+        formatOpeningHours([{ days: "Tuesday", hours: "10:15am-6:45pm" }]),
+      ).toBe("Tu 10:15-18:45")
+    })
+  })
+
+  describe("multiple time ranges", () => {
+    it("should format multiple time ranges separated by commas", () => {
+      const result = formatOpeningHours([
+        {
+          days: "Tuesday–Saturday",
+          hours: "10am–1pm, 2pm–6pm",
+        },
+      ])
+      expect(result).toBe("Tu-Sa 10:00-13:00,14:00-18:00")
+    })
+
+    it("should handle mixed time formats", () => {
+      const result = formatOpeningHours([
+        {
+          days: "Monday, Wednesday",
+          hours: "9am–12pm, 1:30pm–5pm",
+        },
+      ])
+      expect(result).toBe("Mo,We 09:00-12:00,13:30-17:00")
+    })
+  })
+
+  describe("multiple schedules", () => {
+    it("should handle multiple schedule objects", () => {
+      const result = formatOpeningHours([
+        { days: "Monday-Friday", hours: "9am-5pm" },
+        { days: "Saturday", hours: "10am-2pm" },
+      ])
+      expect(result).toBe("Mo-Fr 09:00-17:00 Sa 10:00-14:00")
+    })
+
+    it("should filter out closed schedules", () => {
+      const result = formatOpeningHours([
+        { days: "Monday-Friday", hours: "9am-5pm" },
+        { days: "Saturday", hours: "Closed" },
+        { days: "Sunday", hours: "11am-3pm" },
+      ])
+      expect(result).toBe("Mo-Fr 09:00-17:00 Su 11:00-15:00")
+    })
+
+    it("should return empty string when all schedules are closed", () => {
+      const result = formatOpeningHours([
+        { days: "Monday", hours: "Closed" },
+        { days: "Tuesday", hours: "closed" },
+      ])
+      expect(result).toBe("")
+    })
+  })
+
+  describe("edge cases", () => {
+    it("should handle all days of the week", () => {
+      const result = formatOpeningHours([
+        {
+          days: "Monday-Sunday",
+          hours: "9am-9pm",
+        },
+      ])
+      expect(result).toBe("Mo-Su 09:00-21:00")
+    })
+
+    it("should handle case insensitive day names", () => {
+      const result = formatOpeningHours([
+        {
+          days: "MONDAY, FRIDAY",
+          hours: "9AM-5PM",
+        },
+      ])
+      expect(result).toBe("Mo,Fr 09:00-17:00")
+    })
+
+    it("should handle mixed case", () => {
+      const result = formatOpeningHours([
+        {
+          days: "Monday, WednesdaY, Friday",
+          hours: "9Am-5Pm",
+        },
+      ])
+      expect(result).toBe("Mo,We,Fr 09:00-17:00")
+    })
+
+    it("should handle empty array", () => {
+      const result = formatOpeningHours([])
+      expect(result).toBe("")
+    })
+  })
+
+  describe("real-world examples", () => {
+    it("should handle the provided example inputs", () => {
+      // Example from the comment: mixed closed and open schedules
+      const result = formatOpeningHours([
+        { days: "Monday, Sunday", hours: "Closed" },
+        { days: "Tuesday–Saturday", hours: "10am–1pm, 2pm–6pm" },
+      ])
+      expect(result).toBe("Tu-Sa 10:00-13:00,14:00-18:00")
+    })
+
+    it("should handle typical gallery schedule", () => {
+      const result = formatOpeningHours([
+        { days: "Monday", hours: "Closed" },
+        { days: "Tuesday-Friday", hours: "10am-6pm" },
+        { days: "Saturday-Sunday", hours: "10am-5pm" },
+      ])
+      expect(result).toBe("Tu-Fr 10:00-18:00 Sa-Su 10:00-17:00")
+    })
+  })
+})

--- a/src/Apps/Partner/Components/PartnerMeta/formatOpeningHours.ts
+++ b/src/Apps/Partner/Components/PartnerMeta/formatOpeningHours.ts
@@ -1,0 +1,115 @@
+/**
+ * The general opening hours for a business. Opening hours can be specified as a weekly time range, starting with days, then times per day. Multiple days can be listed with commas ',' separating each day. Day or time ranges are specified using a hyphen '-'.
+ * - Days are specified using the following two-letter combinations: `Mo`, `Tu`, `We`, `Th`, `Fr`, `Sa`, `Su`.
+ * - Times are specified using 24:00 format. For example, 3pm is specified as `15:00`, 10am as `10:00`.
+ * - Here is an example: `<time itemprop="openingHours" datetime="Tu,Th 16:00-20:00">Tuesdays and Thursdays 4-8pm</time>`.
+ * - If a business is open 7 days a week, then it can be specified as `<time itemprop="openingHours" datetime="Mo-Su">Monday through Sunday, all day</time>`.
+ *
+ * Example input:
+ * [{
+ *   "hours": "Closed",
+ *   "days": "Monday, Sunday"
+ * },
+ * {
+ *   "hours": "10am–1pm, 2pm–6pm",
+ *   "days": "Tuesday–Saturday"
+ * }]
+ */
+
+// Day name mappings for schema.org format
+const DAY_MAP: Record<string, string> = {
+  monday: "Mo",
+  tuesday: "Tu",
+  wednesday: "We",
+  thursday: "Th",
+  friday: "Fr",
+  saturday: "Sa",
+  sunday: "Su",
+} as const
+
+// Time parsing regex pattern
+const TIME_PATTERN = /(\d{1,2})(?::(\d{2}))?\s*(am|pm)/i
+const DAY_RANGE_PATTERN = /(\w+)[-–](\w+)/
+const TIME_RANGE_PATTERN = /(.+?)[-–](.+)/
+
+const isClosed = (hours: string): boolean =>
+  hours.toLowerCase().includes("closed")
+
+const convertTime = (timeStr: string): string => {
+  const timeMatch = timeStr.match(TIME_PATTERN)
+
+  if (!timeMatch) return timeStr
+
+  const [, hours, minutes = "00", period] = timeMatch
+  let hour24 = Number.parseInt(hours, 10)
+
+  if (period.toLowerCase() === "pm" && hour24 !== 12) {
+    hour24 += 12
+  } else if (period.toLowerCase() === "am" && hour24 === 12) {
+    hour24 = 0
+  }
+
+  return `${hour24.toString().padStart(2, "0")}:${minutes}`
+}
+
+const formatDayRange = (startDay: string, endDay: string): string => {
+  const startCode = DAY_MAP[startDay.toLowerCase()]
+  const endCode = DAY_MAP[endDay.toLowerCase()]
+
+  return startCode && endCode ? `${startCode}-${endCode}` : ""
+}
+
+const formatIndividualDays = (daysStr: string): string => {
+  const daysList = daysStr.split(",").map(day => day.trim())
+  const dayCodes = daysList
+    .map(day => DAY_MAP[day.toLowerCase()])
+    .filter(Boolean)
+
+  return dayCodes.join(",")
+}
+
+const formatDays = (daysStr: string): string => {
+  const rangeMatch = daysStr.match(DAY_RANGE_PATTERN)
+
+  return rangeMatch
+    ? formatDayRange(rangeMatch[1], rangeMatch[2])
+    : formatIndividualDays(daysStr)
+}
+
+const formatTimeRange = (range: string): string => {
+  const rangeMatch = range.match(TIME_RANGE_PATTERN)
+
+  if (!rangeMatch) return convertTime(range)
+
+  const [, startTime, endTime] = rangeMatch
+  const start24 = convertTime(startTime.trim())
+  const end24 = convertTime(endTime.trim())
+
+  return `${start24}-${end24}`
+}
+
+const formatTimeRanges = (hoursStr: string): string =>
+  hoursStr
+    .split(",")
+    .map(range => range.trim())
+    .map(formatTimeRange)
+    .join(",")
+
+const processSchedule = ({
+  days,
+  hours,
+}: {
+  days: string
+  hours: string
+}): string => {
+  if (isClosed(hours)) return ""
+
+  const formattedDays = formatDays(days)
+  const formattedTimes = formatTimeRanges(hours)
+
+  return `${formattedDays} ${formattedTimes}`
+}
+
+export const formatOpeningHours = (
+  schedules: Array<{ days: string; hours: string }>,
+): string => schedules.map(processSchedule).filter(Boolean).join(" ")

--- a/src/Apps/Partner/Components/PartnerMeta/index.tsx
+++ b/src/Apps/Partner/Components/PartnerMeta/index.tsx
@@ -1,6 +1,5 @@
-import { LocalBusiness } from "Components/Seo/LocalBusiness"
+import { PartnerMetaStructuredData } from "Apps/Partner/Components/PartnerMeta/PartnerMetaStructuredData"
 import { useRouter } from "System/Hooks/useRouter"
-import { extractNodes } from "Utils/extractNodes"
 import { getENV } from "Utils/getENV"
 import type { PartnerMeta_partner$data } from "__generated__/PartnerMeta_partner.graphql"
 import type * as React from "react"
@@ -12,7 +11,7 @@ interface PartnerMetaProps {
 }
 
 const PartnerMeta: React.FC<React.PropsWithChildren<PartnerMetaProps>> = ({
-  partner: { locationsConnection, meta, name, slug },
+  partner,
 }) => {
   const {
     match: {
@@ -21,12 +20,12 @@ const PartnerMeta: React.FC<React.PropsWithChildren<PartnerMetaProps>> = ({
     },
   } = useRouter()
 
+  const { meta, slug } = partner
+
   const href = `${getENV("APP_URL")}${pathname}`
   const canonicalHref = artistId
     ? `${getENV("APP_URL")}/partner/${slug}/artists/${artistId}`
     : `${getENV("APP_URL")}/partner/${slug}`
-
-  const partnerLocation = extractNodes(locationsConnection)[0]
 
   return (
     <>
@@ -45,31 +44,8 @@ const PartnerMeta: React.FC<React.PropsWithChildren<PartnerMetaProps>> = ({
 
       {meta?.image && <Meta property="og:image" content={meta?.image} />}
       {meta?.image && <Meta name="thumbnail" content={meta?.image} />}
-      <LocalBusiness
-        partnerData={{
-          name: name ?? "",
-          profile: {
-            locations: partnerLocation
-              ? [
-                  {
-                    city: partnerLocation.city ?? null,
-                    address: partnerLocation.address ?? null,
-                    address2: partnerLocation.address2 ?? null,
-                    postalCode: partnerLocation.postalCode ?? null,
-                    state: partnerLocation.state ?? null,
-                    country: partnerLocation.country ?? null,
-                    coordinates: partnerLocation.coordinates
-                      ? {
-                          lat: partnerLocation.coordinates.lat ?? null,
-                          lng: partnerLocation.coordinates.lng ?? null,
-                        }
-                      : null,
-                  },
-                ]
-              : [],
-          },
-        }}
-      />
+
+      <PartnerMetaStructuredData partner={partner} />
     </>
   )
 }
@@ -79,29 +55,12 @@ export const PartnerMetaFragmentContainer = createFragmentContainer(
   {
     partner: graphql`
       fragment PartnerMeta_partner on Partner {
-        locationsConnection(first: 1) {
-          edges {
-            node {
-              address
-              address2
-              city
-              coordinates {
-                lat
-                lng
-              }
-              country
-              phone
-              postalCode
-              state
-            }
-          }
-        }
+        ...PartnerMetaStructuredData_partner
         meta {
           image
           title
           description
         }
-        name
         slug
       }
     `,

--- a/src/__generated__/PartnerApp_Test_Query.graphql.ts
+++ b/src/__generated__/PartnerApp_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<699b11ce7de03f801a18b71dd3e0401d>>
+ * @generated SignedSource<<0c977f369d66567076fbd1d59d047de4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -50,99 +50,128 @@ v3 = {
   "name": "name",
   "storageKey": null
 },
-v4 = {
+v4 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "url",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "width",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "height",
+    "storageKey": null
+  }
+],
+v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "city",
   "storageKey": null
 },
-v5 = {
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "totalCount",
   "storageKey": null
 },
-v6 = [
-  (v5/*: any*/)
+v7 = [
+  (v6/*: any*/)
 ],
-v7 = {
+v8 = {
   "kind": "Literal",
   "name": "displayOnPartnerProfile",
   "value": true
 },
-v8 = {
+v9 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v9 = {
+v10 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v10 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "String"
-},
 v11 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "FormattedNumber"
+  "type": "String"
 },
 v12 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Boolean"
+  "type": "FormattedNumber"
 },
 v13 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "LocationConnection"
+  "type": "Boolean"
 },
 v14 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "LocationConnection"
+},
+v15 = {
   "enumValues": null,
   "nullable": true,
   "plural": true,
   "type": "LocationEdge"
 },
-v15 = {
+v16 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Location"
 },
-v16 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "Float"
-},
 v17 = {
   "enumValues": null,
-  "nullable": true,
+  "nullable": false,
   "plural": false,
-  "type": "ArtistPartnerConnection"
+  "type": "String"
 },
 v18 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Image"
+  "type": "ArtistPartnerConnection"
 },
 v19 = {
   "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Image"
+},
+v20 = {
+  "enumValues": null,
   "nullable": false,
   "plural": false,
-  "type": "String"
+  "type": "Int"
+},
+v21 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "ResizedImageUrl"
 };
 return {
   "fragment": {
@@ -255,6 +284,27 @@ return {
                     "kind": "ScalarField",
                     "name": "url",
                     "storageKey": "url(version:\"wide\")"
+                  },
+                  {
+                    "alias": null,
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 1920
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 1920
+                      }
+                    ],
+                    "concreteType": "ResizedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "resized",
+                    "plural": false,
+                    "selections": (v4/*: any*/),
+                    "storageKey": "resized(height:1920,width:1920)"
                   }
                 ],
                 "storageKey": null
@@ -263,22 +313,10 @@ return {
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "ProfileCounts",
-                "kind": "LinkedField",
-                "name": "counts",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "follows",
-                    "storageKey": null
-                  }
-                ],
+                "kind": "ScalarField",
+                "name": "bio",
                 "storageKey": null
               },
-              (v1/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -287,6 +325,36 @@ return {
                 "name": "icon",
                 "plural": false,
                 "selections": [
+                  {
+                    "alias": null,
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 250
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "version",
+                        "value": [
+                          "untouched-png",
+                          "large",
+                          "square"
+                        ]
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 250
+                      }
+                    ],
+                    "concreteType": "CroppedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "cropped",
+                    "plural": false,
+                    "selections": (v4/*: any*/),
+                    "storageKey": "cropped(height:250,version:[\"untouched-png\",\"large\",\"square\"],width:250)"
+                  },
                   {
                     "alias": null,
                     "args": [
@@ -330,17 +398,51 @@ return {
                   }
                 ],
                 "storageKey": null
-              }
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ProfileCounts",
+                "kind": "LinkedField",
+                "name": "counts",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "follows",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v1/*: any*/)
             ],
             "storageKey": null
           },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "href",
+            "storageKey": null
+          },
+          (v3/*: any*/),
           {
             "alias": null,
             "args": [
               {
                 "kind": "Literal",
                 "name": "first",
-                "value": 1
+                "value": 50
               }
             ],
             "concreteType": "LocationConnection",
@@ -371,51 +473,12 @@ return {
                         "name": "address",
                         "storageKey": null
                       },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "address2",
-                        "storageKey": null
-                      },
-                      (v4/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "LatLng",
-                        "kind": "LinkedField",
-                        "name": "coordinates",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "lat",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "lng",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
+                      (v5/*: any*/),
                       {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
                         "name": "country",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "phone",
                         "storageKey": null
                       },
                       {
@@ -432,6 +495,70 @@ return {
                         "name": "state",
                         "storageKey": null
                       },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "openingHours",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "__typename",
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "FormattedDaySchedules",
+                                "kind": "LinkedField",
+                                "name": "schedules",
+                                "plural": true,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "days",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "hours",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "OpeningHoursArray",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "text",
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "OpeningHoursText",
+                            "abstractKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
                       (v2/*: any*/)
                     ],
                     "storageKey": null
@@ -440,7 +567,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "locationsConnection(first:1)"
+            "storageKey": "locationsConnection(first:50)"
           },
           {
             "alias": null,
@@ -474,14 +601,6 @@ return {
             ],
             "storageKey": null
           },
-          (v3/*: any*/),
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "slug",
-            "storageKey": null
-          },
           {
             "alias": null,
             "args": null,
@@ -510,7 +629,7 @@ return {
             "name": "locationsConnection",
             "plural": false,
             "selections": [
-              (v5/*: any*/),
+              (v6/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -527,7 +646,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v4/*: any*/),
+                      (v5/*: any*/),
                       (v2/*: any*/)
                     ],
                     "storageKey": null
@@ -584,13 +703,13 @@ return {
             "kind": "LinkedField",
             "name": "articlesConnection",
             "plural": false,
-            "selections": (v6/*: any*/),
+            "selections": (v7/*: any*/),
             "storageKey": null
           },
           {
             "alias": "representedArtists",
             "args": [
-              (v7/*: any*/),
+              (v8/*: any*/),
               {
                 "kind": "Literal",
                 "name": "representedBy",
@@ -601,13 +720,13 @@ return {
             "kind": "LinkedField",
             "name": "artistsConnection",
             "plural": false,
-            "selections": (v6/*: any*/),
+            "selections": (v7/*: any*/),
             "storageKey": "artistsConnection(displayOnPartnerProfile:true,representedBy:true)"
           },
           {
             "alias": "notRepresentedArtists",
             "args": [
-              (v7/*: any*/),
+              (v8/*: any*/),
               {
                 "kind": "Literal",
                 "name": "hasPublishedArtworks",
@@ -623,7 +742,7 @@ return {
             "kind": "LinkedField",
             "name": "artistsConnection",
             "plural": false,
-            "selections": (v6/*: any*/),
+            "selections": (v7/*: any*/),
             "storageKey": "artistsConnection(displayOnPartnerProfile:true,hasPublishedArtworks:true,representedBy:false)"
           },
           {
@@ -643,7 +762,7 @@ return {
             "kind": "LinkedField",
             "name": "viewingRoomsConnection",
             "plural": false,
-            "selections": (v6/*: any*/),
+            "selections": (v7/*: any*/),
             "storageKey": "viewingRoomsConnection(statuses:[\"live\",\"closed\",\"scheduled\"])"
           },
           (v2/*: any*/)
@@ -653,7 +772,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "cf9949ac8b6111df71dcc9fe2a22acaa",
+    "cacheID": "df7808aae5137531445a46c51ac4f62b",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -669,116 +788,132 @@ return {
           "plural": false,
           "type": "ArticleConnection"
         },
-        "partner.articles.totalCount": (v8/*: any*/),
+        "partner.articles.totalCount": (v9/*: any*/),
         "partner.categories": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "PartnerCategory"
         },
-        "partner.categories.id": (v9/*: any*/),
-        "partner.categories.name": (v10/*: any*/),
+        "partner.categories.id": (v10/*: any*/),
+        "partner.categories.name": (v11/*: any*/),
         "partner.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "PartnerCounts"
         },
-        "partner.counts.displayableShows": (v11/*: any*/),
-        "partner.counts.eligibleArtworks": (v11/*: any*/),
-        "partner.displayArtistsSection": (v12/*: any*/),
-        "partner.displayFullPartnerPage": (v12/*: any*/),
-        "partner.displayWorksSection": (v12/*: any*/),
+        "partner.counts.displayableShows": (v12/*: any*/),
+        "partner.counts.eligibleArtworks": (v12/*: any*/),
+        "partner.displayArtistsSection": (v13/*: any*/),
+        "partner.displayFullPartnerPage": (v13/*: any*/),
+        "partner.displayWorksSection": (v13/*: any*/),
         "partner.hasVisibleFollowsCount": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "Boolean"
         },
-        "partner.id": (v9/*: any*/),
-        "partner.internalID": (v9/*: any*/),
-        "partner.isDefaultProfilePublic": (v12/*: any*/),
-        "partner.locations": (v13/*: any*/),
-        "partner.locations.edges": (v14/*: any*/),
-        "partner.locations.edges.node": (v15/*: any*/),
-        "partner.locations.edges.node.city": (v10/*: any*/),
-        "partner.locations.edges.node.id": (v9/*: any*/),
-        "partner.locations.totalCount": (v8/*: any*/),
-        "partner.locationsConnection": (v13/*: any*/),
-        "partner.locationsConnection.edges": (v14/*: any*/),
-        "partner.locationsConnection.edges.node": (v15/*: any*/),
-        "partner.locationsConnection.edges.node.address": (v10/*: any*/),
-        "partner.locationsConnection.edges.node.address2": (v10/*: any*/),
-        "partner.locationsConnection.edges.node.city": (v10/*: any*/),
-        "partner.locationsConnection.edges.node.coordinates": {
+        "partner.href": (v11/*: any*/),
+        "partner.id": (v10/*: any*/),
+        "partner.internalID": (v10/*: any*/),
+        "partner.isDefaultProfilePublic": (v13/*: any*/),
+        "partner.locations": (v14/*: any*/),
+        "partner.locations.edges": (v15/*: any*/),
+        "partner.locations.edges.node": (v16/*: any*/),
+        "partner.locations.edges.node.city": (v11/*: any*/),
+        "partner.locations.edges.node.id": (v10/*: any*/),
+        "partner.locations.totalCount": (v9/*: any*/),
+        "partner.locationsConnection": (v14/*: any*/),
+        "partner.locationsConnection.edges": (v15/*: any*/),
+        "partner.locationsConnection.edges.node": (v16/*: any*/),
+        "partner.locationsConnection.edges.node.address": (v11/*: any*/),
+        "partner.locationsConnection.edges.node.city": (v11/*: any*/),
+        "partner.locationsConnection.edges.node.country": (v11/*: any*/),
+        "partner.locationsConnection.edges.node.id": (v10/*: any*/),
+        "partner.locationsConnection.edges.node.openingHours": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "LatLng"
+          "type": "OpeningHoursUnion"
         },
-        "partner.locationsConnection.edges.node.coordinates.lat": (v16/*: any*/),
-        "partner.locationsConnection.edges.node.coordinates.lng": (v16/*: any*/),
-        "partner.locationsConnection.edges.node.country": (v10/*: any*/),
-        "partner.locationsConnection.edges.node.id": (v9/*: any*/),
-        "partner.locationsConnection.edges.node.phone": (v10/*: any*/),
-        "partner.locationsConnection.edges.node.postalCode": (v10/*: any*/),
-        "partner.locationsConnection.edges.node.state": (v10/*: any*/),
+        "partner.locationsConnection.edges.node.openingHours.__typename": (v17/*: any*/),
+        "partner.locationsConnection.edges.node.openingHours.schedules": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "FormattedDaySchedules"
+        },
+        "partner.locationsConnection.edges.node.openingHours.schedules.days": (v11/*: any*/),
+        "partner.locationsConnection.edges.node.openingHours.schedules.hours": (v11/*: any*/),
+        "partner.locationsConnection.edges.node.openingHours.text": (v11/*: any*/),
+        "partner.locationsConnection.edges.node.postalCode": (v11/*: any*/),
+        "partner.locationsConnection.edges.node.state": (v11/*: any*/),
         "partner.meta": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "PartnerMeta"
         },
-        "partner.meta.description": (v10/*: any*/),
-        "partner.meta.image": (v10/*: any*/),
-        "partner.meta.title": (v10/*: any*/),
-        "partner.name": (v10/*: any*/),
-        "partner.notRepresentedArtists": (v17/*: any*/),
-        "partner.notRepresentedArtists.totalCount": (v8/*: any*/),
-        "partner.partnerPageEligible": (v12/*: any*/),
-        "partner.partnerType": (v10/*: any*/),
+        "partner.meta.description": (v11/*: any*/),
+        "partner.meta.image": (v11/*: any*/),
+        "partner.meta.title": (v11/*: any*/),
+        "partner.name": (v11/*: any*/),
+        "partner.notRepresentedArtists": (v18/*: any*/),
+        "partner.notRepresentedArtists.totalCount": (v9/*: any*/),
+        "partner.partnerPageEligible": (v13/*: any*/),
+        "partner.partnerType": (v11/*: any*/),
         "partner.profile": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Profile"
         },
+        "partner.profile.bio": (v11/*: any*/),
         "partner.profile.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ProfileCounts"
         },
-        "partner.profile.counts.follows": (v11/*: any*/),
-        "partner.profile.icon": (v18/*: any*/),
-        "partner.profile.icon.resized": {
+        "partner.profile.counts.follows": (v12/*: any*/),
+        "partner.profile.icon": (v19/*: any*/),
+        "partner.profile.icon.cropped": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "ResizedImageUrl"
+          "type": "CroppedImageUrl"
         },
-        "partner.profile.icon.resized.src": (v19/*: any*/),
-        "partner.profile.icon.resized.srcSet": (v19/*: any*/),
-        "partner.profile.id": (v9/*: any*/),
-        "partner.profile.image": (v18/*: any*/),
-        "partner.profile.image.url": (v10/*: any*/),
-        "partner.profile.internalID": (v9/*: any*/),
-        "partner.representedArtists": (v17/*: any*/),
-        "partner.representedArtists.totalCount": (v8/*: any*/),
-        "partner.slug": (v9/*: any*/),
-        "partner.type": (v10/*: any*/),
+        "partner.profile.icon.cropped.height": (v20/*: any*/),
+        "partner.profile.icon.cropped.url": (v17/*: any*/),
+        "partner.profile.icon.cropped.width": (v20/*: any*/),
+        "partner.profile.icon.resized": (v21/*: any*/),
+        "partner.profile.icon.resized.src": (v17/*: any*/),
+        "partner.profile.icon.resized.srcSet": (v17/*: any*/),
+        "partner.profile.id": (v10/*: any*/),
+        "partner.profile.image": (v19/*: any*/),
+        "partner.profile.image.resized": (v21/*: any*/),
+        "partner.profile.image.resized.height": (v9/*: any*/),
+        "partner.profile.image.resized.url": (v17/*: any*/),
+        "partner.profile.image.resized.width": (v9/*: any*/),
+        "partner.profile.image.url": (v11/*: any*/),
+        "partner.profile.internalID": (v10/*: any*/),
+        "partner.representedArtists": (v18/*: any*/),
+        "partner.representedArtists.totalCount": (v9/*: any*/),
+        "partner.slug": (v10/*: any*/),
+        "partner.type": (v11/*: any*/),
         "partner.viewingRooms": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ViewingRoomsConnection"
         },
-        "partner.viewingRooms.totalCount": (v8/*: any*/)
+        "partner.viewingRooms.totalCount": (v9/*: any*/)
       }
     },
     "name": "PartnerApp_Test_Query",
     "operationKind": "query",
-    "text": "query PartnerApp_Test_Query {\n  partner(id: \"example\") {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n  partnerType\n  displayArtistsSection\n  displayWorksSection\n  counts {\n    eligibleArtworks\n    displayableShows\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n  }\n  articles: articlesConnection {\n    totalCount\n  }\n  representedArtists: artistsConnection(representedBy: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  notRepresentedArtists: artistsConnection(representedBy: false, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  viewingRooms: viewingRoomsConnection(statuses: [live, closed, scheduled]) {\n    totalCount\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  internalID\n  partnerType\n  displayFullPartnerPage\n  partnerPageEligible\n  isDefaultProfilePublic\n  categories {\n    id\n    name\n  }\n  profile {\n    ...PartnerHeaderImage_profile\n    id\n  }\n  ...PartnerMeta_partner\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeaderImage_profile on Profile {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  hasVisibleFollowsCount\n  profile {\n    counts {\n      follows\n    }\n    internalID\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMeta_partner on Partner {\n  locationsConnection(first: 1) {\n    edges {\n      node {\n        address\n        address2\n        city\n        coordinates {\n          lat\n          lng\n        }\n        country\n        phone\n        postalCode\n        state\n        id\n      }\n    }\n  }\n  meta {\n    image\n    title\n    description\n  }\n  name\n  slug\n}\n"
+    "text": "query PartnerApp_Test_Query {\n  partner(id: \"example\") {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n  partnerType\n  displayArtistsSection\n  displayWorksSection\n  counts {\n    eligibleArtworks\n    displayableShows\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n  }\n  articles: articlesConnection {\n    totalCount\n  }\n  representedArtists: artistsConnection(representedBy: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  notRepresentedArtists: artistsConnection(representedBy: false, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  viewingRooms: viewingRoomsConnection(statuses: [live, closed, scheduled]) {\n    totalCount\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  internalID\n  partnerType\n  displayFullPartnerPage\n  partnerPageEligible\n  isDefaultProfilePublic\n  categories {\n    id\n    name\n  }\n  profile {\n    ...PartnerHeaderImage_profile\n    id\n  }\n  ...PartnerMeta_partner\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeaderImage_profile on Profile {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  hasVisibleFollowsCount\n  profile {\n    counts {\n      follows\n    }\n    internalID\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMetaStructuredData_partner on Partner {\n  slug\n  href\n  name\n  profile {\n    bio\n    image {\n      resized(width: 1920, height: 1920) {\n        url\n        width\n        height\n      }\n    }\n    icon {\n      cropped(width: 250, height: 250, version: [\"untouched-png\", \"large\", \"square\"]) {\n        url\n        width\n        height\n      }\n    }\n    id\n  }\n  locationsConnection(first: 50) {\n    edges {\n      node {\n        address\n        city\n        country\n        postalCode\n        state\n        openingHours {\n          __typename\n          ... on OpeningHoursArray {\n            schedules {\n              days\n              hours\n            }\n          }\n          ... on OpeningHoursText {\n            text\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMeta_partner on Partner {\n  ...PartnerMetaStructuredData_partner\n  meta {\n    image\n    title\n    description\n  }\n  slug\n}\n"
   }
 };
 })();

--- a/src/__generated__/PartnerMetaStructuredData_partner.graphql.ts
+++ b/src/__generated__/PartnerMetaStructuredData_partner.graphql.ts
@@ -1,0 +1,340 @@
+/**
+ * @generated SignedSource<<ba0ff51dd9226a13c05fb3c1019bc0c3>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type PartnerMetaStructuredData_partner$data = {
+  readonly href: string | null | undefined;
+  readonly locationsConnection: {
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly address: string | null | undefined;
+        readonly city: string | null | undefined;
+        readonly country: string | null | undefined;
+        readonly openingHours: {
+          readonly schedules?: ReadonlyArray<{
+            readonly days: string | null | undefined;
+            readonly hours: string | null | undefined;
+          } | null | undefined> | null | undefined;
+          readonly text?: string | null | undefined;
+        } | null | undefined;
+        readonly postalCode: string | null | undefined;
+        readonly state: string | null | undefined;
+      } | null | undefined;
+    } | null | undefined> | null | undefined;
+  } | null | undefined;
+  readonly name: string | null | undefined;
+  readonly profile: {
+    readonly bio: string | null | undefined;
+    readonly icon: {
+      readonly cropped: {
+        readonly height: number;
+        readonly url: string;
+        readonly width: number;
+      } | null | undefined;
+    } | null | undefined;
+    readonly image: {
+      readonly resized: {
+        readonly height: number | null | undefined;
+        readonly url: string;
+        readonly width: number | null | undefined;
+      } | null | undefined;
+    } | null | undefined;
+  } | null | undefined;
+  readonly slug: string;
+  readonly " $fragmentType": "PartnerMetaStructuredData_partner";
+};
+export type PartnerMetaStructuredData_partner$key = {
+  readonly " $data"?: PartnerMetaStructuredData_partner$data;
+  readonly " $fragmentSpreads": FragmentRefs<"PartnerMetaStructuredData_partner">;
+};
+
+const node: ReaderFragment = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "url",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "width",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "height",
+    "storageKey": null
+  }
+];
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "PartnerMetaStructuredData_partner",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slug",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "href",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Profile",
+      "kind": "LinkedField",
+      "name": "profile",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "bio",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Image",
+          "kind": "LinkedField",
+          "name": "image",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": [
+                {
+                  "kind": "Literal",
+                  "name": "height",
+                  "value": 1920
+                },
+                {
+                  "kind": "Literal",
+                  "name": "width",
+                  "value": 1920
+                }
+              ],
+              "concreteType": "ResizedImageUrl",
+              "kind": "LinkedField",
+              "name": "resized",
+              "plural": false,
+              "selections": (v0/*: any*/),
+              "storageKey": "resized(height:1920,width:1920)"
+            }
+          ],
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Image",
+          "kind": "LinkedField",
+          "name": "icon",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": [
+                {
+                  "kind": "Literal",
+                  "name": "height",
+                  "value": 250
+                },
+                {
+                  "kind": "Literal",
+                  "name": "version",
+                  "value": [
+                    "untouched-png",
+                    "large",
+                    "square"
+                  ]
+                },
+                {
+                  "kind": "Literal",
+                  "name": "width",
+                  "value": 250
+                }
+              ],
+              "concreteType": "CroppedImageUrl",
+              "kind": "LinkedField",
+              "name": "cropped",
+              "plural": false,
+              "selections": (v0/*: any*/),
+              "storageKey": "cropped(height:250,version:[\"untouched-png\",\"large\",\"square\"],width:250)"
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 50
+        }
+      ],
+      "concreteType": "LocationConnection",
+      "kind": "LinkedField",
+      "name": "locationsConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "LocationEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Location",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "address",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "city",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "country",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "postalCode",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "state",
+                  "storageKey": null
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "concreteType": null,
+                  "kind": "LinkedField",
+                  "name": "openingHours",
+                  "plural": false,
+                  "selections": [
+                    {
+                      "kind": "InlineFragment",
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "concreteType": "FormattedDaySchedules",
+                          "kind": "LinkedField",
+                          "name": "schedules",
+                          "plural": true,
+                          "selections": [
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "days",
+                              "storageKey": null
+                            },
+                            {
+                              "alias": null,
+                              "args": null,
+                              "kind": "ScalarField",
+                              "name": "hours",
+                              "storageKey": null
+                            }
+                          ],
+                          "storageKey": null
+                        }
+                      ],
+                      "type": "OpeningHoursArray",
+                      "abstractKey": null
+                    },
+                    {
+                      "kind": "InlineFragment",
+                      "selections": [
+                        {
+                          "alias": null,
+                          "args": null,
+                          "kind": "ScalarField",
+                          "name": "text",
+                          "storageKey": null
+                        }
+                      ],
+                      "type": "OpeningHoursText",
+                      "abstractKey": null
+                    }
+                  ],
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "locationsConnection(first:50)"
+    }
+  ],
+  "type": "Partner",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "b0cf9fe238bf7a64e5319a0482387881";
+
+export default node;

--- a/src/__generated__/PartnerMeta_partner.graphql.ts
+++ b/src/__generated__/PartnerMeta_partner.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<afd3887750959f9bb905d465931d6424>>
+ * @generated SignedSource<<c3035799f25a8f320bda98646a8efd02>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,30 +11,13 @@
 import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type PartnerMeta_partner$data = {
-  readonly locationsConnection: {
-    readonly edges: ReadonlyArray<{
-      readonly node: {
-        readonly address: string | null | undefined;
-        readonly address2: string | null | undefined;
-        readonly city: string | null | undefined;
-        readonly coordinates: {
-          readonly lat: number | null | undefined;
-          readonly lng: number | null | undefined;
-        } | null | undefined;
-        readonly country: string | null | undefined;
-        readonly phone: string | null | undefined;
-        readonly postalCode: string | null | undefined;
-        readonly state: string | null | undefined;
-      } | null | undefined;
-    } | null | undefined> | null | undefined;
-  } | null | undefined;
   readonly meta: {
     readonly description: string | null | undefined;
     readonly image: string | null | undefined;
     readonly title: string | null | undefined;
   } | null | undefined;
-  readonly name: string | null | undefined;
   readonly slug: string;
+  readonly " $fragmentSpreads": FragmentRefs<"PartnerMetaStructuredData_partner">;
   readonly " $fragmentType": "PartnerMeta_partner";
 };
 export type PartnerMeta_partner$key = {
@@ -49,117 +32,9 @@ const node: ReaderFragment = {
   "name": "PartnerMeta_partner",
   "selections": [
     {
-      "alias": null,
-      "args": [
-        {
-          "kind": "Literal",
-          "name": "first",
-          "value": 1
-        }
-      ],
-      "concreteType": "LocationConnection",
-      "kind": "LinkedField",
-      "name": "locationsConnection",
-      "plural": false,
-      "selections": [
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": "LocationEdge",
-          "kind": "LinkedField",
-          "name": "edges",
-          "plural": true,
-          "selections": [
-            {
-              "alias": null,
-              "args": null,
-              "concreteType": "Location",
-              "kind": "LinkedField",
-              "name": "node",
-              "plural": false,
-              "selections": [
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "address",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "address2",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "city",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "concreteType": "LatLng",
-                  "kind": "LinkedField",
-                  "name": "coordinates",
-                  "plural": false,
-                  "selections": [
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "lat",
-                      "storageKey": null
-                    },
-                    {
-                      "alias": null,
-                      "args": null,
-                      "kind": "ScalarField",
-                      "name": "lng",
-                      "storageKey": null
-                    }
-                  ],
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "country",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "phone",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "postalCode",
-                  "storageKey": null
-                },
-                {
-                  "alias": null,
-                  "args": null,
-                  "kind": "ScalarField",
-                  "name": "state",
-                  "storageKey": null
-                }
-              ],
-              "storageKey": null
-            }
-          ],
-          "storageKey": null
-        }
-      ],
-      "storageKey": "locationsConnection(first:1)"
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "PartnerMetaStructuredData_partner"
     },
     {
       "alias": null,
@@ -197,13 +72,6 @@ const node: ReaderFragment = {
       "alias": null,
       "args": null,
       "kind": "ScalarField",
-      "name": "name",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
       "name": "slug",
       "storageKey": null
     }
@@ -212,6 +80,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "fa6bf65fcb4cf96ca003cd619d351ea1";
+(node as any).hash = "2d13af1d1398c7b1b7d3cb9d0e5ec54b";
 
 export default node;

--- a/src/__generated__/partnerRoutes_PartnerQuery.graphql.ts
+++ b/src/__generated__/partnerRoutes_PartnerQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<425aa01ca1619d1b7fd99c826ab4ce14>>
+ * @generated SignedSource<<112ec66755b5007a01ff69c0821de703>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -75,24 +75,47 @@ v6 = {
   "name": "name",
   "storageKey": null
 },
-v7 = {
+v7 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "url",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "width",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "height",
+    "storageKey": null
+  }
+],
+v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "city",
   "storageKey": null
 },
-v8 = {
+v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "totalCount",
   "storageKey": null
 },
-v9 = [
-  (v8/*: any*/)
+v10 = [
+  (v9/*: any*/)
 ],
-v10 = {
+v11 = {
   "kind": "Literal",
   "name": "displayOnPartnerProfile",
   "value": true
@@ -198,6 +221,27 @@ return {
                     "kind": "ScalarField",
                     "name": "url",
                     "storageKey": "url(version:\"wide\")"
+                  },
+                  {
+                    "alias": null,
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 1920
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 1920
+                      }
+                    ],
+                    "concreteType": "ResizedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "resized",
+                    "plural": false,
+                    "selections": (v7/*: any*/),
+                    "storageKey": "resized(height:1920,width:1920)"
                   }
                 ],
                 "storageKey": null
@@ -206,22 +250,10 @@ return {
               {
                 "alias": null,
                 "args": null,
-                "concreteType": "ProfileCounts",
-                "kind": "LinkedField",
-                "name": "counts",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "follows",
-                    "storageKey": null
-                  }
-                ],
+                "kind": "ScalarField",
+                "name": "bio",
                 "storageKey": null
               },
-              (v4/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -230,6 +262,36 @@ return {
                 "name": "icon",
                 "plural": false,
                 "selections": [
+                  {
+                    "alias": null,
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 250
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "version",
+                        "value": [
+                          "untouched-png",
+                          "large",
+                          "square"
+                        ]
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 250
+                      }
+                    ],
+                    "concreteType": "CroppedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "cropped",
+                    "plural": false,
+                    "selections": (v7/*: any*/),
+                    "storageKey": "cropped(height:250,version:[\"untouched-png\",\"large\",\"square\"],width:250)"
+                  },
                   {
                     "alias": null,
                     "args": [
@@ -273,17 +335,51 @@ return {
                   }
                 ],
                 "storageKey": null
-              }
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ProfileCounts",
+                "kind": "LinkedField",
+                "name": "counts",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "follows",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v4/*: any*/)
             ],
             "storageKey": null
           },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "href",
+            "storageKey": null
+          },
+          (v6/*: any*/),
           {
             "alias": null,
             "args": [
               {
                 "kind": "Literal",
                 "name": "first",
-                "value": 1
+                "value": 50
               }
             ],
             "concreteType": "LocationConnection",
@@ -314,51 +410,12 @@ return {
                         "name": "address",
                         "storageKey": null
                       },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "address2",
-                        "storageKey": null
-                      },
-                      (v7/*: any*/),
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "LatLng",
-                        "kind": "LinkedField",
-                        "name": "coordinates",
-                        "plural": false,
-                        "selections": [
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "lat",
-                            "storageKey": null
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "lng",
-                            "storageKey": null
-                          }
-                        ],
-                        "storageKey": null
-                      },
+                      (v8/*: any*/),
                       {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
                         "name": "country",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "phone",
                         "storageKey": null
                       },
                       {
@@ -375,6 +432,70 @@ return {
                         "name": "state",
                         "storageKey": null
                       },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "openingHours",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "__typename",
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "FormattedDaySchedules",
+                                "kind": "LinkedField",
+                                "name": "schedules",
+                                "plural": true,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "days",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "hours",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "OpeningHoursArray",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "text",
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "OpeningHoursText",
+                            "abstractKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
                       (v5/*: any*/)
                     ],
                     "storageKey": null
@@ -383,7 +504,7 @@ return {
                 "storageKey": null
               }
             ],
-            "storageKey": "locationsConnection(first:1)"
+            "storageKey": "locationsConnection(first:50)"
           },
           {
             "alias": null,
@@ -417,14 +538,6 @@ return {
             ],
             "storageKey": null
           },
-          (v6/*: any*/),
-          {
-            "alias": null,
-            "args": null,
-            "kind": "ScalarField",
-            "name": "slug",
-            "storageKey": null
-          },
           {
             "alias": null,
             "args": null,
@@ -453,7 +566,7 @@ return {
             "name": "locationsConnection",
             "plural": false,
             "selections": [
-              (v8/*: any*/),
+              (v9/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -470,7 +583,7 @@ return {
                     "name": "node",
                     "plural": false,
                     "selections": [
-                      (v7/*: any*/),
+                      (v8/*: any*/),
                       (v5/*: any*/)
                     ],
                     "storageKey": null
@@ -527,13 +640,13 @@ return {
             "kind": "LinkedField",
             "name": "articlesConnection",
             "plural": false,
-            "selections": (v9/*: any*/),
+            "selections": (v10/*: any*/),
             "storageKey": null
           },
           {
             "alias": "representedArtists",
             "args": [
-              (v10/*: any*/),
+              (v11/*: any*/),
               {
                 "kind": "Literal",
                 "name": "representedBy",
@@ -544,13 +657,13 @@ return {
             "kind": "LinkedField",
             "name": "artistsConnection",
             "plural": false,
-            "selections": (v9/*: any*/),
+            "selections": (v10/*: any*/),
             "storageKey": "artistsConnection(displayOnPartnerProfile:true,representedBy:true)"
           },
           {
             "alias": "notRepresentedArtists",
             "args": [
-              (v10/*: any*/),
+              (v11/*: any*/),
               {
                 "kind": "Literal",
                 "name": "hasPublishedArtworks",
@@ -566,7 +679,7 @@ return {
             "kind": "LinkedField",
             "name": "artistsConnection",
             "plural": false,
-            "selections": (v9/*: any*/),
+            "selections": (v10/*: any*/),
             "storageKey": "artistsConnection(displayOnPartnerProfile:true,hasPublishedArtworks:true,representedBy:false)"
           },
           {
@@ -586,7 +699,7 @@ return {
             "kind": "LinkedField",
             "name": "viewingRoomsConnection",
             "plural": false,
-            "selections": (v9/*: any*/),
+            "selections": (v10/*: any*/),
             "storageKey": "viewingRoomsConnection(statuses:[\"live\",\"closed\",\"scheduled\"])"
           },
           (v5/*: any*/)
@@ -596,12 +709,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4ef4522ef3ac8d7662f03290f462b8bc",
+    "cacheID": "1f6a5261fbbe53249d72a1517b3e2a32",
     "id": null,
     "metadata": {},
     "name": "partnerRoutes_PartnerQuery",
     "operationKind": "query",
-    "text": "query partnerRoutes_PartnerQuery(\n  $partnerId: String!\n) @cacheable {\n  partner(id: $partnerId) @principalField {\n    partnerType\n    displayFullPartnerPage\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n  partnerType\n  displayArtistsSection\n  displayWorksSection\n  counts {\n    eligibleArtworks\n    displayableShows\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n  }\n  articles: articlesConnection {\n    totalCount\n  }\n  representedArtists: artistsConnection(representedBy: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  notRepresentedArtists: artistsConnection(representedBy: false, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  viewingRooms: viewingRoomsConnection(statuses: [live, closed, scheduled]) {\n    totalCount\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  internalID\n  partnerType\n  displayFullPartnerPage\n  partnerPageEligible\n  isDefaultProfilePublic\n  categories {\n    id\n    name\n  }\n  profile {\n    ...PartnerHeaderImage_profile\n    id\n  }\n  ...PartnerMeta_partner\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeaderImage_profile on Profile {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  hasVisibleFollowsCount\n  profile {\n    counts {\n      follows\n    }\n    internalID\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMeta_partner on Partner {\n  locationsConnection(first: 1) {\n    edges {\n      node {\n        address\n        address2\n        city\n        coordinates {\n          lat\n          lng\n        }\n        country\n        phone\n        postalCode\n        state\n        id\n      }\n    }\n  }\n  meta {\n    image\n    title\n    description\n  }\n  name\n  slug\n}\n"
+    "text": "query partnerRoutes_PartnerQuery(\n  $partnerId: String!\n) @cacheable {\n  partner(id: $partnerId) @principalField {\n    partnerType\n    displayFullPartnerPage\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n  partnerType\n  displayArtistsSection\n  displayWorksSection\n  counts {\n    eligibleArtworks\n    displayableShows\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n  }\n  articles: articlesConnection {\n    totalCount\n  }\n  representedArtists: artistsConnection(representedBy: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  notRepresentedArtists: artistsConnection(representedBy: false, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  viewingRooms: viewingRoomsConnection(statuses: [live, closed, scheduled]) {\n    totalCount\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  internalID\n  partnerType\n  displayFullPartnerPage\n  partnerPageEligible\n  isDefaultProfilePublic\n  categories {\n    id\n    name\n  }\n  profile {\n    ...PartnerHeaderImage_profile\n    id\n  }\n  ...PartnerMeta_partner\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeaderImage_profile on Profile {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  hasVisibleFollowsCount\n  profile {\n    counts {\n      follows\n    }\n    internalID\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMetaStructuredData_partner on Partner {\n  slug\n  href\n  name\n  profile {\n    bio\n    image {\n      resized(width: 1920, height: 1920) {\n        url\n        width\n        height\n      }\n    }\n    icon {\n      cropped(width: 250, height: 250, version: [\"untouched-png\", \"large\", \"square\"]) {\n        url\n        width\n        height\n      }\n    }\n    id\n  }\n  locationsConnection(first: 50) {\n    edges {\n      node {\n        address\n        city\n        country\n        postalCode\n        state\n        openingHours {\n          __typename\n          ... on OpeningHoursArray {\n            schedules {\n              days\n              hours\n            }\n          }\n          ... on OpeningHoursText {\n            text\n          }\n        }\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMeta_partner on Partner {\n  ...PartnerMetaStructuredData_partner\n  meta {\n    image\n    title\n    description\n  }\n  slug\n}\n"
   }
 };
 })();


### PR DESCRIPTION
As far as the proposed schema goes, we can't implement a `makesOffer` leaf. We *could* do `members` for representation but will have to handle it carefully since some outlier "galleries" have hundreds of artists. I think a reasonable limit is good enough. I'll follow up with that bit.

Funnily enough the hard part here was translating our opening hours format.

```json
{
  "@context": "https://schema.org",
  "@type": "ArtGallery",
  "@id": "http://localhost:5050/partner/robilant-plus-voena",
  "name": "Robilant+Voena",
  "url": "http://localhost:5050/partner/robilant-plus-voena",
  "description": "A leading international art gallery of European and International Masterworks from the Renaissance to the present.\r\n",
  "image": {
    "@type": "ImageObject",
    "url": "https://d196wkiy8qx2u5.cloudfront.net?height=1920&quality=80&resize_to=fit&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FHykvOownWd254stujTOaqQ%2Fwide.jpg&width=1920",
    "width": {
      "@type": "QuantitativeValue",
      "value": 0,
      "unitCode": "E37"
    },
    "height": {
      "@type": "QuantitativeValue",
      "value": 0,
      "unitCode": "E37"
    }
  },
  "logo": {
    "@type": "ImageObject",
    "url": "https://d196wkiy8qx2u5.cloudfront.net?height=250&quality=80&resize_to=fill&src=https%3A%2F%2Fd32dm0rphc51dk.cloudfront.net%2FkVoZMFCSBtY60MVN9OFT9A%2Funtouched-png.png&width=250",
    "width": {
      "@type": "QuantitativeValue",
      "value": 250,
      "unitCode": "E37"
    },
    "height": {
      "@type": "QuantitativeValue",
      "value": 250,
      "unitCode": "E37"
    }
  },
  "mainEntityOfPage": {
    "@type": "WebPage",
    "@id": "http://localhost:5050/partner/robilant-plus-voena"
  },
  "address": {
    "@type": "PostalAddress",
    "streetAddress": "38 Dover Street",
    "addressLocality": "London",
    "addressRegion": "",
    "postalCode": "W1S 4NL",
    "addressCountry": "GB"
  },
  "openingHours": "Mo-Fr 10:00-18:00"
}
```