### PR TITLE
chore(DIAM-101): populate Featured Galleries rail from Galleries page carousel set

### DIFF
--- a/src/Apps/Home/Components/HomeFeaturedGalleriesRail.tsx
+++ b/src/Apps/Home/Components/HomeFeaturedGalleriesRail.tsx
@@ -129,7 +129,7 @@ export const HomeFeaturedGalleriesRailQueryRenderer: React.FC<
       environment={relayEnvironment}
       query={graphql`
         query HomeFeaturedGalleriesRailQuery {
-          orderedSet(id: "6193c9ede70512000fbf3e8d") {
+          orderedSet(id: "5638fdfb7261690296000031") {
             ...HomeFeaturedGalleriesRail_orderedSet
           }
         }

--- a/src/__generated__/HomeFeaturedGalleriesRailQuery.graphql.ts
+++ b/src/__generated__/HomeFeaturedGalleriesRailQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a9a9a991ab67b3ceb1b0996eea388928>>
+ * @generated SignedSource<<ff1d75e7a229fc073a952338ce39f21e>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -26,7 +26,7 @@ var v0 = [
   {
     "kind": "Literal",
     "name": "id",
-    "value": "6193c9ede70512000fbf3e8d"
+    "value": "5638fdfb7261690296000031"
   }
 ],
 v1 = {
@@ -120,7 +120,7 @@ return {
             "name": "HomeFeaturedGalleriesRail_orderedSet"
           }
         ],
-        "storageKey": "orderedSet(id:\"6193c9ede70512000fbf3e8d\")"
+        "storageKey": "orderedSet(id:\"5638fdfb7261690296000031\")"
       }
     ],
     "type": "Query",
@@ -420,21 +420,21 @@ return {
           },
           (v5/*: any*/)
         ],
-        "storageKey": "orderedSet(id:\"6193c9ede70512000fbf3e8d\")"
+        "storageKey": "orderedSet(id:\"5638fdfb7261690296000031\")"
       }
     ]
   },
   "params": {
-    "cacheID": "574fc440cb4dfc39a32d3500dfcbc99a",
+    "cacheID": "87515d13b404b59b084baeb9e341b07a",
     "id": null,
     "metadata": {},
     "name": "HomeFeaturedGalleriesRailQuery",
     "operationKind": "query",
-    "text": "query HomeFeaturedGalleriesRailQuery {\n  orderedSet(id: \"6193c9ede70512000fbf3e8d\") {\n    ...HomeFeaturedGalleriesRail_orderedSet\n    id\n  }\n}\n\nfragment CellPartner_partner on Partner {\n  ...EntityHeaderPartner_partner\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    image {\n      cropped(width: 445, height: 334, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    internalID\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment HomeFeaturedGalleriesRail_orderedSet on OrderedSet {\n  orderedItemsConnection(first: 20) {\n    edges {\n      node {\n        __typename\n        ... on Profile {\n          owner {\n            __typename\n            ...CellPartner_partner\n            ... on Partner {\n              internalID\n              slug\n            }\n            ... on Node {\n              __isNode: __typename\n              id\n            }\n            ... on FairOrganizer {\n              id\n            }\n          }\n          id\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n        ... on FeaturedLink {\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query HomeFeaturedGalleriesRailQuery {\n  orderedSet(id: \"5638fdfb7261690296000031\") {\n    ...HomeFeaturedGalleriesRail_orderedSet\n    id\n  }\n}\n\nfragment CellPartner_partner on Partner {\n  ...EntityHeaderPartner_partner\n  internalID\n  slug\n  name\n  href\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    image {\n      cropped(width: 445, height: 334, version: [\"wide\", \"large\", \"featured\", \"larger\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment EntityHeaderPartner_partner on Partner {\n  internalID\n  type\n  slug\n  href\n  name\n  initials\n  locationsConnection(first: 15) {\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n  categories {\n    name\n    slug\n    id\n  }\n  profile {\n    internalID\n    avatar: image {\n      cropped(width: 45, height: 45) {\n        src\n        srcSet\n      }\n    }\n    icon {\n      cropped(width: 45, height: 45, version: [\"untouched-png\", \"large\", \"square\"]) {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment HomeFeaturedGalleriesRail_orderedSet on OrderedSet {\n  orderedItemsConnection(first: 20) {\n    edges {\n      node {\n        __typename\n        ... on Profile {\n          owner {\n            __typename\n            ...CellPartner_partner\n            ... on Partner {\n              internalID\n              slug\n            }\n            ... on Node {\n              __isNode: __typename\n              id\n            }\n            ... on FairOrganizer {\n              id\n            }\n          }\n          id\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n        ... on FeaturedLink {\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "8093210d3ba1837d4fb975d4ae3d3001";
+(node as any).hash = "2ba946f2a1e9916ac12d7481531b6f9f";
 
 export default node;


### PR DESCRIPTION
This PR updates the home page's Featured Galleries rail to display the same list of galleries as those in the carousel at the top of the `/galleries` page. These are both populated from "ordered sets," which are manually curated lists that can be managed in Forque. By having them populate from the one ordered set, we can halve the time and effort of managing two!

Things to consider...

1. The Featured Galleries rails only fetches the first 20 galleries. The ordered set for the Galleries page carousel has exactly 20 galleries,  so we need to let stakeholders know that they are at the limit (and that we can increase it if needed).
2. The carousel on the `/galleries` page shuffles the galleries on each reload, but the Featured Galleries rail does not. We need to let stakeholders know about this difference in case they expected the shuffling behavior.

cc: @artsy/diamond-devs 