### PR TITLE
feat(dia-1453): adds an authors index page

### DIFF
--- a/src/Apps/Articles/AuthorsApp.tsx
+++ b/src/Apps/Articles/AuthorsApp.tsx
@@ -1,0 +1,28 @@
+import { Spacer, Stack, Text } from "@artsy/palette"
+import {
+  ArticlesAuthors,
+  ArticlesAuthorsPlaceholder,
+} from "Apps/Articles/Components/ArticlesAuthors"
+import { ClientSuspense } from "Components/ClientSuspense"
+import { MetaTags } from "Components/MetaTags"
+import type { FC } from "react"
+
+export const AuthorsApp: FC<React.PropsWithChildren<unknown>> = () => {
+  return (
+    <>
+      <MetaTags title="Authors | Artsy" />
+
+      <Spacer y={4} />
+
+      <Stack gap={4}>
+        <Text as="h1" variant="xl">
+          Authors
+        </Text>
+
+        <ClientSuspense fallback={<ArticlesAuthorsPlaceholder />}>
+          <ArticlesAuthors />
+        </ClientSuspense>
+      </Stack>
+    </>
+  )
+}

--- a/src/Apps/Articles/Components/ArticlesAuthors.tsx
+++ b/src/Apps/Articles/Components/ArticlesAuthors.tsx
@@ -1,0 +1,112 @@
+import { Box, SkeletonText, Stack, Text, media } from "@artsy/palette"
+import { themeGet } from "@styled-system/theme-get"
+import { PaginationFragmentContainer } from "Components/Pagination"
+import { RouterLink } from "System/Components/RouterLink"
+import { useRouter } from "System/Hooks/useRouter"
+import { extractNodes } from "Utils/extractNodes"
+import type { ArticlesAuthorsQuery } from "__generated__/ArticlesAuthorsQuery.graphql"
+import { useState } from "react"
+import { graphql, useLazyLoadQuery } from "react-relay"
+import styled from "styled-components"
+
+export const ArticlesAuthors = () => {
+  const { match, router } = useRouter()
+
+  const [page, setPage] = useState(Number(match.location.query.page ?? 1))
+
+  const { authorsConnection } = useLazyLoadQuery<ArticlesAuthorsQuery>(QUERY, {
+    page,
+    size: 100,
+  })
+
+  const authors = extractNodes(authorsConnection)
+
+  const handlePageChange = (page: number) => {
+    setPage(page)
+
+    router.replace({
+      pathname: match.location.pathname,
+      query: { page },
+    })
+  }
+
+  return (
+    <Stack gap={2}>
+      <Columns>
+        {authors.map(author => {
+          return (
+            <Name
+              key={author.internalID}
+              to={`/articles/author/${author.internalID}`}
+              inline
+            >
+              <Text variant="sm">{author.name}</Text>
+            </Name>
+          )
+        })}
+      </Columns>
+
+      <PaginationFragmentContainer
+        hasNextPage={!!authorsConnection?.pageInfo?.hasNextPage}
+        pageCursors={authorsConnection?.pageCursors}
+        onClick={(_cursor, page) => handlePageChange(page)}
+        onNext={page => handlePageChange(page)}
+      />
+    </Stack>
+  )
+}
+
+const QUERY = graphql`
+  query ArticlesAuthorsQuery($page: Int, $size: Int) {
+    authorsConnection(first: $size, page: $page)
+      @connection(key: "AuthorsApp_authorsConnection") {
+      edges {
+        node {
+          internalID
+          name
+        }
+      }
+      pageCursors {
+        ...Pagination_pageCursors
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+`
+
+const Columns = styled(Box)`
+  column-count: 4;
+  ${media.md`column-count: 3;`}
+  ${media.xs`column-count: 1;`}
+`
+
+const Name = styled(RouterLink)`
+  display: block;
+  text-decoration: none;
+  padding: ${themeGet("space.half")} 0;
+`
+
+export const ArticlesAuthorsPlaceholder = () => {
+  return (
+    <Stack gap={2}>
+      <Columns>
+        {Array.from({ length: 100 }).map((_, index) => (
+          <SkeletonText key={index} variant="sm">
+            {
+              [
+                "First Last",
+                "Andy Warhol",
+                "Pablo Picasso",
+                "Alan Smithee",
+                "Jane Doe",
+              ][index % 5]
+            }
+          </SkeletonText>
+        ))}
+      </Columns>
+    </Stack>
+  )
+}

--- a/src/Apps/Articles/articlesRoutes.tsx
+++ b/src/Apps/Articles/articlesRoutes.tsx
@@ -23,6 +23,11 @@ const AuthorApp = loadable(
   { resolveComponent: component => component.AuthorApp },
 )
 
+const AuthorsApp = loadable(
+  () => import(/* webpackChunkName: "articlesBundle" */ "./AuthorsApp"),
+  { resolveComponent: component => component.AuthorsApp },
+)
+
 export const articlesRoutes: RouteProps[] = [
   {
     path: "/articles",
@@ -83,5 +88,12 @@ export const articlesRoutes: RouteProps[] = [
       }
     `,
     serverCacheTTL: serverCacheTTLs.articles,
+  },
+  {
+    path: "/articles/authors",
+    Component: AuthorsApp,
+    onPreloadJS: () => {
+      AuthorsApp.preload()
+    },
   },
 ]

--- a/src/Apps/Artists/Routes/ArtistsByLetter.tsx
+++ b/src/Apps/Artists/Routes/ArtistsByLetter.tsx
@@ -7,15 +7,15 @@ import {
   Text,
   VisuallyHidden,
   media,
-  space,
 } from "@artsy/palette"
-import { PaginatedMetaTags } from "Components/PaginatedMetaTags"
+import { themeGet } from "@styled-system/theme-get"
 import { ArtistsLetterNav } from "Apps/Artists/Components/ArtistsLetterNav"
 import { LoadingArea } from "Components/LoadingArea"
+import { PaginatedMetaTags } from "Components/PaginatedMetaTags"
 import { PaginationFragmentContainer } from "Components/Pagination"
 import { RouterLink } from "System/Components/RouterLink"
 import { useRouter } from "System/Hooks/useRouter"
-import { getPageNumber, buildPageQuery } from "Utils/url"
+import { buildPageQuery, getPageNumber } from "Utils/url"
 import type { ArtistsByLetter_viewer$data } from "__generated__/ArtistsByLetter_viewer.graphql"
 import { useState } from "react"
 import type * as React from "react"
@@ -35,7 +35,7 @@ const Columns = styled(Box)`
 const Name = styled(RouterLink)`
   display: block;
   text-decoration: none;
-  padding: ${space(0.5)}px 0;
+  padding: ${themeGet("space.half")} 0;
 `
 
 interface ArtistsByLetterProps {

--- a/src/__generated__/ArticlesAuthorsQuery.graphql.ts
+++ b/src/__generated__/ArticlesAuthorsQuery.graphql.ts
@@ -1,0 +1,345 @@
+/**
+ * @generated SignedSource<<0f31d515ef28b1b06167d65a27f29b75>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ArticlesAuthorsQuery$variables = {
+  page?: number | null | undefined;
+  size?: number | null | undefined;
+};
+export type ArticlesAuthorsQuery$data = {
+  readonly authorsConnection: {
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly internalID: string;
+        readonly name: string;
+      } | null | undefined;
+    } | null | undefined> | null | undefined;
+    readonly pageCursors: {
+      readonly " $fragmentSpreads": FragmentRefs<"Pagination_pageCursors">;
+    };
+    readonly pageInfo: {
+      readonly endCursor: string | null | undefined;
+      readonly hasNextPage: boolean;
+    };
+  } | null | undefined;
+};
+export type ArticlesAuthorsQuery = {
+  response: ArticlesAuthorsQuery$data;
+  variables: ArticlesAuthorsQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "page"
+  },
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "size"
+  }
+],
+v1 = {
+  "kind": "Variable",
+  "name": "page",
+  "variableName": "page"
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "cursor",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "PageInfo",
+  "kind": "LinkedField",
+  "name": "pageInfo",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "hasNextPage",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "endCursor",
+      "storageKey": null
+    }
+  ],
+  "storageKey": null
+},
+v7 = [
+  {
+    "kind": "Variable",
+    "name": "first",
+    "variableName": "size"
+  },
+  (v1/*: any*/)
+],
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "page",
+  "storageKey": null
+},
+v9 = [
+  (v5/*: any*/),
+  (v8/*: any*/),
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "isCurrent",
+    "storageKey": null
+  }
+];
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ArticlesAuthorsQuery",
+    "selections": [
+      {
+        "alias": "authorsConnection",
+        "args": [
+          (v1/*: any*/)
+        ],
+        "concreteType": "AuthorConnection",
+        "kind": "LinkedField",
+        "name": "__AuthorsApp_authorsConnection_connection",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "AuthorEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Author",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v2/*: any*/),
+                  (v3/*: any*/),
+                  (v4/*: any*/)
+                ],
+                "storageKey": null
+              },
+              (v5/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "PageCursors",
+            "kind": "LinkedField",
+            "name": "pageCursors",
+            "plural": false,
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "Pagination_pageCursors"
+              }
+            ],
+            "storageKey": null
+          },
+          (v6/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ArticlesAuthorsQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v7/*: any*/),
+        "concreteType": "AuthorConnection",
+        "kind": "LinkedField",
+        "name": "authorsConnection",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "AuthorEdge",
+            "kind": "LinkedField",
+            "name": "edges",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Author",
+                "kind": "LinkedField",
+                "name": "node",
+                "plural": false,
+                "selections": [
+                  (v2/*: any*/),
+                  (v3/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "id",
+                    "storageKey": null
+                  },
+                  (v4/*: any*/)
+                ],
+                "storageKey": null
+              },
+              (v5/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "PageCursors",
+            "kind": "LinkedField",
+            "name": "pageCursors",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageCursor",
+                "kind": "LinkedField",
+                "name": "around",
+                "plural": true,
+                "selections": (v9/*: any*/),
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageCursor",
+                "kind": "LinkedField",
+                "name": "first",
+                "plural": false,
+                "selections": (v9/*: any*/),
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageCursor",
+                "kind": "LinkedField",
+                "name": "last",
+                "plural": false,
+                "selections": (v9/*: any*/),
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageCursor",
+                "kind": "LinkedField",
+                "name": "previous",
+                "plural": false,
+                "selections": [
+                  (v5/*: any*/),
+                  (v8/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          (v6/*: any*/)
+        ],
+        "storageKey": null
+      },
+      {
+        "alias": null,
+        "args": (v7/*: any*/),
+        "filters": [
+          "page"
+        ],
+        "handle": "connection",
+        "key": "AuthorsApp_authorsConnection",
+        "kind": "LinkedHandle",
+        "name": "authorsConnection"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "0f9aef820131ccd4102226f296174b3e",
+    "id": null,
+    "metadata": {
+      "connection": [
+        {
+          "count": "size",
+          "cursor": null,
+          "direction": "forward",
+          "path": [
+            "authorsConnection"
+          ]
+        }
+      ]
+    },
+    "name": "ArticlesAuthorsQuery",
+    "operationKind": "query",
+    "text": "query ArticlesAuthorsQuery(\n  $page: Int\n  $size: Int\n) {\n  authorsConnection(first: $size, page: $page) {\n    edges {\n      node {\n        internalID\n        name\n        id\n        __typename\n      }\n      cursor\n    }\n    pageCursors {\n      ...Pagination_pageCursors\n    }\n    pageInfo {\n      hasNextPage\n      endCursor\n    }\n  }\n}\n\nfragment Pagination_pageCursors on PageCursors {\n  around {\n    cursor\n    page\n    isCurrent\n  }\n  first {\n    cursor\n    page\n    isCurrent\n  }\n  last {\n    cursor\n    page\n    isCurrent\n  }\n  previous {\n    cursor\n    page\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "e874957d4b8d8a9530a09b385f3bbb0a";
+
+export default node;


### PR DESCRIPTION
Adds a simple authors index page to assist in crawling.

<img width="2706" height="4208" alt="localhost_5050_articles_authors_page=1" src="https://github.com/user-attachments/assets/3731d002-c92a-4f3e-a94e-3d002092f29d" />


cc @artsy/diamond-devs 