### PR TITLE
fix(EMI-3010): prevent navigation on artwork press on checkout on eigen

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/Order2CollapsibleOrderSummary.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2CollapsibleOrderSummary.tsx
@@ -40,8 +40,6 @@ export const Order2CollapsibleOrderSummary: React.FC<
     ? artworkVersion?.thumbnail?.resizedSquare?.url
     : fallbackImageUrl
 
-  console.log("LOGD APP")
-
   return (
     <Box backgroundColor="mono0">
       <Clickable

--- a/src/Apps/Order2/Routes/Checkout/Components/Order2CollapsibleOrderSummary.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2CollapsibleOrderSummary.tsx
@@ -4,6 +4,7 @@ import { Box, Clickable, Flex, Image, Spacer, Text } from "@artsy/palette"
 import { Order2CheckoutPricingBreakdown } from "Apps/Order2/Routes/Checkout/Components/Order2CheckoutPricingBreakdown"
 import { useCheckoutContext } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext"
 import { RouterLink } from "System/Components/RouterLink"
+import { useSystemContext } from "System/Hooks/useSystemContext"
 import type { Order2CollapsibleOrderSummary_order$key } from "__generated__/Order2CollapsibleOrderSummary_order.graphql"
 import type * as React from "react"
 import { useState } from "react"
@@ -17,6 +18,7 @@ export const Order2CollapsibleOrderSummary: React.FC<
   Order2CollapsibleOrderSummaryProps
 > = ({ order }) => {
   const { checkoutTracking, artworkPath } = useCheckoutContext()
+  const { isEigen } = useSystemContext()
   const orderData = useFragment(FRAGMENT, order)
   const [isExpanded, setIsExpanded] = useState(false)
 
@@ -38,6 +40,8 @@ export const Order2CollapsibleOrderSummary: React.FC<
     ? artworkVersion?.thumbnail?.resizedSquare?.url
     : fallbackImageUrl
 
+  console.log("LOGD APP")
+
   return (
     <Box backgroundColor="mono0">
       <Clickable
@@ -55,7 +59,14 @@ export const Order2CollapsibleOrderSummary: React.FC<
             flex={0}
             to={artworkPath}
             target="_blank"
-            onClick={() => {
+            rel="noopener noreferrer"
+            onClick={event => {
+              if (isEigen) {
+                event.preventDefault()
+                event.stopPropagation()
+                return
+              }
+
               const artworkInternalID =
                 orderData.lineItems[0]?.artwork?.internalID
               if (artworkInternalID) {

--- a/src/Apps/Order2/Routes/Checkout/Components/__tests__/Order2CollapsibleOrderSummary.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/__tests__/Order2CollapsibleOrderSummary.jest.tsx
@@ -9,6 +9,8 @@ import { Order2CollapsibleOrderSummary } from "../Order2CollapsibleOrderSummary"
 jest.unmock("react-relay")
 jest.mock("react-tracking")
 
+let mockIsEigen = false
+
 jest.mock("Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext", () => ({
   useCheckoutContext: () => {
     const checkoutTracking = useCheckoutTracking({
@@ -17,8 +19,15 @@ jest.mock("Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext", () => ({
     })
     return {
       checkoutTracking,
+      artworkPath: "/artwork/test-artwork",
     }
   },
+}))
+
+jest.mock("System/Hooks/useSystemContext", () => ({
+  useSystemContext: () => ({
+    isEigen: mockIsEigen,
+  }),
 }))
 
 jest.mock("System/Hooks/useAnalyticsContext", () => {
@@ -32,6 +41,7 @@ jest.mock("System/Hooks/useAnalyticsContext", () => {
 
 const mockTrackEvent = jest.fn()
 beforeEach(() => {
+  mockIsEigen = false
   mockTrackEvent.mockClear()
   ;(useTracking as jest.Mock).mockImplementation(() => ({
     trackEvent: mockTrackEvent,
@@ -49,6 +59,7 @@ const mockOrder = {
     {
       artwork: {
         slug: "test-artwork",
+        internalID: "artwork-id",
       },
       artworkVersion: {
         title: "Test Artwork",
@@ -253,6 +264,109 @@ describe("Order2CollapsibleOrderSummary", () => {
     expect(image).toHaveAttribute(
       "src",
       "https://example.com/fallback-image.jpg",
+    )
+  })
+
+  it("opens artwork link in a new tab for non-Eigen", async () => {
+    await renderWithRelay({
+      Order: () => ({
+        ...mockOrder,
+        lineItems: [
+          {
+            artwork: {
+              slug: "test-artwork",
+              internalID: "artwork-id",
+              figures: [
+                {
+                  __typename: "Image",
+                  resizedSquare: {
+                    url: "https://example.com/fallback-image.jpg",
+                  },
+                },
+              ],
+            },
+            artworkVersion: {
+              title: "Test Artwork",
+              date: "2023",
+              artistNames: "Test Artist",
+              thumbnail: {
+                url: "https://example.com/thumbnail.jpg",
+                resizedSquare: {
+                  url: "https://example.com/thumbnail-resized.jpg",
+                },
+              },
+            },
+          },
+        ],
+      }),
+    })
+
+    const artworkLink = screen.getByRole("link", { name: "Test Artwork" })
+
+    expect(artworkLink).toHaveAttribute("target", "_blank")
+    expect(artworkLink).toHaveAttribute("rel", "noopener noreferrer")
+
+    mockTrackEvent.mockClear()
+    fireEvent.click(artworkLink)
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: "clickedOrderArtworkImage",
+        context_module: "ordersCheckout",
+        destination_page_owner_id: "artwork-id",
+        destination_page_owner_type: "artwork",
+      }),
+    )
+  })
+
+  it("prevents tap navigation for Eigen", async () => {
+    mockIsEigen = true
+
+    await renderWithRelay({
+      Order: () => ({
+        ...mockOrder,
+        lineItems: [
+          {
+            artwork: {
+              slug: "test-artwork",
+              internalID: "artwork-id",
+              figures: [
+                {
+                  __typename: "Image",
+                  resizedSquare: {
+                    url: "https://example.com/fallback-image.jpg",
+                  },
+                },
+              ],
+            },
+            artworkVersion: {
+              title: "Test Artwork",
+              date: "2023",
+              artistNames: "Test Artist",
+              thumbnail: {
+                url: "https://example.com/thumbnail.jpg",
+                resizedSquare: {
+                  url: "https://example.com/thumbnail-resized.jpg",
+                },
+              },
+            },
+          },
+        ],
+      }),
+    })
+
+    const artworkLink = screen.getByRole("link", { name: "Test Artwork" })
+    const clickEvent = new MouseEvent("click", {
+      bubbles: true,
+      cancelable: true,
+    })
+
+    mockTrackEvent.mockClear()
+    const shouldContinueDefaultBehavior = artworkLink.dispatchEvent(clickEvent)
+
+    expect(shouldContinueDefaultBehavior).toBe(false)
+    expect(mockTrackEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ action: "clickedOrderArtworkImage" }),
     )
   })
 })


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-3010]

### Description

<!-- Implementation description -->
More info https://artsy.slack.com/archives/C02JHHHKP5K/p1777036481973189

The 
1. On Eigen tap: click is blocked via preventDefault + stopPropagation
2. Long press in Eigen: should still be available because it remains a real link element.
3. On non-Eigen tap: link is allowed and opens via target _blank.



<video src="https://github.com/user-attachments/assets/98f6bf0b-a101-4c9a-a8e2-e4f6900ecad9" width="250" />

[EMI-3010]: https://artsyproduct.atlassian.net/browse/EMI-3010?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ