### PR TITLE
fix: scroll to bottom with attachments

### DIFF
--- a/src/Apps/Conversations/components/Message/ConversationMessage.tsx
+++ b/src/Apps/Conversations/components/Message/ConversationMessage.tsx
@@ -29,6 +29,7 @@ interface ConversationMessageProps {
   >["formattedFirstMessage"]
   toInitials?: string
   toName?: string
+  onImageLoad?: () => void
 }
 
 export const ConversationMessage: React.FC<
@@ -40,6 +41,7 @@ export const ConversationMessage: React.FC<
   formattedFirstMessage,
   toInitials,
   toName,
+  onImageLoad,
 }) => {
   const { appendElementRef } = useScrollPagination()
 
@@ -118,6 +120,7 @@ export const ConversationMessage: React.FC<
                 <ConversationMessageImage
                   src={attachment.downloadURL}
                   alt="Attached image"
+                  onImageLoad={messageIndex === 0 ? onImageLoad : undefined}
                 />
               ) : (
                 <ConversationMessageFile

--- a/src/Apps/Conversations/components/Message/ConversationMessageImage.tsx
+++ b/src/Apps/Conversations/components/Message/ConversationMessageImage.tsx
@@ -1,10 +1,21 @@
 import { Clickable, Image, type ImageProps } from "@artsy/palette"
 import { type FC, useState } from "react"
 
+interface ConversationMessageImageProps extends ImageProps {
+  onImageLoad?: () => void
+}
+
 export const ConversationMessageImage: FC<
-  React.PropsWithChildren<ImageProps>
-> = ({ alt, src, ...props }) => {
+  React.PropsWithChildren<ConversationMessageImageProps>
+> = ({ alt, src, onImageLoad, ...props }) => {
   const [isLoading, setIsLoading] = useState(true)
+
+  const handleLoad = () => {
+    setIsLoading(false)
+    if (onImageLoad) {
+      setTimeout(onImageLoad, 0)
+    }
+  }
 
   return (
     <>
@@ -16,9 +27,7 @@ export const ConversationMessageImage: FC<
           alt={alt}
           width="100%"
           style={{ display: isLoading ? "none" : "block" }}
-          onLoad={() => {
-            setIsLoading(false)
-          }}
+          onLoad={handleLoad}
         />
       </Clickable>
     </>

--- a/src/Apps/Conversations/components/Message/ConversationMessages.tsx
+++ b/src/Apps/Conversations/components/Message/ConversationMessages.tsx
@@ -210,6 +210,7 @@ export const ConversationMessages: FC<
                         }
                         toInitials={toInitials}
                         toName={toName}
+                        onImageLoad={triggerAutoScroll}
                       />
                     </Fragment>
                   )


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

After revisiting #16122, noticed that the scrolling to bottom is not working properly if there are attachments. Here I'm suggesting a working solution, waiting for the image to load to scroll.

Before:

https://github.com/user-attachments/assets/45052c05-f576-41fa-b9c9-f79e2a066a79

After:

https://github.com/user-attachments/assets/befc5e61-6651-4734-93a9-7c0103ed7bef

