### PR TITLE
fix: Braze in-app messages on artist pages

### DIFF
--- a/src/Server/analytics/__tests__/brazeMessagingIntegration.jest.ts
+++ b/src/Server/analytics/__tests__/brazeMessagingIntegration.jest.ts
@@ -21,13 +21,11 @@ describe("isMatchingRoute", () => {
     "/viewing-rooms",
   ]
 
-  it("returns true for valid routes", () => {
-    const validResults = validRoutes.map(route => isMatchingRoute(route))
-    expect(validResults.length).toEqual(validResults.length)
+  it.each(validRoutes)("returns true for %s", route => {
+    expect(isMatchingRoute(route)).toBe(true)
   })
 
   const invalidRoutes = [
-    "/artist/andy-warhol",
     "/auction/fancy-prints-2022",
     "/categories",
     "/collections",
@@ -35,8 +33,7 @@ describe("isMatchingRoute", () => {
     "/sell",
   ]
 
-  it("returns false for invalid routes", () => {
-    const invalidResults = invalidRoutes.map(route => !isMatchingRoute(route))
-    expect(invalidResults.length).toEqual(invalidResults.length)
+  it.each(invalidRoutes)("returns false for %s", route => {
+    expect(isMatchingRoute(route)).toBe(false)
   })
 })

--- a/src/Server/analytics/brazeMessagingIntegration.ts
+++ b/src/Server/analytics/brazeMessagingIntegration.ts
@@ -5,7 +5,7 @@ const allowedPatterns = [
   "/art-fairs",
   "/article/:slug",
   "/articles",
-  "/artist/:slug,",
+  "/artist/:slug",
   "/artists",
   "/auctions",
   "/collect",


### PR DESCRIPTION
This PR fixes a typo in the list of URL patterns that Braze is allowed to show in-app messages to. I believe that this typo was preventing pages like `/artist/andy-warhol` from being allowed because it was expecting `/artist/andy-warhol,` (with a comma) instead.

P.S. I learned that we don't use in-app messages anymore, so while this is a bug, it's not affecting anything in production.

cc: @artsy/diamond-devs 