### PR TITLE
fix(EMI-2570): both express checkout and phone input work now

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/CheckoutContext/Order2CheckoutContext.tsx
+++ b/src/Apps/Order2/Routes/Checkout/CheckoutContext/Order2CheckoutContext.tsx
@@ -512,6 +512,10 @@ const CheckoutLoadingManager: React.FC<{
   const [minimumLoadingPassed, setMinimumLoadingPassed] = useState(false)
   const [orderValidated, setOrderValidated] = useState(false)
 
+  const isExpressCheckoutLoaded = Order2CheckoutContext.useStoreState(
+    state => state.expressCheckoutPaymentMethods !== null,
+  )
+
   const isLoading = Order2CheckoutContext.useStoreState(
     state => state.isLoading,
   )
@@ -558,6 +562,7 @@ const CheckoutLoadingManager: React.FC<{
       [
         minimumLoadingPassed,
         orderValidated,
+        isExpressCheckoutLoaded,
         isPartnerOfferLoadingComplete,
         isLoading,
         setLoadingComplete,
@@ -568,6 +573,7 @@ const CheckoutLoadingManager: React.FC<{
   }, [
     minimumLoadingPassed,
     orderValidated,
+    isExpressCheckoutLoaded,
     isPartnerOfferLoadingComplete,
     isLoading,
     setLoadingComplete,

--- a/src/Apps/Order2/Routes/Checkout/Order2CheckoutApp.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Order2CheckoutApp.tsx
@@ -103,56 +103,62 @@ export const Order2CheckoutApp: React.FC<Order2CheckoutAppProps> = ({
             : "width=device-width, initial-scale=1, maximum-scale=5 viewport-fit=cover"
         }
       />
-      {isLoading ? (
-        <Order2CheckoutLoadingSkeleton order={orderData} />
-      ) : (
-        <GridColumns py={[0, 4]} px={[0, 4]}>
-          <Column span={[12, 7, 6, 5]} start={[1, 1, 2, 3]}>
-            {expressCheckoutSubmitting ? (
-              <SubmittingOrderSpinner />
-            ) : (
-              <>
-                <Stack gap={1}>
-                  <Box display={["block", "none"]}>
-                    <Order2CollapsibleOrderSummary order={orderData} />
-                  </Box>
-                  {isExpressCheckoutEligible && (
-                    <Order2ExpressCheckout order={orderData} />
-                  )}
-                  <Order2FulfillmentDetailsStep order={orderData} />
-                  <Order2DeliveryOptionsStep order={orderData} />
-                  <Order2PaymentStep order={orderData} me={meData} />
-                </Stack>
-                <Box display={["block", "none"]}>
-                  <Spacer y={1} />
-                  <Order2ReviewStep order={orderData} />
-                  <Order2HelpLinksWithInquiry
-                    order={orderData}
-                    artworkID={artworkSlug as string}
-                    contextModule={ContextModule.ordersCheckout}
-                  />
-                </Box>
-              </>
-            )}
-          </Column>
-
-          <Column
-            span={[12, 5, 4, 3]}
-            start={[1, 8, 8, 8]}
-            display={["none", "block"]}
+      {isLoading && <Order2CheckoutLoadingSkeleton order={orderData} />}
+      <GridColumns
+        py={[0, 4]}
+        px={[0, 4]}
+        style={{
+          opacity: isLoading ? 0 : 1,
+          pointerEvents: isLoading ? "none" : "auto",
+        }}
+      >
+        <Column span={[12, 7, 6, 5]} start={[1, 1, 2, 3]}>
+          {expressCheckoutSubmitting && <SubmittingOrderSpinner />}
+          <Box
+            style={{
+              opacity: expressCheckoutSubmitting ? 0 : 1,
+              pointerEvents: expressCheckoutSubmitting ? "none" : "auto",
+            }}
           >
-            <Box position={["initial", "sticky"]} top="100px">
+            <Stack gap={1}>
+              <Box display={["block", "none"]}>
+                <Order2CollapsibleOrderSummary order={orderData} />
+              </Box>
+              {isExpressCheckoutEligible && (
+                <Order2ExpressCheckout order={orderData} />
+              )}
+              <Order2FulfillmentDetailsStep order={orderData} />
+              <Order2DeliveryOptionsStep order={orderData} />
+              <Order2PaymentStep order={orderData} me={meData} />
+            </Stack>
+            <Box display={["block", "none"]}>
+              <Spacer y={1} />
               <Order2ReviewStep order={orderData} />
-              <Separator as="hr" />
               <Order2HelpLinksWithInquiry
                 order={orderData}
                 artworkID={artworkSlug as string}
                 contextModule={ContextModule.ordersCheckout}
               />
             </Box>
-          </Column>
-        </GridColumns>
-      )}
+          </Box>
+        </Column>
+
+        <Column
+          span={[12, 5, 4, 3]}
+          start={[1, 8, 8, 8]}
+          display={["none", "block"]}
+        >
+          <Box position={["initial", "sticky"]} top="100px">
+            <Order2ReviewStep order={orderData} />
+            <Separator as="hr" />
+            <Order2HelpLinksWithInquiry
+              order={orderData}
+              artworkID={artworkSlug as string}
+              contextModule={ContextModule.ordersCheckout}
+            />
+          </Box>
+        </Column>
+      </GridColumns>
       <ConnectedModalDialog />
     </Provider>
   )

--- a/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
@@ -375,13 +375,6 @@ describe("Order2CheckoutRoute", () => {
         screen.getByLabelText("Checkout loading skeleton"),
       ).toBeInTheDocument()
 
-      // Express checkout is not rendered during loading anymore
-      expect(MockExpressCheckout).not.toHaveBeenCalled()
-
-      // Wait for loading to complete
-      await helpers.waitForLoadingComplete()
-
-      // Now express checkout should be rendered
       expect(MockExpressCheckout).toHaveBeenCalled()
     })
 


### PR DESCRIPTION
The type of this PR is: Fix

This PR solves [EMI-2570](https://artsyproduct.atlassian.net/browse/EMI-2570)

### Description
- Re-added isExpressCheckoutLoaded that was removed with the previous fix attempt (#15992)
- Reverted both previous fix attempts (#15992,#15989) and used opacity instead of display to hide the wanted elements

@artsy/emerald-devs 