### PR TITLE
chore: update text for the offer details to note that gallery will reply to offer as opposed to confirm order.

### DIFF
--- a/src/Apps/Order2/Routes/Details/Components/Order2DetailsMessage.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/Order2DetailsMessage.tsx
@@ -88,11 +88,12 @@ const getMessageContent = (order): React.ReactNode => {
           </Text>
           <Spacer y={2} />
           <Text variant="sm">
-            The gallery will confirm by <b>{formattedStateExpireTime}</b>.
+            The gallery will respond to your offer by{" "}
+            <b>{formattedStateExpireTime}</b>.
           </Text>
           <Spacer y={2} />
           <Text variant="sm">
-            You can contact the gallery with any questions about your order.
+            You can contact the gallery with any questions about your offer.
           </Text>
         </>
       )


### PR DESCRIPTION
@erikdstock - that was totally legit catch on this one: https://www.notion.so/artsy/Maybe-for-an-offer-order-the-copy-should-say-the-gallery-will-respond-rather-than-confirm-215cab0764a0806da1e3f2f54dd794eb?source=copy_link

Sorry blanked on it initially and updated only part of the message. Here is the second part. 
