### PR TITLE
fix: error for missing user-shared collection

### DIFF
--- a/src/Apps/User/Routes/UserCollectionRoute.tsx
+++ b/src/Apps/User/Routes/UserCollectionRoute.tsx
@@ -7,6 +7,7 @@ import { MetaTags } from "Components/MetaTags"
 import { useRouter } from "System/Hooks/useRouter"
 import { Jump } from "Utils/Hooks/useJump"
 import type { UserCollectionRoute_collection$data } from "__generated__/UserCollectionRoute_collection.graphql"
+import { HttpError } from "found"
 import { useEffect } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -25,6 +26,10 @@ const UserCollectionRoute = ({ collection }: UserCollectionRouteProps) => {
   useEffect(() => {
     trackEvent(tracks.openedPage(collection))
   }, [collection, trackEvent])
+
+  if (!collection) {
+    throw new HttpError(404)
+  }
 
   return (
     <>


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [ONYX-1568]

### Description

Users can share their saved artwork lists publicly as of last Hackathon.

Once they un-share the list it becomes inaccessible to the public, which we want. But we currently show a 500 error page in that case, which we don't want.

My first attempt was to add a `@principalField` directive to [the `collection` field in question](https://github.com/artsy/force/blob/13c617885d37acb012bc2f7d3675ea2e635d3cc7/src/Apps/User/userRoutes.tsx#L30) but that just propagated the 403 error — which I assume we don't want in this case because it divulges the existence of a private resource:

<img width="300" alt="403" src="https://github.com/user-attachments/assets/4ce31efa-3bb2-4d40-92bf-70535b6e2714" />

Instead we'd prefer to show a 404, so that's how I ended up with the current change:

| Before | After |
|--------|--------|
| <img width="auto" alt="500" src="https://github.com/user-attachments/assets/a4b1dfce-bb2d-4ee4-ad29-cfcc6ce32d67" /> | <img width="auto" alt="404" src="https://github.com/user-attachments/assets/753b1761-175e-4dda-b8ff-973d6888846e" /> |






[ONYX-1568]: https://artsyproduct.atlassian.net/browse/ONYX-1568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ