### PR TITLE
fix: Adding temporary /signup redirect to prevent integrity test failures

### DIFF
--- a/src/Apps/Authentication/authenticationRoutes.tsx
+++ b/src/Apps/Authentication/authenticationRoutes.tsx
@@ -135,6 +135,15 @@ export const authenticationRoutes: RouteProps[] = [
     },
   },
   {
+    path: "/signup",
+    onServerSideRender: ({ res, req }) => {
+      // Temporary redirect to old signup while new page is in QA
+      const queryString =
+        Object.keys(req.query).length > 0 ? `?${stringify(req.query)}` : ""
+      res.redirect(301, `/signup-old${queryString}`)
+    },
+  },
+  {
     path: "/signup-new",
     layout: "ContainerOnly",
     getComponent: () => SignupNewRoute,

--- a/src/Apps/Authentication/authenticationRoutes.tsx
+++ b/src/Apps/Authentication/authenticationRoutes.tsx
@@ -117,7 +117,7 @@ export const authenticationRoutes: RouteProps[] = [
     },
   },
   {
-    path: "/signup-old",
+    path: "/signup",
     layout: "ContainerOnly",
     getComponent: () => SignupRoute,
     onServerSideRender: props => {
@@ -132,15 +132,6 @@ export const authenticationRoutes: RouteProps[] = [
     },
     onPreloadJS: () => {
       SignupRoute.preload()
-    },
-  },
-  {
-    path: "/signup",
-    onServerSideRender: ({ res, req }) => {
-      // Temporary redirect to old signup while new page is in QA
-      const queryString =
-        Object.keys(req.query).length > 0 ? `?${stringify(req.query)}` : ""
-      res.redirect(301, `/signup-old${queryString}`)
     },
   },
   {


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

### Description
I noticed that some integrity tests were failing in the Diamond channel. This is the result of recent restructured authentication routes to prepare for the new signup landing page:
  - Renamed `/signup` → `/signup-old` (old modal)
  - Added `/signup-new` (new landing page for QA)
  - `/signup` route no longer exists

  This caused 5 Cypress integrity tests to fail because they hardcode `/signup` in their helpers:
  - artQuiz.cy.ts
  - cookieConsent.cy.ts (2 tests)
  - onboarding.cy.ts (2 tests)

  (All failures showed the same error 404: Not Found when visiting `/signup?redirectTo=...`)

I've added this temporary redirect `/signup` → `/signup-old`. After QA I will remove this and the old sign up route. 

<!-- Implementation description -->
