### PR TITLE
feat(artwork): add artwork ID to Unleash context before useTrackFeatureVariantOnMount call

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkMeta.tsx
+++ b/src/Apps/Artwork/Components/ArtworkMeta.tsx
@@ -6,6 +6,9 @@ import type { ArtworkMeta_artwork$key } from "__generated__/ArtworkMeta_artwork.
 import { Link, Meta, Title } from "react-head"
 import { graphql, useFragment } from "react-relay"
 import { ArtworkChatBubbleFragmentContainer } from "./ArtworkChatBubble"
+import { useUnleashContext, useVariant } from "@unleash/proxy-client-react"
+import { useEffect, useState } from "react"
+import { useTrackFeatureVariantOnMount } from "System/Hooks/useTrackFeatureVariant"
 
 interface ArtworkMetaProps {
   artwork: ArtworkMeta_artwork$key
@@ -16,6 +19,26 @@ export const ArtworkMeta: React.FC<
 > = ({ artwork }) => {
   const { match } = useRouter()
   const data = useFragment(artworkMetaFragment, artwork)
+
+  const updateContext = useUnleashContext()
+  const variant = useVariant("diamond_artwork-title-experiment")
+  const [contextReady, setContextReady] = useState(false)
+
+  useEffect(() => {
+    /**
+     * Since the experiment is sticky per-artwork (rather than per-user or
+     * per-session) we need to add the artwork id to the Unleash context before
+     * checking or tracking the experiment flag's values.
+     */
+    updateContext({ properties: { artworkId: data.internalID } }).then(() => {
+      setContextReady(true)
+    })
+  }, [data.internalID, updateContext])
+
+  useTrackFeatureVariantOnMount({
+    experimentName: "diamond_artwork-title-experiment",
+    variantName: contextReady ? variant.name : "disabled",
+  })
 
   const pathname = match.location.pathname
   const imageURL = data.metaImage?.resized?.url

--- a/src/Apps/Artwork/Components/__tests__/ArtworkMeta.jest.tsx
+++ b/src/Apps/Artwork/Components/__tests__/ArtworkMeta.jest.tsx
@@ -1,7 +1,10 @@
+import { act } from "@testing-library/react"
+import { useUnleashContext, useVariant } from "@unleash/proxy-client-react"
 import { ArtworkMeta } from "Apps/Artwork/Components/ArtworkMeta"
 import { MockBoot } from "DevTools/MockBoot"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
 import { useRouter } from "System/Hooks/useRouter"
+import { useTrackFeatureVariantOnMount } from "System/Hooks/useTrackFeatureVariant"
 import type { ArtworkMeta_Test_Query } from "__generated__/ArtworkMeta_Test_Query.graphql"
 import { graphql } from "react-relay"
 
@@ -17,8 +20,21 @@ jest.mock("Utils/getENV", () => ({
   },
 }))
 
+jest.mock("@unleash/proxy-client-react", () => ({
+  useUnleashContext: jest.fn(),
+  useVariant: jest.fn(),
+}))
+
+jest.mock("System/Hooks/useTrackFeatureVariant", () => ({
+  useTrackFeatureVariantOnMount: jest.fn(),
+}))
+
 describe("ArtworkMeta", () => {
   const mockUseRouter = useRouter as jest.Mock
+  const mockUseUnleashContext = useUnleashContext as jest.Mock
+  const mockUseVariant = useVariant as jest.Mock
+  const mockUseTrackFeatureVariantOnMount =
+    useTrackFeatureVariantOnMount as jest.Mock
 
   const { renderWithRelay } = setupTestWrapperTL<ArtworkMeta_Test_Query>({
     Component: props => (
@@ -50,6 +66,15 @@ describe("ArtworkMeta", () => {
 
   const unlistedArtworkID =
     "https://staging.artsy.net/artwork/662658cd2bfa240016cd95fe"
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockUseRouter.mockReturnValue({
+      match: { location: { pathname: "/artwork/some-slug" } },
+    })
+    mockUseUnleashContext.mockReturnValue(jest.fn(() => Promise.resolve()))
+    mockUseVariant.mockReturnValue({ name: "disabled", enabled: false })
+  })
 
   afterEach(() => {
     document.getElementsByTagName("html")[0].innerHTML = ""
@@ -125,6 +150,53 @@ describe("ArtworkMeta", () => {
       const tags = getTags()
 
       expect(tags.meta.find(tag => tag.name === "robots")).toEqual(undefined)
+    })
+  })
+
+  describe("experiment tracking", () => {
+    it("passes the artwork internalID to the Unleash context", () => {
+      const updateContext = jest.fn(() => Promise.resolve())
+      mockUseUnleashContext.mockReturnValue(updateContext)
+
+      renderWithRelay({ Artwork: () => ({ internalID: "artwork-123" }) })
+
+      expect(updateContext).toHaveBeenCalledWith({
+        properties: { artworkId: "artwork-123" },
+      })
+    })
+
+    it("does not track before the Unleash context has been updated", () => {
+      const updateContext = jest.fn(() => new Promise<void>(() => {}))
+      mockUseUnleashContext.mockReturnValue(updateContext)
+      mockUseVariant.mockReturnValue({ name: "control", enabled: true })
+
+      renderWithRelay({ Artwork: () => ({ internalID: "artwork-123" }) })
+
+      expect(mockUseTrackFeatureVariantOnMount).toHaveBeenCalledWith(
+        expect.objectContaining({ variantName: "disabled" }),
+      )
+    })
+
+    it("tracks the correct variant after the Unleash context resolves", async () => {
+      let resolveContext!: () => void
+      const updateContext = jest.fn(() => {
+        return new Promise<void>(resolve => {
+          resolveContext = resolve
+        })
+      })
+      mockUseUnleashContext.mockReturnValue(updateContext)
+      mockUseVariant.mockReturnValue({ name: "experiment", enabled: true })
+
+      renderWithRelay({ Artwork: () => ({ internalID: "artwork-123" }) })
+
+      await act(async () => {
+        resolveContext()
+      })
+
+      expect(mockUseTrackFeatureVariantOnMount).toHaveBeenLastCalledWith({
+        experimentName: "diamond_artwork-title-experiment",
+        variantName: "experiment",
+      })
     })
   })
 })

--- a/src/Apps/Artwork/__tests__/ArtworkApp.jest.tsx
+++ b/src/Apps/Artwork/__tests__/ArtworkApp.jest.tsx
@@ -4,6 +4,8 @@ import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
 import { mockLocation } from "DevTools/mockLocation"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
 import { useRouter } from "System/Hooks/useRouter"
+import { useUnleashContext, useVariant } from "@unleash/proxy-client-react"
+import { useTrackFeatureVariantOnMount } from "System/Hooks/useTrackFeatureVariant"
 import type { ArtworkAppTestQuery } from "__generated__/ArtworkAppTestQuery.graphql"
 import { graphql } from "react-relay"
 import {
@@ -29,6 +31,13 @@ jest.mock("Components/AuthDialog", () => {
     },
   }
 })
+jest.mock("@unleash/proxy-client-react", () => ({
+  useUnleashContext: jest.fn(),
+  useVariant: jest.fn(),
+}))
+jest.mock("System/Hooks/useTrackFeatureVariant", () => ({
+  useTrackFeatureVariantOnMount: jest.fn(),
+}))
 
 const { renderWithRelay } = setupTestWrapperTL<ArtworkAppTestQuery>({
   Component: props => {
@@ -73,6 +82,10 @@ const defaultMockResolvers = {
 }
 
 const useRouterMock = useRouter as jest.Mock
+const mockUseUnleashContext = useUnleashContext as jest.Mock
+const mockUseVariant = useVariant as jest.Mock
+const mockUseTrackFeatureVariantOnMount =
+  useTrackFeatureVariantOnMount as jest.Mock
 let routerMock: any
 
 beforeEach(() => {
@@ -91,6 +104,9 @@ beforeEach(() => {
     },
   }
   useRouterMock.mockReturnValue(routerMock)
+  mockUseUnleashContext.mockReturnValue(jest.fn(() => Promise.resolve()))
+  mockUseVariant.mockReturnValue({ name: "disabled", enabled: false })
+  mockUseTrackFeatureVariantOnMount.mockReturnValue(undefined)
 })
 
 describe("ArtworkApp", () => {


### PR DESCRIPTION
This PR partially resolves [DI-222](https://www.notion.so/345cab0764a0805db596eb171854860b).

It solves a problem where Force could not accurately report which variant of a `<title>` tag was being displayed to users when they opened an artwork page in our experiment.

---

When running experiments on different groups of artworks (as opposed to groups of users) Force needs to add an artwork's ID into the Unleash context before asking for its variant. Force then calls `useTrackFeatureVariantOnMount` to report which variant the user saw to our analytics backend.

However, updates to the Unleash context are made asynchronously with Promises, so we were not able to get an artwork's variant back in time before `useTrackFeatureVariantOnMount` was fired. As a result, we were reporting the wrong variant to the analytics backend.

 ---

We solved this by passing "disabled" as the variant name to the `useTrackFeatureVariantOnMount` call, which causes these events to be ignored. Once the Promise from the Unleash context reports that it was successfully updated with the artwork ID, we use a state hook to switch the "disabled" variant name to the correct one.