### PR TITLE
fix: new unleash flag for autosuggest experiment

### DIFF
--- a/src/Components/Search/Mobile/MobileSearchBar.tsx
+++ b/src/Components/Search/Mobile/MobileSearchBar.tsx
@@ -14,7 +14,8 @@ import type {
 } from "__generated__/MobileSearchBarSuggestQuery.graphql"
 import { graphql } from "react-relay"
 
-const SEARCH_AUTOSUGGEST_VARIANT_EXPERIMENT = "onyx_search-autosuggest-variant"
+const SEARCH_AUTOSUGGEST_VARIANT_EXPERIMENT =
+  "onyx_search-autosuggest-experiment"
 
 interface MobileSearchBarProps {
   viewer: NonNullable<MobileSearchBarSuggestQuery$data["viewer"]>

--- a/src/Components/Search/SearchBarInput.tsx
+++ b/src/Components/Search/SearchBarInput.tsx
@@ -32,7 +32,8 @@ import { type PillType, SEARCH_DEBOUNCE_DELAY, TOP_PILL } from "./constants"
 import { getLabel } from "./utils/getLabel"
 import { shouldStartSearching } from "./utils/shouldStartSearching"
 
-const SEARCH_AUTOSUGGEST_VARIANT_EXPERIMENT = "onyx_search-autosuggest-variant"
+const SEARCH_AUTOSUGGEST_VARIANT_EXPERIMENT =
+  "onyx_search-autosuggest-experiment"
 
 export interface SearchBarInputProps {
   searchTerm: string


### PR DESCRIPTION
### Description

It’s more convenient for the data analyst if we create a new experiment instead of reusing the old one.
The new experiment is [here](https://unleash.artsy.net/projects/default/features/onyx_search-autosuggest-experiment).