### PR TITLE
test: bump up timeout tentatively until implementing proper improvements

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
@@ -19,6 +19,8 @@ import { useTracking } from "react-tracking"
 import { Order2ExpressCheckout as MockExpressCheckout } from "../Components/ExpressCheckout/Order2ExpressCheckout"
 import { Order2CheckoutRoute } from "../Order2CheckoutRoute"
 
+jest.setTimeout(10000)
+
 jest.unmock("react-relay")
 jest.useFakeTimers()
 jest.mock("react-tracking")


### PR DESCRIPTION
### Description

Reported on [Slack](https://artsy.slack.com/archives/C02JHHHKP5K/p1757432618619149). The Order2CheckoutRoute tests are flaky on CI due to timeout. This bumps up the timeout tentatively for now and we'll ticket and improve the tests separately.

<img width="1252" height="238" alt="Screenshot 2025-09-09 at 11 46 15 AM" src="https://github.com/user-attachments/assets/1c74e758-1f09-4371-a62d-fa8ea6d53be7" />

cc @artsy/emerald-devs 