### PR TITLE
feat(di-231): Launch new signup landing page to production

### DIFF
--- a/src/Apps/Authentication/Routes/SignupLanding/Components/SignupFormSocial.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/Components/SignupFormSocial.tsx
@@ -6,6 +6,10 @@ import { getENV } from "Utils/getENV"
 import { stringify } from "qs"
 
 export const SignupFormSocial = () => {
+  // Read redirectTo from URL query params
+  const params = new URLSearchParams(window.location.search)
+  const redirectUrl = params.get("redirectTo") || "/"
+
   const { applePath, facebookPath, googlePath } = getENV("AP") ?? {
     applePath: "/users/auth/apple",
     facebookPath: "/users/auth/facebook",
@@ -14,7 +18,7 @@ export const SignupFormSocial = () => {
 
   const query = stringify(
     {
-      "redirect-to": "/", // Always redirect to homepage after social auth
+      "redirect-to": redirectUrl,
       "signup-intent": "signup",
       "signup-referer": getENV("AUTHENTICATION_REFERER"), // Use same ENV var
       accepted_terms_of_service: true,

--- a/src/Apps/Authentication/Routes/SignupLanding/Components/SignupFormSocial.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/Components/SignupFormSocial.tsx
@@ -4,11 +4,10 @@ import AppleIcon from "@artsy/icons/AppleIcon"
 import FacebookIcon from "@artsy/icons/FacebookIcon"
 import { getENV } from "Utils/getENV"
 import { stringify } from "qs"
+import { useAfterAuthenticationRedirectUrl } from "Components/AuthDialog/Hooks/useAfterAuthenticationRedirectUrl"
 
 export const SignupFormSocial = () => {
-  // Read redirectTo from URL query params
-  const params = new URLSearchParams(window.location.search)
-  const redirectUrl = params.get("redirectTo") || "/"
+  const { redirectUrl } = useAfterAuthenticationRedirectUrl()
 
   const { applePath, facebookPath, googlePath } = getENV("AP") ?? {
     applePath: "/users/auth/apple",

--- a/src/Apps/Authentication/Routes/SignupLanding/Components/SignupFormSocial.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/Components/SignupFormSocial.tsx
@@ -2,11 +2,17 @@ import { Button, Stack } from "@artsy/palette"
 import GoogleIcon from "@artsy/icons/GoogleIcon"
 import AppleIcon from "@artsy/icons/AppleIcon"
 import FacebookIcon from "@artsy/icons/FacebookIcon"
+import { useAuthDialogContext } from "Components/AuthDialog/AuthDialogContext"
+import { setSocialAuthTracking } from "Components/AuthDialog/Hooks/useSocialAuthTracking"
 import { getENV } from "Utils/getENV"
 import { stringify } from "qs"
 import { useAfterAuthenticationRedirectUrl } from "Components/AuthDialog/Hooks/useAfterAuthenticationRedirectUrl"
 
 export const SignupFormSocial = () => {
+  const {
+    state: { analytics, mode },
+  } = useAuthDialogContext()
+
   const { redirectUrl } = useAfterAuthenticationRedirectUrl()
 
   const { applePath, facebookPath, googlePath } = getENV("AP") ?? {
@@ -19,12 +25,20 @@ export const SignupFormSocial = () => {
     {
       "redirect-to": redirectUrl,
       "signup-intent": "signup",
-      "signup-referer": getENV("AUTHENTICATION_REFERER"), // Use same ENV var
+      "signup-referer": getENV("AUTHENTICATION_REFERER"),
       accepted_terms_of_service: true,
       agreed_to_receive_emails: true,
     },
     { skipNulls: true },
   )
+
+  const handleClick = (service: "facebook" | "apple" | "google") => () => {
+    setSocialAuthTracking({
+      action: { Login: "loggedIn", SignUp: "signedUp" }[mode],
+      analytics,
+      service,
+    })
+  }
 
   return (
     <Stack gap={1}>
@@ -34,6 +48,7 @@ export const SignupFormSocial = () => {
         // @ts-ignore
         as="a"
         href={`${googlePath}?${query}`}
+        onClick={handleClick("google")}
         rel="nofollow"
         Icon={GoogleIcon}
       >
@@ -46,6 +61,7 @@ export const SignupFormSocial = () => {
         // @ts-ignore
         as="a"
         href={`${facebookPath}?${query}`}
+        onClick={handleClick("facebook")}
         rel="nofollow"
         Icon={FacebookIcon}
       >
@@ -58,6 +74,7 @@ export const SignupFormSocial = () => {
         // @ts-ignore
         as="a"
         href={`${applePath}?${query}`}
+        onClick={handleClick("apple")}
         rel="nofollow"
         Icon={AppleIcon}
       >

--- a/src/Apps/Authentication/Routes/SignupLanding/SignupLandingPage.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/SignupLandingPage.tsx
@@ -15,7 +15,7 @@ export const SignupLandingPage: FC<React.PropsWithChildren<unknown>> = () => {
         <MetaTags
           title="Join Artsy - Discover and Buy Art That Moves You"
           description="Join over 3.4 million art collectors and enthusiasts. Explore 1.6 million original artworks for sale from galleries, museums, and artists worldwide."
-          pathname="/signup-new"
+          pathname="/signup"
         />
 
         <SignupHeader />

--- a/src/Apps/Authentication/__tests__/authenticationRoutes.jest.tsx
+++ b/src/Apps/Authentication/__tests__/authenticationRoutes.jest.tsx
@@ -184,30 +184,10 @@ describe("authenticationRoutes", () => {
     })
   })
 
-  describe("/signup-new", () => {
-    describe("server", () => {
-      describe("onServerSideRender", () => {
-        it("runs middleware", () => {
-          renderServerRoute("/signup-new").onServerSideRender()
-          expect(mockRedirectIfLoggedIn).toHaveBeenCalled()
-          expect(mockCheckForRedirect).toHaveBeenCalled()
-          expect(mockSetReferer).toHaveBeenCalled()
-        })
-
-        it("skips the check for login if you are auth-ing with the API", () => {
-          renderServerRoute("/signup-new?oauthLogin=true").onServerSideRender()
-          expect(mockRedirectIfLoggedIn).not.toHaveBeenCalled()
-          expect(mockCheckForRedirect).toHaveBeenCalled()
-          expect(mockSetReferer).toHaveBeenCalled()
-        })
-      })
-    })
-  })
-
-  describe("/signup-new", () => {
+  describe("/signup", () => {
     describe("client", () => {
       it.skip("renders signup landing page", async () => {
-        renderClientRoute("/signup-new")
+        renderClientRoute("/signup")
 
         await waitFor(() => {
           expect(screen.getByText(/Join Artsy today/i)).toBeInTheDocument()

--- a/src/Apps/Authentication/authenticationRoutes.tsx
+++ b/src/Apps/Authentication/authenticationRoutes.tsx
@@ -33,14 +33,6 @@ const LoginRoute = loadable(
   { resolveComponent: component => component.AuthenticationLoginRoute },
 )
 
-const SignupRoute = loadable(
-  () =>
-    import(
-      /* webpackChunkName: "authenticationBundle" */ "./Routes/AuthenticationSignUpRoute"
-    ),
-  { resolveComponent: component => component.AuthenticationSignUpRoute },
-)
-
 const SignupNewRoute = loadable(
   () =>
     import(
@@ -119,26 +111,11 @@ export const authenticationRoutes: RouteProps[] = [
   {
     path: "/signup",
     layout: "ContainerOnly",
-    getComponent: () => SignupRoute,
+    getComponent: () => SignupNewRoute,
     onServerSideRender: props => {
       // We need this check so we allow someone to log into the API even if they
       // have already logged into force. Otherwise, we short-circuit and risk
       // taking the user into an infinite redirect loop.
-      if (!props.req.query.oauthLogin) {
-        redirectIfLoggedIn(props)
-      }
-
-      runAuthMiddleware(props)
-    },
-    onPreloadJS: () => {
-      SignupRoute.preload()
-    },
-  },
-  {
-    path: "/signup-new",
-    layout: "ContainerOnly",
-    getComponent: () => SignupNewRoute,
-    onServerSideRender: props => {
       if (!props.req.query.oauthLogin) {
         redirectIfLoggedIn(props)
       }

--- a/src/Apps/Authentication/authenticationRoutes.tsx
+++ b/src/Apps/Authentication/authenticationRoutes.tsx
@@ -33,7 +33,7 @@ const LoginRoute = loadable(
   { resolveComponent: component => component.AuthenticationLoginRoute },
 )
 
-const SignupNewRoute = loadable(
+const SignupRoute = loadable(
   () =>
     import(
       /* webpackChunkName: "authenticationBundle" */ "./Routes/AuthenticationSignUpNewRoute"
@@ -111,7 +111,7 @@ export const authenticationRoutes: RouteProps[] = [
   {
     path: "/signup",
     layout: "ContainerOnly",
-    getComponent: () => SignupNewRoute,
+    getComponent: () => SignupRoute,
     onServerSideRender: props => {
       // We need this check so we allow someone to log into the API even if they
       // have already logged into force. Otherwise, we short-circuit and risk
@@ -123,7 +123,7 @@ export const authenticationRoutes: RouteProps[] = [
       runAuthMiddleware(props)
     },
     onPreloadJS: () => {
-      SignupNewRoute.preload()
+      SignupRoute.preload()
     },
   },
   {

--- a/src/Apps/Home/Components/HomeHeroUnits/HomeHeroUnitLoggedOut.tsx
+++ b/src/Apps/Home/Components/HomeHeroUnits/HomeHeroUnitLoggedOut.tsx
@@ -1,5 +1,3 @@
-import { ContextModule } from "@artsy/cohesion"
-import { useAuthDialog } from "Components/AuthDialog"
 import { useDeviceDetection } from "Utils/Hooks/useDeviceDetection"
 import type * as React from "react"
 import { HomeHeroUnitBase } from "./HomeHeroUnit"
@@ -8,7 +6,6 @@ export const HomeHeroUnitLoggedOut: React.FC<{ index: number }> = ({
   index,
 }) => {
   const { downloadAppUrl } = useDeviceDetection()
-  const { showAuthDialog } = useAuthDialog()
 
   return (
     <HomeHeroUnitBase
@@ -19,15 +16,6 @@ export const HomeHeroUnitLoggedOut: React.FC<{ index: number }> = ({
         desktop: {
           text: "Sign Up",
           url: "/signup",
-          onClick: e => {
-            e.preventDefault()
-
-            showAuthDialog({
-              analytics: {
-                contextModule: ContextModule.heroUnitsRail,
-              },
-            })
-          },
         },
         mobile: {
           text: "Get the App",

--- a/src/Components/AuthDialog/Hooks/useAfterAuthenticationRedirectUrl.ts
+++ b/src/Components/AuthDialog/Hooks/useAfterAuthenticationRedirectUrl.ts
@@ -55,9 +55,7 @@ const useDefaultRedirect = () => {
 
   // If we're on the login or sign up path; we should redirect to the default (index).
   // Otherwise stay on the same page.
-  const defaultRedirect = ["/login", "/signup", "/signup-new"].includes(
-    location.pathname,
-  )
+  const defaultRedirect = ["/login", "/signup"].includes(location.pathname)
     ? DEFAULT_AFTER_AUTH_REDIRECT_PATH
     : location.pathname + (location.search || "")
 

--- a/src/Components/AuthDialog/Hooks/useAfterAuthenticationRedirectUrl.ts
+++ b/src/Components/AuthDialog/Hooks/useAfterAuthenticationRedirectUrl.ts
@@ -47,17 +47,26 @@ export const useAfterAuthenticationRedirectUrl = () => {
 
 const useDefaultRedirect = () => {
   const router = useRouter()
-
-  // In a client-side context we have the window.location object, but we won't have
-  // the router context. In a server-side context we have the router context,
-  // but we won't have the window.location object.
   const location = router.match ? router.match.location : window.location
 
-  // If we're on the login or sign up path; we should redirect to the default (index).
-  // Otherwise stay on the same page.
-  const defaultRedirect = ["/login", "/signup"].includes(location.pathname)
-    ? DEFAULT_AFTER_AUTH_REDIRECT_PATH
-    : location.pathname + (location.search || "")
+  // Read redirectTo from URL query params (for client-side navigation)
+  let redirectTo: string | null = null
+  if (typeof window !== "undefined") {
+    const params = new URLSearchParams(window.location.search)
+    redirectTo = params.get("redirectTo")
+  }
+
+  const defaultRedirect = (() => {
+    // Use redirectTo from URL if available
+    if (redirectTo) {
+      return redirectTo
+    }
+
+    // Otherwise use default logic
+    return ["/login", "/signup"].includes(location.pathname)
+      ? DEFAULT_AFTER_AUTH_REDIRECT_PATH
+      : location.pathname + (location.search || "")
+  })()
 
   return { defaultRedirect }
 }

--- a/src/Components/NavBar/NavBarLoggedOutActions.tsx
+++ b/src/Components/NavBar/NavBarLoggedOutActions.tsx
@@ -2,11 +2,17 @@ import { ContextModule, Intent } from "@artsy/cohesion"
 import { Button, Flex, Spacer } from "@artsy/palette"
 import { useAuthDialog } from "Components/AuthDialog"
 import { RouterLink } from "System/Components/RouterLink"
+import { useState, useEffect } from "react"
 
 export const NavBarLoggedOutActions = () => {
   const { showAuthDialog } = useAuthDialog()
-  const currentPath =
-    typeof window !== "undefined" ? window.location.pathname : "/"
+  const [currentPath, setCurrentPath] = useState("/")
+  // const currentPath =
+  //   typeof window !== "undefined" ? window.location.pathname : "/"
+
+  useEffect(() => {
+    setCurrentPath(window.location.pathname)
+  }, [])
 
   return (
     <Flex alignItems="center">

--- a/src/Components/NavBar/NavBarLoggedOutActions.tsx
+++ b/src/Components/NavBar/NavBarLoggedOutActions.tsx
@@ -7,8 +7,6 @@ import { useState, useEffect } from "react"
 export const NavBarLoggedOutActions = () => {
   const { showAuthDialog } = useAuthDialog()
   const [currentPath, setCurrentPath] = useState("/")
-  // const currentPath =
-  //   typeof window !== "undefined" ? window.location.pathname : "/"
 
   useEffect(() => {
     setCurrentPath(window.location.pathname)

--- a/src/Components/NavBar/NavBarLoggedOutActions.tsx
+++ b/src/Components/NavBar/NavBarLoggedOutActions.tsx
@@ -1,6 +1,7 @@
 import { ContextModule, Intent } from "@artsy/cohesion"
 import { Button, Flex, Spacer } from "@artsy/palette"
 import { useAuthDialog } from "Components/AuthDialog"
+import { RouterLink } from "System/Components/RouterLink"
 
 export const NavBarLoggedOutActions = () => {
   const { showAuthDialog } = useAuthDialog()
@@ -25,15 +26,10 @@ export const NavBarLoggedOutActions = () => {
       <Spacer x={1} />
 
       <Button
+        // @ts-expect-error
+        as={RouterLink}
+        to="/signup"
         size="small"
-        onClick={() => {
-          showAuthDialog({
-            analytics: {
-              contextModule: ContextModule.header,
-              intent: Intent.signup,
-            },
-          })
-        }}
       >
         Sign Up
       </Button>

--- a/src/Components/NavBar/NavBarLoggedOutActions.tsx
+++ b/src/Components/NavBar/NavBarLoggedOutActions.tsx
@@ -5,6 +5,8 @@ import { RouterLink } from "System/Components/RouterLink"
 
 export const NavBarLoggedOutActions = () => {
   const { showAuthDialog } = useAuthDialog()
+  const currentPath =
+    typeof window !== "undefined" ? window.location.pathname : "/"
 
   return (
     <Flex alignItems="center">
@@ -28,8 +30,8 @@ export const NavBarLoggedOutActions = () => {
       <Button
         // @ts-expect-error
         as={RouterLink}
-        to="/signup"
         size="small"
+        to={`/signup?redirectTo=${encodeURIComponent(currentPath)}`}
       >
         Sign Up
       </Button>

--- a/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuAuthentication.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuAuthentication.tsx
@@ -6,6 +6,7 @@ import { trackEvent } from "Server/analytics/helpers"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import type * as React from "react"
 import { NavBarMobileMenuItemLink } from "./NavBarMobileMenuItem"
+import { useState, useEffect } from "react"
 
 export const NavBarMobileMenuLoggedIn: React.FC<
   React.PropsWithChildren<unknown>
@@ -55,10 +56,16 @@ export const NavBarMobileMenuLoggedIn: React.FC<
 const NavBarMobileMenuLoggedOut: React.FC<
   React.PropsWithChildren<unknown>
 > = () => {
+  const [currentPath, setCurrentPath] = useState("/")
+
+  useEffect(() => {
+    setCurrentPath(window.location.pathname)
+  }, [])
+
   return (
     <>
       <NavBarMobileMenuItemLink
-        to={`/signup?intent=${Intent.signup}&contextModule=${ContextModule.header}`}
+        to={`/signup?redirectTo=${encodeURIComponent(currentPath)}`}
       >
         Sign Up
       </NavBarMobileMenuItemLink>

--- a/src/Components/NavBar/NavBarMobileMenu/__tests__/NavBarMobileMenu.jest.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/__tests__/NavBarMobileMenu.jest.tsx
@@ -129,7 +129,7 @@ describe("NavBarMobileMenu", () => {
         ["/institutions", "Museums"],
         ["/price-database", "Price Database"],
         ["/articles", "Editorial"],
-        ["/signup?intent=signup&contextModule=header", "Sign Up"],
+        ["/signup?redirectTo=%2F", "Sign Up"],
         ["/login?intent=login&contextModule=header", "Log In"],
       ].map(link => link.join(""))
 

--- a/src/Components/NavBar/__tests__/NavBar.jest.tsx
+++ b/src/Components/NavBar/__tests__/NavBar.jest.tsx
@@ -182,7 +182,10 @@ describe("NavBar", () => {
       const signupButton = screen.getByText("Sign Up")
       expect(signupButton).toBeDefined()
 
-      expect(signupButton.closest("a")).toHaveAttribute("href", "/signup")
+      expect(signupButton.closest("a")).toHaveAttribute("href")
+      expect(signupButton.closest("a")?.getAttribute("href")).toMatch(
+        /^\/signup\?redirectTo=/,
+      )
     })
   })
 

--- a/src/Components/NavBar/__tests__/NavBar.jest.tsx
+++ b/src/Components/NavBar/__tests__/NavBar.jest.tsx
@@ -176,22 +176,13 @@ describe("NavBar", () => {
       })
     })
 
-    it("calls signup auth action on signup button click", () => {
-      const showAuthDialog = jest.fn()
-      mockUseAuthDialog.mockImplementation(() => ({ showAuthDialog }))
-
+    it("navigates to signup page on signup button click", () => {
       getWrapper()
 
       const signupButton = screen.getByText("Sign Up")
       expect(signupButton).toBeDefined()
-      fireEvent.click(signupButton)
 
-      expect(showAuthDialog).toBeCalledWith({
-        analytics: {
-          contextModule: "header",
-          intent: "signup",
-        },
-      })
+      expect(signupButton.closest("a")).toHaveAttribute("href", "/signup")
     })
   })
 


### PR DESCRIPTION
The type of this PR is: **feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [DI-231](https://www.notion.so/349cab0764a08073a45ffbfa78a91556)

### Description

This PR launches the new signup landing page at `/signup` and updates all signup entry points to navigate to the page instead of opening the auth dialog modal:
- `/signup` --> New signup landing page 
- Nav bar "Sign Up" button --> Navigates to `/signup`
- Homepage hero "Sign Up" button --> Navigates to `/signup`
- "Log In" flows remain unchanged (still open modal)

<!-- Implementation description -->
