### PR TITLE
chore(dia-1376): update logged out hero footer app download assets copy

### DIFF
--- a/src/Apps/Home/Components/HomeHeroUnits/HomeHeroUnitLoggedOut.tsx
+++ b/src/Apps/Home/Components/HomeHeroUnits/HomeHeroUnitLoggedOut.tsx
@@ -12,12 +12,12 @@ export const HomeHeroUnitLoggedOut: React.FC<{ index: number }> = ({
 
   return (
     <HomeHeroUnitBase
-      title="Your guide to the art world"
-      body="Artsy makes it easy to discover artists and artworks you'll love"
+      title="Discover and Buy Art that Moves You."
+      body="Artsy makes it easy to discover artists and artworks you’ll love."
       imageUrl="https://files.artsy.net/images/new-works-for-you-hero.jpg"
       link={{
         desktop: {
-          text: "Sign up",
+          text: "Sign Up",
           url: "/signup",
           onClick: e => {
             e.preventDefault()

--- a/src/Components/Footer/FooterDownloadAppBanner.tsx
+++ b/src/Components/Footer/FooterDownloadAppBanner.tsx
@@ -7,9 +7,11 @@ import {
   Spacer,
   Text,
 } from "@artsy/palette"
+import { useAuthDialog } from "Components/AuthDialog"
 import { DownloadAppBadge } from "Components/DownloadAppBadges/DownloadAppBadge"
 import { RouterLink } from "System/Components/RouterLink"
 import { useRouter } from "System/Hooks/useRouter"
+import { useSystemContext } from "System/Hooks/useSystemContext"
 import {
   DOWNLOAD_APP_URLS,
   Device,
@@ -27,6 +29,8 @@ export const FooterDownloadAppBanner = () => {
   const { match } = useRouter()
 
   const { device, downloadAppUrl } = useDeviceDetection()
+  const { showAuthDialog } = useAuthDialog()
+  const { isLoggedIn } = useSystemContext()
 
   if (
     IGNORE_PATHS.includes(match.location.pathname) ||
@@ -51,8 +55,8 @@ export const FooterDownloadAppBanner = () => {
           px={[2, 4]}
           py={[6, 2]}
         >
-          <Text variant="xl" textAlign="center">
-            Meet your new art advisor.
+          <Text variant="xl" textAlign="center" style={{ textWrap: "balance" }}>
+            Discover and Buy Art that Moves You
           </Text>
 
           <Media at="xs">
@@ -76,15 +80,31 @@ export const FooterDownloadAppBanner = () => {
           <Media greaterThan="xs">
             <Spacer y={2} />
 
-            <Button
-              variant="secondaryBlack"
-              // @ts-ignore
-              as={RouterLink}
-              to="/meet-your-new-art-advisor"
-              minWidth={[0, 0, 200, 250]}
-            >
-              Discover Artsy
-            </Button>
+            {isLoggedIn ? (
+              <Button
+                variant="secondaryBlack"
+                minWidth={[0, 0, 200, 250]}
+                // @ts-ignore
+                as={RouterLink}
+                to="/meet-your-new-art-advisor"
+              >
+                Get the app
+              </Button>
+            ) : (
+              <Button
+                variant="secondaryBlack"
+                minWidth={[0, 0, 200, 250]}
+                onClick={() => {
+                  showAuthDialog({
+                    analytics: {
+                      contextModule: ContextModule.footer,
+                    },
+                  })
+                }}
+              >
+                Sign Up
+              </Button>
+            )}
           </Media>
         </Column>
 

--- a/src/Components/Footer/__tests__/Footer.jest.enzyme.tsx
+++ b/src/Components/Footer/__tests__/Footer.jest.enzyme.tsx
@@ -78,7 +78,7 @@ describe("Footer", () => {
 
     it("renders the app download banner", () => {
       const wrapper = getWrapper("lg")
-      expect(wrapper.text()).toContain("Meet your new art advisor.")
+      expect(wrapper.text()).toContain("Discover and Buy Art that Moves You")
     })
 
     it("hides the app download banner if we are on an ignored route", () => {
@@ -87,7 +87,9 @@ describe("Footer", () => {
       }))
 
       const wrapper = getWrapper("lg")
-      expect(wrapper.text()).not.toContain("Meet your new art advisor.")
+      expect(wrapper.text()).not.toContain(
+        "Discover and Buy Art that Moves You",
+      )
     })
 
     it("hides the app download banner if the artwork is unlisted", async () => {


### PR DESCRIPTION
Minor asset update with some copy updates. Copy necessitates having a logged/in out state in the footer now.

cc @artsy/diamond-devs 