### PR TITLE
fix: Accounting for additional elements and entity links in Article headers for Follow CTA

### DIFF
--- a/src/Apps/Article/Components/ArticleHTML.tsx
+++ b/src/Apps/Article/Components/ArticleHTML.tsx
@@ -33,19 +33,12 @@ export const ArticleHTML: FC<React.PropsWithChildren<ArticleHTMLProps>> = ({
       if (!isSupportedArticleTooltip(entity)) return
 
       const heading = node.closest("h2")
-      const artistLinks = heading?.querySelectorAll(
-        "a[href^='https://www.artsy.net/artist/']",
-      )
-
-      const partnerLinks = heading?.querySelectorAll(
-        "a[href^='https://www.artsy.net/partner/']",
-      )
 
       const isArtistHeading =
-        entity === "artist" && heading && artistLinks?.length === 1
+        entity === "artist" && isEligibleFollowHeading(heading, entity)
 
       const isPartnerHeading =
-        entity === "partner" && heading && partnerLinks?.length === 1
+        entity === "partner" && isEligibleFollowHeading(heading, entity)
 
       if (isArtistHeading) {
         return (
@@ -107,6 +100,41 @@ export const ArticleHTML: FC<React.PropsWithChildren<ArticleHTMLProps>> = ({
   }
 
   return <Container dangerouslySetInnerHTML={{ __html: children }} {...rest} />
+}
+
+export const hasAdjacentEntityLinks = (heading: Element | null): boolean => {
+  if (!heading) return false
+
+  let sibling = heading.nextElementSibling
+  while (sibling && sibling.tagName === "H3") {
+    if (sibling.querySelector("a[href*='/artist/'], a[href*='/partner/']")) {
+      return true
+    }
+    sibling = sibling.nextElementSibling
+  }
+
+  return false
+}
+
+export const isEligibleFollowHeading = (
+  heading: Element | null,
+  entity: string,
+): boolean => {
+  if (!heading || heading.tagName !== "H2") return false
+  if (hasAdjacentEntityLinks(heading)) return false
+
+  let expectedPrefix: string | null = null
+
+  if (entity === "artist") {
+    expectedPrefix = "https://www.artsy.net/artist/"
+  } else if (entity === "partner") {
+    expectedPrefix = "https://www.artsy.net/partner/"
+  } else {
+    return false
+  }
+
+  const links = heading.querySelectorAll(`a[href^='${expectedPrefix}']`)
+  return links.length === 1
 }
 
 const Container = styled(Box)`


### PR DESCRIPTION
The type of this PR is: **FIX/CHORE**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR is a follow up of [DIA-1310] (see first pr here: https://github.com/artsy/force/pull/15647)

### Description

<!-- Implementation description -->

After adding the additional Follow button intended only for single entity h2 headers in Editorial (artist or partner name only), I noticed a visual bug where the cta was also appearing in cases where there were headers that include multiple artist or partner links on a single line (group shows), which should not receive a CTA.

Now we are only displaying this cta if:
- the h2 heading contains only 1 artist name or partner link, and the heading itself is just the artist/partner name
- if there is an h3 subheading, it contains no other links (descriptive text is ok)
- if there are any multi-entity headers, or non-artist/partner entities, we suppress the cta (existing article tooltips are still in place)

Examples:

![Screenshot 2025-06-04 at 8 37 20 AM](https://github.com/user-attachments/assets/99772bd4-78df-4e01-9430-da5644c9f162)

![Screenshot 2025-06-04 at 8 38 01 AM](https://github.com/user-attachments/assets/c16d5cc9-60f3-4fc1-9467-fd13b675a18f)

![Screenshot 2025-06-04 at 8 38 47 AM](https://github.com/user-attachments/assets/201c4177-4c78-41fb-ada4-bb84b8a5c535)

![Screenshot 2025-06-04 at 8 40 07 AM](https://github.com/user-attachments/assets/fb8a31a3-2184-4cf8-bcb7-c64899c6a18f)




[DIA-1310]: https://artsyproduct.atlassian.net/browse/DIA-1310?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ