### PR TITLE
fix(my-collection): avoids submitting "undefined" strings

### DIFF
--- a/src/Apps/MyCollection/Routes/EditArtwork/Utils/useCreateOrUpdateArtwork.ts
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Utils/useCreateOrUpdateArtwork.ts
@@ -84,8 +84,10 @@ const formValuesToMutationInput = (
     attributionClass: values.attributionClass
       ?.replace(" ", "_")
       ?.toUpperCase() as ArtworkAttributionClassType,
-    editionNumber: String(values.editionNumber),
-    editionSize: String(values.editionSize),
+    editionNumber: values.editionNumber
+      ? String(values.editionNumber)
+      : undefined,
+    editionSize: values.editionSize ? String(values.editionSize) : undefined,
     height: String(values.height),
     width: String(values.width),
     depth: String(values.depth),


### PR DESCRIPTION
Initially submitted: https://github.com/artsy/gravity/pull/19236 — but I didn't realize how open the input is here. Makes sense to just fix the real bug, of course. I think the Gravity PR is still valid but can be improved a bit. Will circle back.

cc @artsy/diamond-devs 