### PR TITLE
chore: add playwright test reports to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,9 @@ server.dist.js.map
 coverage*
 cypress/screenshots
 .nyc_output
+playwright-report
 reports*
+test-results
 junit.xml
 cypress/videos
 .last-run.json


### PR DESCRIPTION
This PR adds the playwright-report and test-results folders that are created as artifacts of Playwright test runs to .gitignore.