### PR TITLE
chore: prevent navigating out popup when completing regular checkout and navigating to the new details page under orders2

### DIFF
--- a/src/Apps/Order/OrderApp.tsx
+++ b/src/Apps/Order/OrderApp.tsx
@@ -64,7 +64,10 @@ const OrderApp: FC<React.PropsWithChildren<OrderAppProps>> = props => {
   }, [])
 
   const handleTransition = () => newLocation => {
-    const isToTheSameApp = newLocation?.pathname?.includes("/orders/")
+    // Regex to test for both 'orders' and 'orders2' pages
+    // as we plan to do a staged release where Order and Order2
+    // will exist in parallel in production for some time
+    const isToTheSameApp = /\/orders?2?\//.test(newLocation?.pathname ?? "")
     const isRedirect = newLocation?.action === "PUSH"
 
     if (isToTheSameApp || isRedirect) {


### PR DESCRIPTION
This addresses at least part of https://artsyproduct.atlassian.net/browse/EMI-2567 and depending if we are ok with orders2 in URL - maybe all of it.

@erikdstock, @rquartararo - we probably need to add some of this 'warn before leaving' logic to the new 'checkout' page as don't think we currently have it implemented.  It will not matter for 'details' page as there is no unsaved changes here.


