### PR TITLE
fix(mycollection): lifts char limit on notes + provenance; wraps provenance in a read more

### DIFF
--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormDetails.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormDetails.tsx
@@ -314,7 +314,6 @@ export const MyCollectionArtworkFormDetails: React.FC<
             title="Provenance"
             name="provenance"
             placeholder="Describe how you acquired the work"
-            maxLength={500}
             onBlur={handleBlur}
             onChange={handleChange}
             value={values.provenance}
@@ -345,7 +344,6 @@ export const MyCollectionArtworkFormDetails: React.FC<
           <TextArea
             title="Notes"
             name="confidentialNotes"
-            maxLength={500}
             onBlur={handleBlur}
             onChange={({ value }) => {
               setFieldValue("confidentialNotes", value)

--- a/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormMain.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/Components/MyCollectionArtworkFormMain.tsx
@@ -70,7 +70,7 @@ export const MyCollectionArtworkFormMain: React.FC<
         pathname: "/collector-profile/my-collection",
       })
     } catch (error) {
-      logger.error(`Artwork not deleted`, error)
+      logger.error("Artwork not deleted", error)
 
       sendToast({
         variant: "error",

--- a/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionEditArtwork.tsx
+++ b/src/Apps/MyCollection/Routes/EditArtwork/MyCollectionEditArtwork.tsx
@@ -91,7 +91,7 @@ export const MyCollectionEditArtwork: React.FC<
         pathname: `/collector-profile/my-collection/artwork/${updatedArtwork?.internalID}`,
       })
     } catch (error) {
-      logger.error(`Artwork not updated`, error)
+      logger.error("Artwork not updated", error)
 
       sendToast({
         variant: "error",

--- a/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkDetails.tsx
+++ b/src/Apps/MyCollection/Routes/MyCollectionArtwork/Components/MyCollectionArtworkDetails.tsx
@@ -43,7 +43,7 @@ export const MyCollectionArtworkDetails: React.FC<
           label: "Location",
           value: buildLocationDisplay(collectorLocation),
         },
-        { label: "Provenance", value: provenance },
+        { label: "Provenance", value: provenance, truncateLimit: 200 },
         { label: "Price Paid", value: pricePaid?.display },
         ...(exhibitionHistory
           ? [{ label: "Exhibition History", value: exhibitionHistory }]


### PR DESCRIPTION
It appears that there was no real underlying reason for the character limit on the input. Which is only enforced client-side anyway. This came up as really annoying when I for instance wanted to clip part of a press release concerning a work. This lifts the limit. And ensures we wrap the provenance in the same truncation.

![](https://capture.static.damonzucconi.com/Screen-Shot-2025-08-19-09-12-46.61-xGSVtdrnIdvxGOGlHxwuvQnvBtMptbtKWIbBmD3q0fQsNdTa0YChN3beZyN4aQcN4CTWGcSb31RY9WL3oAlu3FGZLhEUNFBgv5um.png)

cc @artsy/diamond-devs 