### PR TITLE
feat(EMI-2785): conversation sidebar style changes

### DIFF
--- a/src/Apps/Conversations/components/Sidebar/ConversationsSidebarItem.tsx
+++ b/src/Apps/Conversations/components/Sidebar/ConversationsSidebarItem.tsx
@@ -88,21 +88,33 @@ export const ConversationsSidebarItem: React.FC<
 
           <Flex flexDirection="column" mx={1} flex={1} overflow="hidden">
             <Box display="inherit">
-              <Text variant="xs" overflowEllipsis>
+              <Text
+                variant="xs"
+                overflowEllipsis
+                fontWeight={isSelected ? "bold" : "regular"}
+              >
                 {data?.to?.name}
               </Text>
             </Box>
 
-            <Text variant="xs" overflowEllipsis>
-              {item.artist.name}
+            <Text
+              variant="xs"
+              overflowEllipsis
+              fontWeight={isSelected ? "bold" : "regular"}
+            >
+              {item.artist.name},{" "}
+              <Text
+                fontStyle="italic"
+                display="inline"
+                variant="xs"
+                fontWeight={isSelected ? "bold" : "regular"}
+              >
+                {item.title}
+              </Text>
             </Text>
 
             <Text variant="xs" color="mono60" overflowEllipsis>
-              <Text fontStyle="italic" display="inline" variant="xs">
-                {item.title}
-              </Text>
-
-              {item.date && `, ${item.date}`}
+              {conversationType}
             </Text>
 
             {item.isUnlisted && (
@@ -113,10 +125,12 @@ export const ConversationsSidebarItem: React.FC<
           </Flex>
 
           <Flex flexDirection="column" alignSelf="flex-start">
-            <Text variant="xs">{conversationType}</Text>
-
             <Flex flexDirection="row" alignItems="center">
-              <Text variant="xs" color="mono60">
+              <Text
+                variant="xs"
+                color={isSelected ? "mono100" : "mono60"}
+                fontWeight={isSelected ? "bold" : "regular"}
+              >
                 {data?.lastMessageAt}
               </Text>
             </Flex>

--- a/src/Apps/Conversations/components/Sidebar/__tests__/ConversationsSidebarItem.jest.tsx
+++ b/src/Apps/Conversations/components/Sidebar/__tests__/ConversationsSidebarItem.jest.tsx
@@ -75,9 +75,8 @@ describe("ConversationSidebarItem", () => {
       "src",
       "https://imamges.com/img.png",
     )
-    expect(screen.getByText("Edgar the doggo")).toBeInTheDocument()
+    expect(screen.getByText("Edgar the doggo,")).toBeInTheDocument()
     expect(screen.getByText("Demo title")).toBeInTheDocument()
-    expect(screen.getByText(", 2022")).toBeInTheDocument()
     expect(screen.getByText("Dec 07")).toBeInTheDocument()
     expect(screen.getByText("Inquiry")).toBeInTheDocument()
     expect(screen.getByRole("link")).toHaveAttribute(


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2785]

### Description

Sidebar changes matching CMS

<img width="427" height="495" alt="Screenshot 2025-09-09 at 10 17 09" src="https://github.com/user-attachments/assets/c266a3d8-4ea9-4fca-85a6-ca997e64dc4f" />



[EMI-2785]: https://artsyproduct.atlassian.net/browse/EMI-2785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ