### PR TITLE
fix(partner): Rename Events tab to Shows & Fairs

### DIFF
--- a/src/Apps/Partner/Components/NavigationTabs/index.tsx
+++ b/src/Apps/Partner/Components/NavigationTabs/index.tsx
@@ -37,7 +37,7 @@ export const NavigationTabs: React.FC<
       exact: true,
     },
     {
-      name: "Events",
+      name: "Shows & Fairs",
       href: route("/shows"),
       exact: true,
       hidden: !counts?.displayableShows,

--- a/src/Apps/Partner/Components/Overview/ShowsRail.tsx
+++ b/src/Apps/Partner/Components/Overview/ShowsRail.tsx
@@ -31,7 +31,7 @@ const ShowsRail: React.FC<React.PropsWithChildren<ShowsRailProps>> = ({
         alignItems="center"
         position="relative"
       >
-        <Text variant="lg-display">All Events</Text>
+        <Text variant="lg-display">All Shows & Fairs</Text>
 
         {displayFullPartnerPage && (
           <ViewAllButton to={`/partner/${slug}/shows`} />

--- a/src/Apps/Partner/Components/__tests__/NavigationTabs.jest.tsx
+++ b/src/Apps/Partner/Components/__tests__/NavigationTabs.jest.tsx
@@ -1,7 +1,7 @@
+import { screen } from "@testing-library/react"
 import { NavigationTabsFragmentContainer as NavigationTabs } from "Apps/Partner/Components/NavigationTabs"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
 import type { NavigationTabsTestPartnerQuery } from "__generated__/NavigationTabsTestPartnerQuery.graphql"
-import { screen } from "@testing-library/react"
 import { graphql } from "react-relay"
 
 jest.unmock("react-relay")
@@ -39,7 +39,7 @@ describe("PartnerNavigationTabs", () => {
     })
 
     expect(screen.getByText("Overview")).toBeInTheDocument()
-    expect(screen.getByText("Events")).toBeInTheDocument()
+    expect(screen.getByText("Shows & Fairs")).toBeInTheDocument()
     expect(screen.getByText("Viewing Rooms")).toBeInTheDocument()
     expect(screen.getByText("Works")).toBeInTheDocument()
     expect(screen.getByText("Artists")).toBeInTheDocument()

--- a/src/Apps/Partner/Routes/Shows/index.tsx
+++ b/src/Apps/Partner/Routes/Shows/index.tsx
@@ -91,7 +91,7 @@ export const Shows: React.FC<React.PropsWithChildren<PartnerShowsProps>> = ({
         )}
 
         <ShowPaginatedEventsRenderer
-          eventTitle="Past Events"
+          eventTitle="Past Shows & Fairs"
           partnerId={partner.slug}
           status="CLOSED"
           first={40}

--- a/src/Apps/Show/Routes/ShowInfo.tsx
+++ b/src/Apps/Show/Routes/ShowInfo.tsx
@@ -107,7 +107,7 @@ const EventList: React.FC<
   return (
     <Box>
       <Text as="h2" variant="xl" mb="2">
-        Events
+        Shows & Fairs
       </Text>
 
       <Join separator={<Spacer y="2" />}>

--- a/src/Apps/Show/__tests__/ShowInfo.jest.tsx
+++ b/src/Apps/Show/__tests__/ShowInfo.jest.tsx
@@ -29,7 +29,7 @@ describe("ShowInfo", () => {
       expect(
         screen.getByRole("heading", { level: 1, name: "About" }),
       ).toBeInTheDocument()
-      expect(screen.queryByText("Events")).not.toBeInTheDocument()
+      expect(screen.queryByText("Shows & Fairs")).not.toBeInTheDocument()
       expect(
         screen.getByRole("heading", { level: 2, name: "Gallery" }),
       ).toBeInTheDocument()
@@ -51,7 +51,7 @@ describe("ShowInfo", () => {
         Partner: () => ({ type: "Gallery" }),
       })
 
-      expect(screen.getByText("Events")).toBeInTheDocument()
+      expect(screen.getByText("Shows & Fairs")).toBeInTheDocument()
       expect(
         screen.getByRole("heading", {
           level: 3,
@@ -96,7 +96,7 @@ describe("ShowInfo", () => {
         Partner: () => ({ type: "Gallery" }),
       })
 
-      expect(screen.getByText("Events")).toBeInTheDocument()
+      expect(screen.getByText("Shows & Fairs")).toBeInTheDocument()
       // No specific event headings should be present when event is null
       const headings = screen.getAllByRole("heading", { level: 3 })
       const eventHeadings = headings.filter(


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

According to [Alex](https://artsy.slack.com/archives/C05F8TNKGAV/p1749504366967369?thread_ts=1749490660.135879&cid=C05F8TNKGAV) this was a throwback from the Covid days, when shows / fairs became remote events, and we never flipped it back. Also shows _have_ events, so functionally this is confusing, culturally. Time to switch it back (which will also help with SEO).

This doesn't address the double 'Current Show' that spans across overview - > shows tab. thats a bit of a larger change. 

Before:

<img width="713" height="586" alt="Screenshot 2025-08-17 at 10 51 19 AM" src="https://github.com/user-attachments/assets/0543f109-067d-443e-a78c-504c2602ec21" />


After: 
<img width="959" height="615" alt="Screenshot 2025-08-17 at 10 50 53 AM" src="https://github.com/user-attachments/assets/1ccb2937-b8dc-45fa-884e-c1116dbec451" />

