### PR TITLE
chore: temporarily disable Sentry denyUrls to debug "Load failed" errors

### DIFF
--- a/src/System/Utils/setupSentryClient.ts
+++ b/src/System/Utils/setupSentryClient.ts
@@ -9,11 +9,7 @@ import {
   startBrowserTracingNavigationSpan,
   startBrowserTracingPageLoadSpan,
 } from "@sentry/browser"
-import {
-  ALLOWED_URLS,
-  DENIED_URLS,
-  IGNORED_ERRORS,
-} from "Server/analytics/sentryFilters"
+import { ALLOWED_URLS, IGNORED_ERRORS } from "Server/analytics/sentryFilters"
 import { findRoutesByPath } from "System/Router/Utils/routeUtils"
 import { getENV } from "Utils/getENV"
 import type { Match } from "found"
@@ -30,7 +26,7 @@ export function setupSentryClient() {
 
   const sentryClient = init({
     allowUrls: ALLOWED_URLS,
-    denyUrls: DENIED_URLS,
+    // denyUrls: DENIED_URLS, // Temporarily disabled to debug "Load failed" errors
     dsn: getENV("SENTRY_PUBLIC_DSN"),
     ignoreErrors: IGNORED_ERRORS,
     tracesSampleRate: 0.08,


### PR DESCRIPTION
## Problem
We're seeing frequent "TypeError: Load failed" errors in Sentry but lack visibility into which third-party services might be causing them. Our current Sentry configuration blocks errors related to external services (Braze, Google Tag Manager, DoubleClick, etc.) via the `denyUrls` filter.

## Solution
Temporarily disable the `denyUrls` configuration in Sentry client setup to allow third-party service errors (occurring on our domain) to reach Sentry.

I will monitor Sentry for 24 hours to collect data and then revert this change.

### What this reveals
- Script loading failures when artsy.net tries to load external services
- SDK initialization errors from third-party services on our pages
- Network errors from external service calls
- Which specific services correlate with "Load failed" error patterns

## Impact
- **No functional changes** - same third-party services will still load/fail as before
- **Increased Sentry visibility** into previously filtered errors
- **Temporary increase** in error volume (expected)
- **Better debugging data** to identify root cause of "Load failed" errors

cc: @artsy/diamond-devs 