### PR TITLE
fix(DIAM-104): duplicate domain in fairs canonical link

### DIFF
--- a/src/Apps/Fair/Components/FairMeta.tsx
+++ b/src/Apps/Fair/Components/FairMeta.tsx
@@ -1,5 +1,4 @@
 import { MetaTags } from "Components/MetaTags"
-import { getENV } from "Utils/getENV"
 import type { FairMeta_fair$data } from "__generated__/FairMeta_fair.graphql"
 import type * as React from "react"
 import { createFragmentContainer, graphql } from "react-relay"
@@ -15,7 +14,7 @@ const FairMeta: React.FC<React.PropsWithChildren<FairMetaProps>> = ({
     <MetaTags
       title={`${name} | Artsy`}
       description={metaDescription || metaDescriptionFallback}
-      pathname={`${getENV("APP_URL")}/fair/${slug}`}
+      pathname={`/fair/${slug}`}
       imageURL={metaImage?.src}
     />
   )

--- a/src/Apps/Fair/Components/__tests__/FairMeta.jest.tsx
+++ b/src/Apps/Fair/Components/__tests__/FairMeta.jest.tsx
@@ -1,0 +1,81 @@
+import { FairMetaFragmentContainer } from "Apps/Fair/Components/FairMeta"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
+import { HeadProvider } from "react-head"
+import { graphql } from "react-relay"
+
+jest.unmock("react-relay")
+
+jest.mock("Utils/getENV", () => ({
+  getENV: (name: string) => {
+    return {
+      APP_URL: "https://www.artsy.net",
+      GEMINI_CLOUDFRONT_URL: "",
+    }[name]
+  },
+}))
+
+const { renderWithRelay } = setupTestWrapperTL({
+  Component: (props: any) => {
+    return (
+      <HeadProvider>
+        <FairMetaFragmentContainer fair={props.fair} />
+      </HeadProvider>
+    )
+  },
+  query: graphql`
+    query FairMeta_Test_Query @relay_test_operation {
+      fair(id: "example") {
+        ...FairMeta_fair
+      }
+    }
+  `,
+})
+
+const getTags = () => {
+  const meta = [...document.getElementsByTagName("meta")].map(tag => ({
+    name: tag.getAttribute("name"),
+    property: tag.getAttribute("property"),
+    content: tag.getAttribute("content"),
+  }))
+
+  const links = [...document.getElementsByTagName("link")].map(tag => ({
+    rel: tag.getAttribute("rel"),
+    href: tag.getAttribute("href"),
+  }))
+
+  const title = document.getElementsByTagName("title")[0]?.textContent
+
+  return { meta, links, title }
+}
+
+describe("FairMeta", () => {
+  afterEach(() => {
+    document.getElementsByTagName("html")[0].innerHTML = ""
+  })
+
+  it("generates canonical URL", () => {
+    renderWithRelay({
+      Fair: () => ({
+        name: "Test Fair",
+        slug: "test-fair",
+      }),
+    })
+
+    const tags = getTags()
+    const canonicalLink = tags.links.find(link => link.rel === "canonical")
+
+    expect(canonicalLink?.href).toBe("https://www.artsy.net/fair/test-fair")
+  })
+
+  it("renders correct title", () => {
+    renderWithRelay({
+      Fair: () => ({
+        name: "Amazing Art Fair",
+        slug: "amazing-art-fair",
+      }),
+    })
+
+    const tags = getTags()
+    expect(tags.title).toBe("Amazing Art Fair | Artsy")
+  })
+})

--- a/src/__generated__/FairMeta_Test_Query.graphql.ts
+++ b/src/__generated__/FairMeta_Test_Query.graphql.ts
@@ -1,0 +1,189 @@
+/**
+ * @generated SignedSource<<d90b66c5691bce2315d6135f33068dc9>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type FairMeta_Test_Query$variables = Record<PropertyKey, never>;
+export type FairMeta_Test_Query$data = {
+  readonly fair: {
+    readonly " $fragmentSpreads": FragmentRefs<"FairMeta_fair">;
+  } | null | undefined;
+};
+export type FairMeta_Test_Query = {
+  response: FairMeta_Test_Query$data;
+  variables: FairMeta_Test_Query$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "example"
+  }
+],
+v1 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v2 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "FairMeta_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Fair",
+        "kind": "LinkedField",
+        "name": "fair",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "FairMeta_fair"
+          }
+        ],
+        "storageKey": "fair(id:\"example\")"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "FairMeta_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Fair",
+        "kind": "LinkedField",
+        "name": "fair",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
+          {
+            "alias": "metaDescription",
+            "args": null,
+            "kind": "ScalarField",
+            "name": "summary",
+            "storageKey": null
+          },
+          {
+            "alias": "metaDescriptionFallback",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "format",
+                "value": "PLAIN"
+              }
+            ],
+            "kind": "ScalarField",
+            "name": "about",
+            "storageKey": "about(format:\"PLAIN\")"
+          },
+          {
+            "alias": "metaImage",
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "image",
+            "plural": false,
+            "selections": [
+              {
+                "alias": "src",
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": "large_rectangle"
+                  }
+                ],
+                "kind": "ScalarField",
+                "name": "url",
+                "storageKey": "url(version:\"large_rectangle\")"
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": "fair(id:\"example\")"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "3de4e21427a05e319aeeaede025004f1",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "fair": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Fair"
+        },
+        "fair.id": (v1/*: any*/),
+        "fair.metaDescription": (v2/*: any*/),
+        "fair.metaDescriptionFallback": (v2/*: any*/),
+        "fair.metaImage": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Image"
+        },
+        "fair.metaImage.src": (v2/*: any*/),
+        "fair.name": (v2/*: any*/),
+        "fair.slug": (v1/*: any*/)
+      }
+    },
+    "name": "FairMeta_Test_Query",
+    "operationKind": "query",
+    "text": "query FairMeta_Test_Query {\n  fair(id: \"example\") {\n    ...FairMeta_fair\n    id\n  }\n}\n\nfragment FairMeta_fair on Fair {\n  name\n  slug\n  metaDescription: summary\n  metaDescriptionFallback: about(format: PLAIN)\n  metaImage: image {\n    src: url(version: \"large_rectangle\")\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "d1759f055d24ed9f4821a913864c86e8";
+
+export default node;


### PR DESCRIPTION
This ticket fixes a bug where the canonical link for fairs pages had a duplicate domain (https://www.artsy.net) prepended to the URL. This is because it was passing a complete URL to the `MetaTags` component, when it was expecting just a pathname.

cc: @artsy/diamond-devs 