### PR TITLE
fix: separate artist bio text and credit

### DIFF
--- a/src/Apps/Artist/Components/ArtistHeader/ArtistHeader.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/ArtistHeader.tsx
@@ -47,7 +47,13 @@ const ArtistHeader: React.FC<React.PropsWithChildren<ArtistHeaderProps>> = ({
   const hasImage = isValidImage(image)
   const altText =
     artist.coverArtwork?.imageTitle ?? `Artwork by ${artist.name!}`
-  const hasBio = artist.biographyBlurb?.text
+  const biographyText = artist.biographyBlurb?.text
+  const biographyCredit = artist.biographyBlurb?.credit
+  const hasBio = !!biographyText
+  const biographyContent =
+    hasBio && biographyCredit
+      ? `${biographyText} ${biographyCredit}`
+      : biographyText
   const hasVerifiedRepresentatives = artist?.verifiedRepresentatives?.length > 0
   const hasInsights = artist.insights.length > 0
   const hasRightDetails = hasVerifiedRepresentatives || hasInsights
@@ -155,9 +161,9 @@ const ArtistHeader: React.FC<React.PropsWithChildren<ArtistHeaderProps>> = ({
           </Flex>
         </Flex>
 
-        {hasBio && (
+        {biographyContent && (
           <Bio variant="sm">
-            <ReadMore maxChars={250} content={artist.biographyBlurb.text} />
+            <ReadMore maxChars={250} content={biographyContent} />
           </Bio>
         )}
 
@@ -253,6 +259,7 @@ export const ArtistHeaderFragmentContainer = createFragmentContainer(
         }
         biographyBlurb(format: HTML) {
           text
+          credit
         }
         insights {
           kind

--- a/src/Apps/Artist/Components/ArtistHeader/__tests__/ArtistHeader.jest.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/__tests__/ArtistHeader.jest.tsx
@@ -187,6 +187,72 @@ describe("ArtistHeaderFragmentContainer", () => {
         screen.getByText(/Pablo Picasso was a Spanish painter/),
       ).toBeInTheDocument()
     })
+
+    it("renders bio with credit when both text and credit are present", () => {
+      renderWithRelay({
+        Artist: () => ({
+          name: "Pablo Picasso",
+          biographyBlurb: {
+            text: "Pablo Picasso was a Spanish painter and sculptor.",
+            credit: "Courtesy of the Museum of Modern Art",
+          },
+        }),
+      })
+
+      expect(
+        screen.getByText(
+          "Pablo Picasso was a Spanish painter and sculptor. Courtesy of the Museum of Modern Art",
+        ),
+      ).toBeInTheDocument()
+    })
+
+    it("renders bio with only text when credit is null", () => {
+      renderWithRelay({
+        Artist: () => ({
+          name: "Pablo Picasso",
+          biographyBlurb: {
+            text: "Pablo Picasso was a Spanish painter and sculptor.",
+            credit: null,
+          },
+        }),
+      })
+
+      expect(
+        screen.getByText("Pablo Picasso was a Spanish painter and sculptor."),
+      ).toBeInTheDocument()
+    })
+
+    it("renders bio with only text when credit is empty string", () => {
+      renderWithRelay({
+        Artist: () => ({
+          name: "Pablo Picasso",
+          biographyBlurb: {
+            text: "Pablo Picasso was a Spanish painter and sculptor.",
+            credit: "",
+          },
+        }),
+      })
+
+      expect(
+        screen.getByText("Pablo Picasso was a Spanish painter and sculptor."),
+      ).toBeInTheDocument()
+    })
+
+    it("does not render bio section when only credit is present without text", () => {
+      renderWithRelay({
+        Artist: () => ({
+          name: "Pablo Picasso",
+          biographyBlurb: {
+            text: null,
+            credit: "Courtesy of the Museum of Modern Art",
+          },
+        }),
+      })
+
+      expect(
+        screen.queryByText(/Courtesy of the Museum/),
+      ).not.toBeInTheDocument()
+    })
   })
 
   describe("Cover artwork", () => {

--- a/src/__generated__/ArtistApp_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistApp_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1da4c77346e27344b37566cf62755f81>>
+ * @generated SignedSource<<3794a2aac65d889d4c05737c26208c10>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -398,6 +398,13 @@ return {
                 "kind": "ScalarField",
                 "name": "text",
                 "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "credit",
+                "storageKey": null
               }
             ],
             "storageKey": "biographyBlurb(format:\"HTML\")"
@@ -540,7 +547,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4c54bdabb9679c2a99babde653a9dff0",
+    "cacheID": "c9822dfe66d67c085ddfdbaec39f85f9",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -562,6 +569,7 @@ return {
           "plural": false,
           "type": "ArtistBlurb"
         },
+        "artist.biographyBlurb.credit": (v9/*: any*/),
         "artist.biographyBlurb.text": (v9/*: any*/),
         "artist.birthday": (v9/*: any*/),
         "artist.counts": {
@@ -707,7 +715,7 @@ return {
     },
     "name": "ArtistApp_Test_Query",
     "operationKind": "query",
-    "text": "query ArtistApp_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistApp_artist\n    id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  internalID\n  slug\n  name\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n  biographyBlurb(format: HTML) {\n    text\n  }\n  insights {\n    kind\n    ...ArtistCareerHighlight_insight\n  }\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          src1x: cropped(width: 30, height: 30) {\n            src\n          }\n          src2x: cropped(width: 60, height: 60) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n  coverArtwork {\n    title\n    imageTitle\n    href\n    image {\n      src: url(version: [\"larger\", \"larger\"])\n      width\n      height\n    }\n    id\n  }\n}\n\nfragment ArtistMeta_artist on Artist {\n  ...ArtistStructuredData_artist\n  slug\n  name\n  nationality\n  birthday\n  deathday\n  href\n  isInSeoExperiment\n  meta(page: ABOUT) {\n    description\n    title\n  }\n  alternateNames\n  coverArtwork {\n    image {\n      large: url(version: \"large\")\n    }\n    id\n  }\n}\n\nfragment ArtistStructuredData_artist on Artist {\n  slug\n  name\n  birthday\n  deathday\n  gender\n  nationality\n  href\n  meta(page: ABOUT) {\n    title\n    description\n  }\n  coverArtwork {\n    image {\n      url(version: \"large\")\n    }\n    id\n  }\n  partnersConnection(first: 10) {\n    edges {\n      node {\n        href\n        id\n      }\n      id\n    }\n  }\n}\n"
+    "text": "query ArtistApp_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistApp_artist\n    id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  internalID\n  slug\n  name\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  insights {\n    kind\n    ...ArtistCareerHighlight_insight\n  }\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          src1x: cropped(width: 30, height: 30) {\n            src\n          }\n          src2x: cropped(width: 60, height: 60) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n  coverArtwork {\n    title\n    imageTitle\n    href\n    image {\n      src: url(version: [\"larger\", \"larger\"])\n      width\n      height\n    }\n    id\n  }\n}\n\nfragment ArtistMeta_artist on Artist {\n  ...ArtistStructuredData_artist\n  slug\n  name\n  nationality\n  birthday\n  deathday\n  href\n  isInSeoExperiment\n  meta(page: ABOUT) {\n    description\n    title\n  }\n  alternateNames\n  coverArtwork {\n    image {\n      large: url(version: \"large\")\n    }\n    id\n  }\n}\n\nfragment ArtistStructuredData_artist on Artist {\n  slug\n  name\n  birthday\n  deathday\n  gender\n  nationality\n  href\n  meta(page: ABOUT) {\n    title\n    description\n  }\n  coverArtwork {\n    image {\n      url(version: \"large\")\n    }\n    id\n  }\n  partnersConnection(first: 10) {\n    edges {\n      node {\n        href\n        id\n      }\n      id\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistHeader_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistHeader_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7e11d2aeffb2642063756b43bf5e63ef>>
+ * @generated SignedSource<<cc044f8228ca917fc85cba075547cef6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -197,6 +197,13 @@ return {
                 "args": null,
                 "kind": "ScalarField",
                 "name": "text",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "credit",
                 "storageKey": null
               }
             ],
@@ -408,7 +415,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "0f6dd77298109086dcb6919993122618",
+    "cacheID": "4b9541f9f74650f28e546bccdd01b296",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -424,6 +431,7 @@ return {
           "plural": false,
           "type": "ArtistBlurb"
         },
+        "artist.biographyBlurb.credit": (v7/*: any*/),
         "artist.biographyBlurb.text": (v7/*: any*/),
         "artist.counts": {
           "enumValues": null,
@@ -527,7 +535,7 @@ return {
     },
     "name": "ArtistHeader_Test_Query",
     "operationKind": "query",
-    "text": "query ArtistHeader_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistHeader_artist\n    id\n  }\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n  biographyBlurb(format: HTML) {\n    text\n  }\n  insights {\n    kind\n    ...ArtistCareerHighlight_insight\n  }\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          src1x: cropped(width: 30, height: 30) {\n            src\n          }\n          src2x: cropped(width: 60, height: 60) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n  coverArtwork {\n    title\n    imageTitle\n    href\n    image {\n      src: url(version: [\"larger\", \"larger\"])\n      width\n      height\n    }\n    id\n  }\n}\n"
+    "text": "query ArtistHeader_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistHeader_artist\n    id\n  }\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  insights {\n    kind\n    ...ArtistCareerHighlight_insight\n  }\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          src1x: cropped(width: 30, height: 30) {\n            src\n          }\n          src2x: cropped(width: 60, height: 60) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n  coverArtwork {\n    title\n    imageTitle\n    href\n    image {\n      src: url(version: [\"larger\", \"larger\"])\n      width\n      height\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistHeader_artist.graphql.ts
+++ b/src/__generated__/ArtistHeader_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<81c3d80ea9dcc361910f2317ceeabdcc>>
+ * @generated SignedSource<<df0b4c314b01db216a2fe760de7ebde6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,6 +13,7 @@ export type ArtistInsightKind = "ACTIVE_SECONDARY_MARKET" | "ARTSY_VANGUARD_YEAR
 import { FragmentRefs } from "relay-runtime";
 export type ArtistHeader_artist$data = {
   readonly biographyBlurb: {
+    readonly credit: string | null | undefined;
     readonly text: string | null | undefined;
   } | null | undefined;
   readonly counts: {
@@ -150,6 +151,13 @@ return {
           "args": null,
           "kind": "ScalarField",
           "name": "text",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "credit",
           "storageKey": null
         }
       ],
@@ -340,6 +348,6 @@ return {
 };
 })();
 
-(node as any).hash = "dad6c9804912c1d31142ea5de0358588";
+(node as any).hash = "c224dda436b4f73fca88cbeed8d625f6";
 
 export default node;

--- a/src/__generated__/artistRoutes_ArtistAppQuery.graphql.ts
+++ b/src/__generated__/artistRoutes_ArtistAppQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c6c666348ebdc99f234e20fcc729e287>>
+ * @generated SignedSource<<939befd39ee1fb4e042605e465650202>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -371,6 +371,13 @@ return {
                 "kind": "ScalarField",
                 "name": "text",
                 "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "credit",
+                "storageKey": null
               }
             ],
             "storageKey": "biographyBlurb(format:\"HTML\")"
@@ -513,12 +520,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "fca9062ad29b9a4932d3ea8558cdfd87",
+    "cacheID": "9ad9a55afd82ff64a030c796a32669bf",
     "id": null,
     "metadata": {},
     "name": "artistRoutes_ArtistAppQuery",
     "operationKind": "query",
-    "text": "query artistRoutes_ArtistAppQuery(\n  $artistID: String!\n) @cacheable {\n  artist(id: $artistID) @principalField {\n    ...ArtistApp_artist\n    id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  internalID\n  slug\n  name\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n  biographyBlurb(format: HTML) {\n    text\n  }\n  insights {\n    kind\n    ...ArtistCareerHighlight_insight\n  }\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          src1x: cropped(width: 30, height: 30) {\n            src\n          }\n          src2x: cropped(width: 60, height: 60) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n  coverArtwork {\n    title\n    imageTitle\n    href\n    image {\n      src: url(version: [\"larger\", \"larger\"])\n      width\n      height\n    }\n    id\n  }\n}\n\nfragment ArtistMeta_artist on Artist {\n  ...ArtistStructuredData_artist\n  slug\n  name\n  nationality\n  birthday\n  deathday\n  href\n  isInSeoExperiment\n  meta(page: ABOUT) {\n    description\n    title\n  }\n  alternateNames\n  coverArtwork {\n    image {\n      large: url(version: \"large\")\n    }\n    id\n  }\n}\n\nfragment ArtistStructuredData_artist on Artist {\n  slug\n  name\n  birthday\n  deathday\n  gender\n  nationality\n  href\n  meta(page: ABOUT) {\n    title\n    description\n  }\n  coverArtwork {\n    image {\n      url(version: \"large\")\n    }\n    id\n  }\n  partnersConnection(first: 10) {\n    edges {\n      node {\n        href\n        id\n      }\n      id\n    }\n  }\n}\n"
+    "text": "query artistRoutes_ArtistAppQuery(\n  $artistID: String!\n) @cacheable {\n  artist(id: $artistID) @principalField {\n    ...ArtistApp_artist\n    id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  internalID\n  slug\n  name\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  insights {\n    kind\n    ...ArtistCareerHighlight_insight\n  }\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          src1x: cropped(width: 30, height: 30) {\n            src\n          }\n          src2x: cropped(width: 60, height: 60) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n  coverArtwork {\n    title\n    imageTitle\n    href\n    image {\n      src: url(version: [\"larger\", \"larger\"])\n      width\n      height\n    }\n    id\n  }\n}\n\nfragment ArtistMeta_artist on Artist {\n  ...ArtistStructuredData_artist\n  slug\n  name\n  nationality\n  birthday\n  deathday\n  href\n  isInSeoExperiment\n  meta(page: ABOUT) {\n    description\n    title\n  }\n  alternateNames\n  coverArtwork {\n    image {\n      large: url(version: \"large\")\n    }\n    id\n  }\n}\n\nfragment ArtistStructuredData_artist on Artist {\n  slug\n  name\n  birthday\n  deathday\n  gender\n  nationality\n  href\n  meta(page: ABOUT) {\n    title\n    description\n  }\n  coverArtwork {\n    image {\n      url(version: \"large\")\n    }\n    id\n  }\n  partnersConnection(first: 10) {\n    edges {\n      node {\n        href\n        id\n      }\n      id\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
This PR updates the artist bio display logic to handle a separate bio text and credit. I had previously joined these together in Metaphysics so that only `biographyBlurb.text` needed to be queried, but that negatively impacted the artist bio edit form in Volt - the credit text was appearing there as well!

cc: @artsy/diamond-devs 