### PR TITLE
chore(cache): Drop page cache times down to default 1hr

### DIFF
--- a/src/Apps/Artist/artistRoutes.tsx
+++ b/src/Apps/Artist/artistRoutes.tsx
@@ -1,6 +1,5 @@
 import loadable from "@loadable/component"
 import { initialAuctionResultsFilterState } from "Apps/Artist/Routes/AuctionResults/initialAuctionResultsFilterState"
-import { serverCacheTTLs } from "Apps/serverCacheTTLs"
 import { paramsToCamelCase } from "Components/ArtworkFilter/Utils/paramsCasing"
 import type { RouteProps } from "System/Router/Route"
 import { RedirectException } from "found"
@@ -103,7 +102,6 @@ export const artistRoutes: RouteProps[] = [
   {
     path: "/artist/:artistID",
     ignoreScrollBehaviorBetweenChildren: true,
-    serverCacheTTL: serverCacheTTLs.artist,
     getComponent: () => ArtistApp,
     onServerSideRender: enableArtistPageCTA,
     onPreloadJS: () => {
@@ -121,7 +119,6 @@ export const artistRoutes: RouteProps[] = [
     children: [
       {
         path: "",
-        serverCacheTTL: serverCacheTTLs.artist,
         getComponent: () => WorksForSaleRoute,
         onServerSideRender: redirectWithCanonicalParams,
         onPreloadJS: () => {
@@ -138,7 +135,6 @@ export const artistRoutes: RouteProps[] = [
       },
       {
         path: "auction-results",
-        serverCacheTTL: serverCacheTTLs.artist,
         getComponent: () => AuctionResultsRoute,
         onPreloadJS: () => {
           AuctionResultsRoute.preload()
@@ -195,7 +191,6 @@ export const artistRoutes: RouteProps[] = [
       },
       {
         path: "about",
-        serverCacheTTL: serverCacheTTLs.artist,
         getComponent: () => OverviewRoute,
         onServerSideRender: enableArtistPageCTA,
         onPreloadJS: () => {
@@ -213,7 +208,6 @@ export const artistRoutes: RouteProps[] = [
   },
   {
     path: "/artist/:artistID",
-    serverCacheTTL: serverCacheTTLs.artist,
     ignoreScrollBehaviorBetweenChildren: true,
     getComponent: () => ArtistSubApp,
     query: graphql`
@@ -226,7 +220,6 @@ export const artistRoutes: RouteProps[] = [
     children: [
       {
         path: "articles/:artworkId?",
-        serverCacheTTL: serverCacheTTLs.artist,
         getComponent: () => ArticlesRoute,
         onPreloadJS: () => {
           ArticlesRoute.preload()
@@ -241,7 +234,6 @@ export const artistRoutes: RouteProps[] = [
       },
       {
         path: "cv",
-        serverCacheTTL: serverCacheTTLs.artist,
         getComponent: () => CVRoute,
         onPreloadJS: () => {
           CVRoute.preload()
@@ -256,7 +248,6 @@ export const artistRoutes: RouteProps[] = [
       },
       {
         path: "series",
-        serverCacheTTL: serverCacheTTLs.artist,
         getComponent: () => ArtistSeriesRoute,
         onPreloadJS: () => {
           ArtistSeriesRoute.preload()
@@ -271,7 +262,6 @@ export const artistRoutes: RouteProps[] = [
       },
       {
         path: "shows",
-        serverCacheTTL: serverCacheTTLs.artist,
         getComponent: () => ShowsRoute,
         onPreloadJS: () => {
           ShowsRoute.preload()
@@ -298,7 +288,6 @@ export const artistRoutes: RouteProps[] = [
   },
   {
     path: "/auction-result/:auctionResultId",
-    serverCacheTTL: serverCacheTTLs.artist,
     getComponent: () => AuctionResultRoute,
     onServerSideRender: enableArtistPageCTA,
     onPreloadJS: () => {

--- a/src/Apps/ArtistSeries/artistSeriesRoutes.tsx
+++ b/src/Apps/ArtistSeries/artistSeriesRoutes.tsx
@@ -1,5 +1,4 @@
 import loadable from "@loadable/component"
-import { serverCacheTTLs } from "Apps/serverCacheTTLs"
 import type { RouteProps } from "System/Router/Route"
 import { graphql } from "react-relay"
 
@@ -13,7 +12,6 @@ const ArtistSeriesApp = loadable(
 export const artistSeriesRoutes: RouteProps[] = [
   {
     path: "/artist-series/:slug",
-    serverCacheTTL: serverCacheTTLs.artistSeries,
     getComponent: () => ArtistSeriesApp,
     onPreloadJS: () => {
       ArtistSeriesApp.preload()

--- a/src/Apps/Artists/artistsRoutes.tsx
+++ b/src/Apps/Artists/artistsRoutes.tsx
@@ -1,5 +1,4 @@
 import loadable from "@loadable/component"
-import { serverCacheTTLs } from "Apps/serverCacheTTLs"
 import type { RouteProps } from "System/Router/Route"
 import { graphql } from "react-relay"
 
@@ -28,7 +27,6 @@ const ArtistsByLetterRoute = loadable(
 export const artistsRoutes: RouteProps[] = [
   {
     path: "/artists",
-    serverCacheTTL: serverCacheTTLs.artists,
     getComponent: () => ArtistsApp,
     onPreloadJS: () => {
       ArtistsApp.preload()
@@ -36,7 +34,6 @@ export const artistsRoutes: RouteProps[] = [
     children: [
       {
         path: "",
-        serverCacheTTL: serverCacheTTLs.artists,
         getComponent: () => ArtistsIndexRoute,
         onPreloadJS: () => {
           ArtistsIndexRoute.preload()
@@ -54,7 +51,6 @@ export const artistsRoutes: RouteProps[] = [
       },
       {
         path: "artists-starting-with-:letter([a-zA-Z])",
-        serverCacheTTL: serverCacheTTLs.artists,
         getComponent: () => ArtistsByLetterRoute,
         onPreloadJS: () => {
           ArtistsByLetterRoute.preload()

--- a/src/Apps/Categories/categoriesRoutes.tsx
+++ b/src/Apps/Categories/categoriesRoutes.tsx
@@ -1,5 +1,4 @@
 import loadable from "@loadable/component"
-import { serverCacheTTLs } from "Apps/serverCacheTTLs"
 import type { RouteProps } from "System/Router/Route"
 import { graphql } from "react-relay"
 
@@ -13,7 +12,6 @@ const CategoriesApp = loadable(
 export const categoriesRoutes: RouteProps[] = [
   {
     path: "/categories",
-    serverCacheTTL: serverCacheTTLs.categories,
     getComponent: () => CategoriesApp,
     onPreloadJS: () => {
       CategoriesApp.preload()

--- a/src/Apps/Collect/collectRoutes.tsx
+++ b/src/Apps/Collect/collectRoutes.tsx
@@ -1,5 +1,4 @@
 import loadable from "@loadable/component"
-import { serverCacheTTLs } from "Apps/serverCacheTTLs"
 import { getInitialFilterState } from "Components/ArtworkFilter/Utils/getInitialFilterState"
 import type { RouteProps } from "System/Router/Route"
 import { graphql } from "react-relay"
@@ -26,7 +25,6 @@ const CollectionApp = loadable(
 export const collectRoutes: RouteProps[] = [
   {
     path: "/collect/:medium?",
-    serverCacheTTL: serverCacheTTLs.collect,
     getComponent: () => CollectApp,
     onPreloadJS: () => {
       CollectApp.preload()
@@ -36,7 +34,6 @@ export const collectRoutes: RouteProps[] = [
   },
   {
     path: "/collect/color/:color?",
-    serverCacheTTL: serverCacheTTLs.collect,
     getComponent: () => CollectApp,
     onPreloadJS: () => {
       CollectApp.preload()
@@ -46,7 +43,6 @@ export const collectRoutes: RouteProps[] = [
   },
   {
     path: "/collections",
-    serverCacheTTL: serverCacheTTLs.collections,
     getComponent: () => CollectionsApp,
     onPreloadJS: () => {
       CollectionsApp.preload()
@@ -61,7 +57,6 @@ export const collectRoutes: RouteProps[] = [
   },
   {
     path: "/collection/:slug",
-    serverCacheTTL: serverCacheTTLs.collections,
     getComponent: () => CollectionApp,
     onPreloadJS: () => {
       CollectionApp.preload()

--- a/src/Apps/Gene/geneRoutes.tsx
+++ b/src/Apps/Gene/geneRoutes.tsx
@@ -1,5 +1,4 @@
 import loadable from "@loadable/component"
-import { serverCacheTTLs } from "Apps/serverCacheTTLs"
 import type { RouteProps } from "System/Router/Route"
 import { RedirectException } from "found"
 import { graphql } from "react-relay"
@@ -22,7 +21,6 @@ const GeneShowRoute = loadable(
 export const geneRoutes: RouteProps[] = [
   {
     path: "/gene/:slug",
-    serverCacheTTL: serverCacheTTLs.gene,
     getComponent: () => GeneApp,
     onServerSideRender: redirectGeneToCollection,
     onPreloadJS: () => {
@@ -41,7 +39,6 @@ export const geneRoutes: RouteProps[] = [
       },
       {
         path: "",
-        serverCacheTTL: serverCacheTTLs.gene,
         getComponent: () => GeneShowRoute,
         onPreloadJS: () => {
           GeneShowRoute.preload()

--- a/src/Apps/serverCacheTTLs.tsx
+++ b/src/Apps/serverCacheTTLs.tsx
@@ -1,5 +1,4 @@
 const NO_CACHE = 0
-const HOURS_24 = 86400 // In seconds
 const MINUTES_5 = 300 // In seconds
 
 /**
@@ -8,16 +7,8 @@ const MINUTES_5 = 300 // In seconds
  * all routes not defined here.
  */
 export const serverCacheTTLs = {
-  artist: HOURS_24,
   article: MINUTES_5,
   articles: MINUTES_5,
-  artists: HOURS_24,
-  artistSeries: HOURS_24,
   auction: NO_CACHE,
-  categories: HOURS_24,
-  collect: HOURS_24,
-  collection: HOURS_24,
-  collections: HOURS_24,
-  gene: HOURS_24,
   sale: NO_CACHE,
 }


### PR DESCRIPTION
The type of this PR is: **Chore**

This PR solves [PBRW-875]

### Description

This updates our serverCacheTTL settings by removing specific entries, in favor of default 1hr cache times. We haven't seen much impact here given our traffic patterns; however, bug reports do come in from confused partners. 


[PBRW-875]: https://artsyproduct.atlassian.net/browse/PBRW-875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ