### PR TITLE
feat: add artworks to partner's JSON-LD structured data

### DIFF
--- a/src/Apps/Partner/Components/PartnerMeta/PartnerMetaStructuredData.tsx
+++ b/src/Apps/Partner/Components/PartnerMeta/PartnerMetaStructuredData.tsx
@@ -104,6 +104,18 @@ export const PartnerMetaStructuredData: React.FC<
     [partner.allArtistsConnection],
   )
 
+  const makesOffer = useMemo(() => {
+    const artworks = extractNodes(partner.filterArtworksConnection)
+    if (artworks.length === 0) return undefined
+
+    return artworks.map(artwork => ({
+      "@type": "Offer" as const,
+      itemOffered: {
+        "@id": `${getENV("APP_URL")}${artwork.href}#visual-artwork`,
+      },
+    }))
+  }, [partner.filterArtworksConnection])
+
   return (
     <StructuredData
       schemaData={{
@@ -122,6 +134,7 @@ export const PartnerMetaStructuredData: React.FC<
         address,
         openingHours,
         member,
+        makesOffer,
       }}
     />
   )
@@ -179,6 +192,13 @@ const fragment = graphql`
       edges {
         node {
           name
+          href
+        }
+      }
+    }
+    filterArtworksConnection(first: 30, sort: "-decayed_merch") {
+      edges {
+        node {
           href
         }
       }

--- a/src/Apps/Partner/Components/PartnerMeta/__tests__/PartnerMetaStructuredData.jest.tsx
+++ b/src/Apps/Partner/Components/PartnerMeta/__tests__/PartnerMetaStructuredData.jest.tsx
@@ -1,0 +1,85 @@
+import { PartnerMetaStructuredData } from "Apps/Partner/Components/PartnerMeta/PartnerMetaStructuredData"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
+import { HeadProvider } from "react-head"
+import { graphql } from "react-relay"
+
+jest.unmock("react-relay")
+
+jest.mock("Utils/getENV", () => ({
+  getENV: (key: string) => {
+    if (key === "APP_URL") return "https://www.artsy.net"
+    return undefined
+  },
+}))
+
+const { renderWithRelay } = setupTestWrapperTL({
+  Component: ({ partner }: any) => {
+    return (
+      <HeadProvider>
+        <PartnerMetaStructuredData partner={partner} />
+      </HeadProvider>
+    )
+  },
+  query: graphql`
+    query PartnerMetaStructuredData_Test_Query @relay_test_operation {
+      partner(id: "example") {
+        ...PartnerMetaStructuredData_partner
+      }
+    }
+  `,
+})
+
+const getStructuredData = () => {
+  const tag = document.querySelector("script[type='application/ld+json']")
+  return tag ? JSON.parse(tag.textContent || "{}") : null
+}
+
+describe("PartnerMetaStructuredData", () => {
+  describe("makesOffer", () => {
+    it("includes makesOffer with artwork node references", () => {
+      renderWithRelay({
+        Partner: () => ({
+          href: "/partner/cerbera-gallery",
+          filterArtworksConnection: {
+            edges: [
+              { node: { href: "/artwork/banksy-gangsta-rat" } },
+              { node: { href: "/artwork/shepard-fairey-future-is-equal" } },
+            ],
+          },
+        }),
+      })
+
+      const data = getStructuredData()
+      expect(data.makesOffer).toEqual([
+        {
+          "@type": "Offer",
+          itemOffered: {
+            "@id":
+              "https://www.artsy.net/artwork/banksy-gangsta-rat#visual-artwork",
+          },
+        },
+        {
+          "@type": "Offer",
+          itemOffered: {
+            "@id":
+              "https://www.artsy.net/artwork/shepard-fairey-future-is-equal#visual-artwork",
+          },
+        },
+      ])
+    })
+
+    it("omits makesOffer when there are no artworks", () => {
+      renderWithRelay({
+        Partner: () => ({
+          href: "/partner/cerbera-gallery",
+          filterArtworksConnection: {
+            edges: [],
+          },
+        }),
+      })
+
+      const data = getStructuredData()
+      expect(data.makesOffer).toBeUndefined()
+    })
+  })
+})

--- a/src/__generated__/PartnerAppTestQuery.graphql.ts
+++ b/src/__generated__/PartnerAppTestQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<aadd304ca52412612caacf0718bab9ec>>
+ * @generated SignedSource<<e093f2e2e43d8d5f101d516f7958eeb7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -616,6 +616,53 @@ return {
           },
           {
             "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 30
+              },
+              {
+                "kind": "Literal",
+                "name": "sort",
+                "value": "-decayed_merch"
+              }
+            ],
+            "concreteType": "FilterArtworksConnection",
+            "kind": "LinkedField",
+            "name": "filterArtworksConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FilterArtworksEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v5/*: any*/),
+                      (v2/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v2/*: any*/)
+            ],
+            "storageKey": "filterArtworksConnection(first:30,sort:\"-decayed_merch\")"
+          },
+          {
+            "alias": null,
             "args": null,
             "concreteType": "PartnerMeta",
             "kind": "LinkedField",
@@ -813,7 +860,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "7bc81ccc5c296372622077811a4622b2",
+    "cacheID": "fe2bea692e26844836398e301d07a1e7",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -866,6 +913,27 @@ return {
         "partner.displayArtistsSection": (v16/*: any*/),
         "partner.displayFullPartnerPage": (v16/*: any*/),
         "partner.displayWorksSection": (v16/*: any*/),
+        "partner.filterArtworksConnection": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "FilterArtworksConnection"
+        },
+        "partner.filterArtworksConnection.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "FilterArtworksEdge"
+        },
+        "partner.filterArtworksConnection.edges.node": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artwork"
+        },
+        "partner.filterArtworksConnection.edges.node.href": (v13/*: any*/),
+        "partner.filterArtworksConnection.edges.node.id": (v12/*: any*/),
+        "partner.filterArtworksConnection.id": (v12/*: any*/),
         "partner.hasVisibleFollowsCount": {
           "enumValues": null,
           "nullable": false,
@@ -971,7 +1039,7 @@ return {
     },
     "name": "PartnerAppTestQuery",
     "operationKind": "query",
-    "text": "query PartnerAppTestQuery {\n  partner(id: \"example\") {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n  partnerType\n  displayArtistsSection\n  displayWorksSection\n  counts {\n    eligibleArtworks\n    displayableShows\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n  }\n  articles: articlesConnection {\n    totalCount\n  }\n  representedArtists: artistsConnection(representedBy: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  notRepresentedArtists: artistsConnection(representedBy: false, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  viewingRooms: viewingRoomsConnection(statuses: [live, closed, scheduled]) {\n    totalCount\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  internalID\n  partnerType\n  displayFullPartnerPage\n  partnerPageEligible\n  isDefaultProfilePublic\n  categories {\n    id\n    name\n  }\n  profile {\n    ...PartnerHeaderImage_profile\n    id\n  }\n  ...PartnerMeta_partner\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeaderImage_profile on Profile {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  hasVisibleFollowsCount\n  profile {\n    counts {\n      follows\n    }\n    internalID\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMetaStructuredData_partner on Partner {\n  slug\n  href\n  name\n  profile {\n    bio\n    image {\n      resized(width: 1920, height: 1920) {\n        url\n        width\n        height\n      }\n    }\n    icon {\n      cropped(width: 250, height: 250, version: [\"untouched-png\", \"large\", \"square\"]) {\n        url\n        width\n        height\n      }\n    }\n    id\n  }\n  locationsConnection(first: 50) {\n    edges {\n      node {\n        address\n        city\n        country\n        postalCode\n        state\n        openingHours {\n          __typename\n          ... on OpeningHoursArray {\n            schedules {\n              days\n              hours\n            }\n          }\n          ... on OpeningHoursText {\n            text\n          }\n        }\n        id\n      }\n    }\n  }\n  allArtistsConnection(representedBy: true) {\n    edges {\n      node {\n        name\n        href\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment PartnerMeta_partner on Partner {\n  ...PartnerMetaStructuredData_partner\n  meta {\n    image\n    title\n    description\n  }\n}\n"
+    "text": "query PartnerAppTestQuery {\n  partner(id: \"example\") {\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n  partnerType\n  displayArtistsSection\n  displayWorksSection\n  counts {\n    eligibleArtworks\n    displayableShows\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n  }\n  articles: articlesConnection {\n    totalCount\n  }\n  representedArtists: artistsConnection(representedBy: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  notRepresentedArtists: artistsConnection(representedBy: false, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  viewingRooms: viewingRoomsConnection(statuses: [live, closed, scheduled]) {\n    totalCount\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  internalID\n  partnerType\n  displayFullPartnerPage\n  partnerPageEligible\n  isDefaultProfilePublic\n  categories {\n    id\n    name\n  }\n  profile {\n    ...PartnerHeaderImage_profile\n    id\n  }\n  ...PartnerMeta_partner\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeaderImage_profile on Profile {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  hasVisibleFollowsCount\n  profile {\n    counts {\n      follows\n    }\n    internalID\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMetaStructuredData_partner on Partner {\n  slug\n  href\n  name\n  profile {\n    bio\n    image {\n      resized(width: 1920, height: 1920) {\n        url\n        width\n        height\n      }\n    }\n    icon {\n      cropped(width: 250, height: 250, version: [\"untouched-png\", \"large\", \"square\"]) {\n        url\n        width\n        height\n      }\n    }\n    id\n  }\n  locationsConnection(first: 50) {\n    edges {\n      node {\n        address\n        city\n        country\n        postalCode\n        state\n        openingHours {\n          __typename\n          ... on OpeningHoursArray {\n            schedules {\n              days\n              hours\n            }\n          }\n          ... on OpeningHoursText {\n            text\n          }\n        }\n        id\n      }\n    }\n  }\n  allArtistsConnection(representedBy: true) {\n    edges {\n      node {\n        name\n        href\n        id\n      }\n      id\n    }\n  }\n  filterArtworksConnection(first: 30, sort: \"-decayed_merch\") {\n    edges {\n      node {\n        href\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment PartnerMeta_partner on Partner {\n  ...PartnerMetaStructuredData_partner\n  meta {\n    image\n    title\n    description\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/PartnerMetaStructuredData_Test_Query.graphql.ts
+++ b/src/__generated__/PartnerMetaStructuredData_Test_Query.graphql.ts
@@ -1,0 +1,626 @@
+/**
+ * @generated SignedSource<<6dd841c22b68a12a6bfe91a09daacb53>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type PartnerMetaStructuredData_Test_Query$variables = Record<PropertyKey, never>;
+export type PartnerMetaStructuredData_Test_Query$data = {
+  readonly partner: {
+    readonly " $fragmentSpreads": FragmentRefs<"PartnerMetaStructuredData_partner">;
+  } | null | undefined;
+};
+export type PartnerMetaStructuredData_Test_Query = {
+  response: PartnerMetaStructuredData_Test_Query$data;
+  variables: PartnerMetaStructuredData_Test_Query$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "example"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v3 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "url",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "width",
+    "storageKey": null
+  },
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "height",
+    "storageKey": null
+  }
+],
+v4 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v5 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v6 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v7 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "String"
+},
+v8 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Image"
+},
+v9 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "Int"
+},
+v10 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Int"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "PartnerMetaStructuredData_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Partner",
+        "kind": "LinkedField",
+        "name": "partner",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "PartnerMetaStructuredData_partner"
+          }
+        ],
+        "storageKey": "partner(id:\"example\")"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "PartnerMetaStructuredData_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Partner",
+        "kind": "LinkedField",
+        "name": "partner",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "slug",
+            "storageKey": null
+          },
+          (v1/*: any*/),
+          (v2/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Profile",
+            "kind": "LinkedField",
+            "name": "profile",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "bio",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Image",
+                "kind": "LinkedField",
+                "name": "image",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 1920
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 1920
+                      }
+                    ],
+                    "concreteType": "ResizedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "resized",
+                    "plural": false,
+                    "selections": (v3/*: any*/),
+                    "storageKey": "resized(height:1920,width:1920)"
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Image",
+                "kind": "LinkedField",
+                "name": "icon",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 250
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "version",
+                        "value": [
+                          "untouched-png",
+                          "large",
+                          "square"
+                        ]
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 250
+                      }
+                    ],
+                    "concreteType": "CroppedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "cropped",
+                    "plural": false,
+                    "selections": (v3/*: any*/),
+                    "storageKey": "cropped(height:250,version:[\"untouched-png\",\"large\",\"square\"],width:250)"
+                  }
+                ],
+                "storageKey": null
+              },
+              (v4/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 50
+              }
+            ],
+            "concreteType": "LocationConnection",
+            "kind": "LinkedField",
+            "name": "locationsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "LocationEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Location",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "address",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "city",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "country",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "postalCode",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "state",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": null,
+                        "kind": "LinkedField",
+                        "name": "openingHours",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "__typename",
+                            "storageKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "FormattedDaySchedules",
+                                "kind": "LinkedField",
+                                "name": "schedules",
+                                "plural": true,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "days",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "hours",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "OpeningHoursArray",
+                            "abstractKey": null
+                          },
+                          {
+                            "kind": "InlineFragment",
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "text",
+                                "storageKey": null
+                              }
+                            ],
+                            "type": "OpeningHoursText",
+                            "abstractKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      (v4/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "locationsConnection(first:50)"
+          },
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "representedBy",
+                "value": true
+              }
+            ],
+            "concreteType": "ArtistPartnerConnection",
+            "kind": "LinkedField",
+            "name": "allArtistsConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ArtistPartnerEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artist",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v2/*: any*/),
+                      (v1/*: any*/),
+                      (v4/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  (v4/*: any*/)
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "allArtistsConnection(representedBy:true)"
+          },
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 30
+              },
+              {
+                "kind": "Literal",
+                "name": "sort",
+                "value": "-decayed_merch"
+              }
+            ],
+            "concreteType": "FilterArtworksConnection",
+            "kind": "LinkedField",
+            "name": "filterArtworksConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FilterArtworksEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v1/*: any*/),
+                      (v4/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v4/*: any*/)
+            ],
+            "storageKey": "filterArtworksConnection(first:30,sort:\"-decayed_merch\")"
+          },
+          (v4/*: any*/)
+        ],
+        "storageKey": "partner(id:\"example\")"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "f315ac629c8b455e8029d68a3f066016",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "partner": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Partner"
+        },
+        "partner.allArtistsConnection": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtistPartnerConnection"
+        },
+        "partner.allArtistsConnection.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "ArtistPartnerEdge"
+        },
+        "partner.allArtistsConnection.edges.id": (v5/*: any*/),
+        "partner.allArtistsConnection.edges.node": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artist"
+        },
+        "partner.allArtistsConnection.edges.node.href": (v6/*: any*/),
+        "partner.allArtistsConnection.edges.node.id": (v5/*: any*/),
+        "partner.allArtistsConnection.edges.node.name": (v6/*: any*/),
+        "partner.filterArtworksConnection": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "FilterArtworksConnection"
+        },
+        "partner.filterArtworksConnection.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "FilterArtworksEdge"
+        },
+        "partner.filterArtworksConnection.edges.node": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artwork"
+        },
+        "partner.filterArtworksConnection.edges.node.href": (v6/*: any*/),
+        "partner.filterArtworksConnection.edges.node.id": (v5/*: any*/),
+        "partner.filterArtworksConnection.id": (v5/*: any*/),
+        "partner.href": (v6/*: any*/),
+        "partner.id": (v5/*: any*/),
+        "partner.locationsConnection": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "LocationConnection"
+        },
+        "partner.locationsConnection.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "LocationEdge"
+        },
+        "partner.locationsConnection.edges.node": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Location"
+        },
+        "partner.locationsConnection.edges.node.address": (v6/*: any*/),
+        "partner.locationsConnection.edges.node.city": (v6/*: any*/),
+        "partner.locationsConnection.edges.node.country": (v6/*: any*/),
+        "partner.locationsConnection.edges.node.id": (v5/*: any*/),
+        "partner.locationsConnection.edges.node.openingHours": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "OpeningHoursUnion"
+        },
+        "partner.locationsConnection.edges.node.openingHours.__typename": (v7/*: any*/),
+        "partner.locationsConnection.edges.node.openingHours.schedules": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "FormattedDaySchedules"
+        },
+        "partner.locationsConnection.edges.node.openingHours.schedules.days": (v6/*: any*/),
+        "partner.locationsConnection.edges.node.openingHours.schedules.hours": (v6/*: any*/),
+        "partner.locationsConnection.edges.node.openingHours.text": (v6/*: any*/),
+        "partner.locationsConnection.edges.node.postalCode": (v6/*: any*/),
+        "partner.locationsConnection.edges.node.state": (v6/*: any*/),
+        "partner.name": (v6/*: any*/),
+        "partner.profile": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Profile"
+        },
+        "partner.profile.bio": (v6/*: any*/),
+        "partner.profile.icon": (v8/*: any*/),
+        "partner.profile.icon.cropped": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "CroppedImageUrl"
+        },
+        "partner.profile.icon.cropped.height": (v9/*: any*/),
+        "partner.profile.icon.cropped.url": (v7/*: any*/),
+        "partner.profile.icon.cropped.width": (v9/*: any*/),
+        "partner.profile.id": (v5/*: any*/),
+        "partner.profile.image": (v8/*: any*/),
+        "partner.profile.image.resized": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ResizedImageUrl"
+        },
+        "partner.profile.image.resized.height": (v10/*: any*/),
+        "partner.profile.image.resized.url": (v7/*: any*/),
+        "partner.profile.image.resized.width": (v10/*: any*/),
+        "partner.slug": (v5/*: any*/)
+      }
+    },
+    "name": "PartnerMetaStructuredData_Test_Query",
+    "operationKind": "query",
+    "text": "query PartnerMetaStructuredData_Test_Query {\n  partner(id: \"example\") {\n    ...PartnerMetaStructuredData_partner\n    id\n  }\n}\n\nfragment PartnerMetaStructuredData_partner on Partner {\n  slug\n  href\n  name\n  profile {\n    bio\n    image {\n      resized(width: 1920, height: 1920) {\n        url\n        width\n        height\n      }\n    }\n    icon {\n      cropped(width: 250, height: 250, version: [\"untouched-png\", \"large\", \"square\"]) {\n        url\n        width\n        height\n      }\n    }\n    id\n  }\n  locationsConnection(first: 50) {\n    edges {\n      node {\n        address\n        city\n        country\n        postalCode\n        state\n        openingHours {\n          __typename\n          ... on OpeningHoursArray {\n            schedules {\n              days\n              hours\n            }\n          }\n          ... on OpeningHoursText {\n            text\n          }\n        }\n        id\n      }\n    }\n  }\n  allArtistsConnection(representedBy: true) {\n    edges {\n      node {\n        name\n        href\n        id\n      }\n      id\n    }\n  }\n  filterArtworksConnection(first: 30, sort: \"-decayed_merch\") {\n    edges {\n      node {\n        href\n        id\n      }\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "6ba5a0a7300182d4c78bb2dfdd1e51c8";
+
+export default node;

--- a/src/__generated__/PartnerMetaStructuredData_partner.graphql.ts
+++ b/src/__generated__/PartnerMetaStructuredData_partner.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<efbc187b1c58415f0cb4ffe68b4d41c4>>
+ * @generated SignedSource<<743c84a984747556ee465b3c033d5941>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -16,6 +16,13 @@ export type PartnerMetaStructuredData_partner$data = {
       readonly node: {
         readonly href: string | null | undefined;
         readonly name: string | null | undefined;
+      } | null | undefined;
+    } | null | undefined> | null | undefined;
+  } | null | undefined;
+  readonly filterArtworksConnection: {
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly href: string | null | undefined;
       } | null | undefined;
     } | null | undefined> | null | undefined;
   } | null | undefined;
@@ -379,6 +386,51 @@ return {
         }
       ],
       "storageKey": "allArtistsConnection(representedBy:true)"
+    },
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 30
+        },
+        {
+          "kind": "Literal",
+          "name": "sort",
+          "value": "-decayed_merch"
+        }
+      ],
+      "concreteType": "FilterArtworksConnection",
+      "kind": "LinkedField",
+      "name": "filterArtworksConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "FilterArtworksEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Artwork",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                (v0/*: any*/)
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "filterArtworksConnection(first:30,sort:\"-decayed_merch\")"
     }
   ],
   "type": "Partner",
@@ -386,6 +438,6 @@ return {
 };
 })();
 
-(node as any).hash = "4f3b2455314e15667ce289696a9aeda0";
+(node as any).hash = "cfe95fed99302e96b82316784165cd2d";
 
 export default node;

--- a/src/__generated__/partnerRoutes_PartnerQuery.graphql.ts
+++ b/src/__generated__/partnerRoutes_PartnerQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<7625fb965a85ff23490d3a07f540c534>>
+ * @generated SignedSource<<e15beea89d67b7e96b02e744bcbde185>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -556,6 +556,53 @@ return {
           },
           {
             "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 30
+              },
+              {
+                "kind": "Literal",
+                "name": "sort",
+                "value": "-decayed_merch"
+              }
+            ],
+            "concreteType": "FilterArtworksConnection",
+            "kind": "LinkedField",
+            "name": "filterArtworksConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "FilterArtworksEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v9/*: any*/),
+                      (v6/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              (v6/*: any*/)
+            ],
+            "storageKey": "filterArtworksConnection(first:30,sort:\"-decayed_merch\")"
+          },
+          {
+            "alias": null,
             "args": null,
             "concreteType": "PartnerMeta",
             "kind": "LinkedField",
@@ -753,12 +800,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4f74ae7b919a7a90e1203373bb336afd",
+    "cacheID": "0459082b3b16bdb5e9aa80941a112a37",
     "id": null,
     "metadata": {},
     "name": "partnerRoutes_PartnerQuery",
     "operationKind": "query",
-    "text": "query partnerRoutes_PartnerQuery(\n  $partnerId: String!\n) @cacheable {\n  partner(id: $partnerId) @principalField {\n    slug\n    partnerType\n    displayFullPartnerPage\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n  partnerType\n  displayArtistsSection\n  displayWorksSection\n  counts {\n    eligibleArtworks\n    displayableShows\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n  }\n  articles: articlesConnection {\n    totalCount\n  }\n  representedArtists: artistsConnection(representedBy: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  notRepresentedArtists: artistsConnection(representedBy: false, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  viewingRooms: viewingRoomsConnection(statuses: [live, closed, scheduled]) {\n    totalCount\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  internalID\n  partnerType\n  displayFullPartnerPage\n  partnerPageEligible\n  isDefaultProfilePublic\n  categories {\n    id\n    name\n  }\n  profile {\n    ...PartnerHeaderImage_profile\n    id\n  }\n  ...PartnerMeta_partner\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeaderImage_profile on Profile {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  hasVisibleFollowsCount\n  profile {\n    counts {\n      follows\n    }\n    internalID\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMetaStructuredData_partner on Partner {\n  slug\n  href\n  name\n  profile {\n    bio\n    image {\n      resized(width: 1920, height: 1920) {\n        url\n        width\n        height\n      }\n    }\n    icon {\n      cropped(width: 250, height: 250, version: [\"untouched-png\", \"large\", \"square\"]) {\n        url\n        width\n        height\n      }\n    }\n    id\n  }\n  locationsConnection(first: 50) {\n    edges {\n      node {\n        address\n        city\n        country\n        postalCode\n        state\n        openingHours {\n          __typename\n          ... on OpeningHoursArray {\n            schedules {\n              days\n              hours\n            }\n          }\n          ... on OpeningHoursText {\n            text\n          }\n        }\n        id\n      }\n    }\n  }\n  allArtistsConnection(representedBy: true) {\n    edges {\n      node {\n        name\n        href\n        id\n      }\n      id\n    }\n  }\n}\n\nfragment PartnerMeta_partner on Partner {\n  ...PartnerMetaStructuredData_partner\n  meta {\n    image\n    title\n    description\n  }\n}\n"
+    "text": "query partnerRoutes_PartnerQuery(\n  $partnerId: String!\n) @cacheable {\n  partner(id: $partnerId) @principalField {\n    slug\n    partnerType\n    displayFullPartnerPage\n    ...PartnerApp_partner\n    id\n  }\n}\n\nfragment NavigationTabs_partner on Partner {\n  slug\n  partnerType\n  displayArtistsSection\n  displayWorksSection\n  counts {\n    eligibleArtworks\n    displayableShows\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n  }\n  articles: articlesConnection {\n    totalCount\n  }\n  representedArtists: artistsConnection(representedBy: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  notRepresentedArtists: artistsConnection(representedBy: false, hasPublishedArtworks: true, displayOnPartnerProfile: true) {\n    totalCount\n  }\n  viewingRooms: viewingRoomsConnection(statuses: [live, closed, scheduled]) {\n    totalCount\n  }\n}\n\nfragment PartnerApp_partner on Partner {\n  internalID\n  partnerType\n  displayFullPartnerPage\n  partnerPageEligible\n  isDefaultProfilePublic\n  categories {\n    id\n    name\n  }\n  profile {\n    ...PartnerHeaderImage_profile\n    id\n  }\n  ...PartnerMeta_partner\n  ...PartnerHeader_partner\n  ...NavigationTabs_partner\n}\n\nfragment PartnerHeaderImage_profile on Profile {\n  image {\n    url(version: \"wide\")\n  }\n}\n\nfragment PartnerHeader_partner on Partner {\n  name\n  type\n  slug\n  hasVisibleFollowsCount\n  profile {\n    counts {\n      follows\n    }\n    internalID\n    icon {\n      resized(width: 80, height: 80, version: \"square140\") {\n        src\n        srcSet\n      }\n    }\n    id\n  }\n  locations: locationsConnection(first: 20) {\n    totalCount\n    edges {\n      node {\n        city\n        id\n      }\n    }\n  }\n}\n\nfragment PartnerMetaStructuredData_partner on Partner {\n  slug\n  href\n  name\n  profile {\n    bio\n    image {\n      resized(width: 1920, height: 1920) {\n        url\n        width\n        height\n      }\n    }\n    icon {\n      cropped(width: 250, height: 250, version: [\"untouched-png\", \"large\", \"square\"]) {\n        url\n        width\n        height\n      }\n    }\n    id\n  }\n  locationsConnection(first: 50) {\n    edges {\n      node {\n        address\n        city\n        country\n        postalCode\n        state\n        openingHours {\n          __typename\n          ... on OpeningHoursArray {\n            schedules {\n              days\n              hours\n            }\n          }\n          ... on OpeningHoursText {\n            text\n          }\n        }\n        id\n      }\n    }\n  }\n  allArtistsConnection(representedBy: true) {\n    edges {\n      node {\n        name\n        href\n        id\n      }\n      id\n    }\n  }\n  filterArtworksConnection(first: 30, sort: \"-decayed_merch\") {\n    edges {\n      node {\n        href\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment PartnerMeta_partner on Partner {\n  ...PartnerMetaStructuredData_partner\n  meta {\n    image\n    title\n    description\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [DI-125](https://www.notion.so/33dcab0764a0803b8066fe65fc2bf691)

Adds a list of artworks offered by the gallery to the JSON-LD structured data, under the property `makesOffer` ([reference](https://schema.org/makesOffer))

This raises two questions:

##  Which artworks?

I chose to use a set of artworks corresponding to the first page of the partner's artwork grid, i.e. `filterArtworksConnection(first: 30, sort: "-decayed_merch")`

## Include artwork metadata by value or by reference?

I've seen conflicting info about this, but for now I am persuaded that using node references is better because that leaves less room for inconsistency.

Scenario: imagine an artwork json-ld being crawled from an artwork page one day, and then the gallery json-ld being crawled from the gallery page later — yielding potentially different values for that artwork's availability, price etc.

Better, then, to let the artwork page declare the authoritative metadata for that artwork, and have other pages refer to it.

In addition to the consistency benefit, this also results in a ~26KB savings in the page's text weight:

<img width="66%" alt="gallery full" src="https://github.com/user-attachments/assets/72995110-3aaf-45d7-a04a-5e9454067d2f" />

<img width="66%" alt="gallery ref" src="https://github.com/user-attachments/assets/2f95af93-da82-4a35-ba86-612ca0329a94" />

<img width="66%" alt="artwork" src="https://github.com/user-attachments/assets/a53cc194-d5ff-465b-9578-e9a80f60fa3d" /> 
