### PR TITLE
fix(PBRW-1178): align attachments properly

### DIFF
--- a/src/Apps/Conversations/components/Message/ConversationMessage.tsx
+++ b/src/Apps/Conversations/components/Message/ConversationMessage.tsx
@@ -110,7 +110,7 @@ export const ConversationMessage: React.FC<
             <Spacer y={2} />
 
             <ConversationMessageBubble
-              fromViewer={!data.isFromUser}
+              fromViewer={data.isFromUser}
               simplified
               seenBy={index === attachmentLength - 1 ? seenBy : undefined}
             >


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PBRW-1178]

### Description

Align attachments to the gallery's side of the convo

Before:
<img width="866" height="607" alt="Screenshot 2025-09-12 at 11 31 24" src="https://github.com/user-attachments/assets/bebc699b-d100-464b-833f-8dc3dda6a873" />

After:
<img width="859" height="451" alt="Screenshot 2025-09-12 at 11 31 33" src="https://github.com/user-attachments/assets/68894dd3-1cc1-4739-8ca4-06b198f2be37" />



[PBRW-1178]: https://artsyproduct.atlassian.net/browse/PBRW-1178?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ