### PR TITLE
chore(EMI-2772): update bank account icon

### DIFF
--- a/src/Apps/Order/Routes/Details/Components/OrderDetailsPaymentInfo.tsx
+++ b/src/Apps/Order/Routes/Details/Components/OrderDetailsPaymentInfo.tsx
@@ -1,6 +1,6 @@
 import ApplePayMarkIcon from "@artsy/icons/ApplePayMarkIcon"
 import GooglePayIcon from "@artsy/icons/GooglePayIcon"
-import HomeIcon from "@artsy/icons/HomeIcon"
+import InstitutionIcon from "@artsy/icons/InstitutionIcon"
 import { Box, Flex, Spacer, Text } from "@artsy/palette"
 import { type Brand, BrandCreditCardIcon } from "Components/BrandCreditCardIcon"
 import type {
@@ -74,13 +74,13 @@ const getPaymentMethodContent = (
 
     case "BankAccount":
       return {
-        Icon: HomeIcon,
+        Icon: InstitutionIcon,
         text: `Bank transfer •••• ${paymentMethodDetails.last4}`,
       }
 
     case "WireTransfer":
       return {
-        Icon: HomeIcon,
+        Icon: InstitutionIcon,
         text: "Wire transfer",
       }
 

--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentCompletedView.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentCompletedView.tsx
@@ -1,5 +1,5 @@
 import CheckmarkIcon from "@artsy/icons/CheckmarkIcon"
-import HomeIcon from "@artsy/icons/HomeIcon"
+import InstitutionIcon from "@artsy/icons/InstitutionIcon"
 import { Clickable, Flex, Spacer, Text } from "@artsy/palette"
 import { useCheckoutContext } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext"
 import { type Brand, BrandCreditCardIcon } from "Components/BrandCreditCardIcon"
@@ -57,7 +57,7 @@ export const Order2PaymentCompletedView: React.FC<
       <Flex alignItems="center" ml="30px" mt={1}>
         {(isBankAccount || isSEPA) && (
           <>
-            <HomeIcon
+            <InstitutionIcon
               fill="mono100"
               width={["18px", "26px"]}
               height={["18px", "26px"]}
@@ -90,7 +90,7 @@ export const Order2PaymentCompletedView: React.FC<
         )}
         {isWireTransfer && (
           <>
-            <HomeIcon
+            <InstitutionIcon
               fill="mono100"
               width={["18px", "26px"]}
               height={["18px", "26px"]}

--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
@@ -1,5 +1,5 @@
 import { ContextModule } from "@artsy/cohesion"
-import HomeIcon from "@artsy/icons/HomeIcon"
+import InstitutionIcon from "@artsy/icons/InstitutionIcon"
 import InfoIcon from "@artsy/icons/InfoIcon"
 import LockIcon from "@artsy/icons/LockIcon"
 import ReceiptIcon from "@artsy/icons/ReceiptIcon"
@@ -626,13 +626,16 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({
                               </>
                             ) : (
                               <>
-                                <HomeIcon
+                                <InstitutionIcon
                                   fill="mono100"
                                   width={["18px", "26px"]}
                                   height={["18px", "26px"]}
                                   mr={1}
                                 />
-                                <Text variant={["xs", "sm-display"]}>
+                                <Text
+                                  variant={["xs", "sm-display"]}
+                                  mt={["0px", "3px"]}
+                                >
                                   Bank account •••• {paymentMethod.last4}
                                 </Text>
                               </>


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2772]

### Description

Replacing `HomeIcon` for `InstitutionIcon` in 3 different places in the new checkout flow.

**Saved payment methods**
<img width="715" height="728" alt="SCR-20250909-jbge" src="https://github.com/user-attachments/assets/d37840e7-795f-4fa4-976f-3613daf36447" />

**Payment completed view**
<img width="1260" height="696" alt="SCR-20250909-iybs" src="https://github.com/user-attachments/assets/56b03d82-afa2-474b-b171-ad14075c40ed" />

**Order details page**
<img width="716" height="567" alt="SCR-20250909-iypy" src="https://github.com/user-attachments/assets/7ef9b9ed-7e85-46c4-8d1c-f3c9ca277376" />

@artsy/emerald-devs 


<!-- Implementation description -->


[EMI-2772]: https://artsyproduct.atlassian.net/browse/EMI-2772?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ