### PR TITLE
fix(EMI-2802): Fix SEPA/ACH checkout hanging on loading skeleton

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/CheckoutContext/Order2CheckoutContext.tsx
+++ b/src/Apps/Order2/Routes/Checkout/CheckoutContext/Order2CheckoutContext.tsx
@@ -496,9 +496,19 @@ const CheckoutLoadingManager: React.FC<{
   const [minimumLoadingPassed, setMinimumLoadingPassed] = useState(false)
   const [orderValidated, setOrderValidated] = useState(false)
 
-  const isExpressCheckoutLoaded = Order2CheckoutContext.useStoreState(
-    state => state.expressCheckoutPaymentMethods !== null,
-  )
+  const isExpressCheckoutLoaded = Order2CheckoutContext.useStoreState(state => {
+    // Express Checkout is considered "loaded" if:
+    // 1. It's actually loaded (not null), OR
+    // 2. We're in post-payment state where Express Checkout should be hidden
+    const isActuallyLoaded = state.expressCheckoutPaymentMethods !== null
+    const activeStep = state.steps.find(
+      step => step.state === CheckoutStepState.ACTIVE,
+    )
+    const isInPostPaymentState =
+      activeStep?.name === CheckoutStepName.CONFIRMATION
+
+    return isActuallyLoaded || isInPostPaymentState
+  })
 
   const isLoading = Order2CheckoutContext.useStoreState(
     state => state.isLoading,


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2802]

### Description


https://github.com/user-attachments/assets/b5915c71-1b99-42b5-83b5-a8013921e3d8

The checkout loading manager was waiting for Express Checkout to load even when it should be hidden (like on the review step), causing an infinite loading state. Updated the loading condition to consider Express Checkout "loaded" when we're in post-payment states where it shouldn't be shown anyway.

This resolves the hanging issue that occurred after clicking "Continue to Review" with SEPA or ACH payment methods.

@artsy/emerald-devs 

<!-- Implementation description -->


[EMI-2802]: https://artsyproduct.atlassian.net/browse/EMI-2802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ