### PR TITLE
chore: add space between time range ends

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/utils.ts
+++ b/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/utils.ts
@@ -36,7 +36,7 @@ const dateRangeString = (args: {
 
   const endDateFormat = startDate.month !== endDate.month ? "MMM d" : "d"
 
-  return `${startDate.toFormat("MMM d")} - ${endDate.toFormat(endDateFormat)}`
+  return `${startDate.toFormat("MMM d")}–${endDate.toFormat(endDateFormat)}`
 }
 
 export const deliveryOptionTimeEstimate = (

--- a/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/utils.ts
+++ b/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/utils.ts
@@ -36,7 +36,7 @@ const dateRangeString = (args: {
 
   const endDateFormat = startDate.month !== endDate.month ? "MMM d" : "d"
 
-  return `${startDate.toFormat("MMM d")}-${endDate.toFormat(endDateFormat)}`
+  return `${startDate.toFormat("MMM d")} - ${endDate.toFormat(endDateFormat)}`
 }
 
 export const deliveryOptionTimeEstimate = (


### PR DESCRIPTION
Just some more breathing room:
<img width="479" height="261" alt="screenshot_2026-04-15_at_2 21 11___pm_480" src="https://github.com/user-attachments/assets/0aaa3cca-1773-415f-936e-001c60b176c1" />


vs previous
<img width="480" height="324" alt="screenshot_2026-04-15_at_2 15 35___pm_480" src="https://github.com/user-attachments/assets/478fb5f2-18f9-4ef9-865d-10d57e4bfb94" />


