### PR TITLE
chore(DI-93): Tracking for new sign up page

### DIFF
--- a/src/Apps/Authentication/Routes/SignupLanding/Components/SignupForm.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/Components/SignupForm.tsx
@@ -13,6 +13,7 @@ import * as Yup from "yup"
 import { signUp } from "Utils/auth"
 import { useRecaptcha } from "Utils/EnableRecaptcha"
 import { useAfterAuthentication } from "Components/AuthDialog/Hooks/useAfterAuthentication"
+import { useAuthDialogTracking } from "Components/AuthDialog/Hooks/useAuthDialogTracking"
 import { SignupFormSocial } from "./SignupFormSocial"
 import { SignupFormDisclaimer } from "./SignupFormDisclaimer"
 import { useCountryCode } from "Components/AuthDialog/Hooks/useCountryCode"
@@ -43,6 +44,8 @@ export const SignupForm = () => {
   const { runAfterAuthentication } = useAfterAuthentication()
   const { isAutomaticallySubscribed } = useCountryCode()
 
+  const track = useAuthDialogTracking()
+
   const handleSubmit = async (values, actions) => {
     try {
       const response = await signUp({
@@ -51,7 +54,9 @@ export const SignupForm = () => {
         password: values.password,
         agreedToReceiveEmails: values.agreedToReceiveEmails,
       })
-      // Match existing /signup behavior - onboarding modal will appear
+
+      track.signedUp({ service: "email", userId: response.user.id })
+
       await runAfterAuthentication({ accessToken: response.user.accessToken })
     } catch (err) {
       setError(err.message || "Something went wrong. Please try again.")

--- a/src/Apps/Authentication/Routes/SignupLanding/Components/SignupValueProps.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/Components/SignupValueProps.tsx
@@ -13,9 +13,23 @@ import { AppContainer } from "Apps/Components/AppContainer"
 import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
 import { cropped } from "Utils/resized"
 import { FACTS_AND_FIGURES } from "Utils/factsAndFigures"
+import { ActionType } from "@artsy/cohesion"
+import { useTracking } from "react-tracking"
 
 export const SignupValueProps = () => {
   const { theme } = useTheme()
+  const { trackEvent } = useTracking()
+
+  const handleBuyerGuaranteeClick = () => {
+    trackEvent({
+      action: ActionType.clickedBuyerProtection,
+      context_module: "about",
+      context_page_owner_type: "signup",
+      context_page_owner_id: null,
+      destination_page_owner_type: "articles",
+      destination_page_owner_slug: "360048946973-How-does-Artsy-protect-me",
+    })
+  }
 
   return (
     <FullBleed bg="mono5" py={[6, 12]}>
@@ -122,7 +136,12 @@ export const SignupValueProps = () => {
                   Shop with total confidence. Artsy’s trusted checkout and buyer
                   protections mean there’s no guesswork—just art you love,
                   delivered to your door. Learn more about the{" "}
-                  <a href="/buyer-guarantee">Artsy Guarantee.</a>
+                  <a
+                    href="/buyer-guarantee"
+                    onClick={handleBuyerGuaranteeClick}
+                  >
+                    Artsy Guarantee.
+                  </a>
                 </Text>
               </Box>
             </Column>

--- a/src/Apps/Authentication/Routes/SignupLanding/Components/__tests__/SignupValueProps.jest.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/Components/__tests__/SignupValueProps.jest.tsx
@@ -1,7 +1,24 @@
 import { render, screen } from "@testing-library/react"
 import { SignupValueProps } from "../SignupValueProps"
+import { useTracking } from "react-tracking"
+import { ActionType } from "@artsy/cohesion"
+import userEvent from "@testing-library/user-event"
+
+jest.mock("react-tracking")
 
 describe("SignupValueProps", () => {
+  const trackEvent = jest.fn()
+
+  beforeAll(() => {
+    ;(useTracking as jest.Mock).mockImplementation(() => ({
+      trackEvent,
+    }))
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
   it("renders the section title", () => {
     render(<SignupValueProps />)
     expect(screen.getByText("Why Choose Artsy")).toBeInTheDocument()
@@ -19,5 +36,23 @@ describe("SignupValueProps", () => {
     expect(
       screen.getByText("Secure art buying, every time"),
     ).toBeInTheDocument()
+  })
+
+  it("tracks clickedBuyerProtection when Artsy Guarantee link is clicked", () => {
+    render(<SignupValueProps />)
+
+    const link = screen.getByText("Artsy Guarantee.")
+
+    userEvent.click(link)
+
+    expect(trackEvent).toHaveBeenCalledTimes(1)
+    expect(trackEvent).toHaveBeenCalledWith({
+      action: ActionType.clickedBuyerProtection,
+      context_module: "about",
+      context_page_owner_type: "signup",
+      context_page_owner_id: null,
+      destination_page_owner_type: "articles",
+      destination_page_owner_slug: "360048946973-How-does-Artsy-protect-me",
+    })
   })
 })


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [DI-93](https://www.notion.so/33bcab0764a08015ad76f60461caf902)

### Description

Implements tracking for /signup-new

- Fires `createdAccount` event when the user completes the signup and actually creates an account. 
<img width="1451" height="691" alt="Screenshot 2026-04-27 at 8 46 39 AM" src="https://github.com/user-attachments/assets/bbcc11bb-3bd8-4637-8de5-54b0d2fbf938" />


- Fires `clickedBuyerProtection` event when the user clicks on the Artsy Buyer guarantee link.
<img width="1451" height="682" alt="Screenshot 2026-04-27 at 8 51 35 AM" src="https://github.com/user-attachments/assets/c259c5df-b1dd-4093-9063-e76684fd664c" />

<!-- Implementation description -->
