### PR TITLE
fix: national gallery of art, washington, and d.c.

### DIFF
--- a/src/Apps/Artist/Routes/Overview/Components/ArtistCareerHighlight.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtistCareerHighlight.tsx
@@ -25,9 +25,7 @@ export const ArtistCareerHighlight: FC<
               },
             }
           : {
-              children: insight.entities
-                .join(", ")
-                .replace(/,\s([^,]+)$/, ", and $1"),
+              children: formatList(insight.entities),
             })}
       />
     </Expandable>
@@ -46,6 +44,15 @@ export const ArtistCareerHighlightFragmentContainer = createFragmentContainer(
     `,
   },
 )
+
+const formatList = (entities: readonly string[]) => {
+  if (entities.length === 0) return ""
+  if (entities.length === 1) return entities[0]
+  if (entities.length === 2) return entities.join(" and ")
+  return (
+    entities.slice(0, -1).join(", ") + ", and " + entities[entities.length - 1]
+  )
+}
 
 // remove paragraph margins from markdown
 const Description = styled(Text)`

--- a/src/Apps/Artist/Routes/Overview/Components/__tests__/ArtistCareerHighlights.jest.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/__tests__/ArtistCareerHighlights.jest.tsx
@@ -55,6 +55,30 @@ describe("ArtistCareerHighlights", () => {
     expect(screen.getByText("View CV")).toBeInTheDocument()
   })
 
+  it("renders one Career Highlight with commas correctly", () => {
+    renderWithRelay({
+      Artist: () => ({
+        insights: [
+          {
+            label: "Solo show at a major institution",
+            entities: ["National Gallery of Art, Washington, D.C."],
+            kind: "SOLO_SHOW",
+            description: null,
+          },
+        ],
+        name: "Test Artist",
+        slug: "test-artist",
+      }),
+    })
+
+    const button = screen.getByRole("button")
+    fireEvent.click(button)
+
+    expect(
+      screen.getByText("National Gallery of Art, Washington, D.C."),
+    ).toBeInTheDocument()
+  })
+
   it("renders multiple Career Highlights correctly", () => {
     renderWithRelay({
       Artist: () => ({
@@ -78,8 +102,38 @@ describe("ArtistCareerHighlights", () => {
     expect(
       screen.getByText("Solo show at 2 major institutions"),
     ).toBeInTheDocument()
-    expect(screen.getByText("Foo Museum, and Bar Museum")).toBeInTheDocument()
+    expect(screen.getByText("Foo Museum and Bar Museum")).toBeInTheDocument()
     expect(screen.getByText("View CV")).toBeInTheDocument()
+  })
+
+  it("renders multiple Career Highlights with commas correctly", () => {
+    renderWithRelay({
+      Artist: () => ({
+        insights: [
+          {
+            label: "Solo show at major institutions",
+            entities: [
+              "Tate Modern",
+              "Museum of Modern Art, New York",
+              "National Gallery of Art, Washington, D.C.",
+            ],
+            kind: "SOLO_SHOW",
+            description: null,
+          },
+        ],
+        name: "Test Artist",
+        slug: "test-artist",
+      }),
+    })
+
+    const button = screen.getByRole("button")
+    fireEvent.click(button)
+
+    expect(
+      screen.getByText(
+        "Tate Modern, Museum of Modern Art, New York, and National Gallery of Art, Washington, D.C.",
+      ),
+    ).toBeInTheDocument()
   })
 
   it("does not render if there are no Career Highlights", () => {


### PR DESCRIPTION
This PR fixes a bug that was reported in the artist career highlights where "National Gallery of Art, Washington, D.C." was being formatted as "National Gallery of Art, Washington, and D.C." when it was the last item in the list of collecting institutions.

This was happening because in order to render a list of institutions, the template was concatenating the institution names separated by a comma, and replacing the last comma with `", and"`. When the National Gallery of Art in Washington, D.C. was the last (or only) institution in that list, it would incorrectly identify "D.C." as the last institution.

The solution was to replace the last comma with `", and"` outside of the concatenation.

| Before | After |
| --------|------|
| <img width="1151" height="684" alt="Screenshot 2025-07-15 at 11 31 30 AM" src="https://github.com/user-attachments/assets/02033151-edbe-4a37-9087-db4448aa8390" /> | <img width="1151" height="684" alt="Screenshot 2025-07-15 at 11 31 21 AM" src="https://github.com/user-attachments/assets/82a09c20-ca34-4e74-a045-8eaf0e4575c6" /> |



cc: @artsy/diamond-devs 