### PR TITLE
fix(article): adjusts toc display threshold

### DIFF
--- a/src/Apps/Article/Components/ArticleTableOfContents.tsx
+++ b/src/Apps/Article/Components/ArticleTableOfContents.tsx
@@ -11,7 +11,7 @@ interface ArticleTableOfContentsProps {
   article: ArticleTableOfContents_article$key
 }
 
-const MIN_OUTLINE_ENTRIES = 5
+const MIN_OUTLINE_ENTRIES = 3
 
 export const ArticleTableOfContents: FC<ArticleTableOfContentsProps> = ({
   article: articleRef,

--- a/src/Apps/Article/Components/__tests__/ArticleTableOfContents.jest.tsx
+++ b/src/Apps/Article/Components/__tests__/ArticleTableOfContents.jest.tsx
@@ -28,22 +28,20 @@ const { renderWithRelay } = setupTestWrapperTL({
   `,
 })
 
-const FIVE_HEADINGS = [
+const THREE_HEADINGS = [
   { heading: "Section One", slug: "section-one" },
   { heading: "Section Two", slug: "section-two" },
   { heading: "Section Three", slug: "section-three" },
-  { heading: "Section Four", slug: "section-four" },
-  { heading: "Section Five", slug: "section-five" },
 ]
 
 describe("ArticleTableOfContents", () => {
-  describe("when the outline has fewer than five entries", () => {
+  describe("when the outline has fewer than three entries", () => {
     it("renders nothing", () => {
       renderWithRelay({
         Article: () => ({
           slug: "example-article",
           href: "/article/example-article",
-          outline: FIVE_HEADINGS.slice(0, 4),
+          outline: THREE_HEADINGS.slice(0, 2),
         }),
       })
 
@@ -53,13 +51,13 @@ describe("ArticleTableOfContents", () => {
     })
   })
 
-  describe("when the outline has at least five entries", () => {
+  describe("when the outline has at least three entries", () => {
     const renderToc = () =>
       renderWithRelay({
         Article: () => ({
           slug: "example-article",
           href: "/article/example-article",
-          outline: FIVE_HEADINGS,
+          outline: THREE_HEADINGS,
         }),
       })
 
@@ -71,9 +69,9 @@ describe("ArticleTableOfContents", () => {
 
       const list = nav.querySelector("ol")
       expect(list).not.toBeNull()
-      expect(list?.querySelectorAll("li")).toHaveLength(FIVE_HEADINGS.length)
+      expect(list?.querySelectorAll("li")).toHaveLength(THREE_HEADINGS.length)
 
-      for (const { heading, slug } of FIVE_HEADINGS) {
+      for (const { heading, slug } of THREE_HEADINGS) {
         const link = screen.getByRole("link", { name: heading })
         expect(link).toHaveAttribute("href", `#JUMP--example-article--${slug}`)
       }
@@ -97,7 +95,7 @@ describe("ArticleTableOfContents", () => {
         name: "Table of contents",
       })
       expect(data.itemListElement).toEqual(
-        FIVE_HEADINGS.map((entry, index) => ({
+        THREE_HEADINGS.map((entry, index) => ({
           "@type": "ListItem",
           position: index + 1,
           name: entry.heading,


### PR DESCRIPTION
Displays ToC on articles with 3 or more h2s.

Example:

<img width="2096" height="1332" alt="image" src="https://github.com/user-attachments/assets/7738b6b4-8de1-49c5-83b8-301a5ef1afb9" />

cc @artsy/diamond-devs 