### PR TITLE
chore: adjustment to the layout for checkout page

### DIFF
--- a/src/Apps/Order2/Layouts/LayoutCheckout.tsx
+++ b/src/Apps/Order2/Layouts/LayoutCheckout.tsx
@@ -35,7 +35,6 @@ export const LayoutCheckout: FC<React.PropsWithChildren<BaseLayoutProps>> = ({
 
       <Flex
         width="100%"
-        overflowX="hidden"
         minHeight="100vh"
         flexDirection="column"
         backgroundColor="mono5"

--- a/src/Apps/Order2/Layouts/LayoutCheckout.tsx
+++ b/src/Apps/Order2/Layouts/LayoutCheckout.tsx
@@ -18,7 +18,7 @@ export const LayoutCheckout: FC<React.PropsWithChildren<BaseLayoutProps>> = ({
       <AppToasts />
 
       <Box
-        position={["initial", "initial", "sticky"]}
+        position={["initial", "sticky"]}
         py={1}
         top={0}
         bg="mono0"

--- a/src/Apps/Order2/Routes/Checkout/Components/Order2CheckoutLoadingSkeleton.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2CheckoutLoadingSkeleton.tsx
@@ -48,8 +48,8 @@ const Order2CollapsibleOrderSummarySkeleton: React.FC<
   Order2CollapsibleOrderSummarySkeletonProps
 > = props => {
   return (
-    <GridColumns py={[0, 4]} px={[0, 0, 4]}>
-      <Column span={[12, 12, 6]} start={[1, 1, 2]}>
+    <GridColumns py={[0, 4]} px={[0, 4]}>
+      <Column span={[12, 7, 6, 5]} start={[1, 1, 2, 3]}>
         <Stack gap={1}>
           <Box display={["block", "block", "none"]}>
             <Flex height={60} py={1} px={2} backgroundColor="mono0">
@@ -82,9 +82,9 @@ const Order2CollapsibleOrderSummarySkeleton: React.FC<
       </Column>
 
       <Column
-        span={[12, 12, 4, 3]}
-        start={[1, 1, 8, 8]}
-        display={["none", "none", "block"]}
+        span={[12, 5, 4, 3]}
+        start={[1, 8, 8, 8]}
+        display={["none", "block"]}
       >
         {/* Order summary skeleton for desktop */}
         <Box backgroundColor="mono0" p={2}>

--- a/src/Apps/Order2/Routes/Checkout/Order2CheckoutApp.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Order2CheckoutApp.tsx
@@ -103,14 +103,14 @@ export const Order2CheckoutApp: React.FC<Order2CheckoutAppProps> = ({
       {expressCheckoutSubmitting && <SubmittingOrderSpinner />}
       <GridColumns
         py={[0, 4]}
-        px={[0, 0, 4]}
+        px={[0, 4]}
         style={{
           display: isLoading || expressCheckoutSubmitting ? "none" : "grid",
         }}
       >
-        <Column span={[12, 12, 6]} start={[1, 1, 2]}>
+        <Column span={[12, 7, 6, 5]} start={[1, 1, 2, 3]}>
           <Stack gap={1}>
-            <Box display={["block", "block", "none"]}>
+            <Box display={["block", "none"]}>
               <Order2CollapsibleOrderSummary order={order} />
             </Box>
             {isExpressCheckoutEligible && (
@@ -120,7 +120,7 @@ export const Order2CheckoutApp: React.FC<Order2CheckoutAppProps> = ({
             <Order2DeliveryOptionsStep />
             <Order2PaymentStep order={order} />
           </Stack>
-          <Box display={["block", "block", "none"]}>
+          <Box display={["block", "none"]}>
             <Spacer y={1} />
             <Order2ReviewStep order={order} />
             <Order2HelpLinksWithInquiry
@@ -132,11 +132,11 @@ export const Order2CheckoutApp: React.FC<Order2CheckoutAppProps> = ({
         </Column>
 
         <Column
-          span={[12, 12, 4, 3]}
-          start={[1, 1, 8, 8]}
-          display={["none", "none", "block"]}
+          span={[12, 5, 4, 3]}
+          start={[1, 8, 8, 8]}
+          display={["none", "block"]}
         >
-          <Box position={["initial", "initial", "fixed"]}>
+          <Box position={["initial", "fixed"]}>
             <Order2ReviewStep order={order} />
             <Separator as="hr" />
             <Order2HelpLinksWithInquiry

--- a/src/Apps/Order2/Routes/Checkout/Order2CheckoutApp.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Order2CheckoutApp.tsx
@@ -136,7 +136,7 @@ export const Order2CheckoutApp: React.FC<Order2CheckoutAppProps> = ({
           start={[1, 8, 8, 8]}
           display={["none", "block"]}
         >
-          <Box position={["initial", "fixed"]}>
+          <Box position={["initial", "sticky"]} top="100px">
             <Order2ReviewStep order={order} />
             <Separator as="hr" />
             <Order2HelpLinksWithInquiry


### PR DESCRIPTION
This is updating Checkout layout with the changes that we've made for Details page yesterday.

This looks ok as far as I can tell but there is still one small visual issue here. 
On a smaller screen with 2 column layout right column is not given the proper `40px` margin on the right. The content is resized properly but the margin is not appearing.  I suspect it's something with the fact that the position is `fixed for it`. Suspect we might need to have some placeholder dummy element to give it a proper sizing but unfortunately do not have time to play with it right now.


<img width="865" alt="Screenshot 2025-06-27 at 11 31 33 AM" src="https://github.com/user-attachments/assets/8d63ebf8-d2b1-430b-b445-78a6e3f8847d" />

@rquartararo and @erikdstock - tagging you here and you can decide if you want to use this just for reference or merge it and do the fixes based on this code.