### PR TITLE
fix(DIA-1395): artist directory pagination title

### DIFF
--- a/src/Apps/Artists/Components/ArtistsByLetterMeta.tsx
+++ b/src/Apps/Artists/Components/ArtistsByLetterMeta.tsx
@@ -52,5 +52,5 @@ const buildTitle = (letter: string, page: number): string => {
   const baseTitle = `Artists Starting with ${letter.toUpperCase()} | ${TITLE}`
   const isPagedContent = page > 1
 
-  return isPagedContent ? `Page ${page}: ${baseTitle}` : baseTitle
+  return isPagedContent ? `${baseTitle} - Page ${page}` : baseTitle
 }

--- a/src/Apps/Artists/Routes/ArtistsByLetter.tsx
+++ b/src/Apps/Artists/Routes/ArtistsByLetter.tsx
@@ -145,7 +145,7 @@ const buildH1Title = (letter: string, page: number): string => {
   const baseTitle = `Artists - ${letter.toUpperCase()}`
   const isPagedContent = page > 1
 
-  return isPagedContent ? `Page ${page}: ${baseTitle}` : baseTitle
+  return isPagedContent ? `${baseTitle} - Page ${page}` : baseTitle
 }
 
 const getH1Text = (letter: string | undefined, page: number): string => {


### PR DESCRIPTION
This PR updates the artist directory to show a page number (only when navigating beyond page 1) after the title instead of before it.

This applies to both the H1 and the TITLE of that page.

<img width="925" height="653" alt="Screenshot 2025-07-30 at 4 24 11 PM" src="https://github.com/user-attachments/assets/8fe9128e-e990-40c1-9b30-4bb7a3621fd8" />
