### PR TITLE
fix: order 2 summary display

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/Order2CheckoutLoadingSkeleton.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2CheckoutLoadingSkeleton.tsx
@@ -88,7 +88,11 @@ const Order2CollapsibleOrderSummarySkeleton: React.FC<
         </Box>
       </Column>
 
-      <Column span={[12, 12, 4, 3]} start={[1, 1, 8, 8]}>
+      <Column
+        span={[12, 12, 4, 3]}
+        start={[1, 1, 8, 8]}
+        display={["none", "none", "block"]}
+      >
         {/* Order summary skeleton for desktop */}
         <Box backgroundColor="mono0" p={2}>
           <SkeletonText variant="lg-display" mb={2}>

--- a/src/Apps/Order2/Routes/Checkout/Order2CheckoutApp.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Order2CheckoutApp.tsx
@@ -129,7 +129,11 @@ export const Order2CheckoutApp: React.FC<Order2CheckoutAppProps> = ({
           </Box>
         </Column>
 
-        <Column span={[12, 12, 4, 3]} start={[1, 1, 8, 8]}>
+        <Column
+          span={[12, 12, 4, 3]}
+          start={[1, 1, 8, 8]}
+          display={["none", "none", "block"]}
+        >
           <Box position={["initial", "initial", "fixed"]}>
             <Order2ReviewStep order={order} />
             <Separator as="hr" />

--- a/src/Apps/Order2/Routes/Details/Components/Order2DetailsPage.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/Order2DetailsPage.tsx
@@ -46,7 +46,11 @@ export const Order2DetailsPage = ({ order }: Order2DetailsPageProps) => {
           <Spacer y={[4, 0]} />
         </Box>
       </Column>
-      <Column span={[12, 12, 4, 3]} start={[1, 1, 8, 8]}>
+      <Column
+        span={[12, 12, 4, 3]}
+        start={[1, 1, 8, 8]}
+        display={["none", "none", "block"]}
+      >
         <Order2DetailsOrderSummary order={orderData} />
         <Spacer y={1} />
         <Order2HelpLinksWithInquiry


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->


### Description
I mistakenly removed the display conditions for the order 2 summaries in https://github.com/artsy/force/pull/15731. Re-added here. 


<!-- Implementation description -->
