### PR TITLE
fix(about): removes spaces and parens from filenames

### DIFF
--- a/src/Apps/About/AboutApp.tsx
+++ b/src/Apps/About/AboutApp.tsx
@@ -38,7 +38,7 @@ export const AboutApp: React.FC<React.PropsWithChildren<unknown>> = () => {
       />
 
       <FullBleedHeader
-        src="https://files.artsy.net/images/00_CVP_About_Hero%20(1).png"
+        src="https://files.artsy.net/images/00_CVP_About_Hero-1.png"
         caption="Detail of Cassi Namoda, A Strange Song, 2022. Detail of Alex Katz,
             Day Lily 1, 1969."
       >
@@ -394,7 +394,7 @@ const SECTION_DATA: SectionProps[] = [
       "Follow artists for updates on their latest works and career milestones.",
     caption: "Amy Beager, Pixie Dust, 2022.",
     href: "/artists",
-    imageUrl: "https://files.artsy.net/images/08_CVP_About_Follow (2).png",
+    imageUrl: "https://files.artsy.net/images/08_CVP_About_Follow-2.png",
   },
 ]
 


### PR DESCRIPTION
A while back, there was a bug with the hero unit on the About page where it wasn't working in some browsers. We were able to replicate it in Safari; unencoded spaces weren't getting encoded properly.

It turns out there was another instance of this further down the page that we missed. A user reported it happening in a recent version of Chrome. I haven't been able to replicate that specific report, but it seems reasonable to just remove any spaces and parentheses from the filenames anyway.

I'll also take a look at how we're encoding these URLs. As a general rule, it seems reasonable to just avoid spaces and parens in filenames.
