### PR TITLE
refactor: removes ReactRelayContext mocks where it is not needed

### DIFF
--- a/src/Apps/Components/__tests__/AppShell.jest.tsx
+++ b/src/Apps/Components/__tests__/AppShell.jest.tsx
@@ -19,9 +19,6 @@ jest.mock("react-tracking", () => ({
 
 jest.mock("react-relay", () => ({
   ...jest.requireActual("react-relay"),
-  ReactRelayContext: {
-    Provider: ({ children }) => children,
-  },
 }))
 
 jest.mock("Utils/Hooks/useAuthValidation")

--- a/src/System/Router/Utils/__tests__/buildAppRoutes.jest.tsx
+++ b/src/System/Router/Utils/__tests__/buildAppRoutes.jest.tsx
@@ -22,9 +22,6 @@ jest.mock("react-tracking", () => ({
 
 jest.mock("react-relay", () => ({
   ...jest.requireActual("react-relay"),
-  ReactRelayContext: {
-    Provider: ({ children }) => children,
-  },
 }))
 
 jest.mock("Apps/Components/AppShell", () => ({

--- a/src/System/Router/__tests__/clientRouter.jest.tsx
+++ b/src/System/Router/__tests__/clientRouter.jest.tsx
@@ -9,9 +9,6 @@ jest.mock("Components/NavBar/NavBar", () => ({
 
 jest.mock("react-relay", () => ({
   ...jest.requireActual("react-relay"),
-  ReactRelayContext: {
-    Provider: ({ children }) => children,
-  },
 }))
 
 jest.mock("Utils/Hooks/useOnboardingModal", () => ({


### PR DESCRIPTION
The type of this PR is: **Refactor**

### Description

So apparently we don't need to mock `ReactRelayContext` in these tests, so I'm removing the mocks