### PR TITLE
chore: cleanup onyx_artist_recommendations_rail_on_web feature flag

### DIFF
--- a/src/Apps/Home/Components/HomeRecommendedArtistsRail.tsx
+++ b/src/Apps/Home/Components/HomeRecommendedArtistsRail.tsx
@@ -1,23 +1,22 @@
 import {
   ActionType,
-  ClickedArtistGroup,
+  type ClickedArtistGroup,
   ContextModule,
   OwnerType,
 } from "@artsy/cohesion"
 import { Skeleton } from "@artsy/palette"
-import { useFlag } from "@unleash/proxy-client-react"
 import {
   CellArtistFragmentContainer,
   CellArtistPlaceholder,
 } from "Components/Cells/CellArtist"
 import { Rail } from "Components/Rail/Rail"
-import { graphql, useFragment } from "react-relay"
-import { useTracking } from "react-tracking"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { extractNodes } from "Utils/extractNodes"
-import type { HomeRecommendedArtistsRail_me$key } from "__generated__/HomeRecommendedArtistsRail_me.graphql"
 import type { HomeRecommendedArtistsRailQuery } from "__generated__/HomeRecommendedArtistsRailQuery.graphql"
+import type { HomeRecommendedArtistsRail_me$key } from "__generated__/HomeRecommendedArtistsRail_me.graphql"
+import { graphql, useFragment } from "react-relay"
+import { useTracking } from "react-tracking"
 
 interface HomeRecommendedArtistsRailProps {
   me: HomeRecommendedArtistsRail_me$key
@@ -94,11 +93,6 @@ export const HomeRecommendedArtistsRailQueryRenderer: React.FC<
   React.PropsWithChildren<unknown>
 > = () => {
   const { relayEnvironment, user } = useSystemContext()
-  const enabled = useFlag("onyx_artist_recommendations_rail_on_web")
-
-  if (!enabled) {
-    return null
-  }
 
   if (!user) {
     return null


### PR DESCRIPTION
The type of this PR is: **Chore**

### Description

Going to remove `onyx_artist_recommendations_rail_on_web` (introduced in https://github.com/artsy/force/pull/15872). There is no really a need for it + for some reason unleash rollout out this feature only for ~70% of users (even thought 100% is specified) - can't figure out why