### PR TITLE
fix(DIA-1407): artist bio credit on artwork pages

### DIFF
--- a/src/Apps/Artwork/Components/ArtistInfo.tsx
+++ b/src/Apps/Artwork/Components/ArtistInfo.tsx
@@ -142,7 +142,7 @@ export const ArtistInfoFragmentContainer = createFragmentContainer(ArtistInfo, {
       ...ArtistMarketInsights_artist
       # The below data is only used to determine whether a section
       # should be rendered
-      biographyBlurb: biographyBlurb(format: HTML, partnerBio: false) {
+      biographyBlurb: biographyBlurb(format: HTML) {
         text
       }
     }

--- a/src/Components/ArtistBio.tsx
+++ b/src/Components/ArtistBio.tsx
@@ -1,9 +1,7 @@
-import { HTML, Text } from "@artsy/palette"
-import { RouterLink } from "System/Components/RouterLink"
+import { HTML } from "@artsy/palette"
 import type { ArtistBio_bio$data } from "__generated__/ArtistBio_bio.graphql"
 import type * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
-import { data as sd } from "sharify"
 
 export interface ArtistBioProps {
   bio: ArtistBio_bio$data
@@ -14,17 +12,16 @@ export interface ArtistBioProps {
 export const ArtistBio: React.FC<React.PropsWithChildren<ArtistBioProps>> = ({
   bio,
 }) => {
-  const { credit, partnerID, text } = bio.biographyBlurb ?? {}
-  const partnerHref = `${sd.APP_URL}/${partnerID}`
+  const { credit, text } = bio.biographyBlurb ?? {}
 
   return (
     <>
       {!!credit && (
-        <Text mb={1} variant="sm">
-          <RouterLink to={partnerHref}>{credit}</RouterLink>
-        </Text>
+        <>
+          <HTML variant="sm" html={credit} />
+          <br />
+        </>
       )}
-
       {text && <HTML variant="sm" html={text} />}
     </>
   )
@@ -33,9 +30,8 @@ export const ArtistBio: React.FC<React.PropsWithChildren<ArtistBioProps>> = ({
 export const ArtistBioFragmentContainer = createFragmentContainer(ArtistBio, {
   bio: graphql`
     fragment ArtistBio_bio on Artist {
-      biographyBlurb: biographyBlurb(format: HTML, partnerBio: false) {
+      biographyBlurb: biographyBlurb(format: HTML) {
         credit
-        partnerID
         text
       }
     }

--- a/src/Components/__tests__/ArtistBio.jest.enzyme.tsx
+++ b/src/Components/__tests__/ArtistBio.jest.enzyme.tsx
@@ -13,7 +13,6 @@ jest.unmock("react-relay")
 describe("ArtistBio", () => {
   const biographyBlurb = {
     credit: "",
-    partnerID: "",
     text: '<a href="hi">hello how are you</a>',
   }
 
@@ -50,11 +49,9 @@ describe("ArtistBio", () => {
 
   it("renders credit when available", async () => {
     biographyBlurb.credit = "Submitted by Great Gallery"
-    biographyBlurb.partnerID = "great-gallery"
 
     const wrapper = await getWrapper()
 
     expect(wrapper.html()).toContain("Submitted by Great Gallery")
-    expect(wrapper.html()).toContain("great-gallery")
   })
 })

--- a/src/__generated__/ArtistBioTestQuery.graphql.ts
+++ b/src/__generated__/ArtistBioTestQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9fda4504b6239f14dcbc93331210af77>>
+ * @generated SignedSource<<581a9476ab7fd016b9f24518c0d9b24d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -20,7 +20,6 @@ export type ArtistBioTestQuery$rawResponse = {
   readonly bio: {
     readonly biographyBlurb: {
       readonly credit: string | null | undefined;
-      readonly partnerID: string | null | undefined;
       readonly text: string | null | undefined;
     } | null | undefined;
     readonly id: string;
@@ -94,11 +93,6 @@ return {
                 "kind": "Literal",
                 "name": "format",
                 "value": "HTML"
-              },
-              {
-                "kind": "Literal",
-                "name": "partnerBio",
-                "value": false
               }
             ],
             "concreteType": "ArtistBlurb",
@@ -117,18 +111,11 @@ return {
                 "alias": null,
                 "args": null,
                 "kind": "ScalarField",
-                "name": "partnerID",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
                 "name": "text",
                 "storageKey": null
               }
             ],
-            "storageKey": "biographyBlurb(format:\"HTML\",partnerBio:false)"
+            "storageKey": "biographyBlurb(format:\"HTML\")"
           },
           {
             "alias": null,
@@ -143,7 +130,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "05ebe8eb11518db5711bac9b45daaf90",
+    "cacheID": "2c5040c3686825f3044089c983f0cc4a",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -160,7 +147,6 @@ return {
           "type": "ArtistBlurb"
         },
         "bio.biographyBlurb.credit": (v1/*: any*/),
-        "bio.biographyBlurb.partnerID": (v1/*: any*/),
         "bio.biographyBlurb.text": (v1/*: any*/),
         "bio.id": {
           "enumValues": null,
@@ -172,7 +158,7 @@ return {
     },
     "name": "ArtistBioTestQuery",
     "operationKind": "query",
-    "text": "query ArtistBioTestQuery {\n  bio: artist(id: \"unused\") {\n    ...ArtistBio_bio\n    id\n  }\n}\n\nfragment ArtistBio_bio on Artist {\n  biographyBlurb(format: HTML, partnerBio: false) {\n    credit\n    partnerID\n    text\n  }\n}\n"
+    "text": "query ArtistBioTestQuery {\n  bio: artist(id: \"unused\") {\n    ...ArtistBio_bio\n    id\n  }\n}\n\nfragment ArtistBio_bio on Artist {\n  biographyBlurb(format: HTML) {\n    credit\n    text\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistBio_bio.graphql.ts
+++ b/src/__generated__/ArtistBio_bio.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b3ec9c13c69f543ab194c8222f67fd48>>
+ * @generated SignedSource<<866720d929493d835c3bc2b0992a6ff2>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -13,7 +13,6 @@ import { FragmentRefs } from "relay-runtime";
 export type ArtistBio_bio$data = {
   readonly biographyBlurb: {
     readonly credit: string | null | undefined;
-    readonly partnerID: string | null | undefined;
     readonly text: string | null | undefined;
   } | null | undefined;
   readonly " $fragmentType": "ArtistBio_bio";
@@ -36,11 +35,6 @@ const node: ReaderFragment = {
           "kind": "Literal",
           "name": "format",
           "value": "HTML"
-        },
-        {
-          "kind": "Literal",
-          "name": "partnerBio",
-          "value": false
         }
       ],
       "concreteType": "ArtistBlurb",
@@ -59,24 +53,17 @@ const node: ReaderFragment = {
           "alias": null,
           "args": null,
           "kind": "ScalarField",
-          "name": "partnerID",
-          "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
           "name": "text",
           "storageKey": null
         }
       ],
-      "storageKey": "biographyBlurb(format:\"HTML\",partnerBio:false)"
+      "storageKey": "biographyBlurb(format:\"HTML\")"
     }
   ],
   "type": "Artist",
   "abstractKey": null
 };
 
-(node as any).hash = "ed3e96658bfe75ed22574c19e19d0634";
+(node as any).hash = "a48596ee5a5f7462c8f8da2ac41272c3";
 
 export default node;

--- a/src/__generated__/ArtistInfoQuery.graphql.ts
+++ b/src/__generated__/ArtistInfoQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<9b2746d64b01e14a4411792e3119b06f>>
+ * @generated SignedSource<<c96cb99821594f4077059ef954c8cd9b>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -544,11 +544,6 @@ return {
                 "kind": "Literal",
                 "name": "format",
                 "value": "HTML"
-              },
-              {
-                "kind": "Literal",
-                "name": "partnerBio",
-                "value": false
               }
             ],
             "concreteType": "ArtistBlurb",
@@ -567,18 +562,11 @@ return {
                 "alias": null,
                 "args": null,
                 "kind": "ScalarField",
-                "name": "partnerID",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
                 "name": "text",
                 "storageKey": null
               }
             ],
-            "storageKey": "biographyBlurb(format:\"HTML\",partnerBio:false)"
+            "storageKey": "biographyBlurb(format:\"HTML\")"
           },
           (v5/*: any*/)
         ],
@@ -587,12 +575,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "2458af69bfe04c0f60db3c10763c76bb",
+    "cacheID": "80b6edb2213eb120891354617ef84042",
     "id": null,
     "metadata": {},
     "name": "ArtistInfoQuery",
     "operationKind": "query",
-    "text": "query ArtistInfoQuery(\n  $slug: String!\n) {\n  artist(id: $slug) {\n    ...ArtistInfo_artist\n    id\n  }\n}\n\nfragment ArtistBio_bio on Artist {\n  biographyBlurb(format: HTML, partnerBio: false) {\n    credit\n    partnerID\n    text\n  }\n}\n\nfragment ArtistInfo_artist on Artist {\n  ...EntityHeaderArtist_artist\n  internalID\n  slug\n  image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n  counts {\n    partnerShows\n  }\n  exhibitionHighlights(size: 3) {\n    ...SelectedExhibitions_exhibitions\n    id\n  }\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          __typename\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        __typename\n        id\n      }\n    }\n  }\n  ...ArtistBio_bio\n  ...ArtistMarketInsights_artist\n  biographyBlurb(format: HTML, partnerBio: false) {\n    text\n  }\n}\n\nfragment ArtistMarketInsights_artist on Artist {\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0.0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  coverArtwork {\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment SelectedExhibitions_exhibitions on Show {\n  partner {\n    __typename\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  name\n  start_at: startAt(format: \"YYYY\")\n  cover_image: coverImage {\n    cropped(width: 800, height: 600) {\n      url\n    }\n  }\n  city\n}\n"
+    "text": "query ArtistInfoQuery(\n  $slug: String!\n) {\n  artist(id: $slug) {\n    ...ArtistInfo_artist\n    id\n  }\n}\n\nfragment ArtistBio_bio on Artist {\n  biographyBlurb(format: HTML) {\n    credit\n    text\n  }\n}\n\nfragment ArtistInfo_artist on Artist {\n  ...EntityHeaderArtist_artist\n  internalID\n  slug\n  image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n  counts {\n    partnerShows\n  }\n  exhibitionHighlights(size: 3) {\n    ...SelectedExhibitions_exhibitions\n    id\n  }\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          __typename\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        __typename\n        id\n      }\n    }\n  }\n  ...ArtistBio_bio\n  ...ArtistMarketInsights_artist\n  biographyBlurb(format: HTML) {\n    text\n  }\n}\n\nfragment ArtistMarketInsights_artist on Artist {\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0.0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  coverArtwork {\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment SelectedExhibitions_exhibitions on Show {\n  partner {\n    __typename\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  name\n  start_at: startAt(format: \"YYYY\")\n  cover_image: coverImage {\n    cropped(width: 800, height: 600) {\n      url\n    }\n  }\n  city\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistInfo_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistInfo_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<feeb4ca3f67f1d2590d6049d6246e423>>
+ * @generated SignedSource<<d6028bf410c4b259d57c99a90f7a8779>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -571,11 +571,6 @@ return {
                 "kind": "Literal",
                 "name": "format",
                 "value": "HTML"
-              },
-              {
-                "kind": "Literal",
-                "name": "partnerBio",
-                "value": false
               }
             ],
             "concreteType": "ArtistBlurb",
@@ -594,18 +589,11 @@ return {
                 "alias": null,
                 "args": null,
                 "kind": "ScalarField",
-                "name": "partnerID",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
                 "name": "text",
                 "storageKey": null
               }
             ],
-            "storageKey": "biographyBlurb(format:\"HTML\",partnerBio:false)"
+            "storageKey": "biographyBlurb(format:\"HTML\")"
           },
           (v4/*: any*/)
         ],
@@ -614,7 +602,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "1a17b8aaf02986dfb1b6c636db0f21df",
+    "cacheID": "2adc91f08f153a9f7a4c65a2c6ef9983",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -660,7 +648,6 @@ return {
           "type": "ArtistBlurb"
         },
         "artist.biographyBlurb.credit": (v9/*: any*/),
-        "artist.biographyBlurb.partnerID": (v9/*: any*/),
         "artist.biographyBlurb.text": (v9/*: any*/),
         "artist.collections": {
           "enumValues": null,
@@ -761,7 +748,7 @@ return {
     },
     "name": "ArtistInfo_Test_Query",
     "operationKind": "query",
-    "text": "query ArtistInfo_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistInfo_artist\n    id\n  }\n}\n\nfragment ArtistBio_bio on Artist {\n  biographyBlurb(format: HTML, partnerBio: false) {\n    credit\n    partnerID\n    text\n  }\n}\n\nfragment ArtistInfo_artist on Artist {\n  ...EntityHeaderArtist_artist\n  internalID\n  slug\n  image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n  counts {\n    partnerShows\n  }\n  exhibitionHighlights(size: 3) {\n    ...SelectedExhibitions_exhibitions\n    id\n  }\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          __typename\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        __typename\n        id\n      }\n    }\n  }\n  ...ArtistBio_bio\n  ...ArtistMarketInsights_artist\n  biographyBlurb(format: HTML, partnerBio: false) {\n    text\n  }\n}\n\nfragment ArtistMarketInsights_artist on Artist {\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0.0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  coverArtwork {\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment SelectedExhibitions_exhibitions on Show {\n  partner {\n    __typename\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  name\n  start_at: startAt(format: \"YYYY\")\n  cover_image: coverImage {\n    cropped(width: 800, height: 600) {\n      url\n    }\n  }\n  city\n}\n"
+    "text": "query ArtistInfo_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistInfo_artist\n    id\n  }\n}\n\nfragment ArtistBio_bio on Artist {\n  biographyBlurb(format: HTML) {\n    credit\n    text\n  }\n}\n\nfragment ArtistInfo_artist on Artist {\n  ...EntityHeaderArtist_artist\n  internalID\n  slug\n  image {\n    cropped(width: 45, height: 45) {\n      src\n      srcSet\n    }\n  }\n  counts {\n    partnerShows\n  }\n  exhibitionHighlights(size: 3) {\n    ...SelectedExhibitions_exhibitions\n    id\n  }\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          __typename\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        __typename\n        id\n      }\n    }\n  }\n  ...ArtistBio_bio\n  ...ArtistMarketInsights_artist\n  biographyBlurb(format: HTML) {\n    text\n  }\n}\n\nfragment ArtistMarketInsights_artist on Artist {\n  collections\n  highlights {\n    partnersConnection(first: 10, displayOnPartnerProfile: true, representedBy: true, partnerCategory: [\"blue-chip\", \"top-established\", \"top-emerging\"]) {\n      edges {\n        node {\n          categories {\n            slug\n            id\n          }\n          id\n        }\n        id\n      }\n    }\n  }\n  auctionResultsConnection(recordsTrusted: true, first: 1, sort: PRICE_AND_DATE_DESC) {\n    edges {\n      node {\n        price_realized: priceRealized {\n          display(format: \"0.0a\")\n        }\n        organization\n        sale_date: saleDate(format: \"YYYY\")\n        id\n      }\n    }\n  }\n}\n\nfragment EntityHeaderArtist_artist on Artist {\n  internalID\n  href\n  slug\n  name\n  initials\n  formattedNationalityAndBirthday\n  counts {\n    artworks\n    forSaleArtworks\n  }\n  coverArtwork {\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment SelectedExhibitions_exhibitions on Show {\n  partner {\n    __typename\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  name\n  start_at: startAt(format: \"YYYY\")\n  cover_image: coverImage {\n    cropped(width: 800, height: 600) {\n      url\n    }\n  }\n  city\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistInfo_artist.graphql.ts
+++ b/src/__generated__/ArtistInfo_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1a56efe9512a6510c19e141294babb94>>
+ * @generated SignedSource<<57d967b8b074c19f98168b9d2c212953>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -321,11 +321,6 @@ return {
           "kind": "Literal",
           "name": "format",
           "value": "HTML"
-        },
-        {
-          "kind": "Literal",
-          "name": "partnerBio",
-          "value": false
         }
       ],
       "concreteType": "ArtistBlurb",
@@ -341,7 +336,7 @@ return {
           "storageKey": null
         }
       ],
-      "storageKey": "biographyBlurb(format:\"HTML\",partnerBio:false)"
+      "storageKey": "biographyBlurb(format:\"HTML\")"
     }
   ],
   "type": "Artist",
@@ -349,6 +344,6 @@ return {
 };
 })();
 
-(node as any).hash = "5d066e98bb28abd4606a54b1ce1e52be";
+(node as any).hash = "e42561b7ef84c53e800ff09f5b23a720";
 
 export default node;


### PR DESCRIPTION
This PR fixes a bug where the credit for an artist bio was appearing as ugly HTML. This is the result of me changing the `biographyBlurb.credit` field to follow the same formatting as the `biographyBlurb.text` field so that we could embed a link to the partner page in it. 

| Before | After |
|--------|------|
| <img width="1113" height="489" alt="Screenshot 2025-07-10 at 2 43 51 PM" src="https://github.com/user-attachments/assets/a34e5c6d-2689-4991-8bfa-3d740b5bf52f" /> | <img width="1109" height="507" alt="Screenshot 2025-07-10 at 2 44 04 PM" src="https://github.com/user-attachments/assets/edb84fd1-ba83-46bb-aaae-e0b0bd166103" /> |

cc: @artsy/diamond-devs 