### PR TITLE
fix(DIAM-103): Missing schema on the About Us page

### DIFF
--- a/src/Apps/About/AboutApp.tsx
+++ b/src/Apps/About/AboutApp.tsx
@@ -10,6 +10,7 @@ import { AboutOurStory } from "Apps/About/Components/AboutOurStory"
 import { AboutOurTeam } from "Apps/About/Components/AboutOurTeam"
 import { AboutPress } from "Apps/About/Components/AboutPress"
 import { AboutStats } from "Apps/About/Components/AboutStats"
+import { AboutStructuredData } from "Apps/About/Components/AboutStructuredData"
 import { AboutTagline } from "Apps/About/Components/AboutTagline"
 import { AboutWhatWeDo } from "Apps/About/Components/AboutWhatWeDo"
 import { MetaTags } from "Components/MetaTags"
@@ -25,6 +26,8 @@ export const AboutApp: React.FC<React.PropsWithChildren<unknown>> = () => {
         imageURL="https://files.artsy.net/images/00_CVP_About_Hero_og.png"
         pathname="/about"
       />
+
+      <AboutStructuredData />
 
       <AboutNavEntry />
 

--- a/src/Apps/About/AboutApp.tsx
+++ b/src/Apps/About/AboutApp.tsx
@@ -10,12 +10,13 @@ import { AboutOurStory } from "Apps/About/Components/AboutOurStory"
 import { AboutOurTeam } from "Apps/About/Components/AboutOurTeam"
 import { AboutPress } from "Apps/About/Components/AboutPress"
 import { AboutStats } from "Apps/About/Components/AboutStats"
-import { AboutStructuredData } from "Apps/About/Components/AboutStructuredData"
+import {
+  AboutStructuredData,
+  DESCRIPTION,
+} from "Apps/About/Components/AboutStructuredData"
 import { AboutTagline } from "Apps/About/Components/AboutTagline"
 import { AboutWhatWeDo } from "Apps/About/Components/AboutWhatWeDo"
 import { MetaTags } from "Components/MetaTags"
-
-export const DESCRIPTION = "Artsy is the leading global online art marketplace."
 
 export const AboutApp: React.FC<React.PropsWithChildren<unknown>> = () => {
   return (

--- a/src/Apps/About/Components/AboutStructuredData.tsx
+++ b/src/Apps/About/Components/AboutStructuredData.tsx
@@ -3,13 +3,17 @@ import { DOWNLOAD_APP_URLS, Device } from "Utils/Hooks/useDeviceDetection"
 import { FACTS_AND_FIGURES } from "Utils/factsAndFigures"
 import type { Organization } from "schema-dts"
 
+const DESCRIPTION = "Artsy is the leading global online art marketplace."
+
+export { DESCRIPTION }
+
 export const ORGANIZATION_STUB_SCHEMA: Organization = {
   "@id": "https://www.artsy.net/#organization",
   "@type": "Organization",
   name: "Artsy",
   alternateName: "Artsy.net",
   url: "https://www.artsy.net",
-  description: "Artsy is the leading global online art marketplace.",
+  description: DESCRIPTION,
   logo: {
     "@type": "ImageObject",
     url: "https://files.artsy.net/images/artsymark-800x800.png",
@@ -38,7 +42,7 @@ export const AboutStructuredData = () => {
           applicationCategory: ["LifestyleApplication", "ShoppingApplication"],
           operatingSystem: "Web",
           browserRequirements: "Requires JavaScript",
-          description: "Artsy is the leading global online art marketplace.",
+          description: DESCRIPTION,
           downloadUrl: [
             DOWNLOAD_APP_URLS[Device.iPhone],
             DOWNLOAD_APP_URLS[Device.Android],

--- a/src/Apps/About/Components/AboutStructuredData.tsx
+++ b/src/Apps/About/Components/AboutStructuredData.tsx
@@ -1,4 +1,3 @@
-import { DESCRIPTION } from "Apps/About/AboutApp"
 import { StructuredData } from "Components/Seo/StructuredData"
 import { DOWNLOAD_APP_URLS, Device } from "Utils/Hooks/useDeviceDetection"
 import { FACTS_AND_FIGURES } from "Utils/factsAndFigures"
@@ -10,7 +9,7 @@ export const ORGANIZATION_STUB_SCHEMA: Organization = {
   name: "Artsy",
   alternateName: "Artsy.net",
   url: "https://www.artsy.net",
-  description: DESCRIPTION,
+  description: "Artsy is the leading global online art marketplace.",
   logo: {
     "@type": "ImageObject",
     url: "https://files.artsy.net/images/artsymark-800x800.png",
@@ -39,7 +38,7 @@ export const AboutStructuredData = () => {
           applicationCategory: ["LifestyleApplication", "ShoppingApplication"],
           operatingSystem: "Web",
           browserRequirements: "Requires JavaScript",
-          description: DESCRIPTION,
+          description: "Artsy is the leading global online art marketplace.",
           downloadUrl: [
             DOWNLOAD_APP_URLS[Device.iPhone],
             DOWNLOAD_APP_URLS[Device.Android],

--- a/src/Apps/Home/Components/HomeStructuredData.tsx
+++ b/src/Apps/Home/Components/HomeStructuredData.tsx
@@ -1,4 +1,5 @@
 import { StructuredData } from "Components/Seo/StructuredData"
+import { DOWNLOAD_APP_URLS, Device } from "Utils/Hooks/useDeviceDetection"
 
 export const HomeStructuredData = () => {
   return (
@@ -25,6 +26,80 @@ export const HomeStructuredData = () => {
             unitCode: "E37",
           },
         },
+        foundingDate: "2009",
+        foundingLocation: {
+          "@type": "Place",
+          address: {
+            "@type": "PostalAddress",
+            addressLocality: "New York",
+            addressRegion: "NY",
+            addressCountry: "US",
+          },
+        },
+        founders: [
+          {
+            "@type": "Person",
+            name: "Carter Cleveland",
+            jobTitle: "Founder",
+            sameAs: "https://www.linkedin.com/in/cartercleveland",
+          },
+        ],
+        employees: [
+          {
+            "@type": "Person",
+            name: "Jeffrey Yin",
+            jobTitle: "Chief Executive Officer",
+            sameAs: "https://www.linkedin.com/in/jeffreyjyin/",
+          },
+        ],
+        address: {
+          "@type": "PostalAddress",
+          streetAddress: "401 Broadway",
+          addressLocality: "New York",
+          addressRegion: "NY",
+          postalCode: "10013",
+          addressCountry: "US",
+        },
+        contactPoint: [
+          {
+            "@type": "ContactPoint",
+            email: "support@artsy.net",
+            contactType: "customer support",
+          },
+        ],
+        brand: {
+          "@type": "Brand",
+          name: "Artsy",
+          logo: "https://files.artsy.net/images/og_image.jpeg",
+          slogan: "Discover and Buy Fine Art",
+        },
+        sameAs: [
+          "https://www.instagram.com/artsy",
+          "https://x.com/artsy",
+          "https://www.linkedin.com/company/artsyinc/",
+          "https://www.facebook.com/artsy",
+          "https://www.youtube.com/artsy",
+          "https://www.threads.com/@artsy",
+          "https://www.tiktok.com/@artsy",
+          "https://www.pinterest.com/artsy/",
+          "https://soundcloud.com/artsypodcast",
+          "https://podcasts.apple.com/us/podcast/the-artsy-podcast/id1096194516",
+          "https://open.spotify.com/show/3Wc2AVcebdEf0yC7NoFQgt",
+          DOWNLOAD_APP_URLS[Device.iPhone],
+          DOWNLOAD_APP_URLS[Device.Android],
+          "https://en.wikipedia.org/wiki/Artsy_(website)",
+          "https://github.com/artsy",
+          "https://artsy.github.io/",
+        ],
+        keywords:
+          "online art, art marketplace, buy art, art auctions, contemporary art, art galleries, emerging artists",
+        knowsAbout: [
+          "Contemporary Art",
+          "Fine Art Auctions",
+          "Art Galleries",
+          "Emerging Artists",
+          "Art Market Trends",
+        ],
       }}
     />
   )

--- a/src/Apps/Home/Components/HomeStructuredData.tsx
+++ b/src/Apps/Home/Components/HomeStructuredData.tsx
@@ -1,0 +1,31 @@
+import { StructuredData } from "Components/Seo/StructuredData"
+
+export const HomeStructuredData = () => {
+  return (
+    <StructuredData
+      schemaData={{
+        "@context": "https://schema.org",
+        "@type": "Organization",
+        "@id": "https://www.artsy.net/#organization",
+        name: "Artsy",
+        alternateName: "Artsy.net",
+        url: "https://www.artsy.net",
+        description: "Artsy is the leading global online art marketplace.",
+        logo: {
+          "@type": "ImageObject",
+          url: "https://files.artsy.net/images/artsymark-800x800.png",
+          width: {
+            "@type": "QuantitativeValue",
+            value: 800,
+            unitCode: "E37",
+          },
+          height: {
+            "@type": "QuantitativeValue",
+            value: 800,
+            unitCode: "E37",
+          },
+        },
+      }}
+    />
+  )
+}

--- a/src/Apps/Home/HomeApp.tsx
+++ b/src/Apps/Home/HomeApp.tsx
@@ -16,6 +16,7 @@ import { HomeFeaturedMarketNewsQueryRenderer } from "./Components/HomeFeaturedMa
 import { HomeFeaturedShowsRailQueryRenderer } from "./Components/HomeFeaturedShowsRail"
 import { HomeHeroUnitsFragmentContainer } from "./Components/HomeHeroUnits"
 import { HomeMeta } from "./Components/HomeMeta"
+import { HomeStructuredData } from "./Components/HomeStructuredData"
 import { HomeTrendingArtistsRailQueryRenderer } from "./Components/HomeTrendingArtistsRail"
 import { HomeWorksForYouTabBar } from "./Components/HomeWorksForYouTabBar"
 import { HomeRecommendedArtistsRailQueryRenderer } from "Apps/Home/Components/HomeRecommendedArtistsRail"
@@ -33,6 +34,8 @@ export const HomeApp: React.FC<React.PropsWithChildren<HomeAppProps>> = ({
   return (
     <>
       <HomeMeta />
+
+      <HomeStructuredData />
 
       <FlashBannerQueryRenderer />
 


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [DIAM-103]

Description
When we visit / and /about we no longer see structure data for the Artsy organization. Jeff at Botify believes we used to have it on the old About page and homepage. So we may be able to look in git history to find it.

Action Performed:
    Visit both 
    Search the HTML source for relevant schema

Expected Result:
should have schema

Actual Result:
didn’t

Additional Info

https://docs.google.com/document/d/1vnSF7UcvLYzGvseZcb10eY3OwIsauwaxsadrBkhA2iw/edit?tab=t.p020j1sr9pjy

__After:__
https://github.com/user-attachments/assets/817bfa90-fbea-4014-864a-f66e400022c4


You can find some examples of organizational schema in https://docs.google.com/document/d/1qU0hbCpQrTKk3s4ZdgCQg653E_pe_tsxoNRcIU21OKY/edit?tab=t.0 embedded within editorial schema.
<!-- Implementation description -->


[DIAM-103]: https://artsyproduct.atlassian.net/browse/DIAM-103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ