### PR TITLE
fix(EMI-2664): completed step margins and address formatting

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/Order2DeliveryOptionsCompletedView.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/Order2DeliveryOptionsCompletedView.tsx
@@ -60,9 +60,7 @@ export const Order2DeliveryOptionsCompletedView: React.FC<
         </Clickable>
       </Flex>
       <Spacer y={1} />
-      <Box>
-        <Spacer y={0.5} />
-
+      <Box ml="30px" mt={1}>
         <Text variant="sm-display" color="mono100">
           {label}
         </Text>

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2FulfillmentDetailsCompletedView.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2FulfillmentDetailsCompletedView.tsx
@@ -83,9 +83,8 @@ export const Order2FulfillmentDetailsCompletedView: React.FC<
           </Text>
         </Clickable>
       </Flex>
-      <Spacer y={0.5} />
 
-      <Box>
+      <Box ml="30px" mt={1}>
         <ShippingContent fulfillmentDetails={fulfillmentDetails} />
       </Box>
     </Flex>
@@ -143,14 +142,10 @@ const ShippingContent = ({ fulfillmentDetails }) => {
       )}
       {(city || region || postalCode) && (
         <Text variant={["xs", "sm-display"]} color="mono100">
-          {[city, region, postalCode].filter(Boolean).join(", ")}
+          {[city, region, country, postalCode].filter(Boolean).join(", ")}
         </Text>
       )}
-      {country && (
-        <Text variant={["xs", "sm-display"]} color="mono100">
-          {country}
-        </Text>
-      )}
+
       {phoneNumber && (
         <Text variant={["xs", "sm-display"]} color="mono100">
           {phoneNumber.display}


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [EMI-2664]

### Description

This PR Fixes the margins and address formatting on our fulfillment details step completed view as well as the delivery options completed view margins.

<details><summary>Fixed view</summary>
<p>

<img width="1156" height="515" alt="image" src="https://github.com/user-attachments/assets/1e70369c-e534-4c04-8f5a-cd551169cda9" />


</p>
</details> 



<!-- Implementation description -->


[EMI-2664]: https://artsyproduct.atlassian.net/browse/EMI-2664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ