### PR TITLE
fix: featured artists rail linking to production instead of current env

### DIFF
--- a/src/Apps/Artists/Components/ArtistsCarouselCell.tsx
+++ b/src/Apps/Artists/Components/ArtistsCarouselCell.tsx
@@ -2,6 +2,7 @@ import { ContextModule } from "@artsy/cohesion"
 import { Box, Image, Text } from "@artsy/palette"
 import { FollowArtistButtonQueryRenderer } from "Components/FollowButton/FollowArtistButton"
 import { RouterLink } from "System/Components/RouterLink"
+import { getInternalHref } from "Utils/url"
 import type { ArtistsCarouselCell_featuredLink$data } from "__generated__/ArtistsCarouselCell_featuredLink.graphql"
 import type * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -17,11 +18,13 @@ const ArtistsCarouselCell: React.FC<
 > = ({ featuredLink, lazyLoad = true }) => {
   const { image, entity } = featuredLink
 
-  if (!image || !entity) return null
+  if (!image || !entity || !featuredLink.href) return null
+
+  const href = getInternalHref(featuredLink.href)
 
   return (
     <>
-      <RouterLink to={featuredLink.href} display="block" textDecoration="none">
+      <RouterLink to={href} display="block" textDecoration="none">
         {image.thumb ? (
           <Image
             src={image.thumb.src}
@@ -44,7 +47,7 @@ const ArtistsCarouselCell: React.FC<
         alignItems="flex-start"
       >
         <RouterLink
-          to={featuredLink.href}
+          to={href}
           display="block"
           textDecoration="none"
           aria-label={featuredLink.title ?? entity.name ?? "Unknown Artist"}


### PR DESCRIPTION
This PR fixes an annoying issue where the Featured Artist rail links to production, even when you are running Force on localhost or staging.

| localhost | staging |
|-|-|
| <img width="1560" height="1039" alt="localhost" src="https://github.com/user-attachments/assets/11647ec6-e7e0-42e2-934e-eae1d19d01ec" /> | <img width="1560" height="1039" alt="staging" src="https://github.com/user-attachments/assets/ec405e3a-3c65-41d2-a066-af763218b003" /> |

This is especially annoying when building and testing features locally because developers will click into an artist page without knowing that they've been taken to production, where they will not be able to see any changes that they made locally.

The solution was to use the [getInternalHref](https://github.com/artsy/force/blob/12fbf3088b69d332d89f2d6c0e51291b4e0a7187/src/Utils/url.ts#L10) util to extract just the path of the artist page so that the router can build an appropriate URL for each env.