### PR TITLE
fix(EMI-3206): fix details layout and 404 page

### DIFF
--- a/src/Apps/Order/Layouts/LayoutOrderDetails.tsx
+++ b/src/Apps/Order/Layouts/LayoutOrderDetails.tsx
@@ -1,6 +1,7 @@
-import { Box } from "@artsy/palette"
+import { Box, Spacer } from "@artsy/palette"
 import { AppContainer } from "Apps/Components/AppContainer"
 import { AppToasts } from "Apps/Components/AppToasts"
+import { HorizontalPadding } from "Apps/Components/HorizontalPadding"
 import type { BaseLayoutProps } from "Apps/Components/Layouts"
 import { LayoutNav } from "Apps/Components/Layouts/Components/LayoutNav"
 import type { FC } from "react"
@@ -21,7 +22,10 @@ export const LayoutOrderDetails: FC<
         <LayoutNav />
 
         <AppContainer as="main" id="main" flex={1}>
-          {children}
+          <HorizontalPadding>
+            <Spacer y={[2, 4]} />
+            {children}
+          </HorizontalPadding>
         </AppContainer>
       </Box>
     </>

--- a/src/Apps/Order/Routes/Details/Components/OrderDetailsPage.tsx
+++ b/src/Apps/Order/Routes/Details/Components/OrderDetailsPage.tsx
@@ -35,7 +35,7 @@ export const OrderDetailsPage = ({ order, me }: OrderDetailsPageProps) => {
   const artworkSlug = orderData.lineItems[0]?.artwork?.slug
 
   return (
-    <GridColumns pt={[0, 4]} px={[0, 4]}>
+    <GridColumns>
       <Column span={[12, 7, 6, 5]} start={[1, 1, 2, 3]}>
         <OrderDetailsHeader order={orderData} />
 

--- a/src/Apps/Order/orderRoutes.tsx
+++ b/src/Apps/Order/orderRoutes.tsx
@@ -1,7 +1,7 @@
 import loadable from "@loadable/component"
+import { OrderErrorApp } from "Apps/Order/Components/OrderErrorApp"
 import { getRedirect } from "Apps/Order/getRedirect"
 import { redirects } from "Apps/Order/redirects"
-import { OrderErrorApp } from "Apps/Order/Components/OrderErrorApp"
 import type { SystemContextProps } from "System/Contexts/SystemContext"
 import type { RouteProps } from "System/Router/Route"
 import { HttpError, Redirect, RedirectException } from "found"

--- a/src/Apps/Order2/order2Routes.tsx
+++ b/src/Apps/Order2/order2Routes.tsx
@@ -1,11 +1,11 @@
 import loadable from "@loadable/component"
 import { newCheckoutEnabled } from "Apps/Order/redirects"
 import { OrderErrorApp } from "Apps/Order2/Components/Order2ErrorApp"
+import { NOT_FOUND_ERROR } from "Apps/Order2/constants"
 import type { SystemContextProps } from "System/Contexts/SystemContext"
 import type { RouteProps } from "System/Router/Route"
 import createLogger from "Utils/logger"
 import type { order2Routes_CheckoutQuery$data } from "__generated__/order2Routes_CheckoutQuery.graphql"
-import { NOT_FOUND_ERROR } from "Apps/Order2/constants"
 import { type Match, RedirectException } from "found"
 import { graphql } from "react-relay"
 


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-3206]

### Description

Follow up on the fix of the 404 pages layout

The `LayoutOrderDetails` component was missing `HorizontalPadding` and `Spacer` - aded those

As for the background color on the details and checkout pages,  I decided to keep the `mono5` background color. The reason is that adding white background would mean making edits to the `OrderErrorApp` component which is used in a lot of places - changing it to respect all layout is tricky and requires a lot of testing
 
<!-- Implementation description -->

| Details Before | Details After (no changes) | Details 404 before | Details 404 After |
| --- | --- | --- | --- |
| <img width="1512" height="902" alt="image" src="https://github.com/user-attachments/assets/4cd4eb30-b1c6-479b-b69a-bc8a4b627627" /> | <img width="1512" height="898" alt="image" src="https://github.com/user-attachments/assets/e10693e3-5815-4427-ba69-b93dc2fa3b63" /> | <img width="1512" height="899" alt="image" src="https://github.com/user-attachments/assets/a60e1d4f-5310-4b51-94a7-7e1ad85291f7" /> | <img width="1512" height="903" alt="image" src="https://github.com/user-attachments/assets/2596a32c-daef-40c5-9522-eeebaf3d78df" /> |

[EMI-3206]: https://artsyproduct.atlassian.net/browse/EMI-3206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ