### PR TITLE
feat: enable apple pay on web for standard checkout

### DIFF
--- a/src/Apps/Order/Components/ExpressCheckout/index.tsx
+++ b/src/Apps/Order/Components/ExpressCheckout/index.tsx
@@ -12,7 +12,7 @@ import type {
   ExpressCheckout_order$data,
   ExpressCheckout_order$key,
 } from "__generated__/ExpressCheckout_order.graphql"
-import { type Dispatch, type SetStateAction, useEffect, useState } from "react"
+import type { Dispatch, SetStateAction } from "react"
 import { graphql, useFragment } from "react-relay"
 
 const stripePromise = loadStripe(getENV("STRIPE_PUBLISHABLE_KEY"))
@@ -29,15 +29,6 @@ type Seller = Exclude<
 
 export const ExpressCheckout = ({ order, setShowSpinner }: Props) => {
   const orderData = useFragment(ORDER_FRAGMENT, order)
-  const [isChrome, setIsChrome] = useState<boolean | null>(null)
-
-  useEffect(() => {
-    const chrome =
-      typeof navigator !== "undefined" && /Chrome/.test(navigator.userAgent)
-    setIsChrome(chrome)
-  }, [])
-
-  if (isChrome === null) return null
 
   const { itemsTotal, seller } = orderData
 
@@ -75,11 +66,7 @@ export const ExpressCheckout = ({ order, setShowSpinner }: Props) => {
   return (
     <>
       <Elements stripe={stripePromise} options={options}>
-        <ExpressCheckoutUI
-          order={orderData}
-          setShowSpinner={setShowSpinner}
-          isChrome={isChrome}
-        />
+        <ExpressCheckoutUI order={orderData} setShowSpinner={setShowSpinner} />
       </Elements>
     </>
   )


### PR DESCRIPTION
The type of this PR is: **Feature/Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

This stops the order from resetting if the express checkout order is being submitted and a Stripe bug calls `onCancel`, allowing us to re-enable Apple Pay on Chrome web for the standard checkout flow. 

<!-- Implementation description -->
