### PR TITLE
chore(EMI-2686): Unset fulfillment method before setting shipping address

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
@@ -9,6 +9,7 @@ import { handleError } from "Apps/Order2/Routes/Checkout/Components/FulfillmentD
 import { useCheckoutContext } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext"
 
 import { useOrder2SetOrderDeliveryAddressMutation } from "Apps/Order2/Routes/Checkout/Mutations/useOrder2SetOrderDeliveryAddressMutation"
+import { useOrder2UnsetOrderFulfillmentOptionMutation } from "Apps/Order2/Routes/Checkout/Mutations/useOrder2UnsetOrderFulfillmentOptionMutation"
 import { getShippableCountries } from "Apps/Order2/Utils/getShippableCountries"
 import {
   AddressFormFields,
@@ -55,6 +56,8 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
     checkoutContext
   const updateShippingAddressMutation =
     useOrder2SetOrderDeliveryAddressMutation()
+  const unsetOrderFulfillmentOption =
+    useOrder2UnsetOrderFulfillmentOptionMutation()
 
   const fulfillmentDetails = orderData.fulfillmentDetails || {
     addressLine1: "",
@@ -101,6 +104,22 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
           ContextModule.ordersFulfillment,
         )
 
+        if (orderData.selectedFulfillmentOption?.type) {
+          // Unset the current fulfillment option if it exists
+          const unsetFulfillmentOptionResult =
+            await unsetOrderFulfillmentOption.submitMutation({
+              variables: {
+                input: {
+                  id: orderData.internalID,
+                },
+              },
+            })
+          validateAndExtractOrderResponse(
+            unsetFulfillmentOptionResult.unsetOrderFulfillmentOption
+              ?.orderOrError,
+          )
+        }
+
         const input = {
           id: orderData.internalID,
           buyerPhoneNumber: values.phoneNumber,
@@ -144,6 +163,8 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
       orderData.internalID,
       updateShippingAddressMutation,
       setFulfillmentDetailsComplete,
+      unsetOrderFulfillmentOption,
+      orderData.selectedFulfillmentOption?.type,
       setCheckoutMode,
     ],
   )

--- a/src/Apps/Order2/Routes/Checkout/Mutations/useOrder2UnsetOrderFulfillmentOptionMutation.ts
+++ b/src/Apps/Order2/Routes/Checkout/Mutations/useOrder2UnsetOrderFulfillmentOptionMutation.ts
@@ -1,0 +1,40 @@
+import { useMutation } from "Utils/Hooks/useMutation"
+import type { useOrder2UnsetOrderFulfillmentOptionMutation as useOrder2UnsetOrderFulfillmentOptionMutationType } from "__generated__/useOrder2UnsetOrderFulfillmentOptionMutation.graphql"
+import { graphql } from "react-relay"
+
+/**
+ * Hook to unset the order fulfillment option.
+ * This hook does not include the typical spreads for Order2CheckoutApp and Order2CheckoutContext.
+ * because we do not want the missing values to flash in the UI:
+ * ```graphql
+ *   # Not included in this mutation
+ *                 ...Order2CheckoutApp_order
+ *                 ...Order2CheckoutContext_order
+ * ```
+ */
+
+export const useOrder2UnsetOrderFulfillmentOptionMutation = () => {
+  return useMutation<useOrder2UnsetOrderFulfillmentOptionMutationType>({
+    mutation: graphql`
+      mutation useOrder2UnsetOrderFulfillmentOptionMutation(
+        $input: unsetOrderFulfillmentOptionInput!
+      ) {
+        unsetOrderFulfillmentOption(input: $input) {
+          orderOrError {
+            __typename
+            ... on OrderMutationSuccess {
+              order {
+                internalID
+              }
+            }
+            ... on OrderMutationError {
+              mutationError {
+                message
+              }
+            }
+          }
+        }
+      }
+    `,
+  })
+}

--- a/src/__generated__/useOrder2UnsetOrderFulfillmentOptionMutation.graphql.ts
+++ b/src/__generated__/useOrder2UnsetOrderFulfillmentOptionMutation.graphql.ts
@@ -1,0 +1,222 @@
+/**
+ * @generated SignedSource<<c028e1f6d43d0594a973ed609a363128>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+export type unsetOrderFulfillmentOptionInput = {
+  clientMutationId?: string | null | undefined;
+  id: string;
+};
+export type useOrder2UnsetOrderFulfillmentOptionMutation$variables = {
+  input: unsetOrderFulfillmentOptionInput;
+};
+export type useOrder2UnsetOrderFulfillmentOptionMutation$data = {
+  readonly unsetOrderFulfillmentOption: {
+    readonly orderOrError: {
+      readonly __typename: "OrderMutationError";
+      readonly mutationError: {
+        readonly message: string;
+      };
+    } | {
+      readonly __typename: "OrderMutationSuccess";
+      readonly order: {
+        readonly internalID: string;
+      };
+    } | {
+      // This will never be '%other', but we need some
+      // value in case none of the concrete values match.
+      readonly __typename: "%other";
+    } | null | undefined;
+  } | null | undefined;
+};
+export type useOrder2UnsetOrderFulfillmentOptionMutation = {
+  response: useOrder2UnsetOrderFulfillmentOptionMutation$data;
+  variables: useOrder2UnsetOrderFulfillmentOptionMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v4 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "ExchangeError",
+      "kind": "LinkedField",
+      "name": "mutationError",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "message",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "OrderMutationError",
+  "abstractKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "useOrder2UnsetOrderFulfillmentOptionMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "unsetOrderFulfillmentOptionPayload",
+        "kind": "LinkedField",
+        "name": "unsetOrderFulfillmentOption",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "orderOrError",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Order",
+                    "kind": "LinkedField",
+                    "name": "order",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "OrderMutationSuccess",
+                "abstractKey": null
+              },
+              (v4/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "useOrder2UnsetOrderFulfillmentOptionMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "unsetOrderFulfillmentOptionPayload",
+        "kind": "LinkedField",
+        "name": "unsetOrderFulfillmentOption",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "orderOrError",
+            "plural": false,
+            "selections": [
+              (v2/*: any*/),
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Order",
+                    "kind": "LinkedField",
+                    "name": "order",
+                    "plural": false,
+                    "selections": [
+                      (v3/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "id",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "OrderMutationSuccess",
+                "abstractKey": null
+              },
+              (v4/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "f7064dcd37fcd20171bc9786c0515ad1",
+    "id": null,
+    "metadata": {},
+    "name": "useOrder2UnsetOrderFulfillmentOptionMutation",
+    "operationKind": "mutation",
+    "text": "mutation useOrder2UnsetOrderFulfillmentOptionMutation(\n  $input: unsetOrderFulfillmentOptionInput!\n) {\n  unsetOrderFulfillmentOption(input: $input) {\n    orderOrError {\n      __typename\n      ... on OrderMutationSuccess {\n        order {\n          internalID\n          id\n        }\n      }\n      ... on OrderMutationError {\n        mutationError {\n          message\n        }\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "fe842570ef84351cc585734f64034bbc";
+
+export default node;


### PR DESCRIPTION
The type of this PR is: **chore**

This PR solves [EMI-2686] 
Split from this PR:
#15938 Fix for [EMI-2550](https://artsyproduct.atlassian.net/browse/EMI-2550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)
#15940 **Blocking:** Refactor of our mutations + new test file for delivery form

### Description
This PR unsets the selected fulfillment option to trigger re-processing shipping costs and updating the UI, particularly when the user is changing between ship and pickup.

~It also contains a significant refactor of all mutations in the checkout flow for consistent naming and no more shared mutations from legacy checkout. Express checkout mutations have their own fields because they operate on the order in a separate context - we don't want them to interfere with the web browser view outside of express checkout.~ - now split out and blocked: #15940 

<details><summary>Screencap showing pickup updating to shipping + tax</summary>

![2025-07-31 13 51 22](https://github.com/user-attachments/assets/98269268-e1f3-42d0-92c8-0cfa51f6a35d)

</details> 




[EMI-2686]: https://artsyproduct.atlassian.net/browse/EMI-2686?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[EMI-2550]: https://artsyproduct.atlassian.net/browse/EMI-2550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ