### PR TITLE
chore: Use Message component with title for info box in Settings → Edit Profile

### DIFF
--- a/src/Apps/Settings/Routes/EditProfile/SettingsEditProfileRoute.tsx
+++ b/src/Apps/Settings/Routes/EditProfile/SettingsEditProfileRoute.tsx
@@ -1,5 +1,4 @@
-import InfoIcon from "@artsy/icons/InfoIcon"
-import { Column, GridColumns, Join, Separator, Text } from "@artsy/palette"
+import { Column, GridColumns, Join, Message, Separator } from "@artsy/palette"
 import { SettingsEditProfileFieldsFragmentContainer } from "Apps/Settings/Routes/EditProfile/Components/SettingsEditProfileFields"
 import type { SettingsEditProfileRoute_me$data } from "__generated__/SettingsEditProfileRoute_me.graphql"
 import type React from "react"
@@ -14,12 +13,14 @@ const SettingsEditProfileRoute: React.FC<
 > = ({ me }) => {
   return (
     <GridColumns>
-      <Column span={8} bg="mono5" p={2} display="flex" gap={1}>
-        <InfoIcon flexShrink={0} />
-        <Text variant="sm-display">
+      <Column span={8}>
+        <Message
+          variant="info"
+          title="Complete your profile and make a great impression"
+        >
           The information you provide here will be shared when you contact a
           gallery or make an offer.
-        </Text>
+        </Message>
       </Column>
 
       <Column span={8}>


### PR DESCRIPTION
The type of this PR is: Chore

This PR solves [EMI-2727](https://artsyproduct.atlassian.net/browse/EMI-2727)

### Description
- Add "Complete your profile and make a great impression" before existing text on web collector settings page to match app language.
- Replace custom implementation with the palette Message component.

| Before | After |
|--------|--------|
| <img width="1934" height="216" alt="Screenshot 2025-08-13 at 10 48 28 (1)" src="https://github.com/user-attachments/assets/b048fde2-bc8b-4cb0-b00e-97072547fc67" /> | <img width="1518" height="270" alt="Screenshot 2025-08-13 at 11 01 56" src="https://github.com/user-attachments/assets/787c5d0d-79dd-437d-a378-7aed816fa0cb" /> |

@artsy/emerald-devs 

[EMI-2727]: https://artsyproduct.atlassian.net/browse/EMI-2727?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ