### PR TITLE
chore(EMI-3234): track address edit

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/Order2SavedAddressOptions.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/Order2SavedAddressOptions.tsx
@@ -331,6 +331,7 @@ export const SavedAddressOptions = ({
                 type="button"
                 aria-label={`Edit address for ${address.name}`}
                 onClick={() => {
+                  checkoutTracking.clickedEditShippingAddress()
                   setUserAddressMode({
                     mode: "edit",
                     address: processedAddress,

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/Order2SavedAddressOptions.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/Order2SavedAddressOptions.jest.tsx
@@ -210,6 +210,7 @@ describe("SavedAddressOptions", () => {
         clickedShippingAddress: jest.fn(),
         savedAddressViewed: jest.fn(),
         clickedAddNewShippingAddress: jest.fn(),
+        clickedEditShippingAddress: jest.fn(),
       },
       steps: [
         {
@@ -860,6 +861,18 @@ describe("SavedAddressOptions", () => {
       await waitFor(() => {
         expect(mockSavedAddressViewed).not.toHaveBeenCalled()
       })
+    })
+
+    it("tracks clickedEditShippingAddress when the edit button is clicked", async () => {
+      renderSavedAddressOptions()
+
+      await userEvent.click(
+        screen.getByRole("button", { name: /Edit address for John Doe/i }),
+      )
+
+      expect(
+        mockCheckoutContext.checkoutTracking.clickedEditShippingAddress,
+      ).toHaveBeenCalledTimes(1)
     })
   })
 })

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/__tests__/Order2DeliveryForm.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/__tests__/Order2DeliveryForm.jest.tsx
@@ -39,6 +39,7 @@ beforeEach(() => {
       clickedOrderProgression: jest.fn(),
       clickedShippingAddress: jest.fn(),
       clickedAddNewShippingAddress: jest.fn(),
+      clickedEditShippingAddress: jest.fn(),
     },
     completeStep: jest.fn(),
     setUserAddressMode: jest.fn(),

--- a/src/Apps/Order2/Routes/Checkout/Hooks/useCheckoutTracking.ts
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/useCheckoutTracking.ts
@@ -6,6 +6,7 @@ import {
   type ClickedChangePaymentMethod,
   type ClickedChangeShippingAddress,
   type ClickedChangeShippingMethod,
+  type ClickedEditShippingAddress,
   type ClickedExpressCheckout,
   type ClickedFulfillmentTab,
   type ClickedOfferOption,
@@ -172,6 +173,16 @@ export const useCheckoutTracking = ({
         const payload: ClickedChangeShippingAddress = {
           action: ActionType.clickedChangeShippingAddress,
           context_module: ContextModule.ordersCheckout,
+          context_page_owner_type: contextPageOwnerType,
+          context_page_owner_id: contextPageOwnerId,
+        }
+        trackEvent(payload)
+      },
+
+      clickedEditShippingAddress: () => {
+        const payload: ClickedEditShippingAddress = {
+          action: ActionType.clickedEditShippingAddress,
+          context_module: ContextModule.ordersFulfillment,
           context_page_owner_type: contextPageOwnerType,
           context_page_owner_id: contextPageOwnerId,
         }


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-3234]

### Description
Adds `clickedEditShippingAddress` tracking event 

<!-- Implementation description -->


[EMI-3234]: https://artsyproduct.atlassian.net/browse/EMI-3234?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ