### PR TITLE
fix(dia-1350): fix non-self-referential canonicals

### DIFF
--- a/src/Apps/Authentication/Components/AuthenticationInlineDialog.tsx
+++ b/src/Apps/Authentication/Components/AuthenticationInlineDialog.tsx
@@ -43,7 +43,7 @@ const AuthenticationInlineDialogContents: FC<
 
   return (
     <>
-      <MetaTags title={pageTitle} />
+      <MetaTags title={pageTitle} pathname={location.pathname} />
 
       <Flex
         alignItems="center"

--- a/src/Apps/Press/PressApp.tsx
+++ b/src/Apps/Press/PressApp.tsx
@@ -3,6 +3,7 @@ import { PageHTML } from "Apps/Page/Components/PageHTML"
 import { MetaTags } from "Components/MetaTags"
 import { RouteTab, RouteTabs } from "Components/RouteTabs"
 import { RouterLink } from "System/Components/RouterLink"
+import { useRouter } from "System/Hooks/useRouter"
 import type { PressApp_page$data } from "__generated__/PressApp_page.graphql"
 import type { FC } from "react"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -14,9 +15,13 @@ interface PressAppProps {
 const PressApp: FC<React.PropsWithChildren<PressAppProps>> = ({ page }) => {
   if (!page.content) return null
 
+  const {
+    match: { location },
+  } = useRouter()
+
   return (
     <>
-      <MetaTags title={`${page.name} | Artsy`} />
+      <MetaTags title={`${page.name} | Artsy`} pathname={location.pathname} />
 
       <Spacer y={4} />
 

--- a/src/Apps/Shows/Components/ShowsMeta.tsx
+++ b/src/Apps/Shows/Components/ShowsMeta.tsx
@@ -7,15 +7,19 @@ const DESCRIPTION =
 
 interface ShowsMetaProps {
   cityName?: string
+  pathname?: string
 }
 
 export const ShowsMeta: React.FC<React.PropsWithChildren<ShowsMetaProps>> = ({
   cityName,
+  pathname = "/shows",
 }) => {
   const title = cityName ? `${cityName} ${TITLE}` : TITLE
   const description = cityName
     ? `Explore shows in ${cityName} on Artsy. ${DESCRIPTION}`
     : DESCRIPTION
 
-  return <MetaTags title={title} description={description} pathname="/shows" />
+  return (
+    <MetaTags title={title} description={description} pathname={pathname} />
+  )
 }

--- a/src/Apps/Shows/Routes/ShowsCity.tsx
+++ b/src/Apps/Shows/Routes/ShowsCity.tsx
@@ -107,7 +107,7 @@ export const ShowsCity: React.FC<React.PropsWithChildren<ShowsCityProps>> = ({
 
   return (
     <>
-      <ShowsMeta cityName={city.name} />
+      <ShowsMeta cityName={city.name} pathname={`/shows/${city.slug}`} />
 
       <Spacer y={4} />
 


### PR DESCRIPTION
A few pages around the site don't set a canonical to themselves where they should.

However, mostly this problem winds up manifesting on the artist page (/auction-results, /about); which we will be tackling with the redesign.