### PR TITLE
fx(EMI-3235): update checkout loading skeletons

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/Order2DeliveryOptionsForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/Order2DeliveryOptionsForm.tsx
@@ -20,8 +20,8 @@ import { MultipleShippingOptionsForm } from "Apps/Order2/Routes/Checkout/Compone
 import { SingleShippingOption } from "Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/SingleShippingOption"
 import {
   ARTA_FULFILLMENT_TYPES,
-  SELECTABLE_TYPES,
   INTERNATIONAL_SHIPPING_WARNING,
+  SELECTABLE_TYPES,
   deliveryOptionTimeEstimate,
 } from "Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/utils"
 import { useCompleteFulfillmentDetailsData } from "Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/useCompleteFulfillmentDetailsData"
@@ -193,11 +193,11 @@ export const Order2DeliveryOptionsForm: React.FC<
 
         <Spacer y={2} />
 
-        {refreshingOptions ? (
+        {!refreshingOptions ? (
           <Skeleton>
             <Flex flexDirection="column" gap={1}>
               {[0, 1, 2].map(i => (
-                <SkeletonBox key={i} height="52px" width="100%" />
+                <SkeletonBox key={i} height={30} width="100%" />
               ))}
             </Flex>
           </Skeleton>

--- a/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/Order2DeliveryOptionsForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/Order2DeliveryOptionsForm.tsx
@@ -193,7 +193,7 @@ export const Order2DeliveryOptionsForm: React.FC<
 
         <Spacer y={2} />
 
-        {!refreshingOptions ? (
+        {refreshingOptions ? (
           <Skeleton>
             <Flex flexDirection="column" gap={1}>
               {[0, 1, 2].map(i => (

--- a/src/Apps/Order2/Routes/Checkout/Components/Order2CheckoutLoadingSkeleton.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2CheckoutLoadingSkeleton.tsx
@@ -101,16 +101,14 @@ const Order2CollapsibleOrderSummarySkeleton: React.FC<
                       {props.artworkArtistNames}
                     </SkeletonText>
                     {/* Price and chevron */}
-                    <Flex
-                      flexGrow={0}
-                      justifyContent={"flex-end"}
-                      display={["none", "block", "none"]}
-                    >
-                      <SkeletonText variant="xs" mr={0.5}>
-                        {props.artworkPrice}
-                      </SkeletonText>
-                      <SkeletonBox width={18} height={16} mt="2px" />
-                    </Flex>
+                    <Box display={["none", "block", "block"]}>
+                      <Flex flexGrow={0} justifyContent={"flex-end"}>
+                        <SkeletonText variant="xs" mr={0.5}>
+                          {props.artworkPrice}
+                        </SkeletonText>
+                        <SkeletonBox width={18} height={16} mt="2px" />
+                      </Flex>
+                    </Box>
                   </Flex>
                   <SkeletonText variant="xs">
                     {props.artworkTitle}, {props.artworkDate}

--- a/src/Apps/Order2/Routes/Checkout/Components/Order2CheckoutLoadingSkeleton.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2CheckoutLoadingSkeleton.tsx
@@ -97,18 +97,22 @@ const Order2CollapsibleOrderSummarySkeleton: React.FC<
                 {/* Artwork details */}
                 <Box ml={1} flexGrow={1}>
                   <Flex>
-                    <SkeletonText variant="sm" flexGrow={1}>
+                    <SkeletonText variant="xs" flexGrow={1}>
                       {props.artworkArtistNames}
                     </SkeletonText>
                     {/* Price and chevron */}
-                    <Flex flexGrow={0} justifyContent={"flex-end"}>
-                      <SkeletonText variant="sm" mr={0.5}>
+                    <Flex
+                      flexGrow={0}
+                      justifyContent={"flex-end"}
+                      display={["none", "block", "none"]}
+                    >
+                      <SkeletonText variant="xs" mr={0.5}>
                         {props.artworkPrice}
                       </SkeletonText>
                       <SkeletonBox width={18} height={16} mt="2px" />
                     </Flex>
                   </Flex>
-                  <SkeletonText variant="sm">
+                  <SkeletonText variant="xs">
                     {props.artworkTitle}, {props.artworkDate}
                   </SkeletonText>
                 </Box>
@@ -156,7 +160,11 @@ const StepsSkeleton = () => {
           First step title
         </SkeletonText>
 
-        <SkeletonText flex={0} variant="sm-display">
+        <SkeletonText
+          flex={0}
+          variant="sm-display"
+          display={["none", "block", "none"]}
+        >
           Loading...
         </SkeletonText>
       </Flex>


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-3235]

### Description

<!-- Implementation description -->
1. Fix cramped loading skeleton in Mweb / mobile
2. Update loading skeleton text to smaller for shipping quotes step 

| 1 | 2 |
| --- | --- |
| <img width="492" height="647" alt="image" src="https://github.com/user-attachments/assets/bd9fc959-8b15-46d3-a567-5ee29cfc9174" /> | <img width="1501" height="804" alt="image" src="https://github.com/user-attachments/assets/fc15685b-f23b-4bba-8eb9-d2dad56d9528" /> |


[EMI-3235]: https://artsyproduct.atlassian.net/browse/EMI-3235?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ