### PR TITLE
chore: update error page layout to add some paddings

### DIFF
--- a/src/Apps/Order/Components/OrderErrorApp.tsx
+++ b/src/Apps/Order/Components/OrderErrorApp.tsx
@@ -25,8 +25,8 @@ export const OrderErrorApp: React.FC<
 
   return (
     <Box data-testid="order-error-page" {...rest}>
-      <GridColumns gridRowGap={4}>
-        <Column span={6} wrap>
+      <GridColumns pt={[2, 4]} px={[2, 4]}>
+        <Column span={8} wrap>
           <Text variant="xl">{headline}</Text>
 
           <Text variant="xl" color="mono60">

--- a/src/Apps/Order/Routes/Details/OrderDetailsRoute.tsx
+++ b/src/Apps/Order/Routes/Details/OrderDetailsRoute.tsx
@@ -6,6 +6,8 @@ import type React from "react"
 import { Title } from "react-head"
 import { graphql, useFragment } from "react-relay"
 
+const NOT_FOUND_ERROR = "Please check the URL or verify your account details."
+
 interface DetailsProps {
   viewer: OrderDetailsRoute_viewer$key
 }
@@ -15,7 +17,7 @@ export const OrderDetailsRoute: React.FC<DetailsProps> = ({ viewer }) => {
   const order = data.me?.order
 
   if (!order) {
-    return <OrderErrorApp code={404} />
+    return <OrderErrorApp code={404} message={NOT_FOUND_ERROR} />
   }
 
   return (

--- a/src/Apps/Order2/Components/Order2ErrorApp.tsx
+++ b/src/Apps/Order2/Components/Order2ErrorApp.tsx
@@ -25,8 +25,8 @@ export const OrderErrorApp: React.FC<
 
   return (
     <Box data-testid="order-error-page" {...rest}>
-      <GridColumns py={[0, 0, 4]} px={[0, 0, 4]}>
-        <Column span={6} wrap>
+      <GridColumns pt={[2, 4]} px={[2, 4]}>
+        <Column span={8} wrap>
           <Spacer y={[2, 2, 4]} />
           <Text variant="xl">{headline}</Text>
 


### PR DESCRIPTION
This should address immediate discrepancy reported here: https://artsyproduct.atlassian.net/browse/EMI-3206

The more proper fix with shuffling layouts might make sense after full release but this change removes the immediate brokenness perception in my opinion.

The details page order not found error now looks like:
<img width="1272" height="557" alt="Screenshot 2026-05-13 at 12 53 18 PM" src="https://github.com/user-attachments/assets/28dd07c5-0e6c-46a4-95f0-533b1dd5a627" />

