### PR TITLE
fix(EMI-2565): Bring back Bank Account last 4 in order details

### DIFF
--- a/src/Apps/Order2/Routes/Details/Components/Order2DetailsPaymentInfo.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/Order2DetailsPaymentInfo.tsx
@@ -75,7 +75,7 @@ const getPaymentMethodContent = (
     case "BankAccount":
       return {
         Icon: HomeIcon,
-        text: "Bank transfer",
+        text: `Bank transfer •••• ${paymentMethodDetails.last4}`,
       }
 
     case "WireTransfer":

--- a/src/Apps/Order2/Routes/Details/Components/__tests__/Order2DetailsPaymentInfo.jest.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/__tests__/Order2DetailsPaymentInfo.jest.tsx
@@ -56,11 +56,11 @@ describe("Order2DetailsPaymentInfo", () => {
     renderWithRelay({
       Order: () => ({
         creditCardWalletType: null,
-        paymentMethodDetails: { __typename: "BankAccount" },
+        paymentMethodDetails: { __typename: "BankAccount", last4: 2468 },
       }),
     })
 
-    expect(screen.getByText("Bank transfer")).toBeInTheDocument()
+    expect(screen.getByText("Bank transfer •••• 2468")).toBeInTheDocument()
   })
 
   it("renders wire transfer order payment details", () => {


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2565]

### Description

This PR brings back the Bank Account last 4 in the new Order Details page

### Screenshots
| | Before | After |
|---|---|---|
| ACH | ![image](https://github.com/user-attachments/assets/0c896b35-d890-41aa-8b07-3a5084e2d0c3) | ![image](https://github.com/user-attachments/assets/3ec4e8a1-5dc3-4d9e-9feb-c7880ada1cd3) |
| SEPA | ![image](https://github.com/user-attachments/assets/976d5b7f-db84-49f2-a713-fe18a24bde7d) | ![image](https://github.com/user-attachments/assets/f2603598-e06c-4302-b430-0bc81d89ed3e) |


<!-- Implementation description -->


[EMI-2565]: https://artsyproduct.atlassian.net/browse/EMI-2565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ