### PR TITLE
fix: Prevent onboarding loop for existing users on social auth

### DIFF
--- a/src/Apps/Authentication/Routes/SignupLanding/Components/SignupFormSocial.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/Components/SignupFormSocial.tsx
@@ -6,14 +6,11 @@ import { useAuthDialogContext } from "Components/AuthDialog/AuthDialogContext"
 import { setSocialAuthTracking } from "Components/AuthDialog/Hooks/useSocialAuthTracking"
 import { getENV } from "Utils/getENV"
 import { stringify } from "qs"
-import { useAfterAuthenticationRedirectUrl } from "Components/AuthDialog/Hooks/useAfterAuthenticationRedirectUrl"
 
 export const SignupFormSocial = () => {
   const {
-    state: { analytics, mode },
+    state: { analytics, mode, options },
   } = useAuthDialogContext()
-
-  const { redirectUrl } = useAfterAuthenticationRedirectUrl()
 
   const { applePath, facebookPath, googlePath } = getENV("AP") ?? {
     applePath: "/users/auth/apple",
@@ -23,7 +20,7 @@ export const SignupFormSocial = () => {
 
   const query = stringify(
     {
-      "redirect-to": redirectUrl,
+      "redirect-to": options.redirectTo || "/",
       "signup-intent": "signup",
       "signup-referer": getENV("AUTHENTICATION_REFERER"),
       accepted_terms_of_service: true,

--- a/src/Apps/Authentication/Routes/SignupLanding/Components/SignupFormSocial.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/Components/SignupFormSocial.tsx
@@ -6,20 +6,14 @@ import { useAuthDialogContext } from "Components/AuthDialog/AuthDialogContext"
 import { setSocialAuthTracking } from "Components/AuthDialog/Hooks/useSocialAuthTracking"
 import { getENV } from "Utils/getENV"
 import { stringify } from "qs"
-import { useRouter } from "System/Hooks/useRouter"
+import { useAfterAuthenticationRedirectUrl } from "Components/AuthDialog/Hooks/useAfterAuthenticationRedirectUrl"
 
 export const SignupFormSocial = () => {
   const {
-    state: { analytics, mode, options },
+    state: { analytics, mode },
   } = useAuthDialogContext()
 
-  const { match } = useRouter()
-  const location = match ? match.location : window.location
-
-  // Compute default redirect without onboarding param
-  const defaultRedirect = ["/login", "/signup"].includes(location.pathname)
-    ? "/"
-    : location.pathname + (location.search || "")
+  const { redirectUrl } = useAfterAuthenticationRedirectUrl(false)
 
   const { applePath, facebookPath, googlePath } = getENV("AP") ?? {
     applePath: "/users/auth/apple",
@@ -29,7 +23,7 @@ export const SignupFormSocial = () => {
 
   const query = stringify(
     {
-      "redirect-to": options.redirectTo || defaultRedirect,
+      "redirect-to": redirectUrl,
       "signup-intent": "signup",
       "signup-referer": getENV("AUTHENTICATION_REFERER"),
       accepted_terms_of_service: true,

--- a/src/Apps/Authentication/Routes/SignupLanding/Components/SignupFormSocial.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/Components/SignupFormSocial.tsx
@@ -6,11 +6,20 @@ import { useAuthDialogContext } from "Components/AuthDialog/AuthDialogContext"
 import { setSocialAuthTracking } from "Components/AuthDialog/Hooks/useSocialAuthTracking"
 import { getENV } from "Utils/getENV"
 import { stringify } from "qs"
+import { useRouter } from "System/Hooks/useRouter"
 
 export const SignupFormSocial = () => {
   const {
     state: { analytics, mode, options },
   } = useAuthDialogContext()
+
+  const { match } = useRouter()
+  const location = match ? match.location : window.location
+
+  // Compute default redirect without onboarding param
+  const defaultRedirect = ["/login", "/signup"].includes(location.pathname)
+    ? "/"
+    : location.pathname + (location.search || "")
 
   const { applePath, facebookPath, googlePath } = getENV("AP") ?? {
     applePath: "/users/auth/apple",
@@ -20,7 +29,7 @@ export const SignupFormSocial = () => {
 
   const query = stringify(
     {
-      "redirect-to": options.redirectTo || "/",
+      "redirect-to": options.redirectTo || defaultRedirect,
       "signup-intent": "signup",
       "signup-referer": getENV("AUTHENTICATION_REFERER"),
       accepted_terms_of_service: true,

--- a/src/Apps/Authentication/Routes/SignupLanding/Components/SignupFormSocial.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/Components/SignupFormSocial.tsx
@@ -13,7 +13,9 @@ export const SignupFormSocial = () => {
     state: { analytics, mode },
   } = useAuthDialogContext()
 
-  const { redirectUrl } = useAfterAuthenticationRedirectUrl(false)
+  const { redirectUrl } = useAfterAuthenticationRedirectUrl({
+    appendOnboarding: false,
+  })
 
   const { applePath, facebookPath, googlePath } = getENV("AP") ?? {
     applePath: "/users/auth/apple",

--- a/src/Components/AuthDialog/Components/AuthDialogSocial.tsx
+++ b/src/Components/AuthDialog/Components/AuthDialogSocial.tsx
@@ -3,11 +3,11 @@ import FacebookIcon from "@artsy/icons/FacebookIcon"
 import GoogleIcon from "@artsy/icons/GoogleIcon"
 import { Button, Stack } from "@artsy/palette"
 import { useAuthDialogContext } from "Components/AuthDialog/AuthDialogContext"
+import { useAfterAuthenticationRedirectUrl } from "Components/AuthDialog/Hooks/useAfterAuthenticationRedirectUrl"
 import { setSocialAuthTracking } from "Components/AuthDialog/Hooks/useSocialAuthTracking"
 import { getENV } from "Utils/getENV"
 import { stringify } from "qs"
 import type { FC } from "react"
-import { useRouter } from "System/Hooks/useRouter"
 
 export const AuthDialogSocial: FC<React.PropsWithChildren<unknown>> = () => {
   const { applePath, facebookPath, googlePath } = getENV("AP") ?? {
@@ -20,12 +20,7 @@ export const AuthDialogSocial: FC<React.PropsWithChildren<unknown>> = () => {
     state: { options, analytics, mode },
   } = useAuthDialogContext()
 
-  const { match } = useRouter()
-  const location = match ? match.location : window.location
-
-  const defaultRedirect = ["/login", "/signup"].includes(location.pathname)
-    ? "/"
-    : location.pathname + (location.search || "")
+  const { redirectUrl } = useAfterAuthenticationRedirectUrl(false)
 
   // These params are handled by the routes in the Passport app,
   // they get pushed onto the session and then handled when the social
@@ -33,7 +28,7 @@ export const AuthDialogSocial: FC<React.PropsWithChildren<unknown>> = () => {
   const query = stringify(
     {
       afterSignUpAction: options.afterAuthAction,
-      "redirect-to": options.redirectTo || defaultRedirect,
+      "redirect-to": redirectUrl,
       "signup-intent": analytics.intent,
       "signup-referer": getENV("AUTHENTICATION_REFERER"),
       accepted_terms_of_service: true,

--- a/src/Components/AuthDialog/Components/AuthDialogSocial.tsx
+++ b/src/Components/AuthDialog/Components/AuthDialogSocial.tsx
@@ -3,7 +3,6 @@ import FacebookIcon from "@artsy/icons/FacebookIcon"
 import GoogleIcon from "@artsy/icons/GoogleIcon"
 import { Button, Stack } from "@artsy/palette"
 import { useAuthDialogContext } from "Components/AuthDialog/AuthDialogContext"
-import { useAfterAuthenticationRedirectUrl } from "Components/AuthDialog/Hooks/useAfterAuthenticationRedirectUrl"
 import { setSocialAuthTracking } from "Components/AuthDialog/Hooks/useSocialAuthTracking"
 import { getENV } from "Utils/getENV"
 import { stringify } from "qs"
@@ -20,15 +19,13 @@ export const AuthDialogSocial: FC<React.PropsWithChildren<unknown>> = () => {
     state: { options, analytics, mode },
   } = useAuthDialogContext()
 
-  const { redirectUrl } = useAfterAuthenticationRedirectUrl()
-
   // These params are handled by the routes in the Passport app,
   // they get pushed onto the session and then handled when the social
   // service redirects back to Force.
   const query = stringify(
     {
       afterSignUpAction: options.afterAuthAction,
-      "redirect-to": redirectUrl,
+      "redirect-to": options.redirectTo || "/",
       "signup-intent": analytics.intent,
       "signup-referer": getENV("AUTHENTICATION_REFERER"),
       accepted_terms_of_service: true,

--- a/src/Components/AuthDialog/Components/AuthDialogSocial.tsx
+++ b/src/Components/AuthDialog/Components/AuthDialogSocial.tsx
@@ -7,6 +7,7 @@ import { setSocialAuthTracking } from "Components/AuthDialog/Hooks/useSocialAuth
 import { getENV } from "Utils/getENV"
 import { stringify } from "qs"
 import type { FC } from "react"
+import { useRouter } from "System/Hooks/useRouter"
 
 export const AuthDialogSocial: FC<React.PropsWithChildren<unknown>> = () => {
   const { applePath, facebookPath, googlePath } = getENV("AP") ?? {
@@ -19,13 +20,20 @@ export const AuthDialogSocial: FC<React.PropsWithChildren<unknown>> = () => {
     state: { options, analytics, mode },
   } = useAuthDialogContext()
 
+  const { match } = useRouter()
+  const location = match ? match.location : window.location
+
+  const defaultRedirect = ["/login", "/signup"].includes(location.pathname)
+    ? "/"
+    : location.pathname + (location.search || "")
+
   // These params are handled by the routes in the Passport app,
   // they get pushed onto the session and then handled when the social
   // service redirects back to Force.
   const query = stringify(
     {
       afterSignUpAction: options.afterAuthAction,
-      "redirect-to": options.redirectTo || "/",
+      "redirect-to": options.redirectTo || defaultRedirect,
       "signup-intent": analytics.intent,
       "signup-referer": getENV("AUTHENTICATION_REFERER"),
       accepted_terms_of_service: true,

--- a/src/Components/AuthDialog/Components/AuthDialogSocial.tsx
+++ b/src/Components/AuthDialog/Components/AuthDialogSocial.tsx
@@ -20,7 +20,9 @@ export const AuthDialogSocial: FC<React.PropsWithChildren<unknown>> = () => {
     state: { options, analytics, mode },
   } = useAuthDialogContext()
 
-  const { redirectUrl } = useAfterAuthenticationRedirectUrl(false)
+  const { redirectUrl } = useAfterAuthenticationRedirectUrl({
+    appendOnboarding: false,
+  })
 
   // These params are handled by the routes in the Passport app,
   // they get pushed onto the session and then handled when the social

--- a/src/Components/AuthDialog/Hooks/useAfterAuthenticationRedirectUrl.ts
+++ b/src/Components/AuthDialog/Hooks/useAfterAuthenticationRedirectUrl.ts
@@ -6,8 +6,9 @@ import { useMemo } from "react"
 
 /**
  * Returns a string representing the URL to redirect to after authentication.
+ * @param appendOnboarding - Whether to append ?onboarding=true to the URL (defaults to true)
  */
-export const useAfterAuthenticationRedirectUrl = () => {
+export const useAfterAuthenticationRedirectUrl = (appendOnboarding = true) => {
   const {
     state: { options },
   } = useAuthDialogContext()
@@ -24,7 +25,7 @@ export const useAfterAuthenticationRedirectUrl = () => {
       getENV("APP_URL") ?? "https://www.artsy.net",
     )
 
-    if (isElligibleForOnboarding) {
+    if (appendOnboarding && isElligibleForOnboarding) {
       redirectUri.searchParams.append("onboarding", "true")
     }
 
@@ -40,7 +41,12 @@ export const useAfterAuthenticationRedirectUrl = () => {
     }
 
     return redirectUri.toString()
-  }, [defaultRedirect, isElligibleForOnboarding, options.redirectTo])
+  }, [
+    appendOnboarding,
+    defaultRedirect,
+    isElligibleForOnboarding,
+    options.redirectTo,
+  ])
 
   return { redirectUrl }
 }

--- a/src/Components/AuthDialog/Hooks/useAfterAuthenticationRedirectUrl.ts
+++ b/src/Components/AuthDialog/Hooks/useAfterAuthenticationRedirectUrl.ts
@@ -6,9 +6,15 @@ import { useMemo } from "react"
 
 /**
  * Returns a string representing the URL to redirect to after authentication.
- * @param appendOnboarding - Whether to append ?onboarding=true to the URL (defaults to true)
+ * @param onboardingOptions - Configuration object for onboarding behavior
+ * @param onboardingOptions.appendOnboarding - Whether to append ?onboarding=true to the URL (defaults to
+   true)
  */
-export const useAfterAuthenticationRedirectUrl = (appendOnboarding = true) => {
+export const useAfterAuthenticationRedirectUrl = (
+  onboardingOptions: { appendOnboarding?: boolean } = {},
+) => {
+  const appendOnboarding = onboardingOptions.appendOnboarding ?? true
+
   const {
     state: { options },
   } = useAuthDialogContext()

--- a/src/Server/passport/lib/app/__tests__/redirectBack.jest.ts
+++ b/src/Server/passport/lib/app/__tests__/redirectBack.jest.ts
@@ -94,7 +94,7 @@ describe("redirectBack", () => {
 
     const redirect = redirectBack(req)
 
-    expect(redirect).toEqual("/")
+    expect(redirect).toEqual("/?onboarding=true")
   })
 
   it("does not use the after-signup destination when onboarding is skipped", () => {
@@ -186,5 +186,47 @@ describe("redirectBack", () => {
     expect(res.redirect).toHaveBeenCalledWith("/artworks")
     expect(req.session.redirectTo).toBeUndefined()
     expect(req.session.skipOnboarding).toBeUndefined()
+  })
+
+  it("appends onboarding=true for new social auth signups", () => {
+    const req = {
+      artsyPassportSignedUp: true,
+      body: {},
+      params: {},
+      query: { "redirect-to": "/" },
+      session: {},
+    } as any
+
+    const redirect = redirectBack(req)
+
+    expect(redirect).toEqual("/?onboarding=true")
+  })
+
+  it("does not append onboarding=true for existing user logins", () => {
+    const req = {
+      artsyPassportSignedUp: false,
+      body: {},
+      params: {},
+      query: { "redirect-to": "/" },
+      session: {},
+    } as any
+
+    const redirect = redirectBack(req)
+
+    expect(redirect).toEqual("/")
+  })
+
+  it("does not append onboarding=true when skipOnboarding is true", () => {
+    const req = {
+      artsyPassportSignedUp: true,
+      body: {},
+      params: {},
+      query: { "redirect-to": "/" },
+      session: { skipOnboarding: true },
+    } as any
+
+    const redirect = redirectBack(req)
+
+    expect(redirect).toEqual("/")
   })
 })

--- a/src/Server/passport/lib/app/redirectBack.ts
+++ b/src/Server/passport/lib/app/redirectBack.ts
@@ -9,7 +9,7 @@ export const redirectBack = (
   req: ArtsyRequest & { artsyPassportSignedUp?: boolean },
   res: ArtsyResponse | null = null,
 ) => {
-  const url = sanitizeRedirect(
+  let url = sanitizeRedirect(
     req.session.redirectTo ||
       (req.artsyPassportSignedUp && !req.session.skipOnboarding
         ? opts.afterSignupPagePath
@@ -19,6 +19,12 @@ export const redirectBack = (
       req.params.redirect_uri ||
       "/",
   )
+
+  // If this is a new social auth signup, append onboarding=true
+  if (req.artsyPassportSignedUp && !req.session.skipOnboarding) {
+    const separator = url.includes("?") ? "&" : "?"
+    url = `${url}${separator}onboarding=true`
+  }
 
   if (res !== null) {
     delete req.session.redirectTo


### PR DESCRIPTION
The type of this PR is: **FIX**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

We noticed that when existing users signed up via social auth from the `/signup` page, they were incorrectly shown the onboarding modal each time, meaning that they were not being recognized as existing users like they are when logging in with email/pw.

This was happening because `/signup` landing page wrapped everything in `<AuthenticationInlineDialogProvider mode="SignUp">`. The frontend was deciding whether or not to show onboarding by checking `mode="SignUp"` and appending `?onboarding=true` to the redirect URL. But we actually don't yet know if the user is new or existing until the auth flow finishes. 

Instead we want the following behavior:
-A new user signing up via social auth = show onboarding after redirect
-An existing user logging in via social auth = do not show onboarding after redirect

#### Solution:
~~-We removed `useAfterAuthenticationRedirectUrl()` which automatically set onboarding to true.~~
-We modified `useAfterAuthenticationRedirectUrl()` to accept an optional parameter `appendOnboarding`
  (defaults to true). Social auth components call this hook with `false` to prevent the frontend from
  appending `?onboarding=true`.
-Now, after oauth completes, we check if a new account was created `req.artsyPassportSignedUp = true`, if so, append `?onboarding=true`
-We continue redirecting to the previous page that the user was on (or wherever they were in a commercial action, etc)

#### NOTE: 
In the current implementation, email/pw sign up flow does not allow existing users to login. However, if we decide to  change this form to also allow for the login flow ([discussion here](https://artsy.slack.com/archives/C05EEBNEF71/p1778759361473739)), we'll need to change the implementation for email/pw to match this (i.e. not automatically sending the user to onboarding flow after logging in). 
