### PR TITLE
feat(EMI-2558): activate form submit button only after payment was saved

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/CheckoutContext/Order2CheckoutContext.tsx
+++ b/src/Apps/Order2/Routes/Checkout/CheckoutContext/Order2CheckoutContext.tsx
@@ -465,51 +465,29 @@ const reducer = (state: CheckoutState, action: Action): CheckoutState => {
 
     case "FULFILLMENT_DETAILS_COMPLETE":
       const { isPickup } = action.payload
-      // Update steps to mark FULFILLMENT_DETAILS as completed and remove DELIVERY_OPTION if isPickup
-      let nextStepActivated = false
+      let hasActivatedNext = false
 
       return {
         ...state,
-        steps: state.steps.reduce((acc, current) => {
-          const isThisStep =
-            current.name === CheckoutStepName.FULFILLMENT_DETAILS
-          if (isThisStep) {
-            return [
-              ...acc,
-              {
-                ...current,
-                state: CheckoutStepState.COMPLETED,
-              },
-            ]
+        steps: state.steps.map(step => {
+          // Mark fulfillment details as completed
+          if (step.name === CheckoutStepName.FULFILLMENT_DETAILS) {
+            return { ...step, state: CheckoutStepState.COMPLETED }
           }
 
-          if (current.name === CheckoutStepName.DELIVERY_OPTION) {
-            if (isPickup) {
-              return [...acc, { ...current, state: CheckoutStepState.HIDDEN }]
-            }
+          // Hide delivery option if pickup is selected
+          if (step.name === CheckoutStepName.DELIVERY_OPTION && isPickup) {
+            return { ...step, state: CheckoutStepState.HIDDEN }
           }
 
-          // Only activate the first upcoming step after FULFILLMENT_DETAILS is completed
-          if (
-            !nextStepActivated &&
-            current.state === CheckoutStepState.UPCOMING &&
-            acc.some(
-              step =>
-                step.name === CheckoutStepName.FULFILLMENT_DETAILS &&
-                step.state === CheckoutStepState.COMPLETED,
-            )
-          ) {
-            nextStepActivated = true
-            return [
-              ...acc,
-              {
-                ...current,
-                state: CheckoutStepState.ACTIVE,
-              },
-            ]
+          // Activate the first upcoming step
+          if (!hasActivatedNext && step.state === CheckoutStepState.UPCOMING) {
+            hasActivatedNext = true
+            return { ...step, state: CheckoutStepState.ACTIVE }
           }
-          return [...acc, current]
-        }, [] as CheckoutStep[]),
+
+          return step
+        }),
       }
     case "EDIT_PAYMENT":
       return {


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2558]

### Description

The main thing here was adding a `hasActivatedNext` logic to only activate the next section instead of all following sections.

https://github.com/user-attachments/assets/2e843a08-f9b5-407f-a1aa-26ea4062a5b3



<!-- Implementation description -->
