### PR TITLE
chore(DIA-1395): improve artist directory pagination

### DIFF
--- a/src/Apps/Artists/Components/ArtistsByLetterMeta.tsx
+++ b/src/Apps/Artists/Components/ArtistsByLetterMeta.tsx
@@ -1,5 +1,6 @@
 import { useRouter } from "System/Hooks/useRouter"
 import { getENV } from "Utils/getENV"
+import { getPageNumber } from "Utils/url"
 import type * as React from "react"
 import { Link, Meta, Title } from "react-head"
 
@@ -9,16 +10,16 @@ export const ArtistsByLetterMeta: React.FC<
   React.PropsWithChildren<unknown>
 > = () => {
   const {
-    match: { params },
+    match: { params, location },
   } = useRouter()
 
   if (!params.letter) return <Title>{TITLE}</Title>
 
-  const title = `Artists Starting with ${params.letter.toUpperCase()} | ${TITLE}`
-  const description = `Research and discover artists starting with ${params.letter.toUpperCase()} on Artsy. Find works for sale, biographies, CVs, and auction results.`
+  const page = getPageNumber(location)
   const appUrl = getENV("APP_URL")
-  const prefix = "/artists/artists-starting-with-"
-  const href = [appUrl, prefix, params.letter].join("")
+  const href = buildCanonicalUrl(appUrl, params.letter, page)
+  const title = buildTitle(params.letter, page)
+  const description = `Research and discover artists starting with ${params.letter.toUpperCase()} on Artsy. Find works for sale, biographies, CVs, and auction results.`
 
   return (
     <>
@@ -33,4 +34,23 @@ export const ArtistsByLetterMeta: React.FC<
       <Meta property="twitter:card" content="summary" />
     </>
   )
+}
+
+const buildCanonicalUrl = (
+  appUrl: string,
+  letter: string,
+  page: number,
+): string => {
+  const basePath = `/artists/artists-starting-with-${letter}`
+  const isPagedContent = page > 1
+
+  const canonicalPath = isPagedContent ? `${basePath}?page=${page}` : basePath
+  return `${appUrl}${canonicalPath}`
+}
+
+const buildTitle = (letter: string, page: number): string => {
+  const baseTitle = `Artists Starting with ${letter.toUpperCase()} | ${TITLE}`
+  const isPagedContent = page > 1
+
+  return isPagedContent ? `Page ${page}: ${baseTitle}` : baseTitle
 }

--- a/src/Apps/Artists/Components/__tests__/ArtistsByLetterMeta.jest.tsx
+++ b/src/Apps/Artists/Components/__tests__/ArtistsByLetterMeta.jest.tsx
@@ -1,0 +1,251 @@
+import { MockBoot } from "DevTools/MockBoot"
+import { render } from "@testing-library/react"
+import { ArtistsByLetterMeta } from "Apps/Artists/Components/ArtistsByLetterMeta"
+
+const mockUseRouter = jest.fn()
+
+jest.mock("System/Hooks/useRouter", () => ({
+  useRouter: () => mockUseRouter(),
+}))
+
+jest.mock("Utils/getENV", () => ({
+  getENV: (key: string) => {
+    if (key === "APP_URL") return "https://artsy.net"
+    return ""
+  },
+}))
+
+describe("ArtistsByLetterMeta", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("canonical URLs", () => {
+    it("should generate clean canonical URL for page 1 (no page param)", () => {
+      mockUseRouter.mockReturnValue({
+        match: {
+          params: { letter: "d" },
+          location: { query: {} },
+        },
+      })
+
+      render(
+        <MockBoot>
+          <ArtistsByLetterMeta />
+        </MockBoot>,
+      )
+
+      const canonicalLink = document.querySelector('link[rel="canonical"]')
+      expect(canonicalLink?.getAttribute("href")).toBe(
+        "https://artsy.net/artists/artists-starting-with-d",
+      )
+    })
+
+    it("should generate clean canonical URL for page 1 (explicit page=1)", () => {
+      mockUseRouter.mockReturnValue({
+        match: {
+          params: { letter: "d" },
+          location: { query: { page: "1" } },
+        },
+      })
+
+      render(
+        <MockBoot>
+          <ArtistsByLetterMeta />
+        </MockBoot>,
+      )
+
+      const canonicalLink = document.querySelector('link[rel="canonical"]')
+      expect(canonicalLink?.getAttribute("href")).toBe(
+        "https://artsy.net/artists/artists-starting-with-d",
+      )
+    })
+
+    it("should include page parameter in canonical URL for page 2+", () => {
+      mockUseRouter.mockReturnValue({
+        match: {
+          params: { letter: "d" },
+          location: { query: { page: "3" } },
+        },
+      })
+
+      render(
+        <MockBoot>
+          <ArtistsByLetterMeta />
+        </MockBoot>,
+      )
+
+      const canonicalLink = document.querySelector('link[rel="canonical"]')
+      expect(canonicalLink?.getAttribute("href")).toBe(
+        "https://artsy.net/artists/artists-starting-with-d?page=3",
+      )
+    })
+
+    it("should strip tracking parameters but preserve page parameter", () => {
+      mockUseRouter.mockReturnValue({
+        match: {
+          params: { letter: "d" },
+          location: {
+            query: {
+              page: "2",
+              utm_source: "google",
+              utm_campaign: "summer",
+              fbclid: "12345",
+            },
+          },
+        },
+      })
+
+      render(
+        <MockBoot>
+          <ArtistsByLetterMeta />
+        </MockBoot>,
+      )
+
+      const canonicalLink = document.querySelector('link[rel="canonical"]')
+      expect(canonicalLink?.getAttribute("href")).toBe(
+        "https://artsy.net/artists/artists-starting-with-d?page=2",
+      )
+    })
+  })
+
+  describe("title tags", () => {
+    it("should generate normal title for page 1", () => {
+      mockUseRouter.mockReturnValue({
+        match: {
+          params: { letter: "d" },
+          location: { query: {} },
+        },
+      })
+
+      render(
+        <MockBoot>
+          <ArtistsByLetterMeta />
+        </MockBoot>,
+      )
+
+      expect(document.title).toBe(
+        "Artists Starting with D | Modern and Contemporary Artists",
+      )
+    })
+
+    it("should include page number in title for page 2+", () => {
+      mockUseRouter.mockReturnValue({
+        match: {
+          params: { letter: "d" },
+          location: { query: { page: "4" } },
+        },
+      })
+
+      render(
+        <MockBoot>
+          <ArtistsByLetterMeta />
+        </MockBoot>,
+      )
+
+      expect(document.title).toBe(
+        "Page 4: Artists Starting with D | Modern and Contemporary Artists",
+      )
+    })
+
+    it("should handle different letters correctly", () => {
+      mockUseRouter.mockReturnValue({
+        match: {
+          params: { letter: "z" },
+          location: { query: { page: "2" } },
+        },
+      })
+
+      render(
+        <MockBoot>
+          <ArtistsByLetterMeta />
+        </MockBoot>,
+      )
+
+      expect(document.title).toBe(
+        "Page 2: Artists Starting with Z | Modern and Contemporary Artists",
+      )
+    })
+  })
+
+  describe("meta tags", () => {
+    it("should generate proper og:url matching canonical", () => {
+      mockUseRouter.mockReturnValue({
+        match: {
+          params: { letter: "d" },
+          location: { query: { page: "3" } },
+        },
+      })
+
+      render(
+        <MockBoot>
+          <ArtistsByLetterMeta />
+        </MockBoot>,
+      )
+
+      const ogUrl = document.querySelector('meta[property="og:url"]')
+      const canonicalLink = document.querySelector('link[rel="canonical"]')
+
+      expect(ogUrl?.getAttribute("content")).toBe(
+        canonicalLink?.getAttribute("href"),
+      )
+    })
+
+    it("should generate description with letter context", () => {
+      mockUseRouter.mockReturnValue({
+        match: {
+          params: { letter: "d" },
+          location: { query: {} },
+        },
+      })
+
+      render(
+        <MockBoot>
+          <ArtistsByLetterMeta />
+        </MockBoot>,
+      )
+
+      const description = document.querySelector('meta[name="description"]')
+      expect(description?.getAttribute("content")).toContain("starting with D")
+    })
+  })
+
+  describe("edge cases", () => {
+    it("should handle missing letter parameter", () => {
+      mockUseRouter.mockReturnValue({
+        match: {
+          params: {},
+          location: { query: {} },
+        },
+      })
+
+      render(
+        <MockBoot>
+          <ArtistsByLetterMeta />
+        </MockBoot>,
+      )
+
+      expect(document.title).toBe("Modern and Contemporary Artists")
+    })
+
+    it("should handle invalid page numbers", () => {
+      mockUseRouter.mockReturnValue({
+        match: {
+          params: { letter: "d" },
+          location: { query: { page: "invalid" } },
+        },
+      })
+
+      render(
+        <MockBoot>
+          <ArtistsByLetterMeta />
+        </MockBoot>,
+      )
+
+      const canonicalLink = document.querySelector('link[rel="canonical"]')
+      expect(canonicalLink?.getAttribute("href")).toBe(
+        "https://artsy.net/artists/artists-starting-with-d",
+      )
+    })
+  })
+})

--- a/src/Apps/Artists/Routes/ArtistsByLetter.tsx
+++ b/src/Apps/Artists/Routes/ArtistsByLetter.tsx
@@ -14,6 +14,7 @@ import { LoadingArea } from "Components/LoadingArea"
 import { PaginationFragmentContainer } from "Components/Pagination"
 import { RouterLink } from "System/Components/RouterLink"
 import { useRouter } from "System/Hooks/useRouter"
+import { getPageNumber } from "Utils/url"
 import type { ArtistsByLetter_viewer$data } from "__generated__/ArtistsByLetter_viewer.graphql"
 import { useState } from "react"
 import type * as React from "react"
@@ -49,6 +50,9 @@ export const ArtistsByLetter: React.FC<
     router,
   } = useRouter()
   const [isLoading, setLoading] = useState(false)
+
+  const page = getPageNumber(location)
+  const h1Text = getH1Text(params.letter, page)
 
   if (!viewer?.artistsConnection?.artists) {
     return null
@@ -90,8 +94,7 @@ export const ArtistsByLetter: React.FC<
       <GridColumns mt={4}>
         <Column span={6}>
           <Text as="h1" variant="xl" mb={1}>
-            Artists
-            {params.letter && <> - {params.letter.toUpperCase()}</>}
+            {h1Text}
           </Text>
 
           <Breadcrumbs>
@@ -136,6 +139,17 @@ export const ArtistsByLetter: React.FC<
       />
     </>
   )
+}
+
+const buildH1Title = (letter: string, page: number): string => {
+  const baseTitle = `Artists - ${letter.toUpperCase()}`
+  const isPagedContent = page > 1
+
+  return isPagedContent ? `Page ${page}: ${baseTitle}` : baseTitle
+}
+
+const getH1Text = (letter: string | undefined, page: number): string => {
+  return letter ? buildH1Title(letter, page) : "Artists"
 }
 
 export const ARTISTS_BY_LETTER_QUERY = graphql`

--- a/src/Apps/Artists/__tests__/ArtistsByLetter.jest.tsx
+++ b/src/Apps/Artists/__tests__/ArtistsByLetter.jest.tsx
@@ -8,8 +8,10 @@ import { graphql } from "react-relay"
 jest.unmock("react-relay")
 jest.mock("Components/Pagination/useComputeHref")
 
+const mockUseRouter = jest.fn()
+
 jest.mock("System/Hooks/useRouter", () => ({
-  useRouter: () => ({ match: { params: { letter: "a" } } }),
+  useRouter: () => mockUseRouter(),
 }))
 
 const { renderWithRelay } = setupTestWrapperTL<ArtistsByLetterQuery>({
@@ -31,7 +33,93 @@ const { renderWithRelay } = setupTestWrapperTL<ArtistsByLetterQuery>({
 })
 
 describe("ArtistsByLetter", () => {
-  it("renders the page", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("renders the page with correct H1 for page 1", () => {
+    mockUseRouter.mockReturnValue({
+      match: {
+        params: { letter: "a" },
+        location: { query: {} },
+      },
+    })
+
+    renderWithRelay()
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Artists - A",
+    )
+  })
+
+  it("includes page number in H1 for page 2+", () => {
+    mockUseRouter.mockReturnValue({
+      match: {
+        params: { letter: "d" },
+        location: { query: { page: "3" } },
+      },
+    })
+
+    renderWithRelay()
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Page 3: Artists - D",
+    )
+  })
+
+  it("handles different letters correctly in H1", () => {
+    mockUseRouter.mockReturnValue({
+      match: {
+        params: { letter: "z" },
+        location: { query: { page: "2" } },
+      },
+    })
+
+    renderWithRelay()
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Page 2: Artists - Z",
+    )
+  })
+
+  it("handles explicit page=1 as normal page 1", () => {
+    mockUseRouter.mockReturnValue({
+      match: {
+        params: { letter: "a" },
+        location: { query: { page: "1" } },
+      },
+    })
+
+    renderWithRelay()
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Artists - A",
+    )
+  })
+
+  it("handles missing letter parameter", () => {
+    mockUseRouter.mockReturnValue({
+      match: {
+        params: {},
+        location: { query: {} },
+      },
+    })
+
+    renderWithRelay()
+
+    expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(
+      "Artists",
+    )
+  })
+
+  it("handles invalid page numbers", () => {
+    mockUseRouter.mockReturnValue({
+      match: {
+        params: { letter: "a" },
+        location: { query: { page: "invalid" } },
+      },
+    })
+
     renderWithRelay()
 
     expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent(

--- a/src/Components/Pagination/__tests__/useComputeHref.jest.tsx
+++ b/src/Components/Pagination/__tests__/useComputeHref.jest.tsx
@@ -1,0 +1,190 @@
+import { renderHook } from "@testing-library/react"
+import { useComputeHref } from "Components/Pagination/useComputeHref"
+
+const mockUseRouter = jest.fn()
+const mockUseArtworkFilterContext = jest.fn()
+const mockUseCurrentlySelectedFilters = jest.fn()
+
+jest.mock("System/Hooks/useRouter", () => ({
+  useRouter: () => mockUseRouter(),
+}))
+
+jest.mock("Components/ArtworkFilter/ArtworkFilterContext", () => ({
+  useArtworkFilterContext: () => mockUseArtworkFilterContext(),
+  useCurrentlySelectedFilters: () => mockUseCurrentlySelectedFilters(),
+}))
+
+jest.mock("Components/ArtworkFilter/Utils/urlBuilder", () => ({
+  buildUrl: jest.fn(
+    state => `/test-path?${new URLSearchParams(state).toString()}`,
+  ),
+}))
+
+describe("useComputeHref", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseCurrentlySelectedFilters.mockReturnValue({})
+  })
+
+  describe("generic pagination (non-artwork filter)", () => {
+    beforeEach(() => {
+      mockUseArtworkFilterContext.mockReturnValue({
+        mountedContext: null,
+      })
+    })
+
+    it("should remove page parameter for page 1", () => {
+      mockUseRouter.mockReturnValue({
+        match: {
+          location: {
+            pathname: "/artists/artists-starting-with-d",
+            query: { page: "2", sort: "name" },
+          },
+        },
+      })
+
+      const { result } = renderHook(() => useComputeHref())
+      const computeHref = result.current
+      const href = computeHref(1)
+
+      expect(href).toBe("/artists/artists-starting-with-d?sort=name")
+    })
+
+    it("should include page parameter for page 2+", () => {
+      mockUseRouter.mockReturnValue({
+        match: {
+          location: {
+            pathname: "/artists/artists-starting-with-d",
+            query: { sort: "name" },
+          },
+        },
+      })
+
+      const { result } = renderHook(() => useComputeHref())
+      const computeHref = result.current
+      const href = computeHref(3)
+
+      expect(href).toBe("/artists/artists-starting-with-d?sort=name&page=3")
+    })
+
+    it("should return clean URL when no query params and page=1", () => {
+      mockUseRouter.mockReturnValue({
+        match: {
+          location: {
+            pathname: "/artists/artists-starting-with-d",
+            query: {},
+          },
+        },
+      })
+
+      const { result } = renderHook(() => useComputeHref())
+      const computeHref = result.current
+      const href = computeHref(1)
+
+      expect(href).toBe("/artists/artists-starting-with-d")
+    })
+
+    it("should preserve other query parameters", () => {
+      mockUseRouter.mockReturnValue({
+        match: {
+          location: {
+            pathname: "/artists/artists-starting-with-d",
+            query: {
+              sort: "name",
+              utm_source: "google",
+              filter: "paintings",
+            },
+          },
+        },
+      })
+
+      const { result } = renderHook(() => useComputeHref())
+      const computeHref = result.current
+      const href = computeHref(2)
+
+      expect(href).toContain("sort=name")
+      expect(href).toContain("utm_source=google")
+      expect(href).toContain("filter=paintings")
+      expect(href).toContain("page=2")
+    })
+
+    it("should handle undefined location gracefully", () => {
+      mockUseRouter.mockReturnValue({
+        match: {
+          location: null,
+        },
+      })
+
+      const { result } = renderHook(() => useComputeHref())
+      const computeHref = result.current
+      const href = computeHref(1)
+
+      expect(href).toBe("")
+    })
+
+    it("should handle location with undefined pathname", () => {
+      mockUseRouter.mockReturnValue({
+        match: {
+          location: {
+            pathname: undefined,
+            query: { page: "2" },
+          },
+        },
+      })
+
+      const { result } = renderHook(() => useComputeHref())
+      const computeHref = result.current
+      const href = computeHref(1)
+
+      expect(href).toBe("")
+    })
+
+    it("should handle location with undefined query", () => {
+      mockUseRouter.mockReturnValue({
+        match: {
+          location: {
+            pathname: "/artists/artists-starting-with-d",
+            query: undefined,
+          },
+        },
+      })
+
+      const { result } = renderHook(() => useComputeHref())
+      const computeHref = result.current
+      const href = computeHref(1)
+
+      expect(href).toBe("/artists/artists-starting-with-d")
+    })
+  })
+
+  describe("artwork filter context", () => {
+    beforeEach(() => {
+      mockUseArtworkFilterContext.mockReturnValue({
+        mountedContext: true,
+      })
+    })
+
+    it("should use artwork filter URL building logic", () => {
+      mockUseRouter.mockReturnValue({
+        match: {
+          location: {
+            pathname: "/collect",
+            query: {},
+          },
+        },
+      })
+
+      mockUseCurrentlySelectedFilters.mockReturnValue({
+        medium: "painting",
+      })
+
+      const { result } = renderHook(() => useComputeHref())
+      const computeHref = result.current
+      const href = computeHref(2)
+
+      // Should use the mocked buildUrl function
+      expect(href).toContain("medium=painting")
+      expect(href).toContain("page=2")
+    })
+  })
+})

--- a/src/Components/Pagination/useComputeHref.ts
+++ b/src/Components/Pagination/useComputeHref.ts
@@ -6,6 +6,25 @@ import { buildUrl } from "Components/ArtworkFilter/Utils/urlBuilder"
 import { useRouter } from "System/Hooks/useRouter"
 import { stringify } from "qs"
 
+const buildGenericPageUrl = (
+  pathname: any,
+  query: any,
+  page: number,
+): string => {
+  if (!pathname) return ""
+
+  const updatedQuery = { ...query }
+
+  if (page === 1) {
+    delete updatedQuery.page
+  } else {
+    updatedQuery.page = page
+  }
+
+  const queryString = stringify(updatedQuery)
+  return queryString ? `${pathname}?${queryString}` : pathname
+}
+
 export function useComputeHref() {
   const {
     match: { location },
@@ -16,12 +35,12 @@ export function useComputeHref() {
   // Generic
   if (!artworkFilterContext.mountedContext) {
     return (page: number) =>
-      `${location?.pathname}?${stringify({ ...location.query, page })}`
+      buildGenericPageUrl(location?.pathname, location?.query, page)
   }
 
   // Artwork filter-specific
   // (location doesn't update in the case of artwork filter)
-  const computeHref = page => {
+  const computeHref = (page: number) => {
     const filterState = {
       ...currentlySelectedFilters,
       page,

--- a/src/Utils/__tests__/url.jest.ts
+++ b/src/Utils/__tests__/url.jest.ts
@@ -1,4 +1,4 @@
-import { getInternalHref, getURLHost } from "Utils/url"
+import { getInternalHref, getPageNumber, getURLHost } from "Utils/url"
 
 describe("getURLHost", () => {
   it("returns host for url with host", () => {
@@ -60,5 +60,51 @@ describe("getInternalHref", () => {
     const url = "https://artsy.net"
     const result = getInternalHref(url)
     expect(result).toBe(url)
+  })
+})
+
+describe("getPageNumber", () => {
+  it("should return 1 when location is undefined", () => {
+    const result = getPageNumber(undefined)
+    expect(result).toBe(1)
+  })
+
+  it("should return 1 when location has no query", () => {
+    const location = { pathname: "/artists" }
+    const result = getPageNumber(location)
+    expect(result).toBe(1)
+  })
+
+  it("should return 1 when query has no page parameter", () => {
+    const location = { pathname: "/artists", query: { sort: "name" } }
+    const result = getPageNumber(location)
+    expect(result).toBe(1)
+  })
+
+  it("should return the page number when page parameter exists", () => {
+    const location = { pathname: "/artists", query: { page: "3" } }
+    const result = getPageNumber(location)
+    expect(result).toBe(3)
+  })
+
+  it("should handle numeric page parameter", () => {
+    const location = { pathname: "/artists", query: { page: 5 } }
+    const result = getPageNumber(location)
+    expect(result).toBe(5)
+  })
+
+  it("should return 1 for invalid page parameter", () => {
+    const location = { pathname: "/artists", query: { page: "invalid" } }
+    const result = getPageNumber(location)
+    expect(result).toBe(1)
+  })
+
+  it("should handle page parameter with other query params", () => {
+    const location = {
+      pathname: "/artists",
+      query: { page: "2", sort: "name", utm_source: "google" },
+    }
+    const result = getPageNumber(location)
+    expect(result).toBe(2)
   })
 })

--- a/src/Utils/url.ts
+++ b/src/Utils/url.ts
@@ -16,3 +16,12 @@ export const getInternalHref = (url: string) => {
 
   return href
 }
+
+export const getPageNumber = (location: any): number => {
+  if (!location?.query?.page) return 1
+
+  const page = Number(location.query.page)
+  if (isNaN(page)) return 1
+
+  return page
+}


### PR DESCRIPTION
This PR is one of many that will address improvements to the URLs generated for pagination across our site. It starts with the artist directory that lets users to browse artists by name. For example:

https://www.artsy.net/artists/artists-starting-with-d

### Changes

1. Page parameter (`page=1`) is removed from the canonical URL on the first page.
3. "Page X: " is prepended to Title tag on all but the first page.
4. "Page X: " is prepended to the H1 tag on all but the first page.
5. Page parameter (`page=1`) is removed from pagination links to the first page.

### Impact

- [/artists/artists-starting-with-a](https://www.artsy.net/artists/artists-starting-with-a) through [/artists/artists-starting-with-z](https://www.artsy.net/artists/artists-starting-with-z)
- All paginated variations (e.g., ?page=2, ?page=10)

#### useComputeHref Hook

The changes to the `useComputeHref` hook also impact these pages:

- Collect pages (/collect)
- User saved artworks (/collector-profile/*/saves)
- User artwork lists and collections
- Artwork recommendations (/artwork-recommendations)
- Works for you feed (/works-for-you)
- Search results (/search?term=*)
- Fair listings (/fairs) and fair booths (/fair/*/booths)
- Shows by city (`/shows/*)
- Ending soon auctions (/auctions)
- Articles index (/articles) and news (/news)
- Partner articles and shows
- User purchase history (/settings/purchases)

The following page use blank URL generation (`getHref={() => ""}`) and are not impacted:

- Artist auction results (/artist/*/auction-results)
- Artist articles (/artist/*/articles)
- Artist shows (/artist/*/shows)
- Artist works for sale (/artist/*?page=2)
- Artist series artworks (/artist-series/*?page=2)

### Manual Testing Instructions

1. Visit [/artists/artists-starting-with-d](https://www.artsy.net/artists/artists-starting-with-d)
2. Check canonical tag: `<link rel="canonical" href="https://artsy.net/artists/artists-starting-with-d">`
3. Check H1: "Artists - D"
4. Click page 2 in pagination
5. Verify URL: /artists/artists-starting-with-d?page=2 (no page=1)
6. Check canonical tag: `<link rel="canonical" href="https://artsy.net/artists/artists-starting-with-d?page=2">`
7. Check title: "Page 2: Artists Starting with D | Modern and Contemporary Artists"
8. Check H1: "Page 2: Artists - D"

Test pagination behavior on pages with working pagination controls:
- /collect (artwork filtering with medium/price controls)
- /search?term=picasso (search results)
- /fairs (fairs directory)
- /articles (articles index)
- /collector-profile/saves

Expected Behavior:
- Page 1 links should not include ?page=1
- Page 2+ links should include appropriate page parameter
- Other query parameters should be preserved

cc: @artsy/diamond-devs 