### PR TITLE
fix(EMI-3143): List price empty for artwork with hidden price

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/Order2ReviewStep.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2ReviewStep.tsx
@@ -241,7 +241,7 @@ export const Order2ReviewStep: React.FC<Order2ReviewStepProps> = ({
             {[artworkData.title, artworkData.date].join(", ")}
           </Text>
           <Text overflowEllipsis variant="sm" color="mono60" textAlign="left">
-            List price: {artworkData.price}
+            List price: {artworkData.price || "Not publicly listed"}
           </Text>
           {displayLimitedOfferLine && (
             <Text variant="sm" color="blue100" textAlign="left">


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-3143]

### Description

<!-- Implementation description -->

Fixes checkout artwork summary to show "Not publicly listed" when artwork price is hidden, preventing an empty "List price:" value.

<img width="1295" height="651" alt="image" src="https://github.com/user-attachments/assets/22f47cc4-a30f-4133-a25c-f2c54bca82ab" />


[EMI-3143]: https://artsyproduct.atlassian.net/browse/EMI-3143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ