### PR TITLE
feat(EMI-2785): artwork clickable

### DIFF
--- a/src/Apps/Conversations/components/Details/ConversationArtwork.tsx
+++ b/src/Apps/Conversations/components/Details/ConversationArtwork.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, Image, Separator, Spacer, Text } from "@artsy/palette"
+import { Flex, Image, Separator, Spacer, Text } from "@artsy/palette"
 import { RouterLink } from "System/Components/RouterLink"
 import type { ConversationArtwork_conversation$key } from "__generated__/ConversationArtwork_conversation.graphql"
 import { graphql, useFragment } from "react-relay"
@@ -55,12 +55,24 @@ export const ConversationArtwork: React.FC<
       <Spacer y={2} />
 
       <Flex>
-        <Image
-          src={item?.image?.url as string}
-          height={40}
-          width={40}
-          alt={`Artwork image of ${item?.title}`}
-        />
+        <RouterLink
+          to={`/artwork/${item?.slug}`}
+          onClick={() => {
+            trackEvent({
+              action: "Click",
+              label: "View artwork",
+              context_module: "conversations",
+              artwork_id: item?.id,
+            })
+          }}
+        >
+          <Image
+            src={item?.image?.url as string}
+            height={40}
+            width={40}
+            alt={`Artwork image of ${item?.title}`}
+          />
+        </RouterLink>
 
         <Spacer x={1} />
 
@@ -68,12 +80,24 @@ export const ConversationArtwork: React.FC<
           <RouterLink to={`/artist/${item?.artist?.slug}`}>
             <Text variant="xs">{item?.artist?.name}</Text>
           </RouterLink>
-          <Text variant="xs" color="mono60">
-            <Text fontStyle="italic" display="inline" variant="xs">
-              {item?.title}
+          <RouterLink
+            to={`/artwork/${item?.slug}`}
+            onClick={() => {
+              trackEvent({
+                action: "Click",
+                label: "View artwork",
+                context_module: "conversations",
+                artwork_id: item?.id,
+              })
+            }}
+          >
+            <Text variant="xs" color="mono60">
+              <Text fontStyle="italic" display="inline" variant="xs">
+                {item?.title}
+              </Text>
+              {item?.date && `, ${item?.date}`}
             </Text>
-            {item?.date && `, ${item?.date}`}
-          </Text>
+          </RouterLink>
 
           {item.isUnlisted && (
             <Text display="inline" variant="xs">
@@ -84,22 +108,6 @@ export const ConversationArtwork: React.FC<
       </Flex>
 
       <Spacer y={2} />
-
-      <RouterLink
-        to={`/artwork/${item?.slug}`}
-        onClick={() => {
-          trackEvent({
-            action: "Click",
-            label: "View artwork",
-            context_module: "conversations",
-            artwork_id: item?.id,
-          })
-        }}
-      >
-        <Button variant="secondaryBlack" size="small">
-          View Artwork
-        </Button>
-      </RouterLink>
 
       <Separator borderWidth={1} my={4} />
     </>

--- a/src/Apps/Conversations/components/Details/__tests__/ConversationDetails.jest.tsx
+++ b/src/Apps/Conversations/components/Details/__tests__/ConversationDetails.jest.tsx
@@ -101,12 +101,15 @@ describe("ConversationDetails", () => {
       expect(screen.getByText("Support")).toBeInTheDocument()
     })
 
-    it("tracks click on View Artwork", () => {
+    it("tracks click on artwork title", () => {
       renderWithRelay({
-        ConversationItemType: () => ({ id: "mocked-artwork-id" }),
+        ConversationItemType: () => ({
+          id: "mocked-artwork-id",
+          title: "Test Artwork Title",
+        }),
       })
 
-      fireEvent.click(screen.getByText("View Artwork"))
+      fireEvent.click(screen.getByText("Test Artwork Title"))
 
       expect(trackEvent).toHaveBeenCalledTimes(1)
       expect(trackEvent.mock.calls[0][0]).toMatchObject({


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2785]

### Description

Artwork clickable instead of a button, following CMS changes

<img width="439" height="765" alt="Screenshot 2025-09-09 at 13 13 57" src="https://github.com/user-attachments/assets/af5930dd-8a68-496e-a24c-f2ec139be6d2" />


[EMI-2785]: https://artsyproduct.atlassian.net/browse/EMI-2785?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ