### PR TITLE
fix: sign up page redirect url

### DIFF
--- a/src/Components/NavBar/NavBarLoggedOutActions.tsx
+++ b/src/Components/NavBar/NavBarLoggedOutActions.tsx
@@ -2,15 +2,12 @@ import { ContextModule, Intent } from "@artsy/cohesion"
 import { Button, Flex, Spacer } from "@artsy/palette"
 import { useAuthDialog } from "Components/AuthDialog"
 import { RouterLink } from "System/Components/RouterLink"
-import { useState, useEffect } from "react"
+import { useRouter } from "System/Hooks/useRouter"
 
 export const NavBarLoggedOutActions = () => {
   const { showAuthDialog } = useAuthDialog()
-  const [currentPath, setCurrentPath] = useState("/")
-
-  useEffect(() => {
-    setCurrentPath(window.location.pathname)
-  }, [])
+  const { match } = useRouter()
+  const currentPath = match.location.pathname
 
   return (
     <Flex alignItems="center">

--- a/src/Components/NavBar/__tests__/NavBar.jest.tsx
+++ b/src/Components/NavBar/__tests__/NavBar.jest.tsx
@@ -84,6 +84,12 @@ jest.mock("System/Contexts/NavigationDataContext", () => ({
   NavigationDataProvider: ({ children }) => children,
 }))
 
+jest.mock("System/Hooks/useRouter", () => ({
+  useRouter: jest.fn(() => ({
+    match: { location: { pathname: "/" } },
+  })),
+}))
+
 describe("NavBar", () => {
   const trackEvent = jest.fn()
   const mockUseNavigationData = useNavigationData as jest.Mock

--- a/src/Components/NavBar/__tests__/NavBarTracking.jest.tsx
+++ b/src/Components/NavBar/__tests__/NavBarTracking.jest.tsx
@@ -31,6 +31,12 @@ jest.mock("Components/NavBar/Menus/NavBarUserMenuAvatar", () => ({
   NavBarUserMenuAvatar: () => <div />,
 }))
 
+jest.mock("System/Hooks/useRouter", () => ({
+  useRouter: jest.fn(() => ({
+    match: { location: { pathname: "/" } },
+  })),
+}))
+
 describe("NavBarTracking", () => {
   const trackEvent = jest.fn()
 


### PR DESCRIPTION
This PR fixes an issue with the redirect URL that we were passing to the sign-up page. The path that we were using was only refreshing when the nav bar initially mounted, and was not refreshing on each page we navigated to. Luckily the nav bar receives router changes, so we updated it to use `useRouter` to get the correct path on each navigation.

cc: @artsy/diamond-devs 