### PR TITLE
chore(ci): Only run CI security check if yarn.lock has changed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,6 +235,14 @@ jobs:
     executor: node-executor
     steps:
       - checkout
+      - run:
+          name: Check if yarn.lock changed
+          command: |
+            if git diff HEAD~1 --name-only | grep -q "yarn.lock"; then
+              echo "yarn.lock changed, checking vulnerabilities"
+            else
+              circleci-agent step halt
+            fi
       - node/install-packages:
           pkg-manager: yarn
       - run:


### PR DESCRIPTION
The type of this PR is: **Chore**

### Description

This updates our `check-npm-vulnerabilities` job to only run on lockfile changes. 
