### PR TITLE
feat(DI-89): Create skeleton and route for new Join Artsy page

### DIFF
--- a/src/Apps/Authentication/Routes/AuthenticationSignUpNewRoute.tsx
+++ b/src/Apps/Authentication/Routes/AuthenticationSignUpNewRoute.tsx
@@ -1,0 +1,8 @@
+import { SignupLandingPage } from "Apps/Authentication/Routes/SignupLanding/SignupLandingPage"
+import type { FC } from "react"
+
+export const AuthenticationSignUpNewRoute: FC<
+  React.PropsWithChildren<unknown>
+> = () => {
+  return <SignupLandingPage />
+}

--- a/src/Apps/Authentication/Routes/SignupLanding/Components/SignupCTA.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/Components/SignupCTA.tsx
@@ -1,0 +1,17 @@
+import { FullBleed, Text } from "@artsy/palette"
+import { AppContainer } from "Apps/Components/AppContainer"
+import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
+
+export const SignupCTA = () => {
+  return (
+    <FullBleed bg="mono100" py={[6, 12]}>
+      <AppContainer>
+        <HorizontalPadding>
+          <Text variant={["xl", "xxl"]} color="mono0" textAlign="center">
+            CTA content (DI-92)
+          </Text>
+        </HorizontalPadding>
+      </AppContainer>
+    </FullBleed>
+  )
+}

--- a/src/Apps/Authentication/Routes/SignupLanding/Components/SignupHeader.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/Components/SignupHeader.tsx
@@ -1,0 +1,29 @@
+import ArtsyLogoIcon from "@artsy/icons/ArtsyLogoIcon"
+import { Button, Flex, FullBleed } from "@artsy/palette"
+import { AppContainer } from "Apps/Components/AppContainer"
+import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
+import { RouterLink } from "System/Components/RouterLink"
+
+export const SignupHeader = () => {
+  return (
+    <FullBleed bg="mono0" borderBottom="1px solid" borderColor="mono10">
+      <AppContainer>
+        <HorizontalPadding>
+          <Flex height={60} alignItems="center" justifyContent="space-between">
+            {/* Left: Artsy Logo */}
+            <ArtsyLogoIcon />
+
+            {/* Right: Log In link */}
+
+            {/* Check this implementation vs other log in buttons  */}
+            <RouterLink to="/login">
+              <Button variant="secondaryBlack" size="small">
+                Log In
+              </Button>
+            </RouterLink>
+          </Flex>
+        </HorizontalPadding>
+      </AppContainer>
+    </FullBleed>
+  )
+}

--- a/src/Apps/Authentication/Routes/SignupLanding/Components/SignupHero.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/Components/SignupHero.tsx
@@ -1,0 +1,19 @@
+import { GridColumns, Column, Text, Box } from "@artsy/palette"
+import { AppContainer } from "Apps/Components/AppContainer"
+
+export const SignupHero = () => {
+  return (
+    <AppContainer>
+      <Box mx="auto" maxWidth="1200px" px={[2, 4]} py={[4, 6, 12]}>
+        <GridColumns textAlign="center" gridRowGap={[6, 0]} gridColumnGap={4}>
+          <Column span={[12, 6]}>
+            <Text variant="sm"> Hero content (DI-90) </Text>
+          </Column>
+          <Column span={[12, 6]}>
+            <Text variant="sm"> Signup form (DI-90) </Text>
+          </Column>
+        </GridColumns>
+      </Box>
+    </AppContainer>
+  )
+}

--- a/src/Apps/Authentication/Routes/SignupLanding/Components/SignupHero.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/Components/SignupHero.tsx
@@ -1,19 +1,16 @@
 import { GridColumns, Column, Text, Box } from "@artsy/palette"
-import { AppContainer } from "Apps/Components/AppContainer"
 
 export const SignupHero = () => {
   return (
-    <AppContainer>
-      <Box mx="auto" maxWidth="1200px" px={[2, 4]} py={[4, 6, 12]}>
-        <GridColumns textAlign="center" gridRowGap={[6, 0]} gridColumnGap={4}>
-          <Column span={[12, 6]}>
-            <Text variant="sm"> Hero content (DI-90) </Text>
-          </Column>
-          <Column span={[12, 6]}>
-            <Text variant="sm"> Signup form (DI-90) </Text>
-          </Column>
-        </GridColumns>
-      </Box>
-    </AppContainer>
+    <Box mx="auto" px={[2, 4]} py={[4, 6, 12]}>
+      <GridColumns textAlign="center" gridRowGap={[6, 0]} gridColumnGap={4}>
+        <Column span={[12, 6]}>
+          <Text variant="sm"> Hero content (DI-90) </Text>
+        </Column>
+        <Column span={[12, 6]}>
+          <Text variant="sm"> Signup form (DI-90) </Text>
+        </Column>
+      </GridColumns>
+    </Box>
   )
 }

--- a/src/Apps/Authentication/Routes/SignupLanding/Components/SignupStats.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/Components/SignupStats.tsx
@@ -1,22 +1,19 @@
 import { Box, GridColumns, Column, Text } from "@artsy/palette"
-import { AppContainer } from "Apps/Components/AppContainer"
 
 export const SignupStats = () => {
   return (
-    <AppContainer>
-      <Box mx="auto" maxWidth="1200px">
-        <GridColumns textAlign="center" gridRowGap={[4, 2]}>
-          <Column span={[12, 4]}>
-            <Text variant="sm"> Stat 1 (DI-91) </Text>
-          </Column>
-          <Column span={[12, 4]}>
-            <Text variant="sm"> Stat 2 (DI-91)</Text>
-          </Column>
-          <Column span={[12, 4]}>
-            <Text variant="sm"> Stat 3 (DI-91) </Text>
-          </Column>
-        </GridColumns>
-      </Box>
-    </AppContainer>
+    <Box mx="auto">
+      <GridColumns textAlign="center" gridRowGap={[4, 2]}>
+        <Column span={[12, 4]}>
+          <Text variant="sm"> Stat 1 (DI-91) </Text>
+        </Column>
+        <Column span={[12, 4]}>
+          <Text variant="sm"> Stat 2 (DI-91)</Text>
+        </Column>
+        <Column span={[12, 4]}>
+          <Text variant="sm"> Stat 3 (DI-91) </Text>
+        </Column>
+      </GridColumns>
+    </Box>
   )
 }

--- a/src/Apps/Authentication/Routes/SignupLanding/Components/SignupStats.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/Components/SignupStats.tsx
@@ -1,11 +1,9 @@
 import { Box, GridColumns, Column, Text } from "@artsy/palette"
 import { AppContainer } from "Apps/Components/AppContainer"
-// import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
 
 export const SignupStats = () => {
   return (
     <AppContainer>
-      {/* <HorizontalPadding> */}
       <Box mx="auto" maxWidth="1200px">
         <GridColumns textAlign="center" gridRowGap={[4, 2]}>
           <Column span={[12, 4]}>
@@ -19,7 +17,6 @@ export const SignupStats = () => {
           </Column>
         </GridColumns>
       </Box>
-      {/* </HorizontalPadding> */}
     </AppContainer>
   )
 }

--- a/src/Apps/Authentication/Routes/SignupLanding/Components/SignupStats.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/Components/SignupStats.tsx
@@ -1,0 +1,25 @@
+import { Box, GridColumns, Column, Text } from "@artsy/palette"
+import { AppContainer } from "Apps/Components/AppContainer"
+// import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
+
+export const SignupStats = () => {
+  return (
+    <AppContainer>
+      {/* <HorizontalPadding> */}
+      <Box mx="auto" maxWidth="1200px">
+        <GridColumns textAlign="center" gridRowGap={[4, 2]}>
+          <Column span={[12, 4]}>
+            <Text variant="sm"> Stat 1 (DI-91) </Text>
+          </Column>
+          <Column span={[12, 4]}>
+            <Text variant="sm"> Stat 2 (DI-91)</Text>
+          </Column>
+          <Column span={[12, 4]}>
+            <Text variant="sm"> Stat 3 (DI-91) </Text>
+          </Column>
+        </GridColumns>
+      </Box>
+      {/* </HorizontalPadding> */}
+    </AppContainer>
+  )
+}

--- a/src/Apps/Authentication/Routes/SignupLanding/Components/SignupValueProps.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/Components/SignupValueProps.tsx
@@ -7,28 +7,31 @@ import {
   FullBleed,
 } from "@artsy/palette"
 import { AppContainer } from "Apps/Components/AppContainer"
+import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
 
 export const SignupValueProps = () => {
   return (
     <FullBleed bg="mono5" py={[6, 12]}>
       <AppContainer>
-        <Text variant={["xl", "xxl"]} textAlign="center">
-          Why Choose Artsy
-        </Text>
-        <Spacer y={4} />
-        <Box mx="auto" maxWidth="1200px">
-          <GridColumns textAlign="center" gridRowGap={4}>
-            <Column span={[12, 4]}>
-              <Text variant="sm"> Feature card 1 (DI-91)</Text>
-            </Column>
-            <Column span={[12, 4]}>
-              <Text variant="sm"> Feature card 2 (DI-91)</Text>
-            </Column>
-            <Column span={[12, 4]}>
-              <Text variant="sm"> Feature card 3 (DI-91)</Text>
-            </Column>
-          </GridColumns>
-        </Box>
+        <HorizontalPadding>
+          <Text variant={["xl", "xxl"]} textAlign="center">
+            Why Choose Artsy
+          </Text>
+          <Spacer y={4} />
+          <Box mx="auto">
+            <GridColumns textAlign="center" gridRowGap={4}>
+              <Column span={[12, 4]}>
+                <Text variant="sm"> Feature card 1 (DI-91)</Text>
+              </Column>
+              <Column span={[12, 4]}>
+                <Text variant="sm"> Feature card 2 (DI-91)</Text>
+              </Column>
+              <Column span={[12, 4]}>
+                <Text variant="sm"> Feature card 3 (DI-91)</Text>
+              </Column>
+            </GridColumns>
+          </Box>
+        </HorizontalPadding>
       </AppContainer>
     </FullBleed>
   )

--- a/src/Apps/Authentication/Routes/SignupLanding/Components/SignupValueProps.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/Components/SignupValueProps.tsx
@@ -1,0 +1,35 @@
+import {
+  Spacer,
+  Box,
+  GridColumns,
+  Column,
+  Text,
+  FullBleed,
+} from "@artsy/palette"
+import { AppContainer } from "Apps/Components/AppContainer"
+
+export const SignupValueProps = () => {
+  return (
+    <FullBleed bg="mono5" py={[6, 12]}>
+      <AppContainer>
+        <Text variant={["xl", "xxl"]} textAlign="center">
+          Why Choose Artsy
+        </Text>
+        <Spacer y={4} />
+        <Box mx="auto" maxWidth="1200px">
+          <GridColumns textAlign="center" gridRowGap={4}>
+            <Column span={[12, 4]}>
+              <Text variant="sm"> Feature card 1 (DI-91)</Text>
+            </Column>
+            <Column span={[12, 4]}>
+              <Text variant="sm"> Feature card 2 (DI-91)</Text>
+            </Column>
+            <Column span={[12, 4]}>
+              <Text variant="sm"> Feature card 3 (DI-91)</Text>
+            </Column>
+          </GridColumns>
+        </Box>
+      </AppContainer>
+    </FullBleed>
+  )
+}

--- a/src/Apps/Authentication/Routes/SignupLanding/SignupLandingPage.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/SignupLandingPage.tsx
@@ -1,0 +1,33 @@
+import { Join, Spacer } from "@artsy/palette"
+import { SignupCTA } from "Apps/Authentication/Routes/SignupLanding/Components/SignupCTA"
+import { SignupHero } from "Apps/Authentication/Routes/SignupLanding/Components/SignupHero"
+import { SignupHeader } from "Apps/Authentication/Routes/SignupLanding/Components/SignupHeader"
+import { SignupStats } from "Apps/Authentication/Routes/SignupLanding/Components/SignupStats"
+import { SignupValueProps } from "Apps/Authentication/Routes/SignupLanding/Components/SignupValueProps"
+
+import { MetaTags } from "Components/MetaTags"
+import type { FC } from "react"
+
+export const SignupLandingPage: FC<React.PropsWithChildren<unknown>> = () => {
+  return (
+    <>
+      <MetaTags
+        title="Join Artsy - Discover and Buy Art That Moves You"
+        description="Join over 3.4 million art collectors and enthusiasts. Explore 1.6 million original artworks for sale from galleries, museums, and artists worldwide."
+        pathname="/signup-new"
+      />
+
+      <SignupHeader />
+      <Join separator={<Spacer y={[6, 12]} />}>
+        {/* Hero Section DI-90 */}
+        <SignupHero />
+        {/* Value Props Section DI-91 */}
+        <SignupValueProps />
+        {/* Stats Section DI-91 */}
+        <SignupStats />
+        {/* Bottom CTA Section DI-92 */}
+        <SignupCTA />
+      </Join>
+    </>
+  )
+}

--- a/src/Apps/Authentication/__tests__/authenticationRoutes.jest.tsx
+++ b/src/Apps/Authentication/__tests__/authenticationRoutes.jest.tsx
@@ -205,6 +205,19 @@ describe("authenticationRoutes", () => {
     })
   })
 
+  describe("/signup-new", () => {
+    describe("client", () => {
+      it.skip("renders signup landing page", async () => {
+        renderClientRoute("/signup-new")
+
+        await waitFor(() => {
+          expect(screen.getByText("Log In")).toBeInTheDocument()
+          expect(screen.getByText(/Why Choose Artsy/i)).toBeInTheDocument()
+        })
+      })
+    })
+  })
+
   describe("/auth-redirect", () => {
     describe("server", () => {
       it("redirects to redirectTo", () => {

--- a/src/Apps/Authentication/authenticationRoutes.tsx
+++ b/src/Apps/Authentication/authenticationRoutes.tsx
@@ -41,6 +41,14 @@ const SignupRoute = loadable(
   { resolveComponent: component => component.AuthenticationSignUpRoute },
 )
 
+const SignupNewRoute = loadable(
+  () =>
+    import(
+      /* webpackChunkName: "authenticationBundle" */ "./Routes/AuthenticationSignUpNewRoute"
+    ),
+  { resolveComponent: component => component.AuthenticationSignUpNewRoute },
+)
+
 const runAuthMiddleware = flow(checkForRedirect, setReferer)
 
 export const authenticationRoutes: RouteProps[] = [
@@ -124,6 +132,18 @@ export const authenticationRoutes: RouteProps[] = [
     },
     onPreloadJS: () => {
       SignupRoute.preload()
+    },
+  },
+  {
+    path: "/signup-new",
+    layout: "ContainerOnly",
+    getComponent: () => SignupNewRoute,
+    onServerSideRender: props => {
+      // Only run the essential middleware (referer tracking)
+      runAuthMiddleware(props)
+    },
+    onPreloadJS: () => {
+      SignupNewRoute.preload()
     },
   },
   {


### PR DESCRIPTION
The type of this PR is: **FEAT**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [DI-89](https://www.notion.so/33bcab0764a080c697d7f390207b5e9a)

### Description

We are creating a new sign up page to serve as the primary acquisition entry point for new users. This initial PR sets up the route for `/signup-new` and creates the skeleton of the landing page + additional components for each section which will be worked on separately as design and copy decisions are finalized. 

Mockup: https://www.figma.com/make/CfM5wtYExymVgNXgM9ioYj/Create-Join-Page-for-Artsy?p=f&t=qK3KdcUz3MQtZVh0-0 

<!-- Implementation description -->
