### PR TITLE
chore(EMI-2647): status to details

### DIFF
--- a/src/Apps/Conversations/components/ConversationCTA/ConversationReviewOfferCTA.tsx
+++ b/src/Apps/Conversations/components/ConversationCTA/ConversationReviewOfferCTA.tsx
@@ -134,7 +134,7 @@ const getProps = ({
         variant: "info",
         message: `Congratulations! ${offerType} Accepted`,
         subMessage: "Tap to view",
-        actionUrl: `/orders/${activeOrder.internalID}/status`,
+        actionUrl: `/orders/${activeOrder.internalID}/details`,
         Icon: MoneyFillIcon,
       }
     }
@@ -161,7 +161,7 @@ const getProps = ({
         variant: "info",
         message: "Offer Accepted",
         subMessage: "Tap to view",
-        actionUrl: `/orders/${activeOrder.internalID}/status`,
+        actionUrl: `/orders/${activeOrder.internalID}/details`,
         Icon: MoneyFillIcon,
       }
     }

--- a/src/Apps/Conversations/components/ConversationCTA/__tests__/ConversationReviewOfferCTA.jest.tsx
+++ b/src/Apps/Conversations/components/ConversationCTA/__tests__/ConversationReviewOfferCTA.jest.tsx
@@ -86,7 +86,7 @@ describe("ConversationReviewOfferCTA", () => {
     expect(screen.getByText("Tap to view")).toBeInTheDocument()
     expect(screen.getByTestId("orderActionLink")).toHaveAttribute(
       "href",
-      "/orders/orderID/status",
+      "/orders/orderID/details",
     )
   })
 
@@ -163,7 +163,7 @@ describe("ConversationReviewOfferCTA", () => {
 
     expect(screen.getByTestId("orderActionLink")).toHaveAttribute(
       "href",
-      "/orders/orderID/status",
+      "/orders/orderID/details",
     )
   })
 })

--- a/src/Apps/Conversations/components/Details/OrderInformation/ReviewOrderButton.tsx
+++ b/src/Apps/Conversations/components/Details/OrderInformation/ReviewOrderButton.tsx
@@ -1,7 +1,6 @@
 import { Button, type ButtonProps } from "@artsy/palette"
 import type { CounterOfferState } from "Apps/Conversations/components/Details/OrderState/ConversationOrderState"
 import { RouterLink } from "System/Components/RouterLink"
-import { useRouter } from "System/Hooks/useRouter"
 import type { ReviewOrderButton_order$key } from "__generated__/ReviewOrderButton_order.graphql"
 import { graphql, useFragment } from "react-relay"
 import { useTracking } from "react-tracking"
@@ -13,7 +12,6 @@ interface ReviewOrderButtonProps {
 export const ReviewOrderButton: React.FC<
   React.PropsWithChildren<ReviewOrderButtonProps>
 > = ({ order }) => {
-  const { match } = useRouter()
   const { trackEvent } = useTracking()
 
   const data = useFragment(
@@ -83,7 +81,7 @@ export const ReviewOrderButton: React.FC<
 
   return (
     <RouterLink
-      to={`/orders/${data.id}/status?backToConversationId=${match.params.conversationId}`}
+      to={`/orders/${data.id}/details`}
       enablePrefetch={false}
       onClick={() =>
         trackEvent({

--- a/src/Apps/Conversations/components/Details/OrderInformation/__tests__/ReviewOrderButton.jest.tsx
+++ b/src/Apps/Conversations/components/Details/OrderInformation/__tests__/ReviewOrderButton.jest.tsx
@@ -217,7 +217,7 @@ describe("ReviewOrderButton", () => {
 
     expect(screen.getByRole("link")).toHaveAttribute(
       "href",
-      "/orders/mocked-order-id/status?backToConversationId=conversation-id",
+      "/orders/mocked-order-id/details",
     )
   })
 })

--- a/src/Apps/Order/OrderApp.tsx
+++ b/src/Apps/Order/OrderApp.tsx
@@ -30,8 +30,8 @@ export interface OrderAppProps extends RouterState {
 }
 
 export const preventHardReload = event => {
-  // Don't block navigation for status page, as we've completed the flow
-  if (window.location.pathname.includes("/status")) {
+  // Don't block navigation for details page, as we've completed the flow
+  if (window.location.pathname.includes("/details")) {
     return false
   }
 

--- a/src/Apps/Order/Routes/Accept/index.tsx
+++ b/src/Apps/Order/Routes/Accept/index.tsx
@@ -127,7 +127,7 @@ export const Accept: FC<
       }
 
       if (!orderOrError?.error) {
-        router.push(`/orders/${order.internalID}/status`)
+        router.push(`/orders/${order.internalID}/details`)
         return
       }
 

--- a/src/Apps/Order/Routes/Counter/index.tsx
+++ b/src/Apps/Order/Routes/Counter/index.tsx
@@ -114,7 +114,7 @@ export const CounterRoute: FC<
       order_id: props.order.internalID,
     })
 
-    router.push(`/orders/${order.internalID}/status`)
+    router.push(`/orders/${order.internalID}/details`)
   }
 
   const onChangeResponse = () => {

--- a/src/Apps/Order/Routes/NewPayment/index.tsx
+++ b/src/Apps/Order/Routes/NewPayment/index.tsx
@@ -189,7 +189,7 @@ export const NewPaymentRoute: FC<
           }
         }
 
-        router.push(`/orders/${order.internalID}/status`)
+        router.push(`/orders/${order.internalID}/details`)
       }
     } catch (error) {
       logger.error(error)

--- a/src/Apps/Order/Routes/Reject/index.tsx
+++ b/src/Apps/Order/Routes/Reject/index.tsx
@@ -78,7 +78,7 @@ export const Reject: FC<React.PropsWithChildren<RejectProps>> = ({
         throw orderOrError.error
       }
 
-      router.push(`/orders/${order.internalID}/status`)
+      router.push(`/orders/${order.internalID}/details`)
     } catch (error) {
       logger.error(error)
       dialog.showErrorDialog()

--- a/src/Apps/Order/Routes/Review/index.tsx
+++ b/src/Apps/Order/Routes/Review/index.tsx
@@ -194,7 +194,7 @@ export const ReviewRoute: FC<React.PropsWithChildren<ReviewProps>> = props => {
               // We cannot expect Eigen to respond all the time to messages sent from the webview
               // a default fallback page is safer for old/broken Eigen versions
               setTimeout(() => {
-                router.push(`/orders/${order.internalID}/status`)
+                router.push(`/orders/${order.internalID}/details`)
               }, 500)
               return
             }
@@ -207,7 +207,7 @@ export const ReviewRoute: FC<React.PropsWithChildren<ReviewProps>> = props => {
           }
         }
 
-        // Eigen redirects to the status page for non-Offer orders (must keep
+        // Eigen redirects to the details page for non-Offer orders (must keep
         // the user inside the webview)
         // For in-review offers, we also want to override the default "go to
         // artwork page and display modal linking to conversation" behavior
@@ -219,18 +219,18 @@ export const ReviewRoute: FC<React.PropsWithChildren<ReviewProps>> = props => {
             orderOrError?.order?.state === "IN_REVIEW" &&
             order.source === "artwork_page")
         ) {
-          return router.push(`/orders/${orderId}/status`)
+          return router.push(`/orders/${orderId}/details`)
         }
         // Make offer and Purchase in inquiry redirects to the conversation page
         if (order.source === "inquiry") {
           return router.push(`/user/conversations/${conversationId}`)
         }
-        // Make offer from the artwork page redirects to the status page
+        // Make offer from the artwork page redirects to the details page
         if (order.mode === "OFFER") {
-          return router.push(`/orders/${orderId}/status`)
+          return router.push(`/orders/${orderId}/details`)
         }
-        // Purchase from the artwork page redirects to the status page
-        return router.push(`/orders/${orderId}/status`)
+        // Purchase from the artwork page redirects to the details page
+        return router.push(`/orders/${orderId}/details`)
       }
     } catch (error) {
       handleSubmitError(error)

--- a/src/Apps/Order/Routes/__tests__/Accept.jest.enzyme.tsx
+++ b/src/Apps/Order/Routes/__tests__/Accept.jest.enzyme.tsx
@@ -179,7 +179,7 @@ describe("Accept seller offer", () => {
       global.setInterval = realSetInterval
     })
 
-    it("routes to status page after mutation completes", async () => {
+    it("routes to details page after mutation completes", async () => {
       commitMutation.mockReturnValue(acceptOfferSuccess)
       const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
@@ -188,7 +188,7 @@ describe("Accept seller offer", () => {
 
       await page.clickSubmit()
       expect(pushMock).toHaveBeenCalledWith(
-        `/orders/${testOrder.internalID}/status`,
+        `/orders/${testOrder.internalID}/details`,
       )
     })
 

--- a/src/Apps/Order/Routes/__tests__/Counter.jest.enzyme.tsx
+++ b/src/Apps/Order/Routes/__tests__/Counter.jest.enzyme.tsx
@@ -170,7 +170,7 @@ describe("Submit Pending Counter Offer", () => {
       global.setInterval = realSetInterval
     })
 
-    it("routes to status page after mutation completes", async () => {
+    it("routes to details page after mutation completes", async () => {
       mockCommitMutation.mockResolvedValue(submitPendingOfferSuccess)
       const { wrapper } = getWrapper({
         CommerceOrder: () => commerceOrder,
@@ -179,7 +179,7 @@ describe("Submit Pending Counter Offer", () => {
 
       await page.clickSubmit()
       expect(pushMock).toHaveBeenCalledWith(
-        `/orders/${testOrder?.internalID}/status`,
+        `/orders/${testOrder?.internalID}/details`,
       )
     })
 

--- a/src/Apps/Order/Routes/__tests__/NewPayment.jest.enzyme.tsx
+++ b/src/Apps/Order/Routes/__tests__/NewPayment.jest.enzyme.tsx
@@ -172,13 +172,13 @@ describe("Payment", () => {
     )
   })
 
-  it("takes the user to the status page", async () => {
+  it("takes the user to the details page", async () => {
     mockCommitMutation.mockResolvedValue(fixFailedPaymentSuccess)
     const { wrapper } = getWrapper({ CommerceOrder: () => testOrder })
     const page = new OrderAppTestPage(wrapper)
     await page.clickSubmit()
 
-    expect(pushMock).toHaveBeenCalledWith("/orders/1234/status")
+    expect(pushMock).toHaveBeenCalledWith("/orders/1234/details")
   })
 
   it("does not do anything when there are form errors", async () => {

--- a/src/Apps/Order/Routes/__tests__/Reject.jest.enzyme.tsx
+++ b/src/Apps/Order/Routes/__tests__/Reject.jest.enzyme.tsx
@@ -137,7 +137,7 @@ describe("Buyer rejects seller offer", () => {
       global.setInterval = realSetInterval
     })
 
-    it("routes to status page after mutation completes", async () => {
+    it("routes to details page after mutation completes", async () => {
       mockCommitMutation.mockResolvedValue(rejectOfferSuccess)
       const { wrapper } = getWrapper({
         CommerceOrder: () => testOrder,
@@ -146,7 +146,7 @@ describe("Buyer rejects seller offer", () => {
 
       await page.clickSubmit()
       expect(pushMock).toHaveBeenCalledWith(
-        `/orders/${testOrder?.internalID}/status`,
+        `/orders/${testOrder?.internalID}/details`,
       )
     })
 

--- a/src/Apps/Order/Routes/__tests__/Review.jest.enzyme.enzyme.tsx
+++ b/src/Apps/Order/Routes/__tests__/Review.jest.enzyme.enzyme.tsx
@@ -144,7 +144,7 @@ describe("Review", () => {
       await page.clickSubmit()
 
       expect(mockCommitMutation).toHaveBeenCalledTimes(1)
-      expect(pushMock).toBeCalledWith("/orders/1234/status")
+      expect(pushMock).toBeCalledWith("/orders/1234/details")
     })
 
     it("disables the submit button when props.stripe is not present", () => {
@@ -547,7 +547,7 @@ describe("Review", () => {
 
         await waitFor(() =>
           expect(pushMock).toHaveBeenCalledWith(
-            "/orders/offer-order-id/status",
+            "/orders/offer-order-id/details",
           ),
         )
       })
@@ -771,7 +771,7 @@ describe("Review", () => {
         source: "artwork_page",
       }
 
-      it("routes to the status page", async () => {
+      it("routes to the details page", async () => {
         mockCommitMutation.mockResolvedValue(submitOfferOrderSuccessInReview)
         const { wrapper } = getWrapper({
           CommerceOrder: () => OfferOrderInReviewFromArtworkPage,
@@ -780,7 +780,7 @@ describe("Review", () => {
         await page.clickSubmit()
 
         expect(mockCommitMutation).toHaveBeenCalledTimes(1)
-        expect(pushMock).toBeCalledWith("/orders/offer-order-id/status")
+        expect(pushMock).toBeCalledWith("/orders/offer-order-id/details")
       })
     })
 
@@ -834,7 +834,7 @@ describe("Review", () => {
 
           await waitFor(() =>
             expect(pushMock).toHaveBeenCalledWith(
-              "/orders/offer-order-id/status",
+              "/orders/offer-order-id/details",
             ),
           )
         })
@@ -858,7 +858,7 @@ describe("Review", () => {
 
           await waitFor(() =>
             expect(pushMock).toHaveBeenCalledWith(
-              "/orders/offer-order-id/status",
+              "/orders/offer-order-id/details",
             ),
           )
         })

--- a/src/Apps/Order/__tests__/OrderApp.jest.enzyme.tsx
+++ b/src/Apps/Order/__tests__/OrderApp.jest.enzyme.tsx
@@ -189,7 +189,7 @@ describe("OrderApp routing redirects", () => {
     }
   })
 
-  it("redirects to the status route if the order is not pending", async () => {
+  it("redirects to the details route if the order is not pending", async () => {
     const res = await render(
       "/orders/2939023/shipping",
       mockResolver({
@@ -199,7 +199,7 @@ describe("OrderApp routing redirects", () => {
       }),
     )
 
-    expect(res.redirect.url).toBe("/orders/2939023/status")
+    expect(res.redirect.url).toBe("/orders/2939023/details")
   })
 
   it("redirects to the payment route if order is private sale", async () => {
@@ -364,7 +364,7 @@ describe("OrderApp routing redirects", () => {
         state: "APPROVED",
       }),
     )
-    expect(redirect.url).toBe("/orders/2939023/status")
+    expect(redirect.url).toBe("/orders/2939023/details")
   })
 
   it("stays on the review route if there are payment and shipping options set", async () => {
@@ -386,9 +386,9 @@ describe("OrderApp routing redirects", () => {
     }
   })
 
-  it("redirects from the status route to the review route if the order is pending", async () => {
+  it("redirects from the details route to the review route if the order is pending", async () => {
     const { redirect } = await render(
-      "/orders/2939023/status",
+      "/orders/2939023/details",
       mockResolver({
         ...UntouchedBuyOrder,
         creditCard: {
@@ -404,10 +404,10 @@ describe("OrderApp routing redirects", () => {
     expect(redirect.url).toBe("/orders/2939023/review")
   })
 
-  it("stays on the status page if the order is submitted", async () => {
+  it("stays on the details page if the order is submitted", async () => {
     try {
       await render(
-        "/orders/2939023/status",
+        "/orders/2939023/details",
         mockResolver({
           ...UntouchedBuyOrder,
           ...CreditCardPaymentDetails,
@@ -451,7 +451,7 @@ describe("OrderApp routing redirects", () => {
     expect(redirect.url).toBe("/orders/2939023/shipping")
   })
 
-  it("redirects from the offer route to the status route if the order is not pending", async () => {
+  it("redirects from the offer route to the details route if the order is not pending", async () => {
     const { redirect } = await render(
       "/orders/2939023/offer",
       mockResolver({
@@ -460,10 +460,10 @@ describe("OrderApp routing redirects", () => {
         state: "SUBMITTED",
       }),
     )
-    expect(redirect.url).toBe("/orders/2939023/status")
+    expect(redirect.url).toBe("/orders/2939023/details")
   })
 
-  it("redirects from the respond route to the status route if not offer order", async () => {
+  it("redirects from the respond route to the details route if not offer order", async () => {
     const { redirect } = await render(
       "/orders/2939023/respond",
       mockResolver({
@@ -472,10 +472,10 @@ describe("OrderApp routing redirects", () => {
         state: "SUBMITTED",
       }),
     )
-    expect(redirect.url).toBe("/orders/2939023/status")
+    expect(redirect.url).toBe("/orders/2939023/details")
   })
 
-  it("redirects from the respond route to the status route if order is not submitted", async () => {
+  it("redirects from the respond route to the details route if order is not submitted", async () => {
     const { redirect } = await render(
       "/orders/2939023/respond",
       mockResolver({
@@ -486,7 +486,7 @@ describe("OrderApp routing redirects", () => {
         displayState: "PENDING",
       }),
     )
-    expect(redirect.url).toBe("/orders/2939023/status")
+    expect(redirect.url).toBe("/orders/2939023/details")
   })
 
   it("redirects to the new payment route if lastTransactionFailed failed on offer and state is submitted", async () => {
@@ -519,9 +519,9 @@ describe("OrderApp routing redirects", () => {
     }
   })
 
-  it("Redirects from the status route to the respond route if awaiting buyer response", async () => {
+  it("Redirects from the details route to the respond route if awaiting buyer response", async () => {
     const { redirect } = await render(
-      "/orders/2939023/status",
+      "/orders/2939023/details",
       mockResolver({
         ...OfferOrderWithShippingDetails,
         awaitingResponseFrom: "BUYER",
@@ -561,8 +561,8 @@ describe("OrderApp routing redirects", () => {
         expect(error.message).toBe("No redirect found for order")
       }
     })
-    // goToStatusIfNotOfferOrder,
-    it("redirects to /status if not an offer order", async () => {
+    // goToDetailsIfNotOfferOrder,
+    it("redirects to /details if not an offer order", async () => {
       const { redirect } = await render(
         "/orders/2939023/review/counter",
         mockResolver({
@@ -570,10 +570,10 @@ describe("OrderApp routing redirects", () => {
           mode: "BUY",
         }),
       )
-      expect(redirect.url).toBe("/orders/2939023/status")
+      expect(redirect.url).toBe("/orders/2939023/details")
     })
-    // goToStatusIfNotAwaitingBuyerResponse,
-    it("redirects to /status if not awaiting a buyer response", async () => {
+    // goToDetailsIfNotAwaitingBuyerResponse,
+    it("redirects to /details if not awaiting a buyer response", async () => {
       const { redirect } = await render(
         "/orders/2939023/review/counter",
         mockResolver({
@@ -581,10 +581,10 @@ describe("OrderApp routing redirects", () => {
           awaitingResponseFrom: "SELLER",
         }),
       )
-      expect(redirect.url).toBe("/orders/2939023/status")
+      expect(redirect.url).toBe("/orders/2939023/details")
     })
-    // goToStatusIfOrderIsNotSubmitted,
-    it("redirects to /status if order is not submitted", async () => {
+    // goToDetailsIfOrderIsNotSubmitted,
+    it("redirects to /details if order is not submitted", async () => {
       const { redirect } = await render(
         "/orders/2939023/review/counter",
         mockResolver({
@@ -593,7 +593,7 @@ describe("OrderApp routing redirects", () => {
           displayState: "PENDING",
         }),
       )
-      expect(redirect.url).toBe("/orders/2939023/status")
+      expect(redirect.url).toBe("/orders/2939023/details")
     })
     // goToRespondIfMyLastOfferIsNotMostRecentOffer,
     it("redirects to /respond if myLastOffer is not more recent than lastOffer", async () => {
@@ -642,8 +642,8 @@ describe("OrderApp routing redirects", () => {
         expect(error.message).toBe("No redirect found for order")
       }
     })
-    // goToStatusIfNotOfferOrder,
-    it("redirects to /status if not an offer order", async () => {
+    // goToDetailsIfNotOfferOrder,
+    it("redirects to /details if not an offer order", async () => {
       const { redirect } = await render(
         "/orders/2939023/payment/new",
         mockResolver({
@@ -651,10 +651,10 @@ describe("OrderApp routing redirects", () => {
           mode: "BUY",
         }),
       )
-      expect(redirect.url).toBe("/orders/2939023/status")
+      expect(redirect.url).toBe("/orders/2939023/details")
     })
-    // goToStatusIfOrderIsNotSubmitted,
-    it("redirects to /status if order is not submitted", async () => {
+    // goToDetailsIfOrderIsNotSubmitted,
+    it("redirects to /details if order is not submitted", async () => {
       const { redirect } = await render(
         "/orders/2939023/payment/new",
         mockResolver({
@@ -663,10 +663,10 @@ describe("OrderApp routing redirects", () => {
           displayState: "PENDING",
         }),
       )
-      expect(redirect.url).toBe("/orders/2939023/status")
+      expect(redirect.url).toBe("/orders/2939023/details")
     })
 
-    it("redirects to /status if order does not have a failing last transaction", async () => {
+    it("redirects to /details if order does not have a failing last transaction", async () => {
       const { redirect } = await render(
         "/orders/2939023/payment/new",
         mockResolver({
@@ -674,7 +674,7 @@ describe("OrderApp routing redirects", () => {
           lastTransactionFailed: false,
         }),
       )
-      expect(redirect.url).toBe("/orders/2939023/status")
+      expect(redirect.url).toBe("/orders/2939023/details")
     })
   })
 })

--- a/src/Apps/Order/redirects.tsx
+++ b/src/Apps/Order/redirects.tsx
@@ -209,16 +209,6 @@ export const newCheckoutEnabled = ({
   )
 }
 
-export const newDetailsEnabled = ({
-  order,
-  featureFlags,
-}: Order2RedirectArgs): boolean => {
-  return !!(
-    (order.mode === "BUY" || order.mode === "OFFER") &&
-    featureFlags?.isEnabled?.("emerald_order-details-page")
-  )
-}
-
 export const redirects: RedirectRecord<OrderQuery> = {
   path: "",
   rules: [goToArtworkIfOrderWasAbandoned],

--- a/src/Apps/Order/redirects.tsx
+++ b/src/Apps/Order/redirects.tsx
@@ -14,12 +14,12 @@ interface OrderQuery {
 
 type OrderPredicate = RedirectPredicate<OrderQuery>
 
-const goToStatusIf =
+const goToDetailsIf =
   (pred: (order: redirects_order$data) => boolean, reason): OrderPredicate =>
   ({ order }) => {
     if (pred(order)) {
       return {
-        path: `/orders/${order.internalID}/status`,
+        path: `/orders/${order.internalID}/details`,
         reason,
       }
     }
@@ -39,7 +39,7 @@ const goToArtworkIfOrderWasAbandoned: OrderPredicate = ({ order }) => {
   }
 }
 
-const goToStatusIfOrderIsNotPending = goToStatusIf(
+const goToDetailsIfOrderIsNotPending = goToDetailsIf(
   order => order.state !== "PENDING",
   "Order is no longer pending",
 )
@@ -95,29 +95,29 @@ const goToOfferIfNoOfferMade: OrderPredicate = ({ order }) => {
   }
 }
 
-const goToStatusIfNotOfferOrder = goToStatusIf(
+const goToDetailsIfNotOfferOrder = goToDetailsIf(
   order => order.mode !== "OFFER",
   "Not an offer order",
 )
 
-const goToStatusIfBuyNowCreditCardOrder = goToStatusIf(
+const goToDetailsIfBuyNowCreditCardOrder = goToDetailsIf(
   order => order.paymentMethod === "CREDIT_CARD" && order.mode === "BUY",
   "Order paid by credit card must be offer",
 )
 
-const goToStatusIfNotAwaitingBuyerResponse = goToStatusIf(
+const goToDetailsIfNotAwaitingBuyerResponse = goToDetailsIf(
   order => order.awaitingResponseFrom !== "BUYER",
   "Not currently awaiting buyer response",
 )
 
 // displayState is used here since an order may be in_review, in which case
 // it is still "submitted" to the user and we shouldn't redirect
-const goToStatusIfOrderIsNotSubmitted = goToStatusIf(
+const goToDetailsIfOrderIsNotSubmitted = goToDetailsIf(
   order => order.displayState !== "SUBMITTED",
   "Order was not yet submitted",
 )
 
-const goToStatusIfNotLastTransactionFailed = goToStatusIf(
+const goToDetailsIfNotLastTransactionFailed = goToDetailsIf(
   order => !(order.lastTransactionFailed && order.state === "SUBMITTED"),
   "Order's lastTransactionFailed must be true + state submitted",
 )
@@ -226,16 +226,16 @@ export const redirects: RedirectRecord<OrderQuery> = {
     {
       path: "respond",
       rules: [
-        goToStatusIfNotOfferOrder,
-        goToStatusIfNotAwaitingBuyerResponse,
-        goToStatusIfOrderIsNotSubmitted,
+        goToDetailsIfNotOfferOrder,
+        goToDetailsIfNotAwaitingBuyerResponse,
+        goToDetailsIfOrderIsNotSubmitted,
         goToNewPaymentIfOfferLastTransactionFailed,
       ],
     },
     {
       path: "offer",
       rules: [
-        goToStatusIfOrderIsNotPending,
+        goToDetailsIfOrderIsNotPending,
         goToShippingIfOrderIsNotOfferOrder,
       ],
     },
@@ -243,7 +243,7 @@ export const redirects: RedirectRecord<OrderQuery> = {
       path: "shipping",
       rules: [
         goToPaymentIfPrivateSaleOrder,
-        goToStatusIfOrderIsNotPending,
+        goToDetailsIfOrderIsNotPending,
         goToOfferIfNoOfferMade,
         goToOrder2CheckoutIfEnabled,
       ],
@@ -251,7 +251,7 @@ export const redirects: RedirectRecord<OrderQuery> = {
     {
       path: "payment",
       rules: [
-        goToStatusIfOrderIsNotPending,
+        goToDetailsIfOrderIsNotPending,
         goToShippingIfShippingIsNotCompleted,
         goToOrder2CheckoutIfEnabled,
       ],
@@ -259,14 +259,14 @@ export const redirects: RedirectRecord<OrderQuery> = {
     {
       path: "payment/new",
       rules: [
-        goToStatusIfBuyNowCreditCardOrder,
-        goToStatusIfNotLastTransactionFailed,
+        goToDetailsIfBuyNowCreditCardOrder,
+        goToDetailsIfNotLastTransactionFailed,
       ],
     },
     {
       path: "review",
       rules: [
-        goToStatusIfOrderIsNotPending,
+        goToDetailsIfOrderIsNotPending,
         goToShippingIfShippingIsNotCompleted,
         goToPaymentIfPaymentIsNotCompleted,
         goToOrder2CheckoutIfEnabled,
@@ -275,36 +275,39 @@ export const redirects: RedirectRecord<OrderQuery> = {
     {
       path: "review/counter",
       rules: [
-        goToStatusIfNotOfferOrder,
-        goToStatusIfNotAwaitingBuyerResponse,
-        goToStatusIfOrderIsNotSubmitted,
+        goToDetailsIfNotOfferOrder,
+        goToDetailsIfNotAwaitingBuyerResponse,
+        goToDetailsIfOrderIsNotSubmitted,
         goToRespondIfMyLastOfferIsNotMostRecentOffer,
       ],
     },
     {
       path: "review/accept",
       rules: [
-        goToStatusIfNotOfferOrder,
-        goToStatusIfNotAwaitingBuyerResponse,
-        goToStatusIfOrderIsNotSubmitted,
+        goToDetailsIfNotOfferOrder,
+        goToDetailsIfNotAwaitingBuyerResponse,
+        goToDetailsIfOrderIsNotSubmitted,
       ],
     },
     {
       path: "review/decline",
       rules: [
-        goToStatusIfNotOfferOrder,
-        goToStatusIfNotAwaitingBuyerResponse,
-        goToStatusIfOrderIsNotSubmitted,
+        goToDetailsIfNotOfferOrder,
+        goToDetailsIfNotAwaitingBuyerResponse,
+        goToDetailsIfOrderIsNotSubmitted,
       ],
     },
     {
       path: "status",
+      rules: [goToOrderDetails],
+    },
+    {
+      path: "details",
       rules: [
         goToReviewIfOrderIsPending,
         goToShippingIfShippingIsNotCompleted,
         goToPaymentIfPaymentIsNotCompleted,
         goToRespondIfAwaitingBuyerResponse,
-        goToOrderDetails,
       ],
     },
   ],

--- a/src/Apps/Order2/__tests__/order2Routes.jest.tsx
+++ b/src/Apps/Order2/__tests__/order2Routes.jest.tsx
@@ -1,12 +1,11 @@
-import { order2Routes } from "../order2Routes"
 import { Resolver } from "found-relay"
 import { getFarceResult } from "found/server"
 import type { FarceRedirectResult } from "found/server"
 import { MockPayloadGenerator, createMockEnvironment } from "relay-test-utils"
+import { order2Routes } from "../order2Routes"
 
 jest.mock("Apps/Order/redirects", () => ({
   newCheckoutEnabled: jest.fn(() => true),
-  newDetailsEnabled: jest.fn(() => true),
 }))
 
 jest.mock("Utils/logger", () => ({

--- a/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchasesRow.tsx
+++ b/src/Apps/Settings/Routes/Purchases/Components/SettingsPurchasesRow.tsx
@@ -143,7 +143,7 @@ const OrderLink: FC<OrderLinkProps> = ({
 
   if (isOrderActive) {
     return (
-      <RouterLink inline to={`/orders/${order.internalID}/status`}>
+      <RouterLink inline to={`/orders/${order.internalID}/details`}>
         {order.code}
       </RouterLink>
     )
@@ -179,7 +179,7 @@ const OrderActionButton: FC<OrderActionButtonProps> = ({
         <Button
           // @ts-ignore
           as={RouterLink}
-          to={`/orders/${orderId}/status`}
+          to={`/orders/${orderId}/details`}
           variant="primaryBlack"
           size="large"
           width="50%"

--- a/src/Apps/Settings/Routes/Purchases/Components/__tests__/SettingsPurchases.jest.tsx
+++ b/src/Apps/Settings/Routes/Purchases/Components/__tests__/SettingsPurchases.jest.tsx
@@ -202,7 +202,7 @@ describe("SettingsPurchases", () => {
 
       const link = screen.getByRole("link", { name: /123/i })
       expect(link).toBeInTheDocument()
-      expect(link).toHaveAttribute("href", "/orders/123/status")
+      expect(link).toHaveAttribute("href", "/orders/123/details")
     })
 
     it("renders a button to respond to the offer", () => {
@@ -227,7 +227,7 @@ describe("SettingsPurchases", () => {
         name: /Respond to Counteroffer/i,
       })
       expect(button).toBeInTheDocument()
-      expect(button).toHaveAttribute("href", "/orders/123/status")
+      expect(button).toHaveAttribute("href", "/orders/123/details")
     })
   })
 


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2647]

### Description

Replace `status` with `details`, keeping a `/status` to `/details` redirect for legacy emails and any other routes in other repos that linked to status
