### PR TITLE
feat(EMI-2775): filter saved bank accounts by available payment methods

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
@@ -196,7 +196,10 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({
   const savedCreditCards = extractNodes(me.creditCards)
   const hasSavedCreditCards = savedCreditCards.length > 0
   const savedBankAccounts = extractNodes(me.bankAccounts)
-  const hasSavedBankAccounts = savedBankAccounts.length > 0
+  const allowedSavedBankAccounts = savedBankAccounts.filter(bankAccount =>
+    order.availablePaymentMethods?.includes(bankAccount.type),
+  )
+  const hasSavedBankAccounts = allowedSavedBankAccounts.length > 0
 
   const stepIsActive =
     steps?.find(step => step.name === CheckoutStepName.PAYMENT)?.state ===
@@ -689,7 +692,7 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({
                     setSelectedSavedPaymentMethod(val)
                   }}
                 >
-                  {[...savedCreditCards, ...savedBankAccounts].map(
+                  {[...savedCreditCards, ...allowedSavedBankAccounts].map(
                     paymentMethod => (
                       <Radio
                         key={paymentMethod.internalID}


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2775]

### Description

Filter saved bank accounts to only show those with payment types supported by the order.

<details>

 <summary>Order with ACH available</summary>

| main  | after |
| ------------- | ------------- |
| ![MAIN](https://github.com/user-attachments/assets/4ad2cbfa-83f8-45cf-ad7f-3a78bc2f024f)  | ![after](https://github.com/user-attachments/assets/006029e0-9b3e-429c-8a43-a568e27243c4)  |

</details>


<details>

 <summary>Order with SEPA available</summary>

| main  | after |
| ------------- | ------------- |
| ![MAIN](https://github.com/user-attachments/assets/086ac1f9-e3c2-4a52-853e-fe03c31e678e)  | ![after](https://github.com/user-attachments/assets/3f9f8dc8-4e61-42f8-bd9f-9f9f118ddceb)  |

</details>

@artsy/emerald-devs 


<!-- Implementation description -->
