### PR TITLE
feat: hide payment details header when no payment method is selected

### DIFF
--- a/src/Apps/Order/Routes/Payment/PaymentContent.tsx
+++ b/src/Apps/Order/Routes/Payment/PaymentContent.tsx
@@ -85,7 +85,9 @@ export const PaymentContent: FC<React.PropsWithChildren<Props>> = props => {
           </RadioGroup>
           <Spacer y={4} />
           <Jump id="paymentDetailsTop" />
-          <Text variant="lg-display">Payment details</Text>
+          {selectedPaymentMethod && (
+            <Text variant="lg-display">Payment details</Text>
+          )}
           <Spacer y={2} />
         </>
       )}

--- a/src/Apps/Order/Utils/orderUtils.ts
+++ b/src/Apps/Order/Utils/orderUtils.ts
@@ -14,11 +14,16 @@ export const getInitialPaymentMethodValue = ({
   paymentSet,
   paymentMethod,
   availablePaymentMethods,
-}: Payment_order$data): CommercePaymentMethodEnum | undefined =>
-  paymentSet
-    ? paymentMethod!
-    : availablePaymentMethods.length > 1
-      ? undefined
-      : orderedPaymentMethods.find(method =>
-          availablePaymentMethods.includes(method),
-        )
+}: Payment_order$data): CommercePaymentMethodEnum | undefined => {
+  if (paymentSet && paymentMethod) {
+    return paymentMethod
+  }
+
+  if (availablePaymentMethods.length > 1) {
+    return undefined
+  }
+
+  return orderedPaymentMethods.find(method =>
+    availablePaymentMethods.includes(method),
+  )
+}


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

### Description
Follow up from https://github.com/artsy/force/pull/15752

Hide the payment details header when no payment method is selected


https://github.com/user-attachments/assets/e0493e84-819f-47b0-9158-fa00192abdd9


<!-- Implementation description -->
