### PR TITLE
fix: failing artwork page playwright test

### DIFF
--- a/playwright/e2e/artwork.spec.ts
+++ b/playwright/e2e/artwork.spec.ts
@@ -5,7 +5,7 @@ test.describe("/artwork/:id", () => {
     await page.goto("/artwork/pablo-picasso-guernica")
 
     await expect(page).toHaveTitle(
-      /Pablo Picasso \| Guernica \(1937\) \| Artsy/,
+      /Pablo Picasso \| Guernica \| Art & Prints \| Artsy/,
     )
 
     const metaDescription = page.locator('meta[name="description"]')


### PR DESCRIPTION
This PR fixes a Playwright test that failed in CI after #17107 was merged.

The page title for the artwork used in this test is not part of the control group in our "artwork page title tag" experiment, so it is displaying one of the variants and causing the test to fail.

This is the most straightforward solution that will unblock the CI pipeline for Force, but it is not ideal because the test will fail again when we dismantle the experiment.

Alternatively I can use a regex that covers all variants + control to prevent that from happening, but I will definitely forget to remove that regex when we dismantle the experiment, which will leave a strange and unnecessary regex in our tests.