### PR TITLE
chore: add claude.local.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .cache
 .cache-loader
 .claude/settings.local.json
+.claude.local.md
 .DS_Store
 .env
 .env.*


### PR DESCRIPTION
This PR adds a .gitignore entry for caude.local.md so that Claude Code users can store local project context without the annoyance and risk of committing it.