### PR TITLE
feat: add max image preview tag to articles

### DIFF
--- a/src/Apps/Article/Components/ArticleMetaTags.tsx
+++ b/src/Apps/Article/Components/ArticleMetaTags.tsx
@@ -38,6 +38,8 @@ const ArticleMetaTags: FC<React.PropsWithChildren<ArticleMetaTagsProps>> = ({
         property="article:publisher"
         content="https://www.facebook.com/artsy"
       />
+
+      <Meta name="robots" content="max-image-preview:large" />
     </>
   )
 }


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [DIA-1366]

### Description

This PR adds the `<meta name="robots" content="max-image-preview:large" />` tag to the Article pages.

![Screenshot 2025-07-08 at 9 51 27 AM](https://github.com/user-attachments/assets/18b013dc-16ba-4e0b-9e41-b288956dd7aa)

<!-- Implementation description -->

/cc @artsy/diamond-devs 
