### PR TITLE
fix(EMI-3226): jumping order2 layout

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
+++ b/src/Apps/Artwork/Components/ArtworkSidebar/ArtworkSidebarCommercialButtons.tsx
@@ -36,6 +36,7 @@ import {
 } from "./ArtworkSidebarEditionSets"
 
 import { useSelectedEditionSetContext } from "Apps/Artwork/Components/SelectedEditionSetContext"
+import { newCheckoutEnabled } from "Apps/Order/redirects"
 import { usePartnerOfferCheckoutMutation } from "Apps/PartnerOffer/Routes/Mutations/UsePartnerOfferCheckoutMutation"
 import { CreateAlertButton } from "Components/Alert/Components/CreateAlertButton"
 import { useAuthDialog } from "Components/AuthDialog"
@@ -80,7 +81,8 @@ export const ArtworkSidebarCommercialButtons: React.FC<
   const activePartnerOffer =
     (!partnerOfferTimer.hasEnded && partnerOffer) || null
 
-  const { router, user } = useSystemContext()
+  const { router, user, featureFlags } = useSystemContext()
+  const isOrder2Enabled = newCheckoutEnabled({ order: {}, featureFlags })
   const { match } = useRouter()
 
   const { trackEvent } = useTracking()
@@ -177,7 +179,10 @@ export const ArtworkSidebarCommercialButtons: React.FC<
             throw new ErrorWithMetadata(errorCode, orderOrError.error)
         }
       } else {
-        redirectUrl = `/orders/${orderOrError?.order?.internalID}`
+        const orderId = orderOrError?.order?.internalID
+        redirectUrl = isOrder2Enabled
+          ? `/orders2/${orderId}/checkout`
+          : `/orders/${orderId}`
       }
       setIsCommitingCreateOrderMutation(false)
       router?.push(redirectUrl)
@@ -220,8 +225,10 @@ export const ArtworkSidebarCommercialButtons: React.FC<
             orderOrError.error,
           )
         } else {
-          const url = `/orders/${orderOrError.order.internalID}`
-
+          const orderId = orderOrError.order.internalID
+          const url = isOrder2Enabled
+            ? `/orders2/${orderId}/checkout`
+            : `/orders/${orderId}`
           router?.push(url)
         }
       } catch (e) {
@@ -285,7 +292,10 @@ export const ArtworkSidebarCommercialButtons: React.FC<
             orderOrError.error,
           )
         } else {
-          const url = `/orders/${orderOrError.order.internalID}/offer`
+          const orderId = orderOrError.order.internalID
+          const url = isOrder2Enabled
+            ? `/orders2/${orderId}/checkout`
+            : `/orders/${orderId}/offer`
           router?.push(url)
         }
       } catch (error) {


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-3226]

### Description
**Fix layout shift on checkout navigation**: Purchase/Make Offer buttons now check the `emerald_checkout-redesign` feature flag client-side and navigate directly to `/orders2/{id}/checkout` when enabled, avoiding the intermediate redirect through the old Order routes that caused a visible layout jump.

<!-- Implementation description -->
| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/1479a310-200d-4dcb-bb75-4bab244b9a2c" /> | <video src="https://github.com/user-attachments/assets/dc3998c3-5ccc-4823-ac74-97f4789bda46" />|

[EMI-3226]: https://artsyproduct.atlassian.net/browse/EMI-3226?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ