### PR TITLE
feat: migrate ingress to new controllers (staging)

### DIFF
--- a/hokusai/staging.yml
+++ b/hokusai/staging.yml
@@ -301,11 +301,11 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: force
+  name: force-2025
   annotations:
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ externalIngressAllowSourceIP|join(',') }}
 spec:
-  ingressClassName: nginx
+  ingressClassName: external-nginx
   rules:
   - host: staging.artsy.net
     http:


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [PHIRE-1900]

### Description

The existing ingress controllers are not scalable. We have [created a new set of Ingress Controllers](https://github.com/artsy/substance/pull/420) that are scalable.

We want to migrate the ingress to the new controllers without disruption to traffic.

This PR adds a parallel ingress that is tied to the new controllers.

After Staging deploy:

- [ ] Point the app's DNS to the new controllers. This should be done via Infrastructure repo.
- [ ] Verify that the app still works.
- [ ] Delete the old ingress via kubectl. (`kubectl --context staging delete ingress <old-ingress-name>`)