### PR TITLE
chore: add data-test attribute to order# on new details page as it is used for integrity specs

### DIFF
--- a/src/Apps/Order2/Routes/Details/Components/Order2DetailsHeader.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/Order2DetailsHeader.tsx
@@ -14,7 +14,10 @@ export const Order2DetailsHeader = ({ order }: Order2DetailsHeaderProps) => {
       {/* Title */}
       <Text variant={["lg", "xl"]}>{orderData.displayTexts.title}</Text>
       {/* Order # */}
-      <Text variant={["xs", "sm"]}>Order #{orderData.code} </Text>
+      {/* data-test attribute below used for integrity now. # */}
+      <Text variant={["xs", "sm"]} data-test="OrderCode">
+        Order #{orderData.code}{" "}
+      </Text>
     </Box>
   )
 }


### PR DESCRIPTION
We can probably figure out how to modify it's usage in Integrity - but seems like an ok edition for now.