### PR TITLE
feat: add missing colors to collect app filters

### DIFF
--- a/src/Components/ArtworkFilter/ArtworkFilters/ColorFilter.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/ColorFilter.tsx
@@ -124,7 +124,7 @@ export const ColorFilter: React.FC<
   const hasColorFilter = colors.length > 0
   const resultsSorted = sortResults(
     colors,
-    COLOR_OPTIONS.map(({ name, value }) => ({ name, value })),
+    COLOR_OPTIONS.map(({ name, value, hex }) => ({ name, value, hex })),
   )
 
   return (


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PBRW-1155]

### Description
This PR adds the colors for filters on `/collect` page.  

Before

<img width="436" height="515" alt="Screenshot 2025-08-29 at 15 19 04" src="https://github.com/user-attachments/assets/de7033b2-bbf5-4551-aa1f-a1c14c946da5" />


After 

<img width="432" height="494" alt="Screenshot 2025-08-29 at 15 18 29" src="https://github.com/user-attachments/assets/e3e1fc2a-53bb-475e-9672-31b547ac67e5" />

 
/cc @artsy/diamond-devs 

<!-- Implementation description -->


[PBRW-1155]: https://artsyproduct.atlassian.net/browse/PBRW-1155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ