### PR TITLE
fix(feature): makes featured title/sub/text clickable

### DIFF
--- a/src/Apps/Feature/Components/FeatureFeaturedLink.tsx
+++ b/src/Apps/Feature/Components/FeatureFeaturedLink.tsx
@@ -70,20 +70,14 @@ export const FeatureFeaturedLink: React.FC<
           <Text variant="lg-display" mt={0.5} lineClamp={3}>
             {title}
           </Text>
-
-          {description &&
-            (size === "full" ? (
-              <HTML
-                variant="lg-display"
-                color="mono60"
-                mt={1}
-                html={description}
-              />
-            ) : (
-              <HTML variant="sm" color="mono60" mt={0.5} html={description} />
-            ))}
         </Flex>
       </Figure>
+      {description &&
+        (size === "full" ? (
+          <HTML variant="lg-display" color="mono60" mt={1} html={description} />
+        ) : (
+          <HTML variant="sm" color="mono60" mt={0.5} html={description} />
+        ))}
     </Flex>
   )
 }
@@ -132,7 +126,7 @@ export const FeatureFeaturedLinkFragmentContainer = createFragmentContainer(
 )
 
 const Figure = styled(RouterLink)<RouterLinkProps>`
-  &:hover + div {
+  &:hover {
     color: ${themeGet("colors.blue100")};
   }
 `

--- a/src/Apps/Feature/Components/FeatureFeaturedLink.tsx
+++ b/src/Apps/Feature/Components/FeatureFeaturedLink.tsx
@@ -33,8 +33,8 @@ export const FeatureFeaturedLink: React.FC<
 
   return (
     <Flex flexDirection="column" {...rest}>
-      {img && (
-        <Figure to={href}>
+      <Figure to={href} display="block" textDecoration="none">
+        {img && (
           <ResponsiveBox
             aspectWidth={img.width ?? 0}
             aspectHeight={img.height ?? 0}
@@ -50,40 +50,40 @@ export const FeatureFeaturedLink: React.FC<
               lazyLoad
             />
           </ResponsiveBox>
-        </Figure>
-      )}
+        )}
 
-      {!img && title && (
-        <Text variant="lg-display" color="mono100" my={2}>
-          <RouterLink to={href}>{title || "—"}</RouterLink>
-        </Text>
-      )}
-
-      <Flex flexDirection={size === "large" ? ["column", "row"] : "column"}>
-        <Spacer y={1} />
-
-        {subtitle && (
-          <Text variant="xs" fontWeight="bold">
-            {subtitle}
+        {!img && title && (
+          <Text variant="lg-display" color="mono100" my={2}>
+            <RouterLink to={href}>{title || "—"}</RouterLink>
           </Text>
         )}
 
-        <Text variant="lg-display" mt={0.5} lineClamp={3}>
-          {title}
-        </Text>
+        <Flex flexDirection={size === "large" ? ["column", "row"] : "column"}>
+          <Spacer y={1} />
 
-        {description &&
-          (size === "full" ? (
-            <HTML
-              variant="lg-display"
-              color="mono60"
-              mt={1}
-              html={description}
-            />
-          ) : (
-            <HTML variant="sm" color="mono60" mt={0.5} html={description} />
-          ))}
-      </Flex>
+          {subtitle && (
+            <Text variant="xs" fontWeight="bold">
+              {subtitle}
+            </Text>
+          )}
+
+          <Text variant="lg-display" mt={0.5} lineClamp={3}>
+            {title}
+          </Text>
+
+          {description &&
+            (size === "full" ? (
+              <HTML
+                variant="lg-display"
+                color="mono60"
+                mt={1}
+                html={description}
+              />
+            ) : (
+              <HTML variant="sm" color="mono60" mt={0.5} html={description} />
+            ))}
+        </Flex>
+      </Figure>
     </Flex>
   )
 }

--- a/src/Apps/Feature/Components/FeatureFeaturedLink.tsx
+++ b/src/Apps/Feature/Components/FeatureFeaturedLink.tsx
@@ -54,7 +54,7 @@ export const FeatureFeaturedLink: React.FC<
 
         {!img && title && (
           <Text variant="lg-display" color="mono100" my={2}>
-            <RouterLink to={href}>{title || "—"}</RouterLink>
+            {title || "—"}
           </Text>
         )}
 


### PR DESCRIPTION
The type of this PR is: Fix

This PR solves [DIA-1336]

### Description

The existing image element was wrapped in a link, and if no link was present, the defaulted title would've been linked. but in the case where the image is present, the title and other elements were't getting wrapped. 

Alternately, I could have wrapped each of these elements individually with a router link instead of using the `Figure` to wrap them all like I did here. But I noticed we just wrap other elements like this elsewhere: 
https://github.com/artsy/force/blob/0047c96671d1edb6e24100a063aeb533fba2ba39/src/Apps/Articles/Components/ArticlesIndexArticle.tsx#L28-L45

ps: I was 🤏 this close to having my first ticket number be `1337`.


[DIA-1336]: https://artsyproduct.atlassian.net/browse/DIA-1336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ