### PR TITLE
fix(EMI-2569): remove persistent sticky footer in Order App

### DIFF
--- a/src/Apps/Order/Components/OrderStepper.tsx
+++ b/src/Apps/Order/Components/OrderStepper.tsx
@@ -1,6 +1,5 @@
-import { Box, Clickable, Step, Stepper } from "@artsy/palette"
+import { Clickable, Step, Stepper } from "@artsy/palette"
 import { useRouter } from "System/Hooks/useRouter"
-import { Media } from "Utils/Responsive"
 import { extractNodes } from "Utils/extractNodes"
 import type { OrderStepper_order$data } from "__generated__/OrderStepper_order.graphql"
 import { type FC, useMemo } from "react"
@@ -124,26 +123,12 @@ export const OrderStepper: FC<React.PropsWithChildren<OrderStepperProps>> = ({
   }
 
   return (
-    <>
-      <Media between={["xs", "md"]}>
-        <Box>
-          <StepperComponent
-            steps={steps}
-            currentStep={currentStep}
-            completedOrderSteps={completedOrderSteps}
-            onStepClick={handleStepClick}
-          />
-        </Box>
-      </Media>
-      <Media greaterThan="sm">
-        <StepperComponent
-          steps={steps}
-          currentStep={currentStep}
-          completedOrderSteps={completedOrderSteps}
-          onStepClick={handleStepClick}
-        />
-      </Media>
-    </>
+    <StepperComponent
+      steps={steps}
+      currentStep={currentStep}
+      completedOrderSteps={completedOrderSteps}
+      onStepClick={handleStepClick}
+    />
   )
 }
 


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2569]

### Description
This PR fixes the persistence of the sticky footer of the Order app by removing the `Media` component from the Order Stepper


### Demo

| Before | After |
|---|---|
| <video src="https://github.com/user-attachments/assets/ae0cf8f5-c5f5-4840-9b21-fcff873b1ddb" /> | <video src="https://github.com/user-attachments/assets/2d93a9f4-e387-485b-8355-312f9441869f" /> |
