### PR TITLE
chore(EMI-2669): track saved payment method interactions

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
@@ -181,7 +181,7 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({ order }) => {
           setSavedCreditCards(cards)
           if (cards.length > 0) {
             setSelectedPaymentMethod("saved")
-            setSelectedCreditCard(cards[0])
+            checkoutTracking.savedPaymentMethodViewed(["CREDIT_CARD"])
           }
         }
       } catch (error) {
@@ -192,7 +192,7 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({ order }) => {
     }
 
     fetchSavedCreditCards()
-  }, [environment])
+  }, [environment, checkoutTracking.savedPaymentMethodViewed])
 
   if (!(stripe && elements)) {
     return null
@@ -242,6 +242,11 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({ order }) => {
   }
 
   const onClickSavedPaymentMethods = () => {
+    checkoutTracking.clickedPaymentMethod({
+      paymentMethod: "SAVED_CREDIT_CARD",
+      amountMinor: order.itemsTotal?.minor,
+      currency: order.itemsTotal?.currencyCode ?? "",
+    })
     setErrorMessage(null) // Clear any previous error messages
     setSelectedPaymentMethod("saved")
     elements?.getElement("payment")?.collapse()

--- a/src/Apps/Order2/Routes/Checkout/Hooks/useCheckoutTracking.ts
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/useCheckoutTracking.ts
@@ -3,7 +3,7 @@ import {
   type ClickedCancelExpressCheckout,
   type ClickedChangePaymentMethod,
   type ClickedChangeShippingAddress,
-  ClickedChangeShippingMethod,
+  type ClickedChangeShippingMethod,
   type ClickedExpressCheckout,
   type ClickedFulfillmentTab,
   type ClickedOrderProgression,
@@ -13,6 +13,7 @@ import {
   type ExpressCheckoutViewed,
   type OrderProgressionViewed,
   type PageOwnerType,
+  type SavedPaymentMethodViewed,
   type SubmittedOffer,
   type SubmittedOrder,
   type ToggledCollapsibleOrderSummary,
@@ -234,6 +235,17 @@ export const useCheckoutTracking = ({
           flow,
         }
 
+        trackEvent(payload)
+      },
+
+      savedPaymentMethodViewed: (paymentMethods: string[]) => {
+        const payload: SavedPaymentMethodViewed = {
+          action: ActionType.savedPaymentMethodViewed,
+          context_page_owner_type: contextPageOwnerType,
+          context_page_owner_id: contextPageOwnerId,
+          flow,
+          payment_methods: paymentMethods,
+        }
         trackEvent(payload)
       },
 


### PR DESCRIPTION
The type of this PR is: **Chore**

This PR solves [EMI-2669]

### Description
This PR adds tracking for clicking and viewing saved payment methods. I'd like to double check that I'm doing it right since it seems like every `click` should be followed by a `viewed`.

[EMI-2669]: https://artsyproduct.atlassian.net/browse/EMI-2669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ