### PR TITLE
fix: disable link, paypal, and amazonpay in express checkout

### DIFF
--- a/src/Apps/Order/Components/ExpressCheckout/ExpressCheckoutUI.tsx
+++ b/src/Apps/Order/Components/ExpressCheckout/ExpressCheckoutUI.tsx
@@ -105,6 +105,8 @@ export const ExpressCheckoutUI = ({
       applePay: "always",
       googlePay: "always",
       link: "never",
+      amazonPay: "never",
+      paypal: "never",
     },
     layout: {
       overflow: "never",

--- a/src/Apps/Order/Components/ExpressCheckout/__tests__/ExpressCheckoutUI.jest.tsx
+++ b/src/Apps/Order/Components/ExpressCheckout/__tests__/ExpressCheckoutUI.jest.tsx
@@ -181,6 +181,8 @@ describe("ExpressCheckoutUI", () => {
         applePay: "always",
         googlePay: "always",
         link: "never",
+        amazonPay: "never",
+        paypal: "never",
       },
       buttonType: {
         googlePay: "plain",

--- a/src/Apps/Order2/Routes/Checkout/Components/ExpressCheckout/Order2ExpressCheckoutUI.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/ExpressCheckout/Order2ExpressCheckoutUI.tsx
@@ -117,6 +117,8 @@ export const Order2ExpressCheckoutUI: React.FC<
       applePay: "always",
       googlePay: "always",
       link: "never",
+      amazonPay: "never",
+      paypal: "never",
     },
     layout: {
       overflow: "never",

--- a/src/Apps/Order2/Routes/Checkout/Components/ExpressCheckout/__tests__/Order2ExpressCheckoutUI.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/ExpressCheckout/__tests__/Order2ExpressCheckoutUI.jest.tsx
@@ -192,6 +192,8 @@ describe("ExpressCheckoutUI", () => {
         applePay: "always",
         googlePay: "always",
         link: "never",
+        amazonPay: "never",
+        paypal: "never",
       },
       buttonType: {
         googlePay: "plain",


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

Disable any express payment methods other than ApplePay and GooglePay as disabling them on the Stripe dashboard is not enough in some cases. 

see: https://artsy.slack.com/archives/C02JHHHKP5K/p1754064336986829


<!-- Implementation description -->
