### PR TITLE
refactor: using the address component in settings

### DIFF
--- a/src/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddressForm.tsx
+++ b/src/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddressForm.tsx
@@ -24,16 +24,18 @@ import type { FC } from "react"
 import { useEffect } from "react"
 import * as Yup from "yup"
 
+const DEFAULT_PHONE_COUNTRY_CODE = "us"
+
 export const INITIAL_ADDRESS = {
   name: "",
-  country: "US",
+  country: DEFAULT_PHONE_COUNTRY_CODE.toUpperCase(),
   addressLine1: "",
   addressLine2: "",
   city: "",
   postalCode: "",
   region: "",
   phoneNumber: "",
-  phoneNumberCountryCode: "us",
+  phoneNumberCountryCode: DEFAULT_PHONE_COUNTRY_CODE,
 }
 
 const INITIAL_VALUES = {
@@ -84,7 +86,8 @@ export const SettingsShippingAddressForm: FC<
   const getInitialValues = () => {
     if (!address) {
       const defaultPhoneCountryCode =
-        locationBasedInitialValues.phoneNumberCountryCode || "us"
+        locationBasedInitialValues.phoneNumberCountryCode ||
+        DEFAULT_PHONE_COUNTRY_CODE
       return {
         ...INITIAL_VALUES,
         phoneNumberCountryCode: defaultPhoneCountryCode,
@@ -102,7 +105,7 @@ export const SettingsShippingAddressForm: FC<
         phoneNumberCountryCode ||
         locationBasedInitialValues.phoneNumberCountryCode ||
         addressWithoutPhone.country?.toLowerCase() ||
-        "us",
+        DEFAULT_PHONE_COUNTRY_CODE,
     }
   }
 
@@ -189,7 +192,7 @@ export const SettingsShippingAddressForm: FC<
           if (
             !isEditing &&
             locationBasedInitialValues.phoneNumberCountryCode &&
-            values.phoneNumberCountryCode === "us" &&
+            values.phoneNumberCountryCode === DEFAULT_PHONE_COUNTRY_CODE &&
             !values.phoneNumber
           ) {
             setFieldValue(

--- a/src/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddressForm.tsx
+++ b/src/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddressForm.tsx
@@ -21,7 +21,6 @@ import { useInitialLocationValues } from "Components/Address/utils/useInitialLoc
 import { countries as countryPhoneOptions } from "Utils/countries"
 import { Form, Formik } from "formik"
 import type { FC } from "react"
-import { useEffect } from "react"
 import * as Yup from "yup"
 
 const DEFAULT_PHONE_COUNTRY_CODE = "us"
@@ -112,6 +111,7 @@ export const SettingsShippingAddressForm: FC<
   return (
     <Formik
       validateOnMount
+      enableReinitialize={true}
       validationSchema={VALIDATION_SCHEMA}
       initialValues={getInitialValues()}
       onSubmit={async (
@@ -188,26 +188,6 @@ export const SettingsShippingAddressForm: FC<
         isSubmitting,
         submitForm,
       }) => {
-        useEffect(() => {
-          if (
-            !isEditing &&
-            locationBasedInitialValues.phoneNumberCountryCode &&
-            values.phoneNumberCountryCode === DEFAULT_PHONE_COUNTRY_CODE &&
-            !values.phoneNumber
-          ) {
-            setFieldValue(
-              "phoneNumberCountryCode",
-              locationBasedInitialValues.phoneNumberCountryCode,
-            )
-          }
-        }, [
-          locationBasedInitialValues.phoneNumberCountryCode,
-          isEditing,
-          values.phoneNumberCountryCode,
-          values.phoneNumber,
-          setFieldValue,
-        ])
-
         return (
           <ModalDialog
             title={isEditing ? "Edit Address" : "Add New Address"}

--- a/src/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddressForm.tsx
+++ b/src/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddressForm.tsx
@@ -76,17 +76,13 @@ export const SettingsShippingAddressForm: FC<
   const { submitMutation: submitSetDefaultAddress } = useSetDefaultAddress()
   const { sendToast } = useToasts()
 
-  // If an address is passed in, we are editing an existing address
   const isEditing = !!address
-
-  // Get location-based initial values for phone country code
   const countryInputOptions = sortCountriesForCountryInput(countryPhoneOptions)
   const locationBasedInitialValues =
     useInitialLocationValues(countryInputOptions)
 
   const getInitialValues = () => {
     if (!address) {
-      // For new addresses, use location-based phone country code if available
       const defaultPhoneCountryCode =
         locationBasedInitialValues.phoneNumberCountryCode || "us"
       return {
@@ -95,8 +91,6 @@ export const SettingsShippingAddressForm: FC<
       }
     }
 
-    // For existing addresses, phone fields might not be present in attributes
-    // Extract them if they exist, otherwise use empty defaults
     const { phoneNumber, phoneNumberCountryCode, ...addressWithoutPhone } =
       address.attributes
 
@@ -104,7 +98,6 @@ export const SettingsShippingAddressForm: FC<
       isDefault: address.isDefault,
       address: addressWithoutPhone,
       phoneNumber: phoneNumber || "",
-      // Use existing phone country code, or fall back to location-based, address country, or 'us'
       phoneNumberCountryCode:
         phoneNumberCountryCode ||
         locationBasedInitialValues.phoneNumberCountryCode ||
@@ -192,7 +185,6 @@ export const SettingsShippingAddressForm: FC<
         isSubmitting,
         submitForm,
       }) => {
-        // Update phone country code when location changes for new addresses
         useEffect(() => {
           if (
             !isEditing &&


### PR DESCRIPTION
The type of this PR is: Refactor
This PR solves [EMI-2792](https://artsyproduct.atlassian.net/browse/EMI-2792)

### Description
Refactoring [Settings > Shipping (Add / Edit Addresses)](https://staging.artsy.net/settings/shipping) form so it uses the same address component we already use in for the checkout (both old and new), invoice, and auctions. This space in settings is the last place with a custom implementation.

| Before | After |
|--------|--------|
| <img width="750" height="710" alt="Screenshot 2025-08-28 at 09 12 31" src="https://github.com/user-attachments/assets/7f80af54-b4b0-4b4d-8010-37eba5178d7a" /> | <img width="753" height="668" alt="Screenshot 2025-08-28 at 09 29 05" src="https://github.com/user-attachments/assets/5b5fe2d0-6380-4a25-984a-8f725b948a3a" /> |

@artsy/emerald-devs 

[EMI-2792]: https://artsyproduct.atlassian.net/browse/EMI-2792?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ