### PR TITLE
fix: order of artworks in follow rails

### DIFF
--- a/src/Components/ArtistRail.tsx
+++ b/src/Components/ArtistRail.tsx
@@ -26,7 +26,7 @@ const ArtistRail: FC<React.PropsWithChildren<ArtistRailProps>> = ({
 }) => {
   if (!artist || !artist.name) return null
 
-  const artworks = extractNodes(artist.artworksConnection)
+  const artworks = extractNodes(artist.filterArtworksConnection)
 
   return (
     <>
@@ -77,7 +77,7 @@ export const ArtistRailFragmentContainer = createFragmentContainer(ArtistRail, {
     fragment ArtistRail_artist on Artist {
       ...EntityHeaderArtist_artist
       name
-      artworksConnection(first: 10) {
+      filterArtworksConnection(first: 10, sort: "-decayed_merch") {
         edges {
           node {
             internalID

--- a/src/Components/CategoryRail.tsx
+++ b/src/Components/CategoryRail.tsx
@@ -79,7 +79,10 @@ export const CategoryRailFragmentContainer = createFragmentContainer(
         ...EntityHeaderGene_gene
         name
         href
-        filterArtworks: filterArtworksConnection(first: 10) {
+        filterArtworks: filterArtworksConnection(
+          first: 10
+          sort: "-decayed_merch"
+        ) {
           edges {
             node {
               internalID

--- a/src/__generated__/ArtistRail_artist.graphql.ts
+++ b/src/__generated__/ArtistRail_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9a2b69e4afe7aef353d55a2c1ebcea92>>
+ * @generated SignedSource<<e4799edabf88e0ecde5638316d00315a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,7 +11,7 @@
 import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type ArtistRail_artist$data = {
-  readonly artworksConnection: {
+  readonly filterArtworksConnection: {
     readonly edges: ReadonlyArray<{
       readonly node: {
         readonly internalID: string;
@@ -53,17 +53,22 @@ const node: ReaderFragment = {
           "kind": "Literal",
           "name": "first",
           "value": 10
+        },
+        {
+          "kind": "Literal",
+          "name": "sort",
+          "value": "-decayed_merch"
         }
       ],
-      "concreteType": "ArtworkConnection",
+      "concreteType": "FilterArtworksConnection",
       "kind": "LinkedField",
-      "name": "artworksConnection",
+      "name": "filterArtworksConnection",
       "plural": false,
       "selections": [
         {
           "alias": null,
           "args": null,
-          "concreteType": "ArtworkEdge",
+          "concreteType": "FilterArtworksEdge",
           "kind": "LinkedField",
           "name": "edges",
           "plural": true,
@@ -95,13 +100,13 @@ const node: ReaderFragment = {
           "storageKey": null
         }
       ],
-      "storageKey": "artworksConnection(first:10)"
+      "storageKey": "filterArtworksConnection(first:10,sort:\"-decayed_merch\")"
     }
   ],
   "type": "Artist",
   "abstractKey": null
 };
 
-(node as any).hash = "b65cc544c0dc2494ef6b51408a48f565";
+(node as any).hash = "becb8252736843a838a99b3e5822ad91";
 
 export default node;

--- a/src/__generated__/CategoryRail_category.graphql.ts
+++ b/src/__generated__/CategoryRail_category.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c35d9ffe1c097639e093b6fca7965eff>>
+ * @generated SignedSource<<47d2e33d6b384339d5ae95cb9a36d368>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -61,6 +61,11 @@ const node: ReaderFragment = {
           "kind": "Literal",
           "name": "first",
           "value": 10
+        },
+        {
+          "kind": "Literal",
+          "name": "sort",
+          "value": "-decayed_merch"
         }
       ],
       "concreteType": "FilterArtworksConnection",
@@ -103,13 +108,13 @@ const node: ReaderFragment = {
           "storageKey": null
         }
       ],
-      "storageKey": "filterArtworksConnection(first:10)"
+      "storageKey": "filterArtworksConnection(first:10,sort:\"-decayed_merch\")"
     }
   ],
   "type": "Gene",
   "abstractKey": null
 };
 
-(node as any).hash = "db825c6989cbbbd43370acf8c760f4c7";
+(node as any).hash = "eee9d7605c2388dcceb8091f1558ffff";
 
 export default node;

--- a/src/__generated__/SettingsSavesArtistsQuery.graphql.ts
+++ b/src/__generated__/SettingsSavesArtistsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c683ac8704ecc9578ab5b3be5d31c9cc>>
+ * @generated SignedSource<<180793ab8d4345a330c2dd2cf9515b89>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -312,17 +312,22 @@ return {
                                     "kind": "Literal",
                                     "name": "first",
                                     "value": 10
+                                  },
+                                  {
+                                    "kind": "Literal",
+                                    "name": "sort",
+                                    "value": "-decayed_merch"
                                   }
                                 ],
-                                "concreteType": "ArtworkConnection",
+                                "concreteType": "FilterArtworksConnection",
                                 "kind": "LinkedField",
-                                "name": "artworksConnection",
+                                "name": "filterArtworksConnection",
                                 "plural": false,
                                 "selections": [
                                   {
                                     "alias": null,
                                     "args": null,
-                                    "concreteType": "ArtworkEdge",
+                                    "concreteType": "FilterArtworksEdge",
                                     "kind": "LinkedField",
                                     "name": "edges",
                                     "plural": true,
@@ -768,9 +773,10 @@ return {
                                       }
                                     ],
                                     "storageKey": null
-                                  }
+                                  },
+                                  (v6/*: any*/)
                                 ],
-                                "storageKey": "artworksConnection(first:10)"
+                                "storageKey": "filterArtworksConnection(first:10,sort:\"-decayed_merch\")"
                               },
                               (v6/*: any*/)
                             ],
@@ -844,12 +850,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "cf3cf347ed1db09631ce2e5e387ef8aa",
+    "cacheID": "d90e6fb62575203d9c8b8807583c3fa3",
     "id": null,
     "metadata": {},
     "name": "SettingsSavesArtistsQuery",
     "operationKind": "query",
-    "text": "query SettingsSavesArtistsQuery(\n  $after: String\n) {\n  me {\n    ...SettingsSavesArtists_me_WGPvJ\n    id\n  }\n}\n\nfragment ArtistRail_artist on Artist {\n  ...EntityHeaderArtist_artist\n  name\n  artworksConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        ...ShelfArtwork_artwork\n        id\n      }\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  coverArtwork {\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  internalID\n  collectorSignals {\n    primaryLabel\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n}\n\nfragment SettingsSavesArtists_me_WGPvJ on Me {\n  followsAndSaves {\n    artistsConnection(first: 4, after: $after) {\n      totalCount\n      edges {\n        node {\n          internalID\n          artist {\n            ...ArtistRail_artist\n            id\n          }\n          id\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...ExclusiveAccessBadge_artwork\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  isUnlisted\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
+    "text": "query SettingsSavesArtistsQuery(\n  $after: String\n) {\n  me {\n    ...SettingsSavesArtists_me_WGPvJ\n    id\n  }\n}\n\nfragment ArtistRail_artist on Artist {\n  ...EntityHeaderArtist_artist\n  name\n  filterArtworksConnection(first: 10, sort: \"-decayed_merch\") {\n    edges {\n      node {\n        internalID\n        ...ShelfArtwork_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  coverArtwork {\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  internalID\n  collectorSignals {\n    primaryLabel\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n}\n\nfragment SettingsSavesArtists_me_WGPvJ on Me {\n  followsAndSaves {\n    artistsConnection(first: 4, after: $after) {\n      totalCount\n      edges {\n        node {\n          internalID\n          artist {\n            ...ArtistRail_artist\n            id\n          }\n          id\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...ExclusiveAccessBadge_artwork\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  isUnlisted\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SettingsSavesArtists_test_Query.graphql.ts
+++ b/src/__generated__/SettingsSavesArtists_test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<77a77f40f1b510a0fdf50d753e9c0735>>
+ * @generated SignedSource<<f940ac1dcb892c94f6957605cd6bdf33>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -122,29 +122,29 @@ v14 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Artwork"
+  "type": "FormattedNumber"
 },
 v15 = {
   "enumValues": null,
-  "nullable": false,
+  "nullable": true,
   "plural": false,
-  "type": "ID"
+  "type": "Artwork"
 },
 v16 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Boolean"
+  "type": "Image"
 },
 v17 = {
   "enumValues": null,
-  "nullable": true,
+  "nullable": false,
   "plural": false,
-  "type": "String"
+  "type": "ID"
 },
 v18 = {
   "enumValues": null,
-  "nullable": false,
+  "nullable": true,
   "plural": false,
   "type": "Boolean"
 },
@@ -152,25 +152,25 @@ v19 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Image"
+  "type": "String"
 },
 v20 = {
   "enumValues": null,
-  "nullable": true,
+  "nullable": false,
   "plural": false,
-  "type": "Int"
+  "type": "Boolean"
 },
 v21 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "SaleArtwork"
+  "type": "Int"
 },
 v22 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "FormattedNumber"
+  "type": "SaleArtwork"
 };
 return {
   "fragment": {
@@ -378,17 +378,22 @@ return {
                                     "kind": "Literal",
                                     "name": "first",
                                     "value": 10
+                                  },
+                                  {
+                                    "kind": "Literal",
+                                    "name": "sort",
+                                    "value": "-decayed_merch"
                                   }
                                 ],
-                                "concreteType": "ArtworkConnection",
+                                "concreteType": "FilterArtworksConnection",
                                 "kind": "LinkedField",
-                                "name": "artworksConnection",
+                                "name": "filterArtworksConnection",
                                 "plural": false,
                                 "selections": [
                                   {
                                     "alias": null,
                                     "args": null,
-                                    "concreteType": "ArtworkEdge",
+                                    "concreteType": "FilterArtworksEdge",
                                     "kind": "LinkedField",
                                     "name": "edges",
                                     "plural": true,
@@ -834,9 +839,10 @@ return {
                                       }
                                     ],
                                     "storageKey": null
-                                  }
+                                  },
+                                  (v6/*: any*/)
                                 ],
-                                "storageKey": "artworksConnection(first:10)"
+                                "storageKey": "filterArtworksConnection(first:10,sort:\"-decayed_merch\")"
                               },
                               (v6/*: any*/)
                             ],
@@ -910,7 +916,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "376dcadb5112efb4fa19680a443f74fa",
+    "cacheID": "683d26f58f433231260f46f689195acb",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -947,85 +953,104 @@ return {
         },
         "me.followsAndSaves.artistsConnection.edges.node.__typename": (v12/*: any*/),
         "me.followsAndSaves.artistsConnection.edges.node.artist": (v13/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection": {
+        "me.followsAndSaves.artistsConnection.edges.node.artist.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
-          "type": "ArtworkConnection"
+          "type": "ArtistCounts"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges": {
+        "me.followsAndSaves.artistsConnection.edges.node.artist.counts.artworks": (v14/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.counts.forSaleArtworks": (v14/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.coverArtwork": (v15/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.coverArtwork.avatar": (v16/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.coverArtwork.avatar.cropped": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "CroppedImageUrl"
+        },
+        "me.followsAndSaves.artistsConnection.edges.node.artist.coverArtwork.avatar.cropped.src": (v12/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.coverArtwork.avatar.cropped.srcSet": (v12/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.coverArtwork.id": (v17/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "FilterArtworksConnection"
+        },
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
-          "type": "ArtworkEdge"
+          "type": "FilterArtworksEdge"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node": (v14/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.artist": (v13/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.artist.id": (v15/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.artist.targetSupply": {
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node": (v15/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.artist": (v13/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.artist.id": (v17/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.artist.targetSupply": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "ArtistTargetSupply"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.artist.targetSupply.isP1": (v16/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.artistNames": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.artists": {
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.artist.targetSupply.isP1": (v18/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.artistNames": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.artists": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "Artist"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.artists.href": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.artists.id": (v15/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.artists.name": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.attributionClass": {
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.artists.href": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.artists.id": (v17/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.artists.name": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.attributionClass.id": (v15/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.attributionClass.name": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.collecting_institution": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.collectorSignals": {
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.attributionClass.id": (v17/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.attributionClass.name": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.collecting_institution": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.collectorSignals": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "CollectorSignals"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.collectorSignals.auction": {
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.collectorSignals.auction": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AuctionCollectorSignals"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.collectorSignals.auction.bidCount": {
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.collectorSignals.auction.bidCount": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "Int"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.collectorSignals.auction.liveBiddingStarted": (v18/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.collectorSignals.auction.lotClosesAt": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.collectorSignals.auction.onlineBiddingExtended": (v18/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.collectorSignals.auction.registrationEndsAt": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.collectorSignals.partnerOffer": {
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.collectorSignals.auction.liveBiddingStarted": (v20/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.collectorSignals.auction.lotClosesAt": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.collectorSignals.auction.onlineBiddingExtended": (v20/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.collectorSignals.auction.registrationEndsAt": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.collectorSignals.partnerOffer": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "PartnerOfferToCollector"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.collectorSignals.partnerOffer.endAt": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.collectorSignals.partnerOffer.id": (v15/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.collectorSignals.partnerOffer.priceWithDiscount": {
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.collectorSignals.partnerOffer.endAt": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.collectorSignals.partnerOffer.id": (v17/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.collectorSignals.partnerOffer.priceWithDiscount": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Money"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.collectorSignals.primaryLabel": {
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.collectorSignals.primaryLabel": {
           "enumValues": [
             "CURATORS_PICK",
             "INCREASED_INTEREST",
@@ -1035,141 +1060,123 @@ return {
           "plural": false,
           "type": "LabelSignalEnum"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.cultural_maker": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.date": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.href": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.id": (v15/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.image": (v19/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.image.height": (v20/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.image.src": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.image.width": (v20/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.internalID": (v15/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.isUnlisted": (v18/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.marketPriceInsights": {
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.cultural_maker": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.date": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.href": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.id": (v17/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.image": (v16/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.image.height": (v21/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.image.src": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.image.width": (v21/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.internalID": (v17/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.isUnlisted": (v20/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.marketPriceInsights": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtworkPriceInsights"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.marketPriceInsights.demandRank": {
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.marketPriceInsights.demandRank": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Float"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.mediumType": {
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.mediumType": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtworkMedium"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.mediumType.filterGene": {
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.mediumType.filterGene": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Gene"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.mediumType.filterGene.id": (v15/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.mediumType.filterGene.name": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.partner": {
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.mediumType.filterGene.id": (v17/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.mediumType.filterGene.name": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.partner.href": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.partner.id": (v15/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.partner.name": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale": {
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.partner.href": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.partner.id": (v17/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.partner.name": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.sale": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Sale"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v20/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale.endAt": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v20/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale.id": (v15/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale.isOpen": (v16/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale.is_auction": (v16/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale.is_closed": (v16/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale.startAt": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.saleArtwork": (v21/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.saleArtwork.id": (v15/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.saleArtwork.lotID": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork": (v21/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.counts": {
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.sale.cascadingEndTimeIntervalMinutes": (v21/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.sale.endAt": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.sale.extendedBiddingIntervalMinutes": (v21/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.sale.id": (v17/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.sale.isOpen": (v18/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.sale.is_auction": (v18/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.sale.is_closed": (v18/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.sale.startAt": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.saleArtwork": (v22/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.saleArtwork.id": (v17/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.saleArtwork.lotID": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.sale_artwork": (v22/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.sale_artwork.counts": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkCounts"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.counts.bidder_positions": (v22/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.endAt": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.highest_bid": {
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.sale_artwork.counts.bidder_positions": (v14/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.sale_artwork.endAt": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.sale_artwork.extendedBiddingEndAt": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.sale_artwork.formattedEndDateTime": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.sale_artwork.highest_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkHighestBid"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.highest_bid.display": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.id": (v15/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.lotID": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.lotLabel": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.opening_bid": {
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.sale_artwork.highest_bid.display": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.sale_artwork.id": (v17/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.sale_artwork.lotID": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.sale_artwork.lotLabel": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.sale_artwork.opening_bid": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "SaleArtworkOpeningBid"
         },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_artwork.opening_bid.display": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.sale_message": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.artworksConnection.edges.node.title": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.counts": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "ArtistCounts"
-        },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.counts.artworks": (v22/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.counts.forSaleArtworks": (v22/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.coverArtwork": (v14/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.coverArtwork.avatar": (v19/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.coverArtwork.avatar.cropped": {
-          "enumValues": null,
-          "nullable": true,
-          "plural": false,
-          "type": "CroppedImageUrl"
-        },
-        "me.followsAndSaves.artistsConnection.edges.node.artist.coverArtwork.avatar.cropped.src": (v12/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.coverArtwork.avatar.cropped.srcSet": (v12/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.coverArtwork.id": (v15/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.formattedNationalityAndBirthday": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.href": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.id": (v15/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.initials": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.internalID": (v15/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.name": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.artist.slug": (v15/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.id": (v15/*: any*/),
-        "me.followsAndSaves.artistsConnection.edges.node.internalID": (v15/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.sale_artwork.opening_bid.display": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.sale_message": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.edges.node.title": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.filterArtworksConnection.id": (v17/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.formattedNationalityAndBirthday": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.href": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.id": (v17/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.initials": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.internalID": (v17/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.name": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.artist.slug": (v17/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.id": (v17/*: any*/),
+        "me.followsAndSaves.artistsConnection.edges.node.internalID": (v17/*: any*/),
         "me.followsAndSaves.artistsConnection.pageInfo": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "PageInfo"
         },
-        "me.followsAndSaves.artistsConnection.pageInfo.endCursor": (v17/*: any*/),
-        "me.followsAndSaves.artistsConnection.pageInfo.hasNextPage": (v18/*: any*/),
-        "me.followsAndSaves.artistsConnection.totalCount": (v20/*: any*/),
-        "me.id": (v15/*: any*/)
+        "me.followsAndSaves.artistsConnection.pageInfo.endCursor": (v19/*: any*/),
+        "me.followsAndSaves.artistsConnection.pageInfo.hasNextPage": (v20/*: any*/),
+        "me.followsAndSaves.artistsConnection.totalCount": (v21/*: any*/),
+        "me.id": (v17/*: any*/)
       }
     },
     "name": "SettingsSavesArtists_test_Query",
     "operationKind": "query",
-    "text": "query SettingsSavesArtists_test_Query(\n  $after: String\n) {\n  me {\n    ...SettingsSavesArtists_me_WGPvJ\n    id\n  }\n}\n\nfragment ArtistRail_artist on Artist {\n  ...EntityHeaderArtist_artist\n  name\n  artworksConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        ...ShelfArtwork_artwork\n        id\n      }\n    }\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  coverArtwork {\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  internalID\n  collectorSignals {\n    primaryLabel\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n}\n\nfragment SettingsSavesArtists_me_WGPvJ on Me {\n  followsAndSaves {\n    artistsConnection(first: 4, after: $after) {\n      totalCount\n      edges {\n        node {\n          internalID\n          artist {\n            ...ArtistRail_artist\n            id\n          }\n          id\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...ExclusiveAccessBadge_artwork\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  isUnlisted\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
+    "text": "query SettingsSavesArtists_test_Query(\n  $after: String\n) {\n  me {\n    ...SettingsSavesArtists_me_WGPvJ\n    id\n  }\n}\n\nfragment ArtistRail_artist on Artist {\n  ...EntityHeaderArtist_artist\n  name\n  filterArtworksConnection(first: 10, sort: \"-decayed_merch\") {\n    edges {\n      node {\n        internalID\n        ...ShelfArtwork_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  coverArtwork {\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  internalID\n  collectorSignals {\n    primaryLabel\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n}\n\nfragment SettingsSavesArtists_me_WGPvJ on Me {\n  followsAndSaves {\n    artistsConnection(first: 4, after: $after) {\n      totalCount\n      edges {\n        node {\n          internalID\n          artist {\n            ...ArtistRail_artist\n            id\n          }\n          id\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...ExclusiveAccessBadge_artwork\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  isUnlisted\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SettingsSavesCategoriesQuery.graphql.ts
+++ b/src/__generated__/SettingsSavesCategoriesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<48f75228b111fdcce57e6d3f4d92316f>>
+ * @generated SignedSource<<43eb442690dfbab8e45135641ddadfc3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -298,6 +298,11 @@ return {
                                     "kind": "Literal",
                                     "name": "first",
                                     "value": 10
+                                  },
+                                  {
+                                    "kind": "Literal",
+                                    "name": "sort",
+                                    "value": "-decayed_merch"
                                   }
                                 ],
                                 "concreteType": "FilterArtworksConnection",
@@ -757,7 +762,7 @@ return {
                                   },
                                   (v6/*: any*/)
                                 ],
-                                "storageKey": "filterArtworksConnection(first:10)"
+                                "storageKey": "filterArtworksConnection(first:10,sort:\"-decayed_merch\")"
                               },
                               (v6/*: any*/)
                             ],
@@ -831,12 +836,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "55652fe75e7d6bde9ab98f02b30e495a",
+    "cacheID": "59e93b41bfb319902969a933c9fe90e0",
     "id": null,
     "metadata": {},
     "name": "SettingsSavesCategoriesQuery",
     "operationKind": "query",
-    "text": "query SettingsSavesCategoriesQuery(\n  $after: String\n) {\n  me {\n    ...SettingsSavesCategories_me_WGPvJ\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment CategoryRail_category on Gene {\n  ...EntityHeaderGene_gene\n  name\n  href\n  filterArtworks: filterArtworksConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        ...ShelfArtwork_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment EntityHeaderGene_gene on Gene {\n  internalID\n  href\n  name\n  avatar: image {\n    cropped(width: 45, height: 45, version: [\"big_and_tall\", \"tall\"]) {\n      src\n      srcSet\n    }\n  }\n  filterArtworksConnection(first: 1) {\n    counts {\n      total\n    }\n    id\n  }\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  internalID\n  collectorSignals {\n    primaryLabel\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n}\n\nfragment SettingsSavesCategories_me_WGPvJ on Me {\n  followsAndSaves {\n    categoriesConnection: genesConnection(first: 4, after: $after) {\n      totalCount\n      edges {\n        node {\n          internalID\n          category: gene {\n            internalID\n            ...CategoryRail_category\n            id\n          }\n          id\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...ExclusiveAccessBadge_artwork\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  isUnlisted\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
+    "text": "query SettingsSavesCategoriesQuery(\n  $after: String\n) {\n  me {\n    ...SettingsSavesCategories_me_WGPvJ\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment CategoryRail_category on Gene {\n  ...EntityHeaderGene_gene\n  name\n  href\n  filterArtworks: filterArtworksConnection(first: 10, sort: \"-decayed_merch\") {\n    edges {\n      node {\n        internalID\n        ...ShelfArtwork_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment EntityHeaderGene_gene on Gene {\n  internalID\n  href\n  name\n  avatar: image {\n    cropped(width: 45, height: 45, version: [\"big_and_tall\", \"tall\"]) {\n      src\n      srcSet\n    }\n  }\n  filterArtworksConnection(first: 1) {\n    counts {\n      total\n    }\n    id\n  }\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  internalID\n  collectorSignals {\n    primaryLabel\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n}\n\nfragment SettingsSavesCategories_me_WGPvJ on Me {\n  followsAndSaves {\n    categoriesConnection: genesConnection(first: 4, after: $after) {\n      totalCount\n      edges {\n        node {\n          internalID\n          category: gene {\n            internalID\n            ...CategoryRail_category\n            id\n          }\n          id\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...ExclusiveAccessBadge_artwork\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  isUnlisted\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SettingsSavesCategories_test_Query.graphql.ts
+++ b/src/__generated__/SettingsSavesCategories_test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f1ab224e3990396f09afed824f69b9eb>>
+ * @generated SignedSource<<0a12efd2d5c688d87ced21fcd5964a2b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -364,6 +364,11 @@ return {
                                     "kind": "Literal",
                                     "name": "first",
                                     "value": 10
+                                  },
+                                  {
+                                    "kind": "Literal",
+                                    "name": "sort",
+                                    "value": "-decayed_merch"
                                   }
                                 ],
                                 "concreteType": "FilterArtworksConnection",
@@ -823,7 +828,7 @@ return {
                                   },
                                   (v6/*: any*/)
                                 ],
-                                "storageKey": "filterArtworksConnection(first:10)"
+                                "storageKey": "filterArtworksConnection(first:10,sort:\"-decayed_merch\")"
                               },
                               (v6/*: any*/)
                             ],
@@ -897,7 +902,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "3aaab0e43d209ece042408a4d46b434b",
+    "cacheID": "d3a56c82b5a9b77d46d09060763b5f8f",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -1153,7 +1158,7 @@ return {
     },
     "name": "SettingsSavesCategories_test_Query",
     "operationKind": "query",
-    "text": "query SettingsSavesCategories_test_Query(\n  $after: String\n) {\n  me {\n    ...SettingsSavesCategories_me_WGPvJ\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment CategoryRail_category on Gene {\n  ...EntityHeaderGene_gene\n  name\n  href\n  filterArtworks: filterArtworksConnection(first: 10) {\n    edges {\n      node {\n        internalID\n        ...ShelfArtwork_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment EntityHeaderGene_gene on Gene {\n  internalID\n  href\n  name\n  avatar: image {\n    cropped(width: 45, height: 45, version: [\"big_and_tall\", \"tall\"]) {\n      src\n      srcSet\n    }\n  }\n  filterArtworksConnection(first: 1) {\n    counts {\n      total\n    }\n    id\n  }\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  internalID\n  collectorSignals {\n    primaryLabel\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n}\n\nfragment SettingsSavesCategories_me_WGPvJ on Me {\n  followsAndSaves {\n    categoriesConnection: genesConnection(first: 4, after: $after) {\n      totalCount\n      edges {\n        node {\n          internalID\n          category: gene {\n            internalID\n            ...CategoryRail_category\n            id\n          }\n          id\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...ExclusiveAccessBadge_artwork\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  isUnlisted\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
+    "text": "query SettingsSavesCategories_test_Query(\n  $after: String\n) {\n  me {\n    ...SettingsSavesCategories_me_WGPvJ\n    id\n  }\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment CategoryRail_category on Gene {\n  ...EntityHeaderGene_gene\n  name\n  href\n  filterArtworks: filterArtworksConnection(first: 10, sort: \"-decayed_merch\") {\n    edges {\n      node {\n        internalID\n        ...ShelfArtwork_artwork\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment EntityHeaderGene_gene on Gene {\n  internalID\n  href\n  name\n  avatar: image {\n    cropped(width: 45, height: 45, version: [\"big_and_tall\", \"tall\"]) {\n      src\n      srcSet\n    }\n  }\n  filterArtworksConnection(first: 1) {\n    counts {\n      total\n    }\n    id\n  }\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  internalID\n  collectorSignals {\n    primaryLabel\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n}\n\nfragment SettingsSavesCategories_me_WGPvJ on Me {\n  followsAndSaves {\n    categoriesConnection: genesConnection(first: 4, after: $after) {\n      totalCount\n      edges {\n        node {\n          internalID\n          category: gene {\n            internalID\n            ...CategoryRail_category\n            id\n          }\n          id\n          __typename\n        }\n        cursor\n      }\n      pageInfo {\n        endCursor\n        hasNextPage\n      }\n    }\n  }\n}\n\nfragment ShelfArtwork_artwork on Artwork {\n  ...ExclusiveAccessBadge_artwork\n  ...Metadata_artwork\n  title\n  href\n  artistNames\n  isUnlisted\n  image {\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [ONYX-1751]

### Description

Our follow rails were not specifying an order for the artworks they were displaying, thus often displaying many sold or unavailable works.

This PR ensures that…

- **Followed Artists** and **Followed Categories** rails use the ES-backed filter artworks endpoint
- and they explicitly specify `-decayed_merch` as their sort, so that the rail downranks sold works (and matches the corresponding artwork grid the user will see if they click through)

Now users are much more likely to see for-sale works in these rails:

| Rail | Before | After |
|--------|--------|--------|
| Artists |<img width="300" alt="artworks" src="https://github.com/user-attachments/assets/80ca0504-42af-48c2-9ed5-a12ee8635494" /> |<img width="300" alt="filter" src="https://github.com/user-attachments/assets/b969d218-431b-4cef-b085-4bf7edba6b87" /> |
| <nobr>Categories</nobr> |<img width="300" alt="cat artworks" src="https://github.com/user-attachments/assets/c8aaec49-fb3c-4369-b035-268f6f73d8eb" /> |<img  width="300" alt="cat filter" src="https://github.com/user-attachments/assets/a568d5e1-9f05-44e7-b1fb-4c0fbea932b2" /> | 





[ONYX-1751]: https://artsyproduct.atlassian.net/browse/ONYX-1751?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ