### PR TITLE
chore(DI-284): Revert homepage and nav bar Sign Up CTAs to show modal

### DIFF
--- a/src/Apps/Home/Components/HomeHeroUnits/HomeHeroUnitLoggedOut.tsx
+++ b/src/Apps/Home/Components/HomeHeroUnits/HomeHeroUnitLoggedOut.tsx
@@ -1,3 +1,5 @@
+import { ContextModule } from "@artsy/cohesion"
+import { useAuthDialog } from "Components/AuthDialog"
 import { useDeviceDetection } from "Utils/Hooks/useDeviceDetection"
 import type * as React from "react"
 import { HomeHeroUnitBase } from "./HomeHeroUnit"
@@ -6,6 +8,7 @@ export const HomeHeroUnitLoggedOut: React.FC<{ index: number }> = ({
   index,
 }) => {
   const { downloadAppUrl } = useDeviceDetection()
+  const { showAuthDialog } = useAuthDialog()
 
   return (
     <HomeHeroUnitBase
@@ -16,6 +19,15 @@ export const HomeHeroUnitLoggedOut: React.FC<{ index: number }> = ({
         desktop: {
           text: "Sign Up",
           url: "/signup",
+          onClick: e => {
+            e.preventDefault()
+
+            showAuthDialog({
+              analytics: {
+                contextModule: ContextModule.heroUnitsRail,
+              },
+            })
+          },
         },
         mobile: {
           text: "Get the App",

--- a/src/Components/NavBar/NavBarLoggedOutActions.tsx
+++ b/src/Components/NavBar/NavBarLoggedOutActions.tsx
@@ -1,13 +1,9 @@
 import { ContextModule, Intent } from "@artsy/cohesion"
 import { Button, Flex, Spacer } from "@artsy/palette"
 import { useAuthDialog } from "Components/AuthDialog"
-import { RouterLink } from "System/Components/RouterLink"
-import { useRouter } from "System/Hooks/useRouter"
 
 export const NavBarLoggedOutActions = () => {
   const { showAuthDialog } = useAuthDialog()
-  const { match } = useRouter()
-  const currentPath = match.location.pathname
 
   return (
     <Flex alignItems="center">
@@ -29,10 +25,15 @@ export const NavBarLoggedOutActions = () => {
       <Spacer x={1} />
 
       <Button
-        // @ts-expect-error
-        as={RouterLink}
         size="small"
-        to={`/signup?redirectTo=${encodeURIComponent(currentPath)}`}
+        onClick={() => {
+          showAuthDialog({
+            analytics: {
+              contextModule: ContextModule.header,
+              intent: Intent.signup,
+            },
+          })
+        }}
       >
         Sign Up
       </Button>

--- a/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuAuthentication.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuAuthentication.tsx
@@ -6,7 +6,6 @@ import { trackEvent } from "Server/analytics/helpers"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import type * as React from "react"
 import { NavBarMobileMenuItemLink } from "./NavBarMobileMenuItem"
-import { useState, useEffect } from "react"
 
 export const NavBarMobileMenuLoggedIn: React.FC<
   React.PropsWithChildren<unknown>
@@ -56,16 +55,10 @@ export const NavBarMobileMenuLoggedIn: React.FC<
 const NavBarMobileMenuLoggedOut: React.FC<
   React.PropsWithChildren<unknown>
 > = () => {
-  const [currentPath, setCurrentPath] = useState("/")
-
-  useEffect(() => {
-    setCurrentPath(window.location.pathname)
-  }, [])
-
   return (
     <>
       <NavBarMobileMenuItemLink
-        to={`/signup?redirectTo=${encodeURIComponent(currentPath)}`}
+        to={`/signup?intent=${Intent.signup}&contextModule=${ContextModule.header}`}
       >
         Sign Up
       </NavBarMobileMenuItemLink>

--- a/src/Components/NavBar/NavBarMobileMenu/__tests__/NavBarMobileMenu.jest.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/__tests__/NavBarMobileMenu.jest.tsx
@@ -129,7 +129,7 @@ describe("NavBarMobileMenu", () => {
         ["/institutions", "Museums"],
         ["/price-database", "Price Database"],
         ["/articles", "Editorial"],
-        ["/signup?redirectTo=%2F", "Sign Up"],
+        ["/signup?intent=signup&contextModule=header", "Sign Up"],
         ["/login?intent=login&contextModule=header", "Log In"],
       ].map(link => link.join(""))
 

--- a/src/Components/NavBar/__tests__/NavBar.jest.tsx
+++ b/src/Components/NavBar/__tests__/NavBar.jest.tsx
@@ -182,16 +182,22 @@ describe("NavBar", () => {
       })
     })
 
-    it("navigates to signup page on signup button click", () => {
+    it("calls signup auth action on signup button click", () => {
+      const showAuthDialog = jest.fn()
+      mockUseAuthDialog.mockImplementation(() => ({ showAuthDialog }))
+
       getWrapper()
 
       const signupButton = screen.getByText("Sign Up")
       expect(signupButton).toBeDefined()
+      fireEvent.click(signupButton)
 
-      expect(signupButton.closest("a")).toHaveAttribute("href")
-      expect(signupButton.closest("a")?.getAttribute("href")).toMatch(
-        /^\/signup\?redirectTo=/,
-      )
+      expect(showAuthDialog).toBeCalledWith({
+        analytics: {
+          contextModule: "header",
+          intent: "signup",
+        },
+      })
     })
   })
 

--- a/src/Components/NavBar/__tests__/NavBarLoggedOutActions.jest.tsx
+++ b/src/Components/NavBar/__tests__/NavBarLoggedOutActions.jest.tsx
@@ -30,14 +30,6 @@ describe("NavBarLoggedOutActions", () => {
     expect(screen.getByText("Sign Up")).toBeInTheDocument()
   })
 
-  it("Sign Up button links to /signup with encoded current path", () => {
-    render(<NavBarLoggedOutActions />)
-    expect(screen.getByText("Sign Up").closest("a")).toHaveAttribute(
-      "href",
-      "/signup?redirectTo=%2Fcollect",
-    )
-  })
-
   it("opens auth dialog with correct analytics when Log In is clicked", () => {
     const showAuthDialog = jest.fn()
     mockUseAuthDialog.mockReturnValue({ showAuthDialog })


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PROJECT-[DI-284](https://www.notion.so/35fcab0764a0801ca8a3e1b9d436664a)]

### Description

After launching the dedicated signup page at /signup, data analysis showed no measurable improvement in signup conversion compared to the previous approach (modal). This PR reverts Sign Up CTAs back to showing the auth modal on the homepage (in the navbar and hero section). The dedicated /signup page remains available as is.

(screen recording not working...please hold)

<!-- Implementation description -->
