### PR TITLE
chore(EMI-3208): streamlined checkout tracking updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "sha.js": "^2.4.12"
   },
   "dependencies": {
-    "@artsy/cohesion": "4.352.0",
+    "@artsy/cohesion": "4.353.0",
     "@artsy/detect-responsive-traits": "^0.2.0",
     "@artsy/dismissible": "^0.8.0",
     "@artsy/express-reloadable": "^1.7.0",

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
@@ -388,7 +388,7 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
                   loading={isSubmitting}
                   disabled={!!status?.errorBanner}
                   onClick={() => {
-                    // submission handled by Formik `onSubmit` handler
+                    // tracked separately from onSubmit — fires on click regardless of validation
                     checkoutTracking.clickedOrderProgression(
                       ContextModule.ordersFulfillment,
                     )

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
@@ -211,9 +211,6 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
       try {
         setIsFulfillmentDetailsSaving(true)
         setCheckoutMode("standard")
-        checkoutTracking.clickedOrderProgression(
-          ContextModule.ordersFulfillment,
-        )
 
         // Unset the current fulfillment option if it exists
         if (orderData.selectedFulfillmentOption?.type) {
@@ -318,7 +315,6 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
       }
     },
     [
-      checkoutTracking,
       hasSavedAddresses,
       orderData.internalID,
       orderData.selectedFulfillmentOption?.type,
@@ -391,6 +387,12 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
                   type="submit"
                   loading={isSubmitting}
                   disabled={!!status?.errorBanner}
+                  onClick={() => {
+                    // submission handled by Formik `onSubmit` handler
+                    checkoutTracking.clickedOrderProgression(
+                      ContextModule.ordersFulfillment,
+                    )
+                  }}
                   width="100%"
                 >
                   Save and Continue

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/AddAddressForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/AddAddressForm.tsx
@@ -1,3 +1,4 @@
+import { ContextModule } from "@artsy/cohesion"
 import { Button, Spacer } from "@artsy/palette"
 import { SectionHeading } from "Apps/Order2/Components/SectionHeading"
 import { deliveryAddressValidationSchema } from "Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/utils"
@@ -28,7 +29,7 @@ export const AddAddressForm = ({
 }: AddAddressFormProps) => {
   const createUserAddress = useOrder2CreateUserAddressMutation()
   const updateUserDefaultAddress = useOrder2UpdateUserDefaultAddressMutation()
-  const { setUserAddressMode } = useCheckoutContext()
+  const { setUserAddressMode, checkoutTracking } = useCheckoutContext()
 
   const handleSetAsDefault = async (addressID: string) => {
     await updateUserDefaultAddress.submitMutation({
@@ -102,7 +103,17 @@ export const AddAddressForm = ({
 
             <Spacer y={4} />
 
-            <Button width="100%" type="submit" loading={isSubmitting}>
+            <Button
+              width="100%"
+              type="submit"
+              onClick={() => {
+                // submission handled by Formik `onSubmit` handler
+                checkoutTracking.clickedOrderProgression(
+                  ContextModule.ordersFulfillment,
+                )
+              }}
+              loading={isSubmitting}
+            >
               Save Address
             </Button>
 

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/AddAddressForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/AddAddressForm.tsx
@@ -107,7 +107,7 @@ export const AddAddressForm = ({
               width="100%"
               type="submit"
               onClick={() => {
-                // submission handled by Formik `onSubmit` handler
+                // tracked separately from onSubmit — fires on click regardless of validation
                 checkoutTracking.clickedOrderProgression(
                   ContextModule.ordersFulfillment,
                 )

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/Order2SavedAddressOptions.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/Order2SavedAddressOptions.tsx
@@ -24,7 +24,7 @@ import { useCheckoutContext } from "Apps/Order2/Routes/Checkout/Hooks/useCheckou
 import { useScrollToStep } from "Apps/Order2/Routes/Checkout/Hooks/useScrollToStep"
 import type { FormikContextWithAddress } from "Components/Address/AddressFormFields"
 import type { Order2CheckoutContext_order$data } from "__generated__/Order2CheckoutContext_order.graphql"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 
 const ADDRESS_ERROR_MESSAGES = {
   unableToShipToAddress: {
@@ -75,19 +75,22 @@ export const SavedAddressOptions = ({
   )
 
   // Track when saved addresses are viewed (only once when step is active)
-  // TODO: fires too many times
+  const hasTrackedAddressViewRef = useRef(false)
+
   useEffect(() => {
-    if (
-      !checkoutTracking ||
-      fulfillmentDetailsStep?.state !== CheckoutStepState.ACTIVE ||
-      !!userAddressMode
-    ) {
+    if (fulfillmentDetailsStep?.state !== CheckoutStepState.ACTIVE) {
+      hasTrackedAddressViewRef.current = false
+      return
+    }
+
+    if (!checkoutTracking || !!userAddressMode || hasTrackedAddressViewRef.current) {
       return
     }
 
     if (savedAddresses.length > 0) {
       const addressIds = savedAddresses.map(address => address.internalID)
       checkoutTracking.savedAddressViewed(addressIds)
+      hasTrackedAddressViewRef.current = true
     }
   }, [
     savedAddresses,

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/Order2SavedAddressOptions.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/Order2SavedAddressOptions.tsx
@@ -75,6 +75,7 @@ export const SavedAddressOptions = ({
   )
 
   // Track when saved addresses are viewed (only once when step is active)
+  // TODO: fires too many times
   useEffect(() => {
     if (
       !checkoutTracking ||

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/Order2SavedAddressOptions.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/Order2SavedAddressOptions.tsx
@@ -83,13 +83,16 @@ export const SavedAddressOptions = ({
       return
     }
 
-    if (!checkoutTracking || !!userAddressMode || hasTrackedAddressViewRef.current) {
+    if (
+      !checkoutTracking ||
+      !!userAddressMode ||
+      hasTrackedAddressViewRef.current
+    ) {
       return
     }
 
     if (savedAddresses.length > 0) {
-      const addressIds = savedAddresses.map(address => address.internalID)
-      checkoutTracking.savedAddressViewed(addressIds)
+      checkoutTracking.savedAddressViewed(savedAddresses)
       hasTrackedAddressViewRef.current = true
     }
   }, [

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/UpdateAddressForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/UpdateAddressForm.tsx
@@ -1,3 +1,4 @@
+import { ContextModule } from "@artsy/cohesion"
 import {
   Button,
   Clickable,
@@ -65,7 +66,8 @@ export const UpdateAddressForm = ({
   const deleteUserAddress = useOrder2DeleteUserAddressMutation()
   const unsetOrderFulfillmentOption =
     useOrder2UnsetOrderFulfillmentOptionMutation()
-  const { setUserAddressMode, orderData } = useCheckoutContext()
+  const { setUserAddressMode, orderData, checkoutTracking } =
+    useCheckoutContext()
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   const [deleteError, setDeleteError] = useState<{
@@ -217,7 +219,17 @@ export const UpdateAddressForm = ({
 
             <Spacer y={4} />
 
-            <Button width="100%" type="submit" loading={isSubmitting}>
+            <Button
+              width="100%"
+              type="submit"
+              onClick={() => {
+                // submission handled by Formik `onSubmit` handler
+                checkoutTracking.clickedOrderProgression(
+                  ContextModule.ordersFulfillment,
+                )
+              }}
+              loading={isSubmitting}
+            >
               Save Address
             </Button>
 

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/UpdateAddressForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/UpdateAddressForm.tsx
@@ -223,7 +223,7 @@ export const UpdateAddressForm = ({
               width="100%"
               type="submit"
               onClick={() => {
-                // submission handled by Formik `onSubmit` handler
+                // tracked separately from onSubmit — fires on click regardless of validation
                 checkoutTracking.clickedOrderProgression(
                   ContextModule.ordersFulfillment,
                 )

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/AddAddressForm.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/AddAddressForm.jest.tsx
@@ -66,6 +66,9 @@ describe("AddAddressForm", () => {
 
     mockUseCheckoutContext.mockReturnValue({
       setUserAddressMode: mockSetUserAddressMode,
+      checkoutTracking: {
+        clickedOrderProgression: jest.fn(),
+      },
     } as any)
   })
 

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/Order2SavedAddressOptions.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/Order2SavedAddressOptions.jest.tsx
@@ -846,8 +846,8 @@ describe("SavedAddressOptions", () => {
       await waitFor(() => {
         expect(mockSavedAddressViewed).toHaveBeenCalledTimes(1)
         expect(mockSavedAddressViewed).toHaveBeenCalledWith([
-          "address-id-123",
-          "address-id-456",
+          mockUSAddress1,
+          mockUSAddress2,
         ])
       })
     })

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/UpdateAddressForm.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/UpdateAddressForm.jest.tsx
@@ -120,6 +120,9 @@ describe("UpdateAddressForm", () => {
     mockUseCheckoutContext.mockReturnValue({
       setUserAddressMode: mockSetUserAddressMode,
       orderData: { internalID: "order-id-123" },
+      checkoutTracking: {
+        clickedOrderProgression: jest.fn(),
+      },
     } as any)
   })
 

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/__tests__/Order2DeliveryForm.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/__tests__/Order2DeliveryForm.jest.tsx
@@ -375,10 +375,10 @@ describe("Order2DeliveryForm", () => {
         // Try to submit without filling required fields
         await userEvent.click(screen.getByText("Save and Continue"))
 
-        // Should not trigger tracking because form validation should prevent submission
+        // Tracking fires on click regardless of validation; but the form does not complete
         expect(
           mockCheckoutContext.checkoutTracking.clickedOrderProgression,
-        ).not.toHaveBeenCalled()
+        ).toHaveBeenCalledWith("ordersFulfillment")
         expect(mockCheckoutContext.completeStep).not.toHaveBeenCalled()
       })
 

--- a/src/Apps/Order2/Routes/Checkout/Components/OfferStep/Order2OfferStep.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/OfferStep/Order2OfferStep.tsx
@@ -69,13 +69,8 @@ interface Order2OfferStepFormContentProps {
 
 export const Order2OfferStep: React.FC<Order2OfferStepProps> = ({ order }) => {
   const orderData = useFragment(FRAGMENT, order)
-  const {
-    steps,
-    completeStep,
-    checkoutTracking,
-    messages,
-    setSectionErrorMessage,
-  } = useCheckoutContext()
+  const { steps, completeStep, messages, setSectionErrorMessage } =
+    useCheckoutContext()
 
   const offerAmountError = messages[CheckoutStepName.OFFER_AMOUNT]?.error
 
@@ -119,8 +114,6 @@ export const Order2OfferStep: React.FC<Order2OfferStepProps> = ({ order }) => {
 
     try {
       setIsSubmittingOffer(true)
-
-      checkoutTracking.clickedOrderProgression(ContextModule.ordersOffer)
 
       // Unset the current fulfillment option if it exists
       if (orderData.selectedFulfillmentOption?.type) {
@@ -246,6 +239,9 @@ const Order2OfferStepFormContent: React.FC<Order2OfferStepFormContentProps> = ({
   }
 
   const onContinueButtonPressed = async () => {
+    // tracked separately from onSubmit — fires on click regardless of validation
+    checkoutTracking.clickedOrderProgression(ContextModule.ordersOffer)
+
     if (values.offerValue === undefined || values.offerValue === 0) {
       setFieldValue("offerValue", values.offerValue, true)
       setSectionErrorMessage({

--- a/src/Apps/Order2/Routes/Checkout/Components/Order2ReviewStep.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2ReviewStep.tsx
@@ -134,8 +134,6 @@ export const Order2ReviewStep: React.FC<Order2ReviewStepProps> = ({
   }
 
   const handleSubmit = async (confirmedSetupIntentId?: any) => {
-    checkoutTracking.clickedOrderProgression(ContextModule.ordersReview)
-
     if (!stripe) return
 
     setLoading(true)
@@ -299,7 +297,13 @@ export const Order2ReviewStep: React.FC<Order2ReviewStepProps> = ({
           <Button
             variant="primaryBlack"
             width="100%"
-            onClick={() => handleSubmit()}
+            onClick={() => {
+              // tracked separately from handleSubmit — fires on click regardless of outcome
+              checkoutTracking.clickedOrderProgression(
+                ContextModule.ordersReview,
+              )
+              handleSubmit()
+            }}
             loading={loading}
           >
             Submit

--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
@@ -552,8 +552,6 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({
       return
     }
 
-    checkoutTracking.clickedOrderProgression(ContextModule.ordersPayment)
-
     if (isSelectedPaymentMethodStripe) {
       setIsSubmittingToStripe(true)
 
@@ -823,6 +821,10 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({
         variant="primaryBlack"
         width="100%"
         type="submit"
+        onClick={() => {
+          // tracked separately from onSubmit — fires on click regardless of validation
+          checkoutTracking.clickedOrderProgression(ContextModule.ordersPayment)
+        }}
       >
         Continue to Review
       </Button>

--- a/src/Apps/Order2/Routes/Checkout/Hooks/__tests__/useCheckoutTracking.jest.ts
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/__tests__/useCheckoutTracking.jest.ts
@@ -1,4 +1,5 @@
 import { act, renderHook } from "@testing-library/react-hooks"
+import type { ProcessedUserAddress } from "Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/utils"
 import { useTracking } from "react-tracking"
 import { useCheckoutTracking } from "../useCheckoutTracking"
 jest.mock("react-tracking")
@@ -145,6 +146,73 @@ describe("useCheckoutTracking", () => {
       })
     })
   })
+  describe("savedAddressViewed", () => {
+    const makeAddress = (
+      id: string,
+      country: string,
+      isDefault: boolean,
+    ): ProcessedUserAddress => ({
+      internalID: id,
+      isDefault,
+      isShippable: true,
+      isValid: true,
+      address: {
+        name: "Test User",
+        addressLine1: "123 Main St",
+        addressLine2: "",
+        city: "New York",
+        region: "NY",
+        postalCode: "10001",
+        country,
+      },
+      phoneNumber: "",
+    })
+
+    it("extracts address IDs and default address info from ProcessedUserAddress[]", () => {
+      const { result } = renderHook(() =>
+        useCheckoutTracking({ source: "artwork", mode: "BUY" }),
+      )
+
+      const addresses = [
+        makeAddress("addr-1", "US", false),
+        makeAddress("addr-2", "DE", true),
+      ]
+
+      act(() => {
+        result.current.savedAddressViewed(addresses)
+      })
+
+      assertTracked({
+        action: "savedAddressViewed",
+        address_ids: ["addr-1", "addr-2"],
+        default_address_id: "addr-2",
+        default_address_country: "DE",
+      })
+    })
+
+    it("falls back to the first address when none is marked as default", () => {
+      const { result } = renderHook(() =>
+        useCheckoutTracking({ source: "artwork", mode: "BUY" }),
+      )
+
+      const addresses = [
+        makeAddress("addr-1", "US", false),
+        makeAddress("addr-2", "DE", false),
+      ]
+
+      act(() => {
+        result.current.savedAddressViewed(addresses)
+      })
+
+      assertTracked({
+        action: "savedAddressViewed",
+        address_ids: ["addr-1", "addr-2"],
+        default_address_id: "addr-1",
+        default_address_country: "US",
+      })
+    })
+  })
+
   describe("submittedOrder", () => {
     it("tracks submitted order event with optional wallet type", () => {
       const { result } = renderHook(() =>

--- a/src/Apps/Order2/Routes/Checkout/Hooks/useCheckoutTracking.ts
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/useCheckoutTracking.ts
@@ -27,6 +27,7 @@ import {
   type ToggledCollapsibleOrderSummary,
 } from "@artsy/cohesion"
 import { useOrder2Tracking } from "Apps/Order2/Hooks/useOrder2Tracking"
+import type { ProcessedUserAddress } from "Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/utils"
 import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
 import { useMemo } from "react"
 import { useTracking } from "react-tracking"
@@ -298,13 +299,17 @@ export const useCheckoutTracking = ({
         trackEvent(payload)
       },
 
-      savedAddressViewed: (addressIds: string[]) => {
+      savedAddressViewed: (addresses: ProcessedUserAddress[]) => {
+        const addressIds = addresses.map(a => a.internalID)
+        const defaultAddress = addresses.find(a => a.isDefault) ?? addresses[0]
         const payload: SavedAddressViewed = {
           action: ActionType.savedAddressViewed,
           context_page_owner_type: contextPageOwnerType,
           context_page_owner_id: contextPageOwnerId,
           flow,
           address_ids: addressIds,
+          default_address_id: defaultAddress.internalID,
+          default_address_country: defaultAddress.address.country,
         }
         trackEvent(payload)
       },

--- a/src/Apps/Order2/Routes/Checkout/Order2CheckoutApp.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Order2CheckoutApp.tsx
@@ -35,7 +35,7 @@ import { useSystemContext } from "System/Hooks/useSystemContext"
 import { Jump } from "Utils/Hooks/useJump"
 import type { Order2CheckoutApp_me$key } from "__generated__/Order2CheckoutApp_me.graphql"
 import type { Order2CheckoutApp_order$key } from "__generated__/Order2CheckoutApp_order.graphql"
-import { useEffect } from "react"
+import { useEffect, useMemo } from "react"
 import { Meta, Title } from "react-head"
 import { graphql, useFragment } from "react-relay"
 
@@ -86,29 +86,36 @@ export const Order2CheckoutApp: React.FC<Order2CheckoutAppProps> = ({
     }
   }, [isExpressCheckoutEligible])
 
-  const activeStep = steps.find(step => step.state === CheckoutStepState.ACTIVE)
+  const activeSteps = useMemo(
+    () => steps.filter(step => step.state === CheckoutStepState.ACTIVE),
+    [steps],
+  )
 
   useEffect(() => {
-    switch (activeStep?.name) {
-      case CheckoutStepName.CONFIRMATION:
-        checkoutTracking.orderProgressionViewed(ContextModule.ordersReview)
-        break
-      case CheckoutStepName.FULFILLMENT_DETAILS:
-        checkoutTracking.orderProgressionViewed(ContextModule.ordersFulfillment)
-        break
-      case CheckoutStepName.PAYMENT:
-        checkoutTracking.orderProgressionViewed(ContextModule.ordersPayment)
-        break
-      case CheckoutStepName.OFFER_AMOUNT:
-        checkoutTracking.orderProgressionViewed(ContextModule.ordersOffer)
-        break
-      case CheckoutStepName.DELIVERY_OPTION:
-        checkoutTracking.orderProgressionViewed(
-          ContextModule.ordersShippingMethods,
-        )
-        break
-    }
-  }, [activeStep?.name, checkoutTracking])
+    activeSteps.forEach(step => {
+      switch (step.name) {
+        case CheckoutStepName.CONFIRMATION:
+          checkoutTracking.orderProgressionViewed(ContextModule.ordersReview)
+          break
+        case CheckoutStepName.FULFILLMENT_DETAILS:
+          checkoutTracking.orderProgressionViewed(
+            ContextModule.ordersFulfillment,
+          )
+          break
+        case CheckoutStepName.PAYMENT:
+          checkoutTracking.orderProgressionViewed(ContextModule.ordersPayment)
+          break
+        case CheckoutStepName.OFFER_AMOUNT:
+          checkoutTracking.orderProgressionViewed(ContextModule.ordersOffer)
+          break
+        case CheckoutStepName.DELIVERY_OPTION:
+          checkoutTracking.orderProgressionViewed(
+            ContextModule.ordersShippingMethods,
+          )
+          break
+      }
+    })
+  }, [activeSteps, checkoutTracking])
 
   // Scroll to top when returning to standard checkout mode (and at load time)
   useEffect(() => {

--- a/src/Apps/Order2/Routes/Checkout/Order2CheckoutApp.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Order2CheckoutApp.tsx
@@ -86,14 +86,18 @@ export const Order2CheckoutApp: React.FC<Order2CheckoutAppProps> = ({
     }
   }, [isExpressCheckoutEligible])
 
-  const activeSteps = useMemo(
-    () => steps.filter(step => step.state === CheckoutStepState.ACTIVE),
+  const activeStepNames = useMemo(
+    () =>
+      steps
+        .filter(step => step.state === CheckoutStepState.ACTIVE)
+        .map(step => step.name)
+        .join(","),
     [steps],
   )
 
   useEffect(() => {
-    activeSteps.forEach(step => {
-      switch (step.name) {
+    activeStepNames.split(",").forEach(name => {
+      switch (name) {
         case CheckoutStepName.CONFIRMATION:
           checkoutTracking.orderProgressionViewed(ContextModule.ordersReview)
           break
@@ -115,7 +119,7 @@ export const Order2CheckoutApp: React.FC<Order2CheckoutAppProps> = ({
           break
       }
     })
-  }, [activeSteps, checkoutTracking])
+  }, [activeStepNames, checkoutTracking])
 
   // Scroll to top when returning to standard checkout mode (and at load time)
   useEffect(() => {

--- a/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
@@ -731,10 +731,22 @@ describe("Order2CheckoutRoute", () => {
           flow: "Buy now",
         },
         {
+          action: "orderProgressionViewed",
+          context_module: "ordersShippingMethods",
+          context_page_owner_id: "order-id",
+          flow: "Buy now",
+        },
+        {
           action: "clickedFulfillmentTab",
           context_page_owner_id: "order-id",
           flow: "Buy now",
           method: "Pickup",
+        },
+        {
+          action: "orderProgressionViewed",
+          context_module: "ordersFulfillment",
+          context_page_owner_id: "order-id",
+          flow: "Buy now",
         },
         {
           action: "clickedOrderProgression",
@@ -1283,6 +1295,14 @@ describe("Order2CheckoutRoute", () => {
       expectTrackedEvents({ mockTrackEvent, exact: false }, [
         {
           action: "orderProgressionViewed",
+          context_module: "ordersFulfillment",
+        },
+        {
+          action: "orderProgressionViewed",
+          context_module: "ordersShippingMethods",
+        },
+        {
+          action: "clickedOrderProgression",
           context_module: "ordersFulfillment",
         },
         {
@@ -1937,6 +1957,18 @@ describe("Order2CheckoutRoute", () => {
         {
           action: "clickedOrderProgression",
           context_module: "ordersFulfillment",
+          context_page_owner_id: "order-id",
+          flow: "Buy now",
+        },
+        {
+          action: "orderProgressionViewed",
+          context_module: "ordersPayment",
+          context_page_owner_id: "order-id",
+          flow: "Buy now",
+        },
+        {
+          action: "orderProgressionViewed",
+          context_module: "ordersReview",
           context_page_owner_id: "order-id",
           flow: "Buy now",
         },

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,12 +31,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@artsy/cohesion@npm:4.352.0":
-  version: 4.352.0
-  resolution: "@artsy/cohesion@npm:4.352.0"
+"@artsy/cohesion@npm:4.353.0":
+  version: 4.353.0
+  resolution: "@artsy/cohesion@npm:4.353.0"
   dependencies:
     core-js: "npm:3"
-  checksum: 10c0/3f7634842911b36f22d0328a21ef8ae6ec1a55f6fa96c1d731553fc4ef4647fb011d86babb76e53daed2e74588b929b3bb996710e9093cddc3ddefb68e8717a1
+  checksum: 10c0/e829d5ee821fab590f14e3f00ab0f2f81b4392f95b94bf8f9551eb32c6c8543c3f31fe5f02890afde681e731c2b686a62e5fd65ecba93e643afaf674e3de6c24
   languageName: node
   linkType: hard
 
@@ -8732,7 +8732,7 @@ __metadata:
   resolution: "force@workspace:."
   dependencies:
     "@artaio/arta-browser": "npm:^2.16.1"
-    "@artsy/cohesion": "npm:4.352.0"
+    "@artsy/cohesion": "npm:4.353.0"
     "@artsy/detect-responsive-traits": "npm:^0.2.0"
     "@artsy/dismissible": "npm:^0.8.0"
     "@artsy/express-reloadable": "npm:^1.7.0"


### PR DESCRIPTION
The type of this PR is: **chore**

Testable at https://emi3194-preview.artsy.net

This PR completes [EMI-3208]. ~It is blocked by #17106~.

Paired with @xander-pero 

### Description

Includes update to @artsy/cohesion (same as https://github.com/artsy/force/pull/17124) for new tracking values.

Key changes:
- Track default address id and country in `savedAddressViewed`
- Track clicks on progression buttons regardless of whether the form fires
- Track when steps activate including when they activate simultaneously

<!-- Implementation description -->


[EMI-3208]: https://artsyproduct.atlassian.net/browse/EMI-3208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ