### PR TITLE
feat: enable Google One Tap for users on Chrome

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
     "passport-apple": "https://github.com/artsy/passport-apple#f41adb7822c8344b72bc36a7d68312f6592cb14f",
     "passport-facebook": "^3.0.0",
     "passport-google-oauth20": "^2.0.0",
+    "passport-google-one-tap": "^1.0.1",
     "passport-strategy": "1.x.x",
     "path-to-regexp": "6.3.0",
     "proportional-scale": "^4.0.0",

--- a/src/Apps/Order/__tests__/OrderApp.jest.tsx
+++ b/src/Apps/Order/__tests__/OrderApp.jest.tsx
@@ -35,6 +35,7 @@ jest.mock("System/Hooks/useSystemContext", () => ({
 }))
 
 jest.mock("@unleash/proxy-client-react", () => ({
+  useFlag: jest.fn(() => false),
   useVariant: jest.fn(() => ({ enabled: false, name: "control" })),
 }))
 

--- a/src/Apps/Order2/__tests__/Order2App.jest.tsx
+++ b/src/Apps/Order2/__tests__/Order2App.jest.tsx
@@ -5,6 +5,7 @@ import { useTrackFeatureVariantOnMount } from "System/Hooks/useTrackFeatureVaria
 import { Order2App } from "../Order2App"
 
 jest.mock("@unleash/proxy-client-react", () => ({
+  useFlag: jest.fn(() => false),
   useVariant: jest.fn(),
 }))
 

--- a/src/Components/NavBar/NavBarLoggedOutActions.tsx
+++ b/src/Components/NavBar/NavBarLoggedOutActions.tsx
@@ -3,14 +3,48 @@ import { Button, Flex, Spacer } from "@artsy/palette"
 import { useAuthDialog } from "Components/AuthDialog"
 import { RouterLink } from "System/Components/RouterLink"
 import { useRouter } from "System/Hooks/useRouter"
+import { getENV } from "Utils/getENV"
+import { useEffect, useState } from "react"
 
 export const NavBarLoggedOutActions = () => {
   const { showAuthDialog } = useAuthDialog()
   const { match } = useRouter()
   const currentPath = match.location.pathname
+  const googleClientId = getENV("GOOGLE_CLIENT_ID")
+
+  useEffect(() => {
+    if (!googleClientId) {
+      console.debug(
+        "[OneTap] GOOGLE_CLIENT_ID not set, skipping GSI script load",
+      )
+      return
+    }
+
+    console.debug("[OneTap] GOOGLE_CLIENT_ID found, loading GSI script")
+
+    const script = document.createElement("script")
+    script.src = "https://accounts.google.com/gsi/client"
+    script.async = true
+    script.defer = true
+    script.onload = () => console.debug("[OneTap] GSI script loaded")
+    script.onerror = () => console.debug("[OneTap] GSI script failed to load")
+    document.body.appendChild(script)
+
+    return () => {
+      document.body.removeChild(script)
+    }
+  }, [googleClientId])
 
   return (
     <Flex alignItems="center">
+      {googleClientId && (
+        <div
+          id="g_id_onload"
+          data-client_id={googleClientId}
+          data-login_uri={`${getENV("APP_URL")}/users/auth/google/one_tap/callback`}
+          data-auto_prompt="true"
+        />
+      )}
       <Button
         variant="secondaryBlack"
         size="small"

--- a/src/Components/NavBar/NavBarLoggedOutActions.tsx
+++ b/src/Components/NavBar/NavBarLoggedOutActions.tsx
@@ -1,43 +1,41 @@
 import { ContextModule, Intent } from "@artsy/cohesion"
 import { Button, Flex, Spacer } from "@artsy/palette"
+import { useFlag } from "@unleash/proxy-client-react"
+import { captureException } from "@sentry/browser"
 import { useAuthDialog } from "Components/AuthDialog"
 import { RouterLink } from "System/Components/RouterLink"
 import { useRouter } from "System/Hooks/useRouter"
 import { getENV } from "Utils/getENV"
-import { useEffect, useState } from "react"
+import { useEffect } from "react"
 
 export const NavBarLoggedOutActions = () => {
   const { showAuthDialog } = useAuthDialog()
   const { match } = useRouter()
   const currentPath = match.location.pathname
   const googleClientId = getENV("GOOGLE_CLIENT_ID")
+  const isGoogleOneTapEnabled = !!useFlag("diamond_google-one-tap")
 
   useEffect(() => {
-    if (!googleClientId) {
-      console.debug(
-        "[OneTap] GOOGLE_CLIENT_ID not set, skipping GSI script load",
-      )
+    if (!isGoogleOneTapEnabled || !googleClientId) {
       return
     }
-
-    console.debug("[OneTap] GOOGLE_CLIENT_ID found, loading GSI script")
 
     const script = document.createElement("script")
     script.src = "https://accounts.google.com/gsi/client"
     script.async = true
     script.defer = true
-    script.onload = () => console.debug("[OneTap] GSI script loaded")
-    script.onerror = () => console.debug("[OneTap] GSI script failed to load")
+    script.onerror = () =>
+      captureException(new Error("Google One Tap script failed to load"))
     document.body.appendChild(script)
 
     return () => {
       document.body.removeChild(script)
     }
-  }, [googleClientId])
+  }, [isGoogleOneTapEnabled, googleClientId])
 
   return (
     <Flex alignItems="center">
-      {googleClientId && (
+      {isGoogleOneTapEnabled && googleClientId && (
         <div
           id="g_id_onload"
           data-client_id={googleClientId}

--- a/src/Components/NavBar/NavBarLoggedOutActions.tsx
+++ b/src/Components/NavBar/NavBarLoggedOutActions.tsx
@@ -1,48 +1,16 @@
 import { ContextModule, Intent } from "@artsy/cohesion"
 import { Button, Flex, Spacer } from "@artsy/palette"
-import { useFlag } from "@unleash/proxy-client-react"
-import { captureException } from "@sentry/browser"
 import { useAuthDialog } from "Components/AuthDialog"
 import { RouterLink } from "System/Components/RouterLink"
 import { useRouter } from "System/Hooks/useRouter"
-import { getENV } from "Utils/getENV"
-import { useEffect } from "react"
 
 export const NavBarLoggedOutActions = () => {
   const { showAuthDialog } = useAuthDialog()
   const { match } = useRouter()
   const currentPath = match.location.pathname
-  const googleClientId = getENV("GOOGLE_CLIENT_ID")
-  const isGoogleOneTapEnabled = !!useFlag("diamond_google-one-tap")
-
-  useEffect(() => {
-    if (!isGoogleOneTapEnabled || !googleClientId) {
-      return
-    }
-
-    const script = document.createElement("script")
-    script.src = "https://accounts.google.com/gsi/client"
-    script.async = true
-    script.defer = true
-    script.onerror = () =>
-      captureException(new Error("Google One Tap script failed to load"))
-    document.body.appendChild(script)
-
-    return () => {
-      document.body.removeChild(script)
-    }
-  }, [isGoogleOneTapEnabled, googleClientId])
 
   return (
     <Flex alignItems="center">
-      {isGoogleOneTapEnabled && googleClientId && (
-        <div
-          id="g_id_onload"
-          data-client_id={googleClientId}
-          data-login_uri={`${getENV("APP_URL")}/users/auth/google/one_tap/callback`}
-          data-auto_prompt="true"
-        />
-      )}
       <Button
         variant="secondaryBlack"
         size="small"

--- a/src/Components/NavBar/__tests__/NavBarLoggedOutActions.jest.tsx
+++ b/src/Components/NavBar/__tests__/NavBarLoggedOutActions.jest.tsx
@@ -2,22 +2,6 @@ import { ContextModule, Intent } from "@artsy/cohesion"
 import { fireEvent, render, screen } from "@testing-library/react"
 import { useAuthDialog } from "Components/AuthDialog"
 import { NavBarLoggedOutActions } from "Components/NavBar/NavBarLoggedOutActions"
-import { useFlag } from "@unleash/proxy-client-react"
-import { getENV } from "Utils/getENV"
-
-const mockCaptureException = jest.fn()
-
-jest.mock("@sentry/browser", () => ({
-  captureException: (...args: unknown[]) => mockCaptureException(...args),
-}))
-
-jest.mock("Utils/getENV", () => ({
-  getENV: jest.fn(),
-}))
-
-jest.mock("@unleash/proxy-client-react", () => ({
-  useFlag: jest.fn(),
-}))
 
 jest.mock("System/Hooks/useRouter", () => ({
   useRouter: jest.fn(() => ({
@@ -38,15 +22,7 @@ jest.mock("Components/AuthDialog/useAuthDialog", () => ({
 }))
 
 describe("NavBarLoggedOutActions", () => {
-  const mockUseFlag = useFlag as jest.Mock
-  const mockGetENV = getENV as jest.Mock
   const mockUseAuthDialog = useAuthDialog as jest.Mock
-
-  beforeEach(() => {
-    mockUseFlag.mockReturnValue(false)
-    mockGetENV.mockReturnValue(null)
-    mockCaptureException.mockClear()
-  })
 
   it("renders Log In and Sign Up buttons", () => {
     render(<NavBarLoggedOutActions />)
@@ -74,86 +50,6 @@ describe("NavBarLoggedOutActions", () => {
         contextModule: ContextModule.header,
         intent: Intent.login,
       },
-    })
-  })
-
-  describe("Google One Tap", () => {
-    const enableOneTap = () => {
-      mockUseFlag.mockReturnValue(true)
-      mockGetENV.mockImplementation((key: string) => {
-        if (key === "GOOGLE_CLIENT_ID") return "test-client-id"
-        if (key === "APP_URL") return "https://artsy.net"
-        return null
-      })
-    }
-
-    describe("g_id_onload div", () => {
-      it("renders when feature flag is on and GOOGLE_CLIENT_ID is set", () => {
-        enableOneTap()
-        render(<NavBarLoggedOutActions />)
-        expect(document.getElementById("g_id_onload")).toBeInTheDocument()
-        expect(document.getElementById("g_id_onload")).toHaveAttribute(
-          "data-client_id",
-          "test-client-id",
-        )
-      })
-
-      it("does not render when feature flag is off", () => {
-        mockUseFlag.mockReturnValue(false)
-        mockGetENV.mockReturnValue("test-client-id")
-        render(<NavBarLoggedOutActions />)
-        expect(document.getElementById("g_id_onload")).not.toBeInTheDocument()
-      })
-
-      it("does not render when GOOGLE_CLIENT_ID is not set", () => {
-        mockUseFlag.mockReturnValue(true)
-        mockGetENV.mockReturnValue(null)
-        render(<NavBarLoggedOutActions />)
-        expect(document.getElementById("g_id_onload")).not.toBeInTheDocument()
-      })
-    })
-
-    describe("GSI script injection", () => {
-      const gsiScript = () =>
-        document.body.querySelector(
-          "script[src='https://accounts.google.com/gsi/client']",
-        ) as HTMLScriptElement | null
-
-      it("appends script to body when feature flag is on and GOOGLE_CLIENT_ID is set", () => {
-        enableOneTap()
-        render(<NavBarLoggedOutActions />)
-        expect(gsiScript()).toBeInTheDocument()
-      })
-
-      it("does not append script when feature flag is off", () => {
-        mockUseFlag.mockReturnValue(false)
-        mockGetENV.mockReturnValue("test-client-id")
-        render(<NavBarLoggedOutActions />)
-        expect(gsiScript()).not.toBeInTheDocument()
-      })
-
-      it("does not append script when GOOGLE_CLIENT_ID is not set", () => {
-        mockUseFlag.mockReturnValue(true)
-        mockGetENV.mockReturnValue(null)
-        render(<NavBarLoggedOutActions />)
-        expect(gsiScript()).not.toBeInTheDocument()
-      })
-
-      it("removes script from body on unmount", () => {
-        enableOneTap()
-        const { unmount } = render(<NavBarLoggedOutActions />)
-        unmount()
-        expect(gsiScript()).not.toBeInTheDocument()
-      })
-
-      it("calls captureException when the GSI script fails to load", () => {
-        enableOneTap()
-        render(<NavBarLoggedOutActions />)
-        gsiScript()!.onerror!(new Event("error"))
-        expect(mockCaptureException).toHaveBeenCalledWith(
-          new Error("Google One Tap script failed to load"),
-        )
-      })
     })
   })
 })

--- a/src/Components/NavBar/__tests__/NavBarLoggedOutActions.jest.tsx
+++ b/src/Components/NavBar/__tests__/NavBarLoggedOutActions.jest.tsx
@@ -1,0 +1,159 @@
+import { ContextModule, Intent } from "@artsy/cohesion"
+import { fireEvent, render, screen } from "@testing-library/react"
+import { useAuthDialog } from "Components/AuthDialog"
+import { NavBarLoggedOutActions } from "Components/NavBar/NavBarLoggedOutActions"
+import { useFlag } from "@unleash/proxy-client-react"
+import { getENV } from "Utils/getENV"
+
+const mockCaptureException = jest.fn()
+
+jest.mock("@sentry/browser", () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+}))
+
+jest.mock("Utils/getENV", () => ({
+  getENV: jest.fn(),
+}))
+
+jest.mock("@unleash/proxy-client-react", () => ({
+  useFlag: jest.fn(),
+}))
+
+jest.mock("System/Hooks/useRouter", () => ({
+  useRouter: jest.fn(() => ({
+    match: { location: { pathname: "/collect" } },
+  })),
+}))
+
+jest.mock("System/Components/RouterLink", () => ({
+  RouterLink: ({ to, children, ...rest }: any) => (
+    <a href={to} {...rest}>
+      {children}
+    </a>
+  ),
+}))
+
+jest.mock("Components/AuthDialog/useAuthDialog", () => ({
+  useAuthDialog: jest.fn().mockReturnValue({ showAuthDialog: jest.fn() }),
+}))
+
+describe("NavBarLoggedOutActions", () => {
+  const mockUseFlag = useFlag as jest.Mock
+  const mockGetENV = getENV as jest.Mock
+  const mockUseAuthDialog = useAuthDialog as jest.Mock
+
+  beforeEach(() => {
+    mockUseFlag.mockReturnValue(false)
+    mockGetENV.mockReturnValue(null)
+    mockCaptureException.mockClear()
+  })
+
+  it("renders Log In and Sign Up buttons", () => {
+    render(<NavBarLoggedOutActions />)
+    expect(screen.getByText("Log In")).toBeInTheDocument()
+    expect(screen.getByText("Sign Up")).toBeInTheDocument()
+  })
+
+  it("Sign Up button links to /signup with encoded current path", () => {
+    render(<NavBarLoggedOutActions />)
+    expect(screen.getByText("Sign Up").closest("a")).toHaveAttribute(
+      "href",
+      "/signup?redirectTo=%2Fcollect",
+    )
+  })
+
+  it("opens auth dialog with correct analytics when Log In is clicked", () => {
+    const showAuthDialog = jest.fn()
+    mockUseAuthDialog.mockReturnValue({ showAuthDialog })
+
+    render(<NavBarLoggedOutActions />)
+    fireEvent.click(screen.getByText("Log In"))
+
+    expect(showAuthDialog).toHaveBeenCalledWith({
+      analytics: {
+        contextModule: ContextModule.header,
+        intent: Intent.login,
+      },
+    })
+  })
+
+  describe("Google One Tap", () => {
+    const enableOneTap = () => {
+      mockUseFlag.mockReturnValue(true)
+      mockGetENV.mockImplementation((key: string) => {
+        if (key === "GOOGLE_CLIENT_ID") return "test-client-id"
+        if (key === "APP_URL") return "https://artsy.net"
+        return null
+      })
+    }
+
+    describe("g_id_onload div", () => {
+      it("renders when feature flag is on and GOOGLE_CLIENT_ID is set", () => {
+        enableOneTap()
+        render(<NavBarLoggedOutActions />)
+        expect(document.getElementById("g_id_onload")).toBeInTheDocument()
+        expect(document.getElementById("g_id_onload")).toHaveAttribute(
+          "data-client_id",
+          "test-client-id",
+        )
+      })
+
+      it("does not render when feature flag is off", () => {
+        mockUseFlag.mockReturnValue(false)
+        mockGetENV.mockReturnValue("test-client-id")
+        render(<NavBarLoggedOutActions />)
+        expect(document.getElementById("g_id_onload")).not.toBeInTheDocument()
+      })
+
+      it("does not render when GOOGLE_CLIENT_ID is not set", () => {
+        mockUseFlag.mockReturnValue(true)
+        mockGetENV.mockReturnValue(null)
+        render(<NavBarLoggedOutActions />)
+        expect(document.getElementById("g_id_onload")).not.toBeInTheDocument()
+      })
+    })
+
+    describe("GSI script injection", () => {
+      const gsiScript = () =>
+        document.body.querySelector(
+          "script[src='https://accounts.google.com/gsi/client']",
+        ) as HTMLScriptElement | null
+
+      it("appends script to body when feature flag is on and GOOGLE_CLIENT_ID is set", () => {
+        enableOneTap()
+        render(<NavBarLoggedOutActions />)
+        expect(gsiScript()).toBeInTheDocument()
+      })
+
+      it("does not append script when feature flag is off", () => {
+        mockUseFlag.mockReturnValue(false)
+        mockGetENV.mockReturnValue("test-client-id")
+        render(<NavBarLoggedOutActions />)
+        expect(gsiScript()).not.toBeInTheDocument()
+      })
+
+      it("does not append script when GOOGLE_CLIENT_ID is not set", () => {
+        mockUseFlag.mockReturnValue(true)
+        mockGetENV.mockReturnValue(null)
+        render(<NavBarLoggedOutActions />)
+        expect(gsiScript()).not.toBeInTheDocument()
+      })
+
+      it("removes script from body on unmount", () => {
+        enableOneTap()
+        const { unmount } = render(<NavBarLoggedOutActions />)
+        unmount()
+        expect(gsiScript()).not.toBeInTheDocument()
+      })
+
+      it("calls captureException when the GSI script fails to load", () => {
+        enableOneTap()
+        render(<NavBarLoggedOutActions />)
+        gsiScript()!.onerror!(new Event("error"))
+        expect(mockCaptureException).toHaveBeenCalledWith(
+          new Error("Google One Tap script failed to load"),
+        )
+      })
+    })
+  })
+})

--- a/src/Server/bootstrapSharify.ts
+++ b/src/Server/bootstrapSharify.ts
@@ -59,6 +59,7 @@ export const bootstrapSharify = () => {
       "GEODATA_URL",
       "GOOGLE_ADWORDS_ID",
       "GOOGLE_ANALYTICS_ID",
+      "GOOGLE_CLIENT_ID",
       "GRAPHQL_CACHE_SIZE",
       "GRAPHQL_CACHE_TTL",
       "GRAVITY_WEBSOCKET_URL",

--- a/src/Server/passport/lib/app/__tests__/index.jest.ts
+++ b/src/Server/passport/lib/app/__tests__/index.jest.ts
@@ -24,7 +24,7 @@ describe("passport app setup", () => {
       facebookCallbackPath: "/users/auth/facebook/callback",
       facebookPath: "/users/auth/facebook",
       googleCallbackPath: "/users/auth/google/callback",
-      googleOneTapCallbackPath: "/users/auth/google_one_tap/callback",
+      googleOneTapCallbackPath: "/users/auth/google/one_tap/callback",
       googlePath: "/users/auth/google",
       loginPagePath: "/log_in",
       logoutPath: "/users/sign_out",
@@ -81,7 +81,7 @@ describe("passport app setup", () => {
     setupApp()
 
     const oneTapPost = app.post.mock.calls.find(
-      ([path]) => path === "/users/auth/google_one_tap/callback",
+      ([path]) => path === "/users/auth/google/one_tap/callback",
     )
 
     expect(oneTapPost).toBeDefined()

--- a/src/Server/passport/lib/app/__tests__/index.jest.ts
+++ b/src/Server/passport/lib/app/__tests__/index.jest.ts
@@ -24,6 +24,7 @@ describe("passport app setup", () => {
       facebookCallbackPath: "/users/auth/facebook/callback",
       facebookPath: "/users/auth/facebook",
       googleCallbackPath: "/users/auth/google/callback",
+      googleOneTapCallbackPath: "/users/auth/google_one_tap/callback",
       googlePath: "/users/auth/google",
       loginPagePath: "/log_in",
       logoutPath: "/users/sign_out",
@@ -72,5 +73,17 @@ describe("passport app setup", () => {
     expect(signupPost).toBeDefined()
     expect(signupPost[1]).toBe(csrfMiddleware)
     expect(csrf).toHaveBeenCalledWith({ cookie: true })
+  })
+
+  it("registers the google one tap callback route", () => {
+    const { app, setupApp } = loadSetup()
+
+    setupApp()
+
+    const oneTapPost = app.post.mock.calls.find(
+      ([path]) => path === "/users/auth/google_one_tap/callback",
+    )
+
+    expect(oneTapPost).toBeDefined()
   })
 })

--- a/src/Server/passport/lib/app/index.ts
+++ b/src/Server/passport/lib/app/index.ts
@@ -91,8 +91,8 @@ const setupApp = () => {
   // Google One Tap
   app.post(
     opts.googleOneTapCallbackPath,
-    middleware(afterSocialAuth("google_one_tap")),
-    middleware(trackSignup("google_one_tap")),
+    middleware(afterSocialAuth("google-one-tap")),
+    middleware(trackSignup("google-one-tap")),
     middleware(ssoAndRedirectBack),
   )
 

--- a/src/Server/passport/lib/app/index.ts
+++ b/src/Server/passport/lib/app/index.ts
@@ -2,6 +2,7 @@ import express from "express"
 import type { ErrorRequestHandler, RequestHandler } from "express"
 import passport from "passport"
 import opts from "../options"
+import { setCampaign, trackLogin, trackSignup } from "./analytics"
 import {
   afterSocialAuth,
   beforeSocialAuth,
@@ -11,7 +12,6 @@ import {
   ssoAndRedirectBack,
 } from "./lifecycle"
 import addLocals from "./locals"
-import { setCampaign, trackLogin, trackSignup } from "./analytics"
 import { denyBadLogoutLinks, logout } from "./logout"
 import { headerLogin, trustTokenLogin } from "./token_login"
 
@@ -85,6 +85,14 @@ const setupApp = () => {
     opts.googleCallbackPath,
     middleware(afterSocialAuth("google")),
     middleware(trackSignup("google")),
+    middleware(ssoAndRedirectBack),
+  )
+
+  // Google One Tap
+  app.post(
+    opts.googleOneTapCallbackPath,
+    middleware(afterSocialAuth("google_one_tap")),
+    middleware(trackSignup("google_one_tap")),
     middleware(ssoAndRedirectBack),
   )
 

--- a/src/Server/passport/lib/app/lifecycle.ts
+++ b/src/Server/passport/lib/app/lifecycle.ts
@@ -154,7 +154,7 @@ const signupErrorMessage = (err: GravityError) => {
   return ""
 }
 
-type Provider = "facebook" | "apple" | "google"
+type Provider = "facebook" | "apple" | "google" | "google_one_tap"
 const UNKNOWN_AUTH_ERROR = "An unknown error occurred. Please try again."
 const SOCIAL_LOGIN_TWO_FACTOR_AUTH_ERROR =
   "Please log in with email and password to use two-factor authentication."

--- a/src/Server/passport/lib/app/lifecycle.ts
+++ b/src/Server/passport/lib/app/lifecycle.ts
@@ -154,7 +154,7 @@ const signupErrorMessage = (err: GravityError) => {
   return ""
 }
 
-type Provider = "facebook" | "apple" | "google" | "google_one_tap"
+type Provider = "facebook" | "apple" | "google" | "google-one-tap"
 const UNKNOWN_AUTH_ERROR = "An unknown error occurred. Please try again."
 const SOCIAL_LOGIN_TWO_FACTOR_AUTH_ERROR =
   "Please log in with email and password to use two-factor authentication."

--- a/src/Server/passport/lib/app/locals.ts
+++ b/src/Server/passport/lib/app/locals.ts
@@ -34,6 +34,7 @@ const addLocals = (
       "facebookCallbackPath",
       "googlePath",
       "googleCallbackPath",
+      "googleOneTapCallbackPath",
       "loginPagePath",
       "signupPagePath",
       "settingsPagePath",

--- a/src/Server/passport/lib/options.ts
+++ b/src/Server/passport/lib/options.ts
@@ -8,6 +8,7 @@ const options: PassportOptions = {
   facebookCallbackPath: "/users/auth/facebook/callback",
   googlePath: "/users/auth/google",
   googleCallbackPath: "/users/auth/google/callback",
+  googleOneTapCallbackPath: "/users/auth/google/one_tap/callback",
 
   // Landing pages
   loginPagePath: "/log_in",

--- a/src/Server/passport/lib/passport/__tests__/callbacks.jest.ts
+++ b/src/Server/passport/lib/passport/__tests__/callbacks.jest.ts
@@ -98,6 +98,91 @@ describe("passport callbacks", () => {
     expect(sendArgs.oauth_token).toEqual("foo-token")
   })
 
+  it("gets a user with an access token via google one tap", done => {
+    req.body = { credential: "google-jwt-credential" }
+    mockRequestGravity.mockResolvedValue(
+      gravityResponse({ access_token: "access-token" }),
+    )
+    cbs.googleOneTap(req, {}, (err, user) => {
+      expect(user.accessToken).toEqual("access-token")
+      done()
+    })
+    const sendArgs = mockRequestGravity.mock.calls[0][0].body
+    expect(sendArgs.grant_type).toEqual("jwt")
+    expect(sendArgs.jwt).toEqual("google-jwt-credential")
+    expect(sendArgs.oauth_provider).toEqual("google")
+  })
+
+  it("passes the user agent through google one tap", async () => {
+    req.body = { credential: "google-jwt-credential" }
+    req.get.mockReturnValue("foo-bar-baz-ua")
+    const res = {
+      body: { error_description: "no account linked" },
+      status: 403,
+    }
+    mockRequestGravity
+      .mockRejectedValueOnce(gravityError(res))
+      .mockImplementationOnce(() => new Promise(() => {}))
+    cbs.googleOneTap(req, { displayName: "Some User" })
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(mockRequestGravity.mock.calls[1][0].headers["User-Agent"]).toEqual(
+      "foo-bar-baz-ua",
+    )
+  })
+
+  it("creates a user and retries google one tap login when no account is linked", done => {
+    req.body = { credential: "google-jwt-credential" }
+    req.connection = { remoteAddress: "99.99.99.99" }
+    req.headers = {}
+    req.session = {
+      accepted_terms_of_service: true,
+      agreed_to_receive_emails: false,
+      sign_up_intent: "buy art",
+      sign_up_referer: "auction",
+    }
+    req.get.mockImplementation(header => {
+      if (header === "referer") {
+        return "https://www.artsy.net/sign_up"
+      }
+      return "chrome-foo"
+    })
+    mockRequestGravity
+      .mockRejectedValueOnce(
+        gravityError({
+          body: { error_description: "no account linked" },
+          status: 403,
+        }),
+      )
+      .mockResolvedValueOnce({})
+      .mockResolvedValueOnce(gravityResponse({ access_token: "access-token" }))
+
+    cbs.googleOneTap(req, { displayName: "Some User" }, (err, user) => {
+      expect(err).toBeNull()
+      expect(user.accessToken).toEqual("access-token")
+      expect(req.artsyPassportSignedUp).toBe(true)
+      expect(mockRequestGravity.mock.calls[1][0]).toEqual(
+        expect.objectContaining({
+          body: expect.objectContaining({
+            accepted_terms_of_service: true,
+            agreed_to_receive_emails: false,
+            jwt: "google-jwt-credential",
+            provider: "google",
+            sign_up_intent: "buy art",
+            sign_up_referer: "auction",
+          }),
+          headers: expect.objectContaining({
+            Referer: "https://www.artsy.net/sign_up",
+            "User-Agent": "chrome-foo",
+          }),
+          method: "POST",
+          url: "http://apiz.artsy.net/api/v1/user",
+        }),
+      )
+      done()
+    })
+  })
+
   it("gets a user with an access token apple", done => {
     mockRequestGravity.mockResolvedValue(
       gravityResponse({ access_token: "access-token" }),

--- a/src/Server/passport/lib/passport/__tests__/index.jest.ts
+++ b/src/Server/passport/lib/passport/__tests__/index.jest.ts
@@ -9,12 +9,14 @@ describe("passport setup", () => {
     }
     const FacebookStrategy = jest.fn()
     const GoogleStrategy = jest.fn()
+    const GoogleOneTapStrategy = jest.fn()
     const AppleStrategy = jest.fn()
     const LocalWithOtpStrategy = jest.fn()
     const callbacks = {
       apple: jest.fn(),
       facebook: jest.fn(),
       google: jest.fn(),
+      googleOneTap: jest.fn(),
       local: jest.fn(),
     }
     const serializers = {
@@ -26,6 +28,9 @@ describe("passport setup", () => {
     jest.doMock("passport-facebook", () => ({ Strategy: FacebookStrategy }))
     jest.doMock("passport-google-oauth20", () => ({
       Strategy: GoogleStrategy,
+    }))
+    jest.doMock("passport-google-one-tap", () => ({
+      GoogleOneTapStrategy,
     }))
     jest.doMock("passport-apple", () => AppleStrategy)
     jest.doMock("Server/passport-local-with-otp/lib", () => ({
@@ -46,6 +51,7 @@ describe("passport setup", () => {
     return {
       AppleStrategy,
       FacebookStrategy,
+      GoogleOneTapStrategy,
       GoogleStrategy,
       LocalWithOtpStrategy,
       callbacks,
@@ -91,6 +97,7 @@ describe("passport setup", () => {
       AppleStrategy,
       callbacks,
       FacebookStrategy,
+      GoogleOneTapStrategy,
       GoogleStrategy,
       passport,
       setupPassport,
@@ -128,6 +135,15 @@ describe("passport setup", () => {
       },
       callbacks.google,
     )
+    expect(GoogleOneTapStrategy).toHaveBeenCalledWith(
+      {
+        clientID: "google-client-id",
+        clientSecret: "google-secret",
+        verifyCsrfToken: false,
+        passReqToCallback: true,
+      },
+      callbacks.googleOneTap,
+    )
     expect(AppleStrategy).toHaveBeenCalledWith(
       {
         callbackURL: "https://www.artsy.net/users/auth/apple/callback",
@@ -140,6 +156,6 @@ describe("passport setup", () => {
       },
       callbacks.apple,
     )
-    expect(passport.use).toHaveBeenCalledTimes(4)
+    expect(passport.use).toHaveBeenCalledTimes(5)
   })
 })

--- a/src/Server/passport/lib/passport/callbacks.ts
+++ b/src/Server/passport/lib/passport/callbacks.ts
@@ -2,9 +2,9 @@ import artsyXapp from "@artsy/xapp"
 import ip from "ip"
 import extend from "lodash/extend"
 import {
-  requestGravity,
   type GravityError,
   type GravityResponse,
+  requestGravity,
 } from "../http"
 import type { OAuthProfile, PassportDone, PassportRequest } from "../types"
 
@@ -150,6 +150,52 @@ export const facebook = (
   }
 }
 
+export const googleOneTap = (
+  req: PassportRequest,
+  profile: OAuthProfile,
+  done?: PassportDone,
+) => {
+  console.log("[Google One Tap] data:", {
+    req,
+    profile,
+    credential: req.body.credential,
+  })
+
+  requestGravity({
+    body: {
+      client_id: opts.ARTSY_ID,
+      client_secret: opts.ARTSY_SECRET,
+      grant_type: "jwt",
+      jwt: req.body.credential,
+      oauth_provider: "google",
+    },
+    headers: {
+      "User-Agent": req.get("user-agent"),
+      ...(req && req.connection && req.connection.remoteAddress
+        ? { "X-Forwarded-For": resolveProxies(req) }
+        : {}),
+    },
+    method: "POST",
+    url: `${opts.ARTSY_URL}/oauth2/access_token`,
+  })
+    .then(response => {
+      console.log("[OneTap] - [googleOneTap] response:", response)
+      onAccessToken(req, done, {
+        jwt: req.body.credential,
+        provider: "google",
+        name: profile != null ? profile.displayName : undefined,
+      })(null, response)
+    })
+    .catch((err: GravityError) => {
+      console.log("[OneTap] - [googleOneTap] err:", err)
+      onAccessToken(req, done, {
+        jwt: req.body.credential,
+        provider: "google",
+        name: profile != null ? profile.displayName : undefined,
+      })(err, err.response)
+    })
+}
+
 export const google = (
   req: PassportRequest,
   accessToken: string,
@@ -290,6 +336,7 @@ const onAccessToken =
     // error message.
     let accessTokenError = err
     let msg: string | undefined
+
     if (
       (accessTokenError && !(res != null ? res.body : undefined)) ||
       (!accessTokenError && Number(res != null ? res.status : undefined) > 400)
@@ -328,6 +375,10 @@ const onAccessToken =
       // /user API. Then attempt to fetch the access token again from Gravity and
       // recur back into this onAcccessToken callback.
     } else if (msg!.match("no account linked") != null) {
+      console.log(
+        "[OneTap] - No account linked, creating user in Gravity with params:",
+        params,
+      )
       if ((req != null ? req.session : undefined) != null && params != null) {
         const {
           sign_up_intent,
@@ -367,6 +418,8 @@ const onAccessToken =
             })
           }
 
+          console.log("[OneTap] - [requestGravity] auth_params:", auth_params)
+
           requestGravity({
             body: extend(auth_params, {
               client_id: opts.ARTSY_ID,
@@ -381,10 +434,14 @@ const onAccessToken =
             method: "POST",
             url: `${opts.ARTSY_URL}/oauth2/access_token`,
           })
-            .then(response => onAccessToken(req, done, params!)(null, response))
-            .catch((err: GravityError) =>
-              onAccessToken(req, done, params!)(err, err.response),
-            )
+            .then(response => {
+              console.log("[OneTap] - [requestGravity] response:", response)
+              onAccessToken(req, done, params!)(null, response)
+            })
+            .catch((err: GravityError) => {
+              console.log("[OneTap] - [requestGravity] err:", err)
+              onAccessToken(req, done, params!)(err, err.response)
+            })
         })
         .catch((err: Error) => done!(err))
       // Uncaught Exception.

--- a/src/Server/passport/lib/passport/callbacks.ts
+++ b/src/Server/passport/lib/passport/callbacks.ts
@@ -150,52 +150,6 @@ export const facebook = (
   }
 }
 
-export const googleOneTap = (
-  req: PassportRequest,
-  profile: OAuthProfile,
-  done?: PassportDone,
-) => {
-  console.log("[Google One Tap] data:", {
-    req,
-    profile,
-    credential: req.body.credential,
-  })
-
-  requestGravity({
-    body: {
-      client_id: opts.ARTSY_ID,
-      client_secret: opts.ARTSY_SECRET,
-      grant_type: "jwt",
-      jwt: req.body.credential,
-      oauth_provider: "google",
-    },
-    headers: {
-      "User-Agent": req.get("user-agent"),
-      ...(req && req.connection && req.connection.remoteAddress
-        ? { "X-Forwarded-For": resolveProxies(req) }
-        : {}),
-    },
-    method: "POST",
-    url: `${opts.ARTSY_URL}/oauth2/access_token`,
-  })
-    .then(response => {
-      console.log("[OneTap] - [googleOneTap] response:", response)
-      onAccessToken(req, done, {
-        jwt: req.body.credential,
-        provider: "google",
-        name: profile != null ? profile.displayName : undefined,
-      })(null, response)
-    })
-    .catch((err: GravityError) => {
-      console.log("[OneTap] - [googleOneTap] err:", err)
-      onAccessToken(req, done, {
-        jwt: req.body.credential,
-        provider: "google",
-        name: profile != null ? profile.displayName : undefined,
-      })(err, err.response)
-    })
-}
-
 export const google = (
   req: PassportRequest,
   accessToken: string,
@@ -250,6 +204,44 @@ export const google = (
         })(err, err.response),
       )
   }
+}
+
+export const googleOneTap = (
+  req: PassportRequest,
+  profile: OAuthProfile,
+  done?: PassportDone,
+) => {
+  requestGravity({
+    body: {
+      client_id: opts.ARTSY_ID,
+      client_secret: opts.ARTSY_SECRET,
+      grant_type: "jwt",
+      jwt: req.body.credential,
+      oauth_provider: "google",
+    },
+    headers: {
+      "User-Agent": req.get("user-agent"),
+      ...(req && req.connection && req.connection.remoteAddress
+        ? { "X-Forwarded-For": resolveProxies(req) }
+        : {}),
+    },
+    method: "POST",
+    url: `${opts.ARTSY_URL}/oauth2/access_token`,
+  })
+    .then(response =>
+      onAccessToken(req, done, {
+        jwt: req.body.credential,
+        provider: "google",
+        name: profile != null ? profile.displayName : undefined,
+      })(null, response),
+    )
+    .catch((err: GravityError) =>
+      onAccessToken(req, done, {
+        jwt: req.body.credential,
+        provider: "google",
+        name: profile != null ? profile.displayName : undefined,
+      })(err, err.response),
+    )
 }
 
 export const apple = (
@@ -375,10 +367,6 @@ const onAccessToken =
       // /user API. Then attempt to fetch the access token again from Gravity and
       // recur back into this onAcccessToken callback.
     } else if (msg!.match("no account linked") != null) {
-      console.log(
-        "[OneTap] - No account linked, creating user in Gravity with params:",
-        params,
-      )
       if ((req != null ? req.session : undefined) != null && params != null) {
         const {
           sign_up_intent,
@@ -418,8 +406,6 @@ const onAccessToken =
             })
           }
 
-          console.log("[OneTap] - [requestGravity] auth_params:", auth_params)
-
           requestGravity({
             body: extend(auth_params, {
               client_id: opts.ARTSY_ID,
@@ -434,14 +420,10 @@ const onAccessToken =
             method: "POST",
             url: `${opts.ARTSY_URL}/oauth2/access_token`,
           })
-            .then(response => {
-              console.log("[OneTap] - [requestGravity] response:", response)
-              onAccessToken(req, done, params!)(null, response)
-            })
-            .catch((err: GravityError) => {
-              console.log("[OneTap] - [requestGravity] err:", err)
-              onAccessToken(req, done, params!)(err, err.response)
-            })
+            .then(response => onAccessToken(req, done, params!)(null, response))
+            .catch((err: GravityError) =>
+              onAccessToken(req, done, params!)(err, err.response),
+            )
         })
         .catch((err: Error) => done!(err))
       // Uncaught Exception.

--- a/src/Server/passport/lib/passport/index.ts
+++ b/src/Server/passport/lib/passport/index.ts
@@ -4,7 +4,7 @@ import { Strategy as FacebookStrategy } from "passport-facebook"
 import { Strategy as GoogleStrategy } from "passport-google-oauth20"
 import { GoogleOneTapStrategy } from "passport-google-one-tap"
 import opts from "../options"
-import { apple, facebook, google, local } from "./callbacks"
+import { apple, facebook, google, googleOneTap, local } from "./callbacks"
 import { deserialize, serialize } from "./serializers"
 
 const LocalWithOtpStrategy =
@@ -64,10 +64,7 @@ const setupPassport = () => {
           verifyCsrfToken: false,
           passReqToCallback: true,
         },
-        (req, profile, done) => {
-          console.log("[OneTap] profile:", profile)
-          console.log("[OneTap] id_token:", req.body.credential)
-        },
+        googleOneTap,
       ),
     )
   }

--- a/src/Server/passport/lib/passport/index.ts
+++ b/src/Server/passport/lib/passport/index.ts
@@ -2,6 +2,7 @@ import passport from "passport"
 import AppleStrategy from "passport-apple"
 import { Strategy as FacebookStrategy } from "passport-facebook"
 import { Strategy as GoogleStrategy } from "passport-google-oauth20"
+import { GoogleOneTapStrategy } from "passport-google-one-tap"
 import opts from "../options"
 import { apple, facebook, google, local } from "./callbacks"
 import { deserialize, serialize } from "./serializers"
@@ -53,6 +54,20 @@ const setupPassport = () => {
           scope: ["profile", "email"],
         },
         google,
+      ),
+    )
+    passport.use(
+      new GoogleOneTapStrategy(
+        {
+          clientID: opts.GOOGLE_CLIENT_ID,
+          clientSecret: opts.GOOGLE_SECRET,
+          verifyCsrfToken: false,
+          passReqToCallback: true,
+        },
+        (req, profile, done) => {
+          console.log("[OneTap] profile:", profile)
+          console.log("[OneTap] id_token:", req.body.credential)
+        },
       ),
     )
   }

--- a/src/Server/passport/lib/types.ts
+++ b/src/Server/passport/lib/types.ts
@@ -1,8 +1,8 @@
-import type { NextFunction } from "express"
 import type {
   ArtsyRequest,
   ArtsyResponse,
 } from "Server/middleware/artsyExpress"
+import type { NextFunction } from "express"
 
 export interface PassportOptions {
   APP_URL?: string
@@ -24,6 +24,7 @@ export interface PassportOptions {
   facebookCallbackPath: string
   facebookPath: string
   googleCallbackPath: string
+  googleOneTapCallbackPath: string
   googlePath: string
   loginPagePath: string
   logoutPath: string

--- a/src/System/Boot.tsx
+++ b/src/System/Boot.tsx
@@ -18,6 +18,7 @@ import { FeatureFlagProvider } from "System/FeatureFlags/FeatureFlagContext"
 import type { RouteProps } from "System/Router/Route"
 import type { ClientContext } from "System/Router/Utils/clientAppContext"
 import Events from "Utils/Events"
+import { GoogleOneTapContainer } from "Utils/GoogleOneTapContainer"
 import { AuthIntentProvider } from "Utils/Hooks/useAuthIntent"
 import {
   type MatchingMediaQueries,
@@ -91,6 +92,7 @@ export const Boot: React.FC<
                             >
                               <CookieConsentManager>
                                 <SiftContainer />
+                                <GoogleOneTapContainer />
                                 {isDevelopment && (
                                   <>
                                     <DeveloperBreakpointOverlay />

--- a/src/Typings/sharify.d.ts
+++ b/src/Typings/sharify.d.ts
@@ -58,6 +58,7 @@ declare module "sharify" {
       FAIR?: any // mobile fair app data
       GEMINI_CLOUDFRONT_URL: string
       GOOGLE_ADWORDS_ID: string
+      GOOGLE_CLIENT_ID: string
       GRAPHQL_CACHE_SIZE: string
       GRAPHQL_CACHE_TTL: string
       GRAVITY_WEBSOCKET_URL: string

--- a/src/Utils/GoogleOneTapContainer.tsx
+++ b/src/Utils/GoogleOneTapContainer.tsx
@@ -1,0 +1,45 @@
+import { captureException } from "@sentry/browser"
+import { useFlag } from "@unleash/proxy-client-react"
+import { useSystemContext } from "System/Hooks/useSystemContext"
+import { getENV } from "Utils/getENV"
+import { useEffect } from "react"
+
+export const GoogleOneTapContainer = () => {
+  const { isLoggedIn } = useSystemContext()
+  const isGoogleOneTapEnabled = !!useFlag("diamond_google-one-tap")
+  const googleClientId = getENV("GOOGLE_CLIENT_ID")
+
+  const enabled = !isLoggedIn && isGoogleOneTapEnabled && !!googleClientId
+
+  useEffect(() => {
+    if (!enabled) {
+      return
+    }
+
+    if (document.getElementById("google-one-tap-script")) {
+      return
+    }
+
+    const script = document.createElement("script")
+    script.id = "google-one-tap-script"
+    script.src = "https://accounts.google.com/gsi/client"
+    script.async = true
+    script.defer = true
+    script.onerror = () =>
+      captureException(new Error("Google One Tap script failed to load"))
+    document.body.appendChild(script)
+  }, [enabled])
+
+  if (!enabled) {
+    return null
+  }
+
+  return (
+    <div
+      id="g_id_onload"
+      data-client_id={googleClientId}
+      data-login_uri={`${getENV("APP_URL")}/users/auth/google/one_tap/callback`}
+      data-auto_prompt="true"
+    />
+  )
+}

--- a/src/Utils/__tests__/GoogleOneTapContainer.jest.tsx
+++ b/src/Utils/__tests__/GoogleOneTapContainer.jest.tsx
@@ -1,0 +1,136 @@
+import { render } from "@testing-library/react"
+import { useFlag } from "@unleash/proxy-client-react"
+import { useSystemContext } from "System/Hooks/useSystemContext"
+import { GoogleOneTapContainer } from "Utils/GoogleOneTapContainer"
+import { getENV } from "Utils/getENV"
+
+const mockCaptureException = jest.fn()
+
+jest.mock("@sentry/browser", () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+}))
+
+jest.mock("Utils/getENV", () => ({
+  getENV: jest.fn(),
+}))
+
+jest.mock("@unleash/proxy-client-react", () => ({
+  useFlag: jest.fn(),
+}))
+
+jest.mock("System/Hooks/useSystemContext", () => ({
+  useSystemContext: jest.fn(),
+}))
+
+describe("GoogleOneTapContainer", () => {
+  const mockUseFlag = useFlag as jest.Mock
+  const mockGetENV = getENV as jest.Mock
+  const mockUseSystemContext = useSystemContext as jest.Mock
+
+  const enableOneTap = () => {
+    mockUseFlag.mockReturnValue(true)
+    mockUseSystemContext.mockReturnValue({ isLoggedIn: false })
+    mockGetENV.mockImplementation((key: string) => {
+      if (key === "GOOGLE_CLIENT_ID") return "test-client-id"
+      if (key === "APP_URL") return "https://artsy.net"
+      return null
+    })
+  }
+
+  beforeEach(() => {
+    mockUseFlag.mockReturnValue(false)
+    mockUseSystemContext.mockReturnValue({ isLoggedIn: false })
+    mockGetENV.mockReturnValue(null)
+    mockCaptureException.mockClear()
+  })
+
+  afterEach(() => {
+    document.getElementById("google-one-tap-script")?.remove()
+  })
+
+  const gsiScript = () =>
+    document.body.querySelector(
+      "script[src='https://accounts.google.com/gsi/client']",
+    ) as HTMLScriptElement | null
+
+  describe("g_id_onload div", () => {
+    it("renders when feature flag is on, GOOGLE_CLIENT_ID is set, and user is logged out", () => {
+      enableOneTap()
+      render(<GoogleOneTapContainer />)
+      expect(document.getElementById("g_id_onload")).toBeInTheDocument()
+      expect(document.getElementById("g_id_onload")).toHaveAttribute(
+        "data-client_id",
+        "test-client-id",
+      )
+      expect(document.getElementById("g_id_onload")).toHaveAttribute(
+        "data-login_uri",
+        "https://artsy.net/users/auth/google/one_tap/callback",
+      )
+    })
+
+    it("does not render when feature flag is off", () => {
+      mockUseFlag.mockReturnValue(false)
+      mockUseSystemContext.mockReturnValue({ isLoggedIn: false })
+      mockGetENV.mockReturnValue("test-client-id")
+      render(<GoogleOneTapContainer />)
+      expect(document.getElementById("g_id_onload")).not.toBeInTheDocument()
+    })
+
+    it("does not render when GOOGLE_CLIENT_ID is not set", () => {
+      mockUseFlag.mockReturnValue(true)
+      mockUseSystemContext.mockReturnValue({ isLoggedIn: false })
+      mockGetENV.mockReturnValue(null)
+      render(<GoogleOneTapContainer />)
+      expect(document.getElementById("g_id_onload")).not.toBeInTheDocument()
+    })
+
+    it("does not render when user is logged in", () => {
+      mockUseFlag.mockReturnValue(true)
+      mockUseSystemContext.mockReturnValue({ isLoggedIn: true })
+      mockGetENV.mockReturnValue("test-client-id")
+      render(<GoogleOneTapContainer />)
+      expect(document.getElementById("g_id_onload")).not.toBeInTheDocument()
+    })
+  })
+
+  describe("GSI script injection", () => {
+    it("appends script to body when feature flag is on and user is logged out", () => {
+      enableOneTap()
+      render(<GoogleOneTapContainer />)
+      expect(gsiScript()).toBeInTheDocument()
+    })
+
+    it("does not append script when feature flag is off", () => {
+      mockUseFlag.mockReturnValue(false)
+      mockUseSystemContext.mockReturnValue({ isLoggedIn: false })
+      mockGetENV.mockReturnValue("test-client-id")
+      render(<GoogleOneTapContainer />)
+      expect(gsiScript()).not.toBeInTheDocument()
+    })
+
+    it("does not append script when GOOGLE_CLIENT_ID is not set", () => {
+      mockUseFlag.mockReturnValue(true)
+      mockUseSystemContext.mockReturnValue({ isLoggedIn: false })
+      mockGetENV.mockReturnValue(null)
+      render(<GoogleOneTapContainer />)
+      expect(gsiScript()).not.toBeInTheDocument()
+    })
+
+    it("does not append script when user is logged in", () => {
+      mockUseFlag.mockReturnValue(true)
+      mockUseSystemContext.mockReturnValue({ isLoggedIn: true })
+      mockGetENV.mockReturnValue("test-client-id")
+      render(<GoogleOneTapContainer />)
+      expect(gsiScript()).not.toBeInTheDocument()
+    })
+
+    it("calls captureException when the GSI script fails to load", () => {
+      enableOneTap()
+      render(<GoogleOneTapContainer />)
+      gsiScript()!.onerror!(new Event("error"))
+      expect(mockCaptureException).toHaveBeenCalledWith(
+        new Error("Google One Tap script failed to load"),
+      )
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -5133,6 +5133,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"arrify@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "arrify@npm:2.0.1"
+  checksum: 10c0/3fb30b5e7c37abea1907a60b28a554d2f0fc088757ca9bf5b684786e583fdf14360721eb12575c1ce6f995282eab936712d3c4389122682eafab0e0b57f78dbb
+  languageName: node
+  linkType: hard
+
 "asap@npm:~2.0.3":
   version: 2.0.6
   resolution: "asap@npm:2.0.6"
@@ -5441,7 +5448,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"base64-js@npm:^1.3.1":
+"base64-js@npm:^1.3.0, base64-js@npm:^1.3.1":
   version: 1.5.1
   resolution: "base64-js@npm:1.5.1"
   checksum: 10c0/f23823513b63173a001030fae4f2dabe283b99a9d324ade3ad3d148e218134676f1ee8568c877cd79ec1c53158dcf2d2ba527a97c606618928ba99dd930102bf
@@ -5492,6 +5499,13 @@ __metadata:
   dependencies:
     open: "npm:^8.0.4"
   checksum: 10c0/911ef25d44da75aabfd2444ce7a4294a8000ebcac73068c04a60298b0f7c7506b60421aa4cd02ac82502fb42baaff7e4892234b51e6923eded44c5a11185f2f5
+  languageName: node
+  linkType: hard
+
+"bignumber.js@npm:^9.0.0":
+  version: 9.3.1
+  resolution: "bignumber.js@npm:9.3.1"
+  checksum: 10c0/61342ba5fe1c10887f0ecf5be02ff6709271481aff48631f86b4d37d55a99b87ce441cfd54df3d16d10ee07ceab7e272fc0be430c657ffafbbbf7b7d631efb75
   languageName: node
   linkType: hard
 
@@ -7668,7 +7682,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ecdsa-sig-formatter@npm:1.0.11":
+"ecdsa-sig-formatter@npm:1.0.11, ecdsa-sig-formatter@npm:^1.0.11":
   version: 1.0.11
   resolution: "ecdsa-sig-formatter@npm:1.0.11"
   dependencies:
@@ -8386,7 +8400,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"extend@npm:^3.0.0":
+"extend@npm:^3.0.0, extend@npm:^3.0.2":
   version: 3.0.2
   resolution: "extend@npm:3.0.2"
   checksum: 10c0/73bf6e27406e80aa3e85b0d1c4fd987261e628064e170ca781125c0b635a3dabad5e05adbf07595ea0cf1e6c5396cacb214af933da7cbaf24fe75ff14818e8f9
@@ -8461,6 +8475,13 @@ __metadata:
   version: 2.0.6
   resolution: "fast-levenshtein@npm:2.0.6"
   checksum: 10c0/111972b37338bcb88f7d9e2c5907862c280ebf4234433b95bc611e518d192ccb2d38119c4ac86e26b668d75f7f3894f4ff5c4982899afced7ca78633b08287c4
+  languageName: node
+  linkType: hard
+
+"fast-text-encoding@npm:^1.0.0":
+  version: 1.0.6
+  resolution: "fast-text-encoding@npm:1.0.6"
+  checksum: 10c0/e1d0381bda229c92c7906f63308f3b9caca8c78b732768b1ee16f560089ed21bc159bbe1434138ccd3815931ec8d4785bdade1ad1c45accfdf27ac6606ac67d2
   languageName: node
   linkType: hard
 
@@ -8874,6 +8895,7 @@ __metadata:
     passport-apple: "https://github.com/artsy/passport-apple#f41adb7822c8344b72bc36a7d68312f6592cb14f"
     passport-facebook: "npm:^3.0.0"
     passport-google-oauth20: "npm:^2.0.0"
+    passport-google-one-tap: "npm:^1.0.1"
     passport-strategy: "npm:1.x.x"
     patch-package: "npm:6.2.0"
     path-to-regexp: "npm:6.3.0"
@@ -9190,6 +9212,29 @@ __metadata:
   languageName: node
   linkType: hard
 
+"gaxios@npm:^4.0.0":
+  version: 4.3.3
+  resolution: "gaxios@npm:4.3.3"
+  dependencies:
+    abort-controller: "npm:^3.0.0"
+    extend: "npm:^3.0.2"
+    https-proxy-agent: "npm:^5.0.0"
+    is-stream: "npm:^2.0.0"
+    node-fetch: "npm:^2.6.7"
+  checksum: 10c0/661001bb428dfdb8fabeb0d4b8290edd5ceff4fa7615ef45f447049a38c6379422eafe537c408c0bde333cdf3249fa9673cf8ee66a0658ee174fb85a728efc04
+  languageName: node
+  linkType: hard
+
+"gcp-metadata@npm:^4.2.0":
+  version: 4.3.1
+  resolution: "gcp-metadata@npm:4.3.1"
+  dependencies:
+    gaxios: "npm:^4.0.0"
+    json-bigint: "npm:^1.0.0"
+  checksum: 10c0/1fca413fea44b103443c490895e103e972eab1f18453eabc140de10031ce5f35542d3349f09fa57bd629adf2c202005eda004b7c950272837d55fc7da040ed7d
+  languageName: node
+  linkType: hard
+
 "generator-function@npm:^2.0.0":
   version: 2.0.1
   resolution: "generator-function@npm:2.0.1"
@@ -9449,6 +9494,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"google-auth-library@npm:^7.0.0":
+  version: 7.14.1
+  resolution: "google-auth-library@npm:7.14.1"
+  dependencies:
+    arrify: "npm:^2.0.0"
+    base64-js: "npm:^1.3.0"
+    ecdsa-sig-formatter: "npm:^1.0.11"
+    fast-text-encoding: "npm:^1.0.0"
+    gaxios: "npm:^4.0.0"
+    gcp-metadata: "npm:^4.2.0"
+    gtoken: "npm:^5.0.4"
+    jws: "npm:^4.0.0"
+    lru-cache: "npm:^6.0.0"
+  checksum: 10c0/30b632cfbc312701b4d1b750effbf3575bd826dc2241c8ee4526e8632cef9ee4593d9b3c0b0076a264a79864b13805b6c74c1b13171dfb8eb2ea0bd5c7aa0d43
+  languageName: node
+  linkType: hard
+
+"google-p12-pem@npm:^3.1.3":
+  version: 3.1.4
+  resolution: "google-p12-pem@npm:3.1.4"
+  dependencies:
+    node-forge: "npm:^1.3.1"
+  bin:
+    gp12-pem: build/src/bin/gp12-pem.js
+  checksum: 10c0/d40c7fa17bebd60f18a4eb7355582ab25513b641703bc3f39ddf2f90deb051d5a9622eeb46d4e45d925dc2bf0841d61e8ba34ff20f214019f270a03f39b28fd8
+  languageName: node
+  linkType: hard
+
 "gopd@npm:^1.0.1":
   version: 1.0.1
   resolution: "gopd@npm:1.0.1"
@@ -9504,6 +9577,17 @@ __metadata:
   dependencies:
     iterall: "npm:^1.2.2"
   checksum: 10c0/0d0c6011b5e6ce17a2302b2d862f9351b27b2de9995ad03075ba82e0d87eb59ba893adf5e9a29e2141fe9dd6f2f267268c8b6f35a8b842eb66dbf0f7ef8d79f3
+  languageName: node
+  linkType: hard
+
+"gtoken@npm:^5.0.4":
+  version: 5.3.2
+  resolution: "gtoken@npm:5.3.2"
+  dependencies:
+    gaxios: "npm:^4.0.0"
+    google-p12-pem: "npm:^3.1.3"
+    jws: "npm:^4.0.0"
+  checksum: 10c0/c4a6893cda5a4abe3967e15e0b14f292ebbcc6c0d186bb062ff947cb41f7a2e440c1a451ac94e944aa903a51db1be86e5c2ebf837d9a70a66ae1088bcf5fa3ff
   languageName: node
   linkType: hard
 
@@ -9906,7 +9990,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"https-proxy-agent@npm:^5.0.1":
+"https-proxy-agent@npm:^5.0.0, https-proxy-agent@npm:^5.0.1":
   version: 5.0.1
   resolution: "https-proxy-agent@npm:5.0.1"
   dependencies:
@@ -11375,6 +11459,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"json-bigint@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "json-bigint@npm:1.0.0"
+  dependencies:
+    bignumber.js: "npm:^9.0.0"
+  checksum: 10c0/e3f34e43be3284b573ea150a3890c92f06d54d8ded72894556357946aeed9877fd795f62f37fe16509af189fd314ab1104d0fd0f163746ad231b9f378f5b33f4
+  languageName: node
+  linkType: hard
+
 "json-parse-better-errors@npm:^1.0.1":
   version: 1.0.2
   resolution: "json-parse-better-errors@npm:1.0.2"
@@ -11480,6 +11573,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"jwa@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "jwa@npm:2.0.1"
+  dependencies:
+    buffer-equal-constant-time: "npm:^1.0.1"
+    ecdsa-sig-formatter: "npm:1.0.11"
+    safe-buffer: "npm:^5.0.1"
+  checksum: 10c0/ab3ebc6598e10dc11419d4ed675c9ca714a387481466b10e8a6f3f65d8d9c9237e2826f2505280a739cf4cbcf511cb288eeec22b5c9c63286fc5a2e4f97e78cf
+  languageName: node
+  linkType: hard
+
 "jws@npm:^3.2.2":
   version: 3.2.3
   resolution: "jws@npm:3.2.3"
@@ -11487,6 +11591,16 @@ __metadata:
     jwa: "npm:^1.4.2"
     safe-buffer: "npm:^5.0.1"
   checksum: 10c0/9fdf9d6783b1892ef413ef373cd351eacc847ba01deec6fbfea96830e93241863ccbee66f3b749fc2310c59b6db2209d3f4b52931c0c259b52b17de20715917f
+  languageName: node
+  linkType: hard
+
+"jws@npm:^4.0.0":
+  version: 4.0.1
+  resolution: "jws@npm:4.0.1"
+  dependencies:
+    jwa: "npm:^2.0.1"
+    safe-buffer: "npm:^5.0.1"
+  checksum: 10c0/6be1ed93023aef570ccc5ea8d162b065840f3ef12f0d1bb3114cade844de7a357d5dc558201d9a65101e70885a6fa56b17462f520e6b0d426195510618a154d0
   languageName: node
   linkType: hard
 
@@ -11964,6 +12078,15 @@ __metadata:
   dependencies:
     yallist: "npm:^3.0.2"
   checksum: 10c0/89b2ef2ef45f543011e38737b8a8622a2f8998cddf0e5437174ef8f1f70a8b9d14a918ab3e232cb3ba343b7abddffa667f0b59075b2b80e6b4d63c3de6127482
+  languageName: node
+  linkType: hard
+
+"lru-cache@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "lru-cache@npm:6.0.0"
+  dependencies:
+    yallist: "npm:^4.0.0"
+  checksum: 10c0/cb53e582785c48187d7a188d3379c181b5ca2a9c78d2bce3e7dee36f32761d1c42983da3fe12b55cb74e1779fa94cdc2e5367c028a9b35317184ede0c07a30a9
   languageName: node
   linkType: hard
 
@@ -12696,6 +12819,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"node-forge@npm:^1.3.1":
+  version: 1.4.0
+  resolution: "node-forge@npm:1.4.0"
+  checksum: 10c0/67330a5f1f95257a4c8a93b7d555abe87b5f15e350123aa396c97a21a8ca94f9c6549008eb2c73668a91e0d7e3a905785acbd8f8bd0751c29401292011f8f8e1
+  languageName: node
+  linkType: hard
+
 "node-gyp-build@npm:^3.9.0":
   version: 3.9.0
   resolution: "node-gyp-build@npm:3.9.0"
@@ -13389,6 +13519,16 @@ __metadata:
   languageName: node
   linkType: hard
 
+"passport-google-one-tap@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "passport-google-one-tap@npm:1.0.1"
+  dependencies:
+    google-auth-library: "npm:^7.0.0"
+    passport-strategy: "npm:^1.0.0"
+  checksum: 10c0/60d64d9236b7f78d3bcfba50dad2e87b00a959ecd3b6f8e998d57fc6061c913f3de3d5a988e41906b9c4fde04626519d59c64e2f29af7a1fa21a35ab9b84b867
+  languageName: node
+  linkType: hard
+
 "passport-oauth2@npm:1.x.x, passport-oauth2@npm:^1.5.0":
   version: 1.6.1
   resolution: "passport-oauth2@npm:1.6.1"
@@ -13402,7 +13542,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"passport-strategy@npm:1.x.x":
+"passport-strategy@npm:1.x.x, passport-strategy@npm:^1.0.0":
   version: 1.0.0
   resolution: "passport-strategy@npm:1.0.0"
   checksum: 10c0/cf4cd32e1bf2538a239651581292fbb91ccc83973cde47089f00d2014c24bed63d3e65af21da8ddef649a8896e089eb9c3ac9ca639f36c797654ae9ee4ed65e1


### PR DESCRIPTION
This PR enables Google One Tap for users on Chrome. It adds the `google-one-tap` strategy to Passport and adds a Google Sign-in script to the logged-out nav header (behind a feature flag `diamond_google-one-tap`) that prompts Chrome users to sign in to Arty with their Google account.