### PR TITLE
fix(AMBER-1966): Respect primary image setting on the artwork page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,7 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Imperative Instructions!
+
+- **ALWAYS reference `docs/best_practices.md`** as the primary source of truth for coding patterns and practices in this repository.

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
@@ -24,6 +24,16 @@ export const ArtworkImageBrowser: React.FC<
 > = ({ artwork, isMyCollectionArtwork }) => {
   const { figures } = artwork
 
+  // Calculate the default index first so it can be used to initialize the cursor
+  const defaultIndex = useMemo(() => {
+    const index = figures.findIndex(figure => {
+      if (!("isDefault" in figure)) return false
+      return !!figure.isDefault
+    })
+
+    return index === -1 ? 0 : index
+  }, [figures])
+
   const {
     index: activeIndex,
     handleNext,
@@ -31,6 +41,7 @@ export const ArtworkImageBrowser: React.FC<
     setCursor,
   } = useCursor({
     max: figures.length,
+    initialCursor: defaultIndex,
   })
 
   // Here we pre-emptively scale the figures to figure out which is going
@@ -65,15 +76,6 @@ export const ArtworkImageBrowser: React.FC<
           }
         }
       }),
-    )
-  }, [figures])
-
-  const defaultIndex = useMemo(() => {
-    return (
-      figures.findIndex(figure => {
-        if (!("isDefault" in figure)) return false
-        return !!figure.isDefault
-      }) ?? 0
     )
   }, [figures])
 

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser.tsx
@@ -27,8 +27,7 @@ export const ArtworkImageBrowser: React.FC<
   // Calculate the default index first so it can be used to initialize the cursor
   const defaultIndex = useMemo(() => {
     const index = figures.findIndex(figure => {
-      if (!("isDefault" in figure)) return false
-      return !!figure.isDefault
+      return figure.__typename === "Image" && !!figure.isDefault
     })
 
     return index === -1 ? 0 : index

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkImageBrowser.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkImageBrowser.jest.tsx
@@ -1,7 +1,10 @@
-import { render } from "@testing-library/react"
-import { ArtworkImageBrowser } from "Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser"
+import { ArtworkImageBrowserFragmentContainer } from "Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser"
 import { MockBoot } from "DevTools/MockBoot"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
+import type { ArtworkImageBrowserTestQuery } from "__generated__/ArtworkImageBrowserTestQuery.graphql"
+import { graphql } from "react-relay"
 
+jest.unmock("react-relay")
 jest.mock("react-tracking", () => ({
   useTracking: () => ({ trackEvent: jest.fn() }),
 }))
@@ -10,6 +13,25 @@ const mockUseCursor = jest.fn()
 jest.mock("use-cursor", () => ({
   useCursor: (...args: any[]) => mockUseCursor(...args),
 }))
+
+const { renderWithRelay } = setupTestWrapperTL<ArtworkImageBrowserTestQuery>({
+  Component: props => {
+    if (!props.artwork) return null
+
+    return (
+      <MockBoot>
+        <ArtworkImageBrowserFragmentContainer artwork={props.artwork} />
+      </MockBoot>
+    )
+  },
+  query: graphql`
+    query ArtworkImageBrowserTestQuery @relay_test_operation {
+      artwork(id: "example") {
+        ...ArtworkImageBrowser_artwork
+      }
+    }
+  `,
+})
 
 describe("ArtworkImageBrowser", () => {
   beforeEach(() => {
@@ -24,41 +46,47 @@ describe("ArtworkImageBrowser", () => {
 
   describe("default image selection", () => {
     it("should initialize cursor with index of image marked isDefault: true", () => {
-      const artwork = {
-        internalID: "test-artwork-id",
-        figures: [
-          {
-            __typename: "Image" as const,
-            isDefault: false,
-            width: 800,
-            height: 600,
-          },
-          {
-            __typename: "Image" as const,
-            isDefault: false,
-            width: 800,
-            height: 600,
-          },
-          {
-            __typename: "Image" as const,
-            isDefault: true,
-            width: 800,
-            height: 600,
-          },
-          {
-            __typename: "Image" as const,
-            isDefault: false,
-            width: 800,
-            height: 600,
-          },
-        ],
-      } as any
-
-      render(
-        <MockBoot>
-          <ArtworkImageBrowser artwork={artwork} />
-        </MockBoot>,
-      )
+      renderWithRelay({
+        Artwork: () => ({
+          internalID: "test-artwork-id",
+          figures: [
+            {
+              __typename: "Image",
+              width: 800,
+              height: 600,
+              isDefault: false,
+              aspectRatio: 1.33,
+            },
+            {
+              __typename: "Image",
+              width: 800,
+              height: 600,
+              isDefault: false,
+              aspectRatio: 1.33,
+            },
+            {
+              __typename: "Image",
+              width: 800,
+              height: 600,
+              isDefault: true,
+              aspectRatio: 1.33,
+            },
+            {
+              __typename: "Image",
+              width: 800,
+              height: 600,
+              isDefault: false,
+              aspectRatio: 1.33,
+            },
+          ],
+        }),
+        ResizedImageUrl: () => ({
+          width: 800,
+          height: 600,
+          src: "example.jpg",
+          srcSet: "example.jpg 1x",
+        }),
+      })
 
       expect(mockUseCursor).toHaveBeenCalledWith({
         max: 4,
@@ -67,35 +95,40 @@ describe("ArtworkImageBrowser", () => {
     })
 
     it("should fallback to index 0 when no image has isDefault: true", () => {
-      const artwork = {
-        internalID: "test-artwork-id",
-        figures: [
-          {
-            __typename: "Image" as const,
-            isDefault: false,
-            width: 800,
-            height: 600,
-          },
-          {
-            __typename: "Image" as const,
-            isDefault: false,
-            width: 800,
-            height: 600,
-          },
-          {
-            __typename: "Image" as const,
-            isDefault: false,
-            width: 800,
-            height: 600,
-          },
-        ],
-      } as any
-
-      render(
-        <MockBoot>
-          <ArtworkImageBrowser artwork={artwork} />
-        </MockBoot>,
-      )
+      renderWithRelay({
+        Artwork: () => ({
+          internalID: "test-artwork-id",
+          figures: [
+            {
+              __typename: "Image",
+              width: 800,
+              height: 600,
+              isDefault: false,
+              aspectRatio: 1.33,
+            },
+            {
+              __typename: "Image",
+              width: 800,
+              height: 600,
+              isDefault: false,
+              aspectRatio: 1.33,
+            },
+            {
+              __typename: "Image",
+              width: 800,
+              height: 600,
+              isDefault: false,
+              aspectRatio: 1.33,
+            },
+          ],
+        }),
+        ResizedImageUrl: () => ({
+          width: 800,
+          height: 600,
+          src: "example.jpg",
+          srcSet: "example.jpg 1x",
+        }),
+      })
 
       expect(mockUseCursor).toHaveBeenCalledWith({
         max: 3,
@@ -104,35 +137,40 @@ describe("ArtworkImageBrowser", () => {
     })
 
     it("should fallback to index 0 when all images have isDefault: null", () => {
-      const artwork = {
-        internalID: "test-artwork-id",
-        figures: [
-          {
-            __typename: "Image" as const,
-            isDefault: null,
-            width: 800,
-            height: 600,
-          },
-          {
-            __typename: "Image" as const,
-            isDefault: null,
-            width: 800,
-            height: 600,
-          },
-          {
-            __typename: "Image" as const,
-            isDefault: null,
-            width: 800,
-            height: 600,
-          },
-        ],
-      } as any
-
-      render(
-        <MockBoot>
-          <ArtworkImageBrowser artwork={artwork} />
-        </MockBoot>,
-      )
+      renderWithRelay({
+        Artwork: () => ({
+          internalID: "test-artwork-id",
+          figures: [
+            {
+              __typename: "Image",
+              width: 800,
+              height: 600,
+              isDefault: null,
+              aspectRatio: 1.33,
+            },
+            {
+              __typename: "Image",
+              width: 800,
+              height: 600,
+              isDefault: null,
+              aspectRatio: 1.33,
+            },
+            {
+              __typename: "Image",
+              width: 800,
+              height: 600,
+              isDefault: null,
+              aspectRatio: 1.33,
+            },
+          ],
+        }),
+        ResizedImageUrl: () => ({
+          width: 800,
+          height: 600,
+          src: "example.jpg",
+          srcSet: "example.jpg 1x",
+        }),
+      })
 
       expect(mockUseCursor).toHaveBeenCalledWith({
         max: 3,
@@ -141,30 +179,39 @@ describe("ArtworkImageBrowser", () => {
     })
 
     it("should handle mixed figure types and find default image", () => {
-      const artwork = {
-        internalID: "test-artwork-id",
-        figures: [
-          {
-            __typename: "Image" as const,
-            isDefault: false,
-            width: 800,
-            height: 600,
-          },
-          { __typename: "Video" as const, videoWidth: 800, videoHeight: 600 },
-          {
-            __typename: "Image" as const,
-            isDefault: true,
-            width: 800,
-            height: 600,
-          },
-        ],
-      } as any
-
-      render(
-        <MockBoot>
-          <ArtworkImageBrowser artwork={artwork} />
-        </MockBoot>,
-      )
+      renderWithRelay({
+        Artwork: () => ({
+          internalID: "test-artwork-id",
+          figures: [
+            {
+              __typename: "Image",
+              width: 800,
+              height: 600,
+              isDefault: false,
+              aspectRatio: 1.33,
+            },
+            {
+              __typename: "Video",
+              videoWidth: 800,
+              videoHeight: 600,
+              id: "video-id",
+            },
+            {
+              __typename: "Image",
+              width: 800,
+              height: 600,
+              isDefault: true,
+              aspectRatio: 1.33,
+            },
+          ],
+        }),
+        ResizedImageUrl: () => ({
+          width: 800,
+          height: 600,
+          src: "example.jpg",
+          srcSet: "example.jpg 1x",
+        }),
+      })
 
       expect(mockUseCursor).toHaveBeenCalledWith({
         max: 3,
@@ -173,16 +220,12 @@ describe("ArtworkImageBrowser", () => {
     })
 
     it("should handle empty figures array", () => {
-      const artwork = {
-        internalID: "test-artwork-id",
-        figures: [],
-      } as any
-
-      const { container } = render(
-        <MockBoot>
-          <ArtworkImageBrowser artwork={artwork} />
-        </MockBoot>,
-      )
+      const { container } = renderWithRelay({
+        Artwork: () => ({
+          internalID: "test-artwork-id",
+          figures: [],
+        }),
+      })
 
       expect(container.innerHTML).toBe("")
       expect(mockUseCursor).toHaveBeenCalledWith({
@@ -192,35 +235,40 @@ describe("ArtworkImageBrowser", () => {
     })
 
     it("should select isDefault image when it is not the first image", () => {
-      const artwork = {
-        internalID: "68b82b6a4b9eaf000fe97212",
-        figures: [
-          {
-            __typename: "Image" as const,
-            isDefault: null,
-            width: 2300,
-            height: 1732,
-          },
-          {
-            __typename: "Image" as const,
-            isDefault: null,
-            width: 1304,
-            height: 1732,
-          },
-          {
-            __typename: "Image" as const,
-            isDefault: true,
-            width: 148,
-            height: 196,
-          },
-        ],
-      } as any
-
-      render(
-        <MockBoot>
-          <ArtworkImageBrowser artwork={artwork} />
-        </MockBoot>,
-      )
+      renderWithRelay({
+        Artwork: () => ({
+          internalID: "68b82b6a4b9eaf000fe97212",
+          figures: [
+            {
+              __typename: "Image",
+              width: 2300,
+              height: 1732,
+              isDefault: null,
+              aspectRatio: 1.33,
+            },
+            {
+              __typename: "Image",
+              width: 1304,
+              height: 1732,
+              isDefault: null,
+              aspectRatio: 1.33,
+            },
+            {
+              __typename: "Image",
+              width: 148,
+              height: 196,
+              isDefault: true,
+              aspectRatio: 1.33,
+            },
+          ],
+        }),
+        ResizedImageUrl: () => ({
+          width: 800,
+          height: 600,
+          src: "example.jpg",
+          srcSet: "example.jpg 1x",
+        }),
+      })
 
       expect(mockUseCursor).toHaveBeenCalledWith({
         max: 3,

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkImageBrowser.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkImageBrowser.jest.tsx
@@ -1,0 +1,231 @@
+import { render } from "@testing-library/react"
+import { ArtworkImageBrowser } from "Apps/Artwork/Components/ArtworkImageBrowser/ArtworkImageBrowser"
+import { MockBoot } from "DevTools/MockBoot"
+
+jest.mock("react-tracking", () => ({
+  useTracking: () => ({ trackEvent: jest.fn() }),
+}))
+
+const mockUseCursor = jest.fn()
+jest.mock("use-cursor", () => ({
+  useCursor: (...args: any[]) => mockUseCursor(...args),
+}))
+
+describe("ArtworkImageBrowser", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseCursor.mockReturnValue({
+      index: 0,
+      handleNext: jest.fn(),
+      handlePrev: jest.fn(),
+      setCursor: jest.fn(),
+    })
+  })
+
+  describe("default image selection", () => {
+    it("should initialize cursor with index of image marked isDefault: true", () => {
+      const artwork = {
+        internalID: "test-artwork-id",
+        figures: [
+          {
+            __typename: "Image" as const,
+            isDefault: false,
+            width: 800,
+            height: 600,
+          },
+          {
+            __typename: "Image" as const,
+            isDefault: false,
+            width: 800,
+            height: 600,
+          },
+          {
+            __typename: "Image" as const,
+            isDefault: true,
+            width: 800,
+            height: 600,
+          },
+          {
+            __typename: "Image" as const,
+            isDefault: false,
+            width: 800,
+            height: 600,
+          },
+        ],
+      } as any
+
+      render(
+        <MockBoot>
+          <ArtworkImageBrowser artwork={artwork} />
+        </MockBoot>,
+      )
+
+      expect(mockUseCursor).toHaveBeenCalledWith({
+        max: 4,
+        initialCursor: 2,
+      })
+    })
+
+    it("should fallback to index 0 when no image has isDefault: true", () => {
+      const artwork = {
+        internalID: "test-artwork-id",
+        figures: [
+          {
+            __typename: "Image" as const,
+            isDefault: false,
+            width: 800,
+            height: 600,
+          },
+          {
+            __typename: "Image" as const,
+            isDefault: false,
+            width: 800,
+            height: 600,
+          },
+          {
+            __typename: "Image" as const,
+            isDefault: false,
+            width: 800,
+            height: 600,
+          },
+        ],
+      } as any
+
+      render(
+        <MockBoot>
+          <ArtworkImageBrowser artwork={artwork} />
+        </MockBoot>,
+      )
+
+      expect(mockUseCursor).toHaveBeenCalledWith({
+        max: 3,
+        initialCursor: 0,
+      })
+    })
+
+    it("should fallback to index 0 when all images have isDefault: null", () => {
+      const artwork = {
+        internalID: "test-artwork-id",
+        figures: [
+          {
+            __typename: "Image" as const,
+            isDefault: null,
+            width: 800,
+            height: 600,
+          },
+          {
+            __typename: "Image" as const,
+            isDefault: null,
+            width: 800,
+            height: 600,
+          },
+          {
+            __typename: "Image" as const,
+            isDefault: null,
+            width: 800,
+            height: 600,
+          },
+        ],
+      } as any
+
+      render(
+        <MockBoot>
+          <ArtworkImageBrowser artwork={artwork} />
+        </MockBoot>,
+      )
+
+      expect(mockUseCursor).toHaveBeenCalledWith({
+        max: 3,
+        initialCursor: 0,
+      })
+    })
+
+    it("should handle mixed figure types and find default image", () => {
+      const artwork = {
+        internalID: "test-artwork-id",
+        figures: [
+          {
+            __typename: "Image" as const,
+            isDefault: false,
+            width: 800,
+            height: 600,
+          },
+          { __typename: "Video" as const, videoWidth: 800, videoHeight: 600 },
+          {
+            __typename: "Image" as const,
+            isDefault: true,
+            width: 800,
+            height: 600,
+          },
+        ],
+      } as any
+
+      render(
+        <MockBoot>
+          <ArtworkImageBrowser artwork={artwork} />
+        </MockBoot>,
+      )
+
+      expect(mockUseCursor).toHaveBeenCalledWith({
+        max: 3,
+        initialCursor: 2,
+      })
+    })
+
+    it("should handle empty figures array", () => {
+      const artwork = {
+        internalID: "test-artwork-id",
+        figures: [],
+      } as any
+
+      const { container } = render(
+        <MockBoot>
+          <ArtworkImageBrowser artwork={artwork} />
+        </MockBoot>,
+      )
+
+      expect(container.innerHTML).toBe("")
+      expect(mockUseCursor).toHaveBeenCalledWith({
+        max: 0,
+        initialCursor: 0,
+      })
+    })
+
+    it("should select isDefault image when it is not the first image", () => {
+      const artwork = {
+        internalID: "68b82b6a4b9eaf000fe97212",
+        figures: [
+          {
+            __typename: "Image" as const,
+            isDefault: null,
+            width: 2300,
+            height: 1732,
+          },
+          {
+            __typename: "Image" as const,
+            isDefault: null,
+            width: 1304,
+            height: 1732,
+          },
+          {
+            __typename: "Image" as const,
+            isDefault: true,
+            width: 148,
+            height: 196,
+          },
+        ],
+      } as any
+
+      render(
+        <MockBoot>
+          <ArtworkImageBrowser artwork={artwork} />
+        </MockBoot>,
+      )
+
+      expect(mockUseCursor).toHaveBeenCalledWith({
+        max: 3,
+        initialCursor: 2,
+      })
+    })
+  })
+})

--- a/src/__generated__/ArtworkImageBrowserTestQuery.graphql.ts
+++ b/src/__generated__/ArtworkImageBrowserTestQuery.graphql.ts
@@ -1,0 +1,986 @@
+/**
+ * @generated SignedSource<<845da71aa2ffa9268dce30c40a48cbe7>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ArtworkImageBrowserTestQuery$variables = Record<PropertyKey, never>;
+export type ArtworkImageBrowserTestQuery$data = {
+  readonly artwork: {
+    readonly " $fragmentSpreads": FragmentRefs<"ArtworkImageBrowser_artwork">;
+  } | null | undefined;
+};
+export type ArtworkImageBrowserTestQuery = {
+  response: ArtworkImageBrowserTestQuery$data;
+  variables: ArtworkImageBrowserTestQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "example"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "slug",
+  "storageKey": null
+},
+v4 = [
+  {
+    "kind": "Literal",
+    "name": "includeAll",
+    "value": false
+  }
+],
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isDefault",
+  "storageKey": null
+},
+v6 = {
+  "kind": "Literal",
+  "name": "height",
+  "value": 800
+},
+v7 = {
+  "kind": "Literal",
+  "name": "version",
+  "value": [
+    "main",
+    "normalized",
+    "larger",
+    "large"
+  ]
+},
+v8 = {
+  "kind": "Literal",
+  "name": "width",
+  "value": 800
+},
+v9 = [
+  (v6/*: any*/),
+  {
+    "kind": "Literal",
+    "name": "quality",
+    "value": 80
+  },
+  (v7/*: any*/),
+  (v8/*: any*/)
+],
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "width",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "height",
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "src",
+  "storageKey": null
+},
+v13 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "srcSet",
+  "storageKey": null
+},
+v14 = [
+  (v10/*: any*/),
+  (v11/*: any*/),
+  (v12/*: any*/),
+  (v13/*: any*/)
+],
+v15 = {
+  "alias": "type",
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v16 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v17 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v18 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "Int"
+},
+v19 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "String"
+},
+v20 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Int"
+},
+v21 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "ID"
+},
+v22 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Boolean"
+},
+v23 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Float"
+},
+v24 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Image"
+},
+v25 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "ResizedImageUrl"
+},
+v26 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "Boolean"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ArtworkImageBrowserTestQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ArtworkImageBrowser_artwork"
+          }
+        ],
+        "storageKey": "artwork(id:\"example\")"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "ArtworkImageBrowserTestQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Artwork",
+        "kind": "LinkedField",
+        "name": "artwork",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          (v2/*: any*/),
+          (v3/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "title",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "date",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "artistNames",
+            "storageKey": null
+          },
+          {
+            "alias": "preview",
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "image",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": "square"
+                  }
+                ],
+                "kind": "ScalarField",
+                "name": "url",
+                "storageKey": "url(version:\"square\")"
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isInAuction",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isSavedToAnyList",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Sale",
+            "kind": "LinkedField",
+            "name": "sale",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isAuction",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isClosed",
+                "storageKey": null
+              },
+              (v1/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isLiveOpen",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "isRegistrationClosed",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "liveStartAt",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Bidder",
+                "kind": "LinkedField",
+                "name": "registrationStatus",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "qualifiedForBidding",
+                    "storageKey": null
+                  },
+                  (v1/*: any*/)
+                ],
+                "storageKey": null
+              },
+              (v3/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "registrationEndsAt",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "CollectorSignals",
+            "kind": "LinkedField",
+            "name": "collectorSignals",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "AuctionCollectorSignals",
+                "kind": "LinkedField",
+                "name": "auction",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "lotWatcherCount",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "downloadableImageUrl",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "shallow",
+                "value": true
+              }
+            ],
+            "concreteType": "Artist",
+            "kind": "LinkedField",
+            "name": "artists",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              },
+              (v1/*: any*/)
+            ],
+            "storageKey": "artists(shallow:true)"
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "href",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": (v4/*: any*/),
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "images",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "url",
+                "storageKey": null
+              },
+              (v2/*: any*/),
+              (v5/*: any*/),
+              {
+                "alias": "placeholder",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": [
+                      "small",
+                      "medium"
+                    ]
+                  }
+                ],
+                "kind": "ScalarField",
+                "name": "url",
+                "storageKey": "url(version:[\"small\",\"medium\"])"
+              },
+              {
+                "alias": "fallback",
+                "args": (v9/*: any*/),
+                "concreteType": "CroppedImageUrl",
+                "kind": "LinkedField",
+                "name": "cropped",
+                "plural": false,
+                "selections": (v14/*: any*/),
+                "storageKey": "cropped(height:800,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
+              },
+              {
+                "alias": null,
+                "args": (v9/*: any*/),
+                "concreteType": "ResizedImageUrl",
+                "kind": "LinkedField",
+                "name": "resized",
+                "plural": false,
+                "selections": (v14/*: any*/),
+                "storageKey": "resized(height:800,quality:80,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
+              },
+              {
+                "alias": "mobileLightboxSource",
+                "args": [
+                  (v6/*: any*/),
+                  {
+                    "kind": "Literal",
+                    "name": "quality",
+                    "value": 50
+                  },
+                  (v7/*: any*/),
+                  (v8/*: any*/)
+                ],
+                "concreteType": "ResizedImageUrl",
+                "kind": "LinkedField",
+                "name": "resized",
+                "plural": false,
+                "selections": (v14/*: any*/),
+                "storageKey": "resized(height:800,quality:50,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "versions",
+                "storageKey": null
+              }
+            ],
+            "storageKey": "images(includeAll:false)"
+          },
+          {
+            "alias": "artworkMeta",
+            "args": null,
+            "concreteType": "ArtworkMeta",
+            "kind": "LinkedField",
+            "name": "meta",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "share",
+                "storageKey": null
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "widthCm",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "heightCm",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "image",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  (v6/*: any*/),
+                  (v7/*: any*/),
+                  (v8/*: any*/)
+                ],
+                "concreteType": "ResizedImageUrl",
+                "kind": "LinkedField",
+                "name": "resized",
+                "plural": false,
+                "selections": [
+                  (v12/*: any*/),
+                  (v13/*: any*/),
+                  (v10/*: any*/),
+                  (v11/*: any*/)
+                ],
+                "storageKey": "resized(height:800,version:[\"main\",\"normalized\",\"larger\",\"large\"],width:800)"
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isUnlisted",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isDownloadable",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isHangable",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Partner",
+            "kind": "LinkedField",
+            "name": "partner",
+            "plural": false,
+            "selections": [
+              (v3/*: any*/),
+              (v1/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "caption",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "formattedMetadata",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": (v4/*: any*/),
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "figures",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "__typename",
+                "storageKey": null
+              },
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "playerUrl",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "videoWidth",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "width",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": "videoHeight",
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "height",
+                    "storageKey": null
+                  },
+                  (v1/*: any*/),
+                  (v15/*: any*/)
+                ],
+                "type": "Video",
+                "abstractKey": null
+              },
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "DeepZoom",
+                    "kind": "LinkedField",
+                    "name": "deepZoom",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "DeepZoomImage",
+                        "kind": "LinkedField",
+                        "name": "Image",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "xmlns",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "Url",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "Format",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "TileSize",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "Overlap",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "DeepZoomImageSize",
+                            "kind": "LinkedField",
+                            "name": "Size",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "Width",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "Height",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  (v2/*: any*/),
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "isZoomable",
+                    "storageKey": null
+                  },
+                  (v15/*: any*/),
+                  (v5/*: any*/),
+                  (v10/*: any*/),
+                  (v11/*: any*/)
+                ],
+                "type": "Image",
+                "abstractKey": null
+              }
+            ],
+            "storageKey": "figures(includeAll:false)"
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isSetVideoAsCover",
+            "storageKey": null
+          }
+        ],
+        "storageKey": "artwork(id:\"example\")"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "af9a2bbedc204bdfede2309acfa99154",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "artwork": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artwork"
+        },
+        "artwork.artistNames": (v16/*: any*/),
+        "artwork.artists": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "Artist"
+        },
+        "artwork.artists.id": (v17/*: any*/),
+        "artwork.artists.name": (v16/*: any*/),
+        "artwork.artworkMeta": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtworkMeta"
+        },
+        "artwork.artworkMeta.share": (v16/*: any*/),
+        "artwork.caption": (v16/*: any*/),
+        "artwork.collectorSignals": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "CollectorSignals"
+        },
+        "artwork.collectorSignals.auction": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "AuctionCollectorSignals"
+        },
+        "artwork.collectorSignals.auction.lotWatcherCount": (v18/*: any*/),
+        "artwork.date": (v16/*: any*/),
+        "artwork.downloadableImageUrl": (v16/*: any*/),
+        "artwork.figures": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": true,
+          "type": "ArtworkFigures"
+        },
+        "artwork.figures.__typename": (v19/*: any*/),
+        "artwork.figures.deepZoom": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "DeepZoom"
+        },
+        "artwork.figures.deepZoom.Image": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "DeepZoomImage"
+        },
+        "artwork.figures.deepZoom.Image.Format": (v16/*: any*/),
+        "artwork.figures.deepZoom.Image.Overlap": (v20/*: any*/),
+        "artwork.figures.deepZoom.Image.Size": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "DeepZoomImageSize"
+        },
+        "artwork.figures.deepZoom.Image.Size.Height": (v20/*: any*/),
+        "artwork.figures.deepZoom.Image.Size.Width": (v20/*: any*/),
+        "artwork.figures.deepZoom.Image.TileSize": (v20/*: any*/),
+        "artwork.figures.deepZoom.Image.Url": (v16/*: any*/),
+        "artwork.figures.deepZoom.Image.xmlns": (v16/*: any*/),
+        "artwork.figures.height": (v20/*: any*/),
+        "artwork.figures.id": (v17/*: any*/),
+        "artwork.figures.internalID": (v21/*: any*/),
+        "artwork.figures.isDefault": (v22/*: any*/),
+        "artwork.figures.isZoomable": (v22/*: any*/),
+        "artwork.figures.playerUrl": (v19/*: any*/),
+        "artwork.figures.type": (v19/*: any*/),
+        "artwork.figures.videoHeight": (v18/*: any*/),
+        "artwork.figures.videoWidth": (v18/*: any*/),
+        "artwork.figures.width": (v20/*: any*/),
+        "artwork.formattedMetadata": (v16/*: any*/),
+        "artwork.heightCm": (v23/*: any*/),
+        "artwork.href": (v16/*: any*/),
+        "artwork.id": (v17/*: any*/),
+        "artwork.image": (v24/*: any*/),
+        "artwork.image.resized": (v25/*: any*/),
+        "artwork.image.resized.height": (v20/*: any*/),
+        "artwork.image.resized.src": (v19/*: any*/),
+        "artwork.image.resized.srcSet": (v19/*: any*/),
+        "artwork.image.resized.width": (v20/*: any*/),
+        "artwork.images": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "Image"
+        },
+        "artwork.images.fallback": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "CroppedImageUrl"
+        },
+        "artwork.images.fallback.height": (v18/*: any*/),
+        "artwork.images.fallback.src": (v19/*: any*/),
+        "artwork.images.fallback.srcSet": (v19/*: any*/),
+        "artwork.images.fallback.width": (v18/*: any*/),
+        "artwork.images.internalID": (v21/*: any*/),
+        "artwork.images.isDefault": (v22/*: any*/),
+        "artwork.images.mobileLightboxSource": (v25/*: any*/),
+        "artwork.images.mobileLightboxSource.height": (v20/*: any*/),
+        "artwork.images.mobileLightboxSource.src": (v19/*: any*/),
+        "artwork.images.mobileLightboxSource.srcSet": (v19/*: any*/),
+        "artwork.images.mobileLightboxSource.width": (v20/*: any*/),
+        "artwork.images.placeholder": (v16/*: any*/),
+        "artwork.images.resized": (v25/*: any*/),
+        "artwork.images.resized.height": (v20/*: any*/),
+        "artwork.images.resized.src": (v19/*: any*/),
+        "artwork.images.resized.srcSet": (v19/*: any*/),
+        "artwork.images.resized.width": (v20/*: any*/),
+        "artwork.images.url": (v16/*: any*/),
+        "artwork.images.versions": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "String"
+        },
+        "artwork.internalID": (v17/*: any*/),
+        "artwork.isDownloadable": (v22/*: any*/),
+        "artwork.isHangable": (v22/*: any*/),
+        "artwork.isInAuction": (v22/*: any*/),
+        "artwork.isSavedToAnyList": (v26/*: any*/),
+        "artwork.isSetVideoAsCover": (v22/*: any*/),
+        "artwork.isUnlisted": (v26/*: any*/),
+        "artwork.partner": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Partner"
+        },
+        "artwork.partner.id": (v17/*: any*/),
+        "artwork.partner.slug": (v17/*: any*/),
+        "artwork.preview": (v24/*: any*/),
+        "artwork.preview.url": (v16/*: any*/),
+        "artwork.sale": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Sale"
+        },
+        "artwork.sale.id": (v17/*: any*/),
+        "artwork.sale.isAuction": (v22/*: any*/),
+        "artwork.sale.isClosed": (v22/*: any*/),
+        "artwork.sale.isLiveOpen": (v22/*: any*/),
+        "artwork.sale.isRegistrationClosed": (v22/*: any*/),
+        "artwork.sale.liveStartAt": (v16/*: any*/),
+        "artwork.sale.registrationEndsAt": (v16/*: any*/),
+        "artwork.sale.registrationStatus": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Bidder"
+        },
+        "artwork.sale.registrationStatus.id": (v17/*: any*/),
+        "artwork.sale.registrationStatus.qualifiedForBidding": (v22/*: any*/),
+        "artwork.sale.slug": (v17/*: any*/),
+        "artwork.slug": (v17/*: any*/),
+        "artwork.title": (v16/*: any*/),
+        "artwork.widthCm": (v23/*: any*/)
+      }
+    },
+    "name": "ArtworkImageBrowserTestQuery",
+    "operationKind": "query",
+    "text": "query ArtworkImageBrowserTestQuery {\n  artwork(id: \"example\") {\n    ...ArtworkImageBrowser_artwork\n    id\n  }\n}\n\nfragment ArtworkActionsSaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isInAuction\n  isSavedToAnyList\n  sale {\n    isAuction\n    isClosed\n    id\n  }\n  collectorSignals {\n    auction {\n      lotWatcherCount\n    }\n  }\n  ...ArtworkActionsWatchLotButton_artwork\n}\n\nfragment ArtworkActionsWatchLotButton_artwork on Artwork {\n  sale {\n    isLiveOpen\n    isRegistrationClosed\n    liveStartAt\n    registrationStatus {\n      qualifiedForBidding\n      id\n    }\n    id\n  }\n  ...ArtworkAuctionRegistrationPanel_artwork\n}\n\nfragment ArtworkActions_artwork_FOvjt on Artwork {\n  ...ArtworkActionsSaveButton_artwork\n  ...ArtworkDownloadButton_artwork\n  ...ArtworkSharePanel_artwork_FOvjt\n  ...ViewInRoom_artwork\n  isUnlisted\n  slug\n  downloadableImageUrl\n  isDownloadable\n  isHangable\n  partner {\n    slug\n    id\n  }\n}\n\nfragment ArtworkAuctionRegistrationPanel_artwork on Artwork {\n  sale {\n    slug\n    registrationEndsAt\n    isRegistrationClosed\n    id\n  }\n}\n\nfragment ArtworkDownloadButton_artwork on Artwork {\n  title\n  date\n  downloadableImageUrl\n  artists(shallow: true) {\n    name\n    id\n  }\n}\n\nfragment ArtworkImageBrowserLarge_artwork_FOvjt on Artwork {\n  ...ArtworkLightbox_artwork_FOvjt\n  ...ArtworkVideoPlayer_artwork_FOvjt\n  isSetVideoAsCover\n  figures(includeAll: false) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      __typename\n      internalID\n      isZoomable\n    }\n    ... on Video {\n      __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowserSmall_artwork_FOvjt on Artwork {\n  ...ArtworkLightbox_artwork_FOvjt\n  ...ArtworkVideoPlayer_artwork_FOvjt\n  isSetVideoAsCover\n  figures(includeAll: false) {\n    __typename\n    ... on Image {\n      ...DeepZoom_image\n      internalID\n      isZoomable\n      type: __typename\n    }\n    ... on Video {\n      type: __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkImageBrowser_artwork on Artwork {\n  ...ArtworkActions_artwork_FOvjt\n  ...ArtworkImageBrowserSmall_artwork_FOvjt\n  ...ArtworkImageBrowserLarge_artwork_FOvjt\n  internalID\n  figures(includeAll: false) {\n    __typename\n    ... on Image {\n      isDefault\n      width\n      height\n    }\n    ... on Video {\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment ArtworkLightbox_artwork_FOvjt on Artwork {\n  caption\n  formattedMetadata\n  images(includeAll: false) {\n    internalID\n    isDefault\n    placeholder: url(version: [\"small\", \"medium\"])\n    fallback: cropped(quality: 80, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    resized(quality: 80, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    mobileLightboxSource: resized(quality: 50, width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      width\n      height\n      src\n      srcSet\n    }\n    versions\n  }\n}\n\nfragment ArtworkSharePanel_artwork_FOvjt on Artwork {\n  href\n  images(includeAll: false) {\n    url\n  }\n  artworkMeta: meta {\n    share\n  }\n}\n\nfragment ArtworkVideoPlayer_artwork_FOvjt on Artwork {\n  internalID\n  slug\n  figures(includeAll: false) {\n    __typename\n    ... on Video {\n      __typename\n      playerUrl\n      videoWidth: width\n      videoHeight: height\n      id\n    }\n  }\n}\n\nfragment DeepZoom_image on Image {\n  deepZoom {\n    Image {\n      xmlns\n      Url\n      Format\n      TileSize\n      Overlap\n      Size {\n        Width\n        Height\n      }\n    }\n  }\n}\n\nfragment ViewInRoomArtwork_artwork on Artwork {\n  widthCm\n  heightCm\n  image {\n    resized(width: 800, height: 800, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ViewInRoom_artwork on Artwork {\n  ...ViewInRoomArtwork_artwork\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "020b57633179604be0cdb53d1a197293";
+
+export default node;


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [AMBER-1966]

### Description

The artwork page was always showing the first image instead of the one marked with `isDefault: true` (which corresponds to the primary image set in CMS).

The `useCursor` hook was initializing with `index: 0` instead of using the calculated `defaultIndex` from the `isDefault` field.

### Screenshots:

Example of an artwork with a primary image defined in CMS:
<img width="1679" height="1065" alt="cms" src="https://github.com/user-attachments/assets/ef541ee2-7ceb-4ada-9dcf-d3efdacd401f" />

**Before:** How this artwork looks in artsy.net currently:

<img width="1697" height="972" alt="before" src="https://github.com/user-attachments/assets/88324aad-785c-45e2-9fbc-3d632826cd70" />

**After:** How the same artwork looks like after the changes on this PR:

<img width="1710" height="1057" alt="after" src="https://github.com/user-attachments/assets/4ac88709-1978-41d2-bffa-369530a6e583" />



[AMBER-1966]: https://artsyproduct.atlassian.net/browse/AMBER-1966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

cc @artsy/amber-devs 