### PR TITLE
fix: another failing playwright artwork spec

### DIFF
--- a/playwright/e2e/artwork.spec.ts
+++ b/playwright/e2e/artwork.spec.ts
@@ -5,7 +5,7 @@ test.describe("/artwork/:id", () => {
     await page.goto("/artwork/pablo-picasso-guernica")
 
     await expect(page).toHaveTitle(
-      /Pablo Picasso \| Guernica \| Art & Prints \| Artsy/,
+      /Pablo Picasso \| Guernica \(1937\) \| Art & Prints \| Artsy/,
     )
 
     const metaDescription = page.locator('meta[name="description"]')


### PR DESCRIPTION
This PR fixes a test that started failing after we launched an A/B test related to artwork title tags. We will have to do the same thing when the A/B test concludes.