### PR TITLE
feat: add set as default address checkbox to edit address form

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Mutations/useOrder2UpdateUserDefaultAddressMutation.ts
+++ b/src/Apps/Order2/Routes/Checkout/Mutations/useOrder2UpdateUserDefaultAddressMutation.ts
@@ -1,0 +1,40 @@
+import { useMutation } from "Utils/Hooks/useMutation"
+import type { useOrder2UpdateUserDefaultAddressMutation as useOrder2UpdateUserDefaultAddressMutationType } from "__generated__/useOrder2UpdateUserDefaultAddressMutation.graphql"
+import { graphql } from "react-relay"
+
+export const useOrder2UpdateUserDefaultAddressMutation = () => {
+  return useMutation<useOrder2UpdateUserDefaultAddressMutationType>({
+    mutation: graphql`
+      mutation useOrder2UpdateUserDefaultAddressMutation(
+        $input: UpdateUserDefaultAddressInput!
+      ) {
+        updateUserDefaultAddress(input: $input) {
+          me {
+            ...Order2DeliveryForm_me
+          }
+          userAddressOrErrors {
+            ... on UserAddress {
+              internalID
+              name
+              addressLine1
+              addressLine2
+              city
+              region
+              postalCode
+              country
+              phoneNumber
+              phoneNumberCountryCode
+              isDefault
+            }
+            ... on Errors {
+              errors {
+                code
+                message
+              }
+            }
+          }
+        }
+      }
+    `,
+  })
+}

--- a/src/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddressForm.tsx
+++ b/src/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddressForm.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  Checkbox,
   Column,
   GridColumns,
   Message,
@@ -49,7 +48,7 @@ const INITIAL_VALUES = {
   },
   phoneNumber: INITIAL_ADDRESS.phoneNumber,
   phoneNumberCountryCode: INITIAL_ADDRESS.phoneNumberCountryCode,
-  isDefault: false,
+  setAsDefault: false,
 }
 
 type AddressAttributes = typeof INITIAL_ADDRESS
@@ -57,7 +56,7 @@ type AddressAttributes = typeof INITIAL_ADDRESS
 const VALIDATION_SCHEMA = Yup.object().shape({
   address: yupAddressValidator,
   ...richRequiredPhoneValidators,
-  isDefault: Yup.boolean().optional(),
+  setAsDefault: Yup.boolean().optional(),
 })
 
 interface SettingsShippingAddressFormProps {
@@ -97,7 +96,7 @@ export const SettingsShippingAddressForm: FC<
       address.attributes
 
     return {
-      isDefault: address.isDefault,
+      setAsDefault: address.isDefault,
       address: addressWithoutPhone,
       phoneNumber: phoneNumber || "",
       phoneNumberCountryCode:
@@ -116,7 +115,7 @@ export const SettingsShippingAddressForm: FC<
       initialValues={getInitialValues()}
       onSubmit={async (
         {
-          isDefault,
+          setAsDefault,
           address: addressData,
           phoneNumber,
           phoneNumberCountryCode,
@@ -137,7 +136,7 @@ export const SettingsShippingAddressForm: FC<
               },
             })
 
-            if (isDefault) {
+            if (setAsDefault) {
               await submitSetDefaultAddress({
                 variables: {
                   input: { userAddressID: address!.internalID },
@@ -157,7 +156,7 @@ export const SettingsShippingAddressForm: FC<
             const id =
               response.createUserAddress?.userAddressOrErrors.internalID
 
-            if (isDefault && id) {
+            if (setAsDefault && id) {
               await submitSetDefaultAddress({
                 variables: { input: { userAddressID: id } },
               })
@@ -180,14 +179,7 @@ export const SettingsShippingAddressForm: FC<
         }
       }}
     >
-      {({
-        values,
-        status,
-        setFieldValue,
-        isValid,
-        isSubmitting,
-        submitForm,
-      }) => {
+      {({ status, isValid, isSubmitting, submitForm }) => {
         return (
           <ModalDialog
             title={isEditing ? "Edit Address" : "Add New Address"}
@@ -206,36 +198,27 @@ export const SettingsShippingAddressForm: FC<
             }
           >
             <Form>
-              <AddressFormFields withPhoneNumber />
-              <GridColumns>
-                <Column span={12}>
-                  <Checkbox
-                    mt={2}
-                    selected={values.isDefault}
-                    onSelect={value => {
-                      setFieldValue("isDefault", value)
-                    }}
-                  >
-                    Set as Default
-                  </Checkbox>
-                </Column>
-
-                {status?.error && (
+              <AddressFormFields
+                withPhoneNumber
+                withSetAsDefault={!address?.isDefault}
+              />
+              {status?.error && (
+                <GridColumns>
                   <Column span={12}>
                     <Message variant="error">
                       {status.message ||
                         "Something went wrong. Please try again."}
                     </Message>
                   </Column>
-                )}
+                </GridColumns>
+              )}
 
-                {/* Modal footer button is outside the form element. Hidden button supports <enter> */}
-                <VisuallyHidden>
-                  <button type="submit" tabIndex={-1} disabled={!isValid}>
-                    Save
-                  </button>
-                </VisuallyHidden>
-              </GridColumns>
+              {/* Modal footer button is outside the form element. Hidden button supports <enter> */}
+              <VisuallyHidden>
+                <button type="submit" tabIndex={-1} disabled={!isValid}>
+                  Save
+                </button>
+              </VisuallyHidden>
             </Form>
           </ModalDialog>
         )

--- a/src/Components/Address/AddressFormFields.tsx
+++ b/src/Components/Address/AddressFormFields.tsx
@@ -1,5 +1,13 @@
 import { ContextModule } from "@artsy/cohesion"
-import { Column, GridColumns, Input, Select, SelectInput } from "@artsy/palette"
+import {
+  Checkbox,
+  Column,
+  GridColumns,
+  Input,
+  Select,
+  SelectInput,
+  Spacer,
+} from "@artsy/palette"
 import { AddressAutocompleteInput } from "Components/Address/AddressAutocompleteInput"
 import {
   type Address,
@@ -19,6 +27,7 @@ export interface FormikContextWithAddress {
   address: Address
   phoneNumber?: string
   phoneNumberCountryCode?: string
+  setAsDefault?: boolean
 }
 
 type CountryData = (typeof countryPhoneOptions)[number]
@@ -30,6 +39,8 @@ interface Props {
   withLegacyPhoneInput?: boolean
   /** Whether to only include shippable countries */
   shippableCountries?: CountryData[]
+  /** Whether to show the "Set as default address" checkbox */
+  withSetAsDefault?: boolean
 }
 
 /**
@@ -315,6 +326,20 @@ export const AddressFormFields = <V extends FormikContextWithAddress>(
             enableSearch
             required
           />
+        </Column>
+      )}
+      {props.withSetAsDefault && (
+        <Column span={12}>
+          <Spacer y={1} />
+          <Checkbox
+            onSelect={selected => {
+              setFieldValue("setAsDefault", selected)
+            }}
+            selected={values.setAsDefault || false}
+            data-testid="setAsDefault"
+          >
+            Set as default address
+          </Checkbox>
         </Column>
       )}
     </GridColumns>

--- a/src/__generated__/useOrder2UpdateUserDefaultAddressMutation.graphql.ts
+++ b/src/__generated__/useOrder2UpdateUserDefaultAddressMutation.graphql.ts
@@ -1,0 +1,381 @@
+/**
+ * @generated SignedSource<<ef63dadfe33f76e2a91185c6dbf278cc>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type UpdateUserDefaultAddressInput = {
+  clientMutationId?: string | null | undefined;
+  userAddressID: string;
+};
+export type useOrder2UpdateUserDefaultAddressMutation$variables = {
+  input: UpdateUserDefaultAddressInput;
+};
+export type useOrder2UpdateUserDefaultAddressMutation$data = {
+  readonly updateUserDefaultAddress: {
+    readonly me: {
+      readonly " $fragmentSpreads": FragmentRefs<"Order2DeliveryForm_me">;
+    } | null | undefined;
+    readonly userAddressOrErrors: {
+      readonly addressLine1?: string;
+      readonly addressLine2?: string | null | undefined;
+      readonly city?: string;
+      readonly country?: string;
+      readonly errors?: ReadonlyArray<{
+        readonly code: string;
+        readonly message: string;
+      }>;
+      readonly internalID?: string;
+      readonly isDefault?: boolean;
+      readonly name?: string | null | undefined;
+      readonly phoneNumber?: string | null | undefined;
+      readonly phoneNumberCountryCode?: string | null | undefined;
+      readonly postalCode?: string | null | undefined;
+      readonly region?: string | null | undefined;
+    };
+  } | null | undefined;
+};
+export type useOrder2UpdateUserDefaultAddressMutation = {
+  response: useOrder2UpdateUserDefaultAddressMutation$data;
+  variables: useOrder2UpdateUserDefaultAddressMutation$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "input"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "input",
+    "variableName": "input"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "addressLine1",
+  "storageKey": null
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "addressLine2",
+  "storageKey": null
+},
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "city",
+  "storageKey": null
+},
+v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "region",
+  "storageKey": null
+},
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "postalCode",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "country",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "phoneNumber",
+  "storageKey": null
+},
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "phoneNumberCountryCode",
+  "storageKey": null
+},
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "isDefault",
+  "storageKey": null
+},
+v13 = {
+  "kind": "InlineFragment",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Error",
+      "kind": "LinkedField",
+      "name": "errors",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "code",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "message",
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Errors",
+  "abstractKey": null
+},
+v14 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "useOrder2UpdateUserDefaultAddressMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "UpdateUserDefaultAddressPayload",
+        "kind": "LinkedField",
+        "name": "updateUserDefaultAddress",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Me",
+            "kind": "LinkedField",
+            "name": "me",
+            "plural": false,
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "Order2DeliveryForm_me"
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "userAddressOrErrors",
+            "plural": false,
+            "selections": [
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  (v2/*: any*/),
+                  (v3/*: any*/),
+                  (v4/*: any*/),
+                  (v5/*: any*/),
+                  (v6/*: any*/),
+                  (v7/*: any*/),
+                  (v8/*: any*/),
+                  (v9/*: any*/),
+                  (v10/*: any*/),
+                  (v11/*: any*/),
+                  (v12/*: any*/)
+                ],
+                "type": "UserAddress",
+                "abstractKey": null
+              },
+              (v13/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Mutation",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "useOrder2UpdateUserDefaultAddressMutation",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "UpdateUserDefaultAddressPayload",
+        "kind": "LinkedField",
+        "name": "updateUserDefaultAddress",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Me",
+            "kind": "LinkedField",
+            "name": "me",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "first",
+                    "value": 20
+                  }
+                ],
+                "concreteType": "UserAddressConnection",
+                "kind": "LinkedField",
+                "name": "addressConnection",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "UserAddressEdge",
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "UserAddress",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          (v2/*: any*/),
+                          (v4/*: any*/),
+                          (v5/*: any*/),
+                          (v6/*: any*/),
+                          (v7/*: any*/),
+                          (v8/*: any*/),
+                          (v9/*: any*/),
+                          (v3/*: any*/),
+                          (v10/*: any*/),
+                          (v11/*: any*/),
+                          (v12/*: any*/),
+                          (v14/*: any*/)
+                        ],
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "addressConnection(first:20)"
+              },
+              (v14/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": null,
+            "kind": "LinkedField",
+            "name": "userAddressOrErrors",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "__typename",
+                "storageKey": null
+              },
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  (v2/*: any*/),
+                  (v3/*: any*/),
+                  (v4/*: any*/),
+                  (v5/*: any*/),
+                  (v6/*: any*/),
+                  (v7/*: any*/),
+                  (v8/*: any*/),
+                  (v9/*: any*/),
+                  (v10/*: any*/),
+                  (v11/*: any*/),
+                  (v12/*: any*/),
+                  (v14/*: any*/)
+                ],
+                "type": "UserAddress",
+                "abstractKey": null
+              },
+              (v13/*: any*/)
+            ],
+            "storageKey": null
+          }
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "1dda61d2bf5de46a2110c714a1778fb7",
+    "id": null,
+    "metadata": {},
+    "name": "useOrder2UpdateUserDefaultAddressMutation",
+    "operationKind": "mutation",
+    "text": "mutation useOrder2UpdateUserDefaultAddressMutation(\n  $input: UpdateUserDefaultAddressInput!\n) {\n  updateUserDefaultAddress(input: $input) {\n    me {\n      ...Order2DeliveryForm_me\n      id\n    }\n    userAddressOrErrors {\n      __typename\n      ... on UserAddress {\n        internalID\n        name\n        addressLine1\n        addressLine2\n        city\n        region\n        postalCode\n        country\n        phoneNumber\n        phoneNumberCountryCode\n        isDefault\n        id\n      }\n      ... on Errors {\n        errors {\n          code\n          message\n        }\n      }\n    }\n  }\n}\n\nfragment Order2DeliveryForm_me on Me {\n  addressConnection(first: 20) {\n    edges {\n      node {\n        internalID\n        addressLine1\n        addressLine2\n        city\n        region\n        postalCode\n        country\n        name\n        phoneNumber\n        phoneNumberCountryCode\n        isDefault\n        id\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "94b0faea1eab0ebb7529ac2856bef1c4";
+
+export default node;


### PR DESCRIPTION
The type of this PR is: Feat

This PR adds a "Set as default address" checkbox to the edit address flow during checkout, providing users with the ability to set an address as their default while editing it.

This PR solves [EMI-2800](https://artsyproduct.atlassian.net/browse/EMI-2800)

### Description
- AddressFormFields: Added withSetAsDefault prop to show/hide the “Set as default address” checkbox.
- UpdateAddressForm: Integrated checkbox for non-default addresses, with submission logic to update defaults.
- New Mutation: Added useOrder2UpdateUserDefaultAddressMutation for setting default addresses via updateUserDefaultAddress.
- Settings Cleanup: Updated SettingsShippingAddressForm to use withSetAsDefault, removing duplicate checkbox code for consistency.
- Tests: Added 6 test cases covering checkbox display, user actions, submission, and error handling.