### PR TITLE
feat: unread dot

### DIFF
--- a/src/Apps/Conversations/components/Sidebar/ConversationsSidebarItem.tsx
+++ b/src/Apps/Conversations/components/Sidebar/ConversationsSidebarItem.tsx
@@ -81,7 +81,7 @@ export const ConversationsSidebarItem: React.FC<
           })
         }}
       >
-        <Flex alignItems="center" px={[0, 2]}>
+        <Flex alignItems="center">
           <Image
             src={item.image?.url}
             height={50}
@@ -136,6 +136,16 @@ export const ConversationsSidebarItem: React.FC<
               >
                 {data?.lastMessageAt}
               </Text>
+              <Box ml={1} width={8} height={8}>
+                {isUnread && (
+                  <Box
+                    width={8}
+                    height={8}
+                    backgroundColor="blue100"
+                    borderRadius="50%"
+                  />
+                )}
+              </Box>
             </Flex>
           </Flex>
         </Flex>


### PR DESCRIPTION
### Description

Unread blue dot to match Eigen. Also properly align the Inbox title with the artwork image (no padding)
<img width="432" height="528" alt="Screenshot 2025-09-18 at 16 07 59" src="https://github.com/user-attachments/assets/87550cfb-fd90-4d7d-9860-38c60688bbc1" />
