### PR TITLE
feat(EMI-2523): submit ach order

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentCompletedView.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentCompletedView.tsx
@@ -1,4 +1,5 @@
 import CheckmarkIcon from "@artsy/icons/CheckmarkIcon"
+import HomeIcon from "@artsy/icons/HomeIcon"
 import { Clickable, Flex, Spacer, Text } from "@artsy/palette"
 import { useCheckoutContext } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext"
 import { type Brand, BrandCreditCardIcon } from "Components/BrandCreditCardIcon"
@@ -16,6 +17,9 @@ export const Order2PaymentCompletedView: React.FC<
     checkoutTracking.clickedChangePaymentMethod()
     editPayment()
   }
+
+  const isBankAccount =
+    !savedCreditCard && !confirmationToken?.paymentMethodPreview?.card
   return (
     <Flex flexDirection="column" backgroundColor="mono0">
       <Flex justifyContent="space-between">
@@ -42,20 +46,34 @@ export const Order2PaymentCompletedView: React.FC<
         </Clickable>
       </Flex>
       <Flex alignItems="center" ml="30px" mt={1}>
-        <BrandCreditCardIcon
-          mr={1}
-          type={
-            (confirmationToken?.paymentMethodPreview?.card?.displayBrand ||
-              savedCreditCard?.brand) as Brand
-          }
-          width="26px"
-          height="26px"
-        />
-        <Text variant="sm-display">
-          ••••{" "}
-          {confirmationToken?.paymentMethodPreview?.card?.last4 ||
-            savedCreditCard?.lastDigits}
-        </Text>
+        {isBankAccount ? (
+          <>
+            <HomeIcon
+              fill="mono100"
+              width={["18px", "26px"]}
+              height={["18px", "26px"]}
+              mr={1}
+            />
+            <Text variant={["xs", "sm-display"]}>Bank transfer</Text>
+          </>
+        ) : (
+          <>
+            <BrandCreditCardIcon
+              mr={1}
+              type={
+                (confirmationToken?.paymentMethodPreview?.card?.displayBrand ||
+                  savedCreditCard?.brand) as Brand
+              }
+              width={["18px", "26px"]}
+              height={["18px", "26px"]}
+            />
+            <Text variant={["xs", "sm-display"]}>
+              ••••{" "}
+              {confirmationToken?.paymentMethodPreview?.card?.last4 ||
+                savedCreditCard?.lastDigits}
+            </Text>
+          </>
+        )}
       </Flex>
     </Flex>
   )

--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/__tests__/Order2PaymentForm.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/__tests__/Order2PaymentForm.jest.tsx
@@ -1,0 +1,459 @@
+import { screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
+import type { Order2PaymentFormTestQuery } from "__generated__/Order2PaymentFormTestQuery.graphql"
+import { graphql } from "react-relay"
+import { useTracking } from "react-tracking"
+import { Order2PaymentForm } from "../Order2PaymentForm"
+
+jest.unmock("react-relay")
+jest.mock("react-tracking")
+
+const mockStripe = {
+  createConfirmationToken: jest.fn(),
+}
+
+const mockElements = {
+  getElement: jest.fn(() => ({
+    collapse: jest.fn(),
+  })),
+  submit: jest.fn(),
+  update: jest.fn(),
+}
+
+jest.mock("@stripe/react-stripe-js", () => {
+  const originalModule = jest.requireActual("@stripe/react-stripe-js")
+  const mockPaymentElement = jest.fn(({ onChange }) => {
+    return (
+      <div data-testid="payment-element">
+        <button
+          type="button"
+          data-testid="mock-credit-card"
+          onClick={() => {
+            const changeEvent = {
+              elementType: "payment",
+              collapsed: false,
+              value: { type: "card" },
+            }
+            onChange(changeEvent)
+          }}
+        >
+          Mock Credit Card
+        </button>
+        <button
+          type="button"
+          data-testid="mock-ach"
+          onClick={() => {
+            const changeEvent = {
+              elementType: "payment",
+              collapsed: false,
+              value: { type: "us_bank_account" },
+            }
+            onChange(changeEvent)
+          }}
+        >
+          Mock ACH
+        </button>
+      </div>
+    )
+  })
+  return {
+    ...originalModule,
+    useStripe: jest.fn(() => mockStripe),
+    useElements: jest.fn(() => mockElements),
+    PaymentElement: mockPaymentElement,
+    Elements: jest.fn(({ children }) => <div>{children}</div>),
+  }
+})
+
+const mockCheckoutContext = {
+  setConfirmationToken: jest.fn(),
+  checkoutTracking: {
+    clickedPaymentMethod: jest.fn(),
+    clickedOrderProgression: jest.fn(),
+  },
+}
+
+jest.mock("Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext", () => ({
+  useCheckoutContext: () => mockCheckoutContext,
+}))
+
+// Mock mutations
+const mockUpdateOrderMutation = {
+  submitMutation: jest.fn(),
+}
+
+const mockCreateBankDebitSetupForOrder = {
+  submitMutation: jest.fn(),
+}
+
+jest.mock(
+  "Apps/Order/Components/ExpressCheckout/Mutations/useUpdateOrderMutation",
+  () => ({
+    useUpdateOrderMutation: () => mockUpdateOrderMutation,
+  }),
+)
+
+jest.mock(
+  "Components/BankDebitForm/Mutations/CreateBankDebitSetupForOrder",
+  () => ({
+    CreateBankDebitSetupForOrder: () => mockCreateBankDebitSetupForOrder,
+  }),
+)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+  ;(useTracking as jest.Mock).mockImplementation(() => ({
+    trackEvent: jest.fn(),
+  }))
+})
+
+const { renderWithRelay } = setupTestWrapperTL<Order2PaymentFormTestQuery>({
+  Component: (props: any) => <Order2PaymentForm order={props.me.order} />,
+  query: graphql`
+    query Order2PaymentFormTestQuery @relay_test_operation {
+      me {
+        order(id: "order-id") {
+          ...Order2PaymentForm_order
+        }
+      }
+    }
+  `,
+})
+
+describe("Order2PaymentForm", () => {
+  const baseOrderProps = {
+    id: "T3JkZXI6b3JkZXItaWQ=", // Relay ID
+    internalID: "order-id",
+    mode: "BUY",
+    source: "ARTWORK_PAGE",
+    itemsTotal: {
+      minor: 100000,
+      currencyCode: "USD",
+    },
+    seller: {
+      __typename: "Partner",
+      merchantAccount: {
+        externalId: "merchant-123",
+      },
+    },
+  }
+
+  it("renders the payment form", async () => {
+    renderWithRelay({
+      Me: () => ({
+        order: baseOrderProps,
+      }),
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("Save and Continue")).toBeInTheDocument()
+    })
+
+    expect(screen.getByTestId("payment-element")).toBeInTheDocument()
+  })
+
+  describe("payment method switching behavior", () => {
+    it("updates Stripe's captureMethod and setupFutureUsage when selecting credit card", async () => {
+      renderWithRelay({
+        Me: () => ({
+          order: baseOrderProps,
+        }),
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId("payment-element")).toBeInTheDocument()
+      })
+
+      // Select credit card
+      await userEvent.click(screen.getByTestId("mock-credit-card"))
+
+      // Should update elements to manual capture for credit cards
+      expect(mockElements.update).toHaveBeenCalledWith({
+        captureMethod: "manual",
+        setupFutureUsage: "off_session",
+      })
+
+      // Should track payment method selection
+      expect(
+        mockCheckoutContext.checkoutTracking.clickedPaymentMethod,
+      ).toHaveBeenCalledWith({
+        paymentMethod: "CREDIT_CARD",
+        amountMinor: 100000,
+        currency: "USD",
+      })
+    })
+
+    it("updates Stripe's captureMethod and setupFutureUsage when selecting ACH", async () => {
+      renderWithRelay({
+        Me: () => ({
+          order: baseOrderProps,
+        }),
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId("payment-element")).toBeInTheDocument()
+      })
+
+      // Select ACH
+      await userEvent.click(screen.getByTestId("mock-ach"))
+
+      // Should update elements to automatic capture for ACH
+      expect(mockElements.update).toHaveBeenCalledWith({
+        captureMethod: "automatic",
+        setupFutureUsage: null,
+      })
+    })
+
+    it("switching from credit card to ACH updates Stripe settings correctly", async () => {
+      renderWithRelay({
+        Me: () => ({
+          order: baseOrderProps,
+        }),
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId("payment-element")).toBeInTheDocument()
+      })
+
+      // First select credit card
+      await userEvent.click(screen.getByTestId("mock-credit-card"))
+
+      expect(mockElements.update).toHaveBeenCalledWith({
+        captureMethod: "manual",
+        setupFutureUsage: "off_session",
+      })
+
+      // Clear the mock to check the next call
+      mockElements.update.mockClear()
+
+      // Then select ACH
+      await userEvent.click(screen.getByTestId("mock-ach"))
+
+      expect(mockElements.update).toHaveBeenCalledWith({
+        captureMethod: "automatic",
+        setupFutureUsage: null,
+      })
+    })
+
+    it("switching from ACH to credit card updates Stripe settings correctly", async () => {
+      renderWithRelay({
+        Me: () => ({
+          order: baseOrderProps,
+        }),
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId("payment-element")).toBeInTheDocument()
+      })
+
+      // First select ACH
+      await userEvent.click(screen.getByTestId("mock-ach"))
+
+      expect(mockElements.update).toHaveBeenCalledWith({
+        captureMethod: "automatic",
+        setupFutureUsage: null,
+      })
+
+      // Clear the mock to check the next call
+      mockElements.update.mockClear()
+
+      // Then select credit card
+      await userEvent.click(screen.getByTestId("mock-credit-card"))
+
+      expect(mockElements.update).toHaveBeenCalledWith({
+        captureMethod: "manual",
+        setupFutureUsage: "off_session",
+      })
+
+      // Should track payment method selection for credit card
+      expect(
+        mockCheckoutContext.checkoutTracking.clickedPaymentMethod,
+      ).toHaveBeenCalledWith({
+        paymentMethod: "CREDIT_CARD",
+        amountMinor: 100000,
+        currency: "USD",
+      })
+    })
+  })
+
+  describe("order submission flow", () => {
+    /**
+     * Payment method submission flows differ based on the payment type:
+     *
+     * Credit Card:
+     * 1. elements.submit() -> createConfirmationToken()
+     * 2. Fetch confirmation token details from Gravity
+     * 3. updateOrderMutation with CREDIT_CARD payment method
+     * 4. setConfirmationToken with saveCreditCard option
+     *
+     * ACH (US Bank Account):
+     * 1. elements.submit() -> createConfirmationToken()
+     * 2. createBankDebitSetupForOrder mutation
+     * 3. updateOrderMutation with US_BANK_ACCOUNT payment method
+     * 4. setConfirmationToken without saveCreditCard option
+     *
+     * Saved Credit Card:
+     * 1. No Stripe interaction needed
+     * 2. setPaymentMutation with selected card ID
+     * 3. setSavedCreditCard in context
+     */
+    it("successfully submits an ACH order", async () => {
+      renderWithRelay({
+        Me: () => ({
+          order: baseOrderProps,
+        }),
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId("payment-element")).toBeInTheDocument()
+      })
+
+      await userEvent.click(screen.getByTestId("mock-ach"))
+
+      mockElements.submit.mockResolvedValueOnce({ error: null })
+      mockStripe.createConfirmationToken.mockResolvedValueOnce({
+        error: null,
+        confirmationToken: {
+          id: "ach-confirmation-token-id",
+        },
+      })
+
+      mockCreateBankDebitSetupForOrder.submitMutation.mockResolvedValueOnce({})
+      mockUpdateOrderMutation.submitMutation.mockResolvedValueOnce({
+        updateOrder: {
+          orderOrError: {
+            __typename: "OrderMutationSuccess",
+            order: {
+              ...baseOrderProps,
+              paymentMethod: "US_BANK_ACCOUNT",
+              stripeConfirmationToken: "ach-confirmation-token-id",
+            },
+          },
+        },
+      })
+
+      await userEvent.click(screen.getByText("Save and Continue"))
+
+      expect(mockElements.submit).toHaveBeenCalled()
+      expect(mockStripe.createConfirmationToken).toHaveBeenCalledWith({
+        elements: mockElements,
+      })
+
+      expect(
+        mockCheckoutContext.checkoutTracking.clickedOrderProgression,
+      ).toHaveBeenCalledWith("ordersPayment")
+
+      await waitFor(() => {
+        expect(
+          mockCreateBankDebitSetupForOrder.submitMutation,
+        ).toHaveBeenCalledWith({
+          variables: { input: { id: "order-id" } },
+        })
+      })
+
+      expect(mockUpdateOrderMutation.submitMutation).toHaveBeenCalledWith({
+        variables: {
+          input: {
+            id: "order-id",
+            paymentMethod: "US_BANK_ACCOUNT",
+            stripeConfirmationToken: "ach-confirmation-token-id",
+          },
+        },
+      })
+
+      expect(mockCheckoutContext.setConfirmationToken).toHaveBeenCalledWith({
+        confirmationToken: { id: "ach-confirmation-token-id" },
+        saveCreditCard: false,
+      })
+    })
+
+    it("handles createBankDebitSetupForOrder error", async () => {
+      renderWithRelay({
+        Me: () => ({
+          order: baseOrderProps,
+        }),
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId("payment-element")).toBeInTheDocument()
+      })
+
+      await userEvent.click(screen.getByTestId("mock-ach"))
+
+      // Mock successful Stripe responses
+      mockElements.submit.mockResolvedValueOnce({ error: null })
+      mockStripe.createConfirmationToken.mockResolvedValueOnce({
+        error: null,
+        confirmationToken: {
+          id: "ach-confirmation-token-id",
+        },
+      })
+
+      // Mock bank debit setup failure
+      mockCreateBankDebitSetupForOrder.submitMutation.mockRejectedValueOnce(
+        new Error("Bank setup failed"),
+      )
+
+      await userEvent.click(screen.getByText("Save and Continue"))
+
+      await waitFor(() => {
+        // Should call bank debit setup but it will fail
+        expect(
+          mockCreateBankDebitSetupForOrder.submitMutation,
+        ).toHaveBeenCalled()
+      })
+
+      // Should not proceed to set confirmation token when error occurs
+      expect(mockCheckoutContext.setConfirmationToken).not.toHaveBeenCalled()
+
+      // Button should be available again (not in loading state)
+      expect(screen.getByText("Save and Continue")).toBeInTheDocument()
+    })
+
+    it("handles updateOrderMutation error", async () => {
+      renderWithRelay({
+        Me: () => ({
+          order: baseOrderProps,
+        }),
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId("payment-element")).toBeInTheDocument()
+      })
+
+      await userEvent.click(screen.getByTestId("mock-ach"))
+
+      // Mock successful Stripe responses
+      mockElements.submit.mockResolvedValueOnce({ error: null })
+      mockStripe.createConfirmationToken.mockResolvedValueOnce({
+        error: null,
+        confirmationToken: {
+          id: "ach-confirmation-token-id",
+        },
+      })
+
+      // Mock successful bank debit setup but failed order update
+      mockCreateBankDebitSetupForOrder.submitMutation.mockResolvedValueOnce({})
+      mockUpdateOrderMutation.submitMutation.mockRejectedValueOnce(
+        new Error("Order update failed"),
+      )
+
+      await userEvent.click(screen.getByText("Save and Continue"))
+
+      await waitFor(() => {
+        // Should call both mutations, second one fails
+        expect(
+          mockCreateBankDebitSetupForOrder.submitMutation,
+        ).toHaveBeenCalled()
+        expect(mockUpdateOrderMutation.submitMutation).toHaveBeenCalled()
+      })
+
+      // Should not proceed to set confirmation token when error occurs
+      expect(mockCheckoutContext.setConfirmationToken).not.toHaveBeenCalled()
+
+      // Button should be available again (not in loading state)
+      expect(screen.getByText("Save and Continue")).toBeInTheDocument()
+    })
+  })
+})

--- a/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
@@ -39,23 +39,43 @@ const mockElements = {
     collapse: jest.fn(),
   }),
   submit: jest.fn(),
+  update: jest.fn(),
 }
 
 jest.mock("@stripe/react-stripe-js", () => {
   const originalModule = jest.requireActual("@stripe/react-stripe-js")
-  const mockPaymentElement = jest.fn(({ options: _options, onChange }) => {
+  const mockPaymentElement = jest.fn(({ onChange }) => {
     return (
-      <button
-        type="button"
-        onClick={() =>
-          onChange({
-            elementType: "payment",
-            value: { type: "card" },
-          })
-        }
-      >
-        Mock enter credit card
-      </button>
+      <div data-testid="payment-element">
+        <button
+          type="button"
+          data-testid="mock-credit-card"
+          onClick={() => {
+            const changeEvent = {
+              elementType: "payment",
+              collapsed: false,
+              value: { type: "card" },
+            }
+            onChange(changeEvent)
+          }}
+        >
+          Mock enter credit card
+        </button>
+        <button
+          type="button"
+          data-testid="mock-ach"
+          onClick={() => {
+            const changeEvent = {
+              elementType: "payment",
+              collapsed: false,
+              value: { type: "us_bank_account" },
+            }
+            onChange(changeEvent)
+          }}
+        >
+          Mock ACH
+        </button>
+      </div>
     )
   })
   return {

--- a/src/__generated__/Order2PaymentFormTestQuery.graphql.ts
+++ b/src/__generated__/Order2PaymentFormTestQuery.graphql.ts
@@ -1,0 +1,300 @@
+/**
+ * @generated SignedSource<<eb8dcb9efbea8f5ba21732ace7df0569>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type Order2PaymentFormTestQuery$variables = Record<PropertyKey, never>;
+export type Order2PaymentFormTestQuery$data = {
+  readonly me: {
+    readonly order: {
+      readonly " $fragmentSpreads": FragmentRefs<"Order2PaymentForm_order">;
+    } | null | undefined;
+  } | null | undefined;
+};
+export type Order2PaymentFormTestQuery = {
+  response: Order2PaymentFormTestQuery$data;
+  variables: Order2PaymentFormTestQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "order-id"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v3 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "String"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "Order2PaymentFormTestQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": (v0/*: any*/),
+            "concreteType": "Order",
+            "kind": "LinkedField",
+            "name": "order",
+            "plural": false,
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "Order2PaymentForm_order"
+              }
+            ],
+            "storageKey": "order(id:\"order-id\")"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "Order2PaymentFormTestQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": (v0/*: any*/),
+            "concreteType": "Order",
+            "kind": "LinkedField",
+            "name": "order",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "mode",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "source",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "internalID",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Money",
+                "kind": "LinkedField",
+                "name": "itemsTotal",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "minor",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "currencyCode",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": null,
+                "kind": "LinkedField",
+                "name": "seller",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "__typename",
+                    "storageKey": null
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "PartnerMerchantAccount",
+                        "kind": "LinkedField",
+                        "name": "merchantAccount",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "externalId",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "type": "Partner",
+                    "abstractKey": null
+                  },
+                  {
+                    "kind": "InlineFragment",
+                    "selections": [
+                      (v1/*: any*/)
+                    ],
+                    "type": "Node",
+                    "abstractKey": "__isNode"
+                  }
+                ],
+                "storageKey": null
+              },
+              (v1/*: any*/)
+            ],
+            "storageKey": "order(id:\"order-id\")"
+          },
+          (v1/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "6b51808473b72ee70dd9f886154b22d8",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "me": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Me"
+        },
+        "me.id": (v2/*: any*/),
+        "me.order": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Order"
+        },
+        "me.order.id": (v2/*: any*/),
+        "me.order.internalID": (v2/*: any*/),
+        "me.order.itemsTotal": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Money"
+        },
+        "me.order.itemsTotal.currencyCode": (v3/*: any*/),
+        "me.order.itemsTotal.minor": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "Long"
+        },
+        "me.order.mode": {
+          "enumValues": [
+            "BUY",
+            "OFFER"
+          ],
+          "nullable": false,
+          "plural": false,
+          "type": "OrderModeEnum"
+        },
+        "me.order.seller": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SellerType"
+        },
+        "me.order.seller.__isNode": (v3/*: any*/),
+        "me.order.seller.__typename": (v3/*: any*/),
+        "me.order.seller.id": (v2/*: any*/),
+        "me.order.seller.merchantAccount": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "PartnerMerchantAccount"
+        },
+        "me.order.seller.merchantAccount.externalId": (v3/*: any*/),
+        "me.order.source": {
+          "enumValues": [
+            "ARTWORK_PAGE",
+            "INQUIRY",
+            "PARTNER_OFFER",
+            "PRIVATE_SALE"
+          ],
+          "nullable": false,
+          "plural": false,
+          "type": "OrderSourceEnum"
+        }
+      }
+    },
+    "name": "Order2PaymentFormTestQuery",
+    "operationKind": "query",
+    "text": "query Order2PaymentFormTestQuery {\n  me {\n    order(id: \"order-id\") {\n      ...Order2PaymentForm_order\n      id\n    }\n    id\n  }\n}\n\nfragment Order2PaymentForm_order on Order {\n  mode\n  source\n  internalID\n  itemsTotal {\n    minor\n    currencyCode\n  }\n  seller {\n    __typename\n    ... on Partner {\n      merchantAccount {\n        externalId\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "1b7e93d6e6ad093404d0036d7991ed6d";
+
+export default node;


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2523]

### Description
This enables ACH as a valid payment method that can be used to pay orders with.
For this to work properly https://github.com/artsy/exchange/pull/2665 needs to be merged first.

The demo below was done connecting Force to Exchange locally to allow the order submission to go through. It doesn't reflect the UI changes made in this PR, please see screenshots further below for the UI changes.


https://github.com/user-attachments/assets/76f31fec-e7b2-4780-9f2b-b8c610c11120


UI changes

<img width="1484" height="878" alt="SCR-20250724-news" src="https://github.com/user-attachments/assets/1ccdbf9a-8e5b-4581-911f-358139449e00" />

<img width="417" height="714" alt="SCR-20250724-nezf" src="https://github.com/user-attachments/assets/5e4ae019-8ddb-4629-b026-23bde7c914e5" />


https://artsyproduct.atlassian.net/browse/EMI-2523

@artsy/emerald-devs 

<!-- Implementation description -->


[EMI-2523]: https://artsyproduct.atlassian.net/browse/EMI-2523?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ