### PR TITLE
chore: temporarily silence Google One Tap errors

### DIFF
--- a/src/Utils/GoogleOneTapContainer.tsx
+++ b/src/Utils/GoogleOneTapContainer.tsx
@@ -1,4 +1,3 @@
-import { captureException } from "@sentry/browser"
 import { useFlag } from "@unleash/proxy-client-react"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import { getENV } from "Utils/getENV"
@@ -25,8 +24,9 @@ export const GoogleOneTapContainer = () => {
     script.src = "https://accounts.google.com/gsi/client"
     script.async = true
     script.defer = true
-    script.onerror = () =>
-      captureException(new Error("Google One Tap script failed to load"))
+    // TODO:
+    // script.onerror = () =>
+    //   captureException(new Error("Google One Tap script failed to load"))
     document.body.appendChild(script)
   }, [enabled])
 

--- a/src/Utils/__tests__/GoogleOneTapContainer.jest.tsx
+++ b/src/Utils/__tests__/GoogleOneTapContainer.jest.tsx
@@ -124,13 +124,14 @@ describe("GoogleOneTapContainer", () => {
       expect(gsiScript()).not.toBeInTheDocument()
     })
 
-    it("calls captureException when the GSI script fails to load", () => {
-      enableOneTap()
-      render(<GoogleOneTapContainer />)
-      gsiScript()!.onerror!(new Event("error"))
-      expect(mockCaptureException).toHaveBeenCalledWith(
-        new Error("Google One Tap script failed to load"),
-      )
-    })
+    // TODO:
+    // it("calls captureException when the GSI script fails to load", () => {
+    //   enableOneTap()
+    //   render(<GoogleOneTapContainer />)
+    //   gsiScript()!.onerror!(new Event("error"))
+    //   expect(mockCaptureException).toHaveBeenCalledWith(
+    //     new Error("Google One Tap script failed to load"),
+    //   )
+    // })
   })
 })


### PR DESCRIPTION
This PR temporarily silences Google One Tap GSI loading errors because it is causing our integration tests to raise 303 events in our error logging system every hour. Before reinstating this error, we need to make sure that we run integration tests without creating noise.