### PR TITLE
chore: add error tracking to useLoadScript for debugging "Load failed" errors

### DIFF
--- a/src/Utils/Hooks/useLoadScript.ts
+++ b/src/Utils/Hooks/useLoadScript.ts
@@ -1,3 +1,4 @@
+import { captureException } from "@sentry/browser"
 import { useEffect } from "react"
 
 type UseLoadScript = {
@@ -23,6 +24,12 @@ export const useLoadScript = ({
     script.id = id
     script.async = true
     script.onload = () => onReady?.()
+    script.onerror = () => {
+      captureException(new Error(`Script load failed: ${id}`), {
+        tags: { source: "script_load_failure" },
+        extra: { scriptId: id, src: script.src },
+      })
+    }
 
     if ("src" in rest) {
       script.src = rest.src


### PR DESCRIPTION
## Problem
We're seeing "TypeError: Load failed" errors in Sentry but lack context about which external scripts are failing to load.

## Solution
Added `script.onerror` handler to `useLoadScript` hook that captures:
- Which script failed (scriptId)
- What URL failed to load (src)
- Tagged as "script_load_failure" for easy Sentry filtering

### What useLoadScript Does
Dynamically loads external JavaScript scripts at runtime, including:

1. Google ReCAPTCHA: https://www.google.com/recaptcha/api.js (line 22-24)
2. Salesforce scripts: Various Salesforce integration scripts
3. Google Maps: Location/shipping estimation scripts
4. ArtsyShippingEstimate: Shipping calculation scripts

## Impact
- No functional changes - scripts that fail will still fail
- Better observability into external script loading issues (ReCAPTCHA, Salesforce, etc.)
- Tagged Sentry errors for easier debugging

cc: @artsy/diamond-devs 