### PR TITLE
fix(EMI-3243): validate address when just added

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/Order2SavedAddressOptions.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/Order2SavedAddressOptions.tsx
@@ -176,9 +176,6 @@ export const SavedAddressOptions = ({
 
   const onSaveAddress = useCallback(
     async (values: FormikContextWithAddress, addressID: string) => {
-      await onSelectAddress(values)
-      setUserAddressMode(null)
-
       const isValid = validateAddressFields(values)
       const isShippable = availableShippingCountries.includes(
         values.address.country,
@@ -193,12 +190,21 @@ export const SavedAddressOptions = ({
         isShippable,
         isDefault,
       })
+      setUserAddressMode(null)
+
+      if (!isValid || (!isShippable && !isOfferOrder)) {
+        await onSelectInvalidAddress()
+      } else {
+        await onSelectAddress(values)
+      }
     },
     [
       onSelectAddress,
+      onSelectInvalidAddress,
       setUserAddressMode,
       availableShippingCountries,
       savedAddresses,
+      isOfferOrder,
     ],
   )
 

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/Order2SavedAddressOptions.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/Order2SavedAddressOptions.jest.tsx
@@ -12,6 +12,26 @@ import { SavedAddressOptions } from "../Order2SavedAddressOptions"
 
 jest.mock("Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext")
 
+let mockAddAddressValues: FormikContextWithAddress
+
+jest.mock("../AddAddressForm", () => ({
+  AddAddressForm: ({
+    onSaveAddress,
+  }: {
+    onSaveAddress: (
+      values: FormikContextWithAddress,
+      id: string,
+    ) => Promise<void>
+  }) => (
+    <button
+      type="button"
+      onClick={() => onSaveAddress(mockAddAddressValues, "new-address-id")}
+    >
+      Save new address
+    </button>
+  ),
+}))
+
 jest.mock("../UpdateAddressForm", () => ({
   UpdateAddressForm: ({
     onDeleteAddress,
@@ -700,6 +720,99 @@ describe("SavedAddressOptions", () => {
       await waitFor(() => {
         expect(onSelectAddress).toHaveBeenCalledWith(mockUSAddress2)
       })
+    })
+  })
+
+  describe("Adding a new address", () => {
+    const validNewAddress: FormikContextWithAddress = {
+      phoneNumber: "5551234567",
+      phoneNumberCountryCode: "us",
+      address: {
+        name: "New User",
+        addressLine1: "100 New St",
+        addressLine2: "",
+        city: "New York",
+        region: "NY",
+        postalCode: "10001",
+        country: "US",
+      },
+    }
+
+    beforeEach(() => {
+      mockAddAddressValues = validNewAddress
+      mockUseCheckoutContext.mockReturnValue({
+        ...mockCheckoutContext,
+        userAddressMode: { mode: "add" },
+      })
+    })
+
+    it("calls onSelectAddress when a valid shippable address is saved", async () => {
+      renderSavedAddressOptions({ availableShippingCountries: ["US"] })
+
+      await userEvent.click(screen.getByText("Save new address"))
+
+      await waitFor(() => {
+        expect(onSelectAddress).toHaveBeenCalledWith(validNewAddress)
+      })
+      expect(onSelectInvalidAddress).not.toHaveBeenCalled()
+    })
+
+    it("calls onSelectInvalidAddress when the new address has missing required fields", async () => {
+      mockAddAddressValues = {
+        ...validNewAddress,
+        address: { ...validNewAddress.address, name: "", city: "" },
+      }
+
+      renderSavedAddressOptions({ availableShippingCountries: ["US"] })
+
+      await userEvent.click(screen.getByText("Save new address"))
+
+      await waitFor(() => {
+        expect(onSelectInvalidAddress).toHaveBeenCalled()
+      })
+      expect(onSelectAddress).not.toHaveBeenCalled()
+    })
+
+    it("calls onSelectInvalidAddress when the new address is not shippable in non-OFFER mode", async () => {
+      mockUseCheckoutContext.mockReturnValue({
+        ...mockCheckoutContext,
+        userAddressMode: { mode: "add" },
+        orderData: { mode: "BUY" },
+      })
+      mockAddAddressValues = {
+        ...validNewAddress,
+        address: { ...validNewAddress.address, country: "DE" },
+      }
+
+      renderSavedAddressOptions({ availableShippingCountries: ["US"] })
+
+      await userEvent.click(screen.getByText("Save new address"))
+
+      await waitFor(() => {
+        expect(onSelectInvalidAddress).toHaveBeenCalled()
+      })
+      expect(onSelectAddress).not.toHaveBeenCalled()
+    })
+
+    it("calls onSelectAddress when the new address is not shippable in OFFER mode", async () => {
+      mockUseCheckoutContext.mockReturnValue({
+        ...mockCheckoutContext,
+        userAddressMode: { mode: "add" },
+        orderData: { mode: "OFFER" },
+      })
+      mockAddAddressValues = {
+        ...validNewAddress,
+        address: { ...validNewAddress.address, country: "DE" },
+      }
+
+      renderSavedAddressOptions({ availableShippingCountries: ["US"] })
+
+      await userEvent.click(screen.getByText("Save new address"))
+
+      await waitFor(() => {
+        expect(onSelectAddress).toHaveBeenCalledWith(mockAddAddressValues)
+      })
+      expect(onSelectInvalidAddress).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-3243]

### Description

<!-- Implementation description -->
Addresses this Notion card https://www.notion.so/artsy/The-address-is-not-validated-once-added-causing-a-dead-end-state-cannot-proceed-to-the-payment-no-35dcab0764a080749d00e68b02e5f4b3?source=copy_link
The address that has just been added is now validated

<video src="https://github.com/user-attachments/assets/0f7bc0c7-79b3-4785-8090-3e1a337e6f23" />


[EMI-3243]: https://artsyproduct.atlassian.net/browse/EMI-3243?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ