### PR TITLE
fix: capture initial hydration mismatch errors

### DIFF
--- a/src/Apps/Debug/DebugHydrationErrorRoute.tsx
+++ b/src/Apps/Debug/DebugHydrationErrorRoute.tsx
@@ -1,0 +1,22 @@
+import { Text } from "@artsy/palette"
+import { Title } from "react-head"
+
+export const DebugHydrationErrorRoute = () => {
+  return (
+    <>
+      <Title>Hydration Error</Title>
+
+      <Text variant="sm-display">Hydration Error</Text>
+
+      <HydrationMismatch />
+    </>
+  )
+}
+
+const HydrationMismatch = () => {
+  if (typeof window === "undefined") {
+    return null
+  }
+
+  return <div>HydrationMismatch</div>
+}

--- a/src/Apps/Debug/debugRoutes.tsx
+++ b/src/Apps/Debug/debugRoutes.tsx
@@ -24,6 +24,12 @@ const DebugClientError500Route = loadable(
   { resolveComponent: component => component.DebugClientError500Route },
 )
 
+const DebugHydrationErrorRoute = loadable(
+  () =>
+    import(/* webpackChunkName: "debugBundle" */ "./DebugHydrationErrorRoute"),
+  { resolveComponent: component => component.DebugHydrationErrorRoute },
+)
+
 /**
  * These routes are just for testing baseline page shell stuff -- Lighthouse,
  * Calibre, assets loaded on page, and other debugging things that might
@@ -60,6 +66,10 @@ export const debugRoutes: RouteProps[] = [
       {
         path: "client-error-500",
         getComponent: () => DebugClientError500Route,
+      },
+      {
+        path: "hydration-error",
+        getComponent: () => DebugHydrationErrorRoute,
       },
     ],
   },

--- a/src/Components/HydrationErrorOverlay.tsx
+++ b/src/Components/HydrationErrorOverlay.tsx
@@ -16,19 +16,27 @@ interface HydrationErrorDetail {
   componentStack?: string
 }
 
+const hydrationErrors: HydrationErrorDetail[] = []
+
 export const dispatchHydrationError = (
   error: unknown,
   componentStack?: string,
 ): void => {
   const errorMessage = error instanceof Error ? error.message : String(error)
+  const detail = { message: errorMessage, componentStack }
+
+  hydrationErrors.push(detail)
+
   const event = new CustomEvent<HydrationErrorDetail>(HYDRATION_ERROR_EVENT, {
-    detail: { message: errorMessage, componentStack },
+    detail,
   })
   window.dispatchEvent(event)
 }
 
 export const HydrationErrorOverlay: React.FC = () => {
-  const [errors, setErrors] = useState<HydrationErrorDetail[]>([])
+  const [errors, setErrors] = useState<HydrationErrorDetail[]>(() => [
+    ...hydrationErrors,
+  ])
   const [dismissed, setDismissed] = useState(false)
 
   useEffect(() => {
@@ -39,6 +47,8 @@ export const HydrationErrorOverlay: React.FC = () => {
     }
 
     window.addEventListener(HYDRATION_ERROR_EVENT, handleError)
+    setErrors([...hydrationErrors])
+
     return () => window.removeEventListener(HYDRATION_ERROR_EVENT, handleError)
   }, [])
 


### PR DESCRIPTION
<img width="2814" height="1616" alt="image" src="https://github.com/user-attachments/assets/fac0f839-9751-44dd-b839-c5ae70fde334" />

------

I had initially added this error overlay in an attempt to catch these errors before they hit production.

Before this change, the existing overlay subscribed to hydration error events only after it mounted. Because React can call `onRecoverableError` during the initial `hydrateRoot` pass, those events could be dispatched before the overlay subscribed, causing SSR/client mismatches to appear in the console but not in the overlay.

This change buffers hydration overlay events so errors emitted during the initial `hydrateRoot` pass are shown
I also added a `/debug/hydration-error` route to intentionally trigger an SSR/client mismatch for testing

@iskounen this doesn't fix anything from https://github.com/artsy/force/pull/17196 — though in principle it should surface it (though I can't repro the error locally currently).

cc @artsy/diamond-devs 