### PR TITLE
fix: Hide sticky help footer on Order Details page

### DIFF
--- a/src/Apps/Order/OrderApp.tsx
+++ b/src/Apps/Order/OrderApp.tsx
@@ -111,7 +111,7 @@ const OrderApp: FC<React.PropsWithChildren<OrderAppProps>> = props => {
 
   const stripePromise = loadStripe(getENV("STRIPE_PUBLISHABLE_KEY"))
   const isModal = !!props.match?.location.query.isModal
-  const isOrderDetails = !!props.match.location.pathname.includes("/details")
+  const isOrderDetails = !!props.match?.location.pathname.includes("/details")
   const artwork = extractNodes(order.lineItems)[0].artwork
 
   return (


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves []

### Description
This PR hides the sticky help footer on the Order Details page inside the Order App
Since we already have a help section in the page itself

| Before | After |
|---|---|
| <img width="1412" height="1116" alt="image" src="https://github.com/user-attachments/assets/cf73e9af-cd30-45ef-8bbd-585becb7e758" /> | <img width="1412" height="1116" alt="image" src="https://github.com/user-attachments/assets/7f761777-9b55-44f1-aa86-271a78b94542" /> |


<!-- Implementation description -->
