### PR TITLE
chore: adjust details page to switch to 2 column layout at sm breakpoint instead of md

### DIFF
--- a/src/Apps/Order2/Routes/Details/Components/Order2DetailsPage.tsx
+++ b/src/Apps/Order2/Routes/Details/Components/Order2DetailsPage.tsx
@@ -19,8 +19,8 @@ export const Order2DetailsPage = ({ order }: Order2DetailsPageProps) => {
   const artworkSlug = orderData.lineItems[0]?.artwork?.slug
 
   return (
-    <GridColumns py={[0, 4]} px={[0, 0, 4]}>
-      <Column span={[12, 6, 6, 5]} start={[1, 2, 2, 3]}>
+    <GridColumns py={[0, 4]} px={[0, 4]}>
+      <Column span={[12, 7, 6, 5]} start={[1, 1, 2, 3]}>
         <Order2DetailsHeader order={orderData} />
 
         <Order2DetailsMessage order={orderData} />
@@ -47,7 +47,7 @@ export const Order2DetailsPage = ({ order }: Order2DetailsPageProps) => {
         </Box>
       </Column>
       <Column
-        span={[12, 4, 4, 3]}
+        span={[12, 5, 4, 3]}
         start={[1, 8, 8, 8]}
         display={["none", "block"]}
       >


### PR DESCRIPTION
Based on the slack thread: https://artsy.slack.com/archives/C02JHHHKP5K/p1750947469154539 updating to switch to 2 column layout at sm breakpoint. 

Think we might still need to do some adjustment but that is closer to what we now have in designs?
The views it generates.



**XS**

**widest** possible for XS:
![Screenshot 2025-06-26 at 11 59 53 AM](https://github.com/user-attachments/assets/f78e7ef3-fc1c-469a-ba85-d0ad78b0697b)



**SM:**

**Narrowest** possible for SM
![Screenshot 2025-06-26 at 12 01 39 PM](https://github.com/user-attachments/assets/68437322-e806-49a6-904f-155b154610a4)

**widest** possible for SM
![Screenshot 2025-06-26 at 1 08 54 PM](https://github.com/user-attachments/assets/d56ba22c-b788-49a2-817b-b09f9a559ae0)



**MD:**

**Narrowest** possible for MD
![Screenshot 2025-06-26 at 1 09 43 PM](https://github.com/user-attachments/assets/24566c70-1a01-46f2-9d92-9bca06a843b2)

**widest** possible for MD
![Screenshot 2025-06-26 at 1 10 38 PM](https://github.com/user-attachments/assets/280f3223-bfff-4b96-be2e-bc4cec8d5096)



**LG:**
![Screenshot 2025-06-26 at 1 06 58 PM](https://github.com/user-attachments/assets/5b2711c2-b077-4023-af50-fc063a16e489)
