### PR TITLE
fix: hide progressive onboarding until mounted

### DIFF
--- a/src/Components/ProgressiveOnboarding/withProgressiveOnboardingCounts.tsx
+++ b/src/Components/ProgressiveOnboarding/withProgressiveOnboardingCounts.tsx
@@ -2,6 +2,7 @@ import { useSystemContext } from "System/Hooks/useSystemContext"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import type { withProgressiveOnboardingCountsQuery } from "__generated__/withProgressiveOnboardingCountsQuery.graphql"
 import type { ComponentType } from "react"
+import { useEffect, useState } from "react"
 import { graphql } from "react-relay"
 
 export interface WithProgressiveOnboardingCountsProps {
@@ -29,7 +30,18 @@ export const withProgressiveOnboardingCounts = <
   >,
 ): ComponentType<React.PropsWithChildren<Omit<T, "counts">>> => {
   return (props: T) => {
+    const [mounted, setMounted] = useState(false)
     const { isLoggedIn } = useSystemContext()
+
+    useEffect(() => {
+      setMounted(true)
+    }, [])
+
+    if (!mounted) {
+      return (
+        <Component {...props} counts={{ ...INITIAL_COUNTS, isReady: false }} />
+      )
+    }
 
     if (!isLoggedIn) {
       return (


### PR DESCRIPTION
This PR adds a check to make sure that the `withProgressiveOnboardingCounts` wrapper is mounted before telling its wrapped components (alert/save/follow tooltips) that they are ready to be displayed, so that they aren't rendered before determining whether a user has dismissed them before.

---

When a user dismisses an onboarding tooltip, we store a timestamp in their browser's local storage that tells us not to display that tooltip again.

However, when a page is rendered by SSR, the server does not have access to that information, so it assumes that the user has not seen it. That assumption originates [here](https://github.com/artsy/dismissible/blob/de54e9650df63bc21a01ff49cbaf080b28203e2e/src/DismissibleContext.tsx#L198-L201) in the `DismissibleProvider` when it returns an empty array of dismissals, and is propagated through alert/save/follow CTAs [here](https://github.com/artsy/force/blob/b8b952ddc73077f635bfd03a5713763cecd14a31/src/Components/ProgressiveOnboarding/ProgressiveOnboardingAlertCreate.tsx#L37), [here](https://github.com/artsy/force/blob/b8b952ddc73077f635bfd03a5713763cecd14a31/src/Components/ProgressiveOnboarding/ProgressiveOnboardingFollowArtist.tsx#L31-L32), [here](https://github.com/artsy/force/blob/b8b952ddc73077f635bfd03a5713763cecd14a31/src/Components/ProgressiveOnboarding/ProgressiveOnboardingFollowPartner.tsx#L27-L28) and [here](https://github.com/artsy/force/blob/b8b952ddc73077f635bfd03a5713763cecd14a31/src/Components/ProgressiveOnboarding/ProgressiveOnboardingSaveArtwork.tsx#L25-L26) (just to list a few) when they decide whether they can be displayed.

**Therefore, before hydration occurs on the client-side, every surface with an alert/save/follow CTA is rendering those tooltips in the component tree.**

Once hydration happens, the `useEffect` hooks of each component in the tree fires off, starting from the children to the parents.

This means that `tooltipViewed` [events](https://github.com/artsy/force/blob/b8b952ddc73077f635bfd03a5713763cecd14a31/src/Components/ProgressiveOnboarding/ProgressiveOnboardingPopover.tsx#L19-L27) in `useEffect` hooks at the bottom of the component tree are fired off before `DismissibleProvider` at the top of the component tree has a chance to fire `useDidMount` and determine whether that user has already dismissed the tooltip.

---

I found this issue while looking at the top Sentry bugs for last week. There were approximately 70K events last week such as [this one](https://artsynet.sentry.io/issues/7399191887/?project=28316&query=is%3Aunresolved%20removeChild&referrer=issue-stream) and [this one](https://artsynet.sentry.io/issues/7399191742/?project=28316&query=is%3Aunresolved%20removeChild&referrer=issue-stream). They indicate that an error happens because of the mismatched SSR HTML (with previously dismissed tooltips) v.s. the hydrated HTML (without those tooltips), which led to this investigation.

(These appear starting on April 9 2026 because @starsirius re-enabled client-side Sentry errors [here](https://github.com/artsy/force/pull/17060) but I think they have been firing since Force upgraded to @artsy/dismissible 0.5.0 [here](https://github.com/artsy/force/pull/16292) on October 31 2025.)

cc: @artsy/diamond-devs 