### PR TITLE
feat(search): hardcode autosuggest experiment variant

### DIFF
--- a/src/Components/Search/Mobile/MobileSearchBar.tsx
+++ b/src/Components/Search/Mobile/MobileSearchBar.tsx
@@ -1,10 +1,7 @@
 import SearchIcon from "@artsy/icons/SearchIcon"
 import { LabeledInput, useDidMount } from "@artsy/palette"
 import { type FC, useState } from "react"
-import { useVariant } from "@unleash/proxy-client-react"
-import { useTrackFeatureVariantOnMount } from "System/Hooks/useTrackFeatureVariant"
 import { OverlayRefetchContainer } from "./Overlay"
-
 import { StaticSearchContainer } from "Components/Search/StaticSearchContainer"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
@@ -13,9 +10,6 @@ import type {
   MobileSearchBarSuggestQuery$data,
 } from "__generated__/MobileSearchBarSuggestQuery.graphql"
 import { graphql } from "react-relay"
-
-const SEARCH_AUTOSUGGEST_VARIANT_EXPERIMENT =
-  "onyx_search-autosuggest-experiment"
 
 interface MobileSearchBarProps {
   viewer: NonNullable<MobileSearchBarSuggestQuery$data["viewer"]>
@@ -26,19 +20,6 @@ export const MobileSearchBar: FC<
   React.PropsWithChildren<MobileSearchBarProps>
 > = ({ viewer, onClose }) => {
   const [overlayDisplayed, setOverlayDisplayed] = useState(false)
-
-  // Get variant from Unleash for A/B testing (on page load)
-  const unleashVariant = useVariant(SEARCH_AUTOSUGGEST_VARIANT_EXPERIMENT)
-  const variant =
-    unleashVariant.enabled && unleashVariant.name !== "disabled"
-      ? unleashVariant.name
-      : undefined
-
-  // Track experiment view for analytics (on page load, not on overlay open)
-  useTrackFeatureVariantOnMount({
-    experimentName: SEARCH_AUTOSUGGEST_VARIANT_EXPERIMENT,
-    variantName: unleashVariant.name,
-  })
 
   const displayOverlay = () => {
     setOverlayDisplayed(true)
@@ -55,7 +36,7 @@ export const MobileSearchBar: FC<
         <OverlayRefetchContainer
           viewer={viewer}
           onClose={handleOverlayClose}
-          variant={variant}
+          variant="experiment"
         />
       )}
 
@@ -108,7 +89,7 @@ export const MobileSearchBarQueryRenderer: FC<
         hasTerm: false,
         term: "",
         entities: [],
-        variant: undefined,
+        variant: "experiment",
       }}
       render={({ props: relayProps }) => {
         if (relayProps?.viewer) {

--- a/src/Components/Search/SearchBarInput.tsx
+++ b/src/Components/Search/SearchBarInput.tsx
@@ -14,11 +14,9 @@ import {
   type SearchedWithResults,
   type SelectedItemFromSearch,
 } from "@artsy/cohesion"
-import { useVariant } from "@unleash/proxy-client-react"
 import { DESKTOP_NAV_BAR_TOP_TIER_HEIGHT } from "Components/NavBar/constants"
 import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
 import { useRouter } from "System/Hooks/useRouter"
-import { useTrackFeatureVariantOnMount } from "System/Hooks/useTrackFeatureVariant"
 import { useClientQuery } from "Utils/Hooks/useClientQuery"
 import { extractNodes } from "Utils/extractNodes"
 import type {
@@ -39,9 +37,6 @@ import { type PillType, SEARCH_DEBOUNCE_DELAY, TOP_PILL } from "./constants"
 import { getLabel } from "./utils/getLabel"
 import { shouldStartSearching } from "./utils/shouldStartSearching"
 
-const SEARCH_AUTOSUGGEST_VARIANT_EXPERIMENT =
-  "onyx_search-autosuggest-experiment"
-
 export interface SearchBarInputProps {
   searchTerm: string
 }
@@ -55,26 +50,13 @@ export const SearchBarInput: FC<
 
   const isClient = useDidMount()
 
-  // Get variant from Unleash for A/B testing
-  const unleashVariant = useVariant(SEARCH_AUTOSUGGEST_VARIANT_EXPERIMENT)
-  const variant =
-    unleashVariant.enabled && unleashVariant.name !== "disabled"
-      ? unleashVariant.name
-      : undefined
-
-  // Track experiment view for analytics
-  useTrackFeatureVariantOnMount({
-    experimentName: SEARCH_AUTOSUGGEST_VARIANT_EXPERIMENT,
-    variantName: unleashVariant.name,
-  })
-
   const { data, refetch } = useClientQuery<SearchBarInputSuggestQuery>({
     query: QUERY,
     variables: {
       hasTerm: shouldStartSearching(searchTerm ?? ""),
       term: searchTerm ? String(searchTerm) : "",
       entities: [],
-      variant,
+      variant: "experiment",
     },
     skip: !searchTerm,
   })
@@ -157,7 +139,7 @@ export const SearchBarInput: FC<
       hasTerm: true,
       term: String(value),
       entities,
-      variant,
+      variant: "experiment",
     })
 
     lastRefetchDisposableRef.current = disposable

--- a/src/Components/Search/__tests__/SearchBarInput.jest.tsx
+++ b/src/Components/Search/__tests__/SearchBarInput.jest.tsx
@@ -102,6 +102,18 @@ describe("SearchBarInput", () => {
 
   afterEach(() => jest.clearAllMocks())
 
+  it("passes the experiment variant to autosuggest", () => {
+    render(<SearchBarInput searchTerm="andy" />)
+
+    expect(useClientQuery).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variables: expect.objectContaining({
+          variant: "experiment",
+        }),
+      }),
+    )
+  })
+
   it("redirects on a normal suggestion click", async () => {
     render(<SearchBarInput searchTerm="andy" />)
     await userEvent.click(screen.getByRole("link", { name: "Andy Warhol" }))


### PR DESCRIPTION
### Description

Temporarily hardcodes autosuggest to use the `experiment` variant and removes the Unleash experiment wiring from the search components.

The experiment won, but the long-term fix should live on the backend by changing the default autosuggest behavior there. [That backend PR already exists](https://github.com/artsy/gravity/pull/20131), but I’m holding off on merging it until I’m back from vacation.