### PR TITLE
chore: Remove references to topaz_framed-dims-on-artwork-page feature flag

### DIFF
--- a/src/Apps/Artwork/__tests__/useArtworkDimensions.jest.tsx
+++ b/src/Apps/Artwork/__tests__/useArtworkDimensions.jest.tsx
@@ -1,40 +1,16 @@
 import { renderHook } from "@testing-library/react-hooks"
 import { useArtworkDimensions } from "../useArtworkDimensions"
-import { SystemContextProvider } from "System/Contexts/SystemContext"
-import type { ReactNode } from "react"
-
-const mockFeatureFlags = {
-  isEnabled: jest.fn(),
-  getVariant: jest.fn(),
-}
-
-const wrapper =
-  (featureFlagEnabled: boolean) =>
-  ({ children }: { children: ReactNode }) => {
-    mockFeatureFlags.isEnabled.mockReturnValue(featureFlagEnabled)
-    return (
-      <SystemContextProvider featureFlags={mockFeatureFlags}>
-        {children}
-      </SystemContextProvider>
-    )
-  }
 
 describe("useArtworkDimensions", () => {
-  beforeEach(() => {
-    jest.clearAllMocks()
-  })
-
   describe("Basic dimension formatting", () => {
     it("formats dimensions with both in and cm", () => {
-      const { result } = renderHook(
-        () =>
-          useArtworkDimensions({
-            dimensions: {
-              in: "10 × 20 in",
-              cm: "25.4 × 50.8 cm",
-            },
-          }),
-        { wrapper: wrapper(false) },
+      const { result } = renderHook(() =>
+        useArtworkDimensions({
+          dimensions: {
+            in: "10 × 20 in",
+            cm: "25.4 × 50.8 cm",
+          },
+        }),
       )
 
       expect(result.current.dimensionsLabel).toBe("10 × 20 in | 25.4 × 50.8 cm")
@@ -42,15 +18,13 @@ describe("useArtworkDimensions", () => {
     })
 
     it("formats dimensions with only in", () => {
-      const { result } = renderHook(
-        () =>
-          useArtworkDimensions({
-            dimensions: {
-              in: "10 × 20 in",
-              cm: null,
-            },
-          }),
-        { wrapper: wrapper(false) },
+      const { result } = renderHook(() =>
+        useArtworkDimensions({
+          dimensions: {
+            in: "10 × 20 in",
+            cm: null,
+          },
+        }),
       )
 
       expect(result.current.dimensionsLabel).toBe("10 × 20 in")
@@ -58,15 +32,13 @@ describe("useArtworkDimensions", () => {
     })
 
     it("formats dimensions with only cm", () => {
-      const { result } = renderHook(
-        () =>
-          useArtworkDimensions({
-            dimensions: {
-              in: null,
-              cm: "25.4 × 50.8 cm",
-            },
-          }),
-        { wrapper: wrapper(false) },
+      const { result } = renderHook(() =>
+        useArtworkDimensions({
+          dimensions: {
+            in: null,
+            cm: "25.4 × 50.8 cm",
+          },
+        }),
       )
 
       expect(result.current.dimensionsLabel).toBe("25.4 × 50.8 cm")
@@ -74,15 +46,13 @@ describe("useArtworkDimensions", () => {
     })
 
     it("returns null when no dimensions", () => {
-      const { result } = renderHook(
-        () =>
-          useArtworkDimensions({
-            dimensions: {
-              in: null,
-              cm: null,
-            },
-          }),
-        { wrapper: wrapper(false) },
+      const { result } = renderHook(() =>
+        useArtworkDimensions({
+          dimensions: {
+            in: null,
+            cm: null,
+          },
+        }),
       )
 
       expect(result.current.dimensionsLabel).toBeNull()
@@ -90,54 +60,29 @@ describe("useArtworkDimensions", () => {
     })
 
     it("returns null when dimensions is null", () => {
-      const { result } = renderHook(
-        () => useArtworkDimensions({ dimensions: null }),
-        {
-          wrapper: wrapper(false),
-        },
+      const { result } = renderHook(() =>
+        useArtworkDimensions({ dimensions: null }),
       )
 
       expect(result.current.dimensionsLabel).toBeNull()
     })
 
     it("returns null when dimensions is undefined", () => {
-      const { result } = renderHook(
-        () => useArtworkDimensions({ dimensions: undefined }),
-        {
-          wrapper: wrapper(false),
-        },
+      const { result } = renderHook(() =>
+        useArtworkDimensions({ dimensions: undefined }),
       )
 
       expect(result.current.dimensionsLabel).toBeNull()
     })
   })
 
-  describe("Framed dimensions with feature flag OFF", () => {
-    it("shows regular dimensions when framed dimensions provided but flag is off", () => {
-      const { result } = renderHook(
-        () =>
-          useArtworkDimensions({
-            dimensions: { in: "10 × 20 in", cm: "25.4 × 50.8 cm" },
-            framedDimensions: { in: "12 × 22 in", cm: "30.5 × 55.9 cm" },
-          }),
-        { wrapper: wrapper(false) },
-      )
-
-      expect(result.current.dimensionsLabel).toBe("10 × 20 in | 25.4 × 50.8 cm")
-      expect(result.current.isShowingFramedDimensions).toBe(false)
-      expect(result.current.shouldShowFrameText).toBe(true)
-    })
-  })
-
-  describe("Framed dimensions with feature flag ON", () => {
-    it("shows framed dimensions when flag is on and framed dimensions exist", () => {
-      const { result } = renderHook(
-        () =>
-          useArtworkDimensions({
-            dimensions: { in: "10 × 20 in", cm: "25.4 × 50.8 cm" },
-            framedDimensions: { in: "12 × 22 in", cm: "30.5 × 55.9 cm" },
-          }),
-        { wrapper: wrapper(true) },
+  describe("Framed dimensions", () => {
+    it("shows framed dimensions when framed dimensions exist", () => {
+      const { result } = renderHook(() =>
+        useArtworkDimensions({
+          dimensions: { in: "10 × 20 in", cm: "25.4 × 50.8 cm" },
+          framedDimensions: { in: "12 × 22 in", cm: "30.5 × 55.9 cm" },
+        }),
       )
 
       expect(result.current.dimensionsLabel).toBe(
@@ -150,14 +95,12 @@ describe("useArtworkDimensions", () => {
       expect(result.current.shouldShowFrameText).toBe(false)
     })
 
-    it("shows regular dimensions when flag is on but framed dimensions are null", () => {
-      const { result } = renderHook(
-        () =>
-          useArtworkDimensions({
-            dimensions: { in: "10 × 20 in", cm: "25.4 × 50.8 cm" },
-            framedDimensions: null,
-          }),
-        { wrapper: wrapper(true) },
+    it("shows regular dimensions when framed dimensions are null", () => {
+      const { result } = renderHook(() =>
+        useArtworkDimensions({
+          dimensions: { in: "10 × 20 in", cm: "25.4 × 50.8 cm" },
+          framedDimensions: null,
+        }),
       )
 
       expect(result.current.dimensionsLabel).toBe("10 × 20 in | 25.4 × 50.8 cm")
@@ -165,14 +108,12 @@ describe("useArtworkDimensions", () => {
       expect(result.current.shouldShowFrameText).toBe(true)
     })
 
-    it("shows regular dimensions when flag is on but framed dimensions are empty", () => {
-      const { result } = renderHook(
-        () =>
-          useArtworkDimensions({
-            dimensions: { in: "10 × 20 in", cm: "25.4 × 50.8 cm" },
-            framedDimensions: { in: null, cm: null },
-          }),
-        { wrapper: wrapper(true) },
+    it("shows regular dimensions when framed dimensions are empty", () => {
+      const { result } = renderHook(() =>
+        useArtworkDimensions({
+          dimensions: { in: "10 × 20 in", cm: "25.4 × 50.8 cm" },
+          framedDimensions: { in: null, cm: null },
+        }),
       )
 
       expect(result.current.dimensionsLabel).toBe("10 × 20 in | 25.4 × 50.8 cm")
@@ -180,14 +121,12 @@ describe("useArtworkDimensions", () => {
       expect(result.current.shouldShowFrameText).toBe(true)
     })
 
-    it("shows regular dimensions when flag is on but framed dimensions have no numbers", () => {
-      const { result } = renderHook(
-        () =>
-          useArtworkDimensions({
-            dimensions: { in: "10 × 20 in", cm: "25.4 × 50.8 cm" },
-            framedDimensions: { in: "N/A", cm: "N/A" },
-          }),
-        { wrapper: wrapper(true) },
+    it("shows regular dimensions when framed dimensions have no numbers", () => {
+      const { result } = renderHook(() =>
+        useArtworkDimensions({
+          dimensions: { in: "10 × 20 in", cm: "25.4 × 50.8 cm" },
+          framedDimensions: { in: "N/A", cm: "N/A" },
+        }),
       )
 
       expect(result.current.dimensionsLabel).toBe("10 × 20 in | 25.4 × 50.8 cm")
@@ -198,13 +137,11 @@ describe("useArtworkDimensions", () => {
 
   describe("Frame text", () => {
     it("returns 'Frame included' when frame details is 'Included'", () => {
-      const { result } = renderHook(
-        () =>
-          useArtworkDimensions({
-            dimensions: { in: "10 × 20 in", cm: "25.4 × 50.8 cm" },
-            framed: { details: "Included" },
-          }),
-        { wrapper: wrapper(false) },
+      const { result } = renderHook(() =>
+        useArtworkDimensions({
+          dimensions: { in: "10 × 20 in", cm: "25.4 × 50.8 cm" },
+          framed: { details: "Included" },
+        }),
       )
 
       expect(result.current.frameText).toBe("Frame included")
@@ -212,42 +149,36 @@ describe("useArtworkDimensions", () => {
     })
 
     it("returns 'Frame not included' when unlisted and frame is not included", () => {
-      const { result } = renderHook(
-        () =>
-          useArtworkDimensions({
-            dimensions: { in: "10 × 20 in", cm: "25.4 × 50.8 cm" },
-            framed: { details: "Not included" },
-            isUnlisted: true,
-          }),
-        { wrapper: wrapper(false) },
+      const { result } = renderHook(() =>
+        useArtworkDimensions({
+          dimensions: { in: "10 × 20 in", cm: "25.4 × 50.8 cm" },
+          framed: { details: "Not included" },
+          isUnlisted: true,
+        }),
       )
 
       expect(result.current.frameText).toBe("Frame not included")
     })
 
     it("returns null when frame details is not 'Included' and not unlisted", () => {
-      const { result } = renderHook(
-        () =>
-          useArtworkDimensions({
-            dimensions: { in: "10 × 20 in", cm: "25.4 × 50.8 cm" },
-            framed: { details: "Not included" },
-            isUnlisted: false,
-          }),
-        { wrapper: wrapper(false) },
+      const { result } = renderHook(() =>
+        useArtworkDimensions({
+          dimensions: { in: "10 × 20 in", cm: "25.4 × 50.8 cm" },
+          framed: { details: "Not included" },
+          isUnlisted: false,
+        }),
       )
 
       expect(result.current.frameText).toBe(null)
     })
 
     it("returns null when framed dimensions are shown", () => {
-      const { result } = renderHook(
-        () =>
-          useArtworkDimensions({
-            dimensions: { in: "10 × 20 in", cm: "25.4 × 50.8 cm" },
-            framedDimensions: { in: "12 × 22 in", cm: "30.5 × 55.9 cm" },
-            framed: { details: "Included" },
-          }),
-        { wrapper: wrapper(true) }, // flag ON
+      const { result } = renderHook(() =>
+        useArtworkDimensions({
+          dimensions: { in: "10 × 20 in", cm: "25.4 × 50.8 cm" },
+          framedDimensions: { in: "12 × 22 in", cm: "30.5 × 55.9 cm" },
+          framed: { details: "Included" },
+        }),
       )
 
       expect(result.current.frameText).toBe(null)
@@ -256,32 +187,13 @@ describe("useArtworkDimensions", () => {
     })
 
     it("handles missing framed info", () => {
-      const { result } = renderHook(
-        () =>
-          useArtworkDimensions({
-            dimensions: { in: "10 × 20 in", cm: "25.4 × 50.8 cm" },
-          }),
-        { wrapper: wrapper(false) },
+      const { result } = renderHook(() =>
+        useArtworkDimensions({
+          dimensions: { in: "10 × 20 in", cm: "25.4 × 50.8 cm" },
+        }),
       )
 
       expect(result.current.frameText).toBe(null)
-    })
-  })
-
-  describe("Feature flag check", () => {
-    it("checks the correct feature flag name", () => {
-      renderHook(
-        () =>
-          useArtworkDimensions({
-            dimensions: { in: "10 × 20 in", cm: "25.4 × 50.8 cm" },
-            framedDimensions: { in: "12 × 22 in", cm: "30.5 × 55.9 cm" },
-          }),
-        { wrapper: wrapper(true) },
-      )
-
-      expect(mockFeatureFlags.isEnabled).toHaveBeenCalledWith(
-        "topaz_framed-dims-on-artwork-page",
-      )
     })
   })
 })

--- a/src/Apps/Artwork/useArtworkDimensions.tsx
+++ b/src/Apps/Artwork/useArtworkDimensions.tsx
@@ -1,6 +1,3 @@
-import { SystemContext } from "System/Contexts/SystemContext"
-import { useContext } from "react"
-
 interface ArtworkDimensions {
   in: string | null | undefined
   cm: string | null | undefined
@@ -52,13 +49,7 @@ export const useArtworkDimensions = ({
   framed,
   isUnlisted,
 }: UseArtworkDimensionsOptions) => {
-  const { featureFlags } = useContext(SystemContext)
-  const isFeatureEnabled =
-    featureFlags?.isEnabled("topaz_framed-dims-on-artwork-page") ?? false
-
-  // Decide which dimensions to use based on feature flag and availability
-  const hasFramedDims = hasDimensions(framedDimensions)
-  const shouldUseFramedDims = isFeatureEnabled && hasFramedDims
+  const shouldUseFramedDims = hasDimensions(framedDimensions)
   const activeDimensions = shouldUseFramedDims ? framedDimensions : dimensions
 
   const hasActiveDimensions = hasDimensions(activeDimensions)


### PR DESCRIPTION
The type of this PR is: **CHORE**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [TOP-208](https://artsyproduct.atlassian.net/browse/TOP-208)

### Description

Removes references to `topaz_framed-dims-on-artwork-page` Unleash feature flag now that the project is live
- https://unleash.artsy.net/projects/default/features/topaz_framed-dims-on-artwork-page

cc @artsy/topaz-devs 
<!-- Implementation description -->


[TOP-208]: https://artsyproduct.atlassian.net/browse/TOP-208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ