### PR TITLE
fix(EMI-2544): enable apple pay on chrome

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/ExpressCheckout/Order2ExpressCheckout.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/ExpressCheckout/Order2ExpressCheckout.tsx
@@ -15,7 +15,6 @@ import type {
   Order2ExpressCheckout_order$data,
   Order2ExpressCheckout_order$key,
 } from "__generated__/Order2ExpressCheckout_order.graphql"
-import { useEffect, useState } from "react"
 import { graphql, useFragment } from "react-relay"
 
 const logger = createLogger("Order2ExpressCheckout.tsx")
@@ -35,18 +34,10 @@ export const Order2ExpressCheckout: React.FC<Order2ExpressCheckoutProps> = ({
   order,
 }) => {
   const orderData = useFragment(FRAGMENT, order)
-  const [isChrome, setIsChrome] = useState<boolean | null>(null)
   const { expressCheckoutPaymentMethods } = useCheckoutContext()
 
   const expressCheckoutLoadedEmpty = expressCheckoutPaymentMethods?.length === 0
 
-  useEffect(() => {
-    const chrome =
-      typeof navigator !== "undefined" && /Chrome/.test(navigator.userAgent)
-    setIsChrome(chrome)
-  }, [])
-
-  if (isChrome === null) return null
   if (expressCheckoutLoadedEmpty) {
     return null
   }
@@ -87,7 +78,7 @@ export const Order2ExpressCheckout: React.FC<Order2ExpressCheckoutProps> = ({
   return (
     <Flex flexDirection="column" backgroundColor="mono0" p={2}>
       <Elements stripe={stripePromise} options={options}>
-        <Order2ExpressCheckoutUI order={orderData} isChrome={isChrome} />
+        <Order2ExpressCheckoutUI order={orderData} />
       </Elements>
     </Flex>
   )

--- a/src/Apps/Order2/Routes/Checkout/Components/ExpressCheckout/Order2ExpressCheckoutUI.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/ExpressCheckout/Order2ExpressCheckoutUI.tsx
@@ -50,7 +50,6 @@ import { graphql, useFragment } from "react-relay"
 
 interface Order2ExpressCheckoutUIProps {
   order: Order2ExpressCheckoutUI_order$key
-  isChrome?: boolean
 }
 
 const logger = createLogger("ExpressCheckoutUI")
@@ -62,7 +61,7 @@ type HandleCancelCallback = NonNullable<
 
 export const Order2ExpressCheckoutUI: React.FC<
   Order2ExpressCheckoutUIProps
-> = ({ order, isChrome }) => {
+> = ({ order }) => {
   const orderData = useFragment(FRAGMENT, order)
 
   const elements = useElements()
@@ -89,6 +88,7 @@ export const Order2ExpressCheckoutUI: React.FC<
     setExpressCheckoutLoaded,
     redirectToOrderDetails,
     setExpressCheckoutSubmitting,
+    expressCheckoutSubmitting,
   } = useCheckoutContext()
 
   if (!(stripe && elements)) {
@@ -102,7 +102,7 @@ export const Order2ExpressCheckoutUI: React.FC<
     },
     buttonHeight: 50,
     paymentMethods: {
-      applePay: isChrome ? "never" : "always",
+      applePay: "always",
       googlePay: "always",
     },
     layout: {
@@ -219,7 +219,10 @@ export const Order2ExpressCheckoutUI: React.FC<
     }
 
     setExpressCheckoutType(null)
-    resetOrder()
+
+    if (!expressCheckoutSubmitting) {
+      resetOrder()
+    }
   }
 
   // User selects a shipping address


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2544]

### Description

Stripe confirmed with us that they are calling `onCancel` after the user submits an Apple Pay order on Chrome. This update will not reset the order inside the `onCancel` if the order is being submitted, which should allow the order to process successfully. 

<!-- Implementation description -->


[EMI-2544]: https://artsyproduct.atlassian.net/browse/EMI-2544?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ