### PR TITLE
fix: removes critical path request for webfonts css

### DIFF
--- a/src/System/Router/renderServerApp.tsx
+++ b/src/System/Router/renderServerApp.tsx
@@ -9,6 +9,7 @@ import type { RenderToStreamResult } from "System/Router/Utils/renderToStream"
 import type { ServerAppResults } from "System/Router/serverRouter"
 import { getENV } from "Utils/getENV"
 import { getServerParam } from "Utils/getServerParam"
+import { getFontLinkHeaders } from "fonts"
 import { type HTMLProps, buildHtmlTemplate } from "html"
 import { renderToString } from "react-dom/server"
 
@@ -119,10 +120,7 @@ const setLinkHeaders = (linkHeaders: string[], res: ArtsyResponse) => {
       `<${CDN_URL}>; rel=preconnect; crossorigin`,
       `<${GEMINI_CLOUDFRONT_URL}>; rel=preconnect;`,
       `<${WEBFONT_URL}>; rel=preconnect; crossorigin`,
-      `<${WEBFONT_URL}/all-webfonts.css>; rel=preload; as=style`,
-      `<${WEBFONT_URL}/ll-unica77_regular.woff2>; rel=preload; as=font; crossorigin`,
-      `<${WEBFONT_URL}/ll-unica77_medium.woff2>; rel=preload; as=font; crossorigin`,
-      `<${WEBFONT_URL}/ll-unica77_italic.woff2>; rel=preload; as=font; crossorigin`,
+      ...getFontLinkHeaders(WEBFONT_URL as string),
       ...linkHeaders,
     ])
   }

--- a/src/fonts.ts
+++ b/src/fonts.ts
@@ -1,0 +1,50 @@
+// Shared font configuration consumed by both `html.ts` (rendered into the
+// document <head>) and `renderServerApp.tsx` (emitted as Link HTTP headers
+// for early hints / preload).
+
+const FONT_FACE_CSS = (fontUrl: string) => `
+  @font-face {
+    font-family: "ll-unica77";
+    src: url("${fontUrl}/ll-unica77_regular.woff2") format("woff2"),
+         url("${fontUrl}/ll-unica77_regular.woff")  format("woff");
+    font-weight: normal; font-style: normal; font-display: fallback;
+  }
+  @font-face {
+    font-family: "ll-unica77";
+    src: url("${fontUrl}/ll-unica77_italic.woff2") format("woff2"),
+         url("${fontUrl}/ll-unica77_italic.woff")  format("woff");
+    font-weight: normal; font-style: italic; font-display: fallback;
+  }
+  @font-face {
+    font-family: "ll-unica77";
+    src: url("${fontUrl}/ll-unica77_medium.woff2") format("woff2"),
+         url("${fontUrl}/ll-unica77_medium.woff")  format("woff");
+    font-weight: bold; font-style: normal; font-display: fallback;
+  }
+  @font-face {
+    font-family: "ll-unica77";
+    src: url("${fontUrl}/ll-unica77_medium-italic.woff2") format("woff2"),
+         url("${fontUrl}/ll-unica77_medium-italic.woff")  format("woff");
+    font-weight: bold; font-style: italic; font-display: fallback;
+  }
+`
+
+/**
+ * Returns the markup to be rendered into the document <head>: preload hints
+ * for the most common font weights plus inlined @font-face declarations.
+ */
+export const getFontTags = (fontUrl: string) => `
+  <link rel="preload" href="${fontUrl}/ll-unica77_regular.woff2" as="font" type="font/woff2" crossorigin />
+  <link rel="preload" href="${fontUrl}/ll-unica77_medium.woff2" as="font" type="font/woff2" crossorigin />
+  <link rel="preload" href="${fontUrl}/ll-unica77_italic.woff2" as="font" type="font/woff2" crossorigin />
+  <style>${FONT_FACE_CSS(fontUrl)}</style>
+`
+
+/**
+ * Returns the corresponding `Link` HTTP header entries for early hints.
+ */
+export const getFontLinkHeaders = (fontUrl: string) => [
+  `<${fontUrl}/ll-unica77_regular.woff2>; rel=preload; as=font; crossorigin`,
+  `<${fontUrl}/ll-unica77_italic.woff2>; rel=preload; as=font; crossorigin`,
+  `<${fontUrl}/ll-unica77_medium.woff2>; rel=preload; as=font; crossorigin`,
+]

--- a/src/html.ts
+++ b/src/html.ts
@@ -1,3 +1,5 @@
+import { getFontTags } from "fonts"
+
 export interface HTMLProps {
   cdnUrl: string
   content: {
@@ -51,12 +53,9 @@ export function buildHtmlTemplate({
       <link rel="preconnect" href="${cdnUrl}" crossorigin />
       <link rel="preconnect" href="${imageCdnUrl}" />
 
-      <!-- Create preload tags for most common fonts -->
+      <!-- Webfonts: preload hints + inlined @font-face declarations -->
       <link rel="preconnect" href="${fontUrl}" crossorigin />
-      <link rel="preload" href="${fontUrl}/all-webfonts.css" as="style" />
-      <link rel="preload" href="${fontUrl}/ll-unica77_regular.woff2" as="font" type="font/woff2" crossorigin />
-      <link rel="preload" href="${fontUrl}/ll-unica77_medium.woff2" as="font" type="font/woff2" crossorigin />
-      <link rel="preload" href="${fontUrl}/ll-unica77_italic.woff2" as="font" type="font/woff2" crossorigin />
+      ${getFontTags(fontUrl)}
       <link rel="icon" type="image/png" href="${icons.favicon}" sizes="any" />
       <link rel="icon" type="image/svg+xml" href="${icons.faviconSVG}" />
       <link rel="apple-touch-icon" href="${icons.appleTouchIcon}">
@@ -72,8 +71,6 @@ export function buildHtmlTemplate({
       <meta property="fb:admins" content="7961740" />
       <meta property="fb:app_id" content="308278682573501" />
       <meta property="fb:pages" content="342443413406" />
-
-      <link type="text/css" rel="stylesheet" href="${fontUrl}/all-webfonts.css" />
 
       <script>window.__artsyInitialReferrer = document.referrer</script>
 


### PR DESCRIPTION
The goal here is just to remove this critical path CSS and speed up font discovery.

<img width="462" height="338" alt="image" src="https://github.com/user-attachments/assets/82af1014-c6aa-4110-a71c-db341e6b64fd" />

-----

cc @artsy/diamond-devs 