### PR TITLE
fix(immersive): minor QA items

### DIFF
--- a/src/Components/ArtworkFilter/ImmersiveView.tsx
+++ b/src/Components/ArtworkFilter/ImmersiveView.tsx
@@ -227,6 +227,7 @@ export const ImmersiveView: React.FC<ImmersiveViewProps> = props => {
                     alt={currentArtwork.formattedMetadata ?? "…"}
                     style={{
                       height: "85vh",
+                      width: "85vw",
                       objectFit: "contain",
                     }}
                     display={isImageLoading ? "none" : "block"}

--- a/src/Components/ArtworkFilter/ImmersiveView.tsx
+++ b/src/Components/ArtworkFilter/ImmersiveView.tsx
@@ -61,6 +61,10 @@ export const ImmersiveView: React.FC<ImmersiveViewProps> = props => {
 
   const { filters, setFilter } = useArtworkFilterContext()
 
+  const isFirstPage = (filters?.page ?? 1) === 1
+  const isFirstArtwork = currentIndex === 0
+  const isVeryFirstArtwork = isFirstPage && isFirstArtwork
+
   const navigateToPreviousPage = useCallback(() => {
     const page = filters?.page ?? 1
     if (page > 1) {
@@ -197,6 +201,7 @@ export const ImmersiveView: React.FC<ImmersiveViewProps> = props => {
             <Previous
               onClick={handlePreviousArtwork}
               aria-label="Previous artwork"
+              disabled={isVeryFirstArtwork}
             />
 
             <Next onClick={handleNextArtwork} aria-label="Next artwork" />

--- a/src/Components/ArtworkFilter/__tests__/ImmersiveView.jest.tsx
+++ b/src/Components/ArtworkFilter/__tests__/ImmersiveView.jest.tsx
@@ -135,6 +135,21 @@ describe("ImmersiveView", () => {
     })
   })
 
+  it("disables previous button on the very first artwork", async () => {
+    renderWithRelay({
+      FilterArtworksConnection: () => filterArtworksConnectionData,
+    })
+
+    const prevButton = screen.getByRole("button", { name: "Previous artwork" })
+    expect(prevButton).toBeDisabled()
+
+    screen.getByRole("button", { name: "Next artwork" }).click()
+
+    await waitFor(() => {
+      expect(prevButton).not.toBeDisabled()
+    })
+  })
+
   it("navigates to prev/next pages via keyboard", async () => {
     renderWithRelay(
       { FilterArtworksConnection: () => filterArtworksConnectionData },


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves some old QA cards [here](https://www.notion.so/artsy/web-Immersive-artwork-view-23ecab0764a080789532dffa22cc2f1a?p=242cab0764a080398a48d5bc8577b59c&pm=s) and [here](https://www.notion.so/artsy/web-Immersive-artwork-view-23ecab0764a080789532dffa22cc2f1a?p=23ecab0764a080689e36f08f04375d35&pm=s).

### Description

- Constrains image width to `85vw`
- Removes **Previous** button when you are on the very first artwork within a paginated collection (page 1, work 1)

[This grid](https://staging.artsy.net/artist/barbara-blondeau) demonstrates both:


https://github.com/user-attachments/assets/e45a3ddc-0fba-4f09-91c2-1ff079e95371

