### PR TITLE
fix: only save address automatically for users without saved addresses

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
@@ -218,7 +218,9 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
           updateShippingAddressResult.updateOrderShippingAddress?.orderOrError,
         ).order
 
-        await saveAddressToUser(values)
+        if (!hasSavedAddresses) {
+          await saveAddressToUser(values)
+        }
 
         formikHelpers.setStatus({ errorBanner: null })
         setFulfillmentDetailsComplete({}) // TODO: Clean up signature
@@ -237,6 +239,7 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
     },
     [
       checkoutTracking,
+      hasSavedAddresses,
       orderData.internalID,
       orderData.selectedFulfillmentOption?.type,
       saveAddressToUser,


### PR DESCRIPTION
## Type
Fix

## Description  
Fixed address saving logic to only save automatically for users with no saved addresses. Users with existing saved addresses use the manual 'Add new address' flow.

## Changes
- Updated logic in Order2DeliveryForm.tsx 
- Added test coverage for both scenarios
- Updated existing tests