### PR TITLE
fix: refresh user access tokens before they expire

### DIFF
--- a/src/Server/config.ts
+++ b/src/Server/config.ts
@@ -20,6 +20,8 @@ if (process.env.NODE_ENV !== "test") {
 
 export const PORT: any = 4000
 
+export const ACCESS_TOKEN_REFRESH_ENABLED: any = false
+export const ACCESS_TOKEN_REFRESH_THRESHOLD_SECONDS: any = 604800
 export const ACTIVE_BIDS_POLL_INTERVAL: any = 5000
 export const ADMIN_URL: any = "https://tools.artsy.net"
 export const ALLOWED_VANITY_ASSETS: any = "videos/*|vrview/*|hls-videos/*"

--- a/src/Server/middleware/__tests__/refreshAccessTokenMiddleware.jest.ts
+++ b/src/Server/middleware/__tests__/refreshAccessTokenMiddleware.jest.ts
@@ -1,0 +1,168 @@
+import { refreshAccessTokenMiddleware } from "../refreshAccessTokenMiddleware"
+import { refreshAccessToken } from "Server/passport/lib/refreshAccessToken"
+
+jest.mock("Server/config", () => ({
+  ACCESS_TOKEN_REFRESH_ENABLED: true,
+  ACCESS_TOKEN_REFRESH_THRESHOLD_SECONDS: 7 * 24 * 60 * 60,
+  API_URL: "https://example.test",
+  CLIENT_ID: "client-id",
+  CLIENT_SECRET: "client-secret",
+}))
+
+jest.mock("Server/passport/lib/refreshAccessToken", () => ({
+  refreshAccessToken: jest.fn(),
+  shouldRefresh: jest.requireActual("Server/passport/lib/refreshAccessToken")
+    .shouldRefresh,
+}))
+
+jest.mock("Server/passport/lib/app/forwarded_for", () => () => "127.0.0.1")
+
+const mockRefresh = refreshAccessToken as jest.Mock
+
+const buildJwt = (payload: object): string => {
+  const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" }))
+    .toString("base64")
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+  const body = Buffer.from(JSON.stringify(payload))
+    .toString("base64")
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+  return `${header}.${body}.sig`
+}
+
+const tokenExpiringIn = (seconds: number): string =>
+  buildJwt({ exp: Math.floor(Date.now() / 1000) + seconds, sub: "u-1" })
+
+const buildReqRes = (overrides: Partial<any> = {}) => {
+  const next = jest.fn()
+  const defaultToken = tokenExpiringIn(60 * 60 * 24 * 30)
+  const req: any = {
+    method: "GET",
+    path: "/some-page",
+    user: { id: "u-1", accessToken: defaultToken },
+    session: {
+      passport: { user: { id: "u-1", accessToken: defaultToken } },
+    },
+    logout: jest.fn(cb => cb && cb()),
+    ...overrides,
+  }
+  if (req.user && req.session?.passport?.user) {
+    req.session.passport.user.accessToken = req.user.accessToken
+  }
+  const res: any = {}
+  return { req, res, next }
+}
+
+describe("refreshAccessTokenMiddleware", () => {
+  beforeEach(() => {
+    mockRefresh.mockReset()
+  })
+
+  it("no-ops when there is no user", async () => {
+    const { req, res, next } = buildReqRes({ user: undefined, session: {} })
+    await refreshAccessTokenMiddleware(req, res, next)
+    expect(mockRefresh).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalled()
+  })
+
+  it("no-ops when token is fresh", async () => {
+    const { req, res, next } = buildReqRes()
+    await refreshAccessTokenMiddleware(req, res, next)
+    expect(mockRefresh).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalled()
+  })
+
+  it("no-ops on OPTIONS requests", async () => {
+    const { req, res, next } = buildReqRes({
+      method: "OPTIONS",
+      user: { id: "u-1", accessToken: tokenExpiringIn(60) },
+    })
+    await refreshAccessTokenMiddleware(req, res, next)
+    expect(mockRefresh).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalled()
+  })
+
+  it("no-ops on asset paths", async () => {
+    const { req, res, next } = buildReqRes({
+      path: "/assets/foo.js",
+      user: { id: "u-1", accessToken: tokenExpiringIn(60) },
+    })
+    await refreshAccessTokenMiddleware(req, res, next)
+    expect(mockRefresh).not.toHaveBeenCalled()
+    expect(next).toHaveBeenCalled()
+  })
+
+  it("refreshes and writes the new token to req.user and session", async () => {
+    const expiring = tokenExpiringIn(60)
+    const { req, res, next } = buildReqRes({
+      user: { id: "u-1", accessToken: expiring },
+      session: { passport: { user: { id: "u-1", accessToken: expiring } } },
+    })
+    mockRefresh.mockResolvedValue({ ok: true, accessToken: "FRESH" })
+
+    await refreshAccessTokenMiddleware(req, res, next)
+
+    expect(req.user.accessToken).toBe("FRESH")
+    expect(req.session.passport.user.accessToken).toBe("FRESH")
+    expect(next).toHaveBeenCalled()
+  })
+
+  it("logs the user out when refresh returns invalid", async () => {
+    const { req, res, next } = buildReqRes({
+      user: { id: "u-1", accessToken: tokenExpiringIn(60) },
+    })
+    mockRefresh.mockResolvedValue({ ok: false, reason: "invalid" })
+
+    await refreshAccessTokenMiddleware(req, res, next)
+
+    expect(req.logout).toHaveBeenCalled()
+    expect(next).toHaveBeenCalled()
+  })
+
+  it("keeps the current token on transient failures", async () => {
+    const expiring = tokenExpiringIn(60)
+    const { req, res, next } = buildReqRes({
+      user: { id: "u-1", accessToken: expiring },
+      session: { passport: { user: { id: "u-1", accessToken: expiring } } },
+    })
+    mockRefresh.mockResolvedValue({ ok: false, reason: "transient" })
+
+    await refreshAccessTokenMiddleware(req, res, next)
+
+    expect(req.user.accessToken).toBe(expiring)
+    expect(req.session.passport.user.accessToken).toBe(expiring)
+    expect(next).toHaveBeenCalled()
+  })
+
+  it("dedupes concurrent refreshes for the same user", async () => {
+    const expiring = tokenExpiringIn(60)
+    let resolve: (value: any) => void = () => {}
+    mockRefresh.mockReturnValue(
+      new Promise(r => {
+        resolve = r
+      }),
+    )
+
+    const a = buildReqRes({
+      user: { id: "u-1", accessToken: expiring },
+      session: { passport: { user: { id: "u-1", accessToken: expiring } } },
+    })
+    const b = buildReqRes({
+      user: { id: "u-1", accessToken: expiring },
+      session: { passport: { user: { id: "u-1", accessToken: expiring } } },
+    })
+
+    const pA = refreshAccessTokenMiddleware(a.req, a.res, a.next)
+    const pB = refreshAccessTokenMiddleware(b.req, b.res, b.next)
+
+    resolve({ ok: true, accessToken: "FRESH" })
+    await Promise.all([pA, pB])
+
+    expect(mockRefresh).toHaveBeenCalledTimes(1)
+    expect(a.req.user.accessToken).toBe("FRESH")
+    expect(b.req.user.accessToken).toBe("FRESH")
+  })
+})

--- a/src/Server/middleware/refreshAccessTokenMiddleware.ts
+++ b/src/Server/middleware/refreshAccessTokenMiddleware.ts
@@ -1,0 +1,84 @@
+import type { NextFunction, Request, Response } from "express"
+import {
+  ACCESS_TOKEN_REFRESH_ENABLED,
+  ACCESS_TOKEN_REFRESH_THRESHOLD_SECONDS,
+} from "Server/config"
+import createLogger from "Utils/logger"
+import {
+  refreshAccessToken,
+  shouldRefresh,
+} from "Server/passport/lib/refreshAccessToken"
+import forwardedFor from "Server/passport/lib/app/forwarded_for"
+
+const logger = createLogger("Server/middleware/refreshAccessTokenMiddleware")
+
+const inFlight = new Map<string, Promise<string | null>>()
+
+const SKIPPED_PATH_PREFIXES = ["/assets/", "/health", "/favicon"]
+
+export const refreshAccessTokenMiddleware = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    if (!ACCESS_TOKEN_REFRESH_ENABLED) return next()
+    if (req.method === "OPTIONS") return next()
+    if (SKIPPED_PATH_PREFIXES.some(p => req.path.startsWith(p))) return next()
+
+    const user = (req as any).user
+    const currentToken: string | undefined = user?.accessToken
+    const userId: string | undefined = user?.id
+
+    if (!currentToken || !userId) return next()
+
+    const now = Math.floor(Date.now() / 1000)
+    if (
+      !shouldRefresh(currentToken, now, ACCESS_TOKEN_REFRESH_THRESHOLD_SECONDS)
+    ) {
+      return next()
+    }
+
+    let pending = inFlight.get(userId)
+    if (!pending) {
+      pending = (async () => {
+        const result = await refreshAccessToken(currentToken, forwardedFor(req))
+        if (result.ok) return result.accessToken
+        if (result.reason === "invalid") return ""
+        return null
+      })().finally(() => {
+        inFlight.delete(userId)
+      })
+      inFlight.set(userId, pending)
+    }
+
+    const newToken = await pending
+
+    if (newToken === null) {
+      // Transient failure — keep current token, continue.
+      logger.warn("token refresh failed (transient); keeping current token")
+      return next()
+    }
+
+    if (newToken === "") {
+      // Invalid token — log user out and continue.
+      const reqAny = req as any
+      if (typeof reqAny.logout === "function") {
+        return reqAny.logout(() => next())
+      }
+      reqAny.user = null
+      if (reqAny.session) reqAny.session = null
+      return next()
+    }
+
+    user.accessToken = newToken
+    const sessionUser = (req as any).session?.passport?.user
+    if (sessionUser) {
+      sessionUser.accessToken = newToken
+    }
+    return next()
+  } catch (err) {
+    logger.error("unexpected error in refreshAccessTokenMiddleware", err)
+    return next()
+  }
+}

--- a/src/Server/passport/lib/__tests__/refreshAccessToken.jest.ts
+++ b/src/Server/passport/lib/__tests__/refreshAccessToken.jest.ts
@@ -1,0 +1,142 @@
+import {
+  decodeJwtExp,
+  refreshAccessToken,
+  shouldRefresh,
+} from "../refreshAccessToken"
+import request from "superagent"
+
+jest.mock("Server/config", () => ({
+  API_URL: "https://example.test",
+  CLIENT_ID: "client-id",
+  CLIENT_SECRET: "client-secret",
+}))
+
+jest.mock("superagent", () => ({
+  post: jest.fn(),
+}))
+
+const buildJwt = (payload: object): string => {
+  const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" }))
+    .toString("base64")
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+  const body = Buffer.from(JSON.stringify(payload))
+    .toString("base64")
+    .replace(/=+$/, "")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+  return `${header}.${body}.signature`
+}
+
+describe("decodeJwtExp", () => {
+  it("returns the exp claim from a valid JWT", () => {
+    const exp = 1_700_000_000
+    expect(decodeJwtExp(buildJwt({ exp }))).toBe(exp)
+  })
+
+  it("returns null when exp is missing", () => {
+    expect(decodeJwtExp(buildJwt({ sub: "u-1" }))).toBeNull()
+  })
+
+  it("returns null for malformed tokens", () => {
+    expect(decodeJwtExp("not.a.jwt-payload")).toBeNull()
+    expect(decodeJwtExp("only-one-segment")).toBeNull()
+    expect(decodeJwtExp("")).toBeNull()
+  })
+})
+
+describe("shouldRefresh", () => {
+  const now = 1_700_000_000
+  const threshold = 7 * 24 * 60 * 60
+
+  it("returns true when token is within the refresh window", () => {
+    const exp = now + threshold - 60
+    expect(shouldRefresh(buildJwt({ exp }), now, threshold)).toBe(true)
+  })
+
+  it("returns false when token is fresh", () => {
+    const exp = now + threshold + 60
+    expect(shouldRefresh(buildJwt({ exp }), now, threshold)).toBe(false)
+  })
+
+  it("returns false when token is already expired", () => {
+    const exp = now - 60
+    expect(shouldRefresh(buildJwt({ exp }), now, threshold)).toBe(false)
+  })
+
+  it("returns false for malformed tokens", () => {
+    expect(shouldRefresh("garbage", now, threshold)).toBe(false)
+  })
+})
+
+describe("refreshAccessToken", () => {
+  const post = request.post as jest.Mock
+
+  const mockChain = (
+    trust: { body?: any; throw?: { status?: number } },
+    token?: { body?: any; throw?: { status?: number } },
+  ) => {
+    const trustChain: any = {
+      set: jest
+        .fn()
+        .mockImplementation(() =>
+          trust.throw
+            ? Promise.reject({ status: trust.throw.status })
+            : Promise.resolve({ body: trust.body }),
+        ),
+    }
+    const tokenChain: any = {
+      set: jest.fn().mockReturnThis(),
+      send: jest
+        .fn()
+        .mockImplementation(() =>
+          !token
+            ? Promise.resolve({ body: {} })
+            : token.throw
+              ? Promise.reject({ status: token.throw.status })
+              : Promise.resolve({ body: token.body }),
+        ),
+    }
+    post.mockImplementation((url: string) =>
+      url.includes("trust_token") ? trustChain : tokenChain,
+    )
+  }
+
+  beforeEach(() => {
+    post.mockReset()
+  })
+
+  it("returns a fresh access token on success", async () => {
+    mockChain(
+      { body: { trust_token: "TT" } },
+      { body: { access_token: "NEW" } },
+    )
+    const result = await refreshAccessToken("OLD", "127.0.0.1")
+    expect(result).toEqual({ ok: true, accessToken: "NEW" })
+  })
+
+  it("returns invalid when trust_token call returns 401", async () => {
+    mockChain({ throw: { status: 401 } })
+    const result = await refreshAccessToken("OLD", "127.0.0.1")
+    expect(result).toEqual({ ok: false, reason: "invalid" })
+  })
+
+  it("returns invalid when access_token call returns 403", async () => {
+    mockChain({ body: { trust_token: "TT" } }, { throw: { status: 403 } })
+    const result = await refreshAccessToken("OLD", "127.0.0.1")
+    expect(result).toEqual({ ok: false, reason: "invalid" })
+  })
+
+  it("returns transient on 5xx", async () => {
+    mockChain({ throw: { status: 503 } })
+    const result = await refreshAccessToken("OLD", "127.0.0.1")
+    expect(result).toEqual({ ok: false, reason: "transient" })
+  })
+
+  it("returns transient when trust_token body is missing", async () => {
+    mockChain({ body: {} })
+    const result = await refreshAccessToken("OLD", "127.0.0.1")
+    expect(result).toEqual({ ok: false, reason: "transient" })
+  })
+})

--- a/src/Server/passport/lib/refreshAccessToken.ts
+++ b/src/Server/passport/lib/refreshAccessToken.ts
@@ -1,0 +1,75 @@
+import request from "superagent"
+import { API_URL, CLIENT_ID, CLIENT_SECRET } from "Server/config"
+
+export type RefreshResult =
+  | { ok: true; accessToken: string }
+  | { ok: false; reason: "invalid" | "transient" }
+
+export const decodeJwtExp = (token: string): number | null => {
+  const parts = token.split(".")
+  if (parts.length !== 3) return null
+
+  try {
+    const padded = parts[1] + "=".repeat((4 - (parts[1].length % 4)) % 4)
+    const base64 = padded.replace(/-/g, "+").replace(/_/g, "/")
+    const payload = JSON.parse(Buffer.from(base64, "base64").toString("utf8"))
+    return typeof payload?.exp === "number" ? payload.exp : null
+  } catch {
+    return null
+  }
+}
+
+export const shouldRefresh = (
+  token: string,
+  nowSeconds: number,
+  thresholdSeconds: number,
+): boolean => {
+  const exp = decodeJwtExp(token)
+  if (exp === null) return false
+  return exp > nowSeconds && exp - nowSeconds < thresholdSeconds
+}
+
+const isInvalidStatus = (status: number | undefined): boolean =>
+  status === 401 || status === 403
+
+export const refreshAccessToken = async (
+  currentToken: string,
+  forwardedFor: string,
+): Promise<RefreshResult> => {
+  let trustToken: string
+  try {
+    const trustRes = await request
+      .post(`${API_URL}/api/v1/me/trust_token`)
+      .set({
+        "X-Access-Token": currentToken,
+        "X-Forwarded-For": forwardedFor,
+      })
+    trustToken = trustRes.body?.trust_token
+    if (!trustToken) return { ok: false, reason: "transient" }
+  } catch (err: any) {
+    return {
+      ok: false,
+      reason: isInvalidStatus(err?.status) ? "invalid" : "transient",
+    }
+  }
+
+  try {
+    const tokenRes = await request
+      .post(`${API_URL}/oauth2/access_token`)
+      .set({ "X-Forwarded-For": forwardedFor })
+      .send({
+        grant_type: "trust_token",
+        client_id: CLIENT_ID,
+        client_secret: CLIENT_SECRET,
+        code: trustToken,
+      })
+    const accessToken = tokenRes.body?.access_token
+    if (!accessToken) return { ok: false, reason: "transient" }
+    return { ok: true, accessToken }
+  } catch (err: any) {
+    return {
+      ok: false,
+      reason: isInvalidStatus(err?.status) ? "invalid" : "transient",
+    }
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -43,6 +43,7 @@ import { hstsMiddleware } from "./Server/middleware/hsts"
 import { ipFilter } from "./Server/middleware/ipFilter"
 import { localsMiddleware } from "./Server/middleware/locals"
 import { morganMiddleware } from "./Server/middleware/morgan"
+import { refreshAccessTokenMiddleware } from "./Server/middleware/refreshAccessTokenMiddleware"
 import { sameOriginMiddleware } from "./Server/middleware/sameOrigin"
 import { serverTimingHeaders } from "./Server/middleware/serverTimingHeaders"
 import { sessionMiddleware } from "./Server/middleware/session"
@@ -137,6 +138,9 @@ export function initializeMiddleware(app) {
       ],
     }),
   )
+
+  // Refresh near-expiry access tokens before downstream code uses them
+  app.use(refreshAccessTokenMiddleware)
 
   // Require a user for these routes
   app.use(userRequiredMiddleware)


### PR DESCRIPTION
This PR solves [PHIRE-3027]

The type of this PR is: **fix**

**Slack context**: https://artsy.slack.com/archives/C07PRTJSD6G/p1776873987026619

## Description

Our access token always expires after 2 months, so users need to sign in again and again every two months.

This PR is first of many to fix that by refreshing the user access token if the user is active and to push the access token validity each time they log in.

**How do I achieve that?**
We introduce a new middleware that ensures that the token we use for passport is fresh

**What comes next?**
We have some tickets to implement a proper refresh token logic in the backend


[PHIRE-3027]: https://artsyproduct.atlassian.net/browse/PHIRE-3027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ