### PR TITLE
fix(di-118): corrects context modules for entity headers

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkRelatedArtists.tsx
+++ b/src/Apps/Artwork/Components/ArtworkRelatedArtists.tsx
@@ -82,6 +82,7 @@ export const ArtworkRelatedArtists: React.FC<
             <Column key={index} span={[12, 6, 4, 4]}>
               <EntityHeaderArtistFragmentContainer
                 artist={node}
+                contextModule={ContextModule.relatedArtistsRail}
                 onClick={() => {
                   trackEvent({
                     context_module:

--- a/src/Apps/Collect/Routes/Collection/Components/Header/CollectionFeaturedArtists.tsx
+++ b/src/Apps/Collect/Routes/Collection/Components/Header/CollectionFeaturedArtists.tsx
@@ -52,6 +52,7 @@ export const CollectionFeaturedArtists: React.FC<
             >
               <EntityHeaderArtistFragmentContainer
                 artist={artist}
+                contextModule={ContextModule.featuredArtistsRail}
                 width="100%"
                 alignItems="flex-start"
               />

--- a/src/Apps/Fair/Components/FairExhibitors/FairExhibitorCard.tsx
+++ b/src/Apps/Fair/Components/FairExhibitors/FairExhibitorCard.tsx
@@ -48,6 +48,7 @@ export const FairExhibitorCard: React.FC<
   return (
     <EntityHeaderPartnerFragmentContainer
       partner={exhibitor.partner}
+      contextModule={ContextModule.presentingPartner}
       displayAvatar={false}
       alignItems="flex-start"
       href={`/show/${exhibitor.profileID}?back_to_fair_href=${encodedBackToFairHref}`}

--- a/src/Apps/Favorites/Routes/FavoritesFollows/Components/SettingsSavesArtists.tsx
+++ b/src/Apps/Favorites/Routes/FavoritesFollows/Components/SettingsSavesArtists.tsx
@@ -1,3 +1,4 @@
+import { ContextModule } from "@artsy/cohesion"
 import {
   Box,
   Button,
@@ -62,7 +63,11 @@ const SettingsSavesArtists: FC<
               if (!artist) return null
 
               return (
-                <ArtistRailFragmentContainer key={internalID} artist={artist} />
+                <ArtistRailFragmentContainer
+                  key={internalID}
+                  artist={artist}
+                  contextModule={ContextModule.collectorProfile}
+                />
               )
             })}
           </Join>

--- a/src/Apps/Favorites/Routes/FavoritesFollows/Components/SettingsSavesProfiles.tsx
+++ b/src/Apps/Favorites/Routes/FavoritesFollows/Components/SettingsSavesProfiles.tsx
@@ -1,3 +1,4 @@
+import { ContextModule } from "@artsy/cohesion"
 import {
   Box,
   Button,
@@ -71,6 +72,7 @@ const SettingsSavesProfiles: FC<
                           <EntityHeaderPartnerFragmentContainer
                             key={internalID}
                             partner={profile.owner}
+                            contextModule={ContextModule.collectorProfile}
                           />
                         )
 
@@ -79,6 +81,7 @@ const SettingsSavesProfiles: FC<
                           <EntityHeaderFairFragmentContainer
                             key={internalID}
                             fair={profile.owner}
+                            contextModule={ContextModule.collectorProfile}
                           />
                         )
 
@@ -87,6 +90,7 @@ const SettingsSavesProfiles: FC<
                           <EntityHeaderFairOrganizerFragmentContainer
                             key={internalID}
                             fairOrganizer={profile.owner}
+                            contextModule={ContextModule.collectorProfile}
                           />
                         )
                     }

--- a/src/Apps/Show/Routes/ShowInfo.tsx
+++ b/src/Apps/Show/Routes/ShowInfo.tsx
@@ -1,3 +1,4 @@
+import { ContextModule } from "@artsy/cohesion"
 import {
   Box,
   Column,
@@ -75,7 +76,10 @@ export const ShowInfo: React.FC<React.PropsWithChildren<ShowInfoProps>> = ({
                     {partner.type}
                   </Text>
 
-                  <EntityHeaderPartnerFragmentContainer partner={partner} />
+                  <EntityHeaderPartnerFragmentContainer
+                    partner={partner}
+                    contextModule={ContextModule.showInfo}
+                  />
                 </Box>
               )}
 

--- a/src/Components/ArtistRail.tsx
+++ b/src/Components/ArtistRail.tsx
@@ -1,3 +1,4 @@
+import type { AuthContextModule } from "@artsy/cohesion"
 import {
   Box,
   Flex,
@@ -19,10 +20,12 @@ import { EntityHeaderArtistFragmentContainer } from "./EntityHeaders/EntityHeade
 
 interface ArtistRailProps {
   artist: ArtistRail_artist$data
+  contextModule?: AuthContextModule
 }
 
 const ArtistRail: FC<React.PropsWithChildren<ArtistRailProps>> = ({
   artist,
+  contextModule,
 }) => {
   if (!artist || !artist.name) return null
 
@@ -30,7 +33,11 @@ const ArtistRail: FC<React.PropsWithChildren<ArtistRailProps>> = ({
 
   return (
     <>
-      <EntityHeaderArtistFragmentContainer artist={artist} mb={2} />
+      <EntityHeaderArtistFragmentContainer
+        artist={artist}
+        contextModule={contextModule}
+        mb={2}
+      />
       {artworks.length > 0 ? (
         <Shelf>
           {artworks.map(artwork => {

--- a/src/Components/Cells/CellArtist.tsx
+++ b/src/Components/Cells/CellArtist.tsx
@@ -1,3 +1,4 @@
+import type { AuthContextModule } from "@artsy/cohesion"
 import {
   Box,
   Image,
@@ -16,6 +17,7 @@ import { DEFAULT_CELL_WIDTH } from "./constants"
 
 export interface CellArtistProps extends Partial<RouterLinkProps> {
   artist: CellArtist_artist$data
+  contextModule?: AuthContextModule
   /** Defaults to `"RAIL"` */
   mode?: "GRID" | "RAIL"
   displayCounts?: boolean
@@ -25,6 +27,7 @@ export interface CellArtistProps extends Partial<RouterLinkProps> {
 
 const CellArtist: FC<React.PropsWithChildren<CellArtistProps>> = ({
   artist,
+  contextModule,
   mode = "RAIL",
   displayCounts,
   lazyLoad = true,
@@ -72,6 +75,7 @@ const CellArtist: FC<React.PropsWithChildren<CellArtistProps>> = ({
 
       <EntityHeaderArtistFragmentContainer
         artist={artist}
+        contextModule={contextModule}
         displayAvatar={false}
         displayLink={false}
         displayCounts={displayCounts}

--- a/src/Components/Cells/CellPartner.tsx
+++ b/src/Components/Cells/CellPartner.tsx
@@ -1,3 +1,4 @@
+import type { AuthContextModule } from "@artsy/cohesion"
 import { Box, Image, ResponsiveBox, SkeletonBox, Text } from "@artsy/palette"
 import { EntityHeaderPartnerFragmentContainer } from "Components/EntityHeaders/EntityHeaderPartner"
 import { EntityHeaderPlaceholder } from "Components/EntityHeaders/EntityHeaderPlaceholder"
@@ -9,12 +10,14 @@ import { DEFAULT_CELL_WIDTH } from "./constants"
 
 export interface CellPartnerProps extends Omit<RouterLinkProps, "to"> {
   partner: CellPartner_partner$data
+  contextModule?: AuthContextModule
   /** Defaults to `"RAIL"` */
   mode?: "GRID" | "RAIL"
 }
 
 const CellPartner: React.FC<React.PropsWithChildren<CellPartnerProps>> = ({
   partner,
+  contextModule,
   mode = "RAIL",
   ...rest
 }) => {
@@ -35,6 +38,7 @@ const CellPartner: React.FC<React.PropsWithChildren<CellPartnerProps>> = ({
     >
       <EntityHeaderPartnerFragmentContainer
         partner={partner}
+        contextModule={contextModule}
         displayAvatar={false}
         displayLink={false}
         alignItems="flex-end"

--- a/src/Components/Cells/CellPartnerArtist.tsx
+++ b/src/Components/Cells/CellPartnerArtist.tsx
@@ -1,3 +1,4 @@
+import type { AuthContextModule } from "@artsy/cohesion"
 import { Image, ResponsiveBox, Text } from "@artsy/palette"
 import { EntityHeaderArtistFragmentContainer } from "Components/EntityHeaders/EntityHeaderArtist"
 import { RouterLink, type RouterLinkProps } from "System/Components/RouterLink"
@@ -9,6 +10,7 @@ import { DEFAULT_CELL_WIDTH } from "./constants"
 
 export interface CellPartnerArtistProps extends Partial<RouterLinkProps> {
   artistPartnerEdge: CellPartnerArtist_partnerArtist$data
+  contextModule?: AuthContextModule
   /** Defaults to `"RAIL"` */
   mode?: "GRID" | "RAIL"
   displayCounts?: boolean
@@ -19,6 +21,7 @@ const CellPartnerArtist: FC<
   React.PropsWithChildren<CellPartnerArtistProps>
 > = ({
   artistPartnerEdge,
+  contextModule,
   mode = "RAIL",
   displayCounts,
   FollowButton,
@@ -68,6 +71,7 @@ const CellPartnerArtist: FC<
 
       <EntityHeaderArtistFragmentContainer
         artist={artistPartnerEdge.artist}
+        contextModule={contextModule}
         displayAvatar={false}
         displayLink={false}
         displayCounts={displayCounts}

--- a/src/Components/EntityHeaders/EntityHeaderArtist.tsx
+++ b/src/Components/EntityHeaders/EntityHeaderArtist.tsx
@@ -1,4 +1,4 @@
-import { ContextModule } from "@artsy/cohesion"
+import { type AuthContextModule, ContextModule } from "@artsy/cohesion"
 import { Avatar, type BoxProps, Flex, Text } from "@artsy/palette"
 import { FollowArtistButtonQueryRenderer } from "Components/FollowButton/FollowArtistButton"
 import { RouterLink } from "System/Components/RouterLink"
@@ -9,6 +9,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 export interface EntityHeaderArtistProps extends BoxProps {
   artist: EntityHeaderArtist_artist$data
   children?: ReactNode
+  contextModule?: AuthContextModule
   displayAvatar?: boolean
   displayCounts?: boolean
   displayFollowButton?: boolean
@@ -22,6 +23,7 @@ const EntityHeaderArtist: FC<
   React.PropsWithChildren<EntityHeaderArtistProps>
 > = ({
   artist,
+  contextModule = ContextModule.artistHeader,
   displayAvatar = true,
   displayCounts = false,
   displayFollowButton = true,
@@ -82,7 +84,7 @@ const EntityHeaderArtist: FC<
         (FollowButton || (
           <FollowArtistButtonQueryRenderer
             id={artist.internalID}
-            contextModule={ContextModule.artistHeader}
+            contextModule={contextModule}
             size="small"
             onFollow={onFollow}
           />

--- a/src/Components/EntityHeaders/EntityHeaderFair.tsx
+++ b/src/Components/EntityHeaders/EntityHeaderFair.tsx
@@ -1,4 +1,4 @@
-import { ContextModule } from "@artsy/cohesion"
+import { type AuthContextModule, ContextModule } from "@artsy/cohesion"
 import { Avatar, type BoxProps, Flex, Text } from "@artsy/palette"
 import { FollowProfileButtonQueryRenderer } from "Components/FollowButton/FollowProfileButton"
 import { RouterLink } from "System/Components/RouterLink"
@@ -8,6 +8,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 
 export interface EntityHeaderFairProps extends BoxProps {
   fair: EntityHeaderFair_fair$data
+  contextModule?: AuthContextModule
   displayAvatar?: boolean
   displayLink?: boolean
   FollowButton?: JSX.Element
@@ -15,6 +16,7 @@ export interface EntityHeaderFairProps extends BoxProps {
 
 const EntityHeaderFair: FC<React.PropsWithChildren<EntityHeaderFairProps>> = ({
   fair,
+  contextModule = ContextModule.fairsHeader,
   displayAvatar = true,
   displayLink = true,
   FollowButton,
@@ -61,7 +63,7 @@ const EntityHeaderFair: FC<React.PropsWithChildren<EntityHeaderFairProps>> = ({
         (fair.profile && (
           <FollowProfileButtonQueryRenderer
             id={fair.profile.internalID}
-            contextModule={ContextModule.fairsHeader}
+            contextModule={contextModule}
             size="small"
           />
         ))}

--- a/src/Components/EntityHeaders/EntityHeaderFairOrganizer.tsx
+++ b/src/Components/EntityHeaders/EntityHeaderFairOrganizer.tsx
@@ -1,4 +1,4 @@
-import { ContextModule } from "@artsy/cohesion"
+import { type AuthContextModule, ContextModule } from "@artsy/cohesion"
 import { Avatar, type BoxProps, Flex, Text } from "@artsy/palette"
 import { FollowProfileButtonQueryRenderer } from "Components/FollowButton/FollowProfileButton"
 import { RouterLink } from "System/Components/RouterLink"
@@ -8,6 +8,7 @@ import { createFragmentContainer, graphql } from "react-relay"
 
 export interface EntityHeaderFairOrganizerProps extends BoxProps {
   fairOrganizer: EntityHeaderFairOrganizer_fairOrganizer$data
+  contextModule?: AuthContextModule
   displayAvatar?: boolean
   displayLink?: boolean
   FollowButton?: JSX.Element
@@ -17,6 +18,7 @@ const EntityHeaderFairOrganizer: FC<
   React.PropsWithChildren<EntityHeaderFairOrganizerProps>
 > = ({
   fairOrganizer,
+  contextModule = ContextModule.fairsHeader,
   displayAvatar = true,
   displayLink = true,
   FollowButton,
@@ -69,7 +71,7 @@ const EntityHeaderFairOrganizer: FC<
         (fairOrganizer.profile && (
           <FollowProfileButtonQueryRenderer
             id={fairOrganizer.profile.internalID}
-            contextModule={ContextModule.fairsHeader}
+            contextModule={contextModule}
             size="small"
           />
         ))}

--- a/src/Components/EntityHeaders/EntityHeaderPartner.tsx
+++ b/src/Components/EntityHeaders/EntityHeaderPartner.tsx
@@ -1,4 +1,4 @@
-import { ContextModule } from "@artsy/cohesion"
+import { type AuthContextModule, ContextModule } from "@artsy/cohesion"
 import { Avatar, type BoxProps, Flex, Label, Text } from "@artsy/palette"
 import { FollowProfileButtonQueryRenderer } from "Components/FollowButton/FollowProfileButton"
 import { RouterLink } from "System/Components/RouterLink"
@@ -12,6 +12,7 @@ const DISPLAYABLE_BADGES = ["black-owned", "women-owned"]
 
 export interface EntityHeaderPartnerProps extends BoxProps {
   partner: EntityHeaderPartner_partner$data
+  contextModule?: AuthContextModule
   displayAvatar?: boolean
   displayLink?: boolean
   FollowButton?: JSX.Element
@@ -24,6 +25,7 @@ const EntityHeaderPartner: FC<
   React.PropsWithChildren<EntityHeaderPartnerProps>
 > = ({
   partner,
+  contextModule = ContextModule.partnerHeader,
   displayAvatar = true,
   displayLink = true,
   FollowButton,
@@ -91,7 +93,7 @@ const EntityHeaderPartner: FC<
         (FollowButton || (
           <FollowProfileButtonQueryRenderer
             id={partner.profile.internalID}
-            contextModule={ContextModule.partnerHeader}
+            contextModule={contextModule}
             size="small"
             onFollow={onFollow}
           />

--- a/src/Components/EntityTooltip/EntityTooltipArtist.tsx
+++ b/src/Components/EntityTooltip/EntityTooltipArtist.tsx
@@ -1,4 +1,4 @@
-import { ActionType, type ClickedTooltip } from "@artsy/cohesion"
+import { ActionType, type ClickedTooltip, ContextModule } from "@artsy/cohesion"
 import {
   Box,
   HorizontalOverflow,
@@ -75,6 +75,7 @@ const EntityTooltipArtist: FC<
 
       <EntityHeaderArtistFragmentContainer
         artist={artist}
+        contextModule={ContextModule.intextTooltip}
         displayAvatar={false}
         alignItems="flex-start"
       />

--- a/src/Components/EntityTooltip/EntityTooltipPartner.tsx
+++ b/src/Components/EntityTooltip/EntityTooltipPartner.tsx
@@ -1,4 +1,4 @@
-import { ActionType, type ClickedTooltip } from "@artsy/cohesion"
+import { ActionType, type ClickedTooltip, ContextModule } from "@artsy/cohesion"
 import {
   Box,
   Image,
@@ -64,6 +64,7 @@ const EntityTooltipPartner: FC<
 
       <EntityHeaderPartnerFragmentContainer
         partner={partner}
+        contextModule={ContextModule.intextTooltip}
         displayAvatar={false}
         alignItems="flex-start"
       />


### PR DESCRIPTION
So the ticket was just correcting the context module for follows in the related artist rails. I noticed that all of our entity headers used the same hard coded context modules, so I audited all the call sites and took guesses as to which would be appropriate.

Take look at this @xander-pero — obviously out of scope for that one issue but seems like the right call.

cc @artsy/diamond-devs 