### PR TITLE
fix(partner): points to the artist as the true canonical

### DIFF
--- a/src/Apps/Partner/Components/PartnerMeta/index.tsx
+++ b/src/Apps/Partner/Components/PartnerMeta/index.tsx
@@ -24,7 +24,7 @@ const PartnerMeta: React.FC<React.PropsWithChildren<PartnerMetaProps>> = ({
 
   const href = `${getENV("APP_URL")}${pathname}`
   const canonicalHref = artistId
-    ? `${getENV("APP_URL")}/partner/${slug}/artists/${artistId}`
+    ? `${getENV("APP_URL")}/artist/${artistId}`
     : `${getENV("APP_URL")}/partner/${slug}`
 
   return (


### PR DESCRIPTION
> To help consolidate SEO value to our main artist pages and avoid dilution of page rank across duplicate or near-duplicate pages, we should add a canonical tag to all partner artist pages that points to the main /artist/ page.
