### PR TITLE
feat(EMI-2615): add Artsy as business name for payment element

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
@@ -148,6 +148,7 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({ order }) => {
       applePay: "never",
       googlePay: "never",
     },
+    business: { name: "Artsy" },
   }
 
   const onChange = (event: StripePaymentElementChangeEvent) => {


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2615]

### Description
Adds Artsy as the business name for the payment element

<!-- Implementation description -->
<img width="728" height="588" alt="Screenshot 2025-07-16 at 12 02 35 PM" src="https://github.com/user-attachments/assets/368873cb-62fc-422e-8a61-d0e04b2da5b6" />



[EMI-2615]: https://artsyproduct.atlassian.net/browse/EMI-2615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ