### PR TITLE
fix(artwork): removes 1x preload

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkLightbox.tsx
+++ b/src/Apps/Artwork/Components/ArtworkLightbox.tsx
@@ -85,7 +85,6 @@ const ArtworkLightbox: React.FC<
         <Link
           rel="preload"
           as="image"
-          href={image.src}
           imageSrcSet={image.srcSet}
           fetchPriority="high"
         />


### PR DESCRIPTION
Re: https://artsy.slack.com/archives/C05EEBNEF71/p1775828462666819

Noticed we were preloading both the 1x and 2x versions, despite never needing the 1x if you're on a hi-dpi display. This was being triggered from the `href` property.

cc @artsy/diamond-devs 