### PR TITLE
refactor(di-238): centralizes facts & figures formatting

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/Components/ArtistAuctionResultsEmptyState.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/ArtistAuctionResultsEmptyState.tsx
@@ -4,8 +4,6 @@ import { EmptyState } from "Components/EmptyState"
 import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
 import { getFactsAndFigures } from "Utils/factsAndFigures"
 
-const auctionRecordsCount = getFactsAndFigures("auctionRecordsCount")
-
 export const ArtistAuctionResultsEmptyState: React.FC<
   React.PropsWithChildren<unknown>
 > = () => {
@@ -20,7 +18,7 @@ export const ArtistAuctionResultsEmptyState: React.FC<
           We’ll update this area when results become available.
           <br />
           Meanwhile, you can check out free auction results and art market data
-          for over {auctionRecordsCount} artists.
+          for over {getFactsAndFigures("auctionRecordsCount")} artists.
         </>
       }
       action={{

--- a/src/Apps/Artist/Routes/AuctionResults/Components/ArtistAuctionResultsEmptyState.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/ArtistAuctionResultsEmptyState.tsx
@@ -2,7 +2,9 @@ import type { EntityModuleType, OwnerType } from "@artsy/cohesion"
 import { useAuctionResultsTracking } from "Apps/Artist/Routes/AuctionResults/Components/Hooks/useAuctionResultsTracking"
 import { EmptyState } from "Components/EmptyState"
 import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
-import { FACTS_AND_FIGURES } from "Utils/factsAndFigures"
+import { getFactsAndFigures } from "Utils/factsAndFigures"
+
+const auctionRecordsCount = getFactsAndFigures("auctionRecordsCount")
 
 export const ArtistAuctionResultsEmptyState: React.FC<
   React.PropsWithChildren<unknown>
@@ -18,7 +20,7 @@ export const ArtistAuctionResultsEmptyState: React.FC<
           We’ll update this area when results become available.
           <br />
           Meanwhile, you can check out free auction results and art market data
-          for over {FACTS_AND_FIGURES.auctionRecordsCount} artists.
+          for over {auctionRecordsCount} artists.
         </>
       }
       action={{

--- a/src/Apps/Authentication/Routes/SignupLanding/Components/SignupHeroContent.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/Components/SignupHeroContent.tsx
@@ -1,13 +1,8 @@
 import { Box, Flex, Spacer, Stack, Text } from "@artsy/palette"
 import CheckmarkFillIcon from "@artsy/icons/CheckmarkFillIcon"
-import { FACTS_AND_FIGURES } from "Utils/factsAndFigures"
+import { getFactsAndFigures } from "Utils/factsAndFigures"
 
-const formatCompact = (value: string) => {
-  return new Intl.NumberFormat("en", {
-    notation: "compact",
-    maximumFractionDigits: 1,
-  }).format(Number(value.replace(/,/g, "")))
-}
+const artworkCount = getFactsAndFigures("artworksCount", { format: "compact" })
 
 export const SignupHeroContent = () => {
   return (
@@ -18,12 +13,9 @@ export const SignupHeroContent = () => {
       <Spacer y={2} />
       <Stack gap={1}>
         <ValuePropItem>
-          <strong>
-            Explore {formatCompact(FACTS_AND_FIGURES.artworksCount)}+ original
-            artworks
-          </strong>{" "}
-          across paintings, sculptures, prints, and photography from artists at
-          leading global galleries.
+          <strong>Explore {artworkCount}+ original artworks</strong> across
+          paintings, sculptures, prints, and photography from artists at leading
+          global galleries.
         </ValuePropItem>
         <ValuePropItem>
           <strong> Get personalized recommendations</strong> by following

--- a/src/Apps/Authentication/Routes/SignupLanding/Components/SignupHeroContent.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/Components/SignupHeroContent.tsx
@@ -1,8 +1,6 @@
-import { Box, Flex, Spacer, Stack, Text } from "@artsy/palette"
 import CheckmarkFillIcon from "@artsy/icons/CheckmarkFillIcon"
+import { Box, Flex, Spacer, Stack, Text } from "@artsy/palette"
 import { getFactsAndFigures } from "Utils/factsAndFigures"
-
-const artworkCount = getFactsAndFigures("artworksCount", { format: "compact" })
 
 export const SignupHeroContent = () => {
   return (
@@ -13,9 +11,12 @@ export const SignupHeroContent = () => {
       <Spacer y={2} />
       <Stack gap={1}>
         <ValuePropItem>
-          <strong>Explore {artworkCount}+ original artworks</strong> across
-          paintings, sculptures, prints, and photography from artists at leading
-          global galleries.
+          <strong>
+            Explore {getFactsAndFigures("artworksCount", { format: "compact" })}
+            + original artworks
+          </strong>{" "}
+          across paintings, sculptures, prints, and photography from artists at
+          leading global galleries.
         </ValuePropItem>
         <ValuePropItem>
           <strong> Get personalized recommendations</strong> by following

--- a/src/Apps/Authentication/Routes/SignupLanding/Components/SignupStats.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/Components/SignupStats.tsx
@@ -1,29 +1,32 @@
-import { Box, GridColumns, Column, Text } from "@artsy/palette"
+import { Box, Column, GridColumns, Text } from "@artsy/palette"
 import { getFactsAndFigures } from "Utils/factsAndFigures"
-
-const artworkCount = getFactsAndFigures("artworksCount", { format: "compact" })
-const galleryCount = getFactsAndFigures("galleriesCount", { format: "compact" })
 
 export const SignupStats = () => {
   return (
     <Box mx="auto">
       <GridColumns textAlign="center" gridRowGap={[4, 2]}>
         <Column span={[12, 4]}>
-          <Text variant={["xl", "xxl"]}>{artworkCount}+</Text>
+          <Text variant={["xl", "xxl"]}>
+            {getFactsAndFigures("artworksCount", { format: "compact" })}+
+          </Text>
           <Text variant="sm-display" color="mono60">
             {" "}
             Artworks available
           </Text>
         </Column>
         <Column span={[12, 4]}>
-          <Text variant={["xl", "xxl"]}>{galleryCount}+</Text>
+          <Text variant={["xl", "xxl"]}>
+            {getFactsAndFigures("galleriesCount", { format: "compact" })}+
+          </Text>
           <Text variant="sm-display" color="mono60">
             {" "}
             Gallery partners
           </Text>
         </Column>
         <Column span={[12, 4]}>
-          <Text variant={["xl", "xxl"]}>3.4M</Text>
+          <Text variant={["xl", "xxl"]}>
+            {getFactsAndFigures("membersCount", { format: "compact" })}+
+          </Text>
           <Text variant="sm-display" color="mono60">
             {" "}
             Artsy members

--- a/src/Apps/Authentication/Routes/SignupLanding/Components/SignupStats.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/Components/SignupStats.tsx
@@ -1,30 +1,22 @@
 import { Box, GridColumns, Column, Text } from "@artsy/palette"
-import { FACTS_AND_FIGURES } from "Utils/factsAndFigures"
+import { getFactsAndFigures } from "Utils/factsAndFigures"
 
-const formatCompact = (value: string) => {
-  return new Intl.NumberFormat("en", {
-    notation: "compact",
-    maximumFractionDigits: 1,
-  }).format(Number(value.replace(/,/g, "")))
-}
+const artworkCount = getFactsAndFigures("artworksCount", { format: "compact" })
+const galleryCount = getFactsAndFigures("galleriesCount", { format: "compact" })
 
 export const SignupStats = () => {
   return (
     <Box mx="auto">
       <GridColumns textAlign="center" gridRowGap={[4, 2]}>
         <Column span={[12, 4]}>
-          <Text variant={["xl", "xxl"]}>
-            {formatCompact(FACTS_AND_FIGURES.artworksCount)}+
-          </Text>
+          <Text variant={["xl", "xxl"]}>{artworkCount}+</Text>
           <Text variant="sm-display" color="mono60">
             {" "}
             Artworks available
           </Text>
         </Column>
         <Column span={[12, 4]}>
-          <Text variant={["xl", "xxl"]}>
-            {formatCompact(FACTS_AND_FIGURES.galleriesCount)}+
-          </Text>
+          <Text variant={["xl", "xxl"]}>{galleryCount}+</Text>
           <Text variant="sm-display" color="mono60">
             {" "}
             Gallery partners

--- a/src/Apps/Authentication/Routes/SignupLanding/Components/SignupValueProps.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/Components/SignupValueProps.tsx
@@ -1,20 +1,18 @@
 import {
-  Spacer,
-  GridColumns,
-  Column,
-  Text,
-  FullBleed,
-  ResponsiveBox,
-  Image,
   Box,
+  Column,
+  FullBleed,
+  GridColumns,
+  Image,
+  ResponsiveBox,
+  Spacer,
+  Text,
   useTheme,
 } from "@artsy/palette"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
-import { cropped } from "Utils/resized"
 import { getFactsAndFigures } from "Utils/factsAndFigures"
-
-const galleryCount = getFactsAndFigures("galleriesCount")
+import { cropped } from "Utils/resized"
 
 export const SignupValueProps = () => {
   const { theme } = useTheme()
@@ -55,8 +53,9 @@ export const SignupValueProps = () => {
                 </Text>
                 <Text variant="sm" color="mono60" mt={1}>
                   Artsy is where collectors come to discover and buy original
-                  art online. With works from {galleryCount}+ gallery and
-                  auction partners, the entire art world is waiting for you.
+                  art online. With works from{" "}
+                  {getFactsAndFigures("galleriesCount")}+ gallery and auction
+                  partners, the entire art world is waiting for you.
                 </Text>
               </Box>
             </Column>

--- a/src/Apps/Authentication/Routes/SignupLanding/Components/SignupValueProps.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/Components/SignupValueProps.tsx
@@ -12,7 +12,9 @@ import {
 import { AppContainer } from "Apps/Components/AppContainer"
 import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
 import { cropped } from "Utils/resized"
-import { FACTS_AND_FIGURES } from "Utils/factsAndFigures"
+import { getFactsAndFigures } from "Utils/factsAndFigures"
+
+const galleryCount = getFactsAndFigures("galleriesCount")
 
 export const SignupValueProps = () => {
   const { theme } = useTheme()
@@ -53,9 +55,8 @@ export const SignupValueProps = () => {
                 </Text>
                 <Text variant="sm" color="mono60" mt={1}>
                   Artsy is where collectors come to discover and buy original
-                  art online. With works from {FACTS_AND_FIGURES.galleriesCount}
-                  + gallery and auction partners, the entire art world is
-                  waiting for you.
+                  art online. With works from {galleryCount}+ gallery and
+                  auction partners, the entire art world is waiting for you.
                 </Text>
               </Box>
             </Column>

--- a/src/Apps/Collect/Routes/Collect/Utils/getMetadata.ts
+++ b/src/Apps/Collect/Routes/Collect/Utils/getMetadata.ts
@@ -1,6 +1,6 @@
 import type { FILTER_CATEGORIES } from "Apps/Artwork/Utils/createCollectUrl"
 import type { COLOR_OPTIONS } from "Components/ArtworkFilter/ArtworkFilters/ColorFilter"
-import { FACTS_AND_FIGURES } from "Utils/factsAndFigures"
+import { getFactsAndFigures } from "Utils/factsAndFigures"
 
 export type Medium = (typeof FILTER_CATEGORIES)[keyof typeof FILTER_CATEGORIES]
 export type Color = (typeof COLOR_OPTIONS)[number]["value"]
@@ -22,87 +22,87 @@ const MEDIUM_METADATA: Record<Medium, { title: string; description: string }> =
   {
     architecture: {
       title: "Architecture",
-      description: `${FACTS_AND_FIGURES.categoriesCounts.architecture}+ architectural works`,
+      description: `${getFactsAndFigures("categoriesCounts.architecture")}+ architectural works`,
     },
     "books-and-portfolios": {
       title: "Books and Portfolios",
-      description: `${FACTS_AND_FIGURES.categoriesCounts["books-and-portfolios"]}+ books and portfolios`,
+      description: `${getFactsAndFigures("categoriesCounts.books-and-portfolios")}+ books and portfolios`,
     },
     design: {
       title: "Design Works",
-      description: `${FACTS_AND_FIGURES.categoriesCounts.design}+ design works`,
+      description: `${getFactsAndFigures("categoriesCounts.design")}+ design works`,
     },
     "digital-art": {
       title: "Digital Art",
-      description: `${FACTS_AND_FIGURES.categoriesCounts["digital-art"]}+ digital art works`,
+      description: `${getFactsAndFigures("categoriesCounts.digital-art")}+ digital art works`,
     },
     drawing: {
       title: "Drawings",
-      description: `${FACTS_AND_FIGURES.categoriesCounts.drawing}+ drawings`,
+      description: `${getFactsAndFigures("categoriesCounts.drawing")}+ drawings`,
     },
     "ephemera-or-merchandise": {
       title: "Ephemera or Merchandise",
-      description: `${FACTS_AND_FIGURES.categoriesCounts["ephemera-or-merchandise"]}+ ephemera or merchandise`,
+      description: `${getFactsAndFigures("categoriesCounts.ephemera-or-merchandise")}+ ephemera or merchandise`,
     },
     "fashion-design-and-wearable-art": {
       title: "Fashion Design and Wearable Art",
-      description: `${FACTS_AND_FIGURES.categoriesCounts["fashion-design-and-wearable-art"]}+ pieces of fashion design and wearable art`,
+      description: `${getFactsAndFigures("categoriesCounts.fashion-design-and-wearable-art")}+ pieces of fashion design and wearable art`,
     },
     "film-slash-video": {
       title: "Films & Videos",
-      description: `${FACTS_AND_FIGURES.categoriesCounts["film-slash-video"]}+ Films & Videos works`,
+      description: `${getFactsAndFigures("categoriesCounts.film-slash-video")}+ Films & Videos works`,
     },
     installation: {
       title: "Installations",
-      description: `${FACTS_AND_FIGURES.categoriesCounts.installation}+ installations`,
+      description: `${getFactsAndFigures("categoriesCounts.installation")}+ installations`,
     },
     jewelry: {
       title: "Jewelry",
-      description: `${FACTS_AND_FIGURES.categoriesCounts.jewelry}+ pieces of jewelry`,
+      description: `${getFactsAndFigures("categoriesCounts.jewelry")}+ pieces of jewelry`,
     },
     "mixed-media": {
       title: "Mixed Media",
-      description: `${FACTS_AND_FIGURES.categoriesCounts["mixed-media"]}+ mixed media works`,
+      description: `${getFactsAndFigures("categoriesCounts.mixed-media")}+ mixed media works`,
     },
     nft: {
       title: "NFTs",
-      description: `${FACTS_AND_FIGURES.categoriesCounts.nft}+ NFTs`,
+      description: `${getFactsAndFigures("categoriesCounts.nft")}+ NFTs`,
     },
     painting: {
       title: "Paintings",
-      description: `${FACTS_AND_FIGURES.categoriesCounts.painting}+ paintings`,
+      description: `${getFactsAndFigures("categoriesCounts.painting")}+ paintings`,
     },
     "performance-art": {
       title: "Performance Art Works",
-      description: `${FACTS_AND_FIGURES.categoriesCounts["performance-art"]}+ performance art works`,
+      description: `${getFactsAndFigures("categoriesCounts.performance-art")}+ performance art works`,
     },
     photography: {
       title: "Photography",
-      description: `${FACTS_AND_FIGURES.categoriesCounts.photography}+ photographs`,
+      description: `${getFactsAndFigures("categoriesCounts.photography")}+ photographs`,
     },
     poster: {
       title: "Posters",
-      description: `${FACTS_AND_FIGURES.categoriesCounts.poster}+ posters`,
+      description: `${getFactsAndFigures("categoriesCounts.poster")}+ posters`,
     },
     prints: {
       title: "Prints",
-      description: `${FACTS_AND_FIGURES.categoriesCounts.prints}+ prints`,
+      description: `${getFactsAndFigures("categoriesCounts.prints")}+ prints`,
     },
     reproduction: {
       title: "Reproduction",
-      description: `${FACTS_AND_FIGURES.categoriesCounts.reproduction}+ reproductions`,
+      description: `${getFactsAndFigures("categoriesCounts.reproduction")}+ reproductions`,
     },
     sculpture: {
       title: "Sculptures",
-      description: `${FACTS_AND_FIGURES.categoriesCounts.sculpture}+ sculptures`,
+      description: `${getFactsAndFigures("categoriesCounts.sculpture")}+ sculptures`,
     },
     textiles: {
       title: "Textiles",
-      description: `${FACTS_AND_FIGURES.categoriesCounts.textiles}+ textiles`,
+      description: `${getFactsAndFigures("categoriesCounts.textiles")}+ textiles`,
     },
     "work-on-paper": {
       title: "Works on Paper",
-      description: `${FACTS_AND_FIGURES.categoriesCounts["work-on-paper"]}+ works on paper`,
+      description: `${getFactsAndFigures("categoriesCounts.work-on-paper")}+ works on paper`,
     },
   }
 

--- a/src/Apps/PriceDatabase/Components/PriceDatabaseBenefits.tsx
+++ b/src/Apps/PriceDatabase/Components/PriceDatabaseBenefits.tsx
@@ -10,9 +10,11 @@ import {
   Text,
 } from "@artsy/palette"
 import { Media } from "Utils/Responsive"
-import { FACTS_AND_FIGURES } from "Utils/factsAndFigures"
+import { getFactsAndFigures } from "Utils/factsAndFigures"
 import type { ReactElement } from "react"
 import type * as React from "react"
+
+const auctionRecordsCount = getFactsAndFigures("auctionRecordsCount")
 
 export const PriceDatabaseBenefits: React.FC<
   React.PropsWithChildren<unknown>
@@ -22,7 +24,7 @@ export const PriceDatabaseBenefits: React.FC<
       <GridColumns gridRowGap={[2, 0]}>
         <Column span={12}>
           <Text as="h1" variant={["xl", "xxl"]}>
-            Auction records from {FACTS_AND_FIGURES.auctionRecordsCount}
+            Auction records from {auctionRecordsCount}
             <br />
             artists—and counting
           </Text>

--- a/src/Apps/PriceDatabase/Components/PriceDatabaseBenefits.tsx
+++ b/src/Apps/PriceDatabase/Components/PriceDatabaseBenefits.tsx
@@ -14,8 +14,6 @@ import { getFactsAndFigures } from "Utils/factsAndFigures"
 import type { ReactElement } from "react"
 import type * as React from "react"
 
-const auctionRecordsCount = getFactsAndFigures("auctionRecordsCount")
-
 export const PriceDatabaseBenefits: React.FC<
   React.PropsWithChildren<unknown>
 > = () => {
@@ -24,7 +22,7 @@ export const PriceDatabaseBenefits: React.FC<
       <GridColumns gridRowGap={[2, 0]}>
         <Column span={12}>
           <Text as="h1" variant={["xl", "xxl"]}>
-            Auction records from {auctionRecordsCount}
+            Auction records from {getFactsAndFigures("auctionRecordsCount")}
             <br />
             artists—and counting
           </Text>

--- a/src/Apps/Sitemaps/templates/llms.ts
+++ b/src/Apps/Sitemaps/templates/llms.ts
@@ -1,18 +1,24 @@
 import { DOWNLOAD_APP_URLS } from "Utils/Hooks/useDeviceDetection"
 import { Device } from "Utils/Hooks/useDeviceDetection"
-import { FACTS_AND_FIGURES } from "Utils/factsAndFigures"
+import { getFactsAndFigures } from "Utils/factsAndFigures"
+
+const artworkCount = getFactsAndFigures("artworksCount")
+const artistCount = getFactsAndFigures("artistsCount")
+const fairCount = getFactsAndFigures("fairsCount")
+const galleryCount = getFactsAndFigures("galleriesCount")
+const institutionCount = getFactsAndFigures("institutionsCount")
 
 export const LLMS_TXT = `# Artsy
 
-> Artsy is the world’s largest online art marketplace. Browse over ${FACTS_AND_FIGURES.artworksCount} artworks by iconic and emerging artists from ${FACTS_AND_FIGURES.galleriesCount}+ galleries and top auction houses.
+> Artsy is the world’s largest online art marketplace. Browse over ${artworkCount} artworks by iconic and emerging artists from ${galleryCount}+ galleries and top auction houses.
 
 ## Browse & Buy Art
-- [Artists](https://www.artsy.net/artists): Profiles for over ${FACTS_AND_FIGURES.artistsCount}+ artists: bios, works, auction results.
-- [Artworks](https://www.artsy.net/collect): Global inventory of over ${FACTS_AND_FIGURES.artworksCount}+ artworks searchable by medium, price, size, and more.
-- [Galleries](https://www.artsy.net/galleries): A global index of Artsy’s ${FACTS_AND_FIGURES.galleriesCount}+ partner galleries, organized by city and specialty. Listings surface the gallery’s current, upcoming, and past shows, along with artworks that are available to buy immediately.
-- [Museums](https://www.artsy.net/institutions): A directory of more than ${FACTS_AND_FIGURES.institutionsCount} museum and nonprofit institution partners worldwide. Each profile showcases current and past exhibitions, highlights from the collection, and a “Follow” button so collectors get notified when new shows go live.
+- [Artists](https://www.artsy.net/artists): Profiles for over ${artistCount}+ artists: bios, works, auction results.
+- [Artworks](https://www.artsy.net/collect): Global inventory of over ${artworkCount}+ artworks searchable by medium, price, size, and more.
+- [Galleries](https://www.artsy.net/galleries): A global index of Artsy’s ${galleryCount}+ partner galleries, organized by city and specialty. Listings surface the gallery’s current, upcoming, and past shows, along with artworks that are available to buy immediately.
+- [Museums](https://www.artsy.net/institutions): A directory of more than ${institutionCount} museum and nonprofit institution partners worldwide. Each profile showcases current and past exhibitions, highlights from the collection, and a “Follow” button so collectors get notified when new shows go live.
 - [Shows](https://www.artsy.net/shows): Artsy’s calendar of gallery and museum exhibitions worldwide. Filter by city or “Online Exclusive,” browse featured shows, and track live countdowns until opening or closing.
-- [Fairs & Events](https://www.artsy.net/fairs): A hub for ${FACTS_AND_FIGURES.fairsCount}+ international art fairs—from Art Basel and Frieze to regional pop-ups. Users can preview booths, filter by “Current / Upcoming / Past,” and buy works before, during, or after the physical fair dates.
+- [Fairs & Events](https://www.artsy.net/fairs): A hub for ${fairCount}+ international art fairs—from Art Basel and Frieze to regional pop-ups. Users can preview booths, filter by “Current / Upcoming / Past,” and buy works before, during, or after the physical fair dates.
 - [Viewing Rooms](https://www.artsy.net/viewing-rooms): Time-limited online exhibitions where leading galleries and institutions present tightly curated selections of work. Pages blend high-resolution images, curatorial storytelling, and instant purchase or inquiry options.
 - [Collections](https://www.artsy.net/collections): Curated thematic groups (e.g., Surrealism, Women Sculptors).
 - [Categories](https://www.artsy.net/categories): *The Art Genome Project* taxonomy of 1,000+ art-historical “genes.”

--- a/src/Utils/factsAndFigures.ts
+++ b/src/Utils/factsAndFigures.ts
@@ -19,6 +19,7 @@ export const FACTS_AND_FIGURES = {
   artistsCount: 100000,
   fairsCount: 80,
   auctionHouseCount: 25,
+  membersCount: 3400000,
   categoriesCounts: {
     architecture: 55000,
     "books-and-portfolios": 7500,

--- a/src/Utils/factsAndFigures.ts
+++ b/src/Utils/factsAndFigures.ts
@@ -1,43 +1,66 @@
+import { get } from "lodash"
+
 // See https://docs.google.com/document/d/187m0Nt3LWCd0q3lz5RaTYM2B_epvpVaUQzl1jkMX2LE
 
 export const FACTS_AND_FIGURES = {
   iosApp: {
-    ratingValue: "4.8",
-    reviewCount: "5500",
+    ratingValue: 4.8,
+    reviewCount: 5500,
   },
   androidApp: {
-    ratingValue: "4.5",
-    reviewCount: "1230",
+    ratingValue: 4.5,
+    reviewCount: 1230,
   },
-  auctionRecordsCount: "300,000",
-  institutionsCount: "800",
-  galleriesCount: "3,000",
-  forSaleArtworksCount: "700,000",
-  artworksCount: "1,000,000",
-  artistsCount: "100,000",
-  fairsCount: "80",
-  auctionHouseCount: "25",
+  auctionRecordsCount: 300000,
+  institutionsCount: 800,
+  galleriesCount: 3000,
+  forSaleArtworksCount: 700000,
+  artworksCount: 1000000,
+  artistsCount: 100000,
+  fairsCount: 80,
+  auctionHouseCount: 25,
   categoriesCounts: {
-    architecture: "55,000",
-    "books-and-portfolios": "7,500",
-    design: "60,000",
-    "digital-art": "2,000",
-    drawing: "70,000",
-    "ephemera-or-merchandise": "5,000", // FIXME: Unable to access count
-    "fashion-design-and-wearable-art": "2,500",
-    "film-slash-video": "8,000",
-    installation: "30,000",
-    jewelry: "3,500",
-    "mixed-media": "250,000",
-    nft: "100",
-    painting: "850,000",
-    "performance-art": "7,500",
-    photography: "300,000",
-    poster: "10,000",
-    prints: "350,000",
-    reproduction: "3,000", // FIXME: Unable to access count
-    sculpture: "225,000",
-    textiles: "20,000",
-    "work-on-paper": "210,000",
+    architecture: 55000,
+    "books-and-portfolios": 7500,
+    design: 60000,
+    "digital-art": 2000,
+    drawing: 70000,
+    "ephemera-or-merchandise": 5000, // FIXME: Unable to access count
+    "fashion-design-and-wearable-art": 2500,
+    "film-slash-video": 8000,
+    installation: 30000,
+    jewelry: 3500,
+    "mixed-media": 250000,
+    nft: 100,
+    painting: 850000,
+    "performance-art": 7500,
+    photography: 300000,
+    poster: 10000,
+    prints: 350000,
+    reproduction: 3000, // FIXME: Unable to access count
+    sculpture: 225000,
+    textiles: 20000,
+    "work-on-paper": 210000,
   },
 } as const
+
+export type FactsAndFiguresFormat = "comma" | "compact"
+
+const FORMATTERS: Record<FactsAndFiguresFormat, Intl.NumberFormat> = {
+  comma: new Intl.NumberFormat("en"),
+  compact: new Intl.NumberFormat("en", {
+    notation: "compact",
+    maximumFractionDigits: 1,
+  }),
+}
+
+export const getFactsAndFigures = (
+  path: string,
+  {
+    format: formatName = "comma",
+  }: {
+    format?: FactsAndFiguresFormat
+  } = {},
+) => {
+  return FORMATTERS[formatName].format(get(FACTS_AND_FIGURES, path))
+}

--- a/src/Utils/factsAndFigures.ts
+++ b/src/Utils/factsAndFigures.ts
@@ -46,6 +46,23 @@ export const FACTS_AND_FIGURES = {
 
 export type FactsAndFiguresFormat = "comma" | "compact"
 
+type FactsAndFigures = typeof FACTS_AND_FIGURES
+
+type JoinPath<
+  Parent extends string,
+  Child extends string,
+> = `${Parent}.${Child}`
+
+type NumericPath<T> = {
+  [Key in Extract<keyof T, string>]: T[Key] extends number
+    ? Key
+    : T[Key] extends object
+      ? JoinPath<Key, NumericPath<T[Key]>>
+      : never
+}[Extract<keyof T, string>]
+
+export type FactsAndFiguresPath = NumericPath<FactsAndFigures>
+
 const FORMATTERS: Record<FactsAndFiguresFormat, Intl.NumberFormat> = {
   comma: new Intl.NumberFormat("en"),
   compact: new Intl.NumberFormat("en", {
@@ -54,13 +71,13 @@ const FORMATTERS: Record<FactsAndFiguresFormat, Intl.NumberFormat> = {
   }),
 }
 
+interface GetFactsAndFiguresOptions {
+  format?: FactsAndFiguresFormat
+}
+
 export const getFactsAndFigures = (
-  path: string,
-  {
-    format: formatName = "comma",
-  }: {
-    format?: FactsAndFiguresFormat
-  } = {},
+  path: FactsAndFiguresPath,
+  { format = "comma" }: GetFactsAndFiguresOptions = {},
 ) => {
-  return FORMATTERS[formatName].format(get(FACTS_AND_FIGURES, path))
+  return FORMATTERS[format].format(get(FACTS_AND_FIGURES, path))
 }


### PR DESCRIPTION
We had to do some workarounds to parse the strings to format them here: https://github.com/artsy/force/blob/41743e70f604db9562c02b2f2ce67d281a5aa778/src/Apps/Authentication/Routes/SignupLanding/Components/SignupHeroContent.tsx#L5-L10

Plus some duplication, and inconsistent formatting for other strings.

Let's just store these as numbers and consolidate the formatters.

cc @artsy/diamond-devs 