### PR TITLE
chore(security): Disable postinstall scripts from 3rd party libs on yarn install

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,7 @@
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.9.4.cjs
+
+# Disable postinstall scripts from 3rd parties. In 2025, libraries really
+# shouldn't need this, and if they do we should evaulate them one-by-one.
+enableScripts: false


### PR DESCRIPTION
Related:
- https://github.com/artsy/force/pull/16141

The type of this PR is: **Chore**

### Description

The [current npm supply chain attack](https://www.stepsecurity.io/blog/ctrl-tinycolor-and-40-npm-packages-compromised) relies on executing a postInstall script to exfiltrate data. Yarn has the [ability to disable this behavior](https://v3.yarnpkg.com/configuration/yarnrc) via `enableScripts: false`. 

In the past it was common to use this, but in 2025 the need to build, etc, npm package scripts is much less given latest tools. If we run into issues however we should assess. 
