### PR TITLE
chore: improve sentry reporting for error boundaries

### DIFF
--- a/src/System/Components/ContentErrorBoundary.tsx
+++ b/src/System/Components/ContentErrorBoundary.tsx
@@ -60,6 +60,11 @@ export class ContentErrorBoundary extends React.Component<
         componentStack: errorInfo.componentStack,
       })
       scope.setTag("errorBoundary", "content")
+      scope.setFingerprint([
+        "ContentErrorBoundary",
+        "{{ error.type }}",
+        "{{ default }}",
+      ])
       captureException(error)
     })
   }

--- a/src/System/Components/ErrorBoundary.tsx
+++ b/src/System/Components/ErrorBoundary.tsx
@@ -41,6 +41,11 @@ export class ErrorBoundary extends React.Component<Props, State> {
         componentStack: errorInfo.componentStack,
       })
       scope.setTag("errorBoundary", "outer")
+      scope.setFingerprint([
+        "ErrorBoundary",
+        "{{ error.type }}",
+        "{{ default }}",
+      ])
       captureException(error)
     })
 

--- a/src/System/Components/__tests__/ContentErrorBoundary.jest.tsx
+++ b/src/System/Components/__tests__/ContentErrorBoundary.jest.tsx
@@ -10,6 +10,7 @@ jest.mock("Utils/getENV", () => ({
 const mockCaptureException = jest.fn()
 const mockSetContext = jest.fn()
 const mockSetTag = jest.fn()
+const mockSetFingerprint = jest.fn()
 
 jest.mock("@sentry/browser", () => ({
   captureException: (...args: unknown[]) => mockCaptureException(...args),
@@ -17,6 +18,7 @@ jest.mock("@sentry/browser", () => ({
     cb({
       setContext: mockSetContext,
       setTag: mockSetTag,
+      setFingerprint: mockSetFingerprint,
     }),
 }))
 
@@ -39,7 +41,7 @@ describe("ContentErrorBoundary", () => {
     render(
       <ContentErrorBoundary pathname="/test">
         <div>Hello World</div>
-      </ContentErrorBoundary>
+      </ContentErrorBoundary>,
     )
 
     expect(screen.getByText("Hello World")).toBeInTheDocument()
@@ -53,7 +55,7 @@ describe("ContentErrorBoundary", () => {
     render(
       <ContentErrorBoundary pathname="/test">
         <ErrorComponent />
-      </ContentErrorBoundary>
+      </ContentErrorBoundary>,
     )
 
     expect(screen.getByTestId("error-page")).toBeInTheDocument()
@@ -68,7 +70,7 @@ describe("ContentErrorBoundary", () => {
     render(
       <ContentErrorBoundary pathname="/test">
         <ErrorComponent />
-      </ContentErrorBoundary>
+      </ContentErrorBoundary>,
     )
 
     expect(screen.getByText("Something Went Wrong")).toBeInTheDocument()
@@ -95,7 +97,7 @@ describe("ContentErrorBoundary", () => {
           <ContentErrorBoundary pathname="/test">
             <ErrorComponent />
           </ContentErrorBoundary>
-        </OuterBoundary>
+        </OuterBoundary>,
       )
     }).toThrow("Loading chunk abc123.js failed")
   })
@@ -111,7 +113,7 @@ describe("ContentErrorBoundary", () => {
         }}
       >
         <div>Content</div>
-      </ContentErrorBoundary>
+      </ContentErrorBoundary>,
     )
 
     // Simulate an error state
@@ -133,7 +135,7 @@ describe("ContentErrorBoundary", () => {
         }}
       >
         <div>Content</div>
-      </ContentErrorBoundary>
+      </ContentErrorBoundary>,
     )
 
     expect(screen.getByText("Content")).toBeInTheDocument()
@@ -150,7 +152,7 @@ describe("ContentErrorBoundary", () => {
         }}
       >
         <div>Content</div>
-      </ContentErrorBoundary>
+      </ContentErrorBoundary>,
     )
 
     act(() => {
@@ -171,13 +173,13 @@ describe("ContentErrorBoundary", () => {
         }}
       >
         <div>Content</div>
-      </ContentErrorBoundary>
+      </ContentErrorBoundary>,
     )
 
     expect(screen.getByText("Something Went Wrong")).toBeInTheDocument()
   })
 
-  it("reports to Sentry with errorBoundary: 'content' tag", () => {
+  it("reports to Sentry with tags, fingerprint, and exception", () => {
     const ErrorComponent = () => {
       throw new Error("sentry test error")
     }
@@ -185,10 +187,15 @@ describe("ContentErrorBoundary", () => {
     render(
       <ContentErrorBoundary pathname="/test">
         <ErrorComponent />
-      </ContentErrorBoundary>
+      </ContentErrorBoundary>,
     )
 
     expect(mockSetTag).toHaveBeenCalledWith("errorBoundary", "content")
+    expect(mockSetFingerprint).toHaveBeenCalledWith([
+      "ContentErrorBoundary",
+      "{{ error.type }}",
+      "{{ default }}",
+    ])
     expect(mockCaptureException).toHaveBeenCalled()
   })
 
@@ -201,7 +208,7 @@ describe("ContentErrorBoundary", () => {
       render(
         <ContentErrorBoundary pathname="/test">
           <ErrorComponent />
-        </ContentErrorBoundary>
+        </ContentErrorBoundary>,
       )
     }).toThrow()
 

--- a/src/System/Components/__tests__/ErrorBoundary.jest.tsx
+++ b/src/System/Components/__tests__/ErrorBoundary.jest.tsx
@@ -6,6 +6,21 @@ jest.mock("Utils/getENV", () => ({
   getENV: () => "development",
 }))
 
+const mockCaptureException = jest.fn()
+const mockSetContext = jest.fn()
+const mockSetTag = jest.fn()
+const mockSetFingerprint = jest.fn()
+
+jest.mock("@sentry/browser", () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+  withScope: (cb: (scope: unknown) => void) =>
+    cb({
+      setContext: mockSetContext,
+      setTag: mockSetTag,
+      setFingerprint: mockSetFingerprint,
+    }),
+}))
+
 describe("ErrorBoundary", () => {
   const errorLog = console.error
 
@@ -14,6 +29,7 @@ describe("ErrorBoundary", () => {
   })
 
   afterEach(() => {
+    jest.clearAllMocks()
     console.error = errorLog
   })
 
@@ -32,7 +48,6 @@ describe("ErrorBoundary", () => {
 
     const ErrorComponent = () => {
       throw new Error("throw error")
-      return null
     }
 
     try {
@@ -51,7 +66,6 @@ describe("ErrorBoundary", () => {
   it("updates `detail` state with stack trace", () => {
     const ErrorComponent = () => {
       throw new Error("throw error")
-      return null
     }
 
     let errorBoundaryInstance: any = null
@@ -159,5 +173,25 @@ describe("ErrorBoundary", () => {
 
     expect(state.kind).toBe("AsyncChunkLoadError")
     expect(state.message).toContain("Loading chunk c3495.js failed")
+  })
+
+  it("reports to Sentry with tags, fingerprint, and exception", () => {
+    const ErrorComponent = () => {
+      throw new Error("sentry test error")
+    }
+
+    render(
+      <ErrorBoundary>
+        <ErrorComponent />
+      </ErrorBoundary>,
+    )
+
+    expect(mockSetTag).toHaveBeenCalledWith("errorBoundary", "outer")
+    expect(mockSetFingerprint).toHaveBeenCalledWith([
+      "ErrorBoundary",
+      "{{ error.type }}",
+      "{{ default }}",
+    ])
+    expect(mockCaptureException).toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
Force has two error boundaries that act as the last line of defense against errors that bubble up from the React component tree. These error boundaries have been reporting about 70K events to Sentry every week since client-side reporting was enabled on April 9 2026. Unfortunately, they are all being grouped together under the same issue in Sentry, so it is difficult to target and observe the most impactful errors.

- Read about [error boundaries](https://github.com/artsy/force/blob/main/docs/error-handling.md) in Force.
- See the [Sentry issues](https://artsynet.sentry.io/issues/?groupStatsPeriod=auto&project=28316&query=is%3Aunresolved%20removeChild&referrer=issue-list&statsPeriod=90d) that are being captured by these error boundaries.

This PR attempts to group these events a bit better by "fingerprinting" each one with the name of the error boundary that caught it, and the type of error it is (followed by the default fingerprint). Once the events are properly grouped, we can focus on the most common ones.

- Read about [event fingerprinting](https://docs.sentry.io/platforms/javascript/enriching-events/fingerprinting/) and the [variables](https://docs.sentry.io/concepts/data-management/event-grouping/fingerprint-rules/#variables) used in this PR.

cc: @artsy/diamond-devs