### PR TITLE
chore: revert commit 17107

### DIFF
--- a/playwright/e2e/artwork.spec.ts
+++ b/playwright/e2e/artwork.spec.ts
@@ -5,7 +5,7 @@ test.describe("/artwork/:id", () => {
     await page.goto("/artwork/pablo-picasso-guernica")
 
     await expect(page).toHaveTitle(
-      /Pablo Picasso \| Guernica \(1937\) \| Artsy/,
+      /Pablo Picasso \| Guernica \| Art & Prints \| Artsy/,
     )
 
     const metaDescription = page.locator('meta[name="description"]')

--- a/playwright/e2e/artwork.spec.ts
+++ b/playwright/e2e/artwork.spec.ts
@@ -5,7 +5,7 @@ test.describe("/artwork/:id", () => {
     await page.goto("/artwork/pablo-picasso-guernica")
 
     await expect(page).toHaveTitle(
-      /Pablo Picasso \| Guernica \| Art & Prints \| Artsy/,
+      /Pablo Picasso \| Guernica \(1937\) \| Artsy/,
     )
 
     const metaDescription = page.locator('meta[name="description"]')

--- a/src/Apps/Artwork/Components/ArtworkMeta.tsx
+++ b/src/Apps/Artwork/Components/ArtworkMeta.tsx
@@ -6,9 +6,6 @@ import type { ArtworkMeta_artwork$key } from "__generated__/ArtworkMeta_artwork.
 import { Link, Meta, Title } from "react-head"
 import { graphql, useFragment } from "react-relay"
 import { ArtworkChatBubbleFragmentContainer } from "./ArtworkChatBubble"
-import { useUnleashContext, useVariant } from "@unleash/proxy-client-react"
-import { useEffect, useState } from "react"
-import { useTrackFeatureVariantOnMount } from "System/Hooks/useTrackFeatureVariant"
 
 interface ArtworkMetaProps {
   artwork: ArtworkMeta_artwork$key
@@ -19,26 +16,6 @@ export const ArtworkMeta: React.FC<
 > = ({ artwork }) => {
   const { match } = useRouter()
   const data = useFragment(artworkMetaFragment, artwork)
-
-  const updateContext = useUnleashContext()
-  const variant = useVariant("diamond_artwork-title-experiment")
-  const [contextReady, setContextReady] = useState(false)
-
-  useEffect(() => {
-    /**
-     * Since the experiment is sticky per-artwork (rather than per-user or
-     * per-session) we need to add the artwork id to the Unleash context before
-     * checking or tracking the experiment flag's values.
-     */
-    updateContext({ properties: { artworkId: data.internalID } }).then(() => {
-      setContextReady(true)
-    })
-  }, [data.internalID, updateContext])
-
-  useTrackFeatureVariantOnMount({
-    experimentName: "diamond_artwork-title-experiment",
-    variantName: contextReady ? variant.name : "disabled",
-  })
 
   const pathname = match.location.pathname
   const imageURL = data.metaImage?.resized?.url

--- a/src/Apps/Artwork/Components/__tests__/ArtworkMeta.jest.tsx
+++ b/src/Apps/Artwork/Components/__tests__/ArtworkMeta.jest.tsx
@@ -1,10 +1,7 @@
-import { act } from "@testing-library/react"
-import { useUnleashContext, useVariant } from "@unleash/proxy-client-react"
 import { ArtworkMeta } from "Apps/Artwork/Components/ArtworkMeta"
 import { MockBoot } from "DevTools/MockBoot"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
 import { useRouter } from "System/Hooks/useRouter"
-import { useTrackFeatureVariantOnMount } from "System/Hooks/useTrackFeatureVariant"
 import type { ArtworkMeta_Test_Query } from "__generated__/ArtworkMeta_Test_Query.graphql"
 import { graphql } from "react-relay"
 
@@ -20,21 +17,8 @@ jest.mock("Utils/getENV", () => ({
   },
 }))
 
-jest.mock("@unleash/proxy-client-react", () => ({
-  useUnleashContext: jest.fn(),
-  useVariant: jest.fn(),
-}))
-
-jest.mock("System/Hooks/useTrackFeatureVariant", () => ({
-  useTrackFeatureVariantOnMount: jest.fn(),
-}))
-
 describe("ArtworkMeta", () => {
   const mockUseRouter = useRouter as jest.Mock
-  const mockUseUnleashContext = useUnleashContext as jest.Mock
-  const mockUseVariant = useVariant as jest.Mock
-  const mockUseTrackFeatureVariantOnMount =
-    useTrackFeatureVariantOnMount as jest.Mock
 
   const { renderWithRelay } = setupTestWrapperTL<ArtworkMeta_Test_Query>({
     Component: props => (
@@ -66,15 +50,6 @@ describe("ArtworkMeta", () => {
 
   const unlistedArtworkID =
     "https://staging.artsy.net/artwork/662658cd2bfa240016cd95fe"
-
-  beforeEach(() => {
-    jest.clearAllMocks()
-    mockUseRouter.mockReturnValue({
-      match: { location: { pathname: "/artwork/some-slug" } },
-    })
-    mockUseUnleashContext.mockReturnValue(jest.fn(() => Promise.resolve()))
-    mockUseVariant.mockReturnValue({ name: "disabled", enabled: false })
-  })
 
   afterEach(() => {
     document.getElementsByTagName("html")[0].innerHTML = ""
@@ -150,53 +125,6 @@ describe("ArtworkMeta", () => {
       const tags = getTags()
 
       expect(tags.meta.find(tag => tag.name === "robots")).toEqual(undefined)
-    })
-  })
-
-  describe("experiment tracking", () => {
-    it("passes the artwork internalID to the Unleash context", () => {
-      const updateContext = jest.fn(() => Promise.resolve())
-      mockUseUnleashContext.mockReturnValue(updateContext)
-
-      renderWithRelay({ Artwork: () => ({ internalID: "artwork-123" }) })
-
-      expect(updateContext).toHaveBeenCalledWith({
-        properties: { artworkId: "artwork-123" },
-      })
-    })
-
-    it("does not track before the Unleash context has been updated", () => {
-      const updateContext = jest.fn(() => new Promise<void>(() => {}))
-      mockUseUnleashContext.mockReturnValue(updateContext)
-      mockUseVariant.mockReturnValue({ name: "control", enabled: true })
-
-      renderWithRelay({ Artwork: () => ({ internalID: "artwork-123" }) })
-
-      expect(mockUseTrackFeatureVariantOnMount).toHaveBeenCalledWith(
-        expect.objectContaining({ variantName: "disabled" }),
-      )
-    })
-
-    it("tracks the correct variant after the Unleash context resolves", async () => {
-      let resolveContext!: () => void
-      const updateContext = jest.fn(() => {
-        return new Promise<void>(resolve => {
-          resolveContext = resolve
-        })
-      })
-      mockUseUnleashContext.mockReturnValue(updateContext)
-      mockUseVariant.mockReturnValue({ name: "experiment", enabled: true })
-
-      renderWithRelay({ Artwork: () => ({ internalID: "artwork-123" }) })
-
-      await act(async () => {
-        resolveContext()
-      })
-
-      expect(mockUseTrackFeatureVariantOnMount).toHaveBeenLastCalledWith({
-        experimentName: "diamond_artwork-title-experiment",
-        variantName: "experiment",
-      })
     })
   })
 })

--- a/src/Apps/Artwork/__tests__/ArtworkApp.jest.tsx
+++ b/src/Apps/Artwork/__tests__/ArtworkApp.jest.tsx
@@ -4,8 +4,6 @@ import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
 import { mockLocation } from "DevTools/mockLocation"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
 import { useRouter } from "System/Hooks/useRouter"
-import { useUnleashContext, useVariant } from "@unleash/proxy-client-react"
-import { useTrackFeatureVariantOnMount } from "System/Hooks/useTrackFeatureVariant"
 import type { ArtworkAppTestQuery } from "__generated__/ArtworkAppTestQuery.graphql"
 import { graphql } from "react-relay"
 import {
@@ -31,13 +29,6 @@ jest.mock("Components/AuthDialog", () => {
     },
   }
 })
-jest.mock("@unleash/proxy-client-react", () => ({
-  useUnleashContext: jest.fn(),
-  useVariant: jest.fn(),
-}))
-jest.mock("System/Hooks/useTrackFeatureVariant", () => ({
-  useTrackFeatureVariantOnMount: jest.fn(),
-}))
 
 const { renderWithRelay } = setupTestWrapperTL<ArtworkAppTestQuery>({
   Component: props => {
@@ -82,10 +73,6 @@ const defaultMockResolvers = {
 }
 
 const useRouterMock = useRouter as jest.Mock
-const mockUseUnleashContext = useUnleashContext as jest.Mock
-const mockUseVariant = useVariant as jest.Mock
-const mockUseTrackFeatureVariantOnMount =
-  useTrackFeatureVariantOnMount as jest.Mock
 let routerMock: any
 
 beforeEach(() => {
@@ -104,9 +91,6 @@ beforeEach(() => {
     },
   }
   useRouterMock.mockReturnValue(routerMock)
-  mockUseUnleashContext.mockReturnValue(jest.fn(() => Promise.resolve()))
-  mockUseVariant.mockReturnValue({ name: "disabled", enabled: false })
-  mockUseTrackFeatureVariantOnMount.mockReturnValue(undefined)
 })
 
 describe("ArtworkApp", () => {


### PR DESCRIPTION
This PR reverts the changes made in #17107 because we no longer need this tracking for our experiment.

Instead of running an experiment with variants A, B and a control simultaneously, we will be changing all artworks to variant A, followed by variant B sequentially. Therefore, we do not need to report which variant users are viewing (since they will all be viewing the same one).