### PR TITLE
fix(EMI-2737): Hide Express Checkout on Review step in the new checkout

### DIFF
--- a/src/Apps/Order/Components/Collapse.tsx
+++ b/src/Apps/Order/Components/Collapse.tsx
@@ -21,8 +21,6 @@ export class Collapse extends React.Component<
     // so that if the content of the wrapper changes it's height will change too
     if (ev.propertyName === "height") {
       this.wrapperRef.style.height = this.props.open ? "auto" : "0px"
-      // Set visibility for accessibility - hidden when closed, visible when open
-      this.wrapperRef.style.visibility = this.props.open ? "visible" : "hidden"
     }
   }
 
@@ -40,8 +38,6 @@ export class Collapse extends React.Component<
     }
     if (this.props.open && this.wrapperRef.style.height !== "auto") {
       // animate opening
-      // make content visible immediately when opening
-      this.wrapperRef.style.visibility = "visible"
       // measure goal height
       const prevHeight = this.wrapperRef.style.height || "0px"
       this.wrapperRef.style.height = "auto"
@@ -103,7 +99,6 @@ export class Collapse extends React.Component<
         style={{
           transition: "height 0.3s ease",
           overflow: "hidden",
-          visibility: open ? "visible" : "hidden",
           ...heightProps,
         }}
       >

--- a/src/Apps/Order/Components/__tests__/CreditCardPicker.jest.tsx
+++ b/src/Apps/Order/Components/__tests__/CreditCardPicker.jest.tsx
@@ -4,6 +4,7 @@ import { creatingCreditCardSuccess } from "Apps/Order/Routes/__fixtures__/Mutati
 import {
   BuyOrderPickup,
   BuyOrderWithShippingDetails,
+  OfferOrderWithShippingDetails,
   ShippingDetails,
 } from "Apps/__tests__/Fixtures/Order"
 import type { Address } from "Components/Address/utils"
@@ -677,7 +678,7 @@ describe("CreditCardPickerFragmentContainer", () => {
     it("doesn't track clicks on the address checkbox when order status is not pending", async () => {
       const { user } = renderWithRelay({
         CommerceOrder: () => ({
-          ...defaultData.order,
+          ...OfferOrderWithShippingDetails,
           state: "SUBMITTED",
         }),
         Me: () => defaultData.me,

--- a/src/Apps/Order/Routes/Shipping/Components/__tests__/FulfillmentDetailsForm.jest.tsx
+++ b/src/Apps/Order/Routes/Shipping/Components/__tests__/FulfillmentDetailsForm.jest.tsx
@@ -248,8 +248,6 @@ describe("FulfillmentDetailsForm", () => {
     })
 
     it("user can select shipping and see shipping fields", async () => {
-      mockShippingContext.state.shippingFormMode = "new_address"
-
       renderTree(testProps)
       await userEvent.click(screen.getByRole("radio", { name: "Shipping" }))
 
@@ -260,8 +258,6 @@ describe("FulfillmentDetailsForm", () => {
     })
 
     it("user can select shipping if pickup fulfillment is already saved to order", async () => {
-      mockShippingContext.state.shippingFormMode = "new_address"
-
       testProps.initialValues!.fulfillmentType = FulfillmentType.PICKUP
       testProps.initialValues!.attributes = {
         name: "John Doe",


### PR DESCRIPTION
The type of this PR is: **Feature**

This PR solves [EMI-2737]

### Description
This PR hides the express checkout when the user is on the Review step in the new checkout

### Video (updated)
 <video src="https://github.com/user-attachments/assets/d1df05b8-2559-441c-a4dc-fcd112bece0e" />


<!-- Implementation description -->


[EMI-2737]: https://artsyproduct.atlassian.net/browse/EMI-2737?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ