### PR TITLE
fix: some phone numbers inputs  are not required

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2PickupForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2PickupForm.tsx
@@ -11,7 +11,7 @@ import { validateAndExtractOrderResponse } from "Apps/Order/Components/ExpressCh
 import { useCheckoutContext } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext"
 import { useOrder2SetOrderFulfillmentOptionMutation } from "Apps/Order2/Routes/Checkout/Mutations/useOrder2SetOrderFulfillmentOptionMutation"
 import { useOrder2SetOrderPickupDetailsMutation } from "Apps/Order2/Routes/Checkout/Mutations/useOrder2SetOrderPickupDetailsMutation"
-import { richPhoneValidators } from "Components/Address/utils"
+import { richRequiredPhoneValidators } from "Components/Address/utils"
 import { countries as phoneCountryOptions } from "Utils/countries"
 import createLogger from "Utils/logger"
 import type { Order2PickupForm_order$key } from "__generated__/Order2PickupForm_order.graphql"
@@ -213,7 +213,7 @@ export const Order2PickupForm: React.FC<Order2PickupFormProps> = ({
 }
 
 const VALIDATION_SCHEMA = Yup.object().shape({
-  ...richPhoneValidators,
+  ...richRequiredPhoneValidators,
 })
 
 const FRAGMENT = graphql`

--- a/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsInformation.tsx
+++ b/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsInformation.tsx
@@ -182,6 +182,7 @@ export const SettingsEditSettingsInformation: React.FC<
                 placeholder="(000) 000 0000"
                 autoComplete="tel-national"
                 enableSearch
+                error={touched.phoneNumber && errors.phoneNumber}
               />
 
               <Select

--- a/src/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddressForm.tsx
+++ b/src/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddressForm.tsx
@@ -14,7 +14,7 @@ import { useAddAddress } from "Apps/Settings/Routes/Shipping/useAddAddress"
 import { useEditAddress } from "Apps/Settings/Routes/Shipping/useEditAddress"
 import { useSetDefaultAddress } from "Apps/Settings/Routes/Shipping/useSetDefaultAddress"
 import { CountrySelect } from "Components/CountrySelect"
-import { richPhoneValidators } from "Components/Address/utils"
+import { richRequiredPhoneValidators } from "Components/Address/utils"
 import { countries } from "Utils/countries"
 import { Form, Formik } from "formik"
 import type { FC } from "react"
@@ -47,7 +47,7 @@ const VALIDATION_SCHEMA = Yup.object().shape({
     city: Yup.string().required("City is required"),
     region: Yup.string().required("Region is required"),
     postalCode: Yup.string().required("Postal Code is required"),
-    ...richPhoneValidators,
+    ...richRequiredPhoneValidators,
   }),
   isDefault: Yup.boolean().optional(),
 })

--- a/src/Components/Address/AddressFormFields.tsx
+++ b/src/Components/Address/AddressFormFields.tsx
@@ -6,7 +6,7 @@ import {
   basicPhoneValidator,
   isPostalCodeRequired,
   isRegionRequired,
-  richPhoneValidators,
+  richRequiredPhoneValidators,
   yupAddressValidator,
 } from "Components/Address/utils"
 import { sortCountriesForCountryInput } from "Components/Address/utils/sortCountriesForCountryInput"
@@ -54,7 +54,7 @@ interface Props {
 export const addressFormFieldsValidator = (args: Props = {}) => ({
   address: yupAddressValidator,
   ...(args.withLegacyPhoneInput && basicPhoneValidator),
-  ...(args.withPhoneNumber && richPhoneValidators),
+  ...(args.withPhoneNumber && richRequiredPhoneValidators),
 })
 
 /**

--- a/src/Components/Address/utils/utils.ts
+++ b/src/Components/Address/utils/utils.ts
@@ -140,7 +140,6 @@ export const richPhoneValidators = {
     name: "phone-number-is-valid",
     message: "Please enter a valid phone number",
     test: (national, context) => {
-      // If no value provided, it's valid (will be caught by .required() if needed)
       if (!national || national.length === 0) {
         return true
       }

--- a/src/Components/Address/utils/utils.ts
+++ b/src/Components/Address/utils/utils.ts
@@ -95,7 +95,10 @@ export const validatePhoneNumber = (
  * @param regionCode The region/country code
  * @returns Boolean indicating if phone number is valid
  */
-export const useValidatePhoneNumber = ({ national, regionCode }: PhoneNumber) => {
+export const useValidatePhoneNumber = ({
+  national,
+  regionCode,
+}: PhoneNumber) => {
   const [isPhoneNumberValid, setIsPhoneNumberValid] = useState(true)
 
   const validate = useCallback(async () => {
@@ -133,20 +136,29 @@ export const basicPhoneValidator = {
 }
 
 export const richPhoneValidators = {
-  phoneNumber: Yup.string()
-    .required("Phone number is required")
-    .test({
-      name: "phone-number-is-valid",
-      message: "Please enter a valid phone number",
-      test: (national, context) => {
-        return validatePhoneNumber({
-          national: `${national}`,
-          regionCode: `${context.parent.phoneNumberCountryCode}`,
-        })
-      },
-    }),
-  phoneNumberCountryCode: Yup.string().required(
-    "Phone number country code is required",
+  phoneNumber: Yup.string().test({
+    name: "phone-number-is-valid",
+    message: "Please enter a valid phone number",
+    test: (national, context) => {
+      // If no value provided, it's valid (will be caught by .required() if needed)
+      if (!national || national.length === 0) {
+        return true
+      }
+      return validatePhoneNumber({
+        national: `${national}`,
+        regionCode: `${context.parent.phoneNumberCountryCode}`,
+      })
+    },
+  }),
+  phoneNumberCountryCode: Yup.string(),
+}
+
+export const richRequiredPhoneValidators = {
+  phoneNumber: richPhoneValidators.phoneNumber.required(
+    "Phone number is required",
+  ),
+  phoneNumberCountryCode: richPhoneValidators.phoneNumberCountryCode.required(
+    "Country code is required",
   ),
 }
 


### PR DESCRIPTION
follow-up on: #16050 

The Settings' Phone Input shouldn't be required, so I created richRequiredPhoneValidators extensions of richPhoneValidators.