### PR TITLE
feat: add display for tracking info in the order details message for orders in shipped state

### DIFF
--- a/src/Apps/Order2/Routes/Details/Components/Order2DetailsFulfillmentInfo.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/Order2DetailsFulfillmentInfo.tsx
@@ -16,6 +16,8 @@ export const Order2DetailsFulfillmentInfo: React.FC<
   const { fulfillmentDetails, selectedFulfillmentOption, shippingOrigin } =
     orderData
 
+  if (!selectedFulfillmentOption) return null
+
   const isPickup = selectedFulfillmentOption?.type === "PICKUP"
 
   return (

--- a/src/Apps/Order2/Routes/Details/Components/Order2DetailsMessage.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/Order2DetailsMessage.tsx
@@ -227,10 +227,64 @@ const getMessageContent = (order): React.ReactNode => {
         </>
       )
     case "SHIPPED":
+      const {
+        shipperName,
+        trackingNumber,
+        trackingURL,
+        estimatedDelivery,
+        estimatedDeliveryWindow,
+      } = order.deliveryInfo
+
+      const isDeliveryInfoPresent =
+        shipperName ||
+        trackingNumber ||
+        trackingURL ||
+        estimatedDelivery ||
+        estimatedDeliveryWindow
+
+      const formattedEstimatedDelivery =
+        estimatedDelivery &&
+        new Date(estimatedDelivery).toLocaleDateString("en-US", {
+          month: "short",
+          day: "numeric",
+          year: "numeric",
+        })
+      const estimatedDeliveryDisplay =
+        (estimatedDeliveryWindow || formattedEstimatedDelivery) &&
+        (estimatedDeliveryWindow
+          ? estimatedDeliveryWindow
+          : formattedEstimatedDelivery)
+
       return (
         <>
           <Text variant="sm">Your work is on its way.</Text>
-          {/* TODO: Add shipping tracking info when available */}
+          {isDeliveryInfoPresent && (
+            <>
+              <Spacer y={2} />
+              {shipperName && <Text variant="sm">Shipper: {shipperName}</Text>}
+              {trackingNumber && (
+                <Text variant="sm">
+                  Tracking:{" "}
+                  {trackingURL ? (
+                    <RouterLink
+                      to={trackingURL}
+                      target="_blank"
+                      display="inline"
+                    >
+                      {trackingNumber}
+                    </RouterLink>
+                  ) : (
+                    trackingNumber
+                  )}
+                </Text>
+              )}
+              {estimatedDeliveryDisplay && (
+                <Text variant="sm">
+                  Estimated delivery: {estimatedDeliveryDisplay}
+                </Text>
+              )}
+            </>
+          )}
           <Spacer y={2} />
           <YourCollectionNote />
         </>
@@ -267,6 +321,13 @@ const FRAGMENT = graphql`
     internalID
     displayTexts {
       messageType
+    }
+    deliveryInfo {
+      shipperName
+      trackingNumber
+      trackingURL
+      estimatedDelivery
+      estimatedDeliveryWindow
     }
   }
 `

--- a/src/Apps/Order2/Routes/Details/Components/Order2DetailsMessage.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/Order2DetailsMessage.tsx
@@ -82,8 +82,8 @@ const getMessageContent = (order): React.ReactNode => {
         <>
           <Text variant="sm">
             Thank you! Your offer has been submitted. You will receive an email
-            shortly with all the details. Please note making an offer doesn’t
-            guarantee you the work.
+            shortly with all the details. Please note making an offer
+            doesn&rsquo;t guarantee you the work.
           </Text>
           <Spacer y={2} />
           <Text variant="sm">

--- a/src/Apps/Order2/Routes/Details/Components/__tests__/Order2DetailsMessage.jest.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/__tests__/Order2DetailsMessage.jest.tsx
@@ -110,4 +110,28 @@ describe("Order2DetailsMessage", () => {
 
     expect(screen.getByText("orders@artsy.net")).toBeInTheDocument()
   })
+
+  describe("SHIPPED state tracking information", () => {
+    it("renders tracking number as a link when tracking URL is present", () => {
+      renderWithRelay({
+        Order: () => ({
+          displayTexts: {
+            messageType: "SHIPPED",
+          },
+          deliveryInfo: {
+            trackingNumber: "trackMe",
+            trackingURL: "https://tracking.example.com/trackMe",
+          },
+        }),
+      })
+
+      const trackingLink = screen.getByRole("link", { name: "trackMe" })
+      expect(trackingLink).toBeInTheDocument()
+      expect(trackingLink).toHaveAttribute(
+        "href",
+        "https://tracking.example.com/trackMe",
+      )
+      expect(trackingLink).toHaveAttribute("target", "_blank")
+    })
+  })
 })

--- a/src/__generated__/Order2DetailsMessage_Test_Query.graphql.ts
+++ b/src/__generated__/Order2DetailsMessage_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d1d8cf340ab10ca8154cbc5bc1c7ecdd>>
+ * @generated SignedSource<<e66bb2389adb04d2f16047218435b189>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,6 +26,13 @@ export type Order2DetailsMessage_Test_Query$rawResponse = {
       readonly buyerStateExpiresAt: string | null | undefined;
       readonly code: string;
       readonly currencyCode: string;
+      readonly deliveryInfo: {
+        readonly estimatedDelivery: string | null | undefined;
+        readonly estimatedDeliveryWindow: string | null | undefined;
+        readonly shipperName: string | null | undefined;
+        readonly trackingNumber: string | null | undefined;
+        readonly trackingURL: string | null | undefined;
+      } | null | undefined;
       readonly displayTexts: {
         readonly messageType: DisplayTextsMessageTypeEnum;
       };
@@ -161,6 +168,52 @@ return {
                 ],
                 "storageKey": null
               },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "DeliveryInfo",
+                "kind": "LinkedField",
+                "name": "deliveryInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "shipperName",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "trackingNumber",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "trackingURL",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "estimatedDelivery",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "estimatedDeliveryWindow",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
               (v1/*: any*/)
             ],
             "storageKey": "order(id:\"123\")"
@@ -172,12 +225,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "ad9d13880b5046dfddbc8c297366e6f9",
+    "cacheID": "0bca8a581ab71e4c435d91e57d86b52c",
     "id": null,
     "metadata": {},
     "name": "Order2DetailsMessage_Test_Query",
     "operationKind": "query",
-    "text": "query Order2DetailsMessage_Test_Query {\n  me {\n    order(id: \"123\") {\n      ...Order2DetailsMessage_order\n      id\n    }\n    id\n  }\n}\n\nfragment Order2DetailsMessage_order on Order {\n  buyerStateExpiresAt\n  code\n  currencyCode\n  internalID\n  displayTexts {\n    messageType\n  }\n}\n"
+    "text": "query Order2DetailsMessage_Test_Query {\n  me {\n    order(id: \"123\") {\n      ...Order2DetailsMessage_order\n      id\n    }\n    id\n  }\n}\n\nfragment Order2DetailsMessage_order on Order {\n  buyerStateExpiresAt\n  code\n  currencyCode\n  internalID\n  displayTexts {\n    messageType\n  }\n  deliveryInfo {\n    shipperName\n    trackingNumber\n    trackingURL\n    estimatedDelivery\n    estimatedDeliveryWindow\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/Order2DetailsMessage_order.graphql.ts
+++ b/src/__generated__/Order2DetailsMessage_order.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<fdd4bd904ed4b60e7555cc7b22389581>>
+ * @generated SignedSource<<ecbdbaf162127285fc3d6320f04f0985>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,6 +15,13 @@ export type Order2DetailsMessage_order$data = {
   readonly buyerStateExpiresAt: string | null | undefined;
   readonly code: string;
   readonly currencyCode: string;
+  readonly deliveryInfo: {
+    readonly estimatedDelivery: string | null | undefined;
+    readonly estimatedDeliveryWindow: string | null | undefined;
+    readonly shipperName: string | null | undefined;
+    readonly trackingNumber: string | null | undefined;
+    readonly trackingURL: string | null | undefined;
+  } | null | undefined;
   readonly displayTexts: {
     readonly messageType: DisplayTextsMessageTypeEnum;
   };
@@ -77,12 +84,58 @@ const node: ReaderFragment = {
         }
       ],
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "DeliveryInfo",
+      "kind": "LinkedField",
+      "name": "deliveryInfo",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "shipperName",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "trackingNumber",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "trackingURL",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "estimatedDelivery",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "estimatedDeliveryWindow",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
     }
   ],
   "type": "Order",
   "abstractKey": null
 };
 
-(node as any).hash = "d4a3de784c48a5844b365765f8ecc8ee";
+(node as any).hash = "1a5c2bf181daccef0b8b7c9e2fcf3ca0";
 
 export default node;

--- a/src/__generated__/Order2DetailsPage_Test_Query.graphql.ts
+++ b/src/__generated__/Order2DetailsPage_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<52e7217f39eed212c306e604fecd38f1>>
+ * @generated SignedSource<<a130ba8cc746942ace1ef7f23b79713c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -30,6 +30,13 @@ export type Order2DetailsPage_Test_Query$rawResponse = {
       readonly code: string;
       readonly creditCardWalletType: OrderCreditCardWalletTypeEnum | null | undefined;
       readonly currencyCode: string;
+      readonly deliveryInfo: {
+        readonly estimatedDelivery: string | null | undefined;
+        readonly estimatedDeliveryWindow: string | null | undefined;
+        readonly shipperName: string | null | undefined;
+        readonly trackingNumber: string | null | undefined;
+        readonly trackingURL: string | null | undefined;
+      } | null | undefined;
       readonly displayTexts: {
         readonly messageType: DisplayTextsMessageTypeEnum;
         readonly title: string;
@@ -500,6 +507,52 @@ return {
               {
                 "alias": null,
                 "args": null,
+                "concreteType": "DeliveryInfo",
+                "kind": "LinkedField",
+                "name": "deliveryInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "shipperName",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "trackingNumber",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "trackingURL",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "estimatedDelivery",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "estimatedDeliveryWindow",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
                 "concreteType": null,
                 "kind": "LinkedField",
                 "name": "pricingBreakdownLines",
@@ -786,12 +839,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "2c5d178e5897a783be521b26a715caf2",
+    "cacheID": "9130fd3a00517c3036aa314a3b3f370c",
     "id": null,
     "metadata": {},
     "name": "Order2DetailsPage_Test_Query",
     "operationKind": "query",
-    "text": "query Order2DetailsPage_Test_Query {\n  me {\n    order(id: \"123\") {\n      ...Order2DetailsPage_order\n      id\n    }\n    id\n  }\n}\n\nfragment Order2DetailsFulfillmentInfo_order on Order {\n  fulfillmentDetails {\n    addressLine1\n    addressLine2\n    city\n    country\n    name\n    postalCode\n    region\n    phoneNumber {\n      display\n    }\n  }\n  selectedFulfillmentOption {\n    type\n  }\n  shippingOrigin\n}\n\nfragment Order2DetailsHeader_order on Order {\n  code\n  displayTexts {\n    title\n  }\n}\n\nfragment Order2DetailsMessage_order on Order {\n  buyerStateExpiresAt\n  code\n  currencyCode\n  internalID\n  displayTexts {\n    messageType\n  }\n}\n\nfragment Order2DetailsOrderSummary_order on Order {\n  ...Order2PricingBreakdown_order\n  source\n  totalListPrice {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      attributionClass {\n        shortDescription\n        id\n      }\n      dimensions {\n        in\n        cm\n      }\n      image {\n        resized(height: 360, width: 700) {\n          url\n          width\n          height\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment Order2DetailsPage_order on Order {\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    id\n  }\n  ...Order2DetailsHeader_order\n  ...Order2DetailsMessage_order\n  ...Order2DetailsOrderSummary_order\n  ...Order2PricingBreakdown_order\n  ...Order2DetailsPaymentInfo_order\n  ...Order2DetailsFulfillmentInfo_order\n  ...Order2HelpLinks_order\n}\n\nfragment Order2DetailsPaymentInfo_order on Order {\n  creditCardWalletType\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      brand\n      lastDigits\n      expirationYear\n      expirationMonth\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n}\n\nfragment Order2HelpLinks_order on Order {\n  internalID\n}\n\nfragment Order2PricingBreakdown_order on Order {\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n}\n"
+    "text": "query Order2DetailsPage_Test_Query {\n  me {\n    order(id: \"123\") {\n      ...Order2DetailsPage_order\n      id\n    }\n    id\n  }\n}\n\nfragment Order2DetailsFulfillmentInfo_order on Order {\n  fulfillmentDetails {\n    addressLine1\n    addressLine2\n    city\n    country\n    name\n    postalCode\n    region\n    phoneNumber {\n      display\n    }\n  }\n  selectedFulfillmentOption {\n    type\n  }\n  shippingOrigin\n}\n\nfragment Order2DetailsHeader_order on Order {\n  code\n  displayTexts {\n    title\n  }\n}\n\nfragment Order2DetailsMessage_order on Order {\n  buyerStateExpiresAt\n  code\n  currencyCode\n  internalID\n  displayTexts {\n    messageType\n  }\n  deliveryInfo {\n    shipperName\n    trackingNumber\n    trackingURL\n    estimatedDelivery\n    estimatedDeliveryWindow\n  }\n}\n\nfragment Order2DetailsOrderSummary_order on Order {\n  ...Order2PricingBreakdown_order\n  source\n  totalListPrice {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      attributionClass {\n        shortDescription\n        id\n      }\n      dimensions {\n        in\n        cm\n      }\n      image {\n        resized(height: 360, width: 700) {\n          url\n          width\n          height\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment Order2DetailsPage_order on Order {\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    id\n  }\n  ...Order2DetailsHeader_order\n  ...Order2DetailsMessage_order\n  ...Order2DetailsOrderSummary_order\n  ...Order2PricingBreakdown_order\n  ...Order2DetailsPaymentInfo_order\n  ...Order2DetailsFulfillmentInfo_order\n  ...Order2HelpLinks_order\n}\n\nfragment Order2DetailsPaymentInfo_order on Order {\n  creditCardWalletType\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      brand\n      lastDigits\n      expirationYear\n      expirationMonth\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n}\n\nfragment Order2HelpLinks_order on Order {\n  internalID\n}\n\nfragment Order2PricingBreakdown_order on Order {\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/order2Routes_DetailsQuery.graphql.ts
+++ b/src/__generated__/order2Routes_DetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c2cd2673ed7573f38fbce6919b5d02c8>>
+ * @generated SignedSource<<ff4d0f77a7ea50869b60c69271560eba>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -420,6 +420,52 @@ return {
                   {
                     "alias": null,
                     "args": null,
+                    "concreteType": "DeliveryInfo",
+                    "kind": "LinkedField",
+                    "name": "deliveryInfo",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "shipperName",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "trackingNumber",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "trackingURL",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "estimatedDelivery",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "estimatedDeliveryWindow",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
                     "concreteType": null,
                     "kind": "LinkedField",
                     "name": "pricingBreakdownLines",
@@ -710,12 +756,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "e8a8cb025a185a7fab0af726152bf68f",
+    "cacheID": "579142b14e23353c2f3004aaf6af5f2a",
     "id": null,
     "metadata": {},
     "name": "order2Routes_DetailsQuery",
     "operationKind": "query",
-    "text": "query order2Routes_DetailsQuery(\n  $orderID: ID!\n) {\n  viewer {\n    ...Order2DetailsRoute_viewer_3HPek8\n    me {\n      order(id: $orderID) {\n        internalID\n        mode\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment Order2DetailsFulfillmentInfo_order on Order {\n  fulfillmentDetails {\n    addressLine1\n    addressLine2\n    city\n    country\n    name\n    postalCode\n    region\n    phoneNumber {\n      display\n    }\n  }\n  selectedFulfillmentOption {\n    type\n  }\n  shippingOrigin\n}\n\nfragment Order2DetailsHeader_order on Order {\n  code\n  displayTexts {\n    title\n  }\n}\n\nfragment Order2DetailsMessage_order on Order {\n  buyerStateExpiresAt\n  code\n  currencyCode\n  internalID\n  displayTexts {\n    messageType\n  }\n}\n\nfragment Order2DetailsOrderSummary_order on Order {\n  ...Order2PricingBreakdown_order\n  source\n  totalListPrice {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      attributionClass {\n        shortDescription\n        id\n      }\n      dimensions {\n        in\n        cm\n      }\n      image {\n        resized(height: 360, width: 700) {\n          url\n          width\n          height\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment Order2DetailsPage_order on Order {\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    id\n  }\n  ...Order2DetailsHeader_order\n  ...Order2DetailsMessage_order\n  ...Order2DetailsOrderSummary_order\n  ...Order2PricingBreakdown_order\n  ...Order2DetailsPaymentInfo_order\n  ...Order2DetailsFulfillmentInfo_order\n  ...Order2HelpLinks_order\n}\n\nfragment Order2DetailsPaymentInfo_order on Order {\n  creditCardWalletType\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      brand\n      lastDigits\n      expirationYear\n      expirationMonth\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n}\n\nfragment Order2DetailsRoute_viewer_3HPek8 on Viewer {\n  me {\n    order(id: $orderID) {\n      ...Order2DetailsPage_order\n      internalID\n      id\n    }\n    id\n  }\n}\n\nfragment Order2HelpLinks_order on Order {\n  internalID\n}\n\nfragment Order2PricingBreakdown_order on Order {\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n}\n"
+    "text": "query order2Routes_DetailsQuery(\n  $orderID: ID!\n) {\n  viewer {\n    ...Order2DetailsRoute_viewer_3HPek8\n    me {\n      order(id: $orderID) {\n        internalID\n        mode\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment Order2DetailsFulfillmentInfo_order on Order {\n  fulfillmentDetails {\n    addressLine1\n    addressLine2\n    city\n    country\n    name\n    postalCode\n    region\n    phoneNumber {\n      display\n    }\n  }\n  selectedFulfillmentOption {\n    type\n  }\n  shippingOrigin\n}\n\nfragment Order2DetailsHeader_order on Order {\n  code\n  displayTexts {\n    title\n  }\n}\n\nfragment Order2DetailsMessage_order on Order {\n  buyerStateExpiresAt\n  code\n  currencyCode\n  internalID\n  displayTexts {\n    messageType\n  }\n  deliveryInfo {\n    shipperName\n    trackingNumber\n    trackingURL\n    estimatedDelivery\n    estimatedDeliveryWindow\n  }\n}\n\nfragment Order2DetailsOrderSummary_order on Order {\n  ...Order2PricingBreakdown_order\n  source\n  totalListPrice {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      attributionClass {\n        shortDescription\n        id\n      }\n      dimensions {\n        in\n        cm\n      }\n      image {\n        resized(height: 360, width: 700) {\n          url\n          width\n          height\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment Order2DetailsPage_order on Order {\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    id\n  }\n  ...Order2DetailsHeader_order\n  ...Order2DetailsMessage_order\n  ...Order2DetailsOrderSummary_order\n  ...Order2PricingBreakdown_order\n  ...Order2DetailsPaymentInfo_order\n  ...Order2DetailsFulfillmentInfo_order\n  ...Order2HelpLinks_order\n}\n\nfragment Order2DetailsPaymentInfo_order on Order {\n  creditCardWalletType\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      brand\n      lastDigits\n      expirationYear\n      expirationMonth\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n}\n\nfragment Order2DetailsRoute_viewer_3HPek8 on Viewer {\n  me {\n    order(id: $orderID) {\n      ...Order2DetailsPage_order\n      internalID\n      id\n    }\n    id\n  }\n}\n\nfragment Order2HelpLinks_order on Order {\n  internalID\n}\n\nfragment Order2PricingBreakdown_order on Order {\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
<img width="1211" alt="Screenshot 2025-06-04 at 12 50 18 PM" src="https://github.com/user-attachments/assets/4818f6ad-c87c-4d81-b815-77f30633c8b2" />

The linking will only work for Arta shipped orders for now as those will have link stored. The regular orders will not for now. We will have a separate follow up ticket if we want to try and generate links for partner shipped orders as well.