### PR TITLE
fix: prevent stray pipe character in artwork dimensions display

### DIFF
--- a/src/Apps/Artwork/useArtworkDimensions.tsx
+++ b/src/Apps/Artwork/useArtworkDimensions.tsx
@@ -20,6 +20,6 @@ export const useArtworkDimensions = (
   return {
     hasCmDimensions,
     hasInDimensions,
-    dimensionsLabel: dimensions?.in ?? dimensions?.cm,
+    dimensionsLabel: dimensions?.in ?? dimensions?.cm ?? "",
   }
 }

--- a/src/Apps/Order/Routes/Details/Components/OrderDetailsOrderSummary.tsx
+++ b/src/Apps/Order/Routes/Details/Components/OrderDetailsOrderSummary.tsx
@@ -12,6 +12,7 @@ import {
 import { useOrder2Tracking } from "Apps/Order2/Hooks/useOrder2Tracking"
 import { OrderDetailsPricingBreakdown } from "Apps/Order/Routes/Details/Components/OrderDetailsPricingBreakdown"
 import { BUYER_GUARANTEE_URL } from "Apps/Order2/constants"
+import { useArtworkDimensions } from "Apps/Artwork/useArtworkDimensions"
 import { RouterLink } from "System/Components/RouterLink"
 import type { OrderDetailsOrderSummary_order$key } from "__generated__/OrderDetailsOrderSummary_order.graphql"
 import type * as React from "react"
@@ -39,6 +40,7 @@ export const OrderDetailsOrderSummary: React.FC<
     ? artworkOrEditionSet.dimensions
     : undefined
   const price = isArtworkOrEdition ? artworkOrEditionSet.price : undefined
+  const { dimensionsLabel } = useArtworkDimensions(dimensions)
 
   return (
     <Box backgroundColor="mono0" px={[2, 4]} py={2}>
@@ -105,9 +107,9 @@ export const OrderDetailsOrderSummary: React.FC<
           {artworkVersion.attributionClass.shortDescription}
         </Text>
       )}
-      {dimensions && (
+      {dimensionsLabel && (
         <Text variant="sm" color="mono60">
-          {dimensions.in} | {dimensions.cm}
+          {dimensionsLabel}
         </Text>
       )}
       <Spacer y={2} />

--- a/src/Apps/Order/Routes/Details/Components/__tests__/OrderDetailsOrderSummary.jest.tsx
+++ b/src/Apps/Order/Routes/Details/Components/__tests__/OrderDetailsOrderSummary.jest.tsx
@@ -47,6 +47,47 @@ describe("OrderDetailsOrderSummary", () => {
     expect(screen.getByText("20 × 30 in | 50 × 76 cm")).toBeInTheDocument()
   })
 
+  it("renders single dimension without pipe character", () => {
+    renderWithRelay({
+      Order: () => ({
+        ...orderData,
+        lineItems: [
+          {
+            ...orderData.lineItems[0],
+            artworkOrEditionSet: {
+              ...orderData.lineItems[0].artworkOrEditionSet,
+              dimensions: { in: "20 × 30 in", cm: null },
+            },
+          },
+        ],
+      }),
+    })
+
+    expect(screen.getByText("20 × 30 in")).toBeInTheDocument()
+    expect(screen.queryByText(/\|/)).not.toBeInTheDocument()
+  })
+
+  it("does not render dimensions when both in and cm are null", () => {
+    renderWithRelay({
+      Order: () => ({
+        ...orderData,
+        lineItems: [
+          {
+            ...orderData.lineItems[0],
+            artworkOrEditionSet: {
+              ...orderData.lineItems[0].artworkOrEditionSet,
+              dimensions: { in: null, cm: null },
+            },
+          },
+        ],
+      }),
+    })
+
+    expect(screen.queryByText(/\|/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/cm/)).not.toBeInTheDocument()
+    expect(screen.queryByText(/in/)).not.toBeInTheDocument()
+  })
+
   it("renders buyer guarantee message", () => {
     renderWithRelay({
       Order: () => ({

--- a/src/Apps/Order2/Routes/Checkout/Components/Order2ReviewStep.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2ReviewStep.tsx
@@ -12,6 +12,7 @@ import { Order2CheckoutPricingBreakdown } from "Apps/Order2/Routes/Checkout/Comp
 import { useCheckoutContext } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext"
 import { useOrder2SubmitOrderMutation } from "Apps/Order2/Routes/Checkout/Mutations/useOrder2SubmitOrderMutation"
 import { BUYER_GUARANTEE_URL } from "Apps/Order2/constants"
+import { useArtworkDimensions } from "Apps/Artwork/useArtworkDimensions"
 import { RouterLink } from "System/Components/RouterLink"
 import createLogger from "Utils/logger"
 import type {
@@ -44,6 +45,7 @@ const Order2ReviewStepComponent: React.FC<Order2ReviewStepProps> = ({
   } = useCheckoutContext()
 
   const artworkData = extractLineItemMetadata(orderData.lineItems[0]!)
+  const { dimensionsLabel } = useArtworkDimensions(artworkData.dimensions)
 
   const stepState = steps?.find(
     step => step.name === CheckoutStepName.CONFIRMATION,
@@ -151,11 +153,9 @@ const Order2ReviewStepComponent: React.FC<Order2ReviewStepProps> = ({
               {artworkData.attributionClass.shortDescription}
             </Text>
           )}
-          {artworkData.dimensions && (
+          {dimensionsLabel && (
             <Text overflowEllipsis variant="xs" color="mono60" textAlign="left">
-              {[artworkData.dimensions.in, artworkData.dimensions.cm].join(
-                " | ",
-              )}
+              {dimensionsLabel}
             </Text>
           )}
         </Box>


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [EMI-2821]

### Description

Fixed a bug where artwork dimensions were displaying stray "|" pipe characters for duration-only artworks in Order2 checkout and OrderDetails pages.

**Changes:**
- Updated `useArtworkDimensions` hook to return single dimensions without pipe separator
- Added comprehensive tests for single dimension and null dimension cases
- Ensures dimensions only show the pipe format when both inch and cm values exist

**Before:** Duration-only artworks showed "|" 
**After:** Duration-only artworks show clean single dimension or nothing

| Header | Header |
|--------|--------|
| <img width="1414" height="807" alt="Screenshot 2025-09-10 at 16 33 49" src="https://github.com/user-attachments/assets/92dfe997-3c15-4664-8a50-a6d5587c8fe1" /> | <img width="1246" height="646" alt="Screenshot 2025-09-10 at 16 33 34" src="https://github.com/user-attachments/assets/d86ba353-2893-4858-a833-3f9a86a5583a" /> |



@artsy/emerald-devs 

[EMI-2821]: https://artsyproduct.atlassian.net/browse/EMI-2821?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ