### PR TITLE
chore(EMI-2835): add clickedCompleteYourProfile tracking

### DIFF
--- a/src/Apps/Order/Routes/Details/Components/OrderDetailsMessage.tsx
+++ b/src/Apps/Order/Routes/Details/Components/OrderDetailsMessage.tsx
@@ -103,7 +103,9 @@ const MessageContent = ({
           <Spacer y={2} />
           <Text variant="sm">
             The gallery will confirm by <b>{formattedStateExpireTime}</b>.
-            {hasIncompleteProfile && <CompleteCollectorProfilePrompt />}
+            {hasIncompleteProfile && (
+              <CompleteCollectorProfilePrompt tracking={tracking} />
+            )}
           </Text>
           <Spacer y={2} />
           <Text variant="sm">
@@ -123,7 +125,9 @@ const MessageContent = ({
           <Text variant="sm">
             The gallery will respond to your offer by{" "}
             <b>{formattedStateExpireTime}</b>.
-            {hasIncompleteProfile && <CompleteCollectorProfilePrompt />}
+            {hasIncompleteProfile && (
+              <CompleteCollectorProfilePrompt tracking={tracking} />
+            )}
           </Text>
           <Spacer y={2} />
           <Text variant="sm">
@@ -409,11 +413,24 @@ const MessageContent = ({
   }
 }
 
-const CompleteCollectorProfilePrompt: React.FC = () => (
+interface CompleteCollectorProfilePromptProps {
+  tracking: ReturnType<typeof useOrder2Tracking>
+}
+
+const CompleteCollectorProfilePrompt: React.FC<
+  CompleteCollectorProfilePromptProps
+> = ({ tracking }) => (
   <>
     {" "}
     You're more likely to receive quick responses from galleries by{" "}
-    <RouterLink to="/settings/edit-profile" target="_blank" display="inline">
+    <RouterLink
+      onClick={() => {
+        tracking.clickedCompleteYourProfile()
+      }}
+      to="/settings/edit-profile"
+      target="_blank"
+      display="inline"
+    >
       completing your profile
     </RouterLink>
     .

--- a/src/Apps/Order2/Hooks/useOrder2Tracking.tsx
+++ b/src/Apps/Order2/Hooks/useOrder2Tracking.tsx
@@ -2,10 +2,11 @@ import {
   ActionType,
   type ClickedAskSpecialist,
   type ClickedBuyerProtection,
+  type ClickedCompleteYourProfile,
   type ClickedContactGallery,
   type ClickedImportFees,
   type ClickedVisitHelpCenter,
-  type ContextModule,
+  ContextModule,
   type OrderDetailsViewed,
   OwnerType,
   type PageOwnerType,
@@ -105,6 +106,16 @@ export const useOrder2Tracking = (
           context_owner_id: contextPageOwnerId,
           context_owner_type: contextPageOwnerType,
           message_type: messageType,
+        }
+
+        trackEvent(payload)
+      },
+      clickedCompleteYourProfile: () => {
+        const payload: ClickedCompleteYourProfile = {
+          action: ActionType.clickedCompleteYourProfile,
+          context_module: ContextModule.ordersDetail,
+          context_page_owner_type: contextPageOwnerType,
+          context_page_owner_id: contextPageOwnerId,
         }
 
         trackEvent(payload)


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2835]

### Description

Adds `clickedCompleteYourProfile` tracking. 

@artsy/emerald-devs 

<!-- Implementation description -->


[EMI-2835]: https://artsyproduct.atlassian.net/browse/EMI-2835?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ