### PR TITLE
feat(EMI-2537): Allow saving credit card when submitting an order

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/CheckoutContext/Order2CheckoutContext.tsx
+++ b/src/Apps/Order2/Routes/Checkout/CheckoutContext/Order2CheckoutContext.tsx
@@ -42,6 +42,7 @@ interface CheckoutState {
   steps: CheckoutStep[]
   activeFulfillmentDetailsTab: FulfillmentDetailsTab | null
   confirmationToken: any
+  saveCreditCard: boolean
   checkoutMode: CheckoutMode
 }
 
@@ -59,7 +60,10 @@ interface CheckoutActions {
   editPayment: () => void
   setLoadingError: (error: CheckoutLoadingError | null) => void
   setLoadingComplete: () => void
-  setConfirmationToken: (args: { confirmationToken: any }) => void
+  setConfirmationToken: (args: {
+    confirmationToken: any
+    saveCreditCard: boolean
+  }) => void
   redirectToOrderDetails: () => void
   setCheckoutMode: (mode: CheckoutMode) => void
 }
@@ -318,10 +322,16 @@ const useBuildCheckoutContext = (
   )
 
   const setConfirmationToken = useCallback(
-    ({ confirmationToken }: { confirmationToken: any }) => {
+    ({
+      confirmationToken,
+      saveCreditCard,
+    }: {
+      confirmationToken: any
+      saveCreditCard: boolean
+    }) => {
       dispatch({
         type: "PAYMENT_COMPLETE",
-        payload: { confirmationToken: confirmationToken },
+        payload: { confirmationToken, saveCreditCard },
       })
     },
     [],
@@ -435,6 +445,7 @@ const initialStateForOrder = (
     expressCheckoutPaymentMethods: null,
     activeFulfillmentDetailsTab: null,
     confirmationToken: null,
+    saveCreditCard: true,
     steps,
     checkoutMode: savedCheckoutMode || "standard",
   }
@@ -470,7 +481,7 @@ type Action =
     }
   | {
       type: "PAYMENT_COMPLETE"
-      payload: { confirmationToken: any }
+      payload: { confirmationToken: any; saveCreditCard: boolean }
     }
   | {
       type: "SET_ACTIVE_FULFILLMENT_DETAILS_TAB"
@@ -664,6 +675,7 @@ const reducer = (state: CheckoutState, action: Action): CheckoutState => {
       return {
         ...state,
         confirmationToken: action.payload.confirmationToken,
+        saveCreditCard: action.payload.saveCreditCard,
         steps: newSteps,
       }
     case "SET_EXPRESS_CHECKOUT_SUBMITTING":

--- a/src/Apps/Order2/Routes/Checkout/Components/Order2ReviewStep.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2ReviewStep.tsx
@@ -33,8 +33,13 @@ const Order2ReviewStepComponent: React.FC<Order2ReviewStepProps> = ({
 }) => {
   const orderData = useFragment(FRAGMENT, order)
   const submitOrderMutation = useSubmitOrderMutation()
-  const { steps, confirmationToken, redirectToOrderDetails, checkoutTracking } =
-    useCheckoutContext()
+  const {
+    steps,
+    confirmationToken,
+    saveCreditCard,
+    redirectToOrderDetails,
+    checkoutTracking,
+  } = useCheckoutContext()
 
   const artworkData = extractLineItemMetadata(orderData.lineItems[0]!)
 
@@ -71,6 +76,7 @@ const Order2ReviewStepComponent: React.FC<Order2ReviewStepProps> = ({
           input: {
             id: orderData.internalID,
             confirmationToken: confirmationToken.id,
+            oneTimeUse: !saveCreditCard,
           },
         },
       })

--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
@@ -1,7 +1,15 @@
 import { ContextModule } from "@artsy/cohesion"
 import LockIcon from "@artsy/icons/LockIcon"
 import ReceiptIcon from "@artsy/icons/ReceiptIcon"
-import { Box, Button, Flex, Spacer, Text, useTheme } from "@artsy/palette"
+import {
+  Box,
+  Button,
+  Checkbox,
+  Flex,
+  Spacer,
+  Text,
+  useTheme,
+} from "@artsy/palette"
 import {
   Elements,
   PaymentElement,
@@ -121,6 +129,7 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({ order }) => {
   const [selectedPaymentMethod, setSelectedPaymentMethod] = useState<
     null | "saved" | "stripe-card" | "wire" | "stripe-other"
   >(null)
+  const [saveCreditCard, setSaveCreditCard] = useState(true)
 
   const isSelectedPaymentMethodStripe = selectedPaymentMethod?.match(/^stripe/)
 
@@ -271,6 +280,7 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({ order }) => {
           id: confirmationToken.id,
           ...response?.me?.confirmationToken,
         },
+        saveCreditCard,
       })
     }
 
@@ -376,6 +386,15 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({ order }) => {
           </Collapse>
         </Box>
       </FadeInBox>
+
+      <Collapse open={selectedPaymentMethod === "stripe-card"}>
+        <Box p={2}>
+          <Checkbox selected={saveCreditCard} onSelect={setSaveCreditCard}>
+            Save credit card for later use
+          </Checkbox>
+        </Box>
+      </Collapse>
+
       <Spacer y={2} />
       {/* Stripe error messages are displayed within the Payment Element, so we don't need to handle them here. */}
       {errorMessage && !isSelectedPaymentMethodStripe && (


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2537]

### Description

> [!warning]
> This PR requires artsy/metaphysics#6902 to be merged first

This PR allows saving a credit card when submitting an order

### Videos

| One Time Use | Save Credit Card |
|---|---|
| <video src="https://github.com/user-attachments/assets/8a601d12-81fa-4853-b577-53a631e163b7" /> | <video src="https://github.com/user-attachments/assets/75a49d2e-f9dd-4849-991c-79a8fce2e8b4" /> |

<!-- Implementation description -->


[EMI-2537]: https://artsyproduct.atlassian.net/browse/EMI-2537?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ