### PR TITLE
fix: one tap follow ups

### DIFF
--- a/src/Apps/Authentication/Components/AuthenticationInlineDialog.tsx
+++ b/src/Apps/Authentication/Components/AuthenticationInlineDialog.tsx
@@ -103,6 +103,5 @@ const ERROR_CODES = {
 const PROVIDERS = {
   facebook: "Facebook",
   google: "Google",
-  "google-one-tap": "Google",
   apple: "Apple",
 }

--- a/src/Apps/Authentication/Components/AuthenticationInlineDialog.tsx
+++ b/src/Apps/Authentication/Components/AuthenticationInlineDialog.tsx
@@ -103,5 +103,6 @@ const ERROR_CODES = {
 const PROVIDERS = {
   facebook: "Facebook",
   google: "Google",
+  "google-one-tap": "Google",
   apple: "Apple",
 }

--- a/src/Server/passport/lib/app/__tests__/lifecycle.jest.ts
+++ b/src/Server/passport/lib/app/__tests__/lifecycle.jest.ts
@@ -42,6 +42,7 @@ describe("lifecycle", () => {
     }
 
     res = {
+      cookie: jest.fn(),
       redirect: jest.fn(),
       send,
       status: jest.fn().mockReturnValue({ send }),
@@ -435,6 +436,41 @@ describe("lifecycle", () => {
 
       expect(res.redirect).toHaveBeenCalledWith("/settings")
       expect(next).not.toHaveBeenCalled()
+    })
+
+    describe('with mode "one-tap"', () => {
+      it('delegates to the "google-one-tap" passport strategy', () => {
+        lifecycle.afterSocialAuth("google", "one-tap")(req, res, next)
+        expect(passport.authenticate).toHaveBeenCalledWith("google-one-tap")
+      })
+
+      it("sets the suppress cookie on auth error", () => {
+        passport.authenticate.mockReturnValueOnce((_req, _res, next) =>
+          next(new Error("auth error")),
+        )
+        lifecycle.afterSocialAuth("google", "one-tap")(req, res, next)
+        expect(res.cookie).toHaveBeenCalledWith(
+          "g_one_tap_suppress",
+          "1",
+          expect.objectContaining({ maxAge: expect.any(Number) }),
+        )
+      })
+
+      it("does not set the suppress cookie on success", () => {
+        passport.authenticate.mockReturnValueOnce((_req, _res, next) => next())
+        lifecycle.afterSocialAuth("google", "one-tap")(req, res, next)
+        expect(res.cookie).not.toHaveBeenCalled()
+      })
+
+      it("uses google as the provider in error redirects", () => {
+        passport.authenticate.mockReturnValueOnce((_req, _res, next) => {
+          next(new Error("Unauthorized source IP address"))
+        })
+        lifecycle.afterSocialAuth("google", "one-tap")(req, res, next)
+        expect(res.redirect).toHaveBeenCalledWith(
+          "/login?error_code=IP_BLOCKED&provider=google",
+        )
+      })
     })
   })
 

--- a/src/Server/passport/lib/app/index.ts
+++ b/src/Server/passport/lib/app/index.ts
@@ -91,7 +91,7 @@ const setupApp = () => {
   // Google One Tap
   app.post(
     opts.googleOneTapCallbackPath,
-    middleware(afterSocialAuth("google-one-tap")),
+    middleware(afterSocialAuth("google", "one-tap")),
     middleware(trackSignup("google-one-tap")),
     middleware(ssoAndRedirectBack),
   )

--- a/src/Server/passport/lib/app/lifecycle.ts
+++ b/src/Server/passport/lib/app/lifecycle.ts
@@ -154,14 +154,14 @@ const signupErrorMessage = (err: GravityError) => {
   return ""
 }
 
-type Provider = "facebook" | "apple" | "google" | "google-one-tap"
+type Provider = "facebook" | "apple" | "google"
 const UNKNOWN_AUTH_ERROR = "An unknown error occurred. Please try again."
 
 const ONE_TAP_SUPPRESS_COOKIE = "g_one_tap_suppress"
 const ONE_TAP_SUPPRESS_DURATION_MS = 30 * 60 * 1000
 
-const suppressOneTapPrompt = (provider: Provider, res: ArtsyResponse) => {
-  if (provider === "google-one-tap") {
+const suppressOneTapPrompt = (isOneTap: boolean, res: ArtsyResponse) => {
+  if (isOneTap) {
     res.cookie(ONE_TAP_SUPPRESS_COOKIE, "1", {
       maxAge: ONE_TAP_SUPPRESS_DURATION_MS,
     })
@@ -212,8 +212,11 @@ export const beforeSocialAuth =
   }
 
 export const afterSocialAuth =
-  (provider: Provider) =>
+  (provider: Provider, mode?: "one-tap") =>
   (req: Req, res: ArtsyResponse, next: NextFunction) => {
+    const isOneTap = provider === "google" && mode === "one-tap"
+    const strategyName = isOneTap ? "google-one-tap" : provider
+
     if (req.query.denied) {
       return next(new Error(`${provider} denied`))
     }
@@ -223,9 +226,9 @@ export const afterSocialAuth =
     const linkingAccount = req.user != null
     const redirectPath = req.user ? opts.settingsPagePath : opts.loginPagePath
 
-    passport.authenticate(provider)(req, res, (err: any) => {
+    passport.authenticate(strategyName)(req, res, (err: any) => {
       if (err != null) {
-        suppressOneTapPrompt(provider, res)
+        suppressOneTapPrompt(isOneTap, res)
       }
 
       if (

--- a/src/Server/passport/lib/app/lifecycle.ts
+++ b/src/Server/passport/lib/app/lifecycle.ts
@@ -156,6 +156,17 @@ const signupErrorMessage = (err: GravityError) => {
 
 type Provider = "facebook" | "apple" | "google" | "google-one-tap"
 const UNKNOWN_AUTH_ERROR = "An unknown error occurred. Please try again."
+
+const ONE_TAP_SUPPRESS_COOKIE = "g_one_tap_suppress"
+const ONE_TAP_SUPPRESS_DURATION_MS = 30 * 60 * 1000
+
+const suppressOneTapPrompt = (provider: Provider, res: ArtsyResponse) => {
+  if (provider === "google-one-tap") {
+    res.cookie(ONE_TAP_SUPPRESS_COOKIE, "1", {
+      maxAge: ONE_TAP_SUPPRESS_DURATION_MS,
+    })
+  }
+}
 const SOCIAL_LOGIN_TWO_FACTOR_AUTH_ERROR =
   "Please log in with email and password to use two-factor authentication."
 const SOCIAL_LINKING_TWO_FACTOR_AUTH_ERROR =
@@ -220,6 +231,7 @@ export const afterSocialAuth =
         // A user with the email address <req.socialProfileEmail> already exists.
         // Log in to Artsy via email and password and link ${providerName} in your settings instead.
         // Redirect back to login page.
+        suppressOneTapPrompt(provider, res)
         return res.redirect(
           redirectWithQuery(redirectPath, {
             email: req.socialProfileEmail,
@@ -233,6 +245,7 @@ export const afterSocialAuth =
         // Provider account previously linked to Artsy.
         // Log in to your Artsy account via email and password and link the provider in your settings instead.
         // Redirect back to login page.
+        suppressOneTapPrompt(provider, res)
         return res.redirect(
           redirectWithQuery(redirectPath, {
             error_code: "PREVIOUSLY_LINKED_SETTINGS",
@@ -243,6 +256,7 @@ export const afterSocialAuth =
 
       if (err?.response?.body?.error === "Another Account Already Linked") {
         // Provider account previously linked to Artsy. Redirect back to settings page.
+        suppressOneTapPrompt(provider, res)
         return res.redirect(
           redirectWithQuery(redirectPath, {
             error_code: "PREVIOUSLY_LINKED",
@@ -253,6 +267,7 @@ export const afterSocialAuth =
 
       if (err?.message?.match("Unauthorized source IP address")) {
         // Your IP address was blocked by the provider. Redirect back to login page.
+        suppressOneTapPrompt(provider, res)
         return res.redirect(
           redirectWithQuery(redirectPath, {
             error_code: "IP_BLOCKED",
@@ -265,6 +280,7 @@ export const afterSocialAuth =
         const message = extractError(err)
 
         if (message.includes("missing two-factor authentication code")) {
+          suppressOneTapPrompt(provider, res)
           return res.redirect(
             redirectWithQuery(redirectPath, {
               error: SOCIAL_LOGIN_TWO_FACTOR_AUTH_ERROR,
@@ -279,6 +295,7 @@ export const afterSocialAuth =
             "Unable to link third-party authentication if account has Artsy two-factor authentication enabled",
           )
         ) {
+          suppressOneTapPrompt(provider, res)
           return res.redirect(
             redirectWithQuery(redirectPath, {
               error: SOCIAL_LINKING_TWO_FACTOR_AUTH_ERROR,
@@ -290,6 +307,7 @@ export const afterSocialAuth =
 
         // Unknown error. Redirect back to login page. Do not show error message to user; log to console.
         console.warn(`Error authenticating with ${provider}: ${message}`)
+        suppressOneTapPrompt(provider, res)
         return res.redirect(
           redirectWithQuery(redirectPath, {
             error: UNKNOWN_AUTH_ERROR,

--- a/src/Server/passport/lib/app/lifecycle.ts
+++ b/src/Server/passport/lib/app/lifecycle.ts
@@ -224,6 +224,10 @@ export const afterSocialAuth =
     const redirectPath = req.user ? opts.settingsPagePath : opts.loginPagePath
 
     passport.authenticate(provider)(req, res, (err: any) => {
+      if (err != null) {
+        suppressOneTapPrompt(provider, res)
+      }
+
       if (
         err?.response?.body?.error === "User Already Exists" &&
         req.socialProfileEmail
@@ -231,7 +235,6 @@ export const afterSocialAuth =
         // A user with the email address <req.socialProfileEmail> already exists.
         // Log in to Artsy via email and password and link ${providerName} in your settings instead.
         // Redirect back to login page.
-        suppressOneTapPrompt(provider, res)
         return res.redirect(
           redirectWithQuery(redirectPath, {
             email: req.socialProfileEmail,
@@ -245,7 +248,6 @@ export const afterSocialAuth =
         // Provider account previously linked to Artsy.
         // Log in to your Artsy account via email and password and link the provider in your settings instead.
         // Redirect back to login page.
-        suppressOneTapPrompt(provider, res)
         return res.redirect(
           redirectWithQuery(redirectPath, {
             error_code: "PREVIOUSLY_LINKED_SETTINGS",
@@ -256,7 +258,6 @@ export const afterSocialAuth =
 
       if (err?.response?.body?.error === "Another Account Already Linked") {
         // Provider account previously linked to Artsy. Redirect back to settings page.
-        suppressOneTapPrompt(provider, res)
         return res.redirect(
           redirectWithQuery(redirectPath, {
             error_code: "PREVIOUSLY_LINKED",
@@ -267,7 +268,6 @@ export const afterSocialAuth =
 
       if (err?.message?.match("Unauthorized source IP address")) {
         // Your IP address was blocked by the provider. Redirect back to login page.
-        suppressOneTapPrompt(provider, res)
         return res.redirect(
           redirectWithQuery(redirectPath, {
             error_code: "IP_BLOCKED",
@@ -280,7 +280,6 @@ export const afterSocialAuth =
         const message = extractError(err)
 
         if (message.includes("missing two-factor authentication code")) {
-          suppressOneTapPrompt(provider, res)
           return res.redirect(
             redirectWithQuery(redirectPath, {
               error: SOCIAL_LOGIN_TWO_FACTOR_AUTH_ERROR,
@@ -295,7 +294,6 @@ export const afterSocialAuth =
             "Unable to link third-party authentication if account has Artsy two-factor authentication enabled",
           )
         ) {
-          suppressOneTapPrompt(provider, res)
           return res.redirect(
             redirectWithQuery(redirectPath, {
               error: SOCIAL_LINKING_TWO_FACTOR_AUTH_ERROR,
@@ -307,7 +305,6 @@ export const afterSocialAuth =
 
         // Unknown error. Redirect back to login page. Do not show error message to user; log to console.
         console.warn(`Error authenticating with ${provider}: ${message}`)
-        suppressOneTapPrompt(provider, res)
         return res.redirect(
           redirectWithQuery(redirectPath, {
             error: UNKNOWN_AUTH_ERROR,

--- a/src/Server/passport/lib/passport/callbacks.ts
+++ b/src/Server/passport/lib/passport/callbacks.ts
@@ -20,6 +20,7 @@ interface AccessTokenParams extends Record<string, unknown> {
   apple_uid?: string
   email?: string
   id_token?: string
+  jwt?: string
   name?: string | null
   oauth_token?: string
   provider?: string
@@ -398,6 +399,11 @@ const onAccessToken =
           if (params!.provider === "apple") {
             auth_params = extend(params, {
               grant_type: "apple_uid",
+            })
+          } else if (params!.jwt) {
+            auth_params = extend(params, {
+              grant_type: "jwt",
+              oauth_provider: "google",
             })
           } else {
             auth_params = extend(params, {

--- a/src/Server/passport/lib/passport/callbacks.ts
+++ b/src/Server/passport/lib/passport/callbacks.ts
@@ -400,7 +400,7 @@ const onAccessToken =
             auth_params = extend(params, {
               grant_type: "apple_uid",
             })
-          } else if (params!.jwt) {
+          } else if (params!.provider === "google" && params!.jwt) {
             auth_params = extend(params, {
               grant_type: "jwt",
               oauth_provider: "google",

--- a/src/Utils/GoogleOneTapContainer.tsx
+++ b/src/Utils/GoogleOneTapContainer.tsx
@@ -40,6 +40,7 @@ export const GoogleOneTapContainer = () => {
       data-client_id={googleClientId}
       data-login_uri={`${getENV("APP_URL")}/users/auth/google/one_tap/callback`}
       data-auto_prompt="true"
+      data-skip_prompt_cookie="g_one_tap_suppress"
     />
   )
 }

--- a/src/Utils/GoogleOneTapContainer.tsx
+++ b/src/Utils/GoogleOneTapContainer.tsx
@@ -3,12 +3,29 @@ import { useSystemContext } from "System/Hooks/useSystemContext"
 import { getENV } from "Utils/getENV"
 import { useEffect } from "react"
 
+const AUTH_PATHS = [
+  "/log_in",
+  "/sign_up",
+  "/login",
+  "/signup",
+  "/forgot",
+  "/reset_password",
+  "/auth-redirect",
+]
+
+const isAuthPath = (pathname: string) =>
+  AUTH_PATHS.some(path => pathname.startsWith(path))
+
 export const GoogleOneTapContainer = () => {
   const { isLoggedIn } = useSystemContext()
   const isGoogleOneTapEnabled = !!useFlag("diamond_google-one-tap")
   const googleClientId = getENV("GOOGLE_CLIENT_ID")
 
-  const enabled = !isLoggedIn && isGoogleOneTapEnabled && !!googleClientId
+  const enabled =
+    !isLoggedIn &&
+    isGoogleOneTapEnabled &&
+    !!googleClientId &&
+    !isAuthPath(window.location.pathname)
 
   useEffect(() => {
     if (!enabled) {

--- a/src/Utils/GoogleOneTapContainer.tsx
+++ b/src/Utils/GoogleOneTapContainer.tsx
@@ -41,9 +41,6 @@ export const GoogleOneTapContainer = () => {
     script.src = "https://accounts.google.com/gsi/client"
     script.async = true
     script.defer = true
-    // TODO:
-    // script.onerror = () =>
-    //   captureException(new Error("Google One Tap script failed to load"))
     document.body.appendChild(script)
   }, [enabled])
 

--- a/src/Utils/__tests__/GoogleOneTapContainer.jest.tsx
+++ b/src/Utils/__tests__/GoogleOneTapContainer.jest.tsx
@@ -152,15 +152,5 @@ describe("GoogleOneTapContainer", () => {
       render(<GoogleOneTapContainer />)
       expect(gsiScript()).not.toBeInTheDocument()
     })
-
-    // TODO:
-    // it("calls captureException when the GSI script fails to load", () => {
-    //   enableOneTap()
-    //   render(<GoogleOneTapContainer />)
-    //   gsiScript()!.onerror!(new Event("error"))
-    //   expect(mockCaptureException).toHaveBeenCalledWith(
-    //     new Error("Google One Tap script failed to load"),
-    //   )
-    // })
   })
 })

--- a/src/Utils/__tests__/GoogleOneTapContainer.jest.tsx
+++ b/src/Utils/__tests__/GoogleOneTapContainer.jest.tsx
@@ -91,6 +91,35 @@ describe("GoogleOneTapContainer", () => {
       render(<GoogleOneTapContainer />)
       expect(document.getElementById("g_id_onload")).not.toBeInTheDocument()
     })
+
+    describe("on auth paths", () => {
+      const originalPathname = window.location.pathname
+
+      afterEach(() => {
+        Object.defineProperty(window, "location", {
+          value: { ...window.location, pathname: originalPathname },
+          writable: true,
+        })
+      })
+
+      it.each([
+        "/log_in",
+        "/sign_up",
+        "/login",
+        "/signup",
+        "/forgot",
+        "/reset_password",
+        "/auth-redirect",
+      ])("does not render on %s", path => {
+        enableOneTap()
+        Object.defineProperty(window, "location", {
+          value: { ...window.location, pathname: path },
+          writable: true,
+        })
+        render(<GoogleOneTapContainer />)
+        expect(document.getElementById("g_id_onload")).not.toBeInTheDocument()
+      })
+    })
   })
 
   describe("GSI script injection", () => {


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [DI-272](https://www.notion.so/artsy/Newly-Created-User-Not-Logged-In-35dcab0764a08073a4c2f9cf260b6f38?v=310cab0764a08156aa73000cda8f267f) [DI-273](https://www.notion.so/artsy/User-Registered-with-Gmail-Account-Can-t-One-Tap-35dcab0764a080d0be2ddd2af2423b5e?v=310cab0764a08151b558000cc3bc6840&source=copy_link)

### Description

<!-- Implementation description -->

- Fixes error messages not showing a provider name for Google One Tap
- Fixes initial sign in after creating an account throwing errors due to incorrect params
- Suppresses the one tap prompt for 30 minutes via cookie in event of error
- Suppress one tap prompt on auth paths 
