### PR TITLE
fix(EMI-2797): remove phone number input tooltip

### DIFF
--- a/src/Apps/Order/Routes/Shipping/Components/FulfillmentDetailsForm.tsx
+++ b/src/Apps/Order/Routes/Shipping/Components/FulfillmentDetailsForm.tsx
@@ -553,7 +553,6 @@ const FulfillmentDetailsFormLayout = (
               name="attributes.phoneNumber"
               title="Phone number"
               type="tel"
-              description={"Required for pickup logistics"}
               placeholder="Add phone number including country code"
               pattern="[^a-z]+"
               value={values.attributes.phoneNumber}
@@ -564,6 +563,7 @@ const FulfillmentDetailsFormLayout = (
                 errors.attributes?.phoneNumber
               }
               data-testid="AddressForm_pickupPhoneNumber"
+              required
             />
             <Spacer y={4} />
           </>

--- a/src/Apps/Order/Routes/Shipping/Components/__tests__/FulfillmentDetailsForm.jest.tsx
+++ b/src/Apps/Order/Routes/Shipping/Components/__tests__/FulfillmentDetailsForm.jest.tsx
@@ -7,6 +7,7 @@ import {
   within,
 } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import { useFlag } from "@unleash/proxy-client-react"
 import {
   FulfillmentDetailsForm,
   type FulfillmentDetailsFormProps,
@@ -18,7 +19,6 @@ import {
 } from "Apps/Order/Routes/Shipping/Utils/shippingUtils"
 import { fillAddressForm } from "Components/__tests__/Utils/addressForm2"
 import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
-import { useFlag } from "@unleash/proxy-client-react"
 import type { DeepPartial } from "Utils/typeSupport"
 import { useTracking } from "react-tracking"
 
@@ -160,9 +160,7 @@ describe("FulfillmentDetailsForm", () => {
       )
 
       expect(phoneNumberField).toBeVisible()
-      expect(
-        screen.getByText("Required for pickup logistics"),
-      ).toBeInTheDocument()
+      expect(screen.getByText("*Required")).toBeInTheDocument()
     })
 
     it("tries to go back to fulfillment details when the user clicks pickup", async () => {


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2797]

### Description

This removes the phone number input tooltip in favor of the "*Required" message, fixing tooltip popup issues with mobile. 

### Before
<img width="968" height="468" alt="Screenshot 2025-09-03 at 10 47 32 AM" src="https://github.com/user-attachments/assets/e86d77a4-f64d-4cf7-9c00-e21fcebb9b55" />


### After

<img width="945" height="535" alt="Screenshot 2025-09-03 at 11 18 47 AM" src="https://github.com/user-attachments/assets/f34a7de0-c497-4b1e-ada3-4b670eaff3a5" />

<!-- Implementation description -->


[EMI-2797]: https://artsyproduct.atlassian.net/browse/EMI-2797?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ