### PR TITLE
feat(EMI-2556): stripe error handling and display

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
@@ -101,8 +101,8 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({ order }) => {
   const [isSubmittingToStripe, setIsSubmittingToStripe] = useState(false)
   const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [subtitleErrorMessage, setSubtitleErrorMessage] = useState<
-    string | undefined
-  >()
+    string | null
+  >(null)
   const [selectedPaymentMethod, setSelectedPaymentMethod] = useState<
     "none" | "saved" | "stripe" | "wire"
   >("none")

--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
@@ -37,6 +37,8 @@ import {
 
 const stripePromise = loadStripe(getENV("STRIPE_PUBLISHABLE_KEY"))
 const logger = createLogger("Order2PaymentForm")
+const defaultErrorMessage =
+  "Something went wrong. Please try again or contact orders@artsy.net"
 
 interface Order2PaymentFormProps {
   order: Order2PaymentForm_order$key
@@ -104,10 +106,8 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({ order }) => {
     string | null
   >(null)
   const [selectedPaymentMethod, setSelectedPaymentMethod] = useState<
-    "none" | "saved" | "stripe" | "wire"
-  >("none")
-  const defaultErrorMessage =
-    "Something went wrong. Please try again or contact orders@artsy.net"
+    null | "saved" | "stripe" | "wire"
+  >(null)
 
   if (!(stripe && elements)) {
     return null
@@ -149,7 +149,7 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({ order }) => {
   const handleSubmit = async event => {
     event.preventDefault()
 
-    if (selectedPaymentMethod === "none") {
+    if (!selectedPaymentMethod) {
       setSubtitleErrorMessage("Select a payment method")
       return
     }
@@ -243,7 +243,7 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({ order }) => {
 
   return (
     <form onSubmit={handleSubmit}>
-      {subtitleErrorMessage && selectedPaymentMethod === "none" && (
+      {subtitleErrorMessage && !selectedPaymentMethod && (
         <Text variant="xs" color="red100" mb={2}>
           {subtitleErrorMessage}
         </Text>

--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
@@ -98,13 +98,14 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({ order }) => {
   const environment = useRelayEnvironment()
   const updateOrderMutation = useUpdateOrderMutation()
   const { setConfirmationToken } = useCheckoutContext()
-  const [isPaymentMethodSelected, setIsPaymentMethodSelected] = useState(false)
   const [isSubmittingToStripe, setIsSubmittingToStripe] = useState(false)
-  const [errorMessage, setErrorMessage] = useState<string | undefined>()
+  const [errorMessage, setErrorMessage] = useState<string | null>(null)
   const [subtitleErrorMessage, setSubtitleErrorMessage] = useState<
     string | undefined
   >()
-  const [selectedPaymentMethod, setSelectedPaymentMethod] = useState("new")
+  const [selectedPaymentMethod, setSelectedPaymentMethod] = useState<
+    "none" | "saved" | "stripe" | "wire"
+  >("none")
   const defaultErrorMessage =
     "Something went wrong. Please try again or contact orders@artsy.net"
 
@@ -121,24 +122,21 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({ order }) => {
     },
   }
 
-  const onChange = event => {
-    const { elementType, collapsed } = event
+  const onChange = StripePaymentElementChangeEvent => {
+    const { elementType, collapsed } = StripePaymentElementChangeEvent
     if (elementType === "payment" && !collapsed) {
       setSelectedPaymentMethod("stripe")
-      setIsPaymentMethodSelected(true)
     }
   }
 
   const onClickSavedPaymentMethods = () => {
-    setErrorMessage(undefined) // Clear any previous error messages
-    setIsPaymentMethodSelected(true)
+    setErrorMessage(null) // Clear any previous error messages
     setSelectedPaymentMethod("saved")
     elements?.getElement("payment")?.collapse()
   }
 
   const onClickWirePaymentMethods = () => {
-    setErrorMessage(undefined) // Clear any previous error messages
-    setIsPaymentMethodSelected(true)
+    setErrorMessage(null) // Clear any previous error messages
     setSelectedPaymentMethod("wire")
     elements?.getElement("payment")?.collapse()
   }
@@ -151,7 +149,7 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({ order }) => {
   const handleSubmit = async event => {
     event.preventDefault()
 
-    if (!isPaymentMethodSelected) {
+    if (selectedPaymentMethod === "none") {
       setSubtitleErrorMessage("Select a payment method")
       return
     }
@@ -245,7 +243,7 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({ order }) => {
 
   return (
     <form onSubmit={handleSubmit}>
-      {subtitleErrorMessage && !isPaymentMethodSelected && (
+      {subtitleErrorMessage && selectedPaymentMethod === "none" && (
         <Text variant="xs" color="red100" mb={2}>
           {subtitleErrorMessage}
         </Text>
@@ -325,7 +323,7 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({ order }) => {
       )}
       <Button
         loading={isSubmittingToStripe}
-        variant={"primaryBlack"}
+        variant="primaryBlack"
         width="100%"
         type="submit"
       >

--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
@@ -286,6 +286,7 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({ order }) => {
           marginBottom="10px"
           style={{ cursor: "pointer" }}
           onClick={onClickWirePaymentMethods}
+          data-testid={"PaymentFormWire"}
         >
           <Flex alignItems="center">
             <ReceiptIcon fill="mono100" />

--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentStep.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentStep.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Spacer, Text } from "@artsy/palette"
+import { Box, Flex, Text } from "@artsy/palette"
 import {
   CheckoutStepName,
   CheckoutStepState,

--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentStep.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentStep.tsx
@@ -53,10 +53,6 @@ export const Order2PaymentStep: React.FC<Order2PaymentStepProps> = ({
             <Text variant="sm-display" fontWeight="bold" color="mono100">
               Payment
             </Text>
-            <Text variant="xs" color="mono60">
-              Options vary based on price, gallery, and location
-            </Text>
-            <Spacer y={2} />
             <Order2PaymentForm order={orderData} />
           </Flex>
         </Box>

--- a/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
@@ -103,6 +103,7 @@ const testIDs = {
   pickupDetailsForm: "PickupDetailsForm",
   // Use with screen.getByRole
   phoneCountryPickerListRole: "listbox",
+  paymentFormWire: "PaymentFormWire",
 }
 
 const orderMutationSuccess = (initialValues, newValues) => {
@@ -504,6 +505,100 @@ describe("Order2CheckoutRoute", () => {
           userEvent.click(screen.getByText("Delivery"))
         })
         expect(screen.queryByText("Shipping Method")).toBeInTheDocument()
+      })
+    })
+
+    describe("within the payment section", () => {
+      describe("error handling when saving and continuing", () => {
+        it("shows an error if no payment method is selected", async () => {
+          const props = {
+            ...baseProps,
+            me: {
+              ...baseProps.me,
+              order: {
+                ...baseProps.me.order,
+                fulfillmentOptions: [
+                  {
+                    type: "PICKUP",
+                    __typename: "PickupFulfillmentOption",
+                    selected: true,
+                  },
+                  { type: "DOMESTIC_FLAT" },
+                ],
+                fulfillmentDetails: {
+                  phoneNumber: {
+                    originalNumber: "03012345678",
+                    regionCode: "de",
+                  },
+                },
+                selectedFulfillmentOption: {
+                  type: "PICKUP",
+                },
+              },
+            },
+          }
+          const initialOrder = props.me.order
+
+          const { mockResolveLastOperation } =
+            await renderWithLoadingComplete(props)
+
+          await waitFor(() => {
+            act(() => {
+              userEvent.click(screen.getByText("Continue to Payment"))
+            })
+          })
+
+          // PICKUP MUTATIONS
+          await act(async () => {
+            await waitFor(() => {
+              return mockResolveLastOperation({
+                setOrderFulfillmentOptionPayload: () =>
+                  orderMutationSuccess(initialOrder, {
+                    selectedFulfillmentOption: {
+                      type: "PICKUP",
+                    },
+                  }),
+              })
+            })
+            await flushPromiseQueue()
+          })
+
+          await act(async () => {
+            await waitFor(() => {
+              return mockResolveLastOperation({
+                updateOrderShippingAddressPayload: () =>
+                  orderMutationSuccess(initialOrder, {
+                    selectedFulfillmentOption: {
+                      type: "PICKUP",
+                    },
+                    fulfillmentDetails: {
+                      phoneNumber: {
+                        originalNumber: "03012345678",
+                        countryCode: "de",
+                      },
+                    },
+                  }),
+              })
+            })
+
+            await flushPromiseQueue()
+          })
+
+          await userEvent.click(screen.getByText("Save and Continue"))
+          expect(
+            screen.getByText("Select a payment method"),
+          ).toBeInTheDocument()
+
+          const wirePaymentOption = screen.getByTestId(testIDs.paymentFormWire)
+          act(() => {
+            userEvent.click(wirePaymentOption)
+          })
+          await waitFor(() => {
+            expect(
+              screen.queryByLabelText("Select a payment method"),
+            ).not.toBeInTheDocument()
+          })
+        })
       })
     })
   })


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2556]

### Description

This has a few changes on how we handle the payment section, more specifically:

- Added a condition to check which payment method is chosen and proceed accordingly;
- Added a `IsPaymentMethodSelected` logic to handle the scenario where the page is loaded and no payment method is selected;
- Added a subtitleErrorMessage logic to handle the scenario above;
- Let Stripe handle it's errors on the element itself;
- Added an error "box" at the bottom of the section to handle all other errors;
- Clear error messages when changing the payment method;


[EMI-2556]: https://artsyproduct.atlassian.net/browse/EMI-2556?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ