### PR TITLE
chore: paginate artist page canonical link

### DIFF
--- a/src/Apps/Artist/Components/ArtistMeta/__tests__/ArtistMeta.jest.tsx
+++ b/src/Apps/Artist/Components/ArtistMeta/__tests__/ArtistMeta.jest.tsx
@@ -41,7 +41,11 @@ const getMetaBy = (selectors): Element | null => {
 
 describe("AdminMeta", () => {
   describe("canonical link", () => {
-    it("renders", () => {
+    beforeEach(() => {
+      mockLocation.query = {}
+    })
+
+    it("renders basic canonical URL", () => {
       renderWithRelay({
         Artist: () => ({
           href: "/artist/example-artist",
@@ -50,6 +54,72 @@ describe("AdminMeta", () => {
 
       const linkTag = document.querySelector("link[rel='canonical']")
       expect(linkTag?.getAttribute("href")).toEqual("/artist/example-artist")
+    })
+
+    it("strips query parameters from canonical URL", () => {
+      mockLocation.query = {
+        sort: "recently_updated",
+        price_range: "1000-5000",
+        additional_gene_ids: ["prints"],
+      }
+
+      renderWithRelay({
+        Artist: () => ({
+          href: "/artist/picasso",
+        }),
+      })
+
+      const linkTag = document.querySelector("link[rel='canonical']")
+      expect(linkTag?.getAttribute("href")).toEqual("/artist/picasso")
+    })
+
+    it("includes page parameter in canonical URL when page > 1", () => {
+      mockLocation.query = {
+        page: "3",
+      }
+
+      renderWithRelay({
+        Artist: () => ({
+          href: "/artist/picasso",
+        }),
+      })
+
+      const linkTag = document.querySelector("link[rel='canonical']")
+      expect(linkTag?.getAttribute("href")).toEqual("/artist/picasso?page=3")
+    })
+
+    it("includes page parameter but strips other query parameters", () => {
+      mockLocation.query = {
+        page: "2",
+        sort: "recently_updated",
+        additional_gene_ids: ["prints"],
+        price_range: "1000-5000",
+      }
+
+      renderWithRelay({
+        Artist: () => ({
+          href: "/artist/picasso",
+        }),
+      })
+
+      const linkTag = document.querySelector("link[rel='canonical']")
+      expect(linkTag?.getAttribute("href")).toEqual("/artist/picasso?page=2")
+    })
+
+    it("uses base URL when page is 1", () => {
+      mockLocation.query = {
+        page: "1",
+        sort: "recently_updated",
+      }
+
+      renderWithRelay({
+        Artist: () => ({
+          href: "/artist/picasso",
+        }),
+      })
+
+      const linkTag = document.querySelector("link[rel='canonical']")
+      expect(linkTag?.getAttribute("href")).toEqual("/artist/picasso")
     })
   })
 

--- a/src/Apps/Artist/Components/ArtistMeta/useCanonicalHref.ts
+++ b/src/Apps/Artist/Components/ArtistMeta/useCanonicalHref.ts
@@ -1,5 +1,6 @@
 import { useRouter } from "System/Hooks/useRouter"
 import { compact } from "lodash"
+import { getPageNumber } from "Utils/url"
 
 // Allowlist of valid medium filters for SEO
 export const VALID_MEDIUM_FILTERS = [
@@ -23,6 +24,7 @@ export const useCanonicalHref = ({
 }: UseCanonicalHrefParams): string => {
   const { match } = useRouter()
   const additionalGeneIds = compact(match.location.query.additional_gene_ids)
+  const page = getPageNumber(match?.location)
 
   const mediumFilter = additionalGeneIds[0]
 
@@ -33,7 +35,15 @@ export const useCanonicalHref = ({
     // Only consider it valid if there's exactly one medium filter
     additionalGeneIds.length === 1
 
-  return isInSeoExperiment && hasValidMediumFilter
-    ? `${href}?additional_gene_ids[0]=${mediumFilter}`
-    : href
+  const params: string[] = []
+
+  if (isInSeoExperiment && hasValidMediumFilter) {
+    params.push(`additional_gene_ids[0]=${mediumFilter}`)
+  }
+
+  if (page > 1) {
+    params.push(`page=${page}`)
+  }
+
+  return params.length > 0 ? `${href}?${params.join("&")}` : href
 }


### PR DESCRIPTION
This PR adds page (and only page) params to the canonical link of the paginated artist page, with the caveat that it will only work with direct page access to paginated pages.

This means that if a user (or crawler) directly accesses https://www.artsy.net/artists/andy-warhol?page=2, the canonical link will correctly include `page=2`. However, if a user navigates to the second page by clicking a pagination link, the canonical link not be updated to include `page=2`.

This happens because we synthetically update the URL in the browser's address bar and history when a user clicks a pagination link to make it look like the user is on a new page, but in reality they are on the same route as far as React Router is concerned.

Instead of solving that problem, I want to see if this simple solution is enough to get Google to index these paginated pages. If these pages are still not indexed after this change, then I will do more work to ensure that `useCannonicalHref` has access to synthetic URL changes.

cc: @artsy/diamond-devs