### PR TITLE
feat(partner): links to hash instead of full route

### DIFF
--- a/src/Apps/Partner/Components/PartnerArtists/PartnerArtistDetails/PartnerArtistDetails.tsx
+++ b/src/Apps/Partner/Components/PartnerArtists/PartnerArtistDetails/PartnerArtistDetails.tsx
@@ -38,16 +38,17 @@ export const PartnerArtistDetails: React.FC<
 
   const {
     match: {
-      location: { pathname },
+      location: { pathname, hash },
     },
   } = useRouter()
 
   const artist = partnerArtist.node
-  const partnerArtistHref = `${partner.href}/artists/${artist.slug}`
+  const isArtistDetailsPath =
+    pathname === `${partner.href}/artists` && hash === `#${artist.slug}`
 
   return (
     <>
-      {pathname === partnerArtistHref && (
+      {isArtistDetailsPath && (
         <Meta
           name="description"
           content={`Discover and buy artworks by ${name}, available through ${partner.name} on Artsy. Browse paintings, prints, and more offered by the gallery.`}

--- a/src/Apps/Partner/Components/PartnerArtists/PartnerArtistList/PartnerArtistList.tsx
+++ b/src/Apps/Partner/Components/PartnerArtists/PartnerArtistList/PartnerArtistList.tsx
@@ -73,7 +73,7 @@ export const PartnerArtistList: React.FC<
                     key={artist.internalID}
                     to={
                       partner.displayFullPartnerPage
-                        ? `${partner.href}/artists/${artist.slug}`
+                        ? `${partner.href}/artists#${artist.slug}`
                         : `${artist.href}`
                     }
                     display="block"

--- a/src/Apps/Partner/Routes/Artists/ArtistsRoute.tsx
+++ b/src/Apps/Partner/Routes/Artists/ArtistsRoute.tsx
@@ -24,12 +24,16 @@ export const ArtistsRoute: React.FC<
 
   const { jumpTo } = useJump()
 
+  const artistId = match.location.hash
+    ? match.location.hash.replace(/^#/, "")
+    : undefined
+
   // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
-    if (match.params.artistId && isLoaded && isMobile !== null) {
+    if (artistId && isLoaded && isMobile !== null) {
       jumpTo("PartnerArtistDetails")
     }
-  }, [isLoaded, isMobile, match.params.artistId])
+  }, [isLoaded, isMobile, artistId])
 
   return (
     <Box mt={4}>
@@ -42,10 +46,10 @@ export const ArtistsRoute: React.FC<
           <Separator />
         </Jump>
 
-        {match.params.artistId ? (
+        {artistId ? (
           <PartnerArtistDetailsRenderer
             partnerId={match.params.partnerId}
-            artistId={match.params.artistId}
+            artistId={artistId}
           />
         ) : (
           <PartnerArtistDetailsListRenderer

--- a/src/Apps/Partner/partnerRoutes.tsx
+++ b/src/Apps/Partner/partnerRoutes.tsx
@@ -232,7 +232,17 @@ export const partnerRoutes: RouteProps[] = [
         },
       },
       {
-        path: "artists/:artistId?",
+        path: "artists/:artistId",
+        render: ({ match }) => {
+          // Legacy path: redirect to hash-based anchor
+          throw new RedirectException(
+            `/partner/${match.params.partnerId}/artists#${match.params.artistId}`,
+            301,
+          )
+        },
+      },
+      {
+        path: "artists",
         ignoreScrollBehavior: true,
         getComponent: () => ArtistsRoute,
         onPreloadJS: () => {

--- a/src/Components/Cells/CellPartnerArtist.tsx
+++ b/src/Components/Cells/CellPartnerArtist.tsx
@@ -34,7 +34,7 @@ const CellPartnerArtist: FC<
 
   return (
     <RouterLink
-      to={`/partner/${partnerSlug}/artists/${artistSlug}`}
+      to={`/partner/${partnerSlug}/artists#${artistSlug}`}
       display="block"
       textDecoration="none"
       width={width}


### PR DESCRIPTION
Switches to the form: `/partner/:partnerId/artists#artistId` replacing: `/partner/:partnerId/artists/:artistId`. All other functionality remains the same. Old paths get 301 redirected to the new. We do not have these in sitemaps, so nothing to do there.

cc @artsy/diamond-devs 