### PR TITLE
feat(EMI-2592): handle order submission errors

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Order2CheckoutApp.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Order2CheckoutApp.tsx
@@ -8,6 +8,7 @@ import {
   Stack,
 } from "@artsy/palette"
 import { SubmittingOrderSpinner } from "Apps/Order/Components/SubmittingOrderSpinner"
+import { ConnectedModalDialog } from "Apps/Order/Dialogs"
 import {
   CheckoutStepName,
   CheckoutStepState,
@@ -27,6 +28,8 @@ import type { Order2CheckoutApp_viewer$key } from "__generated__/Order2CheckoutA
 import { useEffect } from "react"
 import { Meta, Title } from "react-head"
 import { graphql, useFragment } from "react-relay"
+// eslint-disable-next-line no-restricted-imports
+import { Provider } from "unstated"
 interface Order2CheckoutAppProps {
   viewer: Order2CheckoutApp_viewer$key
 }
@@ -86,7 +89,7 @@ export const Order2CheckoutApp: React.FC<Order2CheckoutAppProps> = ({
   }, [activeStep?.name, checkoutTracking])
 
   return (
-    <>
+    <Provider>
       <Title>Checkout | Artsy</Title>
       <Meta
         name="viewport"
@@ -146,7 +149,8 @@ export const Order2CheckoutApp: React.FC<Order2CheckoutAppProps> = ({
           </Box>
         </Column>
       </GridColumns>
-    </>
+      <ConnectedModalDialog />
+    </Provider>
   )
 }
 


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2592]

### Description
This is working nicely, but I am not sure if re-using the order modal is the direction we wanna go, so I would appreciate any input from more experienced React people.

Once we have a decision, I can write the specs.

https://github.com/user-attachments/assets/e943260c-5a35-4836-984a-3a7f2ad37e37



@artsy/emerald-devs 

<!-- Implementation description -->


[EMI-2592]: https://artsyproduct.atlassian.net/browse/EMI-2592?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ