### PR TITLE
fix: prefer server-side highlights over client-side in search suggestions

### DIFF
--- a/src/Components/Search/SuggestionItem/DefaultSuggestion.tsx
+++ b/src/Components/Search/SuggestionItem/DefaultSuggestion.tsx
@@ -81,19 +81,19 @@ function resolveSuggestionParts(
       ? parseHighlightFragments(firstAlternateFragment)
       : null
 
+  if (firstNameFragment) {
+    return {
+      nameParts: parseHighlightFragments(firstNameFragment),
+      alternateParts,
+    }
+  }
+
   if (hasClientHighlights) {
     return {
       nameParts: parse(option.text, clientMatches).map(
         ({ highlight, text }, index) =>
           highlight ? <Highlight key={index}>{text}</Highlight> : text
       ),
-      alternateParts,
-    }
-  }
-
-  if (firstNameFragment) {
-    return {
-      nameParts: parseHighlightFragments(firstNameFragment),
       alternateParts,
     }
   }

--- a/src/Components/Search/SuggestionItem/__tests__/DefaultSuggestion.jest.tsx
+++ b/src/Components/Search/SuggestionItem/__tests__/DefaultSuggestion.jest.tsx
@@ -35,7 +35,7 @@ const baseOption: SuggestionItemOptionProps = {
 
 describe("DefaultSuggestion", () => {
   describe("display name highlighting", () => {
-    it("uses client-side substring matching as primary strategy", () => {
+    it("falls back to client-side substring matching when no server highlights are present", () => {
       const { container } = render(
         <DefaultSuggestion option={baseOption} query="warhol" />
       )
@@ -61,7 +61,7 @@ describe("DefaultSuggestion", () => {
       expect(highlighted).toHaveTextContent("Andy Warhol")
     })
 
-    it("prefers client-side over server-side when both could match", () => {
+    it("prefers server-side over client-side when both could match", () => {
       const option: SuggestionItemOptionProps = {
         ...baseOption,
         highlights: [
@@ -74,8 +74,9 @@ describe("DefaultSuggestion", () => {
       )
 
       const highlights = container.querySelectorAll("strong")
-      expect(highlights).toHaveLength(1)
-      expect(highlights[0]).toHaveTextContent("War")
+      expect(highlights).toHaveLength(2)
+      expect(highlights[0]).toHaveTextContent("Andy")
+      expect(highlights[1]).toHaveTextContent("Warhol")
     })
 
     it("renders plain text when neither strategy produces highlights", () => {


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

Client-side autosuggest-highlight only does exact substring matching, so a query like "Andy Warhlo" would match "Andy" but not "Warhol", setting hasClientHighlights=true and causing the server's fuzzy/phonetic highlight for "Warhol" to be silently ignored. Inverting the priority so server-side highlights (when present) always win fixes partial-query cases.

<!-- Implementation description -->

### Screenshots

**Before**

<img width="1656" height="1350" alt="Screenshot 2026-04-13 at 13 11 06" src="https://github.com/user-attachments/assets/57ab0b72-fdad-45dc-ac14-d731a02976de" />


**After**

<img width="1656" height="1350" alt="Screenshot 2026-04-13 at 13 11 46" src="https://github.com/user-attachments/assets/20dd7b81-5273-4550-a519-2283ad5ee15e" />
