### PR TITLE
fix: scroll messages on first load

### DIFF
--- a/src/Apps/Conversations/components/Message/ConversationMessages.tsx
+++ b/src/Apps/Conversations/components/Message/ConversationMessages.tsx
@@ -364,7 +364,23 @@ const useAutoScrollToBottom = ({
         inline: "end",
       })
     }
-  }, [lastMessageId, autoScrollToBottomRef, triggerAutoScroll])
+  }, [lastMessageId, triggerAutoScroll])
+
+  // Additional effect to ensure initial scroll after component mount
+  // biome-ignore lint/correctness/useExhaustiveDependencies:
+  useEffect(() => {
+    if (lastMessageId) {
+      const timeoutId = setTimeout(() => {
+        triggerAutoScroll({
+          behavior: "instant",
+          block: "end",
+          inline: "end",
+        })
+      }, 0)
+
+      return () => clearTimeout(timeoutId)
+    }
+  }, [])
 
   return { triggerAutoScroll }
 }


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

Noticed that on first load of the conversations page, the conversation that opens doesn't scroll to the last message. Subsequent conversations scroll fine so it's seems to be a matter of DOM rendering and execution timing.
Adding a timeout solves the issue, not sure if there's a more elegant way of achieving the same result.

Before:

https://github.com/user-attachments/assets/7dd347b8-2bcf-4470-aadd-713c6681a10d

After:

https://github.com/user-attachments/assets/25b2a243-d12c-4d5b-810d-baf9ef49a262


