### PR TITLE
feat(tracking): add home artwork item impression events (NWFY and art…

### DIFF
--- a/src/Apps/ArtworkRecommendations/Components/ArtworkRecommendationsArtworksGrid.tsx
+++ b/src/Apps/ArtworkRecommendations/Components/ArtworkRecommendationsArtworksGrid.tsx
@@ -1,8 +1,10 @@
+import { ContextModule, OwnerType } from "@artsy/cohesion"
 import { Text } from "@artsy/palette"
 import ArtworkGrid, {
-  ArtworkGridLayout,
+  type ArtworkGridLayout,
 } from "Components/ArtworkGrid/ArtworkGrid"
 import { InfiniteScrollSentinel } from "Components/InfiniteScrollSentinel"
+import { ArtworkItemImpression } from "Components/RailImpression/ArtworkItemImpression"
 import { useRouter } from "System/Hooks/useRouter"
 import type { ArtworkRecommendationsArtworksGrid_me$key } from "__generated__/ArtworkRecommendationsArtworksGrid_me.graphql"
 import type { FC } from "react"
@@ -50,6 +52,19 @@ export const ArtworkRecommendationsArtworksGrid: FC<
         artworks={data.artworkRecommendations}
         columnCount={[2, 3, 4]}
         layout={layout}
+        renderItemWrapper={({ artwork, artworkIndex, children }) => {
+          return (
+            <ArtworkItemImpression
+              artworkID={artwork.internalID}
+              contextModule={ContextModule.artworkGrid}
+              contextScreen={OwnerType.artworkRecommendations}
+              position={artworkIndex}
+              width="100%"
+            >
+              {children}
+            </ArtworkItemImpression>
+          )
+        }}
       />
 
       {hasNext && <InfiniteScrollSentinel onNext={handleNext} />}

--- a/src/Apps/ArtworkRecommendations/Components/__tests__/ArtworkRecommendationsArtworksGrid.jest.tsx
+++ b/src/Apps/ArtworkRecommendations/Components/__tests__/ArtworkRecommendationsArtworksGrid.jest.tsx
@@ -1,0 +1,76 @@
+import { act, screen } from "@testing-library/react"
+import { ArtworkRecommendationsArtworksGrid } from "Apps/ArtworkRecommendations/Components/ArtworkRecommendationsArtworksGrid"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
+import { graphql } from "react-relay"
+import { useTracking } from "react-tracking"
+import { intersect } from "Utils/Hooks/__tests__/mockIntersectionObserver"
+
+jest.unmock("react-relay")
+jest.mock("react-tracking")
+jest.mock("System/Hooks/useAnalyticsContext", () => ({
+  useAnalyticsContext: () => ({
+    contextPageOwnerType: "artworkRecommendations",
+  }),
+}))
+
+const { renderWithRelay } = setupTestWrapperTL({
+  Component: (props: any) => {
+    return <ArtworkRecommendationsArtworksGrid me={props.me!} />
+  },
+  query: graphql`
+    query ArtworkRecommendationsArtworksGrid_Test_Query @relay_test_operation {
+      me {
+        ...ArtworkRecommendationsArtworksGrid_me
+      }
+    }
+  `,
+})
+
+const trackEvent = jest.fn()
+
+beforeAll(() => {
+  ;(useTracking as jest.Mock).mockImplementation(() => ({ trackEvent }))
+})
+
+afterEach(() => {
+  trackEvent.mockClear()
+  jest.useRealTimers()
+})
+
+describe("ArtworkRecommendationsArtworksGrid", () => {
+  it("tracks artwork item viewed impressions", () => {
+    jest.useFakeTimers()
+
+    renderWithRelay({
+      ArtworkConnection: () => ({
+        totalCount: 1,
+        edges: [
+          {
+            node: {
+              internalID: "artwork-1-id",
+              slug: "artwork-1",
+            },
+          },
+        ],
+      }),
+    })
+
+    const item = screen.getAllByTestId("ArtworkItemImpression")[0]
+
+    act(() => intersect(item, true))
+    act(() => jest.advanceTimersByTime(500))
+
+    expect(trackEvent).not.toHaveBeenCalled()
+
+    act(() => jest.advanceTimersByTime(501))
+
+    expect(trackEvent).toHaveBeenCalledWith({
+      action: "item_viewed",
+      context_module: "artworkGrid",
+      context_screen: "artworkRecommendations",
+      item_id: "artwork-1-id",
+      item_type: "artwork",
+      position: 0,
+    })
+  })
+})

--- a/src/Apps/Home/Components/HomeArtworkItemImpression.tsx
+++ b/src/Apps/Home/Components/HomeArtworkItemImpression.tsx
@@ -1,0 +1,27 @@
+import { OwnerType, type ContextModule } from "@artsy/cohesion"
+import type * as React from "react"
+import { ArtworkItemImpression } from "Components/RailImpression/ArtworkItemImpression"
+
+interface HomeArtworkItemImpressionProps {
+  artworkID: string
+  contextModule: ContextModule
+  disabled?: boolean
+  position: number
+}
+
+export const HomeArtworkItemImpression: React.FC<
+  React.PropsWithChildren<HomeArtworkItemImpressionProps>
+> = props => {
+  return (
+    <ArtworkItemImpression
+      artworkID={props.artworkID}
+      contextModule={props.contextModule}
+      contextScreen={OwnerType.home}
+      disabled={props.disabled}
+      display="inline-flex"
+      position={props.position}
+    >
+      {props.children}
+    </ArtworkItemImpression>
+  )
+}

--- a/src/Apps/Home/Components/HomeArtworkRecommendationsRail.tsx
+++ b/src/Apps/Home/Components/HomeArtworkRecommendationsRail.tsx
@@ -18,6 +18,7 @@ import { useSystemContext } from "System/Hooks/useSystemContext"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { extractNodes } from "Utils/extractNodes"
 import { getSignalLabel } from "Utils/getSignalLabel"
+import { HomeArtworkItemImpression } from "Apps/Home/Components/HomeArtworkItemImpression"
 import type { HomeArtworkRecommendationsRailQuery } from "__generated__/HomeArtworkRecommendationsRailQuery.graphql"
 import type { HomeArtworkRecommendationsRail_me$key } from "__generated__/HomeArtworkRecommendationsRail_me.graphql"
 import { graphql, useFragment } from "react-relay"
@@ -64,36 +65,43 @@ export const HomeArtworkRecommendationsRail: React.FC<
         trackEvent(trackingEvent)
       }}
       getItems={() => {
-        return artworks.map(artwork => (
-          <ShelfArtworkFragmentContainer
-            artwork={artwork}
+        return artworks.map((artwork, index) => (
+          <HomeArtworkItemImpression
+            artworkID={artwork.internalID}
+            contextModule={ContextModule.artworkRecommendationsRail}
+            disabled={railPositionY === undefined}
             key={artwork.internalID}
-            lazyLoad
-            contextModule={
-              ContextModule.artworkRecommendationsRail as AuthContextModule
-            }
-            onClick={() => {
-              const trackingEvent: ClickedArtworkGroup = {
-                action: ActionType.clickedArtworkGroup,
-                context_module: ContextModule.artworkRecommendationsRail,
-                context_page_owner_type: OwnerType.home,
-                destination_page_owner_id: artwork.internalID,
-                destination_page_owner_slug: artwork.slug,
-                destination_page_owner_type: OwnerType.artwork,
-                type: "thumbnail",
-                signal_label: getSignalLabel({
-                  signals: signals?.[artwork.internalID] ?? [],
-                }),
-                signal_bid_count:
-                  artwork.collectorSignals?.auction?.bidCount ?? undefined,
-                signal_lot_watcher_count:
-                  artwork.collectorSignals?.auction?.lotWatcherCount ??
-                  undefined,
+            position={index}
+          >
+            <ShelfArtworkFragmentContainer
+              artwork={artwork}
+              lazyLoad
+              contextModule={
+                ContextModule.artworkRecommendationsRail as AuthContextModule
               }
+              onClick={() => {
+                const trackingEvent: ClickedArtworkGroup = {
+                  action: ActionType.clickedArtworkGroup,
+                  context_module: ContextModule.artworkRecommendationsRail,
+                  context_page_owner_type: OwnerType.home,
+                  destination_page_owner_id: artwork.internalID,
+                  destination_page_owner_slug: artwork.slug,
+                  destination_page_owner_type: OwnerType.artwork,
+                  type: "thumbnail",
+                  signal_label: getSignalLabel({
+                    signals: signals?.[artwork.internalID] ?? [],
+                  }),
+                  signal_bid_count:
+                    artwork.collectorSignals?.auction?.bidCount ?? undefined,
+                  signal_lot_watcher_count:
+                    artwork.collectorSignals?.auction?.lotWatcherCount ??
+                    undefined,
+                }
 
-              trackEvent(trackingEvent)
-            }}
-          />
+                trackEvent(trackingEvent)
+              }}
+            />
+          </HomeArtworkItemImpression>
         ))
       }}
     />

--- a/src/Apps/Home/Components/HomeNewWorksForYouRail.tsx
+++ b/src/Apps/Home/Components/HomeNewWorksForYouRail.tsx
@@ -16,6 +16,7 @@ import { useSystemContext } from "System/Hooks/useSystemContext"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import { extractNodes } from "Utils/extractNodes"
 import { getSignalLabel } from "Utils/getSignalLabel"
+import { HomeArtworkItemImpression } from "Apps/Home/Components/HomeArtworkItemImpression"
 import type { HomeNewWorksForYouRailQuery } from "__generated__/HomeNewWorksForYouRailQuery.graphql"
 import type { HomeNewWorksForYouRail_artworksForUser$data } from "__generated__/HomeNewWorksForYouRail_artworksForUser.graphql"
 import type * as React from "react"
@@ -50,32 +51,39 @@ const HomeNewWorksForYouRail: React.FC<
           }
 
           return (
-            <ShelfArtworkFragmentContainer
-              artwork={artwork}
-              key={index}
+            <HomeArtworkItemImpression
+              artworkID={artwork.internalID}
               contextModule={ContextModule.newWorksForYouRail}
-              lazyLoad
-              onClick={() => {
-                const trackingEvent: ClickedArtworkGroup = {
-                  action: ActionType.clickedArtworkGroup,
-                  context_module: ContextModule.newWorksForYouRail,
-                  context_page_owner_type: OwnerType.home,
-                  destination_page_owner_id: artwork.internalID,
-                  destination_page_owner_slug: artwork.slug,
-                  destination_page_owner_type: OwnerType.artwork,
-                  type: "thumbnail",
-                  signal_label: getSignalLabel({
-                    signals: signals?.[artwork.internalID] ?? [],
-                  }),
-                  signal_bid_count:
-                    artwork.collectorSignals?.auction?.bidCount ?? undefined,
-                  signal_lot_watcher_count:
-                    artwork.collectorSignals?.auction?.lotWatcherCount ??
-                    undefined,
-                }
-                trackEvent(trackingEvent)
-              }}
-            />
+              disabled={railPositionY === undefined}
+              key={index}
+              position={index}
+            >
+              <ShelfArtworkFragmentContainer
+                artwork={artwork}
+                contextModule={ContextModule.newWorksForYouRail}
+                lazyLoad
+                onClick={() => {
+                  const trackingEvent: ClickedArtworkGroup = {
+                    action: ActionType.clickedArtworkGroup,
+                    context_module: ContextModule.newWorksForYouRail,
+                    context_page_owner_type: OwnerType.home,
+                    destination_page_owner_id: artwork.internalID,
+                    destination_page_owner_slug: artwork.slug,
+                    destination_page_owner_type: OwnerType.artwork,
+                    type: "thumbnail",
+                    signal_label: getSignalLabel({
+                      signals: signals?.[artwork.internalID] ?? [],
+                    }),
+                    signal_bid_count:
+                      artwork.collectorSignals?.auction?.bidCount ?? undefined,
+                    signal_lot_watcher_count:
+                      artwork.collectorSignals?.auction?.lotWatcherCount ??
+                      undefined,
+                  }
+                  trackEvent(trackingEvent)
+                }}
+              />
+            </HomeArtworkItemImpression>
           )
         })}
       </Shelf>

--- a/src/Apps/Home/Components/__tests__/HomeNewWorksForYouRail.jest.tsx
+++ b/src/Apps/Home/Components/__tests__/HomeNewWorksForYouRail.jest.tsx
@@ -1,17 +1,22 @@
-import { fireEvent, screen } from "@testing-library/react"
+import { act, fireEvent, screen } from "@testing-library/react"
 import { HomeNewWorksForYouRailFragmentContainer } from "Apps/Home/Components/HomeNewWorksForYouRail"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
 import { graphql } from "react-relay"
 import { useTracking } from "react-tracking"
+import { intersect } from "Utils/Hooks/__tests__/mockIntersectionObserver"
 
 jest.unmock("react-relay")
 jest.mock("react-tracking")
+jest.mock("System/Hooks/useAnalyticsContext", () => ({
+  useAnalyticsContext: () => ({ contextPageOwnerType: "home" }),
+}))
 
 const { renderWithRelay } = setupTestWrapperTL({
   Component: (props: any) => {
     return (
       <HomeNewWorksForYouRailFragmentContainer
         artworksForUser={props.artworksForUser!}
+        railPositionY={4}
       />
     )
   },
@@ -32,6 +37,7 @@ beforeAll(() => {
 
 afterEach(() => {
   trackEvent.mockClear()
+  jest.useRealTimers()
 })
 
 describe("HomeNewWorksForYouRail", () => {
@@ -102,6 +108,35 @@ describe("HomeNewWorksForYouRail", () => {
         signal_label: "",
         signal_bid_count: 1,
         signal_lot_watcher_count: 5,
+      })
+    })
+
+    it("tracks item viewed impressions", () => {
+      jest.useFakeTimers()
+
+      renderWithRelay({
+        Artwork: () => ({
+          internalID: "artwork-1-id",
+          slug: "artwork-1",
+        }),
+      })
+
+      const item = screen.getAllByTestId("ArtworkItemImpression")[0]
+
+      act(() => intersect(item, true))
+      act(() => jest.advanceTimersByTime(500))
+
+      expect(trackEvent).not.toHaveBeenCalled()
+
+      act(() => jest.advanceTimersByTime(501))
+
+      expect(trackEvent).toHaveBeenCalledWith({
+        action: "item_viewed",
+        context_module: "newWorksForYouRail",
+        context_screen: "home",
+        item_id: "artwork-1-id",
+        item_type: "artwork",
+        position: 0,
       })
     })
   })

--- a/src/Components/ArtworkGrid/ArtworkGrid.tsx
+++ b/src/Components/ArtworkGrid/ArtworkGrid.tsx
@@ -54,6 +54,11 @@ interface ArtworkGridProps {
   to?: (artwork: Artwork) => string | null
   savedListId?: string
   renderSaveButton?: (artworkId: string) => React.ReactNode
+  renderItemWrapper?: (props: {
+    artwork: Artwork
+    artworkIndex: number
+    children: React.ReactElement
+  }) => React.ReactNode
   popoverContent?: ReactNode | null
   onPopoverDismiss?: () => void
   className?: string
@@ -137,6 +142,22 @@ export class ArtworkGridContainer extends React.Component<
     }
   }
 
+  renderArtworkItemWrapper(
+    artwork: Artwork,
+    artworkIndex: number,
+    children: React.ReactElement,
+  ) {
+    if (!this.props.renderItemWrapper) {
+      return children
+    }
+
+    return this.props.renderItemWrapper({
+      artwork,
+      artworkIndex,
+      children,
+    })
+  }
+
   renderSectionsForSingleBreakpoint(
     columnCount: number,
     sectionedArtworks: SectionedArtworks,
@@ -174,40 +195,45 @@ export class ArtworkGridContainer extends React.Component<
         const artwork = sectionedArtworks[column][row]
 
         artworkComponents.push(
-          <GridItem
-            contextModule={contextModule}
-            artwork={artwork}
-            hideSaleInfo={hideSaleInfo}
-            key={artwork.id}
-            lazyLoad={
-              !!(
-                typeof preloadImageCount === "number" &&
-                artworkIndex >= preloadImageCount
-              )
-            }
-            onClick={() => {
-              if (this.props.onBrickClick) {
-                this.props.onBrickClick(artwork, artworkIndex)
-              }
-            }}
-            showHighDemandIcon={showHighDemandIcon}
-            showHoverDetails={
-              showHoverDetails === undefined ? true : showSaveButton
-            }
-            showSaveButton={
-              showSaveButton === undefined ? true : showSaveButton
-            }
-            to={to?.(artwork)}
-            savedListId={this.props.savedListId}
-            renderSaveButton={this.props.renderSaveButton}
-            popoverContent={
-              firstP1Artwork?.id === artwork.id
-                ? this.props.popoverContent
-                : null
-            }
-            onPopoverDismiss={this.props.onPopoverDismiss}
-            showSubmissionStatus={showSubmissionStatus}
-          />,
+          <React.Fragment key={artwork.id}>
+            {this.renderArtworkItemWrapper(
+              artwork,
+              artworkIndex,
+              <GridItem
+                contextModule={contextModule}
+                artwork={artwork}
+                hideSaleInfo={hideSaleInfo}
+                lazyLoad={
+                  !!(
+                    typeof preloadImageCount === "number" &&
+                    artworkIndex >= preloadImageCount
+                  )
+                }
+                onClick={() => {
+                  if (this.props.onBrickClick) {
+                    this.props.onBrickClick(artwork, artworkIndex)
+                  }
+                }}
+                showHighDemandIcon={showHighDemandIcon}
+                showHoverDetails={
+                  showHoverDetails === undefined ? true : showSaveButton
+                }
+                showSaveButton={
+                  showSaveButton === undefined ? true : showSaveButton
+                }
+                to={to?.(artwork)}
+                savedListId={this.props.savedListId}
+                renderSaveButton={this.props.renderSaveButton}
+                popoverContent={
+                  firstP1Artwork?.id === artwork.id
+                    ? this.props.popoverContent
+                    : null
+                }
+                onPopoverDismiss={this.props.onPopoverDismiss}
+                showSubmissionStatus={showSubmissionStatus}
+              />,
+            )}
+          </React.Fragment>,
         )
         // Setting a marginBottom on the artwork component didn’t work, so using a spacer view instead.
         if (row < sectionedArtworks[column].length - 1) {
@@ -248,14 +274,18 @@ export class ArtworkGridContainer extends React.Component<
         {nodes.map((artwork, index) => {
           return (
             <Column span={[6, 3]} key={artwork.internalID} minWidth={0}>
-              <FlatGridItemFragmentContainer
-                onClick={() => {
-                  if (this.props.onBrickClick) {
-                    this.props.onBrickClick(artwork, index)
-                  }
-                }}
-                artwork={artwork}
-              />
+              {this.renderArtworkItemWrapper(
+                artwork,
+                index,
+                <FlatGridItemFragmentContainer
+                  onClick={() => {
+                    if (this.props.onBrickClick) {
+                      this.props.onBrickClick(artwork, index)
+                    }
+                  }}
+                  artwork={artwork}
+                />,
+              )}
             </Column>
           )
         })}

--- a/src/Components/RailImpression/ArtworkItemImpression.tsx
+++ b/src/Components/RailImpression/ArtworkItemImpression.tsx
@@ -1,0 +1,46 @@
+import { Box, type BoxProps } from "@artsy/palette"
+import type { ContextModule, OwnerType } from "@artsy/cohesion"
+import type * as React from "react"
+import { useArtworkItemImpressionTracking } from "Components/RailImpression/useArtworkItemImpressionTracking"
+
+interface ArtworkItemImpressionProps {
+  artworkID: string
+  contextModule: ContextModule
+  contextScreen: OwnerType
+  disabled?: boolean
+  display?: BoxProps["display"]
+  position: number
+  width?: BoxProps["width"]
+}
+
+export const ArtworkItemImpression: React.FC<
+  React.PropsWithChildren<ArtworkItemImpressionProps>
+> = ({
+  artworkID,
+  children,
+  contextModule,
+  contextScreen,
+  disabled,
+  display,
+  position,
+  width,
+}) => {
+  const { itemImpressionRef } = useArtworkItemImpressionTracking({
+    contextModule,
+    contextScreen,
+    disabled,
+    itemID: artworkID,
+    position,
+  })
+
+  return (
+    <Box
+      ref={itemImpressionRef}
+      display={display}
+      width={width}
+      data-testid="ArtworkItemImpression"
+    >
+      {children}
+    </Box>
+  )
+}

--- a/src/Components/RailImpression/__tests__/useArtworkItemImpressionTracking.jest.tsx
+++ b/src/Components/RailImpression/__tests__/useArtworkItemImpressionTracking.jest.tsx
@@ -1,0 +1,231 @@
+import { act, render, screen } from "@testing-library/react"
+import { ActionType, ContextModule, OwnerType } from "@artsy/cohesion"
+import { useArtworkItemImpressionTracking } from "Components/RailImpression/useArtworkItemImpressionTracking"
+import { DEFAULT_RAIL_VISIBILITY_COVERAGE_SLACK } from "Components/RailImpression/useRailImpressionTracking"
+import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
+import type * as React from "react"
+import { useTracking } from "react-tracking"
+import { intersect } from "Utils/Hooks/__tests__/mockIntersectionObserver"
+
+jest.mock("react-tracking")
+jest.mock("System/Hooks/useAnalyticsContext")
+
+const mockDomRect = (height: number, width: number): DOMRectReadOnly =>
+  ({
+    height,
+    width,
+    top: 0,
+    left: 0,
+    bottom: height,
+    right: width,
+    x: 0,
+    y: 0,
+    toJSON: () => ({}),
+  }) as DOMRectReadOnly
+
+const TestItem: React.FC<{
+  contextScreen?: OwnerType
+  disabled?: boolean
+  itemID?: string
+  position?: number
+  visibilityDurationMs?: number
+  visibilityCoverageSlack?: number
+}> = ({
+  contextScreen = OwnerType.home,
+  disabled,
+  itemID = "artwork-1-id",
+  position = 0,
+  visibilityDurationMs,
+  visibilityCoverageSlack = DEFAULT_RAIL_VISIBILITY_COVERAGE_SLACK,
+}) => {
+  const { itemImpressionRef } = useArtworkItemImpressionTracking({
+    contextModule: ContextModule.newWorksForYouRail,
+    contextScreen,
+    disabled,
+    itemID,
+    position,
+    visibilityDurationMs,
+    visibilityCoverageSlack,
+  })
+
+  return (
+    <div ref={itemImpressionRef} data-testid="item-root">
+      artwork
+    </div>
+  )
+}
+
+describe("useArtworkItemImpressionTracking", () => {
+  const mockTrackEvent = jest.fn()
+
+  beforeEach(() => {
+    jest.useFakeTimers()
+    ;(useTracking as jest.Mock).mockReturnValue({ trackEvent: mockTrackEvent })
+    ;(useAnalyticsContext as jest.Mock).mockReturnValue({
+      contextPageOwnerType: OwnerType.home,
+    })
+    mockTrackEvent.mockClear()
+  })
+
+  afterEach(() => {
+    jest.useRealTimers()
+  })
+
+  it("fires itemViewed after the artwork stays in view for visibilityDurationMs", () => {
+    render(<TestItem visibilityDurationMs={500} />)
+
+    const root = screen.getByTestId("item-root")
+
+    act(() => intersect(root, true))
+    act(() => jest.advanceTimersByTime(499))
+    expect(mockTrackEvent).not.toHaveBeenCalled()
+
+    act(() => jest.advanceTimersByTime(1))
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1)
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      action: ActionType.itemViewed,
+      context_module: ContextModule.newWorksForYouRail,
+      context_screen: OwnerType.home,
+      item_id: "artwork-1-id",
+      item_type: "artwork",
+      position: 0,
+    })
+  })
+
+  it("does not fire if the artwork leaves the viewport before visibilityDurationMs", () => {
+    render(<TestItem visibilityDurationMs={1000} />)
+
+    const root = screen.getByTestId("item-root")
+
+    act(() => intersect(root, true))
+    act(() => jest.advanceTimersByTime(500))
+    act(() => intersect(root, false))
+    act(() => jest.advanceTimersByTime(1000))
+
+    expect(mockTrackEvent).not.toHaveBeenCalled()
+  })
+
+  it("fires only once for the same mounted artwork", () => {
+    render(<TestItem visibilityDurationMs={100} />)
+
+    const root = screen.getByTestId("item-root")
+
+    act(() => intersect(root, true))
+    act(() => jest.advanceTimersByTime(100))
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1)
+
+    act(() => intersect(root, false))
+    act(() => intersect(root, true))
+    act(() => jest.advanceTimersByTime(500))
+
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1)
+  })
+
+  it("starts tracking again after unmount and remount", () => {
+    const { unmount } = render(<TestItem visibilityDurationMs={100} />)
+
+    act(() => intersect(screen.getByTestId("item-root"), true))
+    act(() => jest.advanceTimersByTime(100))
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1)
+
+    unmount()
+
+    render(<TestItem visibilityDurationMs={100} />)
+
+    act(() => intersect(screen.getByTestId("item-root"), true))
+    act(() => jest.advanceTimersByTime(100))
+
+    expect(mockTrackEvent).toHaveBeenCalledTimes(2)
+  })
+
+  it("includes position when provided", () => {
+    render(<TestItem position={3} visibilityDurationMs={100} />)
+
+    const root = screen.getByTestId("item-root")
+
+    act(() => intersect(root, true))
+    act(() => jest.advanceTimersByTime(100))
+
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ position: 3 }),
+    )
+  })
+
+  it("does not observe or fire when disabled", () => {
+    render(<TestItem disabled visibilityDurationMs={100} />)
+
+    const root = screen.getByTestId("item-root")
+
+    expect(IntersectionObserver).not.toHaveBeenCalled()
+
+    act(() => intersect(root, true))
+    act(() => jest.advanceTimersByTime(100))
+
+    expect(mockTrackEvent).not.toHaveBeenCalled()
+  })
+
+  it("does not observe or fire outside the home screen", () => {
+    ;(useAnalyticsContext as jest.Mock).mockReturnValue({
+      contextPageOwnerType: OwnerType.artist,
+    })
+
+    render(<TestItem visibilityDurationMs={100} />)
+
+    const root = screen.getByTestId("item-root")
+
+    expect(IntersectionObserver).not.toHaveBeenCalled()
+
+    act(() => intersect(root, true))
+    act(() => jest.advanceTimersByTime(100))
+
+    expect(mockTrackEvent).not.toHaveBeenCalled()
+  })
+
+  it("fires on a configured non-home screen", () => {
+    ;(useAnalyticsContext as jest.Mock).mockReturnValue({
+      contextPageOwnerType: OwnerType.artworkRecommendations,
+    })
+
+    render(
+      <TestItem
+        contextScreen={OwnerType.artworkRecommendations}
+        visibilityDurationMs={100}
+      />,
+    )
+
+    const root = screen.getByTestId("item-root")
+
+    act(() => intersect(root, true))
+    act(() => jest.advanceTimersByTime(100))
+
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      action: ActionType.itemViewed,
+      context_module: ContextModule.newWorksForYouRail,
+      context_screen: OwnerType.artworkRecommendations,
+      item_id: "artwork-1-id",
+      item_type: "artwork",
+      position: 0,
+    })
+  })
+
+  it("fires for a tall item when roughly as much as can fit is visible", () => {
+    render(<TestItem visibilityDurationMs={100} />)
+
+    const root = screen.getByTestId("item-root")
+    const rootH = 800
+    const targetH = 2500
+    const maxRatio = rootH / targetH
+    const required = maxRatio * DEFAULT_RAIL_VISIBILITY_COVERAGE_SLACK
+
+    act(() =>
+      intersect(root, true, {
+        intersectionRatio: required + 0.02,
+        boundingClientRect: mockDomRect(targetH, 100),
+        rootBounds: mockDomRect(rootH, 400),
+      }),
+    )
+    act(() => jest.advanceTimersByTime(100))
+
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/Components/RailImpression/useArtworkItemImpressionTracking.ts
+++ b/src/Components/RailImpression/useArtworkItemImpressionTracking.ts
@@ -1,0 +1,61 @@
+import {
+  ActionType,
+  type ContextModule,
+  type ItemViewed,
+  type OwnerType,
+} from "@artsy/cohesion"
+import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
+import {
+  DEFAULT_RAIL_IMPRESSION_VISIBILITY_MS,
+  DEFAULT_RAIL_VISIBILITY_COVERAGE_SLACK,
+  useDwellImpressionTracking,
+} from "Components/RailImpression/useDwellImpressionTracking"
+import type { RefCallback } from "react"
+import { useTracking } from "react-tracking"
+
+interface UseArtworkItemImpressionTrackingOptions {
+  contextModule: ContextModule
+  contextScreen: OwnerType
+  disabled?: boolean
+  itemID: string
+  position: number
+  visibilityDurationMs?: number
+  visibilityCoverageSlack?: number
+}
+
+interface UseArtworkItemImpressionTrackingResult {
+  itemImpressionRef: RefCallback<HTMLDivElement>
+}
+
+export const useArtworkItemImpressionTracking = ({
+  contextModule,
+  contextScreen,
+  disabled = false,
+  itemID,
+  position,
+  visibilityDurationMs = DEFAULT_RAIL_IMPRESSION_VISIBILITY_MS,
+  visibilityCoverageSlack = DEFAULT_RAIL_VISIBILITY_COVERAGE_SLACK,
+}: UseArtworkItemImpressionTrackingOptions): UseArtworkItemImpressionTrackingResult => {
+  const { trackEvent } = useTracking()
+  const { contextPageOwnerType } = useAnalyticsContext()
+
+  const { impressionRef } = useDwellImpressionTracking({
+    disabled: disabled || contextPageOwnerType !== contextScreen,
+    visibilityDurationMs,
+    visibilityCoverageSlack,
+    onImpression: () => {
+      const payload: ItemViewed = {
+        action: ActionType.itemViewed,
+        context_module: contextModule,
+        context_screen: contextPageOwnerType as OwnerType,
+        item_id: itemID,
+        item_type: "artwork",
+        position,
+      }
+
+      trackEvent(payload)
+    },
+  })
+
+  return { itemImpressionRef: impressionRef }
+}

--- a/src/Components/RailImpression/useDwellImpressionTracking.ts
+++ b/src/Components/RailImpression/useDwellImpressionTracking.ts
@@ -1,0 +1,139 @@
+import {
+  type RefCallback,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react"
+
+/** Default dwell time (ms) before an impression event is emitted. */
+export const DEFAULT_RAIL_IMPRESSION_VISIBILITY_MS = 1000
+
+/**
+ * How much of the target must be on screen, expressed as a fraction of the
+ * maximum visible ratio physically achievable for the target.
+ */
+export const DEFAULT_RAIL_VISIBILITY_COVERAGE_SLACK = 0.98
+
+export const RAIL_IMPRESSION_INTERSECTION_THRESHOLDS = Array.from(
+  { length: 21 },
+  (_, i) => i / 20,
+)
+
+function requiredVisibilityRatio(
+  entry: IntersectionObserverEntry,
+  coverageSlack: number,
+): number {
+  const targetHeight = entry.boundingClientRect.height
+  const rootHeight = entry.rootBounds?.height
+
+  if (!Number.isFinite(targetHeight) || targetHeight <= 0) {
+    return coverageSlack
+  }
+  if (
+    rootHeight === undefined ||
+    !Number.isFinite(rootHeight) ||
+    rootHeight <= 0
+  ) {
+    return coverageSlack
+  }
+
+  const maxAchievableRatio = Math.min(1, rootHeight / targetHeight)
+  return maxAchievableRatio * coverageSlack
+}
+
+export function meetsRailVisibilityRequirement(
+  entry: IntersectionObserverEntry,
+  coverageSlack: number,
+): boolean {
+  if (!entry.isIntersecting) return false
+  const required = requiredVisibilityRatio(entry, coverageSlack)
+  // Guards against floating-point drift where the browser reports e.g.
+  // 0.9999999 when the element is exactly at the threshold.
+  return entry.intersectionRatio + 1e-6 >= required
+}
+
+interface UseDwellImpressionTrackingOptions {
+  disabled?: boolean
+  onImpression: () => void
+  visibilityDurationMs?: number
+  visibilityCoverageSlack?: number
+}
+
+interface UseDwellImpressionTrackingResult {
+  impressionRef: RefCallback<HTMLDivElement>
+}
+
+export const useDwellImpressionTracking = ({
+  disabled = false,
+  onImpression,
+  visibilityDurationMs = DEFAULT_RAIL_IMPRESSION_VISIBILITY_MS,
+  visibilityCoverageSlack = DEFAULT_RAIL_VISIBILITY_COVERAGE_SLACK,
+}: UseDwellImpressionTrackingOptions): UseDwellImpressionTrackingResult => {
+  const [element, setElement] = useState<HTMLDivElement | null>(null)
+  const impressionRef = useCallback((node: HTMLDivElement | null) => {
+    setElement(node)
+  }, [])
+
+  const onImpressionRef = useRef(onImpression)
+  onImpressionRef.current = onImpression
+
+  useEffect(() => {
+    if (disabled) return
+    if (!element || typeof IntersectionObserver === "undefined") return
+
+    let hasTracked = false
+    let timer: ReturnType<typeof setTimeout> | null = null
+    const meetsRequirementRef = { current: false }
+    const observerRef: { current: IntersectionObserver | null } = {
+      current: null,
+    }
+
+    const emit = () => {
+      if (hasTracked) return
+      hasTracked = true
+      onImpressionRef.current()
+      observerRef.current?.disconnect()
+    }
+
+    observerRef.current = new IntersectionObserver(
+      entries => {
+        if (hasTracked) return
+
+        const entry = entries[entries.length - 1]
+        if (!entry) return
+
+        const meets = meetsRailVisibilityRequirement(
+          entry,
+          visibilityCoverageSlack,
+        )
+        meetsRequirementRef.current = meets
+
+        if (meets) {
+          if (timer) clearTimeout(timer)
+          timer = setTimeout(() => {
+            if (hasTracked || !meetsRequirementRef.current) return
+            emit()
+          }, visibilityDurationMs)
+        } else if (timer) {
+          clearTimeout(timer)
+          timer = null
+        }
+      },
+      {
+        threshold: RAIL_IMPRESSION_INTERSECTION_THRESHOLDS,
+        root: null,
+        rootMargin: "0px",
+      },
+    )
+
+    observerRef.current.observe(element)
+
+    return () => {
+      observerRef.current?.disconnect()
+      if (timer) clearTimeout(timer)
+    }
+  }, [disabled, element, visibilityCoverageSlack, visibilityDurationMs])
+
+  return { impressionRef }
+}

--- a/src/Components/RailImpression/useRailImpressionTracking.ts
+++ b/src/Components/RailImpression/useRailImpressionTracking.ts
@@ -6,97 +6,20 @@ import {
 } from "@artsy/cohesion"
 import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
 import {
-  type RefCallback,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from "react"
+  DEFAULT_RAIL_IMPRESSION_VISIBILITY_MS,
+  DEFAULT_RAIL_VISIBILITY_COVERAGE_SLACK,
+  RAIL_IMPRESSION_INTERSECTION_THRESHOLDS,
+  meetsRailVisibilityRequirement,
+  useDwellImpressionTracking,
+} from "Components/RailImpression/useDwellImpressionTracking"
+import { type RefCallback, useEffect, useRef } from "react"
 import { useTracking } from "react-tracking"
 
-/** Default dwell time (ms) before a {@link RailViewed} event is emitted. */
-export const DEFAULT_RAIL_IMPRESSION_VISIBILITY_MS = 1000
-
-/**
- * How much of the rail must be on screen, expressed as a fraction of the
- * **maximum visible ratio physically achievable** for the rail (not a fraction
- * of the rail itself). See {@link requiredVisibilityRatio} for the math.
- *
- * - Short rail (fits in viewport): max achievable ratio is 1.0, so we require
- *   ~98% of the rail visible. The 2% slack absorbs sub-pixel rounding,
- *   fractional device pixel ratios, sticky headers, etc. — without it,
- *   "fully visible" rails would never satisfy `intersectionRatio >= 1.0` on
- *   some browsers.
- * - Tall rail (taller than viewport, e.g. Market News at ~2500px in an 800px
- *   viewport): max achievable ratio is `viewportH / railH` ≈ 0.32, so we
- *   require ~0.98 × 0.32 ≈ 31% of the rail visible — i.e. the rail is filling
- *   roughly as much of the viewport as it possibly can.
- */
-export const DEFAULT_RAIL_VISIBILITY_COVERAGE_SLACK = 0.98
-
-/**
- * Thresholds passed to {@link IntersectionObserver}. The observer wakes our
- * callback whenever the target's visible fraction **crosses** one of these
- * values; with 21 evenly-spaced points (0%, 5%, 10%, …, 100%) we re-evaluate
- * roughly every 5% of visibility change.
- *
- * Why an array rather than a single threshold: the required ratio is computed
- * dynamically per-element (see {@link DEFAULT_RAIL_VISIBILITY_COVERAGE_SLACK}),
- * so we need wake-ups across the whole 0–1 range. Why 5% and not 1%: 1% steps
- * would fire ~100 callbacks per scroll-past — wasteful and finer than the
- * `0.98 × maxRatio` precision we actually need.
- */
-export const RAIL_IMPRESSION_INTERSECTION_THRESHOLDS = Array.from(
-  { length: 21 },
-  (_, i) => i / 20,
-)
-
-/**
- * Minimum `intersectionRatio` the entry must meet to count as "in view."
- *
- *   maxAchievableRatio = min(1, viewportHeight / railHeight)
- *   required           = maxAchievableRatio * coverageSlack
- *
- * When the rail fits in the viewport, `maxAchievableRatio` is 1 and the result
- * is just `coverageSlack` (≈ 0.98). When the rail is taller than the viewport
- * the rail can never reach ratio 1, so we scale the requirement down to "as
- * much as can fit, minus the slack."
- *
- * Falls back to `coverageSlack` (the stricter short-rail threshold) when the
- * heights are missing or invalid — that's safe for short rails but means a
- * tall rail without `rootBounds` (rare iframe/SSR edge cases) won't fire.
- */
-function requiredVisibilityRatio(
-  entry: IntersectionObserverEntry,
-  coverageSlack: number,
-): number {
-  const targetHeight = entry.boundingClientRect.height
-  const rootHeight = entry.rootBounds?.height
-
-  if (!Number.isFinite(targetHeight) || targetHeight <= 0) {
-    return coverageSlack
-  }
-  if (
-    rootHeight === undefined ||
-    !Number.isFinite(rootHeight) ||
-    rootHeight <= 0
-  ) {
-    return coverageSlack
-  }
-
-  const maxAchievableRatio = Math.min(1, rootHeight / targetHeight)
-  return maxAchievableRatio * coverageSlack
-}
-
-function meetsRailVisibilityRequirement(
-  entry: IntersectionObserverEntry,
-  coverageSlack: number,
-): boolean {
-  if (!entry.isIntersecting) return false
-  const required = requiredVisibilityRatio(entry, coverageSlack)
-  // 1e-6 epsilon: guards against floating-point drift where the browser
-  // reports e.g. 0.9999999 when the element is exactly at the threshold.
-  return entry.intersectionRatio + 1e-6 >= required
+export {
+  DEFAULT_RAIL_IMPRESSION_VISIBILITY_MS,
+  DEFAULT_RAIL_VISIBILITY_COVERAGE_SLACK,
+  RAIL_IMPRESSION_INTERSECTION_THRESHOLDS,
+  meetsRailVisibilityRequirement,
 }
 
 export interface UseRailImpressionTrackingOptions {
@@ -161,34 +84,11 @@ export const useRailImpressionTracking = ({
     console.warn("Missing analytics context for rail impression")
   }, [contextPageOwnerType, disabled])
 
-  const [element, setElement] = useState<HTMLDivElement | null>(null)
-  const railImpressionRef = useCallback((node: HTMLDivElement | null) => {
-    setElement(node)
-  }, [])
-
-  const trackEventRef = useRef(trackEvent)
-  trackEventRef.current = trackEvent
-
-  useEffect(() => {
-    if (disabled) return
-    if (!element || typeof IntersectionObserver === "undefined") {
-      return
-    }
-    // Don't fire without a screen — would ship `context_screen: undefined`.
-    // The effect re-runs when contextPageOwnerType resolves.
-    if (!contextPageOwnerType) return
-
-    let hasTracked = false
-    let timer: ReturnType<typeof setTimeout> | null = null
-    const meetsRequirementRef = { current: false }
-    const observerRef: { current: IntersectionObserver | null } = {
-      current: null,
-    }
-
-    const emit = () => {
-      if (hasTracked) return
-      hasTracked = true
-
+  const { impressionRef } = useDwellImpressionTracking({
+    disabled: disabled || !contextPageOwnerType,
+    visibilityDurationMs,
+    visibilityCoverageSlack,
+    onImpression: () => {
       const payload: RailViewed = {
         action: ActionType.railViewed,
         context_module: contextModule,
@@ -196,56 +96,9 @@ export const useRailImpressionTracking = ({
         ...(positionY !== undefined ? { position_y: positionY } : {}),
       }
 
-      trackEventRef.current(payload)
-      observerRef.current?.disconnect()
-    }
+      trackEvent(payload)
+    },
+  })
 
-    observerRef.current = new IntersectionObserver(
-      entries => {
-        if (hasTracked) return
-
-        const entry = entries[entries.length - 1]
-        if (!entry) return
-
-        const meets = meetsRailVisibilityRequirement(
-          entry,
-          visibilityCoverageSlack,
-        )
-        meetsRequirementRef.current = meets
-
-        if (meets) {
-          if (timer) clearTimeout(timer)
-          timer = setTimeout(() => {
-            if (hasTracked || !meetsRequirementRef.current) return
-            emit()
-          }, visibilityDurationMs)
-        } else if (timer) {
-          clearTimeout(timer)
-          timer = null
-        }
-      },
-      {
-        threshold: RAIL_IMPRESSION_INTERSECTION_THRESHOLDS,
-        root: null,
-        rootMargin: "0px",
-      },
-    )
-
-    observerRef.current.observe(element)
-
-    return () => {
-      observerRef.current?.disconnect()
-      if (timer) clearTimeout(timer)
-    }
-  }, [
-    contextModule,
-    contextPageOwnerType,
-    disabled,
-    element,
-    positionY,
-    visibilityCoverageSlack,
-    visibilityDurationMs,
-  ])
-
-  return { railImpressionRef }
+  return { railImpressionRef: impressionRef }
 }

--- a/src/System/Contexts/AnalyticsContext.tsx
+++ b/src/System/Contexts/AnalyticsContext.tsx
@@ -131,6 +131,8 @@ export const pathToOwnerType = (path: string): PageOwnerType => {
       return OwnerType.article
     case type === "artFairs":
       return OwnerType.fairs
+    case type === "recommendations" && slug === "artworks":
+      return OwnerType.artworkRecommendations
     case type === "settings":
     case type === "collectorProfile":
       return OwnerType.editProfile

--- a/src/System/Contexts/__tests__/AnalyticsContext.jest.tsx
+++ b/src/System/Contexts/__tests__/AnalyticsContext.jest.tsx
@@ -1,0 +1,10 @@
+import { OwnerType } from "@artsy/cohesion"
+import { pathToOwnerType } from "System/Contexts/AnalyticsContext"
+
+describe("pathToOwnerType", () => {
+  it("maps artwork recommendations to the artwork recommendations owner type", () => {
+    expect(pathToOwnerType("/recommendations/artworks")).toBe(
+      OwnerType.artworkRecommendations,
+    )
+  })
+})

--- a/src/__generated__/ArtworkRecommendationsArtworksGrid_Test_Query.graphql.ts
+++ b/src/__generated__/ArtworkRecommendationsArtworksGrid_Test_Query.graphql.ts
@@ -1,0 +1,1094 @@
+/**
+ * @generated SignedSource<<257755e8acae9919b47fd3dd8030bc4b>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ArtworkRecommendationsArtworksGrid_Test_Query$variables = Record<PropertyKey, never>;
+export type ArtworkRecommendationsArtworksGrid_Test_Query$data = {
+  readonly me: {
+    readonly " $fragmentSpreads": FragmentRefs<"ArtworkRecommendationsArtworksGrid_me">;
+  } | null | undefined;
+};
+export type ArtworkRecommendationsArtworksGrid_Test_Query = {
+  response: ArtworkRecommendationsArtworksGrid_Test_Query$data;
+  variables: ArtworkRecommendationsArtworksGrid_Test_Query$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "__typename",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v3 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "internalID",
+  "storageKey": null
+},
+v4 = {
+  "kind": "Literal",
+  "name": "version",
+  "value": [
+    "larger",
+    "large"
+  ]
+},
+v5 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "endAt",
+  "storageKey": null
+},
+v6 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+],
+v7 = [
+  {
+    "kind": "Literal",
+    "name": "shallow",
+    "value": true
+  }
+],
+v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "name",
+  "storageKey": null
+},
+v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "lotID",
+  "storageKey": null
+},
+v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "extendedBiddingEndAt",
+  "storageKey": null
+},
+v11 = [
+  (v8/*: any*/),
+  (v0/*: any*/)
+],
+v12 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "String"
+},
+v13 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v14 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Boolean"
+},
+v15 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v16 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "Boolean"
+},
+v17 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Int"
+},
+v18 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "SaleArtwork"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ArtworkRecommendationsArtworksGrid_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ArtworkRecommendationsArtworksGrid_me"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "ArtworkRecommendationsArtworksGrid_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "ArtworkConnection",
+            "kind": "LinkedField",
+            "name": "artworkRecommendations",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "totalCount",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ArtworkEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Artwork",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v0/*: any*/),
+                      (v1/*: any*/)
+                    ],
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "cursor",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "PageInfo",
+                "kind": "LinkedField",
+                "name": "pageInfo",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "endCursor",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "hasNextPage",
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              },
+              {
+                "kind": "InlineFragment",
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": null,
+                    "kind": "LinkedField",
+                    "name": "edges",
+                    "plural": true,
+                    "selections": [
+                      (v1/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Artwork",
+                        "kind": "LinkedField",
+                        "name": "node",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "slug",
+                            "storageKey": null
+                          },
+                          (v2/*: any*/),
+                          (v3/*: any*/),
+                          {
+                            "alias": null,
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "includeAll",
+                                "value": false
+                              }
+                            ],
+                            "concreteType": "Image",
+                            "kind": "LinkedField",
+                            "name": "image",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "aspectRatio",
+                                "storageKey": null
+                              },
+                              (v3/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "placeholder",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": [
+                                  (v4/*: any*/)
+                                ],
+                                "kind": "ScalarField",
+                                "name": "url",
+                                "storageKey": "url(version:[\"larger\",\"large\"])"
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "versions",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": [
+                                  (v4/*: any*/),
+                                  {
+                                    "kind": "Literal",
+                                    "name": "width",
+                                    "value": 445
+                                  }
+                                ],
+                                "concreteType": "ResizedImageUrl",
+                                "kind": "LinkedField",
+                                "name": "resized",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "src",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "srcSet",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "width",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "height",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": "resized(version:[\"larger\",\"large\"],width:445)"
+                              }
+                            ],
+                            "storageKey": "image(includeAll:false)"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "title",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "imageTitle",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "artistNames",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "date",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "CollectorSignals",
+                            "kind": "LinkedField",
+                            "name": "collectorSignals",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "primaryLabel",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "AuctionCollectorSignals",
+                                "kind": "LinkedField",
+                                "name": "auction",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "bidCount",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "lotClosesAt",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "liveBiddingStarted",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "registrationEndsAt",
+                                    "storageKey": null
+                                  },
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "onlineBiddingExtended",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "PartnerOfferToCollector",
+                                "kind": "LinkedField",
+                                "name": "partnerOffer",
+                                "plural": false,
+                                "selections": [
+                                  (v5/*: any*/),
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "concreteType": "Money",
+                                    "kind": "LinkedField",
+                                    "name": "priceWithDiscount",
+                                    "plural": false,
+                                    "selections": (v6/*: any*/),
+                                    "storageKey": null
+                                  },
+                                  (v0/*: any*/)
+                                ],
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "sale_message",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "saleMessage",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "cultural_maker",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "culturalMaker",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": (v7/*: any*/),
+                            "concreteType": "Artist",
+                            "kind": "LinkedField",
+                            "name": "artist",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "ArtistTargetSupply",
+                                "kind": "LinkedField",
+                                "name": "targetSupply",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": null,
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "isP1",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              },
+                              (v0/*: any*/)
+                            ],
+                            "storageKey": "artist(shallow:true)"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ArtworkPriceInsights",
+                            "kind": "LinkedField",
+                            "name": "marketPriceInsights",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "demandRank",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": (v7/*: any*/),
+                            "concreteType": "Artist",
+                            "kind": "LinkedField",
+                            "name": "artists",
+                            "plural": true,
+                            "selections": [
+                              (v0/*: any*/),
+                              (v2/*: any*/),
+                              (v8/*: any*/)
+                            ],
+                            "storageKey": "artists(shallow:true)"
+                          },
+                          {
+                            "alias": "collecting_institution",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "collectingInstitution",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": (v7/*: any*/),
+                            "concreteType": "Partner",
+                            "kind": "LinkedField",
+                            "name": "partner",
+                            "plural": false,
+                            "selections": [
+                              (v8/*: any*/),
+                              (v2/*: any*/),
+                              (v0/*: any*/)
+                            ],
+                            "storageKey": "partner(shallow:true)"
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "Sale",
+                            "kind": "LinkedField",
+                            "name": "sale",
+                            "plural": false,
+                            "selections": [
+                              (v5/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "cascadingEndTimeIntervalMinutes",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "extendedBiddingIntervalMinutes",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "startAt",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "is_auction",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isAuction",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "is_closed",
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isClosed",
+                                "storageKey": null
+                              },
+                              (v0/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "isOpen",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "extendedBiddingPeriodMinutes",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "sale_artwork",
+                            "args": null,
+                            "concreteType": "SaleArtwork",
+                            "kind": "LinkedField",
+                            "name": "saleArtwork",
+                            "plural": false,
+                            "selections": [
+                              (v9/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "lotLabel",
+                                "storageKey": null
+                              },
+                              (v5/*: any*/),
+                              (v10/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "formattedEndDateTime",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "SaleArtworkCounts",
+                                "kind": "LinkedField",
+                                "name": "counts",
+                                "plural": false,
+                                "selections": [
+                                  {
+                                    "alias": "bidder_positions",
+                                    "args": null,
+                                    "kind": "ScalarField",
+                                    "name": "bidderPositions",
+                                    "storageKey": null
+                                  }
+                                ],
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "highest_bid",
+                                "args": null,
+                                "concreteType": "SaleArtworkHighestBid",
+                                "kind": "LinkedField",
+                                "name": "highestBid",
+                                "plural": false,
+                                "selections": (v6/*: any*/),
+                                "storageKey": null
+                              },
+                              {
+                                "alias": "opening_bid",
+                                "args": null,
+                                "concreteType": "SaleArtworkOpeningBid",
+                                "kind": "LinkedField",
+                                "name": "openingBid",
+                                "plural": false,
+                                "selections": (v6/*: any*/),
+                                "storageKey": null
+                              },
+                              (v0/*: any*/)
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "SaleArtwork",
+                            "kind": "LinkedField",
+                            "name": "saleArtwork",
+                            "plural": false,
+                            "selections": [
+                              (v9/*: any*/),
+                              (v0/*: any*/),
+                              (v5/*: any*/),
+                              (v10/*: any*/)
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "AttributionClass",
+                            "kind": "LinkedField",
+                            "name": "attributionClass",
+                            "plural": false,
+                            "selections": (v11/*: any*/),
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "concreteType": "ArtworkMedium",
+                            "kind": "LinkedField",
+                            "name": "mediumType",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "concreteType": "Gene",
+                                "kind": "LinkedField",
+                                "name": "filterGene",
+                                "plural": false,
+                                "selections": (v11/*: any*/),
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": null
+                          },
+                          {
+                            "alias": null,
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "isUnlisted",
+                            "storageKey": null
+                          },
+                          {
+                            "alias": "image_title",
+                            "args": null,
+                            "kind": "ScalarField",
+                            "name": "imageTitle",
+                            "storageKey": null
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      {
+                        "kind": "InlineFragment",
+                        "selections": [
+                          (v0/*: any*/)
+                        ],
+                        "type": "Node",
+                        "abstractKey": "__isNode"
+                      }
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "type": "ArtworkConnectionInterface",
+                "abstractKey": "__isArtworkConnectionInterface"
+              }
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "filters": null,
+            "handle": "connection",
+            "key": "ArtworkRecommendationsArtworksGrid_artworkRecommendations",
+            "kind": "LinkedHandle",
+            "name": "artworkRecommendations"
+          },
+          (v0/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "5fdacdbc3c52d0c2d420ae1d37d39afa",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "me": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Me"
+        },
+        "me.artworkRecommendations": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtworkConnection"
+        },
+        "me.artworkRecommendations.__isArtworkConnectionInterface": (v12/*: any*/),
+        "me.artworkRecommendations.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "ArtworkEdgeInterface"
+        },
+        "me.artworkRecommendations.edges.__isNode": (v12/*: any*/),
+        "me.artworkRecommendations.edges.__typename": (v12/*: any*/),
+        "me.artworkRecommendations.edges.cursor": (v12/*: any*/),
+        "me.artworkRecommendations.edges.id": (v13/*: any*/),
+        "me.artworkRecommendations.edges.node": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artwork"
+        },
+        "me.artworkRecommendations.edges.node.__typename": (v12/*: any*/),
+        "me.artworkRecommendations.edges.node.artist": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artist"
+        },
+        "me.artworkRecommendations.edges.node.artist.id": (v13/*: any*/),
+        "me.artworkRecommendations.edges.node.artist.targetSupply": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "ArtistTargetSupply"
+        },
+        "me.artworkRecommendations.edges.node.artist.targetSupply.isP1": (v14/*: any*/),
+        "me.artworkRecommendations.edges.node.artistNames": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.artists": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "Artist"
+        },
+        "me.artworkRecommendations.edges.node.artists.href": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.artists.id": (v13/*: any*/),
+        "me.artworkRecommendations.edges.node.artists.name": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.attributionClass": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "AttributionClass"
+        },
+        "me.artworkRecommendations.edges.node.attributionClass.id": (v13/*: any*/),
+        "me.artworkRecommendations.edges.node.attributionClass.name": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.collecting_institution": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.collectorSignals": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "CollectorSignals"
+        },
+        "me.artworkRecommendations.edges.node.collectorSignals.auction": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "AuctionCollectorSignals"
+        },
+        "me.artworkRecommendations.edges.node.collectorSignals.auction.bidCount": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "Int"
+        },
+        "me.artworkRecommendations.edges.node.collectorSignals.auction.liveBiddingStarted": (v16/*: any*/),
+        "me.artworkRecommendations.edges.node.collectorSignals.auction.lotClosesAt": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.collectorSignals.auction.onlineBiddingExtended": (v16/*: any*/),
+        "me.artworkRecommendations.edges.node.collectorSignals.auction.registrationEndsAt": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.collectorSignals.partnerOffer": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "PartnerOfferToCollector"
+        },
+        "me.artworkRecommendations.edges.node.collectorSignals.partnerOffer.endAt": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.collectorSignals.partnerOffer.id": (v13/*: any*/),
+        "me.artworkRecommendations.edges.node.collectorSignals.partnerOffer.priceWithDiscount": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Money"
+        },
+        "me.artworkRecommendations.edges.node.collectorSignals.partnerOffer.priceWithDiscount.display": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.collectorSignals.primaryLabel": {
+          "enumValues": [
+            "CURATORS_PICK",
+            "INCREASED_INTEREST",
+            "PARTNER_OFFER"
+          ],
+          "nullable": true,
+          "plural": false,
+          "type": "LabelSignalEnum"
+        },
+        "me.artworkRecommendations.edges.node.cultural_maker": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.date": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.href": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.id": (v13/*: any*/),
+        "me.artworkRecommendations.edges.node.image": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Image"
+        },
+        "me.artworkRecommendations.edges.node.image.aspectRatio": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "Float"
+        },
+        "me.artworkRecommendations.edges.node.image.internalID": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ID"
+        },
+        "me.artworkRecommendations.edges.node.image.placeholder": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.image.resized": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ResizedImageUrl"
+        },
+        "me.artworkRecommendations.edges.node.image.resized.height": (v17/*: any*/),
+        "me.artworkRecommendations.edges.node.image.resized.src": (v12/*: any*/),
+        "me.artworkRecommendations.edges.node.image.resized.srcSet": (v12/*: any*/),
+        "me.artworkRecommendations.edges.node.image.resized.width": (v17/*: any*/),
+        "me.artworkRecommendations.edges.node.image.url": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.image.versions": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "String"
+        },
+        "me.artworkRecommendations.edges.node.imageTitle": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.image_title": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.internalID": (v13/*: any*/),
+        "me.artworkRecommendations.edges.node.isUnlisted": (v16/*: any*/),
+        "me.artworkRecommendations.edges.node.marketPriceInsights": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtworkPriceInsights"
+        },
+        "me.artworkRecommendations.edges.node.marketPriceInsights.demandRank": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Float"
+        },
+        "me.artworkRecommendations.edges.node.mediumType": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArtworkMedium"
+        },
+        "me.artworkRecommendations.edges.node.mediumType.filterGene": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Gene"
+        },
+        "me.artworkRecommendations.edges.node.mediumType.filterGene.id": (v13/*: any*/),
+        "me.artworkRecommendations.edges.node.mediumType.filterGene.name": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.partner": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Partner"
+        },
+        "me.artworkRecommendations.edges.node.partner.href": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.partner.id": (v13/*: any*/),
+        "me.artworkRecommendations.edges.node.partner.name": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.sale": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Sale"
+        },
+        "me.artworkRecommendations.edges.node.sale.cascadingEndTimeIntervalMinutes": (v17/*: any*/),
+        "me.artworkRecommendations.edges.node.sale.endAt": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.sale.extendedBiddingIntervalMinutes": (v17/*: any*/),
+        "me.artworkRecommendations.edges.node.sale.extendedBiddingPeriodMinutes": (v17/*: any*/),
+        "me.artworkRecommendations.edges.node.sale.id": (v13/*: any*/),
+        "me.artworkRecommendations.edges.node.sale.isOpen": (v14/*: any*/),
+        "me.artworkRecommendations.edges.node.sale.is_auction": (v14/*: any*/),
+        "me.artworkRecommendations.edges.node.sale.is_closed": (v14/*: any*/),
+        "me.artworkRecommendations.edges.node.sale.startAt": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.saleArtwork": (v18/*: any*/),
+        "me.artworkRecommendations.edges.node.saleArtwork.endAt": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.saleArtwork.extendedBiddingEndAt": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.saleArtwork.id": (v13/*: any*/),
+        "me.artworkRecommendations.edges.node.saleArtwork.lotID": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.sale_artwork": (v18/*: any*/),
+        "me.artworkRecommendations.edges.node.sale_artwork.counts": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkCounts"
+        },
+        "me.artworkRecommendations.edges.node.sale_artwork.counts.bidder_positions": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "FormattedNumber"
+        },
+        "me.artworkRecommendations.edges.node.sale_artwork.endAt": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.sale_artwork.extendedBiddingEndAt": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.sale_artwork.formattedEndDateTime": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.sale_artwork.highest_bid": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkHighestBid"
+        },
+        "me.artworkRecommendations.edges.node.sale_artwork.highest_bid.display": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.sale_artwork.id": (v13/*: any*/),
+        "me.artworkRecommendations.edges.node.sale_artwork.lotID": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.sale_artwork.lotLabel": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.sale_artwork.opening_bid": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "SaleArtworkOpeningBid"
+        },
+        "me.artworkRecommendations.edges.node.sale_artwork.opening_bid.display": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.sale_message": (v15/*: any*/),
+        "me.artworkRecommendations.edges.node.slug": (v13/*: any*/),
+        "me.artworkRecommendations.edges.node.title": (v15/*: any*/),
+        "me.artworkRecommendations.pageInfo": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": false,
+          "type": "PageInfo"
+        },
+        "me.artworkRecommendations.pageInfo.endCursor": (v15/*: any*/),
+        "me.artworkRecommendations.pageInfo.hasNextPage": (v16/*: any*/),
+        "me.artworkRecommendations.totalCount": (v17/*: any*/),
+        "me.id": (v13/*: any*/)
+      }
+    },
+    "name": "ArtworkRecommendationsArtworksGrid_Test_Query",
+    "operationKind": "query",
+    "text": "query ArtworkRecommendationsArtworksGrid_Test_Query {\n  me {\n    ...ArtworkRecommendationsArtworksGrid_me\n    id\n  }\n}\n\nfragment ArtworkGrid_artworks on ArtworkConnectionInterface {\n  __isArtworkConnectionInterface: __typename\n  edges {\n    __typename\n    node {\n      id\n      slug\n      href\n      internalID\n      image(includeAll: false) {\n        aspectRatio\n      }\n      ...GridItem_artwork\n      ...FlatGridItem_artwork\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment ArtworkRecommendationsArtworksGrid_me on Me {\n  artworkRecommendations {\n    totalCount\n    edges {\n      node {\n        id\n        __typename\n      }\n      cursor\n    }\n    ...ArtworkGrid_artworks\n    pageInfo {\n      endCursor\n      hasNextPage\n    }\n  }\n  id\n}\n\nfragment BidTimerLine_artwork on Artwork {\n  saleArtwork {\n    lotID\n    id\n  }\n  collectorSignals {\n    auction {\n      lotClosesAt\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n}\n\nfragment Details_artwork on Artwork {\n  internalID\n  href\n  title\n  date\n  collectorSignals {\n    primaryLabel\n    auction {\n      bidCount\n      lotClosesAt\n      liveBiddingStarted\n      registrationEndsAt\n      onlineBiddingExtended\n    }\n  }\n  sale_message: saleMessage\n  cultural_maker: culturalMaker\n  artist(shallow: true) {\n    targetSupply {\n      isP1\n    }\n    id\n  }\n  marketPriceInsights {\n    demandRank\n  }\n  artists(shallow: true) {\n    id\n    href\n    name\n  }\n  collecting_institution: collectingInstitution\n  partner(shallow: true) {\n    name\n    href\n    id\n  }\n  sale {\n    endAt\n    cascadingEndTimeIntervalMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    is_auction: isAuction\n    is_closed: isClosed\n    id\n  }\n  sale_artwork: saleArtwork {\n    lotID\n    lotLabel\n    endAt\n    extendedBiddingEndAt\n    formattedEndDateTime\n    counts {\n      bidder_positions: bidderPositions\n    }\n    highest_bid: highestBid {\n      display\n    }\n    opening_bid: openingBid {\n      display\n    }\n    id\n  }\n  ...PrimaryLabelLine_artwork\n  ...BidTimerLine_artwork\n  ...HoverDetails_artwork\n}\n\nfragment ExclusiveAccessBadge_artwork on Artwork {\n  isUnlisted\n}\n\nfragment FlatGridItem_artwork on Artwork {\n  ...Metadata_artwork\n  sale {\n    extendedBiddingPeriodMinutes\n    extendedBiddingIntervalMinutes\n    startAt\n    isOpen\n    id\n  }\n  saleArtwork {\n    endAt\n    extendedBiddingEndAt\n    lotID\n    id\n  }\n  internalID\n  title\n  image_title: imageTitle\n  image(includeAll: false) {\n    resized(width: 445, version: [\"larger\", \"large\"]) {\n      src\n      srcSet\n      width\n      height\n    }\n  }\n  artistNames\n  href\n}\n\nfragment GridItem_artwork on Artwork {\n  internalID\n  title\n  imageTitle\n  image(includeAll: false) {\n    internalID\n    placeholder\n    url(version: [\"larger\", \"large\"])\n    aspectRatio\n    versions\n  }\n  artistNames\n  href\n  ...Metadata_artwork\n  ...ExclusiveAccessBadge_artwork\n}\n\nfragment HoverDetails_artwork on Artwork {\n  internalID\n  attributionClass {\n    name\n    id\n  }\n  mediumType {\n    filterGene {\n      name\n      id\n    }\n  }\n}\n\nfragment Metadata_artwork on Artwork {\n  ...Details_artwork\n  internalID\n  href\n  sale {\n    isOpen\n    id\n  }\n}\n\nfragment PrimaryLabelLine_artwork on Artwork {\n  internalID\n  collectorSignals {\n    primaryLabel\n    partnerOffer {\n      endAt\n      priceWithDiscount {\n        display\n      }\n      id\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "c63c61b3797fb7afb133994b0da30c85";
+
+export default node;


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [ONYX-2118]

### Description

Builds on top of [<PR link>](https://github.com/artsy/force/pull/17200) where we introduce home page rails impression tracking.

Adds `item_viewed` impression tracking for artwork cards using the same dwell/visibility behavior as railViewed.

This tracks artwork impressions in:
- Home: New Works for You
- Home: We Think You'll Love
- `/recommendations/artworks` artwork grid

### Details

- Extracts shared dwell-based impression logic so rail and item impressions use the same observer behavior.
- Adds a reusable ArtworkItemImpression wrapper for artwork card impressions.
- Keeps home tracking scoped to the two rails
- Adds /recommendations/artworks impressions tracking

[ONYX-2118]: https://artsyproduct.atlassian.net/browse/ONYX-2118?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ