### PR TITLE
fix(EMI-3238): do not re-fetch shipping method when clicking on the selected address

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/Order2SavedAddressOptions.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/Order2SavedAddressOptions.tsx
@@ -238,6 +238,8 @@ export const SavedAddressOptions = ({
 
   const handleAddressClick = useCallback(
     async (processedAddress: ProcessedUserAddress) => {
+      if (processedAddress.internalID === selectedAddress?.internalID) return
+
       checkoutTracking.clickedShippingAddress()
       setSelectedAddress(processedAddress)
       setIsSelecting(true)
@@ -266,6 +268,7 @@ export const SavedAddressOptions = ({
       isOfferOrder,
       onSelectAddress,
       onSelectInvalidAddress,
+      selectedAddress,
       setSectionErrorMessage,
     ],
   )

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/Order2SavedAddressOptions.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/Order2SavedAddressOptions.jest.tsx
@@ -267,13 +267,18 @@ describe("SavedAddressOptions", () => {
     })
 
     it("does not call onSelectAddress when clicking the already-selected address", async () => {
-      renderSavedAddressOptions()
+      renderSavedAddressOptions({ initialSelectedAddress: undefined })
 
-      // mockUSAddress1 is the initialSelectedAddress, so it's already selected
-      const firstAddress = screen.getByRole("radio", { name: /John Doe/i })
-      await userEvent.click(firstAddress)
+      const secondAddress = screen.getByRole("radio", { name: /Jane Smith/i })
 
-      expect(onSelectAddress).not.toHaveBeenCalled()
+      // First click: selects Jane Smith and triggers onSelectAddress
+      await userEvent.click(secondAddress)
+      expect(onSelectAddress).toHaveBeenCalledTimes(1)
+      expect(onSelectAddress).toHaveBeenCalledWith(mockUSAddress2)
+
+      // Second click on same address: guard fires, no re-submission
+      await userEvent.click(secondAddress)
+      expect(onSelectAddress).toHaveBeenCalledTimes(1)
     })
 
     it("disables non-selected addresses while a selection is in flight", async () => {

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/Order2SavedAddressOptions.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/Order2SavedAddressOptions.jest.tsx
@@ -266,6 +266,16 @@ describe("SavedAddressOptions", () => {
       ).toHaveBeenCalled()
     })
 
+    it("does not call onSelectAddress when clicking the already-selected address", async () => {
+      renderSavedAddressOptions()
+
+      // mockUSAddress1 is the initialSelectedAddress, so it's already selected
+      const firstAddress = screen.getByRole("radio", { name: /John Doe/i })
+      await userEvent.click(firstAddress)
+
+      expect(onSelectAddress).not.toHaveBeenCalled()
+    })
+
     it("disables non-selected addresses while a selection is in flight", async () => {
       let resolveSelect: () => void = () => {}
       onSelectAddress.mockImplementation(

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/Order2SavedAddressOptions.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/Order2SavedAddressOptions.jest.tsx
@@ -267,18 +267,25 @@ describe("SavedAddressOptions", () => {
     })
 
     it("does not call onSelectAddress when clicking the already-selected address", async () => {
-      renderSavedAddressOptions({ initialSelectedAddress: undefined })
+      mockUseCheckoutContext.mockReturnValue({
+        ...mockCheckoutContext,
+        steps: [
+          {
+            name: CheckoutStepName.FULFILLMENT_DETAILS,
+            state: CheckoutStepState.ACTIVE,
+          },
+          {
+            name: CheckoutStepName.DELIVERY_OPTION,
+            state: CheckoutStepState.ACTIVE,
+          },
+        ],
+      })
 
-      const secondAddress = screen.getByRole("radio", { name: /Jane Smith/i })
+      renderSavedAddressOptions({ initialSelectedAddress: mockUSAddress1 })
 
-      // First click: selects Jane Smith and triggers onSelectAddress
-      await userEvent.click(secondAddress)
-      expect(onSelectAddress).toHaveBeenCalledTimes(1)
-      expect(onSelectAddress).toHaveBeenCalledWith(mockUSAddress2)
+      await userEvent.click(screen.getByRole("radio", { name: /John Doe/i }))
 
-      // Second click on same address: guard fires, no re-submission
-      await userEvent.click(secondAddress)
-      expect(onSelectAddress).toHaveBeenCalledTimes(1)
+      expect(onSelectAddress).not.toHaveBeenCalled()
     })
 
     it("disables non-selected addresses while a selection is in flight", async () => {

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/__tests__/Order2DeliveryForm.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/__tests__/Order2DeliveryForm.jest.tsx
@@ -1,5 +1,9 @@
 import { act, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
+import {
+  CheckoutStepName,
+  CheckoutStepState,
+} from "Apps/Order2/Routes/Checkout/CheckoutContext/types"
 import { useSelectDeliveryOption } from "Apps/Order2/Routes/Checkout/Hooks/useSelectDeliveryOption"
 import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
@@ -9,7 +13,6 @@ import {
   orderMutationError,
   orderMutationSuccess,
 } from "../../../__tests__/utils"
-import { CheckoutStepName } from "Apps/Order2/Routes/Checkout/CheckoutContext/types"
 import { Order2DeliveryForm } from "../Order2DeliveryForm"
 
 jest.unmock("react-relay")
@@ -1292,7 +1295,21 @@ describe("Order2DeliveryForm", () => {
       screen.getByText("Germany")
     })
 
-    it("pre-selects a matching saved address and auto-submits on radio click", async () => {
+    it("pre-selects the saved address matching existing fulfillment details and auto-submits", async () => {
+      mockCheckoutContext = {
+        ...mockCheckoutContext,
+        checkoutTracking: {
+          ...mockCheckoutContext.checkoutTracking,
+          savedAddressViewed: jest.fn(),
+        },
+        steps: [
+          {
+            name: CheckoutStepName.FULFILLMENT_DETAILS,
+            state: CheckoutStepState.ACTIVE,
+          },
+        ],
+      }
+
       const { mockResolveLastOperation } = renderWithRelay({
         Me: () => ({
           ...baseMeProps,
@@ -1316,12 +1333,15 @@ describe("Order2DeliveryForm", () => {
       })
 
       await waitFor(() => {
-        expect(screen.getByText("Delivery address")).toBeInTheDocument()
+        expect(screen.getByText("New York, NY 10001")).toBeInTheDocument()
       })
 
-      // Two addresses share the name "John Doe" — click by street address text
-      userEvent.click(screen.getByText("123 Main St"))
+      // The matching saved address is pre-selected
+      expect(
+        screen.getByRole("radio", { name: /123 Main St/i }),
+      ).toHaveAttribute("aria-checked", "true")
 
+      // Auto-save fires on mount and submits the pre-selected address
       let mutation
       await waitFor(() => {
         mutation = mockResolveLastOperation({
@@ -1629,19 +1649,6 @@ describe("Order2DeliveryForm", () => {
           ...baseMeProps,
           order: {
             ...baseOrderProps,
-            fulfillmentDetails: {
-              name: "John Doe",
-              addressLine1: "123 Main St",
-              addressLine2: "Apt 4",
-              city: "New York",
-              region: "NY",
-              postalCode: "10001",
-              country: "US",
-              phoneNumber: {
-                regionCode: "us",
-                originalNumber: "5551234567",
-              },
-            },
           },
         }),
       })


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-3238]

### Description

<!-- Implementation description -->
Do not re-fetch shipping method when clicking on the selected address

[EMI-3238]: https://artsyproduct.atlassian.net/browse/EMI-3238?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ