### PR TITLE
feat(EMI-2830): display order2 artsy shipping options

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/Order2DeliveryOptionsForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/Order2DeliveryOptionsForm.tsx
@@ -196,15 +196,26 @@ const MultipleShippingOptionsForm = ({
           const [prefix, timeRange] = timeEstimate || []
 
           return (
-            <Radio key={`${option.type}:${i}`} value={option} mt={2}>
+            <Radio
+              label={label}
+              key={`${option.type}:${i}`}
+              value={option}
+              mt={2}
+            >
               <Flex justifyContent="space-between" width="100%">
                 <Flex flexDirection="column">
-                  <Text>{label}</Text>
                   {timeEstimate && (
                     <Text variant="xs" color="mono60">
                       {prefix} <strong>{timeRange}</strong>
                     </Text>
                   )}
+                  {option.type === "ARTSY_WHITE_GLOVE" &&
+                    selectedOption === option && (
+                      <Text variant="xs" color="mono60" mt={0.5}>
+                        This service includes custom packing, transportation on
+                        a fine art shuttle, and in-home delivery.
+                      </Text>
+                    )}
                 </Flex>
                 <Text>{option.amount?.display}</Text>
               </Flex>

--- a/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/Order2DeliveryOptionsForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/Order2DeliveryOptionsForm.tsx
@@ -211,7 +211,7 @@ const MultipleShippingOptionsForm = ({
                   )}
                   {option.type === "ARTSY_WHITE_GLOVE" &&
                     selectedOption === option && (
-                      <Text variant="xs" color="mono60" mt={0.5}>
+                      <Text variant="xs" color="mono60">
                         This service includes custom packing, transportation on
                         a fine art shuttle, and in-home delivery.
                       </Text>

--- a/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/Order2DeliveryOptionsForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/Order2DeliveryOptionsForm.tsx
@@ -190,11 +190,27 @@ const MultipleShippingOptionsForm = ({
           setFieldValue("deliveryOption", selected)
         }}
       >
-        {options.map((option, i) => (
-          <Radio key={`${option.type}:${i}`} value={option}>
-            {option.type} - {option.amount?.display}
-          </Radio>
-        ))}
+        {options.map((option, i) => {
+          const label = deliveryOptionLabel(option.type)
+          const timeEstimate = deliveryOptionTimeEstimate(option.type)
+          const [prefix, timeRange] = timeEstimate || []
+
+          return (
+            <Radio key={`${option.type}:${i}`} value={option} mt={2}>
+              <Flex justifyContent="space-between" width="100%">
+                <Flex flexDirection="column">
+                  <Text>{label}</Text>
+                  {timeEstimate && (
+                    <Text variant="xs" color="mono60">
+                      {prefix} <strong>{timeRange}</strong>
+                    </Text>
+                  )}
+                </Flex>
+                <Text>{option.amount?.display}</Text>
+              </Flex>
+            </Radio>
+          )
+        })}
       </RadioGroup>
     </Flex>
   )

--- a/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/__tests__/Order2DeliveryOptionsForm.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/__tests__/Order2DeliveryOptionsForm.jest.tsx
@@ -1,0 +1,211 @@
+import { screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
+import { graphql } from "react-relay"
+import { Order2DeliveryOptionsForm } from "../Order2DeliveryOptionsForm"
+
+jest.unmock("react-relay")
+
+const mockCheckoutContext: any = {
+  checkoutTracking: {
+    clickedOrderProgression: jest.fn(),
+    clickedBuyerProtection: jest.fn(),
+  },
+  setDeliveryOptionComplete: jest.fn(),
+}
+
+jest.mock("Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext", () => ({
+  useCheckoutContext: () => mockCheckoutContext,
+}))
+
+const mockSetOrderFulfillmentOption = jest.fn()
+
+jest.mock(
+  "Apps/Order2/Routes/Checkout/Mutations/useOrder2SetOrderFulfillmentOptionMutation",
+  () => ({
+    useOrder2SetOrderFulfillmentOptionMutation: () => ({
+      submitMutation: mockSetOrderFulfillmentOption,
+    }),
+  }),
+)
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+const { renderWithRelay } = setupTestWrapperTL({
+  Component: (props: any) => (
+    <Order2DeliveryOptionsForm order={props.me.order} />
+  ),
+  query: graphql`
+    query Order2DeliveryOptionsFormTestQuery @relay_test_operation {
+      me {
+        order(id: "order-id") {
+          ...Order2DeliveryOptionsForm_order
+        }
+      }
+    }
+  `,
+})
+
+describe("Order2DeliveryOptionsForm", () => {
+  describe("with single delivery option", () => {
+    it("renders single shipping option without radio buttons", () => {
+      renderWithRelay({
+        Me: () => ({
+          order: {
+            internalID: "order-123",
+            fulfillmentOptions: [
+              {
+                type: "ARTSY_STANDARD",
+                amount: { display: "$25.00" },
+                selected: true,
+              },
+            ],
+          },
+        }),
+      })
+
+      expect(screen.getByText("Shipping method")).toBeInTheDocument()
+      expect(screen.getByText("Standard")).toBeInTheDocument()
+      expect(screen.getByText("$25.00")).toBeInTheDocument()
+      expect(screen.getByText("Continue to Payment")).toBeInTheDocument()
+
+      expect(screen.queryByRole("radio")).not.toBeInTheDocument()
+    })
+
+    it("displays buyer guarantee link", () => {
+      renderWithRelay({
+        Me: () => ({
+          order: {
+            internalID: "order-123",
+            fulfillmentOptions: [
+              {
+                type: "ARTSY_STANDARD",
+                amount: { display: "$25.00" },
+                selected: true,
+              },
+            ],
+          },
+        }),
+      })
+
+      const guaranteeLink = screen.getByRole("link")
+      expect(guaranteeLink).toBeInTheDocument()
+      expect(guaranteeLink).toHaveAttribute("target", "_blank")
+      expect(guaranteeLink).toHaveAttribute(
+        "href",
+        "https://support.artsy.net/s/article/The-Artsy-Guarantee",
+      )
+    })
+  })
+
+  describe("with multiple delivery options", () => {
+    const multipleOptionsData = {
+      Me: () => ({
+        order: {
+          internalID: "order-123",
+          fulfillmentOptions: [
+            {
+              type: "ARTSY_STANDARD",
+              amount: { display: "$25.00" },
+              selected: true,
+            },
+            {
+              type: "ARTSY_EXPRESS",
+              amount: { display: "$50.00" },
+              selected: false,
+            },
+            {
+              type: "ARTSY_WHITE_GLOVE",
+              amount: { display: "$200.00" },
+              selected: false,
+            },
+          ],
+        },
+      }),
+    }
+
+    it("renders radio group with multiple shipping options", () => {
+      renderWithRelay(multipleOptionsData)
+
+      const radios = screen.getAllByRole("radio")
+      expect(radios).toHaveLength(3)
+
+      expect(screen.getByText("Standard")).toBeInTheDocument()
+      expect(screen.getByText("Express")).toBeInTheDocument()
+      expect(screen.getByText("White Glove")).toBeInTheDocument()
+
+      expect(screen.getByText("$25.00")).toBeInTheDocument()
+      expect(screen.getByText("$50.00")).toBeInTheDocument()
+      expect(screen.getByText("$200.00")).toBeInTheDocument()
+    })
+
+    it("displays time estimates for delivery options", () => {
+      renderWithRelay(multipleOptionsData)
+
+      const timeEstimates = screen.getAllByText(/Estimated to deliver between/)
+      expect(timeEstimates.length).toBeGreaterThan(0)
+    })
+
+    it("shows white glove description only when white glove is selected", async () => {
+      renderWithRelay(multipleOptionsData)
+
+      expect(
+        screen.queryByText(
+          /custom packing, transportation on a fine art shuttle/,
+        ),
+      ).not.toBeInTheDocument()
+
+      const whiteGloveRadio = screen.getByRole("radio", { name: /White Glove/ })
+      await userEvent.click(whiteGloveRadio)
+
+      expect(
+        screen.getByText(
+          /custom packing, transportation on a fine art shuttle/,
+        ),
+      ).toBeInTheDocument()
+    })
+
+    it("allows selecting different delivery options", async () => {
+      renderWithRelay(multipleOptionsData)
+
+      const standardRadio = screen.getByRole("radio", { name: /Standard/ })
+      const expressRadio = screen.getByRole("radio", { name: /Express/ })
+
+      expect(standardRadio).toBeChecked()
+
+      await userEvent.click(expressRadio)
+
+      expect(expressRadio).toBeChecked()
+      expect(standardRadio).not.toBeChecked()
+    })
+  })
+
+  describe("filtering pickup options", () => {
+    it("filters out PICKUP options from delivery options", () => {
+      renderWithRelay({
+        Me: () => ({
+          order: {
+            internalID: "order-123",
+            fulfillmentOptions: [
+              {
+                type: "ARTSY_STANDARD",
+                amount: { display: "$25.00" },
+                selected: true,
+              },
+              {
+                type: "PICKUP",
+                amount: { display: "$0.00" },
+                selected: false,
+              },
+            ],
+          },
+        }),
+      })
+
+      expect(screen.getByText("Standard")).toBeInTheDocument()
+      expect(screen.queryByText("Pickup")).not.toBeInTheDocument()
+    })
+  })
+})

--- a/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/utils.ts
+++ b/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/utils.ts
@@ -10,11 +10,11 @@ export const deliveryOptionLabel = (type?: string | null) => {
     case "INTERNATIONAL_FLAT":
       return "Flat rate"
     case "ARTSY_STANDARD":
-      return "Standard Delivery"
+      return "Standard"
     case "ARTSY_EXPRESS":
-      return "Express Delivery"
+      return "Express"
     case "ARTSY_WHITE_GLOVE":
-      return "White Glove Delivery"
+      return "White Glove"
     default:
       return `(TODO) ${type?.replace(/_/g, " ").toLocaleLowerCase()}`
   }

--- a/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/utils.ts
+++ b/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/utils.ts
@@ -69,8 +69,8 @@ export const deliveryOptionTimeEstimate = (
         "Estimated to deliver between",
         dateRangeString({
           from,
-          startOffsetDays: 5,
-          endOffsetDays: 7,
+          startOffsetDays: 8,
+          endOffsetDays: 11,
         }),
       ]
     case "ARTSY_EXPRESS":
@@ -78,8 +78,8 @@ export const deliveryOptionTimeEstimate = (
         "Estimated to deliver between",
         dateRangeString({
           from,
-          startOffsetDays: 2,
-          endOffsetDays: 4,
+          startOffsetDays: 8,
+          endOffsetDays: 9,
         }),
       ]
     case "ARTSY_WHITE_GLOVE":
@@ -87,8 +87,8 @@ export const deliveryOptionTimeEstimate = (
         "Estimated to deliver between",
         dateRangeString({
           from,
-          startOffsetDays: 7,
-          endOffsetDays: 10,
+          startOffsetDays: 14,
+          endOffsetDays: 56,
         }),
       ]
     default:

--- a/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/utils.ts
+++ b/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/utils.ts
@@ -9,6 +9,12 @@ export const deliveryOptionLabel = (type?: string | null) => {
       return "Flat rate"
     case "INTERNATIONAL_FLAT":
       return "Flat rate"
+    case "ARTSY_STANDARD":
+      return "Standard Delivery"
+    case "ARTSY_EXPRESS":
+      return "Express Delivery"
+    case "ARTSY_WHITE_GLOVE":
+      return "White Glove Delivery"
     default:
       return `(TODO) ${type?.replace(/_/g, " ").toLocaleLowerCase()}`
   }
@@ -55,6 +61,33 @@ export const deliveryOptionTimeEstimate = (
         dateRangeString({
           from,
           startOffsetDays: 8,
+          endOffsetDays: 10,
+        }),
+      ]
+    case "ARTSY_STANDARD":
+      return [
+        "Estimated to deliver between",
+        dateRangeString({
+          from,
+          startOffsetDays: 5,
+          endOffsetDays: 7,
+        }),
+      ]
+    case "ARTSY_EXPRESS":
+      return [
+        "Estimated to deliver between",
+        dateRangeString({
+          from,
+          startOffsetDays: 2,
+          endOffsetDays: 4,
+        }),
+      ]
+    case "ARTSY_WHITE_GLOVE":
+      return [
+        "Estimated to deliver between",
+        dateRangeString({
+          from,
+          startOffsetDays: 7,
           endOffsetDays: 10,
         }),
       ]

--- a/src/__generated__/Order2DeliveryOptionsFormTestQuery.graphql.ts
+++ b/src/__generated__/Order2DeliveryOptionsFormTestQuery.graphql.ts
@@ -1,0 +1,236 @@
+/**
+ * @generated SignedSource<<02b4afdac83d6a86a62c679ddc88ded3>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type Order2DeliveryOptionsFormTestQuery$variables = Record<PropertyKey, never>;
+export type Order2DeliveryOptionsFormTestQuery$data = {
+  readonly me: {
+    readonly order: {
+      readonly " $fragmentSpreads": FragmentRefs<"Order2DeliveryOptionsForm_order">;
+    } | null | undefined;
+  } | null | undefined;
+};
+export type Order2DeliveryOptionsFormTestQuery = {
+  response: Order2DeliveryOptionsFormTestQuery$data;
+  variables: Order2DeliveryOptionsFormTestQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "order-id"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "Order2DeliveryOptionsFormTestQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": (v0/*: any*/),
+            "concreteType": "Order",
+            "kind": "LinkedField",
+            "name": "order",
+            "plural": false,
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "Order2DeliveryOptionsForm_order"
+              }
+            ],
+            "storageKey": "order(id:\"order-id\")"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "Order2DeliveryOptionsFormTestQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": (v0/*: any*/),
+            "concreteType": "Order",
+            "kind": "LinkedField",
+            "name": "order",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "internalID",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FulfillmentOption",
+                "kind": "LinkedField",
+                "name": "fulfillmentOptions",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Money",
+                    "kind": "LinkedField",
+                    "name": "amount",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "display",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "type",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "selected",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v1/*: any*/)
+            ],
+            "storageKey": "order(id:\"order-id\")"
+          },
+          (v1/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "63752bfd79d27740474cdb2d26bbf807",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "me": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Me"
+        },
+        "me.id": (v2/*: any*/),
+        "me.order": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Order"
+        },
+        "me.order.fulfillmentOptions": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": true,
+          "type": "FulfillmentOption"
+        },
+        "me.order.fulfillmentOptions.amount": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Money"
+        },
+        "me.order.fulfillmentOptions.amount.display": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "String"
+        },
+        "me.order.fulfillmentOptions.selected": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Boolean"
+        },
+        "me.order.fulfillmentOptions.type": {
+          "enumValues": [
+            "ARTSY_EXPRESS",
+            "ARTSY_STANDARD",
+            "ARTSY_WHITE_GLOVE",
+            "DOMESTIC_FLAT",
+            "INTERNATIONAL_FLAT",
+            "PICKUP",
+            "SHIPPING_TBD"
+          ],
+          "nullable": false,
+          "plural": false,
+          "type": "FulfillmentOptionTypeEnum"
+        },
+        "me.order.id": (v2/*: any*/),
+        "me.order.internalID": (v2/*: any*/)
+      }
+    },
+    "name": "Order2DeliveryOptionsFormTestQuery",
+    "operationKind": "query",
+    "text": "query Order2DeliveryOptionsFormTestQuery {\n  me {\n    order(id: \"order-id\") {\n      ...Order2DeliveryOptionsForm_order\n      id\n    }\n    id\n  }\n}\n\nfragment Order2DeliveryOptionsForm_order on Order {\n  internalID\n  fulfillmentOptions {\n    amount {\n      display\n    }\n    type\n    selected\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "964511bda3c1a1d85798f76043ef1190";
+
+export default node;


### PR DESCRIPTION
The type of this PR is: **Feature**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-2830]

### Description

This PR displays the Artsy Shipping Options for the new checkout. Note: we can not continue the checkout with Artsy shipping yet, I will make a separate PR for this in Exchange. 

@artsy/emerald-devs 

<!-- Implementation description -->
<img width="930" height="876" alt="Screenshot 2025-09-25 at 12 35 51 PM" src="https://github.com/user-attachments/assets/c73a46fd-7b3c-45d1-b050-95f369450977" />

<img width="926" height="876" alt="Screenshot 2025-09-25 at 12 51 50 PM" src="https://github.com/user-attachments/assets/2de4a09e-1a2a-4691-a328-fc9ecfd0916a" />




[EMI-2830]: https://artsyproduct.atlassian.net/browse/EMI-2830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ