### PR TITLE
fix: manually run patch-package post install

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -29,6 +29,7 @@ EOF
 
 echo "Installing dependencies..."
 yarn install || (npm install --global yarn@latest && yarn install)
+yarn patch-package
 
 # For more info on shared configuration see:
 # https://github.com/artsy/force/blob/main/docs/env_configuration.md


### PR DESCRIPTION
The type of this PR is: **fix**

### Description


After `yarn` v4 upgrade, we noticed that patches were not being applied in Eigen. This is because `yarn` v4 currently have native patching abilities and our `postinstall-prepare` is based on `yarn` v1 . The same issue exists here in Force as well, and this [patch](https://github.com/artsy/force/pull/14911) wasn't getting applied post installation.

In this PR I am fixing that by applying this patch directly (instead of using `prepare`)


https://github.com/user-attachments/assets/2325c9d9-e725-4fb7-9359-6b405ecfa491



Although I _think_ it isn't so much work to already migrate to `yarn` v4 `patch`, I would rather have this conversation with others.


**Useful links:**
- https://github.com/ds300/patch-package?tab=readme-ov-file#yarn-v2
- https://yarnpkg.com/cli/patch



<!-- Implementation description -->
