### PR TITLE
feat(dia-1367): build the scaffolding for the new about page

### DIFF
--- a/src/Apps/About2/About2App.tsx
+++ b/src/Apps/About2/About2App.tsx
@@ -1,0 +1,17 @@
+import { MetaTags } from "Components/MetaTags"
+
+export const DESCRIPTION =
+  "Artsy’s mission is to expand the art market to support more artists and art in the world."
+
+export const About2App: React.FC<React.PropsWithChildren<unknown>> = () => {
+  return (
+    <>
+      <MetaTags
+        title="About | Artsy"
+        description={DESCRIPTION}
+        imageURL="https://files.artsy.net/images/00_CVP_About_Hero_og.png"
+        pathname="/about"
+      />
+    </>
+  )
+}

--- a/src/Apps/About2/About2App.tsx
+++ b/src/Apps/About2/About2App.tsx
@@ -1,3 +1,8 @@
+import { Spacer } from "@artsy/palette"
+import { About2Header } from "Apps/About2/Components/About2Header"
+import { About2Hero } from "Apps/About2/Components/About2Hero"
+import { About2Nav } from "Apps/About2/Components/About2Nav"
+import { About2Stats } from "Apps/About2/Components/About2Stats"
 import { MetaTags } from "Components/MetaTags"
 
 export const DESCRIPTION =
@@ -12,6 +17,20 @@ export const About2App: React.FC<React.PropsWithChildren<unknown>> = () => {
         imageURL="https://files.artsy.net/images/00_CVP_About_Hero_og.png"
         pathname="/about"
       />
+
+      <About2Nav />
+
+      <Spacer y={4} />
+
+      <About2Header />
+
+      <Spacer y={4} />
+
+      <About2Hero />
+
+      <Spacer y={[4, 6]} />
+
+      <About2Stats />
     </>
   )
 }

--- a/src/Apps/About2/Components/About2Header.tsx
+++ b/src/Apps/About2/Components/About2Header.tsx
@@ -1,0 +1,24 @@
+import { Column, GridColumns, Text } from "@artsy/palette"
+
+export const About2Header = () => {
+  return (
+    <GridColumns>
+      <Column
+        span={[12, 8]}
+        start={[1, 3]}
+        textAlign="center"
+        display="flex"
+        gap={1}
+        flexDirection="column"
+      >
+        <Text variant="lg-display" as="h2">
+          About Artsy
+        </Text>
+
+        <Text variant={["xl", "xxl"]} as="h1">
+          Artsy is the leading global online art marketplace
+        </Text>
+      </Column>
+    </GridColumns>
+  )
+}

--- a/src/Apps/About2/Components/About2Hero.tsx
+++ b/src/Apps/About2/Components/About2Hero.tsx
@@ -1,0 +1,34 @@
+import { Column, GridColumns, ResponsiveBox } from "@artsy/palette"
+
+export const About2Hero = () => {
+  return (
+    <GridColumns gridColumnGap={0}>
+      <Column span={[6, 4]}>
+        <ResponsiveBox
+          bg="mono10"
+          aspectWidth={4}
+          aspectHeight={5}
+          maxWidth="100%"
+        />
+      </Column>
+
+      <Column span={[6, 4]} pt={[40, 100]}>
+        <ResponsiveBox
+          bg="mono15"
+          aspectWidth={4}
+          aspectHeight={5}
+          maxWidth="100%"
+        />
+      </Column>
+
+      <Column span={[6, 4]} display={["none", "block"]}>
+        <ResponsiveBox
+          bg="mono10"
+          aspectWidth={4}
+          aspectHeight={5}
+          maxWidth="100%"
+        />
+      </Column>
+    </GridColumns>
+  )
+}

--- a/src/Apps/About2/Components/About2Nav.tsx
+++ b/src/Apps/About2/Components/About2Nav.tsx
@@ -1,0 +1,32 @@
+import { Pill, Stack, useTheme } from "@artsy/palette"
+import { Z } from "Apps/Components/constants"
+
+export const About2Nav = () => {
+  const { theme } = useTheme()
+
+  return (
+    <Stack
+      gap={1}
+      p={1}
+      borderRadius={999}
+      flexDirection="row"
+      bg="mono0"
+      width="fit-content"
+      position="fixed"
+      bottom={2}
+      left="50%"
+      zIndex={Z.globalNav}
+      style={{
+        transform: "translateX(-50%)",
+        boxShadow: theme.effects.dropShadow,
+      }}
+    >
+      <Pill>Mission and vision</Pill>
+      <Pill>Our story</Pill>
+      <Pill>What we do</Pill>
+      <Pill>Our team</Pill>
+      <Pill>Press</Pill>
+      <Pill>Contact</Pill>
+    </Stack>
+  )
+}

--- a/src/Apps/About2/Components/About2Stats.tsx
+++ b/src/Apps/About2/Components/About2Stats.tsx
@@ -1,0 +1,34 @@
+import { Column, GridColumns, Text } from "@artsy/palette"
+
+export const About2Stats = () => {
+  return (
+    <GridColumns textAlign={["left", "center"]}>
+      <Column
+        span={[12, 3]}
+        start={[1, 2]}
+        display="flex"
+        flexDirection="column"
+        gap={2}
+      >
+        <Text variant={["xxl", "xxxl"]}>94K</Text>
+        <Text variant="sm-display" color="mono60">
+          Artists on Artsy
+        </Text>
+      </Column>
+
+      <Column span={[12, 4]} display="flex" flexDirection="column" gap={2}>
+        <Text variant={["xxl", "xxxl"]}>1M+</Text>
+        <Text variant="sm-display" color="mono60">
+          Artworks available
+        </Text>
+      </Column>
+
+      <Column span={[12, 3]} display="flex" flexDirection="column" gap={2}>
+        <Text variant={["xxl", "xxxl"]}>3K</Text>
+        <Text variant="sm-display" color="mono60">
+          Partner galleries and auction houses
+        </Text>
+      </Column>
+    </GridColumns>
+  )
+}

--- a/src/Apps/About2/Components/About2StructuredData.tsx
+++ b/src/Apps/About2/Components/About2StructuredData.tsx
@@ -1,0 +1,171 @@
+import { DESCRIPTION } from "Apps/About2/About2App"
+import { StructuredData } from "Components/Seo/StructuredData"
+import { DOWNLOAD_APP_URLS, Device } from "Utils/Hooks/useDeviceDetection"
+import { FACTS_AND_FIGURES } from "Utils/factsAndFigures"
+
+export const About2StructuredData = () => {
+  return (
+    <>
+      <StructuredData
+        schemaData={{
+          "@context": "https://schema.org",
+          "@type": "WebApplication",
+          name: "Artsy",
+          url: "https://www.artsy.net",
+          applicationCategory: ["LifestyleApplication", "ShoppingApplication"],
+          operatingSystem: "Web",
+          browserRequirements: "Requires JavaScript",
+          description: DESCRIPTION,
+          downloadUrl: [
+            DOWNLOAD_APP_URLS[Device.iPhone],
+            DOWNLOAD_APP_URLS[Device.Android],
+          ],
+          offers: {
+            "@type": "Offer",
+            price: "0",
+            priceCurrency: "USD",
+            category: "free",
+          },
+          inLanguage: "en",
+          author: {
+            "@type": "Organization",
+            name: "Artsy",
+            url: "https://www.artsy.net",
+          },
+          hasPart: [
+            {
+              "@type": "MobileApplication",
+              name: "Artsy",
+              operatingSystem: "iOS 16.6 or later",
+              applicationCategory: [
+                "LifestyleApplication",
+                "ShoppingApplication",
+              ],
+              downloadUrl: DOWNLOAD_APP_URLS[Device.iPhone],
+              installUrl: DOWNLOAD_APP_URLS[Device.iPhone],
+              contentRating: "17+",
+              offers: {
+                "@type": "Offer",
+                price: "0",
+                priceCurrency: "USD",
+                category: "free",
+              },
+              aggregateRating: {
+                "@type": "AggregateRating",
+                ...FACTS_AND_FIGURES.iosApp,
+              },
+            },
+            {
+              "@type": "MobileApplication",
+              name: "Artsy",
+              operatingSystem: "Android 7 or later",
+              applicationCategory: [
+                "LifestyleApplication",
+                "ShoppingApplication",
+              ],
+              downloadUrl: DOWNLOAD_APP_URLS[Device.Android],
+              installUrl: DOWNLOAD_APP_URLS[Device.Android],
+              contentRating: "Teen",
+              offers: {
+                "@type": "Offer",
+                price: "0",
+                priceCurrency: "USD",
+                category: "free",
+              },
+              aggregateRating: {
+                "@type": "AggregateRating",
+                ...FACTS_AND_FIGURES.androidApp,
+              },
+            },
+          ],
+        }}
+      />
+
+      <StructuredData
+        schemaData={{
+          "@context": "https://schema.org",
+          "@type": "Organization",
+          name: "Artsy",
+          alternateName: "Artsy.net",
+          url: "https://www.artsy.net",
+          description: DESCRIPTION,
+          logo: "https://files.artsy.net/images/og_image.jpeg",
+          foundingDate: "2009",
+          foundingLocation: {
+            "@type": "Place",
+            address: {
+              "@type": "PostalAddress",
+              addressLocality: "New York",
+              addressRegion: "NY",
+              addressCountry: "US",
+            },
+          },
+          founders: [
+            {
+              "@type": "Person",
+              name: "Carter Cleveland",
+              jobTitle: "Founder",
+              sameAs: "https://www.linkedin.com/in/cartercleveland",
+            },
+          ],
+          employees: [
+            {
+              "@type": "Person",
+              name: "Jeffrey Yin",
+              jobTitle: "Chief Executive Officer",
+              sameAs: "https://www.linkedin.com/in/jeffreyjyin/",
+            },
+          ],
+          address: {
+            "@type": "PostalAddress",
+            streetAddress: "401 Broadway",
+            addressLocality: "New York",
+            addressRegion: "NY",
+            postalCode: "10013",
+            addressCountry: "US",
+          },
+          contactPoint: [
+            {
+              "@type": "ContactPoint",
+              email: "support@artsy.net",
+              contactType: "customer support",
+            },
+          ],
+          brand: {
+            "@type": "Brand",
+            name: "Artsy",
+            logo: "https://files.artsy.net/images/og_image.jpeg",
+            slogan: "Discover and Buy Fine Art",
+          },
+          sameAs: [
+            "https://www.instagram.com/artsy",
+            "https://x.com/artsy",
+            "https://www.linkedin.com/company/artsyinc/",
+            "https://www.facebook.com/artsy",
+            "https://www.youtube.com/artsy",
+            "https://www.threads.com/@artsy",
+            "https://www.tiktok.com/@artsy",
+            "https://www.pinterest.com/artsy/",
+            "https://soundcloud.com/artsypodcast",
+            "https://podcasts.apple.com/us/podcast/the-artsy-podcast/id1096194516",
+            "https://open.spotify.com/show/3Wc2AVcebdEf0yC7NoFQgt",
+            DOWNLOAD_APP_URLS[Device.iPhone],
+            DOWNLOAD_APP_URLS[Device.Android],
+            "https://en.wikipedia.org/wiki/Artsy_(website)",
+            "https://github.com/artsy",
+            "https://artsy.github.io/",
+          ],
+          keywords:
+            "online art, art marketplace, buy art, art auctions, contemporary art, art galleries, emerging artists",
+          knowsAbout: [
+            "Contemporary Art",
+            "Fine Art Auctions",
+            "Art Galleries",
+            "Emerging Artists",
+            "Art Market Trends",
+          ],
+        }}
+      />
+    </>
+  )
+}

--- a/src/Apps/About2/about2Routes.tsx
+++ b/src/Apps/About2/about2Routes.tsx
@@ -1,0 +1,16 @@
+import loadable from "@loadable/component"
+import type { RouteProps } from "System/Router/Route"
+
+const About2App = loadable(
+  () => import(/* webpackChunkName: "aboutBundle" */ "./About2App"),
+  {
+    resolveComponent: component => component.About2App,
+  },
+)
+
+export const about2Routes: RouteProps[] = [
+  {
+    path: "/about2",
+    getComponent: () => About2App,
+  },
+]

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,4 +1,5 @@
 import { aboutRoutes } from "Apps/About/aboutRoutes"
+import { about2Routes } from "Apps/About2/about2Routes"
 import { adminRoutes } from "Apps/Admin/adminRoutes"
 import { alertRoutes } from "Apps/Alert/alertRoutes"
 import { artAppraisalsRoutes } from "Apps/ArtAppraisals/artAppraisalsRoutes"
@@ -65,6 +66,7 @@ import { worksForYouRoutes } from "./Apps/WorksForYou/worksForYouRoutes"
 
 const ROUTES = buildAppRoutes([
   aboutRoutes,
+  about2Routes,
   adminRoutes,
   artAppraisalsRoutes,
   articleRoutes,


### PR DESCRIPTION
![Screen-Shot-2025-06-18-09-03-42 85-71pSPzjMinTWKZ1NxeeoL06HIa1nVd6oe6FcuPdAejV65vhPHcVqub5kzSx8636L1QFcZGH1kiHKHbqfAhd4poX9Zh3q0xfyBnm1](https://github.com/user-attachments/assets/9c535254-1330-49d5-8763-8fe15abc4190)

Going to split off 2 more tickets here:
1. Will handle the scrollspy nav as it's own thing
2. We'll replace image placeholders once everything is final. Prepping assets is a bit arduous so it doesn't make sense to do yet. (cc @JanaeHijaz)

cc @artsy/diamond-devs 