### PR TITLE
fix(filters): avoids url changes on initial mount for default params

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/AuctionResultsFilterContext.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/AuctionResultsFilterContext.tsx
@@ -5,7 +5,7 @@ import {
 import { type Metric, getSupportedMetric } from "Utils/metrics"
 import { omit } from "lodash"
 import * as React from "react"
-import { useContext, useReducer, useState } from "react"
+import { useContext, useReducer, useRef, useState } from "react"
 import useDeepCompareEffect from "use-deep-compare-effect"
 
 export type Slice =
@@ -145,7 +145,15 @@ export const AuctionResultsFilterContextProvider: React.FC<
   const [shouldStageFilterChanges, setShouldStageFilterChanges] =
     useState(false)
 
+  const isInitialRender = useRef(true)
+
   useDeepCompareEffect(() => {
+    // Skip onChange call on initial render to prevent automatic URL updates with default values
+    if (isInitialRender.current) {
+      isInitialRender.current = false
+      return
+    }
+
     if (onChange) {
       onChange(omit(auctionResultsFilterState, ["reset"]))
     }

--- a/src/Components/ArtworkFilter/ArtworkFilterContext.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilterContext.tsx
@@ -4,7 +4,7 @@ import { updateUrl } from "Components/ArtworkFilter/Utils/urlBuilder"
 import type { SortOptions } from "Components/SortFilter"
 import { DEFAULT_METRIC, type Metric, getSupportedMetric } from "Utils/metrics"
 import { isArray, omit } from "lodash"
-import { useContext, useReducer, useState } from "react"
+import { useContext, useReducer, useRef, useState } from "react"
 import * as React from "react"
 import useDeepCompareEffect from "use-deep-compare-effect"
 import { hasFilters } from "./Utils/hasFilters"
@@ -267,6 +267,7 @@ export const ArtworkFilterContextProvider: React.FC<
   ZeroState,
 }) => {
   const camelCasedFilters: ArtworkFiltersState = paramsToCamelCase(filters)
+
   const defaultSort = sortOptions?.[0].value ?? initialArtworkFilterState.sort
   const defaultMetric = userPreferredMetric ?? initialArtworkFilterState.metric
   const defaultFilters = {
@@ -297,7 +298,15 @@ export const ArtworkFilterContextProvider: React.FC<
   const [followedArtists, setFollowedArtists] =
     useState<FollowedArtists>(_followedArtists)
 
+  const isInitialRender = useRef(true)
+
   useDeepCompareEffect(() => {
+    // Skip onChange call on initial render to prevent automatic URL updates with default values
+    if (isInitialRender.current) {
+      isInitialRender.current = false
+      return
+    }
+
     if (onChange) {
       onChange(omit(artworkFilterState, ["reset"]))
     }


### PR DESCRIPTION
Simple fix: we were pushing changes to the URL bar on mutation of the filter params. This just happened to run on initial mount as well and it doesn't need to. 