### PR TITLE
feat(home): swaps logged out hero unit; supports onclick

### DIFF
--- a/src/Apps/Home/Components/HomeHeroUnits/HomeHeroUnit.tsx
+++ b/src/Apps/Home/Components/HomeHeroUnits/HomeHeroUnit.tsx
@@ -32,10 +32,12 @@ export interface HomeHeroUnitBaseProps {
     desktop: {
       text: string
       url: string
+      onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void
     }
     mobile: {
       text: string
       url: string
+      onClick?: (event: React.MouseEvent<HTMLAnchorElement>) => void
     }
   }
   index: number
@@ -55,8 +57,9 @@ const HomeHeroUnitBaseSmall: React.FC<HomeHeroUnitBaseProps> = ({
 
   const { trackEvent } = useTracking()
 
-  const handleClick = () => {
+  const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
     onClick?.()
+    link.mobile.onClick?.(event)
 
     const payload: ClickedHeroUnitGroup = {
       action: ActionType.clickedHeroUnitGroup,
@@ -141,8 +144,9 @@ const HomeHeroUnitBaseLarge: React.FC<HomeHeroUnitBaseProps> = ({
 
   const { trackEvent } = useTracking()
 
-  const handleClick = () => {
+  const handleClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
     onClick?.()
+    link.desktop.onClick?.(event)
 
     const payload: ClickedHeroUnitGroup = {
       action: ActionType.clickedHeroUnitGroup,

--- a/src/Apps/Home/Components/HomeHeroUnits/HomeHeroUnitLoggedOut.tsx
+++ b/src/Apps/Home/Components/HomeHeroUnits/HomeHeroUnitLoggedOut.tsx
@@ -1,3 +1,5 @@
+import { ContextModule } from "@artsy/cohesion"
+import { useAuthDialog } from "Components/AuthDialog"
 import { useDeviceDetection } from "Utils/Hooks/useDeviceDetection"
 import type * as React from "react"
 import { HomeHeroUnitBase } from "./HomeHeroUnit"
@@ -6,16 +8,26 @@ export const HomeHeroUnitLoggedOut: React.FC<{ index: number }> = ({
   index,
 }) => {
   const { downloadAppUrl } = useDeviceDetection()
+  const { showAuthDialog } = useAuthDialog()
 
   return (
     <HomeHeroUnitBase
       title="Your guide to the art world"
       body="Artsy makes it easy to discover artists and artworks you'll love"
-      imageUrl="https://files.artsy.net/images/02_Artsy_App-Download-HP.jpg"
+      imageUrl="https://files.artsy.net/images/90s-mirror.jpg"
       link={{
         desktop: {
           text: "Sign up",
           url: "/signup",
+          onClick: e => {
+            e.preventDefault()
+
+            showAuthDialog({
+              analytics: {
+                contextModule: ContextModule.heroUnitsRail,
+              },
+            })
+          },
         },
         mobile: {
           text: "Get the App",
@@ -23,7 +35,7 @@ export const HomeHeroUnitLoggedOut: React.FC<{ index: number }> = ({
         },
       }}
       index={index}
-      credit="Sam Gilliam, Annie, 2021. David Kordansky Gallery"
+      credit="France-Lise McGurn, 90s mirror, 2023. Margot Samel"
     />
   )
 }


### PR DESCRIPTION
This swaps out the logged out hero unit image as well as switch from a full page load for login to the auth dialog.

![](https://capture.static.damonzucconi.com/Screen-Shot-2025-06-11-09-27-19.67-jZRrpZfeZz8wkNmEkYcdvyh89W9hzGZuRpD4gifWz1XCm1pEM1jcrjEIUtYvxGm38elhJ6hpoxwftUrsOsTHHmgsyU7zpGy61Muv.png)