### PR TITLE
fix: use caption only for default artwork image

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkLightbox.tsx
+++ b/src/Apps/Artwork/Components/ArtworkLightbox.tsx
@@ -38,10 +38,6 @@ const ArtworkLightbox: React.FC<
 
   const isArtworkCaptionEnabled = useFlag("diamond_artwork-captions")
 
-  const artworkCaption = isArtworkCaptionEnabled
-    ? (artwork.caption ?? artwork.formattedMetadata)
-    : artwork.formattedMetadata
-
   const resizedLocalImage = localImage && {
     src: localImage.data,
     srcSet: undefined,
@@ -58,6 +54,11 @@ const ArtworkLightbox: React.FC<
     resized,
     mobileLightboxSource,
   } = images[activeIndex]
+
+  const artworkCaption =
+    isArtworkCaptionEnabled && isDefault
+      ? (artwork.caption ?? artwork.formattedMetadata)
+      : artwork.formattedMetadata
 
   const image = resizedLocalImage ?? (hasGeometry ? resized : fallback)
 


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

### Description
This PR enables generated caption only for default images.
<!-- Implementation description -->
