### PR TITLE
fix(EMI-3194): track checkout modal errors

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/CheckoutModal.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/CheckoutModal.tsx
@@ -71,7 +71,7 @@ export const CheckoutModal: React.FC<{
       error_code: error,
       title,
       message: description,
-      flow: checkoutTracking.flow,
+      flow: "User submitting order",
     })
   }, [error, title, description, checkoutTracking])
 

--- a/src/Apps/Order2/Routes/Checkout/Components/CheckoutModal.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/CheckoutModal.tsx
@@ -71,7 +71,6 @@ export const CheckoutModal: React.FC<{
       error_code: error,
       title,
       message: description,
-      flow: "User submitting order",
     })
   }, [error, title, description, checkoutTracking])
 

--- a/src/Apps/Order2/Routes/Checkout/Components/CheckoutModal.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/CheckoutModal.tsx
@@ -2,6 +2,7 @@ import { Button, Flex, ModalDialog, Text } from "@artsy/palette"
 import { useCheckoutContext } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext"
 import { useCheckoutModal } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutModal"
 import { useRouter } from "System/Hooks/useRouter"
+import { useEffect } from "react"
 
 export enum CheckoutModalError {
   LOADING_TIMEOUT = "loading_timeout",
@@ -17,17 +18,9 @@ export const CheckoutModal: React.FC<{
   overrideTitle?: string
   overrideDescription?: string
 }> = ({ error, overrideTitle, overrideDescription }) => {
-  const { artworkPath } = useCheckoutContext()
+  const { artworkPath, checkoutTracking } = useCheckoutContext()
   const { dismissCheckoutErrorModal } = useCheckoutModal()
   const { router } = useRouter()
-
-  if (!error) {
-    return null
-  }
-
-  const handleReload = () => {
-    window.location.reload()
-  }
 
   // Determine modal behavior based on error type
   let canReload = false
@@ -70,6 +63,25 @@ export const CheckoutModal: React.FC<{
   // Use override values if provided, otherwise fall back to defaults
   const title = overrideTitle ?? defaultTitle
   const description = overrideDescription ?? defaultDescription
+
+  useEffect(() => {
+    if (!error) return
+
+    checkoutTracking.errorMessageViewed({
+      error_code: error,
+      title,
+      message: description,
+      flow: checkoutTracking.flow,
+    })
+  }, [error, title, description, checkoutTracking])
+
+  if (!error) {
+    return null
+  }
+
+  const handleReload = () => {
+    window.location.reload()
+  }
 
   const handleClose = () => {
     if (canDismiss) {

--- a/src/Apps/Order2/Routes/Checkout/Components/__tests__/CriticalErrorModal.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/__tests__/CriticalErrorModal.jest.tsx
@@ -16,12 +16,17 @@ jest.mock("System/Hooks/useRouter")
 
 const mockRouterReplace = jest.fn()
 const mockDismissCheckoutErrorModal = jest.fn()
+const mockErrorMessageViewed = jest.fn()
 
 describe("CriticalErrorModal", () => {
   beforeEach(() => {
     jest.clearAllMocks()
     ;(useCheckoutContext as jest.Mock).mockReturnValue({
       artworkPath: "/artwork/test-artwork",
+      checkoutTracking: {
+        flow: "Buy now",
+        errorMessageViewed: mockErrorMessageViewed,
+      },
     })
     ;(useCheckoutModal as jest.Mock).mockReturnValue({
       dismissCheckoutErrorModal: mockDismissCheckoutErrorModal,
@@ -224,6 +229,25 @@ describe("CriticalErrorModal", () => {
 
       expect(mockDismissCheckoutErrorModal).toHaveBeenCalled()
       expect(mockRouterReplace).not.toHaveBeenCalled()
+    })
+  })
+
+  describe("tracking", () => {
+    it("tracks errorMessageViewed when error is displayed", () => {
+      render(<CheckoutModal error={CheckoutModalError.LOADING_TIMEOUT} />)
+
+      expect(mockErrorMessageViewed).toHaveBeenCalledWith({
+        error_code: CheckoutModalError.LOADING_TIMEOUT,
+        title: "Checkout error",
+        message: "There was an error loading your checkout.",
+        flow: "Buy now",
+      })
+    })
+
+    it("does not track when error is null", () => {
+      render(<CheckoutModal error={null} />)
+
+      expect(mockErrorMessageViewed).not.toHaveBeenCalled()
     })
   })
 

--- a/src/Apps/Order2/Routes/Checkout/Components/__tests__/CriticalErrorModal.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/__tests__/CriticalErrorModal.jest.tsx
@@ -240,7 +240,6 @@ describe("CriticalErrorModal", () => {
         error_code: CheckoutModalError.LOADING_TIMEOUT,
         title: "Checkout error",
         message: "There was an error loading your checkout.",
-        flow: "User submitting order",
       })
     })
 

--- a/src/Apps/Order2/Routes/Checkout/Components/__tests__/CriticalErrorModal.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/__tests__/CriticalErrorModal.jest.tsx
@@ -240,7 +240,7 @@ describe("CriticalErrorModal", () => {
         error_code: CheckoutModalError.LOADING_TIMEOUT,
         title: "Checkout error",
         message: "There was an error loading your checkout.",
-        flow: "Buy now",
+        flow: "User submitting order",
       })
     })
 

--- a/src/Apps/Order2/Routes/Checkout/Hooks/useCheckoutTracking.ts
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/useCheckoutTracking.ts
@@ -52,6 +52,7 @@ export const useCheckoutTracking = ({
 
   const checkoutTracking = useMemo(() => {
     return {
+      flow,
       clickedExpressCheckout: ({ walletType }: { walletType: string }) => {
         const payload: ClickedExpressCheckout = {
           action: ActionType.clickedExpressCheckout,

--- a/src/Apps/Order2/Routes/Checkout/Hooks/useCheckoutTracking.ts
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/useCheckoutTracking.ts
@@ -263,12 +263,12 @@ export const useCheckoutTracking = ({
         error_code,
         title,
         message,
-        flow,
+        flow: overrideFlow,
       }: {
         error_code: string | null
         title: string
         message: string
-        flow: string
+        flow?: string
       }) => {
         const payload: ErrorMessageViewed = {
           action: ActionType.errorMessageViewed,
@@ -277,7 +277,7 @@ export const useCheckoutTracking = ({
           title,
           message,
           error_code: error_code || undefined,
-          flow,
+          flow: overrideFlow ?? flow,
         }
 
         trackEvent(payload)

--- a/src/Apps/Order2/Routes/Checkout/Hooks/useCheckoutTracking.ts
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/useCheckoutTracking.ts
@@ -52,7 +52,6 @@ export const useCheckoutTracking = ({
 
   const checkoutTracking = useMemo(() => {
     return {
-      flow,
       clickedExpressCheckout: ({ walletType }: { walletType: string }) => {
         const payload: ClickedExpressCheckout = {
           action: ActionType.clickedExpressCheckout,


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-3195]

### Description
Noticed we were not tracking error modal errors on submit. This will ensure errors such as `LOADING_TIMEOUT` will get tracked. 

<!-- Implementation description -->


[EMI-3195]: https://artsyproduct.atlassian.net/browse/EMI-3195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ