### PR TITLE
feat(DIA-1308): allow partner bios on artist page

### DIFF
--- a/src/Apps/Artist/Components/ArtistHeader/ArtistHeader.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/ArtistHeader.tsx
@@ -47,8 +47,7 @@ const ArtistHeader: React.FC<React.PropsWithChildren<ArtistHeaderProps>> = ({
   const hasImage = isValidImage(image)
   const altText =
     artist.coverArtwork?.imageTitle ?? `Artwork by ${artist.name!}`
-  const hasPartnerSuppliedBio = !!artist.biographyBlurb?.credit
-  const hasBio = artist.biographyBlurb?.text && !hasPartnerSuppliedBio
+  const hasBio = artist.biographyBlurb?.text
   const hasVerifiedRepresentatives = artist?.verifiedRepresentatives?.length > 0
   const hasInsights = artist.insights.length > 0
   const hasRightDetails = hasVerifiedRepresentatives || hasInsights
@@ -252,9 +251,8 @@ export const ArtistHeaderFragmentContainer = createFragmentContainer(
         counts {
           follows
         }
-        biographyBlurb(format: HTML, partnerBio: false) {
+        biographyBlurb(format: HTML) {
           text
-          credit
         }
         insights {
           kind

--- a/src/Apps/Artist/Components/ArtistHeader/__tests__/ArtistHeader.jest.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/__tests__/ArtistHeader.jest.tsx
@@ -1,0 +1,454 @@
+import { screen } from "@testing-library/react"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
+import { ArtistHeaderFragmentContainer } from "Apps/Artist/Components/ArtistHeader/ArtistHeader"
+import { graphql } from "react-relay"
+import { useTracking } from "react-tracking"
+import { useRouter } from "System/Hooks/useRouter"
+
+jest.unmock("react-relay")
+jest.mock("react-tracking")
+jest.mock("System/Hooks/useRouter")
+jest.mock("Components/FollowButton/FollowArtistButton", () => ({
+  FollowArtistButtonQueryRenderer: ({ children }) => (
+    <div data-testid="follow-button">{children && children("Follow")}</div>
+  ),
+}))
+jest.mock(
+  "Components/ProgressiveOnboarding/ProgressiveOnboardingFollowArtist",
+  () => ({
+    ProgressiveOnboardingFollowArtist: ({ children }) => children,
+  }),
+)
+
+const mockUseTracking = useTracking as jest.Mock
+const trackEvent = jest.fn()
+
+beforeAll(() => {
+  mockUseTracking.mockImplementation(() => ({ trackEvent }))
+  ;(useRouter as jest.Mock).mockImplementation(() => ({
+    match: {
+      location: {
+        query: {},
+      },
+    },
+  }))
+})
+
+beforeEach(() => {
+  trackEvent.mockClear()
+})
+
+const { renderWithRelay } = setupTestWrapperTL({
+  Component: ArtistHeaderFragmentContainer,
+  query: graphql`
+    query ArtistHeader_Test_Query @relay_test_operation {
+      artist(id: "example") {
+        ...ArtistHeader_artist
+      }
+    }
+  `,
+})
+
+describe("ArtistHeaderFragmentContainer", () => {
+  describe("Basic rendering", () => {
+    it("renders artist name and nationality", () => {
+      renderWithRelay({
+        Artist: () => ({
+          name: "Pablo Picasso",
+          formattedNationalityAndBirthday: "Spanish, 1881–1973",
+        }),
+      })
+
+      expect(screen.getByText("Pablo Picasso")).toBeInTheDocument()
+      expect(screen.getByText("Spanish, 1881–1973")).toBeInTheDocument()
+    })
+
+    it("renders follow button", () => {
+      renderWithRelay({
+        Artist: () => ({
+          name: "Pablo Picasso",
+          internalID: "artist-id",
+        }),
+      })
+
+      expect(screen.getByTestId("follow-button")).toBeInTheDocument()
+    })
+
+    it("renders follower count when available", () => {
+      renderWithRelay({
+        Artist: () => ({
+          name: "Pablo Picasso",
+          counts: {
+            follows: 1234,
+          },
+        }),
+      })
+
+      expect(screen.getByText("1.2k Followers")).toBeInTheDocument()
+    })
+
+    it("renders singular follower when count is 1", () => {
+      renderWithRelay({
+        Artist: () => ({
+          name: "Pablo Picasso",
+          counts: {
+            follows: 1,
+          },
+        }),
+      })
+
+      expect(screen.getByText("1 Follower")).toBeInTheDocument()
+    })
+  })
+
+  describe("Biography rendering", () => {
+    it("renders bio when artist has biographyBlurb text", () => {
+      renderWithRelay({
+        Artist: () => ({
+          name: "Pablo Picasso",
+          biographyBlurb: {
+            text: "Pablo Picasso was a Spanish painter and sculptor.",
+          },
+        }),
+      })
+
+      expect(
+        screen.getByText("Pablo Picasso was a Spanish painter and sculptor."),
+      ).toBeInTheDocument()
+    })
+
+    it("renders bio when partner supplies biography", () => {
+      renderWithRelay({
+        Artist: () => ({
+          name: "Pablo Picasso",
+          biographyBlurb: {
+            text: "This biography is provided by a gallery partner.",
+          },
+        }),
+      })
+
+      expect(
+        screen.getByText("This biography is provided by a gallery partner."),
+      ).toBeInTheDocument()
+    })
+
+    it("does not render bio section when biographyBlurb text is null", () => {
+      renderWithRelay({
+        Artist: () => ({
+          name: "Pablo Picasso",
+          biographyBlurb: {
+            text: null,
+          },
+        }),
+      })
+
+      expect(screen.queryByText(/Pablo Picasso was/)).not.toBeInTheDocument()
+    })
+
+    it("does not render bio section when biographyBlurb text is empty", () => {
+      renderWithRelay({
+        Artist: () => ({
+          name: "Pablo Picasso",
+          biographyBlurb: {
+            text: "",
+          },
+        }),
+      })
+
+      expect(screen.queryByText(/Pablo Picasso was/)).not.toBeInTheDocument()
+    })
+
+    it("does not render bio section when biographyBlurb is null", () => {
+      renderWithRelay({
+        Artist: () => ({
+          name: "Pablo Picasso",
+          biographyBlurb: null,
+        }),
+      })
+
+      expect(screen.queryByText(/Pablo Picasso was/)).not.toBeInTheDocument()
+    })
+
+    it("renders bio with ReadMore functionality for long text", () => {
+      const longBio =
+        "Pablo Picasso was a Spanish painter and sculptor. " + "A".repeat(250) // Text longer than 250 char limit
+
+      renderWithRelay({
+        Artist: () => ({
+          name: "Pablo Picasso",
+          biographyBlurb: {
+            text: longBio,
+          },
+        }),
+      })
+
+      // ReadMore component is present and processes the long text
+      expect(
+        screen.getByText(/Pablo Picasso was a Spanish painter/),
+      ).toBeInTheDocument()
+    })
+  })
+
+  describe("Cover artwork", () => {
+    it("renders cover artwork when valid image is available", () => {
+      renderWithRelay({
+        Artist: () => ({
+          name: "Pablo Picasso",
+          coverArtwork: {
+            title: "Les Demoiselles d'Avignon",
+            imageTitle: "Les Demoiselles d'Avignon by Pablo Picasso",
+            href: "/artwork/les-demoiselles-davignon",
+            image: {
+              src: "https://example.com/image.jpg",
+              width: 400,
+              height: 300,
+            },
+          },
+        }),
+      })
+
+      const image = screen.getByAltText(
+        "Les Demoiselles d'Avignon by Pablo Picasso",
+      )
+      expect(image).toBeInTheDocument()
+      expect(image.closest("a")).toHaveAttribute(
+        "href",
+        "/artwork/les-demoiselles-davignon",
+      )
+    })
+
+    it("uses default alt text when imageTitle is not provided", () => {
+      renderWithRelay({
+        Artist: () => ({
+          name: "Pablo Picasso",
+          coverArtwork: {
+            title: "Les Demoiselles d'Avignon",
+            imageTitle: null,
+            href: "/artwork/les-demoiselles-davignon",
+            image: {
+              src: "https://example.com/image.jpg",
+              width: 400,
+              height: 300,
+            },
+          },
+        }),
+      })
+
+      expect(
+        screen.getByAltText("Artwork by Pablo Picasso"),
+      ).toBeInTheDocument()
+    })
+
+    it("does not render cover artwork when image is invalid", () => {
+      renderWithRelay({
+        Artist: () => ({
+          name: "Pablo Picasso",
+          coverArtwork: {
+            title: "Les Demoiselles d'Avignon",
+            href: "/artwork/les-demoiselles-davignon",
+            image: {
+              src: null,
+              width: 0,
+              height: 0,
+            },
+          },
+        }),
+      })
+
+      expect(screen.queryByRole("img")).not.toBeInTheDocument()
+    })
+  })
+
+  describe("Verified representatives", () => {
+    it("renders verified representatives section when available", () => {
+      renderWithRelay({
+        Artist: () => ({
+          name: "Pablo Picasso",
+          verifiedRepresentatives: [
+            {
+              partner: {
+                internalID: "partner-1",
+                name: "Gagosian Gallery",
+                href: "/partner/gagosian-gallery",
+                profile: {
+                  icon: {
+                    src1x: { src: "https://example.com/icon-30.jpg" },
+                    src2x: { src: "https://example.com/icon-60.jpg" },
+                  },
+                },
+              },
+            },
+          ],
+        }),
+      })
+
+      expect(screen.getByText("Featured representation")).toBeInTheDocument()
+      expect(screen.getByText("Gagosian Gallery")).toBeInTheDocument()
+    })
+
+    it("tracks clicks on verified representatives", () => {
+      renderWithRelay({
+        Artist: () => ({
+          name: "Pablo Picasso",
+          verifiedRepresentatives: [
+            {
+              partner: {
+                internalID: "partner-1",
+                name: "Gagosian Gallery",
+                href: "/partner/gagosian-gallery",
+                profile: {
+                  icon: {
+                    src1x: { src: "https://example.com/icon-30.jpg" },
+                    src2x: { src: "https://example.com/icon-60.jpg" },
+                  },
+                },
+              },
+            },
+          ],
+        }),
+      })
+
+      const partnerLink = screen.getByText("Gagosian Gallery")
+      partnerLink.click()
+
+      expect(trackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: "clickedVerifiedRepresentative",
+          context_module: "artistHeader",
+          destination_page_owner_id: "partner-1",
+          destination_page_owner_type: "partner",
+        }),
+      )
+    })
+
+    it("renders compact pills when more than 3 representatives", () => {
+      const representatives = Array(5)
+        .fill(null)
+        .map((_, i) => ({
+          partner: {
+            internalID: `partner-${i}`,
+            name: `Gallery ${i}`,
+            href: `/partner/gallery-${i}`,
+            profile: { icon: null },
+          },
+        }))
+
+      renderWithRelay({
+        Artist: () => ({
+          name: "Pablo Picasso",
+          verifiedRepresentatives: representatives,
+        }),
+      })
+
+      expect(screen.getByText("Featured representation")).toBeInTheDocument()
+      expect(screen.getByText("Gallery 0")).toBeInTheDocument()
+      expect(screen.getByText("Gallery 4")).toBeInTheDocument()
+    })
+  })
+
+  describe("Career highlights", () => {
+    it("renders career highlights when insights are available", () => {
+      renderWithRelay({
+        Artist: () => ({
+          name: "Pablo Picasso",
+          insights: [
+            {
+              kind: "COLLECTED",
+              label: "Collected by major museums",
+            },
+            {
+              kind: "REVIEWED",
+              label: "Reviewed by art critics",
+            },
+          ],
+        }),
+      })
+
+      // Career highlights would be rendered via ArtistCareerHighlightFragmentContainer
+      // The exact text depends on that component's implementation
+    })
+
+    it("limits insights to ARTIST_HEADER_NUMBER_OF_INSIGHTS", () => {
+      const validKinds = [
+        "COLLECTED",
+        "REVIEWED",
+        "SOLO_SHOW",
+        "GROUP_SHOW",
+        "HIGH_AUCTION_RECORD",
+        "TRENDING_NOW",
+      ]
+      const manyInsights = Array(10)
+        .fill(null)
+        .map((_, i) => ({
+          kind: validKinds[i % validKinds.length],
+          label: `Insight ${i}`,
+        }))
+
+      renderWithRelay({
+        Artist: () => ({
+          name: "Pablo Picasso",
+          insights: manyInsights,
+        }),
+      })
+
+      // Only first 4 insights should be rendered (ARTIST_HEADER_NUMBER_OF_INSIGHTS = 4)
+    })
+  })
+
+  describe("CV link", () => {
+    it("renders CV link", () => {
+      renderWithRelay({
+        Artist: () => ({
+          name: "Pablo Picasso",
+          slug: "pablo-picasso",
+        }),
+      })
+
+      const cvLink = screen.getByText("See all past shows and fair booths")
+      expect(cvLink).toBeInTheDocument()
+      expect(cvLink.closest("a")).toHaveAttribute(
+        "href",
+        "/artist/pablo-picasso/cv",
+      )
+    })
+  })
+
+  describe("Layout behavior", () => {
+    it("adjusts layout when no cover image is present", () => {
+      renderWithRelay({
+        Artist: () => ({
+          name: "Pablo Picasso",
+          coverArtwork: null,
+          verifiedRepresentatives: [
+            {
+              partner: {
+                internalID: "partner-1",
+                name: "Gagosian Gallery",
+                href: "/partner/gagosian-gallery",
+                profile: { icon: null },
+              },
+            },
+          ],
+        }),
+      })
+
+      expect(screen.getByText("Pablo Picasso")).toBeInTheDocument()
+      expect(screen.getByText("Featured representation")).toBeInTheDocument()
+    })
+
+    it("shows different follow button layout when no content is present", () => {
+      renderWithRelay({
+        Artist: () => ({
+          name: "Pablo Picasso",
+          internalID: "artist-id",
+          coverArtwork: null,
+          biographyBlurb: { text: null },
+          verifiedRepresentatives: [],
+          insights: [],
+        }),
+      })
+
+      expect(screen.getByTestId("follow-button")).toBeInTheDocument()
+    })
+  })
+})

--- a/src/__generated__/ArtistApp_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistApp_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d11120212cec1e70b2a5ed6d9bee3d9b>>
+ * @generated SignedSource<<1da4c77346e27344b37566cf62755f81>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -71,11 +71,13 @@ v6 = {
   "name": "internalID",
   "storageKey": null
 },
-v7 = {
-  "kind": "Literal",
-  "name": "format",
-  "value": "HTML"
-},
+v7 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "HTML"
+  }
+],
 v8 = [
   {
     "alias": null,
@@ -384,14 +386,7 @@ return {
           },
           {
             "alias": null,
-            "args": [
-              (v7/*: any*/),
-              {
-                "kind": "Literal",
-                "name": "partnerBio",
-                "value": false
-              }
-            ],
+            "args": (v7/*: any*/),
             "concreteType": "ArtistBlurb",
             "kind": "LinkedField",
             "name": "biographyBlurb",
@@ -403,16 +398,9 @@ return {
                 "kind": "ScalarField",
                 "name": "text",
                 "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "credit",
-                "storageKey": null
               }
             ],
-            "storageKey": "biographyBlurb(format:\"HTML\",partnerBio:false)"
+            "storageKey": "biographyBlurb(format:\"HTML\")"
           },
           {
             "alias": null,
@@ -445,9 +433,7 @@ return {
               },
               {
                 "alias": null,
-                "args": [
-                  (v7/*: any*/)
-                ],
+                "args": (v7/*: any*/),
                 "kind": "ScalarField",
                 "name": "description",
                 "storageKey": "description(format:\"HTML\")"
@@ -554,7 +540,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "0eed772278ad399dafce66dd5c92757a",
+    "cacheID": "4c54bdabb9679c2a99babde653a9dff0",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -576,7 +562,6 @@ return {
           "plural": false,
           "type": "ArtistBlurb"
         },
-        "artist.biographyBlurb.credit": (v9/*: any*/),
         "artist.biographyBlurb.text": (v9/*: any*/),
         "artist.birthday": (v9/*: any*/),
         "artist.counts": {
@@ -722,7 +707,7 @@ return {
     },
     "name": "ArtistApp_Test_Query",
     "operationKind": "query",
-    "text": "query ArtistApp_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistApp_artist\n    id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  internalID\n  slug\n  name\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n  biographyBlurb(format: HTML, partnerBio: false) {\n    text\n    credit\n  }\n  insights {\n    kind\n    ...ArtistCareerHighlight_insight\n  }\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          src1x: cropped(width: 30, height: 30) {\n            src\n          }\n          src2x: cropped(width: 60, height: 60) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n  coverArtwork {\n    title\n    imageTitle\n    href\n    image {\n      src: url(version: [\"larger\", \"larger\"])\n      width\n      height\n    }\n    id\n  }\n}\n\nfragment ArtistMeta_artist on Artist {\n  ...ArtistStructuredData_artist\n  slug\n  name\n  nationality\n  birthday\n  deathday\n  href\n  isInSeoExperiment\n  meta(page: ABOUT) {\n    description\n    title\n  }\n  alternateNames\n  coverArtwork {\n    image {\n      large: url(version: \"large\")\n    }\n    id\n  }\n}\n\nfragment ArtistStructuredData_artist on Artist {\n  slug\n  name\n  birthday\n  deathday\n  gender\n  nationality\n  href\n  meta(page: ABOUT) {\n    title\n    description\n  }\n  coverArtwork {\n    image {\n      url(version: \"large\")\n    }\n    id\n  }\n  partnersConnection(first: 10) {\n    edges {\n      node {\n        href\n        id\n      }\n      id\n    }\n  }\n}\n"
+    "text": "query ArtistApp_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistApp_artist\n    id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  internalID\n  slug\n  name\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n  biographyBlurb(format: HTML) {\n    text\n  }\n  insights {\n    kind\n    ...ArtistCareerHighlight_insight\n  }\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          src1x: cropped(width: 30, height: 30) {\n            src\n          }\n          src2x: cropped(width: 60, height: 60) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n  coverArtwork {\n    title\n    imageTitle\n    href\n    image {\n      src: url(version: [\"larger\", \"larger\"])\n      width\n      height\n    }\n    id\n  }\n}\n\nfragment ArtistMeta_artist on Artist {\n  ...ArtistStructuredData_artist\n  slug\n  name\n  nationality\n  birthday\n  deathday\n  href\n  isInSeoExperiment\n  meta(page: ABOUT) {\n    description\n    title\n  }\n  alternateNames\n  coverArtwork {\n    image {\n      large: url(version: \"large\")\n    }\n    id\n  }\n}\n\nfragment ArtistStructuredData_artist on Artist {\n  slug\n  name\n  birthday\n  deathday\n  gender\n  nationality\n  href\n  meta(page: ABOUT) {\n    title\n    description\n  }\n  coverArtwork {\n    image {\n      url(version: \"large\")\n    }\n    id\n  }\n  partnersConnection(first: 10) {\n    edges {\n      node {\n        href\n        id\n      }\n      id\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistHeader_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistHeader_Test_Query.graphql.ts
@@ -1,0 +1,537 @@
+/**
+ * @generated SignedSource<<7e11d2aeffb2642063756b43bf5e63ef>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ArtistHeader_Test_Query$variables = Record<PropertyKey, never>;
+export type ArtistHeader_Test_Query$data = {
+  readonly artist: {
+    readonly " $fragmentSpreads": FragmentRefs<"ArtistHeader_artist">;
+  } | null | undefined;
+};
+export type ArtistHeader_Test_Query = {
+  response: ArtistHeader_Test_Query$data;
+  variables: ArtistHeader_Test_Query$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "example"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v3 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "HTML"
+  }
+],
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v5 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "src",
+    "storageKey": null
+  }
+],
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v7 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v8 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v9 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Image"
+},
+v10 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Int"
+},
+v11 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "String"
+},
+v12 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "CroppedImageUrl"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ArtistHeader_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Artist",
+        "kind": "LinkedField",
+        "name": "artist",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ArtistHeader_artist"
+          }
+        ],
+        "storageKey": "artist(id:\"example\")"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "ArtistHeader_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Artist",
+        "kind": "LinkedField",
+        "name": "artist",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
+          (v2/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "formattedNationalityAndBirthday",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtistCounts",
+            "kind": "LinkedField",
+            "name": "counts",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "follows",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": (v3/*: any*/),
+            "concreteType": "ArtistBlurb",
+            "kind": "LinkedField",
+            "name": "biographyBlurb",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "text",
+                "storageKey": null
+              }
+            ],
+            "storageKey": "biographyBlurb(format:\"HTML\")"
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtistInsight",
+            "kind": "LinkedField",
+            "name": "insights",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "kind",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "label",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "entities",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": (v3/*: any*/),
+                "kind": "ScalarField",
+                "name": "description",
+                "storageKey": "description(format:\"HTML\")"
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "VerifiedRepresentative",
+            "kind": "LinkedField",
+            "name": "verifiedRepresentatives",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Partner",
+                "kind": "LinkedField",
+                "name": "partner",
+                "plural": false,
+                "selections": [
+                  (v1/*: any*/),
+                  (v2/*: any*/),
+                  (v4/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Profile",
+                    "kind": "LinkedField",
+                    "name": "profile",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "icon",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "src1x",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "height",
+                                "value": 30
+                              },
+                              {
+                                "kind": "Literal",
+                                "name": "width",
+                                "value": 30
+                              }
+                            ],
+                            "concreteType": "CroppedImageUrl",
+                            "kind": "LinkedField",
+                            "name": "cropped",
+                            "plural": false,
+                            "selections": (v5/*: any*/),
+                            "storageKey": "cropped(height:30,width:30)"
+                          },
+                          {
+                            "alias": "src2x",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "height",
+                                "value": 60
+                              },
+                              {
+                                "kind": "Literal",
+                                "name": "width",
+                                "value": 60
+                              }
+                            ],
+                            "concreteType": "CroppedImageUrl",
+                            "kind": "LinkedField",
+                            "name": "cropped",
+                            "plural": false,
+                            "selections": (v5/*: any*/),
+                            "storageKey": "cropped(height:60,width:60)"
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      (v6/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  (v6/*: any*/)
+                ],
+                "storageKey": null
+              },
+              (v6/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Artwork",
+            "kind": "LinkedField",
+            "name": "coverArtwork",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "title",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "imageTitle",
+                "storageKey": null
+              },
+              (v4/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Image",
+                "kind": "LinkedField",
+                "name": "image",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": "src",
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "version",
+                        "value": [
+                          "larger",
+                          "larger"
+                        ]
+                      }
+                    ],
+                    "kind": "ScalarField",
+                    "name": "url",
+                    "storageKey": "url(version:[\"larger\",\"larger\"])"
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "width",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "height",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v6/*: any*/)
+            ],
+            "storageKey": null
+          },
+          (v6/*: any*/)
+        ],
+        "storageKey": "artist(id:\"example\")"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "0f6dd77298109086dcb6919993122618",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "artist": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artist"
+        },
+        "artist.biographyBlurb": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtistBlurb"
+        },
+        "artist.biographyBlurb.text": (v7/*: any*/),
+        "artist.counts": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtistCounts"
+        },
+        "artist.counts.follows": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "FormattedNumber"
+        },
+        "artist.coverArtwork": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artwork"
+        },
+        "artist.coverArtwork.href": (v7/*: any*/),
+        "artist.coverArtwork.id": (v8/*: any*/),
+        "artist.coverArtwork.image": (v9/*: any*/),
+        "artist.coverArtwork.image.height": (v10/*: any*/),
+        "artist.coverArtwork.image.src": (v7/*: any*/),
+        "artist.coverArtwork.image.width": (v10/*: any*/),
+        "artist.coverArtwork.imageTitle": (v7/*: any*/),
+        "artist.coverArtwork.title": (v7/*: any*/),
+        "artist.formattedNationalityAndBirthday": (v7/*: any*/),
+        "artist.id": (v8/*: any*/),
+        "artist.insights": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": true,
+          "type": "ArtistInsight"
+        },
+        "artist.insights.description": (v7/*: any*/),
+        "artist.insights.entities": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": true,
+          "type": "String"
+        },
+        "artist.insights.kind": {
+          "enumValues": [
+            "ACTIVE_SECONDARY_MARKET",
+            "ARTSY_VANGUARD_YEAR",
+            "AWARDS",
+            "BIENNIAL",
+            "COLLECTED",
+            "CRITICALLY_ACCLAIMED",
+            "CURATORS_PICK_EMERGING",
+            "FOUNDATIONS",
+            "GAINING_FOLLOWERS",
+            "GROUP_SHOW",
+            "HIGH_AUCTION_RECORD",
+            "PRIVATE_COLLECTIONS",
+            "RECENT_CAREER_EVENT",
+            "RESIDENCIES",
+            "REVIEWED",
+            "SOLO_SHOW",
+            "TRENDING_NOW"
+          ],
+          "nullable": true,
+          "plural": false,
+          "type": "ArtistInsightKind"
+        },
+        "artist.insights.label": (v11/*: any*/),
+        "artist.internalID": (v8/*: any*/),
+        "artist.name": (v7/*: any*/),
+        "artist.slug": (v8/*: any*/),
+        "artist.verifiedRepresentatives": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": true,
+          "type": "VerifiedRepresentative"
+        },
+        "artist.verifiedRepresentatives.id": (v8/*: any*/),
+        "artist.verifiedRepresentatives.partner": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "Partner"
+        },
+        "artist.verifiedRepresentatives.partner.href": (v7/*: any*/),
+        "artist.verifiedRepresentatives.partner.id": (v8/*: any*/),
+        "artist.verifiedRepresentatives.partner.internalID": (v8/*: any*/),
+        "artist.verifiedRepresentatives.partner.name": (v7/*: any*/),
+        "artist.verifiedRepresentatives.partner.profile": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Profile"
+        },
+        "artist.verifiedRepresentatives.partner.profile.icon": (v9/*: any*/),
+        "artist.verifiedRepresentatives.partner.profile.icon.src1x": (v12/*: any*/),
+        "artist.verifiedRepresentatives.partner.profile.icon.src1x.src": (v11/*: any*/),
+        "artist.verifiedRepresentatives.partner.profile.icon.src2x": (v12/*: any*/),
+        "artist.verifiedRepresentatives.partner.profile.icon.src2x.src": (v11/*: any*/),
+        "artist.verifiedRepresentatives.partner.profile.id": (v8/*: any*/)
+      }
+    },
+    "name": "ArtistHeader_Test_Query",
+    "operationKind": "query",
+    "text": "query ArtistHeader_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistHeader_artist\n    id\n  }\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n  biographyBlurb(format: HTML) {\n    text\n  }\n  insights {\n    kind\n    ...ArtistCareerHighlight_insight\n  }\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          src1x: cropped(width: 30, height: 30) {\n            src\n          }\n          src2x: cropped(width: 60, height: 60) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n  coverArtwork {\n    title\n    imageTitle\n    href\n    image {\n      src: url(version: [\"larger\", \"larger\"])\n      width\n      height\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "488ad05ec853dc8831a05ff896bf0d3c";
+
+export default node;

--- a/src/__generated__/ArtistHeader_artist.graphql.ts
+++ b/src/__generated__/ArtistHeader_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f988faffb52c6045ff20168dce578556>>
+ * @generated SignedSource<<81c3d80ea9dcc361910f2317ceeabdcc>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,7 +13,6 @@ export type ArtistInsightKind = "ACTIVE_SECONDARY_MARKET" | "ARTSY_VANGUARD_YEAR
 import { FragmentRefs } from "relay-runtime";
 export type ArtistHeader_artist$data = {
   readonly biographyBlurb: {
-    readonly credit: string | null | undefined;
     readonly text: string | null | undefined;
   } | null | undefined;
   readonly counts: {
@@ -139,11 +138,6 @@ return {
           "kind": "Literal",
           "name": "format",
           "value": "HTML"
-        },
-        {
-          "kind": "Literal",
-          "name": "partnerBio",
-          "value": false
         }
       ],
       "concreteType": "ArtistBlurb",
@@ -157,16 +151,9 @@ return {
           "kind": "ScalarField",
           "name": "text",
           "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "credit",
-          "storageKey": null
         }
       ],
-      "storageKey": "biographyBlurb(format:\"HTML\",partnerBio:false)"
+      "storageKey": "biographyBlurb(format:\"HTML\")"
     },
     {
       "alias": null,
@@ -353,6 +340,6 @@ return {
 };
 })();
 
-(node as any).hash = "e52c47ac3fe6c7aad115ef19f7f3218d";
+(node as any).hash = "dad6c9804912c1d31142ea5de0358588";
 
 export default node;

--- a/src/__generated__/artistRoutes_ArtistAppQuery.graphql.ts
+++ b/src/__generated__/artistRoutes_ArtistAppQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<893861d5559ab549165d997070e56ee0>>
+ * @generated SignedSource<<c6c666348ebdc99f234e20fcc729e287>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -80,11 +80,13 @@ v7 = {
   "name": "internalID",
   "storageKey": null
 },
-v8 = {
-  "kind": "Literal",
-  "name": "format",
-  "value": "HTML"
-},
+v8 = [
+  {
+    "kind": "Literal",
+    "name": "format",
+    "value": "HTML"
+  }
+],
 v9 = [
   {
     "alias": null,
@@ -357,14 +359,7 @@ return {
           },
           {
             "alias": null,
-            "args": [
-              (v8/*: any*/),
-              {
-                "kind": "Literal",
-                "name": "partnerBio",
-                "value": false
-              }
-            ],
+            "args": (v8/*: any*/),
             "concreteType": "ArtistBlurb",
             "kind": "LinkedField",
             "name": "biographyBlurb",
@@ -376,16 +371,9 @@ return {
                 "kind": "ScalarField",
                 "name": "text",
                 "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "credit",
-                "storageKey": null
               }
             ],
-            "storageKey": "biographyBlurb(format:\"HTML\",partnerBio:false)"
+            "storageKey": "biographyBlurb(format:\"HTML\")"
           },
           {
             "alias": null,
@@ -418,9 +406,7 @@ return {
               },
               {
                 "alias": null,
-                "args": [
-                  (v8/*: any*/)
-                ],
+                "args": (v8/*: any*/),
                 "kind": "ScalarField",
                 "name": "description",
                 "storageKey": "description(format:\"HTML\")"
@@ -527,12 +513,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "5c456c5ab7bae2242c9525875ef81409",
+    "cacheID": "fca9062ad29b9a4932d3ea8558cdfd87",
     "id": null,
     "metadata": {},
     "name": "artistRoutes_ArtistAppQuery",
     "operationKind": "query",
-    "text": "query artistRoutes_ArtistAppQuery(\n  $artistID: String!\n) @cacheable {\n  artist(id: $artistID) @principalField {\n    ...ArtistApp_artist\n    id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  internalID\n  slug\n  name\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n  biographyBlurb(format: HTML, partnerBio: false) {\n    text\n    credit\n  }\n  insights {\n    kind\n    ...ArtistCareerHighlight_insight\n  }\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          src1x: cropped(width: 30, height: 30) {\n            src\n          }\n          src2x: cropped(width: 60, height: 60) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n  coverArtwork {\n    title\n    imageTitle\n    href\n    image {\n      src: url(version: [\"larger\", \"larger\"])\n      width\n      height\n    }\n    id\n  }\n}\n\nfragment ArtistMeta_artist on Artist {\n  ...ArtistStructuredData_artist\n  slug\n  name\n  nationality\n  birthday\n  deathday\n  href\n  isInSeoExperiment\n  meta(page: ABOUT) {\n    description\n    title\n  }\n  alternateNames\n  coverArtwork {\n    image {\n      large: url(version: \"large\")\n    }\n    id\n  }\n}\n\nfragment ArtistStructuredData_artist on Artist {\n  slug\n  name\n  birthday\n  deathday\n  gender\n  nationality\n  href\n  meta(page: ABOUT) {\n    title\n    description\n  }\n  coverArtwork {\n    image {\n      url(version: \"large\")\n    }\n    id\n  }\n  partnersConnection(first: 10) {\n    edges {\n      node {\n        href\n        id\n      }\n      id\n    }\n  }\n}\n"
+    "text": "query artistRoutes_ArtistAppQuery(\n  $artistID: String!\n) @cacheable {\n  artist(id: $artistID) @principalField {\n    ...ArtistApp_artist\n    id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  internalID\n  slug\n  name\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n  biographyBlurb(format: HTML) {\n    text\n  }\n  insights {\n    kind\n    ...ArtistCareerHighlight_insight\n  }\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          src1x: cropped(width: 30, height: 30) {\n            src\n          }\n          src2x: cropped(width: 60, height: 60) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n  coverArtwork {\n    title\n    imageTitle\n    href\n    image {\n      src: url(version: [\"larger\", \"larger\"])\n      width\n      height\n    }\n    id\n  }\n}\n\nfragment ArtistMeta_artist on Artist {\n  ...ArtistStructuredData_artist\n  slug\n  name\n  nationality\n  birthday\n  deathday\n  href\n  isInSeoExperiment\n  meta(page: ABOUT) {\n    description\n    title\n  }\n  alternateNames\n  coverArtwork {\n    image {\n      large: url(version: \"large\")\n    }\n    id\n  }\n}\n\nfragment ArtistStructuredData_artist on Artist {\n  slug\n  name\n  birthday\n  deathday\n  gender\n  nationality\n  href\n  meta(page: ABOUT) {\n    title\n    description\n  }\n  coverArtwork {\n    image {\n      url(version: \"large\")\n    }\n    id\n  }\n  partnersConnection(first: 10) {\n    edges {\n      node {\n        href\n        id\n      }\n      id\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
This PR updates the artist page to display whatever bio Metaphysics serves it - regardless of whether it was written by Artsy, the partner, or (hypothetically) an LLM.

See artsy/metaphysics#6860 for more information.

| Before | After |
|-------|------|
| <img width="1840" alt="BEFORE" src="https://github.com/user-attachments/assets/aacbae9f-c037-44d2-be7e-699cc6a47fa6" /> | <img width="1840" alt="AFTER" src="https://github.com/user-attachments/assets/92b68a55-5546-4be3-bb7e-316cdc96215a" /> |

