### PR TITLE
chore: qa pass for details page

### DIFF
--- a/src/Apps/Order2/Routes/Details/Components/Order2DetailsFulfillmentInfo.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/Order2DetailsFulfillmentInfo.tsx
@@ -16,9 +16,22 @@ export const Order2DetailsFulfillmentInfo: React.FC<
   const { fulfillmentDetails, selectedFulfillmentOption, shippingOrigin } =
     orderData
 
-  if (!selectedFulfillmentOption) return null
-
+  const isBlankFulfillmentDetails =
+    !fulfillmentDetails ||
+    Object.values(fulfillmentDetails).every(
+      part =>
+        !part ||
+        part === undefined ||
+        (typeof part === "string" && part.trim() === ""),
+    )
   const isPickup = selectedFulfillmentOption?.type === "PICKUP"
+
+  if (
+    (isPickup && !shippingOrigin) ||
+    (!isPickup && isBlankFulfillmentDetails)
+  ) {
+    return null
+  }
 
   return (
     <Box p={[2, 4]} backgroundColor="mono0">
@@ -49,32 +62,32 @@ const getShippingContent = (fulfillmentDetails): React.ReactNode => {
   return (
     <>
       {name && (
-        <Text variant="xs" color="mono100">
+        <Text variant={["xs", "sm"]} color="mono100">
           {name}
         </Text>
       )}
       {addressLine1 && (
-        <Text variant="xs" color="mono100">
+        <Text variant={["xs", "sm"]} color="mono100">
           {addressLine1}
         </Text>
       )}
       {addressLine2 && (
-        <Text variant="xs" color="mono100">
+        <Text variant={["xs", "sm"]} color="mono100">
           {addressLine2}
         </Text>
       )}
       {(city || region || postalCode) && (
-        <Text variant="xs" color="mono100">
+        <Text variant={["xs", "sm"]} color="mono100">
           {[city, region, postalCode].filter(Boolean).join(", ")}
         </Text>
       )}
       {country && (
-        <Text variant="xs" color="mono100">
+        <Text variant={["xs", "sm"]} color="mono100">
           {country}
         </Text>
       )}
       {phoneNumber && (
-        <Text variant="xs" color="mono100">
+        <Text variant={["xs", "sm"]} color="mono100">
           {phoneNumber.display}
         </Text>
       )}

--- a/src/Apps/Order2/Routes/Details/Components/Order2DetailsHeader.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/Order2DetailsHeader.tsx
@@ -10,7 +10,7 @@ export const Order2DetailsHeader = ({ order }: Order2DetailsHeaderProps) => {
   const orderData = useFragment(FRAGMENT, order)
 
   return (
-    <Box backgroundColor="mono0" p={[2, 4]}>
+    <Box backgroundColor="mono0" px={[2, 4]} pt={[2, 4]} pb={2}>
       {/* Title */}
       <Text variant={["lg", "xl"]}>{orderData.displayTexts.title}</Text>
       {/* Order # */}

--- a/src/Apps/Order2/Routes/Details/Components/Order2DetailsMessage.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/Order2DetailsMessage.tsx
@@ -12,7 +12,7 @@ export const Order2DetailsMessage = ({ order }: Order2DetailsMessageProps) => {
   const orderData = useFragment(FRAGMENT, order)
 
   return (
-    <Box backgroundColor="mono0" p={[2, 4]}>
+    <Box backgroundColor="mono0" px={[2, 4]} pb={[2, 4]} pt={2}>
       {getMessageContent(orderData)}
     </Box>
   )

--- a/src/Apps/Order2/Routes/Details/Components/WireTransferInfo.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/WireTransferInfo.tsx
@@ -87,16 +87,20 @@ export const WireTransferInfo: React.FC<WireTransferInfoProps> = ({
         Send wire transfer to
       </Text>
       <Stack gap={0} mt={1} mb={4}>
-        {details.transferInfo.map(rowText => (
-          <Text variant="sm">{rowText}</Text>
+        {details.transferInfo.map((rowText, index) => (
+          <Text variant="sm" key={index}>
+            {rowText}
+          </Text>
         ))}
       </Stack>
       <Text variant="sm" fontWeight="bold">
         Bank address
       </Text>
       <Stack gap={0} mt={1} mb={4}>
-        {details.bankAddress.map(rowText => (
-          <Text variant="sm">{rowText}</Text>
+        {details.bankAddress.map((rowText, index) => (
+          <Text variant="sm" key={index}>
+            {rowText}
+          </Text>
         ))}
       </Stack>
       <Text variant="sm" fontWeight="bold">

--- a/src/Apps/Order2/Routes/Details/Components/__tests__/Order2DetailsFulfillmentInfo.jest.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/__tests__/Order2DetailsFulfillmentInfo.jest.tsx
@@ -24,7 +24,7 @@ describe("Order2DetailsFulfillmentInfo", () => {
       `,
     })
 
-  it("renders shipping information correctly", () => {
+  it("renders shipping information correctly for shipped order", () => {
     renderWithRelay({
       Order: () => ({
         selectedFulfillmentOption: { type: "DOMESTIC_FLAT" },
@@ -60,15 +60,50 @@ describe("Order2DetailsFulfillmentInfo", () => {
     expect(screen.getByText("New York, NY, 10011")).toBeInTheDocument()
   })
 
-  it("handles missing fulfillment details gracefully", () => {
+  it("renders when only partial fulfillmentDetails is present but fulfillment is unknown", () => {
     renderWithRelay({
       Order: () => ({
-        selectedFulfillmentOption: { type: "SHIPPING_TBD" },
-        fulfillmentDetails: {},
+        selectedFulfillmentOption: null,
+        fulfillmentDetails: {
+          name: "Andy Warhol",
+          addressLine1: "222 West 23rd Street",
+        },
       }),
     })
 
     expect(screen.getByText("Ship to")).toBeInTheDocument()
-    // Should not throw any errors with empty fulfillment details
+    expect(screen.getByText("Andy Warhol")).toBeInTheDocument()
+    expect(screen.getByText("222 West 23rd Street")).toBeInTheDocument()
+  })
+
+  it("returns null for non pickup orders if fulfillmentDetails are empty", () => {
+    const { container } = renderWithRelay({
+      Order: () => ({
+        selectedFulfillmentOption: { type: "DOMESTIC_FLAT" },
+        fulfillmentDetails: {
+          name: "",
+          addressLine1: "",
+          addressLine2: "",
+          city: "",
+          region: "",
+          postalCode: "",
+          country: "",
+          phoneNumber: null,
+        },
+      }),
+    })
+
+    expect(container).toBeEmptyDOMElement()
+  })
+
+  it("returns null for pickup orders if shippingOrigin is not present", () => {
+    const { container } = renderWithRelay({
+      Order: () => ({
+        selectedFulfillmentOption: { type: "PICKUP" },
+        shippingOrigin: null,
+      }),
+    })
+
+    expect(container).toBeEmptyDOMElement()
   })
 })


### PR DESCRIPTION
Quick pass here on things from Details qa that were easy to just Do. 

- more nuanced logic for fulfillmentDetails part (should solve shipping was not showing)
- text size adjustments
- fix big space between header and message