### PR TITLE
fix(EMI-3222): add loading skeleton when order summary is loading

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/Order2CheckoutPricingBreakdown.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2CheckoutPricingBreakdown.tsx
@@ -1,6 +1,6 @@
 import type { ContextModule } from "@artsy/cohesion"
 import StopwatchIcon from "@artsy/icons/StopwatchIcon"
-import { Flex, Spacer, Text } from "@artsy/palette"
+import { Flex, SkeletonText, Spacer, Text } from "@artsy/palette"
 import { useCheckoutContext } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext"
 import { RouterLink } from "System/Components/RouterLink"
 import { useCountdownTimer } from "Utils/Hooks/useCountdownTimer"
@@ -15,6 +15,7 @@ import { graphql, useFragment } from "react-relay"
 interface Order2CheckoutPricingBreakdownProps {
   order: Order2CheckoutPricingBreakdown_order$key
   contextModule: ContextModule
+  isLoading?: boolean
 }
 
 const TAX_CALCULATION_ARTICLE_URL =
@@ -22,7 +23,7 @@ const TAX_CALCULATION_ARTICLE_URL =
 
 export const Order2CheckoutPricingBreakdown: React.FC<
   Order2CheckoutPricingBreakdownProps
-> = ({ order, contextModule }) => {
+> = ({ order, contextModule, isLoading }) => {
   const { checkoutTracking } = useCheckoutContext()
   const orderData = useFragment(FRAGMENT, order)
   const { mode, pendingOffer, source, buyerStateExpiresAt } = orderData
@@ -64,6 +65,7 @@ export const Order2CheckoutPricingBreakdown: React.FC<
         let secondLine: JSX.Element | null = null
 
         let amountText = ""
+        let showSkeleton = false
         switch (typename) {
           case "SubtotalLine":
             if (line.amount) {
@@ -92,22 +94,35 @@ export const Order2CheckoutPricingBreakdown: React.FC<
 
             break
           case "ShippingLine":
-            amountText = line.amount
-              ? `${line.amount.currencySymbol}${line.amount.amount}`
-              : (line.amountFallbackText as string)
+            if (line.amount) {
+              amountText = `${line.amount.currencySymbol}${line.amount.amount}`
+            } else if (isLoading) {
+              showSkeleton = true
+            } else {
+              amountText = line.amountFallbackText as string
+            }
             break
           case "TaxLine":
-            amountText = line.amount
-              ? `${line.amount.currencySymbol}${line.amount.amount}`
-              : (line.amountFallbackText as string)
+            if (line.amount) {
+              amountText = `${line.amount.currencySymbol}${line.amount.amount}`
+            } else if (isLoading) {
+              showSkeleton = true
+            } else {
+              amountText = line.amountFallbackText as string
+            }
             withAsterisk = true
             break
           case "TotalLine":
             variant = "sm-display"
             fontWeight = "bold"
             color = "mono100"
-            amountText = (line.amount?.display ||
-              line.amountFallbackText) as string
+            if (line.amount?.display) {
+              amountText = line.amount.display
+            } else if (isLoading) {
+              showSkeleton = true
+            } else {
+              amountText = line.amountFallbackText as string
+            }
         }
 
         return (
@@ -119,7 +134,11 @@ export const Order2CheckoutPricingBreakdown: React.FC<
                 {withAsterisk && "*"}
               </Text>
               <Text flexGrow={0} variant={variant} fontWeight={fontWeight}>
-                {amountText}
+                {showSkeleton ? (
+                  <SkeletonText variant={variant}>Loading</SkeletonText>
+                ) : (
+                  amountText
+                )}
               </Text>
             </Flex>
             {secondLine}

--- a/src/Apps/Order2/Routes/Checkout/Components/Order2CollapsibleOrderSummary.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2CollapsibleOrderSummary.tsx
@@ -17,7 +17,8 @@ interface Order2CollapsibleOrderSummaryProps {
 export const Order2CollapsibleOrderSummary: React.FC<
   Order2CollapsibleOrderSummaryProps
 > = ({ order }) => {
-  const { checkoutTracking, artworkPath } = useCheckoutContext()
+  const { checkoutTracking, artworkPath, isFulfillmentDetailsSaving } =
+    useCheckoutContext()
   const { isEigen } = useSystemContext()
   const orderData = useFragment(FRAGMENT, order)
   const [isExpanded, setIsExpanded] = useState(false)
@@ -120,6 +121,7 @@ export const Order2CollapsibleOrderSummary: React.FC<
           <Order2CheckoutPricingBreakdown
             order={orderData}
             contextModule={ContextModule.ordersCheckout}
+            isLoading={isFulfillmentDetailsSaving}
           />
         </Box>
         <Spacer y={1} />

--- a/src/Apps/Order2/Routes/Checkout/Components/Order2ReviewStep.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2ReviewStep.tsx
@@ -77,6 +77,7 @@ export const Order2ReviewStep: React.FC<Order2ReviewStepProps> = ({
     artworkPath,
     editStep,
     setSectionErrorMessage,
+    isFulfillmentDetailsSaving,
   } = useCheckoutContext()
 
   const { showCheckoutErrorModal } = useCheckoutModal()
@@ -265,6 +266,7 @@ export const Order2ReviewStep: React.FC<Order2ReviewStepProps> = ({
         <Order2CheckoutPricingBreakdown
           order={orderData}
           contextModule={ContextModule.ordersReview}
+          isLoading={isFulfillmentDetailsSaving}
         />
       </Box>
       <Spacer y={2} />

--- a/src/Apps/Order2/Routes/Checkout/Components/__tests__/Order2CheckoutPricingBreakdown.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/__tests__/Order2CheckoutPricingBreakdown.jest.tsx
@@ -10,6 +10,7 @@ import { Order2CheckoutPricingBreakdown } from "../Order2CheckoutPricingBreakdow
 
 jest.unmock("react-relay")
 
+let mockIsLoading = false
 let mockCheckoutContext: DeepPartial<ReturnType<typeof useCheckoutContext>>
 jest.mock("Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext", () => ({
   useCheckoutContext: () => {
@@ -38,6 +39,7 @@ jest.mock("Utils/Hooks/useCountdownTimer", () => ({
 }))
 
 beforeEach(() => {
+  mockIsLoading = false
   mockCheckoutContext = {}
   mockCountdownTimer = {
     remainingTime: "Calculating time",
@@ -57,6 +59,7 @@ const { renderWithRelay } =
         <Order2CheckoutPricingBreakdown
           order={order}
           contextModule={ContextModule.ordersCheckout}
+          isLoading={mockIsLoading}
         />
       )
     },
@@ -351,5 +354,95 @@ describe("Order2PricingBreakdown", () => {
 
     const totalRow = screen.getByText("Total").parentElement
     expect(totalRow).toHaveTextContent("Waiting for final totals")
+  })
+
+  describe("skeleton", () => {
+    const pricingLinesWithNoAmounts = [
+      {
+        __typename: "SubtotalLine",
+        displayName: "Subtotal",
+        amount: { amount: "1000", currencySymbol: "$" },
+      },
+      {
+        __typename: "ShippingLine",
+        displayName: "Shipping",
+        amountFallbackText: "Calculated in next steps",
+        amount: null,
+      },
+      {
+        __typename: "TaxLine",
+        displayName: "Tax",
+        amountFallbackText: "Calculated in next steps",
+        amount: null,
+      },
+      {
+        __typename: "TotalLine",
+        displayName: "Total",
+        amountFallbackText: "Waiting for final costs",
+        amount: null,
+      },
+    ]
+
+    it("shows skeleton for shipping, tax, and total when isLoading and amounts are null", () => {
+      mockIsLoading = true
+
+      renderWithRelay({
+        Me: () => ({
+          order: { pricingBreakdownLines: pricingLinesWithNoAmounts },
+        }),
+      })
+
+      expect(
+        screen.queryByText("Calculated in next steps"),
+      ).not.toBeInTheDocument()
+      expect(
+        screen.queryByText("Waiting for final costs"),
+      ).not.toBeInTheDocument()
+    })
+
+    it("shows real amounts instead of skeleton when isLoading but amounts are present", () => {
+      mockIsLoading = true
+
+      renderWithRelay({
+        Me: () => ({
+          order: {
+            pricingBreakdownLines: [
+              {
+                __typename: "ShippingLine",
+                displayName: "Shipping",
+                amountFallbackText: "Calculated in next steps",
+                amount: { amount: "12.00", currencySymbol: "$" },
+              },
+              {
+                __typename: "TotalLine",
+                displayName: "Total",
+                amountFallbackText: "Waiting for final costs",
+                amount: { display: "$US 1012.00" },
+              },
+            ],
+          },
+        }),
+      })
+
+      expect(screen.getByText("Shipping").parentElement).toHaveTextContent(
+        "$12.00",
+      )
+      expect(screen.getByText("Total").parentElement).toHaveTextContent(
+        "$US 1012.00",
+      )
+    })
+
+    it("shows fallback text instead of skeleton when not loading and amounts are null", () => {
+      mockIsLoading = false
+
+      renderWithRelay({
+        Me: () => ({
+          order: { pricingBreakdownLines: pricingLinesWithNoAmounts },
+        }),
+      })
+
+      expect(screen.getAllByText("Calculated in next steps")).toHaveLength(2)
+      expect(screen.getByText("Waiting for final costs")).toBeInTheDocument()
+    })
   })
 })


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-3222]

### Description

<!-- Implementation description -->

Add skeleton loaders to order summary changes instead of “Calculated in next steps”

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/4bf248e8-44f3-4460-8de4-9a46c40ddc66" /> | <video src="https://github.com/user-attachments/assets/239f026e-24e2-43ef-8985-1414724d78dc" /> |


[EMI-3222]: https://artsyproduct.atlassian.net/browse/EMI-3222?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ