### PR TITLE
feat(EMI-2539): Buyer can pay with a saved credit card

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/CheckoutContext/Order2CheckoutContext.tsx
+++ b/src/Apps/Order2/Routes/Checkout/CheckoutContext/Order2CheckoutContext.tsx
@@ -43,6 +43,7 @@ interface CheckoutState {
   activeFulfillmentDetailsTab: FulfillmentDetailsTab | null
   confirmationToken: any
   saveCreditCard: boolean
+  savedCreditCard: any
   checkoutMode: CheckoutMode
 }
 
@@ -74,6 +75,7 @@ interface CheckoutActions {
     confirmationToken: any
     saveCreditCard: boolean
   }) => void
+  setSavedCreditCard: (args: { savedCreditCard: any }) => void
   redirectToOrderDetails: () => void
   setCheckoutMode: (mode: CheckoutMode) => void
 }
@@ -348,6 +350,20 @@ const useBuildCheckoutContext = (
     [],
   )
 
+  const setSavedCreditCard = useCallback(
+    ({ savedCreditCard }: { savedCreditCard: any }) => {
+      dispatch({
+        type: "PAYMENT_COMPLETE",
+        payload: {
+          savedCreditCard,
+          saveCreditCard: false,
+          confirmationToken: null,
+        },
+      })
+    },
+    [],
+  )
+
   const editFulfillmentDetails = useCallback(() => {
     dispatch({
       type: "EDIT_FULFILLMENT_DETAILS",
@@ -380,6 +396,7 @@ const useBuildCheckoutContext = (
       setLoadingError,
       setLoadingComplete,
       setConfirmationToken,
+      setSavedCreditCard,
       redirectToOrderDetails,
       setCheckoutMode,
     }
@@ -397,6 +414,11 @@ const useBuildCheckoutContext = (
     setExpressCheckoutSubmitting,
     setFulfillmentDetailsComplete,
     setLoadingComplete,
+    setConfirmationToken,
+    setSavedCreditCard,
+    setExpressCheckoutSubmitting,
+    redirectToOrderDetails,
+    setCheckoutMode,
     setLoadingError,
   ])
 
@@ -470,6 +492,7 @@ const initialStateForOrder = (
       ? { id: order.stripeConfirmationToken }
       : null,
     saveCreditCard: true,
+    savedCreditCard: null,
     steps,
     checkoutMode: savedCheckoutMode || "standard",
   }
@@ -508,7 +531,14 @@ type Action =
     }
   | {
       type: "PAYMENT_COMPLETE"
-      payload: { confirmationToken: any; saveCreditCard: boolean }
+      payload: {
+        confirmationToken: any
+        saveCreditCard: boolean
+        savedCreditCard?: any
+      }
+    }
+  | {
+      type: "EDIT_PAYMENT"
     }
   | {
       type: "EDIT_PAYMENT"
@@ -777,6 +807,7 @@ const reducer = (state: CheckoutState, action: Action): CheckoutState => {
         ...state,
         confirmationToken: action.payload.confirmationToken,
         saveCreditCard: action.payload.saveCreditCard,
+        savedCreditCard: action.payload.savedCreditCard,
         steps: newSteps,
       }
     case "SET_EXPRESS_CHECKOUT_SUBMITTING":

--- a/src/Apps/Order2/Routes/Checkout/CheckoutContext/Order2CheckoutContext.tsx
+++ b/src/Apps/Order2/Routes/Checkout/CheckoutContext/Order2CheckoutContext.tsx
@@ -388,6 +388,7 @@ const useBuildCheckoutContext = (
       editFulfillmentDetails,
       editDeliveryOption,
       editPayment,
+      redirectToOrderDetails,
       setActiveFulfillmentDetailsTab,
       setExpressCheckoutSubmitting,
       setExpressCheckoutLoaded,
@@ -396,9 +397,8 @@ const useBuildCheckoutContext = (
       setLoadingError,
       setLoadingComplete,
       setConfirmationToken,
-      setSavedCreditCard,
-      redirectToOrderDetails,
       setCheckoutMode,
+      setSavedCreditCard,
     }
   }, [
     checkoutTracking,
@@ -414,12 +414,8 @@ const useBuildCheckoutContext = (
     setExpressCheckoutSubmitting,
     setFulfillmentDetailsComplete,
     setLoadingComplete,
-    setConfirmationToken,
-    setSavedCreditCard,
-    setExpressCheckoutSubmitting,
-    redirectToOrderDetails,
-    setCheckoutMode,
     setLoadingError,
+    setSavedCreditCard,
   ])
 
   return {

--- a/src/Apps/Order2/Routes/Checkout/Components/Order2ReviewStep.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2ReviewStep.tsx
@@ -75,7 +75,7 @@ const Order2ReviewStepComponent: React.FC<Order2ReviewStepProps> = ({
         variables: {
           input: {
             id: orderData.internalID,
-            confirmationToken: confirmationToken.id,
+            confirmationToken: confirmationToken?.id,
             oneTimeUse: !saveCreditCard,
           },
         },

--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentCompletedView.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentCompletedView.tsx
@@ -5,10 +5,11 @@ import { type Brand, BrandCreditCardIcon } from "Components/BrandCreditCardIcon"
 
 interface Order2PaymentCompletedViewProps {
   confirmationToken: any
+  savedCreditCard: any
 }
 export const Order2PaymentCompletedView: React.FC<
   Order2PaymentCompletedViewProps
-> = ({ confirmationToken }) => {
+> = ({ confirmationToken, savedCreditCard }) => {
   const { editPayment, checkoutTracking } = useCheckoutContext()
 
   const onClickEdit = () => {
@@ -44,13 +45,16 @@ export const Order2PaymentCompletedView: React.FC<
         <BrandCreditCardIcon
           mr={1}
           type={
-            confirmationToken?.paymentMethodPreview?.card?.displayBrand as Brand
+            (confirmationToken?.paymentMethodPreview?.card?.displayBrand ||
+              savedCreditCard?.brand) as Brand
           }
           width="26px"
           height="26px"
         />
         <Text variant="sm-display">
-          •••• {confirmationToken?.paymentMethodPreview?.card?.last4}
+          ••••{" "}
+          {confirmationToken?.paymentMethodPreview?.card?.last4 ||
+            savedCreditCard?.lastDigits}
         </Text>
       </Flex>
     </Flex>

--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentStep.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentStep.tsx
@@ -18,7 +18,7 @@ export const Order2PaymentStep: React.FC<Order2PaymentStepProps> = ({
 }) => {
   const orderData = useFragment(FRAGMENT, order)
 
-  const { confirmationToken, steps } = useCheckoutContext()
+  const { confirmationToken, savedCreditCard, steps } = useCheckoutContext()
 
   const stepState = steps?.find(
     step => step.name === CheckoutStepName.PAYMENT,
@@ -46,7 +46,10 @@ export const Order2PaymentStep: React.FC<Order2PaymentStepProps> = ({
         px={[2, 4]}
         hidden={stepState !== CheckoutStepState.COMPLETED}
       >
-        <Order2PaymentCompletedView confirmationToken={confirmationToken} />
+        <Order2PaymentCompletedView
+          savedCreditCard={savedCreditCard}
+          confirmationToken={confirmationToken}
+        />
       </Box>
 
       <Box py={2} px={[2, 4]} hidden={stepState !== CheckoutStepState.ACTIVE}>

--- a/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
@@ -481,6 +481,19 @@ describe("Order2CheckoutRoute", () => {
           })
         })
 
+        await act(async () => {
+          await waitFor(() => {
+            return mockResolveLastOperation({
+              Me: () => ({
+                creditCards: {
+                  edges: [],
+                },
+              }),
+            })
+          })
+          await flushPromiseQueue()
+        })
+
         // Run back-to-back mutations and verify they happened in the correct order
         await act(async () => {
           const setFulfilmentTypeOperation = await waitFor(() => {
@@ -806,6 +819,19 @@ describe("Checkout with flat-rate shipping", () => {
       "Phone number is required",
     ])
 
+    await act(async () => {
+      await waitFor(() => {
+        return mockResolveLastOperation({
+          Me: () => ({
+            creditCards: {
+              edges: [],
+            },
+          }),
+        })
+      })
+      await flushPromiseQueue()
+    })
+
     expect(env.mock.getAllOperations()).toHaveLength(0)
 
     const addressInputValue = {
@@ -1036,6 +1062,19 @@ describe("within the payment section", () => {
         Viewer: () => props,
       })
       await helpers.waitForLoadingComplete()
+
+      await act(async () => {
+        await waitFor(() => {
+          return mockResolveLastOperation({
+            Me: () => ({
+              creditCards: {
+                edges: [],
+              },
+            }),
+          })
+        })
+        await flushPromiseQueue()
+      })
 
       await waitFor(() => {
         act(() => {

--- a/src/__generated__/Order2PaymentFormSavedCreditCardsQuery.graphql.ts
+++ b/src/__generated__/Order2PaymentFormSavedCreditCardsQuery.graphql.ts
@@ -1,0 +1,195 @@
+/**
+ * @generated SignedSource<<a1bc154785f977c15aefe847a82bf9d7>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type Order2PaymentFormSavedCreditCardsQuery$variables = Record<PropertyKey, never>;
+export type Order2PaymentFormSavedCreditCardsQuery$data = {
+  readonly me: {
+    readonly creditCards: {
+      readonly edges: ReadonlyArray<{
+        readonly node: {
+          readonly brand: string;
+          readonly internalID: string;
+          readonly lastDigits: string;
+        } | null | undefined;
+      } | null | undefined> | null | undefined;
+    } | null | undefined;
+  } | null | undefined;
+};
+export type Order2PaymentFormSavedCreditCardsQuery = {
+  response: Order2PaymentFormSavedCreditCardsQuery$data;
+  variables: Order2PaymentFormSavedCreditCardsQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 10
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "brand",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "lastDigits",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "Order2PaymentFormSavedCreditCardsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": (v0/*: any*/),
+            "concreteType": "CreditCardConnection",
+            "kind": "LinkedField",
+            "name": "creditCards",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "CreditCardEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "CreditCard",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v1/*: any*/),
+                      (v2/*: any*/),
+                      (v3/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "creditCards(first:10)"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "Order2PaymentFormSavedCreditCardsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": (v0/*: any*/),
+            "concreteType": "CreditCardConnection",
+            "kind": "LinkedField",
+            "name": "creditCards",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "CreditCardEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "CreditCard",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v1/*: any*/),
+                      (v2/*: any*/),
+                      (v3/*: any*/),
+                      (v4/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "creditCards(first:10)"
+          },
+          (v4/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "9f4389b2b52e4634ee5adb8a5d8a64d2",
+    "id": null,
+    "metadata": {},
+    "name": "Order2PaymentFormSavedCreditCardsQuery",
+    "operationKind": "query",
+    "text": "query Order2PaymentFormSavedCreditCardsQuery {\n  me {\n    creditCards(first: 10) {\n      edges {\n        node {\n          internalID\n          brand\n          lastDigits\n          id\n        }\n      }\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "cc89884ca70e8694574ed2fb72ddf830";
+
+export default node;


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2539]

### Description

https://github.com/user-attachments/assets/6b788b89-967c-41a0-bdfe-c364a58e7245




- When a buyer has saved credit cards, the payment step includes saved payments at the top.
- The saved payments should be expanded by default.
- The saved credit cards are sorted by creation time in descending order.
- The first saved payment method should be selected.
- The buyer can submit the order with the selected credit card as the payment method.

https://artsyproduct.atlassian.net/browse/EMI-2539

@artsy/emerald-devs 

<!-- Implementation description -->


[EMI-2539]: https://artsyproduct.atlassian.net/browse/EMI-2539?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ