### PR TITLE
fix: dynamic breadcrumb for upcoming shows

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkTopContextBar/ArtworkTopContextBarShow.tsx
+++ b/src/Apps/Artwork/Components/ArtworkTopContextBar/ArtworkTopContextBarShow.tsx
@@ -36,9 +36,15 @@ export const ArtworkTopContextBarShow: React.FC<
     { fetchPolicy: "store-or-network" },
   )
 
-  if (!data.show) return null
-
   const { show } = data
+
+  if (!show?.status) return null
+
+  const statusMessage = {
+    running: "Current show",
+    closed: "Past show",
+    upcoming: "Upcoming show",
+  }[show.status]
 
   return (
     <TopContextBar
@@ -50,7 +56,7 @@ export const ArtworkTopContextBarShow: React.FC<
       <Stack gap={1} flexDirection="row">
         {show.name}
         <Box as="span" color="mono60">
-          {show.status === "running" ? "Current show" : "Past show"}
+          {statusMessage}
           {show.partner?.name ? ` at ${show.partner.name}` : null}
         </Box>
       </Stack>

--- a/src/Apps/Artwork/Components/ArtworkTopContextBar/__tests__/ArtworkTopContextBarShow.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkTopContextBar/__tests__/ArtworkTopContextBarShow.jest.tsx
@@ -120,6 +120,27 @@ describe("ArtworkTopContextBarShow", () => {
     ).toBeInTheDocument()
   })
 
+  it("renders upcoming show information correctly", () => {
+    renderWithRelay({
+      Show: () => ({
+        name: "Impressionist & Modern Art",
+        href: "/show/impressionist-modern-art",
+        status: "upcoming",
+        thumbnail: {
+          url: "https://example.com/show-image.jpg",
+        },
+        partner: {
+          name: "Gagosian Gallery",
+        },
+      }),
+    })
+
+    expect(screen.getByText("Impressionist & Modern Art")).toBeInTheDocument()
+    expect(
+      screen.getByText("Upcoming show at Gagosian Gallery"),
+    ).toBeInTheDocument()
+  })
+
   it("handles missing partner name", () => {
     renderWithRelay({
       Show: () => ({


### PR DESCRIPTION
The type of this PR is: **Fix**

[Reported here](https://artsy.slack.com/archives/C07PRTJSD6G/p1750848836071779) on Slack

### Description

Small fix to account for the [all possible values](https://github.com/artsy/gravity/blob/cb9e09fb769b4af045b3b1421a64786ffce131a2/app/models/domain/partner_show.rb#L449-L458) of `show.status`

Here is a show which currently has a status of `upcoming`:

| Before | After |
|--------|--------|
| <img width="1474" alt="Screenshot 2025-06-25 at 3 43 23 PM" src="https://github.com/user-attachments/assets/ddd78fb1-8698-4659-a2f5-4548438c2252" /> | <img width="1474" alt="Screenshot 2025-06-25 at 3 44 09 PM" src="https://github.com/user-attachments/assets/60e6e2d3-1391-4353-8fb2-e4c8405e2e4c" /> | 
