### PR TITLE
feat(EMI-2503): Fulfillment details step error handling

### DIFF
--- a/src/Apps/Order/Components/ExpressCheckout/Util/mutationHandling.ts
+++ b/src/Apps/Order/Components/ExpressCheckout/Util/mutationHandling.ts
@@ -10,7 +10,10 @@ type OrderMutationActionRequired<T> = Extract<
 
 type OrderMutationError<T> = Extract<
   T,
-  { __typename: "OrderMutationError"; mutationError: { message: string } }
+  {
+    __typename: "OrderMutationError"
+    mutationError: { message: string; code?: string }
+  }
 >
 
 const isOrderMutationSuccess = <T extends { __typename?: string }>(
@@ -49,10 +52,23 @@ export const validateAndExtractOrderResponse = <
   }
 
   if (isOrderMutationError(orderOrError)) {
-    throw new Error(orderOrError.mutationError.message)
+    throw new CheckoutError(
+      orderOrError.mutationError.message,
+      orderOrError.mutationError.code,
+    )
   }
 
-  throw new Error(
+  throw new CheckoutError(
     `Unhandled orderOrError response type: ${JSON.stringify(orderOrError)}`,
   )
+}
+
+export class CheckoutError extends Error {
+  code?: string
+
+  constructor(message: string, code?: string) {
+    super(message)
+    this.name = "CheckoutError"
+    this.code = code
+  }
 }

--- a/src/Apps/Order2/Routes/Checkout/Components/CheckoutErrorBanner.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/CheckoutErrorBanner.tsx
@@ -1,27 +1,40 @@
-import { Message } from "@artsy/palette"
+import { Message, type MessageProps } from "@artsy/palette"
 
-interface ErrorBannerProps {
-  error: ErrorProps
+export interface CheckoutErrorBannerProps {
+  error?: {
+    title?: string
+    message?: string | React.ReactNode
+    variant?: MessageProps["variant"]
+  } | null
 }
 
-interface ErrorProps {
-  title?: string
-  message?: string
-}
+const SUPPORT_EMAIL = "orders@artsy.net" as const
 
-const SUPPORT_EMAIL = "orders@artsy.net"
-
-export const CheckoutErrorBanner: React.FC<ErrorBannerProps> = ({ error }) => {
+/**
+ * A banner to display errors that occur during the checkout process.
+ * use [[MAILTO_ORDER_SUPPORT]] in the message to insert the support email.
+ */
+export const CheckoutErrorBanner: React.FC<CheckoutErrorBannerProps> = ({
+  error,
+}) => {
   if (!error) return null
 
   const title = error.title || "An error occurred"
-  const message =
-    error.message ||
-    `Something went wrong. Please try again or contact ${SUPPORT_EMAIL}.`
+  const message = error.message || (
+    <>
+      Something went wrong. Please try again or contact <MailtoOrderSupport />.
+    </>
+  )
+
+  const variant = error.variant || "error"
 
   return (
-    <Message variant="alert" title={title}>
+    <Message variant={variant} title={title}>
       {message}
     </Message>
   )
+}
+
+export const MailtoOrderSupport = () => {
+  return <a href={`mailto:${SUPPORT_EMAIL}`}>{SUPPORT_EMAIL}</a>
 }

--- a/src/Apps/Order2/Routes/Checkout/Components/CheckoutErrorBanner.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/CheckoutErrorBanner.tsx
@@ -1,19 +1,14 @@
-import { Message, type MessageProps } from "@artsy/palette"
+import { Message } from "@artsy/palette"
 
 export interface CheckoutErrorBannerProps {
   error?: {
     title?: string
     message?: string | React.ReactNode
-    variant?: MessageProps["variant"]
   } | null
 }
 
 const SUPPORT_EMAIL = "orders@artsy.net" as const
 
-/**
- * A banner to display errors that occur during the checkout process.
- * use [[MAILTO_ORDER_SUPPORT]] in the message to insert the support email.
- */
 export const CheckoutErrorBanner: React.FC<CheckoutErrorBannerProps> = ({
   error,
 }) => {
@@ -26,7 +21,7 @@ export const CheckoutErrorBanner: React.FC<CheckoutErrorBannerProps> = ({
     </>
   )
 
-  const variant = error.variant || "error"
+  const variant = "error"
 
   return (
     <Message variant={variant} title={title}>

--- a/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/utils.ts
+++ b/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/utils.ts
@@ -45,8 +45,8 @@ export const deliveryOptionTimeEstimate = (
         "Estimated to ship between",
         dateRangeString({
           from,
-          startOffsetDays: 3,
-          endOffsetDays: 5,
+          startOffsetDays: 8,
+          endOffsetDays: 10,
         }),
       ]
     case "INTERNATIONAL_FLAT":
@@ -54,8 +54,8 @@ export const deliveryOptionTimeEstimate = (
         "Estimated to ship between",
         dateRangeString({
           from,
-          startOffsetDays: 3,
-          endOffsetDays: 5,
+          startOffsetDays: 8,
+          endOffsetDays: 10,
         }),
       ]
     default:
@@ -63,8 +63,8 @@ export const deliveryOptionTimeEstimate = (
         "Estimated to ship between",
         dateRangeString({
           from,
-          startOffsetDays: 3,
-          endOffsetDays: 5,
+          startOffsetDays: 8,
+          endOffsetDays: 10,
         }),
       ]
   }

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
@@ -84,25 +84,26 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
         checkoutTracking.clickedOrderProgression(
           ContextModule.ordersFulfillment,
         )
+        const input = {
+          id: orderData.internalID,
+          buyerPhoneNumber: values.phoneNumber,
+          buyerPhoneNumberCountryCode: values.phoneNumberCountryCode,
+          shippingAddressLine1: values.address.addressLine1,
+          shippingAddressLine2: values.address.addressLine2,
+          shippingCity: values.address.city,
+          shippingRegion: values.address.region,
+          shippingPostalCode: values.address.postalCode,
+          shippingCountry: values.address.country,
+          shippingName: values.address.name,
+        }
+
         const updateShippingAddressResult =
           await updateShippingAddressMutation.submitMutation({
             variables: {
-              input: {
-                id: orderData.internalID,
-                buyerPhoneNumber: values.phoneNumber,
-                buyerPhoneNumberCountryCode: values.phoneNumberCountryCode,
-                shippingAddressLine1: values.address.addressLine1,
-                shippingAddressLine2: values.address.addressLine2,
-                shippingCity: values.address.city,
-                shippingRegion: values.address.region,
-                shippingPostalCode: values.address.postalCode,
-                shippingCountry: values.address.country,
-                shippingName: values.address.name,
-              },
+              input,
             },
           })
 
-        console.log("***", updateShippingAddressResult)
         validateAndExtractOrderResponse(
           updateShippingAddressResult.updateOrderShippingAddress?.orderOrError,
         ).order
@@ -110,7 +111,6 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
         formikHelpers.setStatus({ errorBanner: null })
         setFulfillmentDetailsComplete({}) // TODO: Clean up signature
       } catch (error) {
-        console.log("****", error)
         handleError(error, formikHelpers, {
           title: "An error occurred",
           message: (

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
@@ -9,7 +9,7 @@ import {
   type CheckoutErrorBannerProps,
   MailtoOrderSupport,
 } from "Apps/Order2/Routes/Checkout/Components/CheckoutErrorBanner"
-import { handleError } from "Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/utils"
+import { handleError } from "Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/handleError"
 import { useCheckoutContext } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext"
 
 import { useOrder2UpdateShippingAddressMutation } from "Apps/Order2/Routes/Checkout/Mutations/useOrder2UpdateShippingAddressMutation"

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
@@ -1,12 +1,8 @@
 import { ContextModule } from "@artsy/cohesion"
 import { Button, Flex, Spacer, Text } from "@artsy/palette"
-import {
-  CheckoutError,
-  validateAndExtractOrderResponse,
-} from "Apps/Order/Components/ExpressCheckout/Util/mutationHandling"
+import { validateAndExtractOrderResponse } from "Apps/Order/Components/ExpressCheckout/Util/mutationHandling"
 import {
   CheckoutErrorBanner,
-  type CheckoutErrorBannerProps,
   MailtoOrderSupport,
 } from "Apps/Order2/Routes/Checkout/Components/CheckoutErrorBanner"
 import { handleError } from "Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/handleError"

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
@@ -102,6 +102,7 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
             },
           })
 
+        console.log("***", updateShippingAddressResult)
         validateAndExtractOrderResponse(
           updateShippingAddressResult.updateOrderShippingAddress?.orderOrError,
         ).order
@@ -109,6 +110,7 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
         formikHelpers.setStatus({ errorBanner: null })
         setFulfillmentDetailsComplete({}) // TODO: Clean up signature
       } catch (error) {
+        console.log("****", error)
         handleError(error, formikHelpers, {
           title: "An error occurred",
           message: (

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/__tests__/handleError.jest.ts
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/__tests__/handleError.jest.ts
@@ -1,0 +1,99 @@
+import { CheckoutError } from "Apps/Order/Components/ExpressCheckout/Util/mutationHandling"
+import { handleError } from "Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/handleError"
+import type { FormikHelpers } from "formik"
+
+let formikHelpers: Partial<FormikHelpers<any>>
+
+const defaultErrorBannerArgs = {}
+
+beforeEach(() => {
+  formikHelpers = {
+    setFieldError: jest.fn(),
+    setStatus: jest.fn(),
+  }
+})
+
+describe("fulfillment details error handling", () => {
+  it("handles missing postal code error", () => {
+    const error = new CheckoutError(
+      "this is an error `message`",
+      "missing_postal_code",
+    )
+
+    handleError(
+      error,
+      formikHelpers as FormikHelpers<any>,
+      defaultErrorBannerArgs,
+    )
+
+    expect(formikHelpers.setFieldError).toHaveBeenCalledWith(
+      "address.postalCode",
+      "Postal code is required",
+    )
+    expect(formikHelpers.setStatus).toHaveBeenCalledWith({
+      errorBanner: null,
+    })
+  })
+
+  it("handles missing region error", () => {
+    const error = new CheckoutError(
+      "this is an error `message`",
+      "missing_region",
+    )
+
+    handleError(
+      error,
+      formikHelpers as FormikHelpers<any>,
+      defaultErrorBannerArgs,
+    )
+
+    expect(formikHelpers.setFieldError).toHaveBeenCalledWith(
+      "address.region",
+      "Region is required",
+    )
+    expect(formikHelpers.setStatus).toHaveBeenCalledWith({
+      errorBanner: null,
+    })
+  })
+
+  it("handles missing country error", () => {
+    const error = new CheckoutError(
+      "this is an error `message`",
+      "missing_country",
+    )
+
+    handleError(
+      error,
+      formikHelpers as FormikHelpers<any>,
+      defaultErrorBannerArgs,
+    )
+
+    expect(formikHelpers.setFieldError).toHaveBeenCalledWith(
+      "address.country",
+      "Country is required",
+    )
+    expect(formikHelpers.setStatus).toHaveBeenCalledWith({
+      errorBanner: null,
+    })
+  })
+
+  it("handles destination could not be geocoded error", () => {
+    const error = new CheckoutError(
+      "this is an error `message`",
+      "destination_could_not_be_geocoded",
+    )
+
+    handleError(
+      error,
+      formikHelpers as FormikHelpers<any>,
+      defaultErrorBannerArgs,
+    )
+
+    expect(formikHelpers.setFieldError).not.toHaveBeenCalled()
+    expect(formikHelpers.setStatus).toHaveBeenCalledWith({
+      errorBanner: expect.objectContaining({
+        title: "Cannot calculate shipping",
+      }),
+    })
+  })
+})

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/handleError.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/handleError.tsx
@@ -16,7 +16,6 @@ export const handleError = (
   const isCheckoutError = error instanceof CheckoutError
   const errorMatchField = isCheckoutError ? error.code : error.message
 
-  console.log("**", error.message, errorMatchField)
   switch (errorMatchField) {
     case "missing_postal_code":
       errorBanner = null

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/handleError.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/handleError.tsx
@@ -14,13 +14,13 @@ export const handleError = (
   let errorBanner: CheckoutErrorBannerProps["error"] = {}
 
   const isCheckoutError = error instanceof CheckoutError
-  const errorMatchField = isCheckoutError ? error.code : error.message
+  const errorMatchField = (isCheckoutError && error.code) || error.message
 
   switch (errorMatchField) {
     case "missing_postal_code":
       errorBanner = null
-      // TODO: Will this work when the user touches the field? We could set some kind of meta value on the formik context
-      // for the schema to reference, like to say 'actually this field is required'
+      // This error message will not persist through subsequent form validations
+      // that refer to the validation schema.
       formikHelpers.setFieldError(
         "address.postalCode",
         "Postal code is required",

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/utils.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/utils.tsx
@@ -1,0 +1,57 @@
+import { CheckoutError } from "Apps/Order/Components/ExpressCheckout/Util/mutationHandling"
+import {
+  type CheckoutErrorBannerProps,
+  MailtoOrderSupport,
+} from "Apps/Order2/Routes/Checkout/Components/CheckoutErrorBanner"
+import type { FormikContextWithAddress } from "Components/Address/AddressFormFields"
+import type { FormikHelpers } from "formik"
+
+export const handleError = (
+  error: CheckoutError | Error,
+  formikHelpers: FormikHelpers<FormikContextWithAddress>,
+  defaultErrorBanner: CheckoutErrorBannerProps["error"],
+) => {
+  let errorBanner: CheckoutErrorBannerProps["error"] = {}
+
+  const isCheckoutError = error instanceof CheckoutError
+  const errorMatchField = isCheckoutError ? error.code : error.message
+
+  console.error("**", error.message, errorMatchField)
+  switch (errorMatchField) {
+    case "missing_postal_code":
+      errorBanner = null
+      // TODO: Will this work when the user touches the field? We could set some kind of meta value on the formik context
+      // for the schema to reference, like to say 'actually this field is required'
+      formikHelpers.setFieldError(
+        "address.postalCode",
+        "Postal code is required",
+      )
+      break
+    case "missing_region":
+      errorBanner = null
+      formikHelpers.setFieldError("address.region", "Region is required")
+      break
+    case "missing_country":
+      errorBanner = null
+      formikHelpers.setFieldError("address.country", "Country is required")
+      break
+    case "destination_could_not_be_geocoded":
+      errorBanner = {
+        title: "Cannot calculate shipping",
+        message: (
+          <>
+            Please confirm that your address details are correct and try again.
+            If the issue continues contact <MailtoOrderSupport />.
+          </>
+        ),
+      }
+      break
+    default:
+      errorBanner = defaultErrorBanner || {}
+      break
+  }
+
+  formikHelpers.setStatus({
+    errorBanner,
+  })
+}

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/utils.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/utils.tsx
@@ -16,7 +16,7 @@ export const handleError = (
   const isCheckoutError = error instanceof CheckoutError
   const errorMatchField = isCheckoutError ? error.code : error.message
 
-  console.error("**", error.message, errorMatchField)
+  console.log("**", error.message, errorMatchField)
   switch (errorMatchField) {
     case "missing_postal_code":
       errorBanner = null

--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
@@ -134,7 +134,9 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({ order }) => {
     useCheckoutContext()
 
   const [isSubmittingToStripe, setIsSubmittingToStripe] = useState(false)
-  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+  const [errorMessage, setErrorMessage] = useState<JSX.Element | string | null>(
+    null,
+  )
   const [subtitleErrorMessage, setSubtitleErrorMessage] = useState<
     string | null
   >(null)
@@ -250,8 +252,8 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({ order }) => {
     elements?.getElement("payment")?.collapse()
   }
 
-  const handleError = error => {
-    setErrorMessage(error.message)
+  const handleError = (error: { message?: string | JSX.Element }) => {
+    setErrorMessage(error.message || defaultErrorMessage)
     setIsSubmittingToStripe(false)
   }
 
@@ -310,7 +312,7 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({ order }) => {
 
       if (!response) {
         logger.error("Failed to fetch confirmation token from Gravity")
-        handleError(new Error(defaultErrorMessage))
+        handleError({ message: defaultErrorMessage })
         return
       }
 
@@ -331,7 +333,7 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({ order }) => {
         )
       } catch (error) {
         logger.error("Error while updating order payment method", error)
-        handleError(new Error(defaultErrorMessage))
+        handleError({ message: defaultErrorMessage })
       } finally {
         setIsSubmittingToStripe(false)
       }
@@ -375,7 +377,7 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({ order }) => {
         }
       } catch (error) {
         logger.error("Error while updating order payment method", error)
-        handleError(new Error(defaultErrorMessage))
+        handleError({ message: defaultErrorMessage })
       } finally {
         setIsSubmittingToStripe(false)
         setSavedCreditCard({ savedCreditCard: selectedCreditCard })

--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
@@ -18,18 +18,23 @@ import {
   useElements,
   useStripe,
 } from "@stripe/react-stripe-js"
-import {
-  type StripeElementsOptions,
-  type StripeElementsUpdateOptions,
-  type StripePaymentElementChangeEvent,
-  type StripePaymentElementOptions,
+import type {
+  StripeElementsOptions,
+  StripeElementsUpdateOptions,
+  StripePaymentElementChangeEvent,
+  StripePaymentElementOptions,
 } from "@stripe/stripe-js"
 import { Collapse } from "Apps/Order/Components/Collapse"
 import { useUpdateOrderMutation } from "Apps/Order/Components/ExpressCheckout/Mutations/useUpdateOrderMutation"
-import { useSetPayment } from "Apps/Order/Mutations/useSetPayment"
 import { validateAndExtractOrderResponse } from "Apps/Order/Components/ExpressCheckout/Util/mutationHandling"
-import { CheckoutErrorBanner } from "Apps/Order2/Routes/Checkout/Components/CheckoutErrorBanner"
+import { useSetPayment } from "Apps/Order/Mutations/useSetPayment"
+import {
+  CheckoutErrorBanner,
+  MailtoOrderSupport,
+} from "Apps/Order2/Routes/Checkout/Components/CheckoutErrorBanner"
 import { useCheckoutContext } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext"
+
+import { type Brand, BrandCreditCardIcon } from "Components/BrandCreditCardIcon"
 import { FadeInBox } from "Components/FadeInBox"
 import { RouterLink } from "System/Components/RouterLink"
 import { extractNodes } from "Utils/extractNodes"
@@ -41,18 +46,20 @@ import type {
   Order2PaymentForm_order$key,
 } from "__generated__/Order2PaymentForm_order.graphql"
 import type React from "react"
-import { useState, useEffect } from "react"
+import { useEffect, useState } from "react"
 import {
   fetchQuery,
   graphql,
   useFragment,
   useRelayEnvironment,
 } from "react-relay"
-import { Brand, BrandCreditCardIcon } from "Components/BrandCreditCardIcon"
 
 const logger = createLogger("Order2PaymentForm")
-const defaultErrorMessage =
-  "Something went wrong. Please try again or contact orders@artsy.net"
+const defaultErrorMessage = (
+  <>
+    Something went wrong. Please try again or contact <MailtoOrderSupport />.
+  </>
+)
 
 interface Order2PaymentFormProps {
   order: Order2PaymentForm_order$key
@@ -183,7 +190,7 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({ order }) => {
     }
 
     fetchSavedCreditCards()
-  }, [])
+  }, [environment])
 
   if (!(stripe && elements)) {
     return null
@@ -450,7 +457,7 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({ order }) => {
                               <Text variant="sm">•••• {card.lastDigits}</Text>
                             </Flex>
                           }
-                        ></Radio>
+                        />
                       ))}
                     </RadioGroup>
                   </>

--- a/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
@@ -779,7 +779,7 @@ describe("Order2CheckoutRoute", () => {
   })
 
   describe("Checkout with flat-rate shipping", () => {
-    fit("allows the user to progress through order submission with flat-rate shipping + credit card", async () => {
+    it("allows the user to progress through order submission with flat-rate shipping + credit card", async () => {
       const props = {
         ...baseProps,
         me: {
@@ -1029,7 +1029,7 @@ describe("Order2CheckoutRoute", () => {
         },
       ])
     })
-    fit("displays a missing_postal_code error from the server", async () => {
+    it("displays a missing_postal_code error from the server", async () => {
       const props = {
         ...baseProps,
         me: {
@@ -1047,7 +1047,7 @@ describe("Order2CheckoutRoute", () => {
         },
       }
 
-      const { mockResolveLastOperation, env } = renderWithRelay({
+      const { mockResolveLastOperation } = renderWithRelay({
         Viewer: () => props,
       })
 

--- a/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
@@ -6,6 +6,7 @@ import {
   preventHardReload,
 } from "Apps/Order2/Utils/navigationGuards"
 import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
+import mockStripe from "DevTools/mockStripe"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
 import type { Order2CheckoutRouteTestQuery } from "__generated__/Order2CheckoutRouteTestQuery.graphql"
 import { merge } from "lodash"
@@ -18,10 +19,6 @@ import { Order2CheckoutRoute } from "../Order2CheckoutRoute"
 jest.unmock("react-relay")
 jest.useFakeTimers()
 jest.mock("react-tracking")
-
-const mockStripe = {
-  createConfirmationToken: jest.fn(),
-}
 
 jest.mock("System/Hooks/useAnalyticsContext", () => {
   const actual = jest.requireActual("System/Hooks/useAnalyticsContext")
@@ -1029,6 +1026,7 @@ describe("Order2CheckoutRoute", () => {
         },
       ])
     })
+
     it("displays a missing_postal_code error from the server", async () => {
       const props = {
         ...baseProps,
@@ -1094,7 +1092,6 @@ describe("Order2CheckoutRoute", () => {
         addressLine2Input,
         cityInput,
         regionInput,
-        // postalCodeInput,
         phoneNumberInput,
         countryPicker,
       ] = await Promise.all([
@@ -1103,7 +1100,6 @@ describe("Order2CheckoutRoute", () => {
         screen.findByLabelText("Apt, floor, suite, etc. (optional)"),
         screen.findByLabelText("City"),
         screen.findByLabelText("State, region or province"),
-        // screen.findByLabelText("ZIP/Postal code"),
         screen.findByTestId("addressFormFields.phoneNumber"),
         screen.findByTestId(testIDs.phoneCountryPicker),
       ])
@@ -1119,7 +1115,6 @@ describe("Order2CheckoutRoute", () => {
         userEvent.type(addressLine2Input, addressInputValue.addressLine2)
         userEvent.type(cityInput, addressInputValue.city)
         userEvent.type(regionInput, addressInputValue.region)
-        // userEvent.type(postalCodeInput, "xxx")
         userEvent.type(phoneNumberInput, addressInputValue.phoneNumber)
         userEvent.selectOptions(countrySelect, addressInputValue.country)
       })

--- a/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
@@ -1109,7 +1109,7 @@ describe("Order2CheckoutRoute", () => {
         addressInputValue.phoneNumberCountryCode,
       )
 
-      await act(async () => {
+      act(() => {
         userEvent.type(nameInput, addressInputValue.name)
         userEvent.type(addressLine1Input, addressInputValue.addressLine1)
         userEvent.type(addressLine2Input, addressInputValue.addressLine2)

--- a/src/DevTools/mockStripe.ts
+++ b/src/DevTools/mockStripe.ts
@@ -28,6 +28,7 @@ export const mockStripe = () => ({
   paymentRequest: jest.fn(),
   handleCardAction: jest.fn(),
   _registerWrapper: jest.fn(),
+  createConfirmationToken: jest.fn(),
 })
 
 // Export a singleton mock


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2503]
cc @artsy/emerald-devs 

### Description

This PR adds error handling to our fulfillment details step. It also gives us a clickable support email link in our error banners.

Best reviewed with [whitespace off](https://github.com/artsy/force/pull/15873/files?diff=split&w=1) because i adjusted some test indentation.

<!-- Implementation description -->


[EMI-2503]: https://artsyproduct.atlassian.net/browse/EMI-2503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ