### PR TITLE
feat(EMI-2652): Add orderDetailsViewed impression tracking

### DIFF
--- a/src/Apps/Order/Routes/Details/Components/OrderDetailsPage.tsx
+++ b/src/Apps/Order/Routes/Details/Components/OrderDetailsPage.tsx
@@ -8,6 +8,8 @@ import type { OrderDetailsPage_order$key } from "__generated__/OrderDetailsPage_
 import { graphql, useFragment } from "react-relay"
 import { OrderDetailsHeader } from "./OrderDetailsHeader"
 import { OrderDetailsMessage } from "./OrderDetailsMessage"
+import { useEffect } from "react"
+import { useOrder2Tracking } from "Apps/Order2/Hooks/useOrder2Tracking"
 
 interface OrderDetailsPageProps {
   order: OrderDetailsPage_order$key
@@ -15,6 +17,16 @@ interface OrderDetailsPageProps {
 
 export const OrderDetailsPage = ({ order }: OrderDetailsPageProps) => {
   const orderData = useFragment(FRAGMENT, order)
+  const tracking = useOrder2Tracking(orderData.source, orderData.mode)
+
+  useEffect(() => {
+    if (!!orderData) {
+      tracking.orderDetailsViewed(
+        ContextModule.ordersDetail,
+        orderData.displayTexts.messageType,
+      )
+    }
+  }, [])
 
   const artworkSlug = orderData.lineItems[0]?.artwork?.slug
 
@@ -69,6 +81,11 @@ const FRAGMENT = graphql`
       artwork {
         slug
       }
+    }
+    mode
+    source
+    displayTexts {
+      messageType
     }
     ...OrderDetailsHeader_order
     ...OrderDetailsMessage_order

--- a/src/Apps/Order/Routes/Details/Components/__tests__/OrderDetailsPage.jest.tsx
+++ b/src/Apps/Order/Routes/Details/Components/__tests__/OrderDetailsPage.jest.tsx
@@ -3,8 +3,15 @@ import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
 import type { OrderDetailsPage_Test_Query } from "__generated__/OrderDetailsPage_Test_Query.graphql"
 import { graphql } from "react-relay"
 import { OrderDetailsPage } from "../OrderDetailsPage"
+import { useTracking } from "react-tracking"
 
 jest.unmock("react-relay")
+jest.mock("System/Hooks/useAnalyticsContext", () => ({
+  useAnalyticsContext: jest.fn(() => ({
+    contextPageOwnerId: "contextPageOwnerID",
+    contextPageOwnerType: "orderDetails",
+  })),
+}))
 
 const { renderWithRelay } = setupTestWrapperTL<OrderDetailsPage_Test_Query>({
   Component: ({ me }) => me?.order && <OrderDetailsPage order={me.order!} />,
@@ -20,11 +27,27 @@ const { renderWithRelay } = setupTestWrapperTL<OrderDetailsPage_Test_Query>({
 })
 
 describe("OrderDetailsPage", () => {
+  const mockUseTracking = useTracking as jest.Mock
+  const mockTrack = jest.fn()
+
+  beforeEach(() => {
+    mockTrack.mockClear()
+    mockUseTracking.mockImplementation(() => ({ trackEvent: mockTrack }))
+  })
+
   it("renders DetailsHeader with correct title text and order code", () => {
     renderWithRelay({
       Order: () => ({
         ...orderData,
       }),
+    })
+
+    expect(mockTrack).toHaveBeenCalledWith({
+      action: "orderDetailsViewed",
+      context_module: "ordersDetail",
+      context_owner_id: "contextPageOwnerID",
+      context_owner_type: "orderDetails",
+      message_type: "APPROVED_PICKUP",
     })
 
     expect(screen.getByText("Test Order Title")).toBeInTheDocument()
@@ -36,6 +59,7 @@ const orderData = {
   internalID: "a5aaa8b0-93ff-4f2a-8bb3-9589f378d229",
   code: "123",
   displayTexts: {
+    messageType: "APPROVED_PICKUP",
     title: "Test Order Title",
   },
 }

--- a/src/Apps/Order2/Hooks/useOrder2Tracking.tsx
+++ b/src/Apps/Order2/Hooks/useOrder2Tracking.tsx
@@ -6,10 +6,12 @@ import {
   type ClickedImportFees,
   type ClickedVisitHelpCenter,
   type ContextModule,
+  OrderDetailsViewed,
   OwnerType,
   type PageOwnerType,
 } from "@artsy/cohesion"
 import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
+import { DisplayTextsMessageTypeEnum } from "__generated__/OrderDetailsMessage_order.graphql"
 import { useMemo } from "react"
 import { useTracking } from "react-tracking"
 
@@ -91,6 +93,20 @@ export const useOrder2Tracking = (
           context_owner_type: OwnerType.ordersDetail,
           context_owner_id: orderId,
         }
+        trackEvent(payload)
+      },
+      orderDetailsViewed: (
+        contextModule: ContextModule,
+        messageType: DisplayTextsMessageTypeEnum,
+      ) => {
+        const payload: OrderDetailsViewed = {
+          action: ActionType.orderDetailsViewed,
+          context_module: contextModule,
+          context_owner_id: contextPageOwnerId,
+          context_owner_type: contextPageOwnerType,
+          message_type: messageType,
+        }
+
         trackEvent(payload)
       },
     }

--- a/src/__generated__/OrderDetailsPage_Test_Query.graphql.ts
+++ b/src/__generated__/OrderDetailsPage_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<0aa76fe9df62c43282a83c2cbd0af0fd>>
+ * @generated SignedSource<<2dbd44121ff8ec5470d8873b5fd91c11>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -561,7 +561,14 @@ return {
                 "alias": null,
                 "args": null,
                 "kind": "ScalarField",
-                "name": "code",
+                "name": "mode",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "source",
                 "storageKey": null
               },
               {
@@ -572,15 +579,22 @@ return {
                 "name": "displayTexts",
                 "plural": false,
                 "selections": [
-                  (v6/*: any*/),
                   {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
                     "name": "messageType",
                     "storageKey": null
-                  }
+                  },
+                  (v6/*: any*/)
                 ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "code",
                 "storageKey": null
               },
               {
@@ -655,20 +669,6 @@ return {
                     "storageKey": null
                   }
                 ],
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "source",
-                "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "mode",
                 "storageKey": null
               },
               {
@@ -961,12 +961,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "2abdb6191e201cfce676b798f0970a96",
+    "cacheID": "f5ad7ae571c3c328e6eb776bde28f388",
     "id": null,
     "metadata": {},
     "name": "OrderDetailsPage_Test_Query",
     "operationKind": "query",
-    "text": "query OrderDetailsPage_Test_Query {\n  me {\n    order(id: \"123\") {\n      ...OrderDetailsPage_order\n      id\n    }\n    id\n  }\n}\n\nfragment Order2HelpLinks_order on Order {\n  internalID\n  mode\n  source\n}\n\nfragment OrderDetailsFulfillmentInfo_order on Order {\n  fulfillmentDetails {\n    addressLine1\n    addressLine2\n    city\n    country\n    name\n    postalCode\n    region\n    phoneNumber {\n      display(format: INTERNATIONAL)\n    }\n  }\n  selectedFulfillmentOption {\n    type\n  }\n  shippingOrigin\n}\n\nfragment OrderDetailsHeader_order on Order {\n  code\n  displayTexts {\n    title\n  }\n}\n\nfragment OrderDetailsMessage_order on Order {\n  buyerStateExpiresAt\n  code\n  currencyCode\n  internalID\n  impulseConversationId\n  displayTexts {\n    messageType\n  }\n  deliveryInfo {\n    shipperName\n    trackingNumber\n    trackingURL\n    estimatedDelivery\n    estimatedDeliveryWindow\n  }\n  source\n  mode\n}\n\nfragment OrderDetailsOrderSummary_order on Order {\n  ...OrderDetailsPricingBreakdown_order\n  source\n  mode\n  totalListPrice {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artwork {\n      slug\n      published\n      partner {\n        name\n        id\n      }\n      id\n    }\n    artworkOrEditionSet {\n      __typename\n      ... on Artwork {\n        price\n        dimensions {\n          in\n          cm\n        }\n      }\n      ... on EditionSet {\n        price\n        dimensions {\n          in\n          cm\n        }\n        id\n      }\n      ... on Node {\n        __isNode: __typename\n        id\n      }\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      attributionClass {\n        shortDescription\n        id\n      }\n      image {\n        resized(height: 360, width: 700) {\n          url\n          width\n          height\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment OrderDetailsPage_order on Order {\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    id\n  }\n  ...OrderDetailsHeader_order\n  ...OrderDetailsMessage_order\n  ...OrderDetailsOrderSummary_order\n  ...OrderDetailsPricingBreakdown_order\n  ...OrderDetailsPaymentInfo_order\n  ...OrderDetailsFulfillmentInfo_order\n  ...Order2HelpLinks_order\n}\n\nfragment OrderDetailsPaymentInfo_order on Order {\n  creditCardWalletType\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      brand\n      lastDigits\n      expirationYear\n      expirationMonth\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n}\n\nfragment OrderDetailsPricingBreakdown_order on Order {\n  mode\n  source\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n}\n"
+    "text": "query OrderDetailsPage_Test_Query {\n  me {\n    order(id: \"123\") {\n      ...OrderDetailsPage_order\n      id\n    }\n    id\n  }\n}\n\nfragment Order2HelpLinks_order on Order {\n  internalID\n  mode\n  source\n}\n\nfragment OrderDetailsFulfillmentInfo_order on Order {\n  fulfillmentDetails {\n    addressLine1\n    addressLine2\n    city\n    country\n    name\n    postalCode\n    region\n    phoneNumber {\n      display(format: INTERNATIONAL)\n    }\n  }\n  selectedFulfillmentOption {\n    type\n  }\n  shippingOrigin\n}\n\nfragment OrderDetailsHeader_order on Order {\n  code\n  displayTexts {\n    title\n  }\n}\n\nfragment OrderDetailsMessage_order on Order {\n  buyerStateExpiresAt\n  code\n  currencyCode\n  internalID\n  impulseConversationId\n  displayTexts {\n    messageType\n  }\n  deliveryInfo {\n    shipperName\n    trackingNumber\n    trackingURL\n    estimatedDelivery\n    estimatedDeliveryWindow\n  }\n  source\n  mode\n}\n\nfragment OrderDetailsOrderSummary_order on Order {\n  ...OrderDetailsPricingBreakdown_order\n  source\n  mode\n  totalListPrice {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artwork {\n      slug\n      published\n      partner {\n        name\n        id\n      }\n      id\n    }\n    artworkOrEditionSet {\n      __typename\n      ... on Artwork {\n        price\n        dimensions {\n          in\n          cm\n        }\n      }\n      ... on EditionSet {\n        price\n        dimensions {\n          in\n          cm\n        }\n        id\n      }\n      ... on Node {\n        __isNode: __typename\n        id\n      }\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      attributionClass {\n        shortDescription\n        id\n      }\n      image {\n        resized(height: 360, width: 700) {\n          url\n          width\n          height\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment OrderDetailsPage_order on Order {\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    id\n  }\n  mode\n  source\n  displayTexts {\n    messageType\n  }\n  ...OrderDetailsHeader_order\n  ...OrderDetailsMessage_order\n  ...OrderDetailsOrderSummary_order\n  ...OrderDetailsPricingBreakdown_order\n  ...OrderDetailsPaymentInfo_order\n  ...OrderDetailsFulfillmentInfo_order\n  ...Order2HelpLinks_order\n}\n\nfragment OrderDetailsPaymentInfo_order on Order {\n  creditCardWalletType\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      brand\n      lastDigits\n      expirationYear\n      expirationMonth\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n}\n\nfragment OrderDetailsPricingBreakdown_order on Order {\n  mode\n  source\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/OrderDetailsPage_order.graphql.ts
+++ b/src/__generated__/OrderDetailsPage_order.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<69fdaed6130599ad961cc3d55cede0e2>>
+ * @generated SignedSource<<4e4ba56142eb8dd542c53c86300abbee>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -9,13 +9,21 @@
 // @ts-nocheck
 
 import { ReaderFragment } from 'relay-runtime';
+export type DisplayTextsMessageTypeEnum = "APPROVED_PICKUP" | "APPROVED_SHIP" | "APPROVED_SHIP_EXPRESS" | "APPROVED_SHIP_STANDARD" | "APPROVED_SHIP_WHITE_GLOVE" | "CANCELED" | "COMPLETED_PICKUP" | "COMPLETED_SHIP" | "DECLINED_BY_BUYER" | "DECLINED_BY_SELLER" | "PAYMENT_FAILED" | "PROCESSING_PAYMENT_PICKUP" | "PROCESSING_PAYMENT_SHIP" | "PROCESSING_WIRE" | "REFUNDED" | "SHIPPED" | "SUBMITTED_OFFER" | "SUBMITTED_ORDER" | "UNKNOWN" | "%future added value";
+export type OrderModeEnum = "BUY" | "OFFER" | "%future added value";
+export type OrderSourceEnum = "ARTWORK_PAGE" | "INQUIRY" | "PARTNER_OFFER" | "PRIVATE_SALE" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type OrderDetailsPage_order$data = {
+  readonly displayTexts: {
+    readonly messageType: DisplayTextsMessageTypeEnum;
+  };
   readonly lineItems: ReadonlyArray<{
     readonly artwork: {
       readonly slug: string;
     } | null | undefined;
   } | null | undefined>;
+  readonly mode: OrderModeEnum;
+  readonly source: OrderSourceEnum;
   readonly " $fragmentSpreads": FragmentRefs<"Order2HelpLinks_order" | "OrderDetailsFulfillmentInfo_order" | "OrderDetailsHeader_order" | "OrderDetailsMessage_order" | "OrderDetailsOrderSummary_order" | "OrderDetailsPaymentInfo_order" | "OrderDetailsPricingBreakdown_order">;
   readonly " $fragmentType": "OrderDetailsPage_order";
 };
@@ -54,6 +62,38 @@ const node: ReaderFragment = {
               "storageKey": null
             }
           ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "mode",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "source",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "DisplayTexts",
+      "kind": "LinkedField",
+      "name": "displayTexts",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "messageType",
           "storageKey": null
         }
       ],
@@ -99,6 +139,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "d7d2d748011a620af04b554bd3b88ebd";
+(node as any).hash = "3c3294c95f195bc84077b2314e37da85";
 
 export default node;

--- a/src/__generated__/orderRoutes_DetailsQuery.graphql.ts
+++ b/src/__generated__/orderRoutes_DetailsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<617240fb04c515a343797a801542bfeb>>
+ * @generated SignedSource<<857ec566e399f399f93d72a21f88c83a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -414,7 +414,14 @@ return {
                     "alias": null,
                     "args": null,
                     "kind": "ScalarField",
-                    "name": "code",
+                    "name": "mode",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "source",
                     "storageKey": null
                   },
                   {
@@ -425,15 +432,22 @@ return {
                     "name": "displayTexts",
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/),
                       {
                         "alias": null,
                         "args": null,
                         "kind": "ScalarField",
                         "name": "messageType",
                         "storageKey": null
-                      }
+                      },
+                      (v6/*: any*/)
                     ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "code",
                     "storageKey": null
                   },
                   {
@@ -501,20 +515,6 @@ return {
                         "storageKey": null
                       }
                     ],
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "source",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "mode",
                     "storageKey": null
                   },
                   {
@@ -810,12 +810,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "de68e8a7071f4735f60b1a9775bc344b",
+    "cacheID": "145b75c7e816399d760c0ee8106d35ce",
     "id": null,
     "metadata": {},
     "name": "orderRoutes_DetailsQuery",
     "operationKind": "query",
-    "text": "query orderRoutes_DetailsQuery(\n  $orderID: ID!\n) {\n  viewer {\n    ...OrderDetailsRoute_viewer_3HPek8\n  }\n}\n\nfragment Order2HelpLinks_order on Order {\n  internalID\n  mode\n  source\n}\n\nfragment OrderDetailsFulfillmentInfo_order on Order {\n  fulfillmentDetails {\n    addressLine1\n    addressLine2\n    city\n    country\n    name\n    postalCode\n    region\n    phoneNumber {\n      display(format: INTERNATIONAL)\n    }\n  }\n  selectedFulfillmentOption {\n    type\n  }\n  shippingOrigin\n}\n\nfragment OrderDetailsHeader_order on Order {\n  code\n  displayTexts {\n    title\n  }\n}\n\nfragment OrderDetailsMessage_order on Order {\n  buyerStateExpiresAt\n  code\n  currencyCode\n  internalID\n  impulseConversationId\n  displayTexts {\n    messageType\n  }\n  deliveryInfo {\n    shipperName\n    trackingNumber\n    trackingURL\n    estimatedDelivery\n    estimatedDeliveryWindow\n  }\n  source\n  mode\n}\n\nfragment OrderDetailsOrderSummary_order on Order {\n  ...OrderDetailsPricingBreakdown_order\n  source\n  mode\n  totalListPrice {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artwork {\n      slug\n      published\n      partner {\n        name\n        id\n      }\n      id\n    }\n    artworkOrEditionSet {\n      __typename\n      ... on Artwork {\n        price\n        dimensions {\n          in\n          cm\n        }\n      }\n      ... on EditionSet {\n        price\n        dimensions {\n          in\n          cm\n        }\n        id\n      }\n      ... on Node {\n        __isNode: __typename\n        id\n      }\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      attributionClass {\n        shortDescription\n        id\n      }\n      image {\n        resized(height: 360, width: 700) {\n          url\n          width\n          height\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment OrderDetailsPage_order on Order {\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    id\n  }\n  ...OrderDetailsHeader_order\n  ...OrderDetailsMessage_order\n  ...OrderDetailsOrderSummary_order\n  ...OrderDetailsPricingBreakdown_order\n  ...OrderDetailsPaymentInfo_order\n  ...OrderDetailsFulfillmentInfo_order\n  ...Order2HelpLinks_order\n}\n\nfragment OrderDetailsPaymentInfo_order on Order {\n  creditCardWalletType\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      brand\n      lastDigits\n      expirationYear\n      expirationMonth\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n}\n\nfragment OrderDetailsPricingBreakdown_order on Order {\n  mode\n  source\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n}\n\nfragment OrderDetailsRoute_viewer_3HPek8 on Viewer {\n  me {\n    order(id: $orderID) {\n      internalID\n      ...OrderDetailsPage_order\n      id\n    }\n    id\n  }\n}\n"
+    "text": "query orderRoutes_DetailsQuery(\n  $orderID: ID!\n) {\n  viewer {\n    ...OrderDetailsRoute_viewer_3HPek8\n  }\n}\n\nfragment Order2HelpLinks_order on Order {\n  internalID\n  mode\n  source\n}\n\nfragment OrderDetailsFulfillmentInfo_order on Order {\n  fulfillmentDetails {\n    addressLine1\n    addressLine2\n    city\n    country\n    name\n    postalCode\n    region\n    phoneNumber {\n      display(format: INTERNATIONAL)\n    }\n  }\n  selectedFulfillmentOption {\n    type\n  }\n  shippingOrigin\n}\n\nfragment OrderDetailsHeader_order on Order {\n  code\n  displayTexts {\n    title\n  }\n}\n\nfragment OrderDetailsMessage_order on Order {\n  buyerStateExpiresAt\n  code\n  currencyCode\n  internalID\n  impulseConversationId\n  displayTexts {\n    messageType\n  }\n  deliveryInfo {\n    shipperName\n    trackingNumber\n    trackingURL\n    estimatedDelivery\n    estimatedDeliveryWindow\n  }\n  source\n  mode\n}\n\nfragment OrderDetailsOrderSummary_order on Order {\n  ...OrderDetailsPricingBreakdown_order\n  source\n  mode\n  totalListPrice {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artwork {\n      slug\n      published\n      partner {\n        name\n        id\n      }\n      id\n    }\n    artworkOrEditionSet {\n      __typename\n      ... on Artwork {\n        price\n        dimensions {\n          in\n          cm\n        }\n      }\n      ... on EditionSet {\n        price\n        dimensions {\n          in\n          cm\n        }\n        id\n      }\n      ... on Node {\n        __isNode: __typename\n        id\n      }\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      attributionClass {\n        shortDescription\n        id\n      }\n      image {\n        resized(height: 360, width: 700) {\n          url\n          width\n          height\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment OrderDetailsPage_order on Order {\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    id\n  }\n  mode\n  source\n  displayTexts {\n    messageType\n  }\n  ...OrderDetailsHeader_order\n  ...OrderDetailsMessage_order\n  ...OrderDetailsOrderSummary_order\n  ...OrderDetailsPricingBreakdown_order\n  ...OrderDetailsPaymentInfo_order\n  ...OrderDetailsFulfillmentInfo_order\n  ...Order2HelpLinks_order\n}\n\nfragment OrderDetailsPaymentInfo_order on Order {\n  creditCardWalletType\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      brand\n      lastDigits\n      expirationYear\n      expirationMonth\n      id\n    }\n    ... on BankAccount {\n      last4\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n}\n\nfragment OrderDetailsPricingBreakdown_order on Order {\n  mode\n  source\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n}\n\nfragment OrderDetailsRoute_viewer_3HPek8 on Viewer {\n  me {\n    order(id: $orderID) {\n      internalID\n      ...OrderDetailsPage_order\n      id\n    }\n    id\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2652]

### Description
This PR adds impression tracking for Order Details page on render 

<img width="577" height="254" alt="image" src="https://github.com/user-attachments/assets/0faaa8af-12fc-47fa-a440-d2663a885fb8" />


<!-- Implementation description -->


[EMI-2652]: https://artsyproduct.atlassian.net/browse/EMI-2652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ