### PR TITLE
feat(artist): retires editorial nav flag; implements empty state

### DIFF
--- a/src/Apps/Artist/Routes/Combined/ArtistCombinedRoute.tsx
+++ b/src/Apps/Artist/Routes/Combined/ArtistCombinedRoute.tsx
@@ -1,5 +1,4 @@
 import { Box, Separator, Spacer, Spinner, Text, useTheme } from "@artsy/palette"
-import { useVariant } from "@unleash/proxy-client-react"
 import {
   ArtistAuctionResultsQueryRenderer,
   useScrollToTopOfAuctionResults,
@@ -11,7 +10,6 @@ import { ArtistOverviewQueryRenderer } from "Apps/Artist/Routes/Overview/Compone
 import { ArtistArtworkFilterQueryRenderer } from "Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter"
 import { Z } from "Apps/Components/constants"
 import { useRouter } from "System/Hooks/useRouter"
-import { useTrackFeatureVariantOnMount } from "System/Hooks/useTrackFeatureVariant"
 import { useJump } from "Utils/Hooks/useJump"
 import { Section, SectionNavProvider } from "Utils/Hooks/useSectionNav"
 import { useSectionReadiness } from "Utils/Hooks/useSectionReadiness"
@@ -24,20 +22,10 @@ interface ArtistCombinedRouteProps {
   artist: ArtistCombinedRoute_artist$data
 }
 
-const EDITORIAL_SECTION_EXPERIMENT = "diamond_editorial-section"
-
 const ArtistCombinedRoute: React.FC<
   React.PropsWithChildren<ArtistCombinedRouteProps>
 > = ({ artist }) => {
   const { handleScrollToTop } = useScrollToTopOfAuctionResults()
-  const variant = useVariant(EDITORIAL_SECTION_EXPERIMENT)
-  useTrackFeatureVariantOnMount({
-    experimentName: EDITORIAL_SECTION_EXPERIMENT,
-    variantName: variant?.name,
-  })
-
-  const isEditorialSectionExperiment =
-    variant.enabled && variant.name === "experiment"
 
   const { jumpTo } = useJump()
 
@@ -46,6 +34,7 @@ const ArtistCombinedRoute: React.FC<
     "market",
     "auction",
     "about",
+    "editorial",
   ])
 
   const { theme } = useTheme()
@@ -111,11 +100,7 @@ const ArtistCombinedRoute: React.FC<
         </Box>
       )}
 
-      <ArtistCombinedNav
-        waitUntil={waitUntil}
-        navigating={navigating}
-        showEditorialTab={isEditorialSectionExperiment}
-      />
+      <ArtistCombinedNav waitUntil={waitUntil} navigating={navigating} />
 
       <Spacer y={[2, 4]} />
 
@@ -159,28 +144,20 @@ const ArtistCombinedRoute: React.FC<
         />
       </Section>
 
-      {isEditorialSectionExperiment && (
-        <>
-          <Separator my={4} />
-
-          <Section id="artistEditorialTop">
-            <ArtistEditorialNewsGridQueryRenderer
-              id={artist.internalID}
-              showEmptyStateWhenNoArticles
-            />
-          </Section>
-        </>
-      )}
-
       <Separator my={4} />
 
       <Section id="artistAboutTop">
         <ArtistOverviewQueryRenderer
           id={artist.internalID}
-          hideEditorial={isEditorialSectionExperiment}
           lazyLoad={lazy.about}
           onReady={() => markReady("about")}
         />
+      </Section>
+
+      <Separator my={4} />
+
+      <Section id="artistEditorialTop">
+        <ArtistEditorialNewsGridQueryRenderer id={artist.internalID} />
       </Section>
     </SectionNavProvider>
   )

--- a/src/Apps/Artist/Routes/Combined/Components/ArtistCombinedNav.tsx
+++ b/src/Apps/Artist/Routes/Combined/Components/ArtistCombinedNav.tsx
@@ -15,15 +15,38 @@ import { useTracking } from "react-tracking"
 interface ArtistCombinedNavProps {
   waitUntil: (section: string) => Promise<void>
   navigating: Record<string, boolean>
-  // diamond_editorial-section
-  showEditorialTab?: boolean
 }
+
+const ARTIST_COMBINED_NAV_ITEMS = [
+  {
+    activeSection: "artistArtworksTop",
+    label: "Artworks",
+    section: "artworks",
+    subject: "artworks",
+  },
+  {
+    activeSection: "marketSignalsTop",
+    label: "Auction Results",
+    section: "auction",
+    subject: "auction results",
+  },
+  {
+    activeSection: "artistAboutTop",
+    label: "About",
+    section: "about",
+    subject: "about",
+  },
+  {
+    activeSection: "artistEditorialTop",
+    label: "Editorial",
+    section: "editorial",
+    subject: "editorial",
+  },
+] as const
 
 export const ArtistCombinedNav = ({
   waitUntil,
   navigating,
-  // diamond_editorial-section
-  showEditorialTab = false,
 }: ArtistCombinedNavProps) => {
   const backdrop = useStickyBackdrop()
 
@@ -67,59 +90,27 @@ export const ArtistCombinedNav = ({
               <AppContainer>
                 <HorizontalPadding pb={2}>
                   <RouteTabs data-test="navigationTabs" pt={2}>
-                    <BaseTab
-                      as={Clickable}
-                      active={active === "artistArtworksTop"}
-                      disabled={navigating.artworks}
-                      onClick={async () => {
-                        jumpTo("artistArtworksTop")
-                        handleClick("artworks")
-                      }}
-                    >
-                      Artworks
-                    </BaseTab>
+                    {ARTIST_COMBINED_NAV_ITEMS.map((item, index) => {
+                      return (
+                        <BaseTab
+                          key={item.section}
+                          as={Clickable}
+                          active={active === item.activeSection}
+                          disabled={navigating[item.section]}
+                          onClick={async () => {
+                            // The first section is already loaded, so it can jump immediately.
+                            if (index > 0) {
+                              await waitUntil(item.section)
+                            }
 
-                    <BaseTab
-                      as={Clickable}
-                      active={active === "marketSignalsTop"}
-                      disabled={navigating.auction}
-                      onClick={async () => {
-                        await waitUntil("auction")
-                        jumpTo("marketSignalsTop")
-                        handleClick("auction results")
-                      }}
-                    >
-                      Auction Results
-                    </BaseTab>
-
-                    {/* diamond_editorial-section */}
-                    {showEditorialTab && (
-                      <BaseTab
-                        as={Clickable}
-                        active={active === "artistEditorialTop"}
-                        disabled={navigating.about}
-                        onClick={async () => {
-                          await waitUntil("about")
-                          jumpTo("artistEditorialTop")
-                          handleClick("editorial")
-                        }}
-                      >
-                        Stories
-                      </BaseTab>
-                    )}
-
-                    <BaseTab
-                      as={Clickable}
-                      active={active === "artistAboutTop"}
-                      disabled={navigating.about}
-                      onClick={async () => {
-                        await waitUntil("about")
-                        jumpTo("artistAboutTop")
-                        handleClick("about")
-                      }}
-                    >
-                      About
-                    </BaseTab>
+                            jumpTo(item.activeSection)
+                            handleClick(item.subject)
+                          }}
+                        >
+                          {item.label}
+                        </BaseTab>
+                      )
+                    })}
                   </RouteTabs>
                 </HorizontalPadding>
               </AppContainer>

--- a/src/Apps/Artist/Routes/Combined/Components/__tests__/ArtistCombinedNav.jest.tsx
+++ b/src/Apps/Artist/Routes/Combined/Components/__tests__/ArtistCombinedNav.jest.tsx
@@ -60,30 +60,23 @@ describe("ArtistCombinedNav", () => {
     }))
   })
 
-  it("does not render editorial tab by default", () => {
-    render(
-      <ArtistCombinedNav
-        waitUntil={waitUntil}
-        navigating={{ artworks: false, auction: false, about: false }}
-      />,
-    )
-
-    expect(screen.queryByText("Stories")).not.toBeInTheDocument()
-  })
-
   it("renders editorial tab and jumps to editorial section", async () => {
     render(
       <ArtistCombinedNav
         waitUntil={waitUntil}
-        navigating={{ artworks: false, auction: false, about: false }}
-        showEditorialTab
+        navigating={{
+          artworks: false,
+          auction: false,
+          about: false,
+          editorial: false,
+        }}
       />,
     )
 
-    fireEvent.click(screen.getByText("Stories"))
+    fireEvent.click(screen.getByText("Editorial"))
 
     await waitFor(() => {
-      expect(waitUntil).toHaveBeenCalledWith("about")
+      expect(waitUntil).toHaveBeenCalledWith("editorial")
       expect(mockJumpTo).toHaveBeenCalledWith("artistEditorialTop")
       expect(mockTrackEvent).toHaveBeenCalledWith({
         action: "clickedHeader",

--- a/src/Apps/Artist/Routes/Overview/Components/ArtistEditorialNewsEmptyState.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtistEditorialNewsEmptyState.tsx
@@ -1,0 +1,123 @@
+import {
+  ActionType,
+  type ClickedArticleGroup,
+  ContextModule,
+  OwnerType,
+} from "@artsy/cohesion"
+import { Skeleton } from "@artsy/palette"
+import {
+  CellArticleFragmentContainer,
+  CellArticlePlaceholder,
+} from "Components/Cells/CellArticle"
+import { ClientSuspense } from "Components/ClientSuspense"
+import { Rail } from "Components/Rail/Rail"
+import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
+import type { ArtistEditorialNewsEmptyStateQuery } from "__generated__/ArtistEditorialNewsEmptyStateQuery.graphql"
+import { graphql, useLazyLoadQuery } from "react-relay"
+import { useTracking } from "react-tracking"
+
+const ARTICLE_COUNT = 8
+const ARTICLES_HREF = "/articles"
+
+type ArtistEditorialNewsEmptyStateProps = {}
+
+export const ArtistEditorialNewsEmptyState: React.FC<
+  React.PropsWithChildren<ArtistEditorialNewsEmptyStateProps>
+> = () => {
+  return (
+    <ClientSuspense fallback={<ArtistEditorialNewsEmptyStatePlaceholder />}>
+      <ArtistEditorialNewsEmptyStateArticles />
+    </ClientSuspense>
+  )
+}
+
+const ArtistEditorialNewsEmptyStateArticles: React.FC<
+  React.PropsWithChildren<unknown>
+> = () => {
+  const data = useLazyLoadQuery<ArtistEditorialNewsEmptyStateQuery>(
+    graphql`
+      query ArtistEditorialNewsEmptyStateQuery {
+        articles(featured: true, published: true, sort: PUBLISHED_AT_DESC) {
+          ...CellArticle_article
+          internalID
+        }
+      }
+    `,
+    {},
+    { fetchPolicy: "store-or-network" },
+  )
+
+  const { trackEvent } = useTracking()
+
+  const { contextPageOwnerId, contextPageOwnerSlug, contextPageOwnerType } =
+    useAnalyticsContext()
+
+  const articles = data.articles.slice(0, ARTICLE_COUNT)
+
+  if (articles.length === 0) return null
+
+  return (
+    <Rail
+      title="From Artsy Editorial"
+      alignItems="flex-start"
+      viewAllHref={ARTICLES_HREF}
+      viewAllLabel="View All"
+      viewAllOnClick={() => {
+        const trackingEvent: ClickedArticleGroup = {
+          action: ActionType.clickedArticleGroup,
+          context_module: ContextModule.marketNews,
+          context_page_owner_type: contextPageOwnerType!,
+          context_page_owner_id: contextPageOwnerId,
+          context_page_owner_slug: contextPageOwnerSlug,
+          destination_page_owner_type: OwnerType.articles,
+          type: "viewAll",
+        }
+
+        trackEvent(trackingEvent)
+      }}
+      getItems={() => {
+        return articles.map(article => {
+          return (
+            <CellArticleFragmentContainer
+              key={article.internalID}
+              article={article}
+              onClick={() => {
+                const trackingEvent: ClickedArticleGroup = {
+                  action: ActionType.clickedArticleGroup,
+                  context_module: ContextModule.marketNews,
+                  context_page_owner_type: contextPageOwnerType!,
+                  context_page_owner_id: contextPageOwnerId,
+                  context_page_owner_slug: contextPageOwnerSlug,
+                  destination_page_owner_type: OwnerType.article,
+                  type: "thumbnail",
+                }
+
+                trackEvent(trackingEvent)
+              }}
+            />
+          )
+        })
+      }}
+    />
+  )
+}
+
+export const ArtistEditorialNewsEmptyStatePlaceholder: React.FC<
+  React.PropsWithChildren<unknown>
+> = () => {
+  return (
+    <Skeleton>
+      <Rail
+        title="From Artsy Editorial"
+        isLoading
+        viewAllHref={ARTICLES_HREF}
+        viewAllLabel="View All"
+        getItems={() => {
+          return Array.from({ length: ARTICLE_COUNT }).map((_, index) => {
+            return <CellArticlePlaceholder key={index} />
+          })
+        }}
+      />
+    </Skeleton>
+  )
+}

--- a/src/Apps/Artist/Routes/Overview/Components/ArtistEditorialNewsGrid.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtistEditorialNewsGrid.tsx
@@ -2,24 +2,23 @@ import {
   ActionType,
   type ClickedArticleGroup,
   ContextModule,
-  type EntityModuleType,
   OwnerType,
 } from "@artsy/cohesion"
 import {
   Column,
+  GridColumns,
   Image,
+  ResponsiveBox,
   Skeleton,
   SkeletonBox,
   SkeletonText,
-  Stack,
   Text,
 } from "@artsy/palette"
-import { GridColumns, ResponsiveBox } from "@artsy/palette"
+import { ArtistEditorialNewsEmptyState } from "Apps/Artist/Routes/Overview/Components/ArtistEditorialNewsEmptyState"
 import {
   CellArticleFragmentContainer,
   CellArticlePlaceholder,
 } from "Components/Cells/CellArticle"
-import { EmptyState } from "Components/EmptyState"
 import { Masonry } from "Components/Masonry"
 import { RouterLink } from "System/Components/RouterLink"
 import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
@@ -38,17 +37,11 @@ const ARTICLE_COUNT = 6
 
 interface ArtistEditorialNewsGridProps {
   artist: ArtistEditorialNewsGrid_artist$data
-  // diamond_editorial-section
-  showEmptyStateWhenNoArticles?: boolean
 }
 
 const ArtistEditorialNewsGrid: FC<
   React.PropsWithChildren<ArtistEditorialNewsGridProps>
-> = ({
-  artist,
-  // diamond_editorial-section
-  showEmptyStateWhenNoArticles = false,
-}) => {
+> = ({ artist }) => {
   const { trackEvent } = useTracking()
 
   const { contextPageOwnerId, contextPageOwnerSlug, contextPageOwnerType } =
@@ -59,39 +52,7 @@ const ArtistEditorialNewsGrid: FC<
   const viewAllHref = `${artist.href}/articles`
 
   if (articles.length === 0) {
-    // diamond_editorial-section
-    if (showEmptyStateWhenNoArticles) {
-      return (
-        <Stack gap={2}>
-          <Text variant="lg-display">
-            Artsy Editorial Featuring {artist.name}
-          </Text>
-
-          <EmptyState
-            title="There are currently no editorial pieces about this artist."
-            description="Check back soon — we’ll add coverage as it becomes available. In the meantime, browse art world stories and features on Artsy."
-            action={{
-              label: "Browse Artsy Editorial",
-              href: "/articles",
-              onClick: () => {
-                const trackingEvent: ClickedArticleGroup = {
-                  action: ActionType.clickedArticleGroup,
-                  context_module: ContextModule.marketNews,
-                  context_page_owner_type: contextPageOwnerType!,
-                  context_page_owner_id: contextPageOwnerId,
-                  context_page_owner_slug: contextPageOwnerSlug,
-                  destination_page_owner_type: OwnerType.articles,
-                  type: "emptyState" as EntityModuleType,
-                }
-                trackEvent(trackingEvent)
-              },
-            }}
-          />
-        </Stack>
-      )
-    }
-
-    return null
+    return <ArtistEditorialNewsEmptyState />
   }
 
   const [firstArticle, ...restOfArticles] = articles
@@ -297,14 +258,8 @@ const PLACEHOLDER = (
 export const ArtistEditorialNewsGridQueryRenderer: FC<
   React.PropsWithChildren<{
     id: string
-    // diamond_editorial-section
-    showEmptyStateWhenNoArticles?: boolean
   }>
-> = ({
-  id,
-  // diamond_editorial-section
-  showEmptyStateWhenNoArticles = false,
-}) => {
+> = ({ id }) => {
   const { relayEnvironment } = useSystemContext()
 
   return (
@@ -330,11 +285,7 @@ export const ArtistEditorialNewsGridQueryRenderer: FC<
         }
 
         return (
-          <ArtistEditorialNewsGridFragmentContainer
-            artist={props.artist}
-            // diamond_editorial-section
-            showEmptyStateWhenNoArticles={showEmptyStateWhenNoArticles}
-          />
+          <ArtistEditorialNewsGridFragmentContainer artist={props.artist} />
         )
       }}
     />

--- a/src/Apps/Artist/Routes/Overview/Components/ArtistOverview.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtistOverview.tsx
@@ -20,7 +20,6 @@ import {
   ArtistCareerHighlightsQueryRenderer,
 } from "./ArtistCareerHighlights"
 import { ArtistCurrentShowsRailQueryRenderer } from "./ArtistCurrentShowsRail"
-import { ArtistEditorialNewsGridQueryRenderer } from "./ArtistEditorialNewsGrid"
 import { ArtistOverviewEmpty } from "./ArtistOverviewEmpty"
 import { ArtistRelatedArtistsRailQueryRenderer } from "./ArtistRelatedArtistsRail"
 import { ArtistRelatedGeneCategoriesQueryRenderer } from "./ArtistRelatedGeneCategories"
@@ -29,19 +28,11 @@ type ArtistOverviewQueryRendererProps = {
   id: string
   lazyLoad?: boolean
   onReady?: () => void
-  // diamond_editorial-section
-  hideEditorial?: boolean
 }
 
 export const ArtistOverviewQueryRenderer: React.FC<
   ArtistOverviewQueryRendererProps
-> = ({
-  id,
-  lazyLoad,
-  onReady,
-  // diamond_editorial-section
-  hideEditorial,
-}) => {
+> = ({ id, lazyLoad, onReady }) => {
   const { handleReady } = useSectionReady({ onReady })
 
   return (
@@ -68,13 +59,7 @@ export const ArtistOverviewQueryRenderer: React.FC<
 
         handleReady()
 
-        return (
-          <ArtistOverviewFragmentContainer
-            artist={props.artist}
-            // diamond_editorial-section
-            hideEditorial={hideEditorial}
-          />
-        )
+        return <ArtistOverviewFragmentContainer artist={props.artist} />
       }}
     />
   )
@@ -82,17 +67,11 @@ export const ArtistOverviewQueryRenderer: React.FC<
 
 interface ArtistOverviewProps {
   artist: ArtistOverview_artist$data
-  // diamond_editorial-section
-  hideEditorial?: boolean
 }
 
 export const ArtistOverview: React.FC<
   React.PropsWithChildren<ArtistOverviewProps>
-> = ({
-  artist,
-  // diamond_editorial-section
-  hideEditorial = false,
-}) => {
+> = ({ artist }) => {
   const { trackEvent } = useTracking()
 
   const { contextPageOwnerType, contextPageOwnerId, contextPageOwnerSlug } =
@@ -102,8 +81,6 @@ export const ArtistOverview: React.FC<
     Array.isArray(artist.insights) &&
     artist.insights.length > ARTIST_HEADER_NUMBER_OF_INSIGHTS
   const hasArtistSeries = (artist.artistSeriesConnection?.totalCount ?? 0) > 0
-  const hasEditorial = (artist.counts?.articles ?? 0) > 0
-  const hasEditorialContent = hasEditorial && !hideEditorial // diamond_editorial-section
   const hasCurrentShows = (artist.showsConnection?.totalCount ?? 0) > 0
   const hasRelatedArtists = (artist.counts?.relatedArtists ?? 0) > 0
   const hasRelatedCategories =
@@ -126,8 +103,6 @@ export const ArtistOverview: React.FC<
   if (
     !hasCareerHighlights &&
     !hasArtistSeries &&
-    // diamond_editorial-section
-    !hasEditorialContent &&
     !hasCurrentShows &&
     !hasRelatedArtists &&
     !hasRelatedCategories
@@ -157,10 +132,6 @@ export const ArtistOverview: React.FC<
           id={artist.internalID}
           title={`${artist.name} Series`}
         />
-      )}
-
-      {hasEditorialContent && (
-        <ArtistEditorialNewsGridQueryRenderer id={artist.internalID} />
       )}
 
       {hasCurrentShows && (
@@ -197,7 +168,6 @@ export const ArtistOverviewFragmentContainer = createFragmentContainer(
         }
         counts {
           relatedArtists
-          articles
         }
         related {
           genes(first: 1) {

--- a/src/Apps/Artist/Routes/Overview/Components/__tests__/ArtistEditorialNewsGrid.jest.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/__tests__/ArtistEditorialNewsGrid.jest.tsx
@@ -138,8 +138,8 @@ describe("ArtistEditorialNewsGrid", () => {
       })
     })
 
-    it("tracks empty state button click", () => {
-      renderWithRelay(
+    it("tracks empty state article clicks", async () => {
+      const { mockResolveLastOperation } = renderWithRelay(
         {
           Artist: () => ({
             articlesConnection: {
@@ -150,8 +150,18 @@ describe("ArtistEditorialNewsGrid", () => {
         { showEmptyStateWhenNoArticles: true },
       )
 
+      mockResolveLastOperation({
+        Article: () => ({
+          internalID: "featured-article",
+          href: "/article/featured-article",
+          title: "Featured Article",
+          thumbnailTitle: "Featured Article",
+          vertical: "Art Market",
+        }),
+      })
+
       fireEvent.click(
-        screen.getByRole("link", { name: /browse artsy editorial/i }),
+        await screen.findByRole("link", { name: /featured article/i }),
       )
 
       expect(trackEvent).toBeCalledWith({
@@ -160,8 +170,43 @@ describe("ArtistEditorialNewsGrid", () => {
         context_page_owner_id: "example-artist-id",
         context_page_owner_slug: "example-artist-slug",
         context_page_owner_type: "artist",
+        destination_page_owner_type: "article",
+        type: "thumbnail",
+      })
+    })
+
+    it("tracks empty state view all clicks", async () => {
+      const { mockResolveLastOperation } = renderWithRelay(
+        {
+          Artist: () => ({
+            articlesConnection: {
+              edges: [],
+            },
+          }),
+        },
+        { showEmptyStateWhenNoArticles: true },
+      )
+
+      mockResolveLastOperation({
+        Article: () => ({
+          internalID: "featured-article",
+          href: "/article/featured-article",
+          title: "Featured Article",
+          thumbnailTitle: "Featured Article",
+          vertical: "Art Market",
+        }),
+      })
+
+      fireEvent.click(await screen.findByRole("link", { name: "View All" }))
+
+      expect(trackEvent).toBeCalledWith({
+        action: "clickedArticleGroup",
+        context_module: "marketNews",
+        context_page_owner_id: "example-artist-id",
+        context_page_owner_slug: "example-artist-slug",
+        context_page_owner_type: "artist",
         destination_page_owner_type: "articles",
-        type: "emptyState",
+        type: "viewAll",
       })
     })
   })
@@ -181,10 +226,11 @@ describe("ArtistEditorialNewsGrid", () => {
       ).not.toBeInTheDocument()
     })
 
-    it("renders the experiment empty state when enabled and there are no articles", () => {
-      renderWithRelay(
+    it("renders the experiment empty state when enabled and there are no articles", async () => {
+      const { mockResolveLastOperation } = renderWithRelay(
         {
           Artist: () => ({
+            name: "Test Artist",
             articlesConnection: {
               edges: [],
             },
@@ -193,16 +239,24 @@ describe("ArtistEditorialNewsGrid", () => {
         { showEmptyStateWhenNoArticles: true },
       )
 
+      mockResolveLastOperation({
+        Article: () => ({
+          internalID: "featured-article",
+          href: "/article/featured-article",
+          title: "Featured Article",
+          thumbnailTitle: "Featured Article",
+          vertical: "Art Market",
+        }),
+      })
+
       expect(
-        screen.getByText(
-          "There are currently no editorial pieces about this artist.",
-        ),
-      ).toBeInTheDocument()
-      expect(
-        screen.getByText(
-          "Check back soon — we’ll add coverage as it becomes available. In the meantime, browse art world stories and features on Artsy.",
-        ),
-      ).toBeInTheDocument()
+        await screen.findByRole("link", { name: "From Artsy Editorial" }),
+      ).toHaveAttribute("href", "/articles")
+      expect(screen.getByRole("link", { name: "View All" })).toHaveAttribute(
+        "href",
+        "/articles",
+      )
+      expect(await screen.findAllByText("Featured Article")).not.toHaveLength(0)
     })
   })
 })

--- a/src/__generated__/ArtistEditorialNewsEmptyStateQuery.graphql.ts
+++ b/src/__generated__/ArtistEditorialNewsEmptyStateQuery.graphql.ts
@@ -1,0 +1,227 @@
+/**
+ * @generated SignedSource<<0cd892bb0f41974ef7c1df8fce782a72>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ArtistEditorialNewsEmptyStateQuery$variables = Record<PropertyKey, never>;
+export type ArtistEditorialNewsEmptyStateQuery$data = {
+  readonly articles: ReadonlyArray<{
+    readonly internalID: string;
+    readonly " $fragmentSpreads": FragmentRefs<"CellArticle_article">;
+  }>;
+};
+export type ArtistEditorialNewsEmptyStateQuery = {
+  response: ArtistEditorialNewsEmptyStateQuery$data;
+  variables: ArtistEditorialNewsEmptyStateQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "featured",
+    "value": true
+  },
+  {
+    "kind": "Literal",
+    "name": "published",
+    "value": true
+  },
+  {
+    "kind": "Literal",
+    "name": "sort",
+    "value": "PUBLISHED_AT_DESC"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ArtistEditorialNewsEmptyStateQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Article",
+        "kind": "LinkedField",
+        "name": "articles",
+        "plural": true,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "CellArticle_article"
+          },
+          (v1/*: any*/)
+        ],
+        "storageKey": "articles(featured:true,published:true,sort:\"PUBLISHED_AT_DESC\")"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "ArtistEditorialNewsEmptyStateQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Article",
+        "kind": "LinkedField",
+        "name": "articles",
+        "plural": true,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "vertical",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "title",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "thumbnailTitle",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "byline",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "href",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "format",
+                "value": "MMM D, YYYY"
+              }
+            ],
+            "kind": "ScalarField",
+            "name": "publishedAt",
+            "storageKey": "publishedAt(format:\"MMM D, YYYY\")"
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "thumbnailImage",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "height",
+                    "value": 334
+                  },
+                  {
+                    "kind": "Literal",
+                    "name": "width",
+                    "value": 445
+                  }
+                ],
+                "concreteType": "CroppedImageUrl",
+                "kind": "LinkedField",
+                "name": "cropped",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "width",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "height",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "src",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "srcSet",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": "cropped(height:334,width:445)"
+              }
+            ],
+            "storageKey": null
+          },
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "id",
+            "storageKey": null
+          }
+        ],
+        "storageKey": "articles(featured:true,published:true,sort:\"PUBLISHED_AT_DESC\")"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "9db4f2fff00c3d110f92390c89932719",
+    "id": null,
+    "metadata": {},
+    "name": "ArtistEditorialNewsEmptyStateQuery",
+    "operationKind": "query",
+    "text": "query ArtistEditorialNewsEmptyStateQuery {\n  articles(featured: true, published: true, sort: PUBLISHED_AT_DESC) {\n    ...CellArticle_article\n    internalID\n    id\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "9eed18ff6e8ca377f1b9150d12074e5e";
+
+export default node;

--- a/src/__generated__/ArtistOverviewQueryRendererQuery.graphql.ts
+++ b/src/__generated__/ArtistOverviewQueryRendererQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c1c2f55e8ba0f3a2805eda7f50accf82>>
+ * @generated SignedSource<<c3592a0847fd1809e5e05b84817e1ca6>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -183,13 +183,6 @@ return {
                 "kind": "ScalarField",
                 "name": "relatedArtists",
                 "storageKey": null
-              },
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "articles",
-                "storageKey": null
               }
             ],
             "storageKey": null
@@ -253,12 +246,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "bc41d443fb8e1a9fa11061c7b7af5228",
+    "cacheID": "b501bf05149587dcc3d5c0466ac3b12c",
     "id": null,
     "metadata": {},
     "name": "ArtistOverviewQueryRendererQuery",
     "operationKind": "query",
-    "text": "query ArtistOverviewQueryRendererQuery(\n  $artistID: String!\n) @cacheable {\n  artist(id: $artistID) {\n    ...ArtistOverview_artist\n    id\n  }\n}\n\nfragment ArtistOverview_artist on Artist {\n  internalID\n  href\n  name\n  insights {\n    __typename\n  }\n  artistSeriesConnection(first: 0) {\n    totalCount\n  }\n  showsConnection(first: 0, status: \"running\") {\n    totalCount\n  }\n  counts {\n    relatedArtists\n    articles\n  }\n  related {\n    genes(first: 1) {\n      edges {\n        node {\n          __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query ArtistOverviewQueryRendererQuery(\n  $artistID: String!\n) @cacheable {\n  artist(id: $artistID) {\n    ...ArtistOverview_artist\n    id\n  }\n}\n\nfragment ArtistOverview_artist on Artist {\n  internalID\n  href\n  name\n  insights {\n    __typename\n  }\n  artistSeriesConnection(first: 0) {\n    totalCount\n  }\n  showsConnection(first: 0, status: \"running\") {\n    totalCount\n  }\n  counts {\n    relatedArtists\n  }\n  related {\n    genes(first: 1) {\n      edges {\n        node {\n          __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistOverview_artist.graphql.ts
+++ b/src/__generated__/ArtistOverview_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<ad3f50e614716f36f216c81b79d21a9e>>
+ * @generated SignedSource<<40d5af569085b05b2f6dc01c5a31c75a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,7 +15,6 @@ export type ArtistOverview_artist$data = {
     readonly totalCount: number;
   } | null | undefined;
   readonly counts: {
-    readonly articles: number | null | undefined;
     readonly relatedArtists: number | null | undefined;
   } | null | undefined;
   readonly href: string | null | undefined;
@@ -147,13 +146,6 @@ return {
           "kind": "ScalarField",
           "name": "relatedArtists",
           "storageKey": null
-        },
-        {
-          "alias": null,
-          "args": null,
-          "kind": "ScalarField",
-          "name": "articles",
-          "storageKey": null
         }
       ],
       "storageKey": null
@@ -213,6 +205,6 @@ return {
 };
 })();
 
-(node as any).hash = "d409e60c6d511fede7e6b68b24ac5567";
+(node as any).hash = "d045ac74566d56916833c64576a0d522";
 
 export default node;


### PR DESCRIPTION
Thread with some context [here](https://artsy.slack.com/archives/C05EEBNEF71/p1778188463137259)

This retires the editorial navigation experiment (`diamond_editorial-section`) and adds the 'Editorial' option to the end of the artist subnav + includes an empty state that's a rail of recent articles.

This does *not* replace the current editorial grid with the rail format which should be A/B tested.

<img width="3018" height="1392" alt="image" src="https://github.com/user-attachments/assets/32909019-5d31-4b7b-9cb6-5141e54a85b3" />

cc @artsy/diamond-devs 