### PR TITLE
feat: show show location on Show page

### DIFF
--- a/src/Apps/Show/Components/ShowContextualLink.tsx
+++ b/src/Apps/Show/Components/ShowContextualLink.tsx
@@ -29,12 +29,14 @@ export const ShowContextualLink: React.FC<React.PropsWithChildren<Props>> = ({
 export const ContextualLink: React.FC<React.PropsWithChildren<Props>> = ({
   show,
 }) => {
-  const { isFairBooth, partner, fair } = show
+  const { isFairBooth, partner, fair, hasLocation } = show
 
   if (!partner && !fair) return null
 
   const partnerHref = partner?.isLinkable && partner?.href
   const partnerName = partner?.name
+  const shouldShowLocation =
+    hasLocation && !isFairBooth && show.location?.display
   const fairName = fair?.name
   const fairHref = fair?.href || ""
 
@@ -67,6 +69,11 @@ export const ContextualLink: React.FC<React.PropsWithChildren<Props>> = ({
           partnerName
         )}
       </Text>
+      {shouldShowLocation && (
+        <Text variant="sm" color="mono60">
+          {show.location?.display}
+        </Text>
+      )}
     </Box>
   )
 }
@@ -77,6 +84,10 @@ export const ShowContextualLinkFragmentContainer = createFragmentContainer(
     show: graphql`
       fragment ShowContextualLink_show on Show {
         isFairBooth
+        hasLocation
+        location {
+          display
+        }
         fair {
           href
           isActive

--- a/src/Apps/Show/__tests__/ShowContextualLink.jest.tsx
+++ b/src/Apps/Show/__tests__/ShowContextualLink.jest.tsx
@@ -75,5 +75,62 @@ describe("ShowContextualLink", () => {
       expect(screen.queryByRole("link")).not.toBeInTheDocument()
       expect(screen.getByText(/Presented by Catty Partner/)).toBeInTheDocument()
     })
+
+    it("displays location when show has location and is not a fair booth", () => {
+      renderWithRelay({
+        Show: () => ({
+          isFairBooth: false,
+          hasLocation: true,
+          location: { display: "123 Art Street, New York" },
+        }),
+        Partner: () => ({
+          name: "Catty Gallery",
+          href: "/catty-gallery",
+          isLinkable: true,
+        }),
+      })
+
+      expect(screen.getByText("Presented by")).toBeInTheDocument()
+      expect(screen.getByText("Catty Gallery")).toBeInTheDocument()
+      expect(screen.getByText("123 Art Street, New York")).toBeInTheDocument()
+    })
+
+    it("does not display location when show has no location", () => {
+      renderWithRelay({
+        Show: () => ({
+          isFairBooth: false,
+          hasLocation: false,
+          location: null,
+        }),
+        Partner: () => ({
+          name: "Catty Gallery",
+          href: "/catty-gallery",
+          isLinkable: true,
+        }),
+      })
+
+      expect(screen.getByText("Presented by")).toBeInTheDocument()
+      expect(screen.getByText("Catty Gallery")).toBeInTheDocument()
+      expect(
+        screen.queryByText("123 Art Street, New York"),
+      ).not.toBeInTheDocument()
+    })
+
+    it("does not display location when show is a fair booth", () => {
+      renderWithRelay({
+        Show: () => ({
+          isFairBooth: true,
+          hasLocation: true,
+          location: { display: "123 Art Street, New York" },
+        }),
+        Fair: () => ({ name: "Art Fair", isActive: true }),
+      })
+
+      expect(screen.getByText("Part of")).toBeInTheDocument()
+      expect(screen.getByText("Art Fair")).toBeInTheDocument()
+      expect(
+        screen.queryByText("123 Art Street, New York"),
+      ).not.toBeInTheDocument()
+    })
   })
 })

--- a/src/__generated__/ShowAppTestQuery.graphql.ts
+++ b/src/__generated__/ShowAppTestQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ffc00bbe5ca8f4d77b7e8df378a02e85>>
+ * @generated SignedSource<<f8d4e6a2fbe0f543a78956bcd8504447>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -676,6 +676,32 @@ return {
             "storageKey": null
           },
           {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "hasLocation",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Location",
+            "kind": "LinkedField",
+            "name": "location",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "display",
+                "storageKey": null
+              },
+              (v8/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
             "alias": "metaDescription",
             "args": null,
             "kind": "ScalarField",
@@ -709,7 +735,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "8317c5069a7bb028f97f34a2b19344fb",
+    "cacheID": "5ab5ab55f9ece9b51dfadb652b145f76",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -760,6 +786,7 @@ return {
         "show.fair.startAt": (v16/*: any*/),
         "show.formattedEndAt": (v16/*: any*/),
         "show.formattedStartAt": (v16/*: any*/),
+        "show.hasLocation": (v17/*: any*/),
         "show.href": (v16/*: any*/),
         "show.id": (v18/*: any*/),
         "show.images": {
@@ -797,6 +824,14 @@ return {
         "show.images.zoom.width": (v21/*: any*/),
         "show.internalID": (v18/*: any*/),
         "show.isFairBooth": (v17/*: any*/),
+        "show.location": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Location"
+        },
+        "show.location.display": (v16/*: any*/),
+        "show.location.id": (v18/*: any*/),
         "show.metaDescription": (v16/*: any*/),
         "show.metaImage": (v19/*: any*/),
         "show.metaImage.src": (v16/*: any*/),
@@ -890,7 +925,7 @@ return {
     },
     "name": "ShowAppTestQuery",
     "operationKind": "query",
-    "text": "query ShowAppTestQuery {\n  show(id: \"xxx\") {\n    ...ShowApp_show\n    id\n  }\n}\n\nfragment BackToFairBanner_show on Show {\n  fair {\n    name\n    href\n    id\n  }\n}\n\nfragment FairCard_fair on Fair {\n  name\n  image {\n    cropped(width: 768, height: 512, version: \"wide\") {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment ShowAbout_show on Show {\n  about: description\n}\n\nfragment ShowApp_show on Show {\n  name\n  href\n  internalID\n  slug\n  about: description\n  isFairBooth\n  viewingRoomsConnection {\n    edges {\n      __typename\n    }\n  }\n  counts {\n    eligibleArtworks\n  }\n  fair {\n    hasFullFeature\n    id\n  }\n  images(default: false, size: 100) {\n    url\n  }\n  ...BackToFairBanner_show\n  ...ShowHeader_show\n  ...ShowAbout_show\n  ...ShowMeta_show\n  ...ShowInstallShots_show\n  ...ShowViewingRoom_show\n  ...ShowArtworksEmptyState_show\n  ...ShowContextCard_show\n}\n\nfragment ShowArtworksEmptyState_show on Show {\n  isFairBooth\n  status\n}\n\nfragment ShowContextCard_show on Show {\n  isFairBooth\n  partner {\n    __typename\n    ... on Partner {\n      internalID\n      slug\n      href\n      name\n      locations {\n        city\n        id\n      }\n      artworksConnection(first: 3, sort: MERCHANDISABILITY_DESC) {\n        edges {\n          node {\n            image {\n              url(version: \"larger\")\n            }\n            id\n          }\n        }\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  fair {\n    internalID\n    isActive\n    slug\n    href\n    name\n    ...FairTiming_fair\n    ...FairCard_fair\n    id\n  }\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  fair {\n    href\n    isActive\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowHeader_show on Show {\n  name\n  startAt\n  endAt\n  status\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  ...ShowContextualLink_show\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images(default: false, size: 100) {\n    internalID\n    caption\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n    versions\n    zoom: resized(quality: 85, width: 900, height: 900, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  href\n  metaDescription: description\n  metaImage {\n    src: url(version: [\"main\", \"normalized\", \"larger\", \"large\"])\n  }\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n}\n\nfragment ShowViewingRoom_show on Show {\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  viewingRoomsConnection {\n    edges {\n      node {\n        internalID\n        slug\n        status\n        distanceToOpen(short: true)\n        distanceToClose(short: true)\n        title\n        href\n        image {\n          imageURLs {\n            normalized\n          }\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query ShowAppTestQuery {\n  show(id: \"xxx\") {\n    ...ShowApp_show\n    id\n  }\n}\n\nfragment BackToFairBanner_show on Show {\n  fair {\n    name\n    href\n    id\n  }\n}\n\nfragment FairCard_fair on Fair {\n  name\n  image {\n    cropped(width: 768, height: 512, version: \"wide\") {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment ShowAbout_show on Show {\n  about: description\n}\n\nfragment ShowApp_show on Show {\n  name\n  href\n  internalID\n  slug\n  about: description\n  isFairBooth\n  viewingRoomsConnection {\n    edges {\n      __typename\n    }\n  }\n  counts {\n    eligibleArtworks\n  }\n  fair {\n    hasFullFeature\n    id\n  }\n  images(default: false, size: 100) {\n    url\n  }\n  ...BackToFairBanner_show\n  ...ShowHeader_show\n  ...ShowAbout_show\n  ...ShowMeta_show\n  ...ShowInstallShots_show\n  ...ShowViewingRoom_show\n  ...ShowArtworksEmptyState_show\n  ...ShowContextCard_show\n}\n\nfragment ShowArtworksEmptyState_show on Show {\n  isFairBooth\n  status\n}\n\nfragment ShowContextCard_show on Show {\n  isFairBooth\n  partner {\n    __typename\n    ... on Partner {\n      internalID\n      slug\n      href\n      name\n      locations {\n        city\n        id\n      }\n      artworksConnection(first: 3, sort: MERCHANDISABILITY_DESC) {\n        edges {\n          node {\n            image {\n              url(version: \"larger\")\n            }\n            id\n          }\n        }\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  fair {\n    internalID\n    isActive\n    slug\n    href\n    name\n    ...FairTiming_fair\n    ...FairCard_fair\n    id\n  }\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  hasLocation\n  location {\n    display\n    id\n  }\n  fair {\n    href\n    isActive\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowHeader_show on Show {\n  name\n  startAt\n  endAt\n  status\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  ...ShowContextualLink_show\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images(default: false, size: 100) {\n    internalID\n    caption\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n    versions\n    zoom: resized(quality: 85, width: 900, height: 900, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  href\n  metaDescription: description\n  metaImage {\n    src: url(version: [\"main\", \"normalized\", \"larger\", \"large\"])\n  }\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n}\n\nfragment ShowViewingRoom_show on Show {\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  viewingRoomsConnection {\n    edges {\n      node {\n        internalID\n        slug\n        status\n        distanceToOpen(short: true)\n        distanceToClose(short: true)\n        title\n        href\n        image {\n          imageURLs {\n            normalized\n          }\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ShowContextualLinkTestQuery.graphql.ts
+++ b/src/__generated__/ShowContextualLinkTestQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b2939fa2fe12541ab977c3c1816e0618>>
+ * @generated SignedSource<<7bb813bded9249ef9f780b8f2ad868f7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -33,25 +33,25 @@ v1 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "href",
+  "name": "id",
   "storageKey": null
 },
 v2 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "name",
+  "name": "href",
   "storageKey": null
 },
 v3 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "name",
   "storageKey": null
 },
 v4 = [
-  (v3/*: any*/)
+  (v1/*: any*/)
 ],
 v5 = {
   "enumValues": null,
@@ -128,12 +128,38 @@ return {
           {
             "alias": null,
             "args": null,
+            "kind": "ScalarField",
+            "name": "hasLocation",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Location",
+            "kind": "LinkedField",
+            "name": "location",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "display",
+                "storageKey": null
+              },
+              (v1/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "concreteType": "Fair",
             "kind": "LinkedField",
             "name": "fair",
             "plural": false,
             "selections": [
-              (v1/*: any*/),
+              (v2/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -141,8 +167,8 @@ return {
                 "name": "isActive",
                 "storageKey": null
               },
-              (v2/*: any*/),
-              (v3/*: any*/)
+              (v3/*: any*/),
+              (v1/*: any*/)
             ],
             "storageKey": null
           },
@@ -171,8 +197,8 @@ return {
                     "name": "isLinkable",
                     "storageKey": null
                   },
-                  (v2/*: any*/),
-                  (v1/*: any*/)
+                  (v3/*: any*/),
+                  (v2/*: any*/)
                 ],
                 "type": "Partner",
                 "abstractKey": null
@@ -192,14 +218,14 @@ return {
             ],
             "storageKey": null
           },
-          (v3/*: any*/)
+          (v1/*: any*/)
         ],
         "storageKey": "show(id:\"catty-show\")"
       }
     ]
   },
   "params": {
-    "cacheID": "e9c756dc55fdf3cf54132502ad7893b1",
+    "cacheID": "df2029c9d446d172df2ab1e88e147f0f",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -219,8 +245,17 @@ return {
         "show.fair.id": (v6/*: any*/),
         "show.fair.isActive": (v7/*: any*/),
         "show.fair.name": (v5/*: any*/),
+        "show.hasLocation": (v7/*: any*/),
         "show.id": (v6/*: any*/),
         "show.isFairBooth": (v7/*: any*/),
+        "show.location": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Location"
+        },
+        "show.location.display": (v5/*: any*/),
+        "show.location.id": (v6/*: any*/),
         "show.partner": {
           "enumValues": null,
           "nullable": true,
@@ -237,7 +272,7 @@ return {
     },
     "name": "ShowContextualLinkTestQuery",
     "operationKind": "query",
-    "text": "query ShowContextualLinkTestQuery {\n  show(id: \"catty-show\") {\n    ...ShowContextualLink_show\n    id\n  }\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  fair {\n    href\n    isActive\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n"
+    "text": "query ShowContextualLinkTestQuery {\n  show(id: \"catty-show\") {\n    ...ShowContextualLink_show\n    id\n  }\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  hasLocation\n  location {\n    display\n    id\n  }\n  fair {\n    href\n    isActive\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ShowContextualLink_show.graphql.ts
+++ b/src/__generated__/ShowContextualLink_show.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e59f81d71a8fcdcea16f7c4657196f6a>>
+ * @generated SignedSource<<6ac324c03aa7832da14524799f726af9>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,7 +16,11 @@ export type ShowContextualLink_show$data = {
     readonly isActive: boolean | null | undefined;
     readonly name: string | null | undefined;
   } | null | undefined;
+  readonly hasLocation: boolean | null | undefined;
   readonly isFairBooth: boolean | null | undefined;
+  readonly location: {
+    readonly display: string | null | undefined;
+  } | null | undefined;
   readonly partner: {
     readonly href?: string | null | undefined;
     readonly isLinkable?: boolean | null | undefined;
@@ -55,6 +59,31 @@ return {
       "args": null,
       "kind": "ScalarField",
       "name": "isFairBooth",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "hasLocation",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Location",
+      "kind": "LinkedField",
+      "name": "location",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "display",
+          "storageKey": null
+        }
+      ],
       "storageKey": null
     },
     {
@@ -110,6 +139,6 @@ return {
 };
 })();
 
-(node as any).hash = "650b5a3e83cb5f0cd65c87b33c8db18e";
+(node as any).hash = "e33b9a4754faf11bd76e96024f0941ff";
 
 export default node;

--- a/src/__generated__/showRoutes_ShowQuery.graphql.ts
+++ b/src/__generated__/showRoutes_ShowQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d9e793de0bdedc4754040d3cf006f132>>
+ * @generated SignedSource<<62b0946aa58e13f4bf4a64792b1d5b27>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -649,6 +649,32 @@ return {
             "storageKey": null
           },
           {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "hasLocation",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Location",
+            "kind": "LinkedField",
+            "name": "location",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "display",
+                "storageKey": null
+              },
+              (v9/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
             "alias": "metaDescription",
             "args": null,
             "kind": "ScalarField",
@@ -682,12 +708,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "312e141d38874791627bcef8cf0f1405",
+    "cacheID": "e58b1dbd692cff5712ce0597575b8436",
     "id": null,
     "metadata": {},
     "name": "showRoutes_ShowQuery",
     "operationKind": "query",
-    "text": "query showRoutes_ShowQuery(\n  $slug: String!\n) {\n  show(id: $slug) @principalField {\n    ...ShowApp_show\n    id\n  }\n}\n\nfragment BackToFairBanner_show on Show {\n  fair {\n    name\n    href\n    id\n  }\n}\n\nfragment FairCard_fair on Fair {\n  name\n  image {\n    cropped(width: 768, height: 512, version: \"wide\") {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment ShowAbout_show on Show {\n  about: description\n}\n\nfragment ShowApp_show on Show {\n  name\n  href\n  internalID\n  slug\n  about: description\n  isFairBooth\n  viewingRoomsConnection {\n    edges {\n      __typename\n    }\n  }\n  counts {\n    eligibleArtworks\n  }\n  fair {\n    hasFullFeature\n    id\n  }\n  images(default: false, size: 100) {\n    url\n  }\n  ...BackToFairBanner_show\n  ...ShowHeader_show\n  ...ShowAbout_show\n  ...ShowMeta_show\n  ...ShowInstallShots_show\n  ...ShowViewingRoom_show\n  ...ShowArtworksEmptyState_show\n  ...ShowContextCard_show\n}\n\nfragment ShowArtworksEmptyState_show on Show {\n  isFairBooth\n  status\n}\n\nfragment ShowContextCard_show on Show {\n  isFairBooth\n  partner {\n    __typename\n    ... on Partner {\n      internalID\n      slug\n      href\n      name\n      locations {\n        city\n        id\n      }\n      artworksConnection(first: 3, sort: MERCHANDISABILITY_DESC) {\n        edges {\n          node {\n            image {\n              url(version: \"larger\")\n            }\n            id\n          }\n        }\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  fair {\n    internalID\n    isActive\n    slug\n    href\n    name\n    ...FairTiming_fair\n    ...FairCard_fair\n    id\n  }\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  fair {\n    href\n    isActive\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowHeader_show on Show {\n  name\n  startAt\n  endAt\n  status\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  ...ShowContextualLink_show\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images(default: false, size: 100) {\n    internalID\n    caption\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n    versions\n    zoom: resized(quality: 85, width: 900, height: 900, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  href\n  metaDescription: description\n  metaImage {\n    src: url(version: [\"main\", \"normalized\", \"larger\", \"large\"])\n  }\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n}\n\nfragment ShowViewingRoom_show on Show {\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  viewingRoomsConnection {\n    edges {\n      node {\n        internalID\n        slug\n        status\n        distanceToOpen(short: true)\n        distanceToClose(short: true)\n        title\n        href\n        image {\n          imageURLs {\n            normalized\n          }\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query showRoutes_ShowQuery(\n  $slug: String!\n) {\n  show(id: $slug) @principalField {\n    ...ShowApp_show\n    id\n  }\n}\n\nfragment BackToFairBanner_show on Show {\n  fair {\n    name\n    href\n    id\n  }\n}\n\nfragment FairCard_fair on Fair {\n  name\n  image {\n    cropped(width: 768, height: 512, version: \"wide\") {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment FairTiming_fair on Fair {\n  exhibitionPeriod\n  startAt\n  endAt\n}\n\nfragment ShowAbout_show on Show {\n  about: description\n}\n\nfragment ShowApp_show on Show {\n  name\n  href\n  internalID\n  slug\n  about: description\n  isFairBooth\n  viewingRoomsConnection {\n    edges {\n      __typename\n    }\n  }\n  counts {\n    eligibleArtworks\n  }\n  fair {\n    hasFullFeature\n    id\n  }\n  images(default: false, size: 100) {\n    url\n  }\n  ...BackToFairBanner_show\n  ...ShowHeader_show\n  ...ShowAbout_show\n  ...ShowMeta_show\n  ...ShowInstallShots_show\n  ...ShowViewingRoom_show\n  ...ShowArtworksEmptyState_show\n  ...ShowContextCard_show\n}\n\nfragment ShowArtworksEmptyState_show on Show {\n  isFairBooth\n  status\n}\n\nfragment ShowContextCard_show on Show {\n  isFairBooth\n  partner {\n    __typename\n    ... on Partner {\n      internalID\n      slug\n      href\n      name\n      locations {\n        city\n        id\n      }\n      artworksConnection(first: 3, sort: MERCHANDISABILITY_DESC) {\n        edges {\n          node {\n            image {\n              url(version: \"larger\")\n            }\n            id\n          }\n        }\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  fair {\n    internalID\n    isActive\n    slug\n    href\n    name\n    ...FairTiming_fair\n    ...FairCard_fair\n    id\n  }\n}\n\nfragment ShowContextualLink_show on Show {\n  isFairBooth\n  hasLocation\n  location {\n    display\n    id\n  }\n  fair {\n    href\n    isActive\n    name\n    id\n  }\n  partner {\n    __typename\n    ... on Partner {\n      isLinkable\n      name\n      href\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n}\n\nfragment ShowHeader_show on Show {\n  name\n  startAt\n  endAt\n  status\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  ...ShowContextualLink_show\n}\n\nfragment ShowInstallShots_show on Show {\n  name\n  images(default: false, size: 100) {\n    internalID\n    caption\n    src: url(version: [\"larger\", \"large\"])\n    width\n    height\n    versions\n    zoom: resized(quality: 85, width: 900, height: 900, version: [\"main\", \"normalized\", \"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n}\n\nfragment ShowMeta_show on Show {\n  name\n  href\n  metaDescription: description\n  metaImage {\n    src: url(version: [\"main\", \"normalized\", \"larger\", \"large\"])\n  }\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n    ... on ExternalPartner {\n      id\n    }\n  }\n  formattedStartAt: startAt(format: \"MMMM D\")\n  formattedEndAt: endAt(format: \"MMMM D, YYYY\")\n}\n\nfragment ShowViewingRoom_show on Show {\n  partner {\n    __typename\n    ... on Partner {\n      name\n    }\n    ... on ExternalPartner {\n      name\n      id\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  viewingRoomsConnection {\n    edges {\n      node {\n        internalID\n        slug\n        status\n        distanceToOpen(short: true)\n        distanceToClose(short: true)\n        title\n        href\n        image {\n          imageURLs {\n            normalized\n          }\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
This PR adds the address of a show on its main page when the show takes place at a partner location (as opposed to a fair) to make it more accessible for users who wish to visit the show. It will be displayed underneath the gallery name in the show's information panel.

| Before | After |
|-|-|
| <img width="2674" height="9090" alt="localhost_4000_show_susan-sheehan-gallery-schools-out-for-summer (2)" src="https://github.com/user-attachments/assets/87028beb-a85d-4c60-976a-c3b6db2ef42e" /> | <img width="2674" height="9142" alt="localhost_4000_show_susan-sheehan-gallery-schools-out-for-summer (1)" src="https://github.com/user-attachments/assets/1dc67350-486a-4eb4-98c5-31148376cef3" /> |

cc: @artsy/diamond-devs 