### PR TITLE
fix(EMI-2817): add setAsDefault checkbox to AddAddressForm

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
@@ -88,6 +88,7 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
       phoneNumber: "",
       phoneNumberCountryCode:
         locationBasedInitialValues.phoneNumberCountryCode || "",
+      setAsDefault: false,
     }),
     [locationBasedInitialValues],
   )

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/AddAddressForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/AddAddressForm.tsx
@@ -2,6 +2,7 @@ import { Button, Spacer, Text } from "@artsy/palette"
 import { deliveryAddressValidationSchema } from "Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/utils"
 import { useCheckoutContext } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext"
 import { useOrder2CreateUserAddressMutation } from "Apps/Order2/Routes/Checkout/Mutations/useOrder2CreateUserAddressMutation"
+import { useOrder2UpdateUserDefaultAddressMutation } from "Apps/Order2/Routes/Checkout/Mutations/useOrder2UpdateUserDefaultAddressMutation"
 import {
   AddressFormFields,
   type FormikContextWithAddress,
@@ -24,7 +25,18 @@ export const AddAddressForm = ({
   initialValues,
 }: AddAddressFormProps) => {
   const createUserAddress = useOrder2CreateUserAddressMutation()
+  const updateUserDefaultAddress = useOrder2UpdateUserDefaultAddressMutation()
   const { setUserAddressMode } = useCheckoutContext()
+
+  const handleSetAsDefault = async (addressID: string) => {
+    await updateUserDefaultAddress.submitMutation({
+      variables: {
+        input: {
+          userAddressID: addressID,
+        },
+      },
+    })
+  }
 
   return (
     <Formik
@@ -51,10 +63,14 @@ export const AddAddressForm = ({
           })
 
           if (result.createUserAddress?.userAddressOrErrors?.internalID) {
-            await onSaveAddress(
-              values,
-              result.createUserAddress?.userAddressOrErrors.internalID,
-            )
+            const newAddressID =
+              result.createUserAddress.userAddressOrErrors.internalID
+
+            if (values.setAsDefault) {
+              await handleSetAsDefault(newAddressID)
+            }
+
+            await onSaveAddress(values, newAddressID)
             return
           }
 
@@ -81,7 +97,7 @@ export const AddAddressForm = ({
             Add address
           </Text>{" "}
           <Spacer y={2} />
-          <AddressFormFields withPhoneNumber />
+          <AddressFormFields withPhoneNumber withSetAsDefault />
           <Spacer y={4} />
           <Button
             width="100%"

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/AddAddressForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/AddAddressForm.tsx
@@ -62,10 +62,10 @@ export const AddAddressForm = ({
             },
           })
 
-          if (result.createUserAddress?.userAddressOrErrors?.internalID) {
-            const newAddressID =
-              result.createUserAddress.userAddressOrErrors.internalID
+          const newAddressID =
+            result.createUserAddress?.userAddressOrErrors?.internalID
 
+          if (newAddressID) {
             if (values.setAsDefault) {
               await handleSetAsDefault(newAddressID)
             }

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/AddAddressForm.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/AddAddressForm.jest.tsx
@@ -1,0 +1,316 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { AddAddressForm } from "../AddAddressForm"
+import { useOrder2CreateUserAddressMutation } from "Apps/Order2/Routes/Checkout/Mutations/useOrder2CreateUserAddressMutation"
+import { useOrder2UpdateUserDefaultAddressMutation } from "Apps/Order2/Routes/Checkout/Mutations/useOrder2UpdateUserDefaultAddressMutation"
+import { useCheckoutContext } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext"
+import type { FormikContextWithAddress } from "Components/Address/AddressFormFields"
+
+jest.mock(
+  "Apps/Order2/Routes/Checkout/Mutations/useOrder2CreateUserAddressMutation",
+)
+jest.mock(
+  "Apps/Order2/Routes/Checkout/Mutations/useOrder2UpdateUserDefaultAddressMutation",
+)
+jest.mock("Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext")
+jest.mock("Utils/logger")
+
+const mockCreateUserAddress = jest.fn()
+const mockUpdateUserDefaultAddress = jest.fn()
+const mockSetUserAddressMode = jest.fn()
+const mockOnSaveAddress = jest.fn()
+
+const mockUseOrder2CreateUserAddressMutation =
+  useOrder2CreateUserAddressMutation as jest.MockedFunction<
+    typeof useOrder2CreateUserAddressMutation
+  >
+const mockUseOrder2UpdateUserDefaultAddressMutation =
+  useOrder2UpdateUserDefaultAddressMutation as jest.MockedFunction<
+    typeof useOrder2UpdateUserDefaultAddressMutation
+  >
+const mockUseCheckoutContext = useCheckoutContext as jest.MockedFunction<
+  typeof useCheckoutContext
+>
+
+const initialValues: FormikContextWithAddress = {
+  address: {
+    name: "",
+    addressLine1: "",
+    addressLine2: "",
+    city: "",
+    region: "",
+    postalCode: "",
+    country: "US",
+  },
+  phoneNumber: "",
+  phoneNumberCountryCode: "us",
+  setAsDefault: false,
+}
+
+const mockProps = {
+  initialValues,
+  onSaveAddress: mockOnSaveAddress,
+}
+
+describe("AddAddressForm", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockUseOrder2CreateUserAddressMutation.mockReturnValue({
+      submitMutation: mockCreateUserAddress,
+    } as any)
+
+    mockUseOrder2UpdateUserDefaultAddressMutation.mockReturnValue({
+      submitMutation: mockUpdateUserDefaultAddress,
+    } as any)
+
+    mockUseCheckoutContext.mockReturnValue({
+      setUserAddressMode: mockSetUserAddressMode,
+    } as any)
+  })
+
+  it("renders the add address form with setAsDefault checkbox", () => {
+    render(<AddAddressForm {...mockProps} />)
+
+    expect(screen.getByText("Add address")).toBeInTheDocument()
+    expect(screen.getByPlaceholderText("Add full name")).toBeInTheDocument()
+    expect(screen.getByLabelText("Street address")).toBeInTheDocument()
+    expect(screen.getByText("Save Address")).toBeInTheDocument()
+    expect(screen.getByText("Cancel")).toBeInTheDocument()
+
+    // Check that setAsDefault checkbox is present
+    const checkbox = screen.getByTestId("setAsDefault")
+    expect(checkbox).toBeInTheDocument()
+    expect(checkbox).not.toBeChecked()
+    expect(screen.getByText("Set as default address")).toBeInTheDocument()
+  })
+
+  it("calls only createUserAddress when setAsDefault is false", async () => {
+    mockCreateUserAddress.mockResolvedValue({
+      createUserAddress: {
+        userAddressOrErrors: {
+          __typename: "UserAddress",
+          internalID: "new-address-id",
+        },
+      },
+    })
+
+    render(<AddAddressForm {...mockProps} />)
+
+    // Fill out the form
+    await userEvent.type(
+      screen.getByPlaceholderText("Add full name"),
+      "Jane Smith",
+    )
+    await userEvent.type(screen.getByLabelText("Street address"), "456 Oak Ave")
+    await userEvent.type(screen.getByLabelText("City"), "Los Angeles")
+    await userEvent.type(
+      screen.getByLabelText("State, region or province"),
+      "CA",
+    )
+    await userEvent.type(screen.getByLabelText("ZIP/Postal code"), "90210")
+    await userEvent.type(
+      screen.getByTestId("addressFormFields.phoneNumber"),
+      "5559876543",
+    )
+
+    // Verify setAsDefault is unchecked (default)
+    const checkbox = screen.getByTestId("setAsDefault")
+    expect(checkbox).not.toBeChecked()
+
+    // Submit the form
+    await userEvent.click(screen.getByText("Save Address"))
+
+    await waitFor(() => {
+      expect(mockCreateUserAddress).toHaveBeenCalledWith({
+        variables: {
+          input: {
+            attributes: {
+              name: "Jane Smith",
+              addressLine1: "456 Oak Ave",
+              addressLine2: "",
+              city: "Los Angeles",
+              region: "CA",
+              postalCode: "90210",
+              country: "US",
+              phoneNumber: "5559876543",
+              phoneNumberCountryCode: "us",
+            },
+          },
+        },
+      })
+    })
+
+    // Should NOT call updateUserDefaultAddress since setAsDefault is false
+    expect(mockUpdateUserDefaultAddress).not.toHaveBeenCalled()
+
+    // Should call onSaveAddress callback
+    expect(mockOnSaveAddress).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: expect.objectContaining({
+          name: "Jane Smith",
+          addressLine1: "456 Oak Ave",
+        }),
+        setAsDefault: false,
+      }),
+      "new-address-id",
+    )
+  })
+
+  it("calls both createUserAddress and updateUserDefaultAddress when setAsDefault is true", async () => {
+    mockCreateUserAddress.mockResolvedValue({
+      createUserAddress: {
+        userAddressOrErrors: {
+          __typename: "UserAddress",
+          internalID: "new-address-id",
+        },
+      },
+    })
+
+    mockUpdateUserDefaultAddress.mockResolvedValue({
+      updateUserDefaultAddress: {
+        userAddressOrErrors: {
+          __typename: "UserAddress",
+          internalID: "new-address-id",
+        },
+      },
+    })
+
+    render(<AddAddressForm {...mockProps} />)
+
+    // Fill out the form
+    await userEvent.type(
+      screen.getByPlaceholderText("Add full name"),
+      "Jane Smith",
+    )
+    await userEvent.type(screen.getByLabelText("Street address"), "456 Oak Ave")
+    await userEvent.type(screen.getByLabelText("City"), "Los Angeles")
+    await userEvent.type(
+      screen.getByLabelText("State, region or province"),
+      "CA",
+    )
+    await userEvent.type(screen.getByLabelText("ZIP/Postal code"), "90210")
+    await userEvent.type(
+      screen.getByTestId("addressFormFields.phoneNumber"),
+      "5559876543",
+    )
+
+    // Check the setAsDefault checkbox
+    const checkbox = screen.getByTestId("setAsDefault")
+    await userEvent.click(checkbox)
+    expect(checkbox).toBeChecked()
+
+    // Submit the form
+    await userEvent.click(screen.getByText("Save Address"))
+
+    // Should call createUserAddress first
+    await waitFor(() => {
+      expect(mockCreateUserAddress).toHaveBeenCalledWith({
+        variables: {
+          input: {
+            attributes: {
+              name: "Jane Smith",
+              addressLine1: "456 Oak Ave",
+              addressLine2: "",
+              city: "Los Angeles",
+              region: "CA",
+              postalCode: "90210",
+              country: "US",
+              phoneNumber: "5559876543",
+              phoneNumberCountryCode: "us",
+            },
+          },
+        },
+      })
+    })
+
+    // Should ALSO call updateUserDefaultAddress since setAsDefault is true
+    await waitFor(() => {
+      expect(mockUpdateUserDefaultAddress).toHaveBeenCalledWith({
+        variables: {
+          input: {
+            userAddressID: "new-address-id",
+          },
+        },
+      })
+    })
+
+    // Should call onSaveAddress callback
+    expect(mockOnSaveAddress).toHaveBeenCalledWith(
+      expect.objectContaining({
+        address: expect.objectContaining({
+          name: "Jane Smith",
+          addressLine1: "456 Oak Ave",
+        }),
+        setAsDefault: true,
+      }),
+      "new-address-id",
+    )
+  })
+
+  it("allows checking and unchecking the setAsDefault checkbox", async () => {
+    render(<AddAddressForm {...mockProps} />)
+
+    const checkbox = screen.getByTestId("setAsDefault")
+
+    // Initially unchecked
+    expect(checkbox).not.toBeChecked()
+
+    // Check it
+    await userEvent.click(checkbox)
+    expect(checkbox).toBeChecked()
+
+    // Uncheck it
+    await userEvent.click(checkbox)
+    expect(checkbox).not.toBeChecked()
+  })
+
+  it("calls setUserAddressMode(null) when cancel button is clicked", async () => {
+    render(<AddAddressForm {...mockProps} />)
+
+    await userEvent.click(screen.getByText("Cancel"))
+
+    expect(mockSetUserAddressMode).toHaveBeenCalledWith(null)
+  })
+
+  it("handles createUserAddress errors gracefully", async () => {
+    mockCreateUserAddress.mockResolvedValue({
+      createUserAddress: {
+        userAddressOrErrors: {
+          __typename: "Errors",
+          errors: [{ message: "Address creation failed" }],
+        },
+      },
+    })
+
+    render(<AddAddressForm {...mockProps} />)
+
+    // Fill out the form
+    await userEvent.type(
+      screen.getByPlaceholderText("Add full name"),
+      "Jane Smith",
+    )
+    await userEvent.type(screen.getByLabelText("Street address"), "456 Oak Ave")
+    await userEvent.type(screen.getByLabelText("City"), "Los Angeles")
+    await userEvent.type(
+      screen.getByLabelText("State, region or province"),
+      "CA",
+    )
+    await userEvent.type(screen.getByLabelText("ZIP/Postal code"), "90210")
+    await userEvent.type(
+      screen.getByTestId("addressFormFields.phoneNumber"),
+      "5559876543",
+    )
+
+    // Submit the form
+    await userEvent.click(screen.getByText("Save Address"))
+
+    await waitFor(() => {
+      expect(mockCreateUserAddress).toHaveBeenCalled()
+    })
+
+    // Should not call updateUserDefaultAddress or onSaveAddress when creation fails
+    expect(mockUpdateUserDefaultAddress).not.toHaveBeenCalled()
+    expect(mockOnSaveAddress).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [EMI-2817]

### Description

Adds a `setAsDefault` checkbox to the AddAddressForm component that allows users to set their newly created address as their default address when adding a new address.

**Changes:**
- Added `setAsDefault: false` to initial values for form consistency
- AddAddressForm calls `updateUserDefaultAddress` mutation when checkbox is checked
- Added comprehensive tests covering both checkbox states and mutation behavior
- Created AddAddressForm.jest.tsx with 6 test cases

<img width="671" height="788" alt="Screenshot 2025-09-10 at 11 15 06" src="https://github.com/user-attachments/assets/ff566003-a260-4838-a147-b26acd0c94b9" />

🤖 Generated with [Claude Code](https://claude.ai/code)

[EMI-2817]: https://artsyproduct.atlassian.net/browse/EMI-2817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ