### PR TITLE
refactor(passport): migrates from superagent => fetch

### DIFF
--- a/src/Server/passport/lib/__tests__/refreshAccessToken.jest.ts
+++ b/src/Server/passport/lib/__tests__/refreshAccessToken.jest.ts
@@ -1,9 +1,9 @@
+import { requestGravity } from "../http"
 import {
   decodeJwtExp,
   refreshAccessToken,
   shouldRefresh,
 } from "../refreshAccessToken"
-import request from "superagent"
 
 jest.mock("Server/config", () => ({
   API_URL: "https://example.test",
@@ -11,9 +11,9 @@ jest.mock("Server/config", () => ({
   CLIENT_SECRET: "client-secret",
 }))
 
-jest.mock("superagent", () => ({
-  post: jest.fn(),
-}))
+jest.mock("../http")
+
+const mockRequestGravity = requestGravity as jest.Mock
 
 const buildJwt = (payload: object): string => {
   const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" }))
@@ -71,44 +71,38 @@ describe("shouldRefresh", () => {
 })
 
 describe("refreshAccessToken", () => {
-  const post = request.post as jest.Mock
+  type Outcome =
+    | { body: any }
+    | { error: { status?: number; body?: any; message?: string } }
 
-  const mockChain = (
-    trust: { body?: any; throw?: { status?: number } },
-    token?: { body?: any; throw?: { status?: number } },
-  ) => {
-    const trustChain: any = {
-      set: jest
-        .fn()
-        .mockImplementation(() =>
-          trust.throw
-            ? Promise.reject({ status: trust.throw.status })
-            : Promise.resolve({ body: trust.body }),
-        ),
-    }
-    const tokenChain: any = {
-      set: jest.fn().mockReturnThis(),
-      send: jest
-        .fn()
-        .mockImplementation(() =>
-          !token
-            ? Promise.resolve({ body: {} })
-            : token.throw
-              ? Promise.reject({ status: token.throw.status })
-              : Promise.resolve({ body: token.body }),
-        ),
-    }
-    post.mockImplementation((url: string) =>
-      url.includes("trust_token") ? trustChain : tokenChain,
-    )
+  const mockRoute = (trust: Outcome, token?: Outcome) => {
+    mockRequestGravity.mockImplementation(({ url }: { url: string }) => {
+      const outcome = url.includes("trust_token") ? trust : token
+
+      if (!outcome) return Promise.resolve({ body: {} })
+
+      if ("error" in outcome) {
+        return Promise.reject({
+          message: outcome.error.message ?? "Error",
+          response: {
+            body: outcome.error.body ?? {},
+            ok: false,
+            status: outcome.error.status,
+            text: "",
+          },
+        })
+      }
+
+      return Promise.resolve({ body: outcome.body, ok: true })
+    })
   }
 
   beforeEach(() => {
-    post.mockReset()
+    mockRequestGravity.mockReset()
   })
 
   it("returns a fresh access token on success", async () => {
-    mockChain(
+    mockRoute(
       { body: { trust_token: "TT" } },
       { body: { access_token: "NEW" } },
     )
@@ -116,26 +110,65 @@ describe("refreshAccessToken", () => {
     expect(result).toEqual({ ok: true, accessToken: "NEW" })
   })
 
+  it("forwards the access token and IP when requesting a trust token", async () => {
+    mockRoute(
+      { body: { trust_token: "TT" } },
+      { body: { access_token: "NEW" } },
+    )
+    await refreshAccessToken("OLD", "127.0.0.1")
+    expect(mockRequestGravity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "POST",
+        url: "https://example.test/api/v1/me/trust_token",
+        headers: expect.objectContaining({
+          "X-Access-Token": "OLD",
+          "X-Forwarded-For": "127.0.0.1",
+        }),
+      }),
+    )
+    expect(mockRequestGravity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: "POST",
+        url: "https://example.test/oauth2/access_token",
+        headers: expect.objectContaining({
+          "X-Forwarded-For": "127.0.0.1",
+        }),
+        body: expect.objectContaining({
+          grant_type: "trust_token",
+          client_id: "client-id",
+          client_secret: "client-secret",
+          code: "TT",
+        }),
+      }),
+    )
+  })
+
   it("returns invalid when trust_token call returns 401", async () => {
-    mockChain({ throw: { status: 401 } })
+    mockRoute({ error: { status: 401 } })
     const result = await refreshAccessToken("OLD", "127.0.0.1")
     expect(result).toEqual({ ok: false, reason: "invalid" })
   })
 
   it("returns invalid when access_token call returns 403", async () => {
-    mockChain({ body: { trust_token: "TT" } }, { throw: { status: 403 } })
+    mockRoute({ body: { trust_token: "TT" } }, { error: { status: 403 } })
     const result = await refreshAccessToken("OLD", "127.0.0.1")
     expect(result).toEqual({ ok: false, reason: "invalid" })
   })
 
   it("returns transient on 5xx", async () => {
-    mockChain({ throw: { status: 503 } })
+    mockRoute({ error: { status: 503 } })
     const result = await refreshAccessToken("OLD", "127.0.0.1")
     expect(result).toEqual({ ok: false, reason: "transient" })
   })
 
   it("returns transient when trust_token body is missing", async () => {
-    mockChain({ body: {} })
+    mockRoute({ body: {} })
+    const result = await refreshAccessToken("OLD", "127.0.0.1")
+    expect(result).toEqual({ ok: false, reason: "transient" })
+  })
+
+  it("returns transient when access_token body is missing", async () => {
+    mockRoute({ body: { trust_token: "TT" } }, { body: {} })
     const result = await refreshAccessToken("OLD", "127.0.0.1")
     expect(result).toEqual({ ok: false, reason: "transient" })
   })

--- a/src/Server/passport/lib/refreshAccessToken.ts
+++ b/src/Server/passport/lib/refreshAccessToken.ts
@@ -1,5 +1,5 @@
-import request from "superagent"
 import { API_URL, CLIENT_ID, CLIENT_SECRET } from "Server/config"
+import { type GravityError, requestGravity } from "./http"
 
 export type RefreshResult =
   | { ok: true; accessToken: string }
@@ -32,44 +32,45 @@ export const shouldRefresh = (
 const isInvalidStatus = (status: number | undefined): boolean =>
   status === 401 || status === 403
 
+const reasonFromError = (err: GravityError): "invalid" | "transient" =>
+  isInvalidStatus(err?.response?.status) ? "invalid" : "transient"
+
 export const refreshAccessToken = async (
   currentToken: string,
   forwardedFor: string,
 ): Promise<RefreshResult> => {
   let trustToken: string
   try {
-    const trustRes = await request
-      .post(`${API_URL}/api/v1/me/trust_token`)
-      .set({
+    const trustRes = await requestGravity({
+      headers: {
         "X-Access-Token": currentToken,
         "X-Forwarded-For": forwardedFor,
-      })
+      },
+      method: "POST",
+      url: `${API_URL}/api/v1/me/trust_token`,
+    })
     trustToken = trustRes.body?.trust_token
     if (!trustToken) return { ok: false, reason: "transient" }
-  } catch (err: any) {
-    return {
-      ok: false,
-      reason: isInvalidStatus(err?.status) ? "invalid" : "transient",
-    }
+  } catch (err) {
+    return { ok: false, reason: reasonFromError(err as GravityError) }
   }
 
   try {
-    const tokenRes = await request
-      .post(`${API_URL}/oauth2/access_token`)
-      .set({ "X-Forwarded-For": forwardedFor })
-      .send({
+    const tokenRes = await requestGravity({
+      body: {
         grant_type: "trust_token",
         client_id: CLIENT_ID,
         client_secret: CLIENT_SECRET,
         code: trustToken,
-      })
+      },
+      headers: { "X-Forwarded-For": forwardedFor },
+      method: "POST",
+      url: `${API_URL}/oauth2/access_token`,
+    })
     const accessToken = tokenRes.body?.access_token
     if (!accessToken) return { ok: false, reason: "transient" }
     return { ok: true, accessToken }
-  } catch (err: any) {
-    return {
-      ok: false,
-      reason: isInvalidStatus(err?.status) ? "invalid" : "transient",
-    }
+  } catch (err) {
+    return { ok: false, reason: reasonFromError(err as GravityError) }
   }
 }


### PR DESCRIPTION
`superagent` is an artifact of the original force codebase and has an unfamiliar API. I replaced it with `fetch` in https://github.com/artsy/force/pull/17169

This PR just replaces it with the `requestGravity` `fetch` wrapper.

There's one other place it's used, in the 2fa management, which happens on the client. I'll get rid of it there then finally drop the dependency.

cc @artsy/diamond-devs 