### PR TITLE
feat: alter fair experience for The Artsy Edition Shop

### DIFF
--- a/src/Apps/Fair/Components/FairHeader/FairHeader.tsx
+++ b/src/Apps/Fair/Components/FairHeader/FairHeader.tsx
@@ -14,6 +14,7 @@ const FairHeader: React.FC<React.PropsWithChildren<FairHeaderProps>> = ({
   const { name, exhibitionPeriod, profile } = fair
 
   const avatar = profile?.icon?.url
+  const isArtsyEditionShop = fair.slug === "the-artsy-edition-shop"
 
   return (
     <GridColumns>
@@ -33,9 +34,15 @@ const FairHeader: React.FC<React.PropsWithChildren<FairHeaderProps>> = ({
           {name}
         </Text>
 
-        <Text variant={["lg-display", "xl"]} color="mono60">
-          {exhibitionPeriod}
-        </Text>
+        {isArtsyEditionShop ? (
+          <Text variant={["md", "lg-display"]} color="mono60">
+            Your Chance to Own an Icon
+          </Text>
+        ) : (
+          <Text variant={["lg-display", "xl"]} color="mono60">
+            {exhibitionPeriod}
+          </Text>
+        )}
       </Column>
     </GridColumns>
   )
@@ -51,6 +58,7 @@ export const FairHeaderFragmentContainer = createFragmentContainer(FairHeader, {
           url(version: ["large", "square", "square140"])
         }
       }
+      slug
     }
   `,
 })

--- a/src/Apps/Fair/Components/FairOverview/FairAbout.tsx
+++ b/src/Apps/Fair/Components/FairOverview/FairAbout.tsx
@@ -13,18 +13,24 @@ const FairAbout: React.FC<React.PropsWithChildren<FairAboutProps>> = ({
 }) => {
   const { about } = fair
 
+  const isArtsyEditionShop = fair.slug === "the-artsy-edition-shop"
+
   return (
     <>
       <GridColumns mt={[2, 4]}>
-        <Column span={6}>
-          <FairTimer fair={fair} />
-        </Column>
+        {!isArtsyEditionShop && (
+          <Column span={6}>
+            <FairTimer fair={fair} />
+          </Column>
+        )}
 
         {about && (
           <Column span={6}>
-            <Text variant="xs" mb={1}>
-              About
-            </Text>
+            {!isArtsyEditionShop && (
+              <Text variant="xs" mb={1}>
+                About
+              </Text>
+            )}
 
             <HTML variant="sm">
               <ReadMore maxChars={480} content={about} />
@@ -41,6 +47,7 @@ export const FairAboutFragmentContainer = createFragmentContainer(FairAbout, {
     fragment FairAbout_fair on Fair {
       ...FairTimer_fair
       about(format: HTML)
+      slug
     }
   `,
 })

--- a/src/Apps/Fair/Components/__tests__/FairHeader.jest.tsx
+++ b/src/Apps/Fair/Components/__tests__/FairHeader.jest.tsx
@@ -32,4 +32,15 @@ describe("FairHeader", () => {
 
     expect(screen.getByText("Miart 2020")).toBeInTheDocument()
   })
+
+  it("displays subheader for Artsy Edition Shop", () => {
+    renderWithRelay({
+      Fair: () => ({
+        name: "The Artsy Edition Shop",
+        slug: "the-artsy-edition-shop",
+      }),
+    })
+
+    expect(screen.getByText("Your Chance to Own an Icon")).toBeInTheDocument()
+  })
 })

--- a/src/Apps/Fair/Routes/__tests__/FairOverview.jest.tsx
+++ b/src/Apps/Fair/Routes/__tests__/FairOverview.jest.tsx
@@ -134,6 +134,20 @@ describe("FairOverview", () => {
     expect(container.textContent).not.toContain("Closes in:")
   })
 
+  it("does not display the timer for the Artsy Edition Shop", () => {
+    const openTime = new Date()
+    openTime.setDate(openTime.getDate() + 1)
+
+    const { container } = renderWithRelay({
+      Fair: () => ({
+        endAt: openTime.toISOString(),
+        slug: "the-artsy-edition-shop",
+      }),
+    })
+
+    expect(container.textContent).not.toContain("Closes in:")
+  })
+
   it("scrollTo should be called if url contains `focused_boots` query param", async () => {
     mockUseRouter.mockImplementation(() => ({
       match: {

--- a/src/__generated__/FairAbout_fair.graphql.ts
+++ b/src/__generated__/FairAbout_fair.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<6f69ca99dedfc8283a489a9e7edc6d94>>
+ * @generated SignedSource<<37e7df4bb18375f38b4bbdab5714e0b9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,7 @@ import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type FairAbout_fair$data = {
   readonly about: string | null | undefined;
+  readonly slug: string;
   readonly " $fragmentSpreads": FragmentRefs<"FairTimer_fair">;
   readonly " $fragmentType": "FairAbout_fair";
 };
@@ -43,12 +44,19 @@ const node: ReaderFragment = {
       "kind": "ScalarField",
       "name": "about",
       "storageKey": "about(format:\"HTML\")"
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slug",
+      "storageKey": null
     }
   ],
   "type": "Fair",
   "abstractKey": null
 };
 
-(node as any).hash = "648a39c0f14cfdc5bd31a80ef0b4d532";
+(node as any).hash = "2c5bcf4b58e3663c056142e833c01624";
 
 export default node;

--- a/src/__generated__/FairApp_Test_Query.graphql.ts
+++ b/src/__generated__/FairApp_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<aa0d94c7eebd9de17be50411466fa3af>>
+ * @generated SignedSource<<94fec16646e184b0ce6ed5a3c13e8d41>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -281,7 +281,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "6b79956a2616de2994bed2945a63349b",
+    "cacheID": "b0193d7e9dec28124c5da7a12f941fc2",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -335,7 +335,7 @@ return {
     },
     "name": "FairApp_Test_Query",
     "operationKind": "query",
-    "text": "query FairApp_Test_Query {\n  fair(id: \"example\") {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment ExhibitorsLetterNav_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n  }\n}\n\nfragment FairApp_fair on Fair {\n  ...FairTabs_fair\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairHeaderImage_fair\n  ...ExhibitorsLetterNav_fair\n  internalID\n  profile {\n    id\n  }\n}\n\nfragment FairHeaderImage_fair on Fair {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  name\n  exhibitionPeriod\n  profile {\n    icon {\n      url(version: [\"large\", \"square\", \"square140\"])\n    }\n    id\n  }\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaDescriptionFallback: about(format: PLAIN)\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n\nfragment FairTabs_fair on Fair {\n  href\n  counts {\n    artworks\n  }\n}\n"
+    "text": "query FairApp_Test_Query {\n  fair(id: \"example\") {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment ExhibitorsLetterNav_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n  }\n}\n\nfragment FairApp_fair on Fair {\n  ...FairTabs_fair\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairHeaderImage_fair\n  ...ExhibitorsLetterNav_fair\n  internalID\n  profile {\n    id\n  }\n}\n\nfragment FairHeaderImage_fair on Fair {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  name\n  exhibitionPeriod\n  profile {\n    icon {\n      url(version: [\"large\", \"square\", \"square140\"])\n    }\n    id\n  }\n  slug\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaDescriptionFallback: about(format: PLAIN)\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n\nfragment FairTabs_fair on Fair {\n  href\n  counts {\n    artworks\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/FairHeaderTestQuery.graphql.ts
+++ b/src/__generated__/FairHeaderTestQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<543c04d0df3699d912f21dbc28ed445f>>
+ * @generated SignedSource<<2d3052e21294d849c63c2335250001d1>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -143,6 +143,13 @@ return {
             ],
             "storageKey": null
           },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
           (v1/*: any*/)
         ],
         "storageKey": "fair(id:\"example\")"
@@ -150,7 +157,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "cc1090aea89735da3b34f6e1af95c95e",
+    "cacheID": "f45dcb053f03724b9f38425e1262a4fd",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -176,12 +183,13 @@ return {
           "type": "Image"
         },
         "fair.profile.icon.url": (v2/*: any*/),
-        "fair.profile.id": (v3/*: any*/)
+        "fair.profile.id": (v3/*: any*/),
+        "fair.slug": (v3/*: any*/)
       }
     },
     "name": "FairHeaderTestQuery",
     "operationKind": "query",
-    "text": "query FairHeaderTestQuery {\n  fair(id: \"example\") {\n    ...FairHeader_fair\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  name\n  exhibitionPeriod\n  profile {\n    icon {\n      url(version: [\"large\", \"square\", \"square140\"])\n    }\n    id\n  }\n}\n"
+    "text": "query FairHeaderTestQuery {\n  fair(id: \"example\") {\n    ...FairHeader_fair\n    id\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  name\n  exhibitionPeriod\n  profile {\n    icon {\n      url(version: [\"large\", \"square\", \"square140\"])\n    }\n    id\n  }\n  slug\n}\n"
   }
 };
 })();

--- a/src/__generated__/FairHeader_fair.graphql.ts
+++ b/src/__generated__/FairHeader_fair.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<023c9cbc6818abec034513aada303bad>>
+ * @generated SignedSource<<14859199f709f0ca8149852499e8b72f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -18,6 +18,7 @@ export type FairHeader_fair$data = {
       readonly url: string | null | undefined;
     } | null | undefined;
   } | null | undefined;
+  readonly slug: string;
   readonly " $fragmentType": "FairHeader_fair";
 };
 export type FairHeader_fair$key = {
@@ -83,12 +84,19 @@ const node: ReaderFragment = {
         }
       ],
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "slug",
+      "storageKey": null
     }
   ],
   "type": "Fair",
   "abstractKey": null
 };
 
-(node as any).hash = "f406737327f57215c5b236b25647ec44";
+(node as any).hash = "d76057730cc02d72a054ef7fc1e2def0";
 
 export default node;

--- a/src/__generated__/FairOverviewTestQuery.graphql.ts
+++ b/src/__generated__/FairOverviewTestQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b56cc1176b4e3fc5f1ce57be083cc4aa>>
+ * @generated SignedSource<<c20509723134f560abdc245bb93279f7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -424,7 +424,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "75472695b15052b2592d100ae0308ff8",
+    "cacheID": "b3c3acaf599117cd954eaf9b7c8c9c38",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -531,7 +531,7 @@ return {
     },
     "name": "FairOverviewTestQuery",
     "operationKind": "query",
-    "text": "query FairOverviewTestQuery {\n  fair(id: \"example\") {\n    ...FairOverview_fair\n    id\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairAbout_fair on Fair {\n  ...FairTimer_fair\n  about(format: HTML)\n}\n\nfragment FairCollection_collection on MarketingCollection {\n  id\n  slug\n  title\n  artworks: artworksConnection(first: 3) {\n    counts {\n      total\n    }\n    edges {\n      node {\n        image {\n          url(version: \"larger\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairCollections_fair on Fair {\n  marketingCollections(size: 5) {\n    id\n    slug\n    ...FairCollection_collection\n  }\n}\n\nfragment FairEditorialRailArticles_fair on Fair {\n  href\n  articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        ...CellArticle_article\n        internalID\n        slug\n        id\n      }\n    }\n  }\n}\n\nfragment FairOverview_fair on Fair {\n  ...FairEditorialRailArticles_fair\n  ...FairCollections_fair\n  ...FairAbout_fair\n  href\n  slug\n  articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {\n    edges {\n      __typename\n    }\n  }\n  marketingCollections(size: 5) {\n    id\n  }\n}\n\nfragment FairTimer_fair on Fair {\n  endAt\n}\n"
+    "text": "query FairOverviewTestQuery {\n  fair(id: \"example\") {\n    ...FairOverview_fair\n    id\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairAbout_fair on Fair {\n  ...FairTimer_fair\n  about(format: HTML)\n  slug\n}\n\nfragment FairCollection_collection on MarketingCollection {\n  id\n  slug\n  title\n  artworks: artworksConnection(first: 3) {\n    counts {\n      total\n    }\n    edges {\n      node {\n        image {\n          url(version: \"larger\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairCollections_fair on Fair {\n  marketingCollections(size: 5) {\n    id\n    slug\n    ...FairCollection_collection\n  }\n}\n\nfragment FairEditorialRailArticles_fair on Fair {\n  href\n  articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        ...CellArticle_article\n        internalID\n        slug\n        id\n      }\n    }\n  }\n}\n\nfragment FairOverview_fair on Fair {\n  ...FairEditorialRailArticles_fair\n  ...FairCollections_fair\n  ...FairAbout_fair\n  href\n  slug\n  articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {\n    edges {\n      __typename\n    }\n  }\n  marketingCollections(size: 5) {\n    id\n  }\n}\n\nfragment FairTimer_fair on Fair {\n  endAt\n}\n"
   }
 };
 })();

--- a/src/__generated__/fairRoutes_FairOverviewQuery.graphql.ts
+++ b/src/__generated__/fairRoutes_FairOverviewQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<83bb20702a682c088489c93bb59663a8>>
+ * @generated SignedSource<<e4297e20445bc281bd43dec2fdf5a71a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -403,12 +403,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "bc5ff5847608295c5f5eeb95757ae3a0",
+    "cacheID": "0b56c0a94cde87822013c2d3e5028431",
     "id": null,
     "metadata": {},
     "name": "fairRoutes_FairOverviewQuery",
     "operationKind": "query",
-    "text": "query fairRoutes_FairOverviewQuery(\n  $slug: String!\n) @cacheable {\n  fair(id: $slug) @principalField {\n    ...FairOverview_fair\n    id\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairAbout_fair on Fair {\n  ...FairTimer_fair\n  about(format: HTML)\n}\n\nfragment FairCollection_collection on MarketingCollection {\n  id\n  slug\n  title\n  artworks: artworksConnection(first: 3) {\n    counts {\n      total\n    }\n    edges {\n      node {\n        image {\n          url(version: \"larger\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairCollections_fair on Fair {\n  marketingCollections(size: 5) {\n    id\n    slug\n    ...FairCollection_collection\n  }\n}\n\nfragment FairEditorialRailArticles_fair on Fair {\n  href\n  articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        ...CellArticle_article\n        internalID\n        slug\n        id\n      }\n    }\n  }\n}\n\nfragment FairOverview_fair on Fair {\n  ...FairEditorialRailArticles_fair\n  ...FairCollections_fair\n  ...FairAbout_fair\n  href\n  slug\n  articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {\n    edges {\n      __typename\n    }\n  }\n  marketingCollections(size: 5) {\n    id\n  }\n}\n\nfragment FairTimer_fair on Fair {\n  endAt\n}\n"
+    "text": "query fairRoutes_FairOverviewQuery(\n  $slug: String!\n) @cacheable {\n  fair(id: $slug) @principalField {\n    ...FairOverview_fair\n    id\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairAbout_fair on Fair {\n  ...FairTimer_fair\n  about(format: HTML)\n  slug\n}\n\nfragment FairCollection_collection on MarketingCollection {\n  id\n  slug\n  title\n  artworks: artworksConnection(first: 3) {\n    counts {\n      total\n    }\n    edges {\n      node {\n        image {\n          url(version: \"larger\")\n        }\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment FairCollections_fair on Fair {\n  marketingCollections(size: 5) {\n    id\n    slug\n    ...FairCollection_collection\n  }\n}\n\nfragment FairEditorialRailArticles_fair on Fair {\n  href\n  articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        ...CellArticle_article\n        internalID\n        slug\n        id\n      }\n    }\n  }\n}\n\nfragment FairOverview_fair on Fair {\n  ...FairEditorialRailArticles_fair\n  ...FairCollections_fair\n  ...FairAbout_fair\n  href\n  slug\n  articlesConnection(first: 6, sort: PUBLISHED_AT_DESC) {\n    edges {\n      __typename\n    }\n  }\n  marketingCollections(size: 5) {\n    id\n  }\n}\n\nfragment FairTimer_fair on Fair {\n  endAt\n}\n"
   }
 };
 })();

--- a/src/__generated__/fairRoutes_FairQuery.graphql.ts
+++ b/src/__generated__/fairRoutes_FairQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d3b0fff3edc2f3c236bb62812fbca62c>>
+ * @generated SignedSource<<77cebe0db1ebb2a9c3376752dbd9b106>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -272,12 +272,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "aa8cf734a7698b820444c7911a841841",
+    "cacheID": "5d218f86bd8303e494dc8146364d210a",
     "id": null,
     "metadata": {},
     "name": "fairRoutes_FairQuery",
     "operationKind": "query",
-    "text": "query fairRoutes_FairQuery(\n  $slug: String!\n) @cacheable {\n  fair(id: $slug) @principalField {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment ExhibitorsLetterNav_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n  }\n}\n\nfragment FairApp_fair on Fair {\n  ...FairTabs_fair\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairHeaderImage_fair\n  ...ExhibitorsLetterNav_fair\n  internalID\n  profile {\n    id\n  }\n}\n\nfragment FairHeaderImage_fair on Fair {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  name\n  exhibitionPeriod\n  profile {\n    icon {\n      url(version: [\"large\", \"square\", \"square140\"])\n    }\n    id\n  }\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaDescriptionFallback: about(format: PLAIN)\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n\nfragment FairTabs_fair on Fair {\n  href\n  counts {\n    artworks\n  }\n}\n"
+    "text": "query fairRoutes_FairQuery(\n  $slug: String!\n) @cacheable {\n  fair(id: $slug) @principalField {\n    ...FairApp_fair\n    id\n  }\n}\n\nfragment ExhibitorsLetterNav_fair on Fair {\n  exhibitorsGroupedByName {\n    letter\n  }\n}\n\nfragment FairApp_fair on Fair {\n  ...FairTabs_fair\n  ...FairMeta_fair\n  ...FairHeader_fair\n  ...FairHeaderImage_fair\n  ...ExhibitorsLetterNav_fair\n  internalID\n  profile {\n    id\n  }\n}\n\nfragment FairHeaderImage_fair on Fair {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment FairHeader_fair on Fair {\n  name\n  exhibitionPeriod\n  profile {\n    icon {\n      url(version: [\"large\", \"square\", \"square140\"])\n    }\n    id\n  }\n  slug\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaDescriptionFallback: about(format: PLAIN)\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n\nfragment FairTabs_fair on Fair {\n  href\n  counts {\n    artworks\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Feat**

### Description

Part of a set of requests from Marketing to tweak the design of the fair experience to support the use of these surfaces for a persistent "online shop", sourcing works directly from various gallery partners.

- Hide "[open] - [close]" dates in header, replace with subheader copy.
- Hide "Closes in" timer.
- Left-align "about" content.

Long-term, we intend to plan out the introduction of a separate "Shop" concept, which can borrow from some fair behavior (like sourcing directly from partners via CMS) but shed some of the time-specific requirements fairs currently have.

Jira: [ONYX-1872](https://artsyproduct.atlassian.net/browse/ONYX-1872) 🔒 

### Screenshots

|Platform | Before | After |
|--------|--------|--------|
|Desktop Web| <img width="1400" alt="Screenshot 2025-08-14 at 15 13 31" src="https://github.com/user-attachments/assets/24addd96-cecf-4b9c-aa70-f98039a69f39" /> | <img width="1400" alt="Screenshot 2025-08-14 at 15 13 40" src="https://github.com/user-attachments/assets/4e88a21d-bcc9-41e6-a066-589ccc7a1a76" /> |
|Desktop Web| <img width="1400" alt="Screenshot 2025-08-14 at 22 37 07" src="https://github.com/user-attachments/assets/cfe8c49f-93d8-4bd1-8d65-a1f27d706d15" /> | <img width="1400" height="2666" alt="Screenshot 2025-08-14 at 22 12 40" src="https://github.com/user-attachments/assets/d2543f41-5fd0-400a-b58a-f7208e647418" /> |
|Mobile Web| <img width="400" alt="staging artsy net_fair_the-artsy-edition-shop" src="https://github.com/user-attachments/assets/809f270f-6c02-40a7-8d04-67f09891d494" /> | <img width="400" alt="localhost_4000_fair_the-artsy-edition-shop" src="https://github.com/user-attachments/assets/71928338-4116-4d48-abed-a77713fd13d6" /> |
|Mobile Web| <img width="794" height="2052" alt="staging artsy net_fair_intersect-aspen-2025" src="https://github.com/user-attachments/assets/5b93254d-0a62-4006-9ef3-ef4d1e0cc4ce" /> | <img width="400" alt="localhost_4000_fair_intersect-aspen-2025" src="https://github.com/user-attachments/assets/2c7725fc-4f08-4c4b-9264-146387c70e3d" /> |





[ONYX-1872]: https://artsyproduct.atlassian.net/browse/ONYX-1872?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

