### PR TITLE
feat(EMI-2651): Redirect Eigen users to app Order Details screen

### DIFF
--- a/src/Typings/global.d.ts
+++ b/src/Typings/global.d.ts
@@ -28,6 +28,13 @@ declare global {
     embeddedservice_bootstrap?: any
     grecaptcha: any
     ReactNativeWebView?: { postMessage: (message: string) => void }
+    webkit?: {
+      messageHandlers: {
+        ReactNativeWebView?: {
+          postMessage: (message: string) => void
+        }
+      }
+    }
     sd: any
     // Zendesk properties
     zEmbed: { show: () => void; hide: () => void }


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2651]

### Description
This PR simplifies our redirection logic after Purchase or Make Offer
It also updates how we post messages to our Eigen's webview based on platform

Todo:
- [ ] Link Eigen PR with videos

<!-- Implementation description -->
