### PR TITLE
feat(EMI-2535): buyer can see unsaved card when editing payment

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentCompletedView.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentCompletedView.tsx
@@ -10,7 +10,7 @@ export const Order2PaymentCompletedView: React.FC<
   Order2PaymentCompletedViewProps
 > = ({ confirmationToken, onClickEdit }) => {
   return (
-    <Flex flexDirection="column" backgroundColor="mono0" p={2}>
+    <Flex flexDirection="column" backgroundColor="mono0">
       <Flex justifyContent="space-between">
         <Flex alignItems="center">
           <CheckmarkIcon fill="mono100" />

--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentStep.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentStep.tsx
@@ -37,26 +37,21 @@ export const Order2PaymentStep: React.FC<Order2PaymentStepProps> = ({
         </Flex>
       </Box>
 
-      {/* This is used instead of hidden just to force a clean payment element on edit */}
-      {stepState === CheckoutStepState.COMPLETED && (
-        <Box>
-          <Order2PaymentCompletedView
-            confirmationToken={confirmationToken}
-            onClickEdit={() => editPayment()}
-          />
-        </Box>
-      )}
+      <Box p={2} hidden={stepState !== CheckoutStepState.COMPLETED}>
+        <Order2PaymentCompletedView
+          confirmationToken={confirmationToken}
+          onClickEdit={() => editPayment()}
+        />
+      </Box>
 
-      {stepState === CheckoutStepState.ACTIVE && (
-        <Box p={2}>
-          <Flex flexDirection="column">
-            <Text variant="sm-display" fontWeight="bold" color="mono100">
-              Payment
-            </Text>
-            <Order2PaymentForm order={orderData} />
-          </Flex>
-        </Box>
-      )}
+      <Box p={2} hidden={stepState !== CheckoutStepState.ACTIVE}>
+        <Flex flexDirection="column">
+          <Text variant="sm-display" fontWeight="bold" color="mono100">
+            Payment
+          </Text>
+          <Order2PaymentForm order={orderData} />
+        </Flex>
+      </Box>
     </Flex>
   )
 }


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2535]

### Description

https://github.com/user-attachments/assets/05a861e8-b10c-42f8-a457-0f236b78ca51



@artsy/emerald-devs 

<!-- Implementation description -->


[EMI-2535]: https://artsyproduct.atlassian.net/browse/EMI-2535?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ