### PR TITLE
fix(refactor): analytics fixes for social auth and one tap

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
     "@swc/helpers": "^0.5.15",
     "@unleash/proxy-client-react": "^4.5.2",
     "actioncable": "^5.2.7-1",
-    "analytics-node": "2.4.1",
     "autosuggest-highlight": "3.1.1",
     "blurhash": "^2.0.5",
     "body-parser": "1.20.3",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "sha.js": "^2.4.12"
   },
   "dependencies": {
-    "@artsy/cohesion": "4.355.0",
+    "@artsy/cohesion": "4.356.0",
     "@artsy/detect-responsive-traits": "^0.2.0",
     "@artsy/dismissible": "^0.8.1",
     "@artsy/express-reloadable": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "sha.js": "^2.4.12"
   },
   "dependencies": {
-    "@artsy/cohesion": "4.354.0",
+    "@artsy/cohesion": "4.355.0",
     "@artsy/detect-responsive-traits": "^0.2.0",
     "@artsy/dismissible": "^0.8.0",
     "@artsy/express-reloadable": "^1.7.0",

--- a/src/Apps/Authentication/Routes/SignupLanding/Components/SignupFormSocial.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/Components/SignupFormSocial.tsx
@@ -2,17 +2,11 @@ import { Button, Stack } from "@artsy/palette"
 import GoogleIcon from "@artsy/icons/GoogleIcon"
 import AppleIcon from "@artsy/icons/AppleIcon"
 import FacebookIcon from "@artsy/icons/FacebookIcon"
-import { useAuthDialogContext } from "Components/AuthDialog/AuthDialogContext"
-import { setSocialAuthTracking } from "Components/AuthDialog/Hooks/useSocialAuthTracking"
 import { getENV } from "Utils/getENV"
 import { stringify } from "qs"
 import { useAfterAuthenticationRedirectUrl } from "Components/AuthDialog/Hooks/useAfterAuthenticationRedirectUrl"
 
 export const SignupFormSocial = () => {
-  const {
-    state: { analytics, mode },
-  } = useAuthDialogContext()
-
   const { redirectUrl } = useAfterAuthenticationRedirectUrl()
 
   const { applePath, facebookPath, googlePath } = getENV("AP") ?? {
@@ -32,14 +26,6 @@ export const SignupFormSocial = () => {
     { skipNulls: true },
   )
 
-  const handleClick = (service: "facebook" | "apple" | "google") => () => {
-    setSocialAuthTracking({
-      action: { Login: "loggedIn", SignUp: "signedUp" }[mode],
-      analytics,
-      service,
-    })
-  }
-
   return (
     <Stack gap={1}>
       <Button
@@ -48,7 +34,6 @@ export const SignupFormSocial = () => {
         // @ts-ignore
         as="a"
         href={`${googlePath}?${query}`}
-        onClick={handleClick("google")}
         rel="nofollow"
         Icon={GoogleIcon}
       >
@@ -61,7 +46,6 @@ export const SignupFormSocial = () => {
         // @ts-ignore
         as="a"
         href={`${facebookPath}?${query}`}
-        onClick={handleClick("facebook")}
         rel="nofollow"
         Icon={FacebookIcon}
       >
@@ -74,7 +58,6 @@ export const SignupFormSocial = () => {
         // @ts-ignore
         as="a"
         href={`${applePath}?${query}`}
-        onClick={handleClick("apple")}
         rel="nofollow"
         Icon={AppleIcon}
       >

--- a/src/Components/AuthDialog/Components/AuthDialogSocial.tsx
+++ b/src/Components/AuthDialog/Components/AuthDialogSocial.tsx
@@ -4,7 +4,6 @@ import GoogleIcon from "@artsy/icons/GoogleIcon"
 import { Button, Stack } from "@artsy/palette"
 import { useAuthDialogContext } from "Components/AuthDialog/AuthDialogContext"
 import { useAfterAuthenticationRedirectUrl } from "Components/AuthDialog/Hooks/useAfterAuthenticationRedirectUrl"
-import { setSocialAuthTracking } from "Components/AuthDialog/Hooks/useSocialAuthTracking"
 import { getENV } from "Utils/getENV"
 import { stringify } from "qs"
 import type { FC } from "react"
@@ -17,7 +16,7 @@ export const AuthDialogSocial: FC<React.PropsWithChildren<unknown>> = () => {
   }
 
   const {
-    state: { options, analytics, mode },
+    state: { options, analytics },
   } = useAuthDialogContext()
 
   const { redirectUrl } = useAfterAuthenticationRedirectUrl()
@@ -37,14 +36,6 @@ export const AuthDialogSocial: FC<React.PropsWithChildren<unknown>> = () => {
     { skipNulls: true },
   )
 
-  const handleClick = (service: "facebook" | "apple" | "google") => () => {
-    setSocialAuthTracking({
-      action: { Login: "loggedIn", SignUp: "signedUp" }[mode],
-      analytics,
-      service,
-    })
-  }
-
   return (
     <Stack gap={1} flexDirection="row">
       <Button
@@ -53,7 +44,6 @@ export const AuthDialogSocial: FC<React.PropsWithChildren<unknown>> = () => {
         // @ts-ignore
         as="a"
         href={`${applePath}?${query}`}
-        onClick={handleClick("apple")}
         rel="nofollow"
         title="Continue with Apple"
       >
@@ -66,7 +56,6 @@ export const AuthDialogSocial: FC<React.PropsWithChildren<unknown>> = () => {
         // @ts-ignore
         as="a"
         href={`${googlePath}?${query}`}
-        onClick={handleClick("google")}
         rel="nofollow"
         title="Continue with Google"
       >
@@ -79,7 +68,6 @@ export const AuthDialogSocial: FC<React.PropsWithChildren<unknown>> = () => {
         // @ts-ignore
         as="a"
         href={`${facebookPath}?${query}`}
-        onClick={handleClick("facebook")}
         rel="nofollow"
         title="Continue with Facebook"
       >

--- a/src/Components/AuthDialog/Components/AuthDialogSocial.tsx
+++ b/src/Components/AuthDialog/Components/AuthDialogSocial.tsx
@@ -28,8 +28,10 @@ export const AuthDialogSocial: FC<React.PropsWithChildren<unknown>> = () => {
     {
       afterSignUpAction: options.afterAuthAction,
       "redirect-to": redirectUrl,
+      "context-module": analytics.contextModule,
       "signup-intent": analytics.intent,
       "signup-referer": getENV("AUTHENTICATION_REFERER"),
+      trigger: analytics.trigger,
       accepted_terms_of_service: true,
       agreed_to_receive_emails: true,
     },

--- a/src/Components/AuthDialog/Hooks/__tests__/useSocialAuthTracking.jest.ts
+++ b/src/Components/AuthDialog/Hooks/__tests__/useSocialAuthTracking.jest.ts
@@ -57,6 +57,27 @@ describe("useSocialAuthTracking", () => {
     expect(mockCookiesExpire).toBeCalledWith("useSocialAuthTracking")
   })
 
+  it("passes method to the tracking function when present", () => {
+    const loggedIn = jest.fn()
+    mockUseAuthDialogTracking.mockImplementation(() => ({ loggedIn }))
+
+    mockCookiesGet.mockImplementation(() =>
+      JSON.stringify({
+        action: "loggedIn",
+        service: "google",
+        method: "one-tap",
+      }),
+    )
+
+    renderHook(useSocialAuthTracking)
+
+    expect(loggedIn).toBeCalledWith({
+      method: "one-tap",
+      service: "google",
+      userId: "example",
+    })
+  })
+
   it("does not call the tracking function if the cookie is invalid and expires the cookie", () => {
     const loggedIn = jest.fn()
     mockUseAuthDialogTracking.mockImplementation(() => ({ loggedIn }))

--- a/src/Components/AuthDialog/Hooks/useAuthDialogTracking.ts
+++ b/src/Components/AuthDialog/Hooks/useAuthDialogTracking.ts
@@ -49,12 +49,14 @@ export const useAuthDialogTracking = () => {
         userId,
         intent = analytics.intent || Intent.login,
         trigger = analytics.trigger || "click",
+        context_page_path,
       }: {
         contextModule?: SuccessfullyLoggedIn["context_module"]
         service: SuccessfullyLoggedIn["service"]
         userId: SuccessfullyLoggedIn["user_id"]
         intent?: SuccessfullyLoggedIn["intent"]
         trigger?: SuccessfullyLoggedIn["trigger"]
+        context_page_path?: string
       }) => {
         const payload: SuccessfullyLoggedIn = {
           action: ActionType.successfullyLoggedIn,
@@ -67,7 +69,10 @@ export const useAuthDialogTracking = () => {
           user_id: userId,
         }
 
-        return trackEvent(payload)
+        return trackEvent({
+          ...payload,
+          ...(context_page_path ? { context_page_path } : {}),
+        })
       },
 
       signedUp: ({
@@ -76,12 +81,14 @@ export const useAuthDialogTracking = () => {
         userId,
         intent = analytics.intent || Intent.signup,
         trigger = analytics.trigger || "click",
+        context_page_path,
       }: {
         contextModule?: CreatedAccount["context_module"]
         service: CreatedAccount["service"]
         userId: CreatedAccount["user_id"]
         intent?: CreatedAccount["intent"]
         trigger?: CreatedAccount["trigger"]
+        context_page_path?: string
       }) => {
         const payload: CreatedAccount = {
           action: ActionType.createdAccount,
@@ -95,7 +102,10 @@ export const useAuthDialogTracking = () => {
           user_id: userId,
         }
 
-        return trackEvent(payload)
+        return trackEvent({
+          ...payload,
+          ...(context_page_path ? { context_page_path } : {}),
+        })
       },
 
       resetPassword: () => {

--- a/src/Components/AuthDialog/Hooks/useAuthDialogTracking.ts
+++ b/src/Components/AuthDialog/Hooks/useAuthDialogTracking.ts
@@ -49,14 +49,12 @@ export const useAuthDialogTracking = () => {
         userId,
         intent = analytics.intent || Intent.login,
         trigger = analytics.trigger || "click",
-        context_page_path,
       }: {
         contextModule?: SuccessfullyLoggedIn["context_module"]
         service: SuccessfullyLoggedIn["service"]
         userId: SuccessfullyLoggedIn["user_id"]
         intent?: SuccessfullyLoggedIn["intent"]
         trigger?: SuccessfullyLoggedIn["trigger"]
-        context_page_path?: string
       }) => {
         const payload: SuccessfullyLoggedIn = {
           action: ActionType.successfullyLoggedIn,
@@ -71,7 +69,6 @@ export const useAuthDialogTracking = () => {
 
         return trackEvent({
           ...payload,
-          ...(context_page_path ? { context_page_path } : {}),
         })
       },
 
@@ -81,14 +78,12 @@ export const useAuthDialogTracking = () => {
         userId,
         intent = analytics.intent || Intent.signup,
         trigger = analytics.trigger || "click",
-        context_page_path,
       }: {
         contextModule?: CreatedAccount["context_module"]
         service: CreatedAccount["service"]
         userId: CreatedAccount["user_id"]
         intent?: CreatedAccount["intent"]
         trigger?: CreatedAccount["trigger"]
-        context_page_path?: string
       }) => {
         const payload: CreatedAccount = {
           action: ActionType.createdAccount,
@@ -104,7 +99,6 @@ export const useAuthDialogTracking = () => {
 
         return trackEvent({
           ...payload,
-          ...(context_page_path ? { context_page_path } : {}),
         })
       },
 

--- a/src/Components/AuthDialog/Hooks/useAuthDialogTracking.ts
+++ b/src/Components/AuthDialog/Hooks/useAuthDialogTracking.ts
@@ -67,9 +67,7 @@ export const useAuthDialogTracking = () => {
           user_id: userId,
         }
 
-        return trackEvent({
-          ...payload,
-        })
+        return trackEvent(payload)
       },
 
       signedUp: ({
@@ -97,9 +95,7 @@ export const useAuthDialogTracking = () => {
           user_id: userId,
         }
 
-        return trackEvent({
-          ...payload,
-        })
+        return trackEvent(payload)
       },
 
       resetPassword: () => {

--- a/src/Components/AuthDialog/Hooks/useAuthDialogTracking.ts
+++ b/src/Components/AuthDialog/Hooks/useAuthDialogTracking.ts
@@ -45,12 +45,14 @@ export const useAuthDialogTracking = () => {
 
       loggedIn: ({
         contextModule = analytics.contextModule,
+        method,
         service = "email",
         userId,
         intent = analytics.intent || Intent.login,
         trigger = analytics.trigger || "click",
       }: {
         contextModule?: SuccessfullyLoggedIn["context_module"]
+        method?: SuccessfullyLoggedIn["method"]
         service: SuccessfullyLoggedIn["service"]
         userId: SuccessfullyLoggedIn["user_id"]
         intent?: SuccessfullyLoggedIn["intent"]
@@ -61,6 +63,7 @@ export const useAuthDialogTracking = () => {
           auth_redirect: redirectUrl,
           context_module: contextModule,
           intent,
+          method,
           service,
           trigger,
           type: AuthModalType.login,
@@ -72,12 +75,14 @@ export const useAuthDialogTracking = () => {
 
       signedUp: ({
         contextModule = analytics.contextModule,
+        method,
         service = "email",
         userId,
         intent = analytics.intent || Intent.signup,
         trigger = analytics.trigger || "click",
       }: {
         contextModule?: CreatedAccount["context_module"]
+        method?: CreatedAccount["method"]
         service: CreatedAccount["service"]
         userId: CreatedAccount["user_id"]
         intent?: CreatedAccount["intent"]
@@ -88,6 +93,7 @@ export const useAuthDialogTracking = () => {
           auth_redirect: redirectUrl,
           context_module: contextModule,
           intent,
+          method,
           onboarding: isElligibleForOnboarding,
           service,
           trigger,

--- a/src/Components/AuthDialog/Hooks/useSocialAuthTracking.ts
+++ b/src/Components/AuthDialog/Hooks/useSocialAuthTracking.ts
@@ -9,8 +9,8 @@ import * as Yup from "yup"
 const USE_SOCIAL_AUTH_TRACKING_KEY = "useSocialAuthTracking"
 
 /**
- * Picks up on the cookie set by `setSocialAuthTracking` and logs
- * the appropriate event once the user is redirected back to the app successfully.
+ * Picks up on the cookie set by the passport server after social auth and fires
+ * the appropriate Cohesion tracking event once the user is redirected back.
  */
 export const useSocialAuthTracking = () => {
   const {
@@ -53,7 +53,11 @@ export const useSocialAuthTracking = () => {
     track[value.action]({
       service: value.service,
       userId: user.id,
-      ...value.analytics,
+      ...(value.trigger ? { trigger: value.trigger } : {}),
+      ...(value.context_page_path
+        ? { context_page_path: value.context_page_path }
+        : {}),
+      ...(value.analytics ?? {}),
     })
 
     Cookies.expire(USE_SOCIAL_AUTH_TRACKING_KEY)
@@ -63,17 +67,19 @@ export const useSocialAuthTracking = () => {
 const schema = Yup.object({
   action: Yup.string().oneOf(["loggedIn", "signedUp"]).required(),
   analytics: Yup.object({
-    contextModule: Yup.string().required(),
+    contextModule: Yup.string(),
     intent: Yup.string(),
     trigger: Yup.string(),
-  }),
+  }).optional(),
   service: Yup.string().oneOf(["apple", "google", "facebook"]).required(),
+  trigger: Yup.string().oneOf(["click", "tap", "timed", "scroll"]).optional(),
+  context_page_path: Yup.string().optional(),
 })
 
 type Payload = Omit<Yup.InferType<typeof schema>, "analytics"> & {
   // We assume that the unions are valid because it would
   // be difficult to get the runtime values from Cohesion
-  analytics: AuthDialogAnalytics
+  analytics?: AuthDialogAnalytics
 }
 
 const isValid = (value: any): value is Payload => {

--- a/src/Components/AuthDialog/Hooks/useSocialAuthTracking.ts
+++ b/src/Components/AuthDialog/Hooks/useSocialAuthTracking.ts
@@ -67,11 +67,9 @@ const schema = Yup.object({
     contextModule: Yup.string(),
     intent: Yup.string(),
     trigger: Yup.string(),
-  }).optional(),
+  }),
   service: Yup.string().oneOf(["apple", "google", "facebook"]).required(),
-  trigger: Yup.string()
-    .oneOf(["click", "tap", "timed", "scroll", "one-tap"])
-    .optional(),
+  trigger: Yup.string().oneOf(["click", "tap", "timed", "scroll", "one-tap"]),
 })
 
 type Payload = Omit<Yup.InferType<typeof schema>, "analytics"> & {

--- a/src/Components/AuthDialog/Hooks/useSocialAuthTracking.ts
+++ b/src/Components/AuthDialog/Hooks/useSocialAuthTracking.ts
@@ -69,7 +69,9 @@ const schema = Yup.object({
     trigger: Yup.string(),
   }).optional(),
   service: Yup.string().oneOf(["apple", "google", "facebook"]).required(),
-  trigger: Yup.string().oneOf(["click", "tap", "timed", "scroll"]).optional(),
+  trigger: Yup.string()
+    .oneOf(["click", "tap", "timed", "scroll", "one-tap"])
+    .optional(),
 })
 
 type Payload = Omit<Yup.InferType<typeof schema>, "analytics"> & {

--- a/src/Components/AuthDialog/Hooks/useSocialAuthTracking.ts
+++ b/src/Components/AuthDialog/Hooks/useSocialAuthTracking.ts
@@ -53,7 +53,7 @@ export const useSocialAuthTracking = () => {
     track[value.action]({
       service: value.service,
       userId: user.id,
-      ...(value.trigger ? { trigger: value.trigger } : {}),
+      ...(value.method ? { method: value.method } : {}),
       ...(value.analytics ?? {}),
     })
 
@@ -68,8 +68,9 @@ const schema = Yup.object({
     intent: Yup.string(),
     trigger: Yup.string(),
   }),
+  method: Yup.string().oneOf(["one-tap"]),
   service: Yup.string().oneOf(["apple", "google", "facebook"]).required(),
-  trigger: Yup.string().oneOf(["click", "tap", "timed", "scroll", "one-tap"]),
+  trigger: Yup.string().oneOf(["click", "tap", "timed", "scroll"]),
 })
 
 type Payload = Omit<Yup.InferType<typeof schema>, "analytics"> & {

--- a/src/Components/AuthDialog/Hooks/useSocialAuthTracking.ts
+++ b/src/Components/AuthDialog/Hooks/useSocialAuthTracking.ts
@@ -54,9 +54,6 @@ export const useSocialAuthTracking = () => {
       service: value.service,
       userId: user.id,
       ...(value.trigger ? { trigger: value.trigger } : {}),
-      ...(value.context_page_path
-        ? { context_page_path: value.context_page_path }
-        : {}),
       ...(value.analytics ?? {}),
     })
 
@@ -73,7 +70,6 @@ const schema = Yup.object({
   }).optional(),
   service: Yup.string().oneOf(["apple", "google", "facebook"]).required(),
   trigger: Yup.string().oneOf(["click", "tap", "timed", "scroll"]).optional(),
-  context_page_path: Yup.string().optional(),
 })
 
 type Payload = Omit<Yup.InferType<typeof schema>, "analytics"> & {

--- a/src/Server/passport/lib/app/__tests__/analytics.jest.ts
+++ b/src/Server/passport/lib/app/__tests__/analytics.jest.ts
@@ -1,103 +1,110 @@
 const analytics = require("../analytics")
 
-jest.mock("sharify", () => ({
-  data: {
-    SEGMENT_WRITE_KEY: "foobar",
-  },
-}))
-
-describe("analytics", () => {
-  let req, res, next
+describe("setAuthTrackingCookie", () => {
+  let req: any
+  let res: any
+  let next: jest.Mock
 
   beforeEach(() => {
     req = {
       session: {},
       body: {},
+      headers: {},
       user: { id: "foo" },
       query: {},
+      artsyPassportSignedUp: false,
     }
-    res = { locals: { sd: {} } }
+    res = { cookie: jest.fn() }
     next = jest.fn()
   })
 
-  afterEach(() => {
-    jest.resetAllMocks()
+  it("sets a loggedIn cookie when not signed up", () => {
+    analytics.setAuthTrackingCookie("google")(req, res, next)
+
+    expect(res.cookie).toHaveBeenCalledWith(
+      "useSocialAuthTracking",
+      JSON.stringify({ action: "loggedIn", service: "google" }),
+      { httpOnly: false },
+    )
+    expect(next).toHaveBeenCalled()
   })
 
-  it("tracks signup", () => {
-    const spy = jest.spyOn(analytics.analytics, "track")
-    analytics.trackSignup("email")(req, res, next)
-    expect(spy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        event: "Created account",
-        properties: {
-          acquisition_initiative: undefined,
-          modal_id: undefined,
-          signup_service: "email",
-          user_id: "foo",
-        },
-        userId: "foo",
-      }),
+  it("sets a signedUp cookie when artsyPassportSignedUp is true", () => {
+    req.artsyPassportSignedUp = true
+    analytics.setAuthTrackingCookie("facebook")(req, res, next)
+
+    expect(res.cookie).toHaveBeenCalledWith(
+      "useSocialAuthTracking",
+      JSON.stringify({ action: "signedUp", service: "facebook" }),
+      { httpOnly: false },
     )
   })
 
-  it("tracks login", () => {
-    const spy = jest.spyOn(analytics.analytics, "track")
-    analytics.trackLogin(req, res, next)
-    expect(spy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        event: "Successfully logged in",
-        userId: "foo",
-      }),
+  it("maps google-one-tap to service: google, trigger: tap", () => {
+    analytics.setAuthTrackingCookie("google-one-tap")(req, res, next)
+
+    expect(res.cookie).toHaveBeenCalledWith(
+      "useSocialAuthTracking",
+      JSON.stringify({ action: "loggedIn", service: "google", trigger: "tap" }),
+      { httpOnly: false },
     )
   })
 
-  it("passes along modal_id and acquisition_initiative submitted fields", () => {
-    const spy = jest.spyOn(analytics.analytics, "track")
-    req.body.modal_id = "foo"
-    req.body.acquisition_initiative = "bar"
+  it("includes context_page_path from Referer header for one-tap", () => {
+    req.headers = { referer: "https://staging.artsy.net/artist/andy-warhol" }
+    analytics.setAuthTrackingCookie("google-one-tap")(req, res, next)
+
+    expect(res.cookie).toHaveBeenCalledWith(
+      "useSocialAuthTracking",
+      JSON.stringify({
+        action: "loggedIn",
+        service: "google",
+        trigger: "tap",
+        context_page_path: "/artist/andy-warhol",
+      }),
+      { httpOnly: false },
+    )
+  })
+
+  it("omits context_page_path for regular social auth", () => {
+    req.headers = { referer: "https://accounts.google.com/o/oauth2/callback" }
+    analytics.setAuthTrackingCookie("google")(req, res, next)
+
+    expect(res.cookie).toHaveBeenCalledWith(
+      "useSocialAuthTracking",
+      JSON.stringify({ action: "loggedIn", service: "google" }),
+      { httpOnly: false },
+    )
+  })
+})
+
+describe("setCampaign", () => {
+  let req: any
+  let res: any
+  let next: jest.Mock
+
+  beforeEach(() => {
+    req = { session: {}, body: {}, query: {} }
+    res = {}
+    next = jest.fn()
+  })
+
+  it("stores modal_id and acquisition_initiative from body", () => {
+    req.body.modal_id = "modal-1"
+    req.body.acquisition_initiative = "initiative-1"
     analytics.setCampaign(req, res, next)
-    analytics.trackSignup("email")(req, res, next)
 
-    expect(spy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        event: "Created account",
-        properties: {
-          acquisition_initiative: "bar",
-          modal_id: "foo",
-          signup_service: "email",
-          user_id: "foo",
-        },
-        userId: "foo",
-      }),
-    )
+    expect(req.session.modalId).toBe("modal-1")
+    expect(req.session.acquisitionInitiative).toBe("initiative-1")
+    expect(next).toHaveBeenCalled()
   })
 
-  it("passes along acquisition_initiative query params for OAuth links", () => {
-    const spy = jest.spyOn(analytics.analytics, "track")
-    req.query.modal_id = "foo"
-    req.query.acquisition_initiative = "bar"
+  it("falls back to query params", () => {
+    req.query.modal_id = "modal-q"
+    req.query.acquisition_initiative = "initiative-q"
     analytics.setCampaign(req, res, next)
-    analytics.trackSignup("email")(req, res, next)
-    expect(spy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        event: "Created account",
-        properties: {
-          acquisition_initiative: "bar",
-          modal_id: "foo",
-          signup_service: "email",
-          user_id: "foo",
-        },
-        userId: "foo",
-      }),
-    )
-  })
 
-  it("doesnt hold on to the temporary session variable", () => {
-    req.body.modal_id = "foo"
-    req.body.acquisition_initiative = "bar"
-    analytics.setCampaign(req, res, next)
-    analytics.trackSignup("email")(req, res, next)
-    expect(Object.keys(req.session).length).toEqual(0)
+    expect(req.session.modalId).toBe("modal-q")
+    expect(req.session.acquisitionInitiative).toBe("initiative-q")
   })
 })

--- a/src/Server/passport/lib/app/__tests__/analytics.jest.ts
+++ b/src/Server/passport/lib/app/__tests__/analytics.jest.ts
@@ -53,6 +53,54 @@ describe("setAuthTrackingCookie", () => {
       { httpOnly: false },
     )
   })
+
+  it("includes analytics context from session when present", () => {
+    req.session.contextModule = "artworkPage"
+    req.session.sign_up_intent = "follow"
+    req.session.trigger = "click"
+    analytics.setAuthTrackingCookie("apple")(req, res, next)
+
+    expect(res.cookie).toHaveBeenCalledWith(
+      "useSocialAuthTracking",
+      JSON.stringify({
+        action: "loggedIn",
+        service: "apple",
+        analytics: {
+          contextModule: "artworkPage",
+          intent: "follow",
+          trigger: "click",
+        },
+      }),
+      { httpOnly: false },
+    )
+  })
+
+  it("omits analytics when no session context is present", () => {
+    analytics.setAuthTrackingCookie("apple")(req, res, next)
+
+    expect(res.cookie).toHaveBeenCalledWith(
+      "useSocialAuthTracking",
+      JSON.stringify({ action: "loggedIn", service: "apple" }),
+      { httpOnly: false },
+    )
+  })
+
+  it("does not include session trigger in analytics for google-one-tap", () => {
+    req.session.contextModule = "header"
+    req.session.trigger = "click"
+    analytics.setAuthTrackingCookie("google-one-tap")(req, res, next)
+
+    expect(res.cookie).toHaveBeenCalledWith(
+      "useSocialAuthTracking",
+      JSON.stringify({
+        action: "loggedIn",
+        service: "google",
+        trigger: "one-tap",
+        analytics: { contextModule: "header" },
+      }),
+      { httpOnly: false },
+    )
+  })
 })
 
 describe("setCampaign", () => {

--- a/src/Server/passport/lib/app/__tests__/analytics.jest.ts
+++ b/src/Server/passport/lib/app/__tests__/analytics.jest.ts
@@ -52,7 +52,7 @@ describe("setAuthTrackingCookie", () => {
       JSON.stringify({
         action: "loggedIn",
         service: "google",
-        trigger: "one-tap",
+        method: "one-tap",
       }),
       { httpOnly: false },
     )
@@ -103,7 +103,7 @@ describe("setAuthTrackingCookie", () => {
       JSON.stringify({
         action: "loggedIn",
         service: "google",
-        trigger: "one-tap",
+        method: "one-tap",
         analytics: { contextModule: "header" },
       }),
       { httpOnly: false },

--- a/src/Server/passport/lib/app/__tests__/analytics.jest.ts
+++ b/src/Server/passport/lib/app/__tests__/analytics.jest.ts
@@ -40,18 +40,7 @@ describe("setAuthTrackingCookie", () => {
     )
   })
 
-  it("maps google-one-tap to service: google, trigger: tap", () => {
-    analytics.setAuthTrackingCookie("google-one-tap")(req, res, next)
-
-    expect(res.cookie).toHaveBeenCalledWith(
-      "useSocialAuthTracking",
-      JSON.stringify({ action: "loggedIn", service: "google", trigger: "tap" }),
-      { httpOnly: false },
-    )
-  })
-
-  it("includes context_page_path from Referer header for one-tap", () => {
-    req.headers = { referer: "https://staging.artsy.net/artist/andy-warhol" }
+  it("maps google-one-tap to service: google, trigger: one-tap", () => {
     analytics.setAuthTrackingCookie("google-one-tap")(req, res, next)
 
     expect(res.cookie).toHaveBeenCalledWith(
@@ -59,20 +48,8 @@ describe("setAuthTrackingCookie", () => {
       JSON.stringify({
         action: "loggedIn",
         service: "google",
-        trigger: "tap",
-        context_page_path: "/artist/andy-warhol",
+        trigger: "one-tap",
       }),
-      { httpOnly: false },
-    )
-  })
-
-  it("omits context_page_path for regular social auth", () => {
-    req.headers = { referer: "https://accounts.google.com/o/oauth2/callback" }
-    analytics.setAuthTrackingCookie("google")(req, res, next)
-
-    expect(res.cookie).toHaveBeenCalledWith(
-      "useSocialAuthTracking",
-      JSON.stringify({ action: "loggedIn", service: "google" }),
       { httpOnly: false },
     )
   })

--- a/src/Server/passport/lib/app/__tests__/analytics.jest.ts
+++ b/src/Server/passport/lib/app/__tests__/analytics.jest.ts
@@ -19,7 +19,7 @@ describe("setAuthTrackingCookie", () => {
   })
 
   it("sets a loggedIn cookie when not signed up", () => {
-    analytics.setAuthTrackingCookie("google")(req, res, next)
+    analytics.setAuthTrackingCookie({ service: "google" })(req, res, next)
 
     expect(res.cookie).toHaveBeenCalledWith(
       "useSocialAuthTracking",
@@ -31,7 +31,7 @@ describe("setAuthTrackingCookie", () => {
 
   it("sets a signedUp cookie when artsyPassportSignedUp is true", () => {
     req.artsyPassportSignedUp = true
-    analytics.setAuthTrackingCookie("facebook")(req, res, next)
+    analytics.setAuthTrackingCookie({ service: "facebook" })(req, res, next)
 
     expect(res.cookie).toHaveBeenCalledWith(
       "useSocialAuthTracking",
@@ -40,8 +40,12 @@ describe("setAuthTrackingCookie", () => {
     )
   })
 
-  it("maps google-one-tap to service: google, trigger: one-tap", () => {
-    analytics.setAuthTrackingCookie("google-one-tap")(req, res, next)
+  it("sets service: google and trigger: one-tap when mode is one-tap", () => {
+    analytics.setAuthTrackingCookie({ service: "google", mode: "one-tap" })(
+      req,
+      res,
+      next,
+    )
 
     expect(res.cookie).toHaveBeenCalledWith(
       "useSocialAuthTracking",
@@ -58,7 +62,7 @@ describe("setAuthTrackingCookie", () => {
     req.session.contextModule = "artworkPage"
     req.session.sign_up_intent = "follow"
     req.session.trigger = "click"
-    analytics.setAuthTrackingCookie("apple")(req, res, next)
+    analytics.setAuthTrackingCookie({ service: "apple" })(req, res, next)
 
     expect(res.cookie).toHaveBeenCalledWith(
       "useSocialAuthTracking",
@@ -76,7 +80,7 @@ describe("setAuthTrackingCookie", () => {
   })
 
   it("omits analytics when no session context is present", () => {
-    analytics.setAuthTrackingCookie("apple")(req, res, next)
+    analytics.setAuthTrackingCookie({ service: "apple" })(req, res, next)
 
     expect(res.cookie).toHaveBeenCalledWith(
       "useSocialAuthTracking",
@@ -85,10 +89,14 @@ describe("setAuthTrackingCookie", () => {
     )
   })
 
-  it("does not include session trigger in analytics for google-one-tap", () => {
+  it("does not include session trigger in analytics when mode is one-tap", () => {
     req.session.contextModule = "header"
     req.session.trigger = "click"
-    analytics.setAuthTrackingCookie("google-one-tap")(req, res, next)
+    analytics.setAuthTrackingCookie({ service: "google", mode: "one-tap" })(
+      req,
+      res,
+      next,
+    )
 
     expect(res.cookie).toHaveBeenCalledWith(
       "useSocialAuthTracking",

--- a/src/Server/passport/lib/app/__tests__/index.jest.ts
+++ b/src/Server/passport/lib/app/__tests__/index.jest.ts
@@ -32,8 +32,7 @@ describe("passport app setup", () => {
     }))
     jest.doMock("../analytics", () => ({
       setCampaign: jest.fn(),
-      trackLogin: jest.fn(),
-      trackSignup: jest.fn(() => jest.fn()),
+      setAuthTrackingCookie: jest.fn(() => jest.fn()),
     }))
     jest.doMock("../lifecycle", () => ({
       afterSocialAuth: jest.fn(() => jest.fn()),

--- a/src/Server/passport/lib/app/__tests__/lifecycle.jest.ts
+++ b/src/Server/passport/lib/app/__tests__/lifecycle.jest.ts
@@ -275,6 +275,18 @@ describe("lifecycle", () => {
       })
     })
 
+    it("sets analytics context on the session", () => {
+      req.query["context-module"] = "artworkPage"
+      req.query["trigger"] = "click"
+
+      lifecycle.beforeSocialAuth("facebook")(req, res, next)
+
+      expect(req.session).toMatchObject({
+        contextModule: "artworkPage",
+        trigger: "click",
+      })
+    })
+
     it("sets google auth scopes", () => {
       lifecycle.beforeSocialAuth("google")(req, res, next)
 

--- a/src/Server/passport/lib/app/analytics.ts
+++ b/src/Server/passport/lib/app/analytics.ts
@@ -1,68 +1,51 @@
 import type { NextFunction } from "express"
 import type { PassportRequest, PassportResponse } from "../types"
 
-import Analytics from "analytics-node"
-import { data as sd } from "sharify"
+const SOCIAL_AUTH_TRACKING_COOKIE = "useSocialAuthTracking"
 
-export const analytics = sd.SEGMENT_WRITE_KEY
-  ? new Analytics(sd.SEGMENT_WRITE_KEY)
-  : null
+type SocialService = "apple" | "facebook" | "google" | "google-one-tap"
+
+export const setAuthTrackingCookie =
+  (service: SocialService) =>
+  (req: PassportRequest, res: PassportResponse, next: NextFunction) => {
+    const action = req.artsyPassportSignedUp ? "signedUp" : "loggedIn"
+    const isOneTap = service === "google-one-tap"
+    const cookieService = isOneTap ? "google" : service
+
+    let contextPagePath: string | undefined
+    if (isOneTap) {
+      const referer = req.headers?.referer
+      if (referer) {
+        try {
+          contextPagePath = new URL(referer).pathname
+        } catch {
+          // malformed referer — omit
+        }
+      }
+    }
+
+    res.cookie(
+      SOCIAL_AUTH_TRACKING_COOKIE,
+      JSON.stringify({
+        action,
+        service: cookieService,
+        ...(isOneTap ? { trigger: "tap" } : {}),
+        ...(contextPagePath ? { context_page_path: contextPagePath } : {}),
+      }),
+      { httpOnly: false },
+    )
+
+    next()
+  }
 
 export const setCampaign = (
   req: PassportRequest,
   _res: PassportResponse,
   next: NextFunction,
 ) => {
-  if (!sd.SEGMENT_WRITE_KEY) {
-    return next()
-  }
-
   req.session.modalId = req.body.modal_id || req.query.modal_id
   req.session.acquisitionInitiative =
     req.body.acquisition_initiative || req.query.acquisition_initiative
-
-  next()
-}
-
-export const trackSignup =
-  (service: string) =>
-  (req: PassportRequest, _res: PassportResponse, next: NextFunction) => {
-    const { acquisitionInitiative, modalId } = req.session
-
-    delete req.session.acquisitionInitiative
-    delete req.session.modalId
-
-    if (!sd.SEGMENT_WRITE_KEY) {
-      return next()
-    }
-
-    analytics?.track({
-      event: "Created account",
-      userId: req.user!.id,
-      properties: {
-        modal_id: modalId,
-        acquisition_initiative: acquisitionInitiative,
-        signup_service: service,
-        user_id: req.user!.id,
-      },
-    })
-
-    next()
-  }
-
-export const trackLogin = (
-  req: PassportRequest,
-  _res: PassportResponse,
-  next: NextFunction,
-) => {
-  if (!sd.SEGMENT_WRITE_KEY) {
-    return next()
-  }
-
-  analytics?.track({
-    event: "Successfully logged in",
-    userId: req.user!.id,
-  })
 
   next()
 }

--- a/src/Server/passport/lib/app/analytics.ts
+++ b/src/Server/passport/lib/app/analytics.ts
@@ -30,7 +30,7 @@ export const setAuthTrackingCookie =
       JSON.stringify({
         action,
         service: params.service,
-        ...(isOneTap ? { trigger: "one-tap" } : {}),
+        ...(isOneTap ? { method: "one-tap" } : {}),
         ...(hasContext ? { analytics: analyticsContext } : {}),
       }),
       { httpOnly: false },

--- a/src/Server/passport/lib/app/analytics.ts
+++ b/src/Server/passport/lib/app/analytics.ts
@@ -12,12 +12,23 @@ export const setAuthTrackingCookie =
     const isOneTap = service === "google-one-tap"
     const cookieService = isOneTap ? "google" : service
 
+    const analyticsContext: Record<string, string> = {}
+    if (req.session.contextModule)
+      analyticsContext.contextModule = req.session.contextModule as string
+    if (req.session.sign_up_intent)
+      analyticsContext.intent = req.session.sign_up_intent as string
+    if (!isOneTap && req.session.trigger)
+      analyticsContext.trigger = req.session.trigger as string
+
+    const hasContext = Object.keys(analyticsContext).length > 0
+
     res.cookie(
       SOCIAL_AUTH_TRACKING_COOKIE,
       JSON.stringify({
         action,
         service: cookieService,
         ...(isOneTap ? { trigger: "one-tap" } : {}),
+        ...(hasContext ? { analytics: analyticsContext } : {}),
       }),
       { httpOnly: false },
     )

--- a/src/Server/passport/lib/app/analytics.ts
+++ b/src/Server/passport/lib/app/analytics.ts
@@ -12,25 +12,12 @@ export const setAuthTrackingCookie =
     const isOneTap = service === "google-one-tap"
     const cookieService = isOneTap ? "google" : service
 
-    let contextPagePath: string | undefined
-    if (isOneTap) {
-      const referer = req.headers?.referer
-      if (referer) {
-        try {
-          contextPagePath = new URL(referer).pathname
-        } catch {
-          // malformed referer — omit
-        }
-      }
-    }
-
     res.cookie(
       SOCIAL_AUTH_TRACKING_COOKIE,
       JSON.stringify({
         action,
         service: cookieService,
-        ...(isOneTap ? { trigger: "tap" } : {}),
-        ...(contextPagePath ? { context_page_path: contextPagePath } : {}),
+        ...(isOneTap ? { trigger: "one-tap" } : {}),
       }),
       { httpOnly: false },
     )

--- a/src/Server/passport/lib/app/analytics.ts
+++ b/src/Server/passport/lib/app/analytics.ts
@@ -3,14 +3,17 @@ import type { PassportRequest, PassportResponse } from "../types"
 
 const SOCIAL_AUTH_TRACKING_COOKIE = "useSocialAuthTracking"
 
-type SocialService = "apple" | "facebook" | "google" | "google-one-tap"
+type SocialService = "apple" | "facebook" | "google"
+
+type SocialAuthParams =
+  | { service: Exclude<SocialService, "google"> }
+  | { service: "google"; mode?: "one-tap" }
 
 export const setAuthTrackingCookie =
-  (service: SocialService) =>
+  (params: SocialAuthParams) =>
   (req: PassportRequest, res: PassportResponse, next: NextFunction) => {
     const action = req.artsyPassportSignedUp ? "signedUp" : "loggedIn"
-    const isOneTap = service === "google-one-tap"
-    const cookieService = isOneTap ? "google" : service
+    const isOneTap = params.service === "google" && params.mode === "one-tap"
 
     const analyticsContext: Record<string, string> = {}
     if (req.session.contextModule)
@@ -26,7 +29,7 @@ export const setAuthTrackingCookie =
       SOCIAL_AUTH_TRACKING_COOKIE,
       JSON.stringify({
         action,
-        service: cookieService,
+        service: params.service,
         ...(isOneTap ? { trigger: "one-tap" } : {}),
         ...(hasContext ? { analytics: analyticsContext } : {}),
       }),

--- a/src/Server/passport/lib/app/index.ts
+++ b/src/Server/passport/lib/app/index.ts
@@ -2,7 +2,7 @@ import express from "express"
 import type { ErrorRequestHandler, RequestHandler } from "express"
 import passport from "passport"
 import opts from "../options"
-import { setCampaign, trackLogin, trackSignup } from "./analytics"
+import { setCampaign, setAuthTrackingCookie } from "./analytics"
 import {
   afterSocialAuth,
   beforeSocialAuth,
@@ -36,7 +36,6 @@ const setupApp = () => {
     opts.loginPagePath,
     csrf({ cookie: true }),
     middleware(onLocalLogin),
-    middleware(trackLogin),
     middleware(ssoAndRedirectBack),
   )
   app.post(
@@ -45,7 +44,6 @@ const setupApp = () => {
     middleware(setCampaign),
     middleware(onLocalSignup),
     middleware(onLocalLogin),
-    middleware(trackSignup("email")),
     middleware(ssoAndRedirectBack),
   )
 
@@ -58,7 +56,7 @@ const setupApp = () => {
   app.post(
     opts.appleCallbackPath,
     middleware(afterSocialAuth("apple")),
-    middleware(trackSignup("apple")),
+    middleware(setAuthTrackingCookie("apple")),
     middleware(ssoAndRedirectBack),
   )
 
@@ -71,7 +69,7 @@ const setupApp = () => {
   app.get(
     opts.facebookCallbackPath,
     middleware(afterSocialAuth("facebook")),
-    middleware(trackSignup("facebook")),
+    middleware(setAuthTrackingCookie("facebook")),
     middleware(ssoAndRedirectBack),
   )
 
@@ -84,7 +82,7 @@ const setupApp = () => {
   app.get(
     opts.googleCallbackPath,
     middleware(afterSocialAuth("google")),
-    middleware(trackSignup("google")),
+    middleware(setAuthTrackingCookie("google")),
     middleware(ssoAndRedirectBack),
   )
 
@@ -92,7 +90,7 @@ const setupApp = () => {
   app.post(
     opts.googleOneTapCallbackPath,
     middleware(afterSocialAuth("google", "one-tap")),
-    middleware(trackSignup("google-one-tap")),
+    middleware(setAuthTrackingCookie("google-one-tap")),
     middleware(ssoAndRedirectBack),
   )
 

--- a/src/Server/passport/lib/app/index.ts
+++ b/src/Server/passport/lib/app/index.ts
@@ -56,7 +56,7 @@ const setupApp = () => {
   app.post(
     opts.appleCallbackPath,
     middleware(afterSocialAuth("apple")),
-    middleware(setAuthTrackingCookie("apple")),
+    middleware(setAuthTrackingCookie({ service: "apple" })),
     middleware(ssoAndRedirectBack),
   )
 
@@ -69,7 +69,7 @@ const setupApp = () => {
   app.get(
     opts.facebookCallbackPath,
     middleware(afterSocialAuth("facebook")),
-    middleware(setAuthTrackingCookie("facebook")),
+    middleware(setAuthTrackingCookie({ service: "facebook" })),
     middleware(ssoAndRedirectBack),
   )
 
@@ -82,7 +82,7 @@ const setupApp = () => {
   app.get(
     opts.googleCallbackPath,
     middleware(afterSocialAuth("google")),
-    middleware(setAuthTrackingCookie("google")),
+    middleware(setAuthTrackingCookie({ service: "google" })),
     middleware(ssoAndRedirectBack),
   )
 
@@ -90,7 +90,7 @@ const setupApp = () => {
   app.post(
     opts.googleOneTapCallbackPath,
     middleware(afterSocialAuth("google", "one-tap")),
-    middleware(setAuthTrackingCookie("google-one-tap")),
+    middleware(setAuthTrackingCookie({ service: "google", mode: "one-tap" })),
     middleware(ssoAndRedirectBack),
   )
 

--- a/src/Server/passport/lib/app/lifecycle.ts
+++ b/src/Server/passport/lib/app/lifecycle.ts
@@ -194,8 +194,10 @@ export const beforeSocialAuth =
 
     req.session.redirectTo = req.query["redirect-to"]
     req.session.skipOnboarding = req.query["skip-onboarding"]
+    req.session.contextModule = req.query["context-module"]
     req.session.sign_up_intent = req.query["signup-intent"]
     req.session.sign_up_referer = req.query["signup-referer"]
+    req.session.trigger = req.query["trigger"]
     // accepted_terms_of_service and agreed_to_receive_emails use underscores
     req.session.accepted_terms_of_service =
       req.query["accepted_terms_of_service"]

--- a/src/Server/passport/lib/types.ts
+++ b/src/Server/passport/lib/types.ts
@@ -44,11 +44,13 @@ export interface PassportSession {
   accepted_terms_of_service?: unknown
   acquisitionInitiative?: unknown
   agreed_to_receive_emails?: unknown
+  contextModule?: unknown
   modalId?: unknown
   redirectTo?: string
   sign_up_intent?: unknown
   sign_up_referer?: unknown
   skipOnboarding?: unknown
+  trigger?: unknown
   [key: string]: unknown
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,12 +31,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@artsy/cohesion@npm:4.354.0":
-  version: 4.354.0
-  resolution: "@artsy/cohesion@npm:4.354.0"
+"@artsy/cohesion@npm:4.355.0":
+  version: 4.355.0
+  resolution: "@artsy/cohesion@npm:4.355.0"
   dependencies:
     core-js: "npm:3"
-  checksum: 10c0/1383f30bd28449c2c854890baa0a5a2082a16cae8622e1173361919ad5b59658ba72e4ea3647e36c9a53e44e5a2ef29abb08026614121ea0dfb3e0de04101b47
+  checksum: 10c0/7594175dbd941f0ca5872ad124bb2c662b686017a2d92b19c62f796123cc2592588551f18459244942336a299ae52e6ec0892a38b59ecd8886f47a683bee5a9f
   languageName: node
   linkType: hard
 
@@ -8743,7 +8743,7 @@ __metadata:
   resolution: "force@workspace:."
   dependencies:
     "@artaio/arta-browser": "npm:^2.16.1"
-    "@artsy/cohesion": "npm:4.354.0"
+    "@artsy/cohesion": "npm:4.355.0"
     "@artsy/detect-responsive-traits": "npm:^0.2.0"
     "@artsy/dismissible": "npm:^0.8.0"
     "@artsy/express-reloadable": "npm:^1.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2861,16 +2861,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@segment/loosely-validate-event@npm:^1.1.2":
-  version: 1.1.2
-  resolution: "@segment/loosely-validate-event@npm:1.1.2"
-  dependencies:
-    component-type: "npm:^1.2.1"
-    join-component: "npm:^1.1.0"
-  checksum: 10c0/56b0e094dfcf79e752c2f3f92182044b10efd94b9eb1931d29dbb9839fae8bcede88ee8cc696caf413fa1181f6774502a92d0011b8e9bd03ee5e16b458555075
-  languageName: node
-  linkType: hard
-
 "@segment/top-domain@npm:^3.0.0":
   version: 3.0.1
   resolution: "@segment/top-domain@npm:3.0.1"
@@ -4937,25 +4927,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"analytics-node@npm:2.4.1":
-  version: 2.4.1
-  resolution: "analytics-node@npm:2.4.1"
-  dependencies:
-    "@segment/loosely-validate-event": "npm:^1.1.2"
-    clone: "npm:^2.1.1"
-    commander: "npm:^2.9.0"
-    crypto-token: "npm:^1.0.1"
-    debug: "npm:^2.6.2"
-    lodash: "npm:^4.17.4"
-    remove-trailing-slash: "npm:^0.1.0"
-    superagent: "npm:^3.5.0"
-    superagent-retry: "npm:^0.6.0"
-  bin:
-    analytics: bin/analytics
-  checksum: 10c0/e9449499b899ce4a750e55f808020be0e6996545710c71db384ba9ccbb32e192fd0205799efb50339912d68146588447b29b21b7f9f87a563657b7d2dae8f929
-  languageName: node
-  linkType: hard
-
 "ansi-align@npm:^2.0.0":
   version: 2.0.0
   resolution: "ansi-align@npm:2.0.0"
@@ -6278,13 +6249,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"clone@npm:^2.1.1":
-  version: 2.1.2
-  resolution: "clone@npm:2.1.2"
-  checksum: 10c0/ed0601cd0b1606bc7d82ee7175b97e68d1dd9b91fd1250a3617b38d34a095f8ee0431d40a1a611122dcccb4f93295b4fdb94942aa763392b5fe44effa50c2d5e
-  languageName: node
-  linkType: hard
-
 "co@npm:^4.6.0":
   version: 4.6.0
   resolution: "co@npm:4.6.0"
@@ -6371,7 +6335,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"commander@npm:^2.18.0, commander@npm:^2.20.0, commander@npm:^2.9.0":
+"commander@npm:^2.18.0, commander@npm:^2.20.0":
   version: 2.20.3
   resolution: "commander@npm:2.20.3"
   checksum: 10c0/74c781a5248c2402a0a3e966a0a2bba3c054aad144f5c023364be83265e796b20565aa9feff624132ff629aa64e16999fa40a743c10c12f7c61e96a794b99288
@@ -6408,17 +6372,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"component-emitter@npm:^1.2.0, component-emitter@npm:^1.2.1":
+"component-emitter@npm:^1.2.1":
   version: 1.3.0
   resolution: "component-emitter@npm:1.3.0"
   checksum: 10c0/68774a0a3754fb6c0ba53c2e88886dfbd0c773931066abb1d7fd1b0c893b2a838d8f088ab4dca1f18cc1a4fc2e6932019eba3ded2d931b5ba2241ce40e93a24f
-  languageName: node
-  linkType: hard
-
-"component-type@npm:^1.2.1":
-  version: 1.2.1
-  resolution: "component-type@npm:1.2.1"
-  checksum: 10c0/8f9537d529d619484b8572cd569f212ea264d8c84dc65ccaaa0136e4a2e06696e9a2b2b1979ef264251f8b4ebfa075f23c860b6e4270385fd7663b42e5727cee
   languageName: node
   linkType: hard
 
@@ -6627,13 +6584,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookiejar@npm:^2.1.0":
-  version: 2.1.4
-  resolution: "cookiejar@npm:2.1.4"
-  checksum: 10c0/2dae55611c6e1678f34d93984cbd4bda58f4fe3e5247cc4993f4a305cd19c913bbaf325086ed952e892108115073a747596453d3dc1c34947f47f731818b8ad1
-  languageName: node
-  linkType: hard
-
 "cookies-js@npm:1.2.3":
   version: 1.2.3
   resolution: "cookies-js@npm:1.2.3"
@@ -6693,7 +6643,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"core-util-is@npm:1.0.2, core-util-is@npm:~1.0.0":
+"core-util-is@npm:1.0.2":
   version: 1.0.2
   resolution: "core-util-is@npm:1.0.2"
   checksum: 10c0/980a37a93956d0de8a828ce508f9b9e3317039d68922ca79995421944146700e4aaf490a6dbfebcb1c5292a7184600c7710b957d724be1e37b8254c6bc0fe246
@@ -6933,13 +6883,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"crypto-token@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "crypto-token@npm:1.0.1"
-  checksum: 10c0/8c1944bcbc6f43322a11cadd4c0514bde9504510aab53c92b27e07796bfb44454376fb11c808ae81b48b769d448f96837f0c0387d66e874bf96994b205985e8d
-  languageName: node
-  linkType: hard
-
 "csrf@npm:3.1.0":
   version: 3.1.0
   resolution: "csrf@npm:3.1.0"
@@ -7174,7 +7117,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:2.6.9, debug@npm:^2.2.0, debug@npm:^2.3.3, debug@npm:^2.6.2, debug@npm:^2.6.9":
+"debug@npm:2.6.9, debug@npm:^2.2.0, debug@npm:^2.3.3, debug@npm:^2.6.9":
   version: 2.6.9
   resolution: "debug@npm:2.6.9"
   dependencies:
@@ -8383,7 +8326,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"extend@npm:^3.0.0, extend@npm:^3.0.2":
+"extend@npm:^3.0.2":
   version: 3.0.2
   resolution: "extend@npm:3.0.2"
   checksum: 10c0/73bf6e27406e80aa3e85b0d1c4fd987261e628064e170ca781125c0b635a3dabad5e05adbf07595ea0cf1e6c5396cacb214af933da7cbaf24fe75ff14818e8f9
@@ -8820,7 +8763,6 @@ __metadata:
     "@types/yup": "npm:^0.29.13"
     "@unleash/proxy-client-react": "npm:^4.5.2"
     actioncable: "npm:^5.2.7-1"
-    analytics-node: "npm:2.4.1"
     autosuggest-highlight: "npm:3.1.1"
     blurhash: "npm:^2.0.5"
     body-parser: "npm:1.20.3"
@@ -8956,13 +8898,6 @@ __metadata:
     hasown: "npm:^2.0.2"
     mime-types: "npm:^2.1.12"
   checksum: 10c0/373525a9a034b9d57073e55eab79e501a714ffac02e7a9b01be1c820780652b16e4101819785e1e18f8d98f0aee866cc654d660a435c378e16a72f2e7cac9695
-  languageName: node
-  linkType: hard
-
-"formidable@npm:^1.2.0":
-  version: 1.2.1
-  resolution: "formidable@npm:1.2.1"
-  checksum: 10c0/ea0e53492150f16da80401c6aeaca534e37246eabf9a181215e3fb79a126e3631810fc045fe297797156a032ce0fbd5abd17971c3d585f30bf29f62d19bcfe51
   languageName: node
   linkType: hard
 
@@ -10183,7 +10118,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.3, inherits@npm:~2.0.4":
+"inherits@npm:2, inherits@npm:2.0.4, inherits@npm:^2.0.1, inherits@npm:^2.0.3, inherits@npm:^2.0.4, inherits@npm:~2.0.4":
   version: 2.0.4
   resolution: "inherits@npm:2.0.4"
   checksum: 10c0/4e531f648b29039fb7426fb94075e6545faa1eb9fe83c29f0b6d9e7263aceb4289d2d4557db0d428188eeb449cc7c5e77b0a0b2c4e248ff2a65933a0dee49ef2
@@ -10639,7 +10574,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isarray@npm:1.0.0, isarray@npm:~1.0.0":
+"isarray@npm:1.0.0":
   version: 1.0.0
   resolution: "isarray@npm:1.0.0"
   checksum: 10c0/18b5be6669be53425f0b84098732670ed4e727e3af33bc7f948aac01782110eb9a18b3b329c5323bcdd3acdaae547ee077d3951317e7f133bff7105264b3003d
@@ -11331,13 +11266,6 @@ __metadata:
   bin:
     jest: bin/jest.js
   checksum: 10c0/32e29cfa2373530ed323ea65dfb4fd5172026349be48ebb7a2dc5660adadd1c68f6b0fe2b67cc3ee723cc34e2d4552a852730ac787251b406cf58e37a90f6dac
-  languageName: node
-  linkType: hard
-
-"join-component@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "join-component@npm:1.1.0"
-  checksum: 10c0/7319cb1ca6ffc514d82ac1b965c4e6cd6bf852adec1e7833bd8613e17f4965e78e2653c8de75a1fe51d9a2cae36af3298008df4079cfd903ef3ecbd231fe11c1
   languageName: node
   linkType: hard
 
@@ -12293,7 +12221,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"methods@npm:^1.1.1, methods@npm:^1.1.2, methods@npm:~1.1.2":
+"methods@npm:^1.1.2, methods@npm:~1.1.2":
   version: 1.1.2
   resolution: "methods@npm:1.1.2"
   checksum: 10c0/bdf7cc72ff0a33e3eede03708c08983c4d7a173f91348b4b1e4f47d4cdbf734433ad971e7d1e8c77247d9e5cd8adb81ea4c67b0a2db526b758b2233d7814b8b2
@@ -12359,7 +12287,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mime@npm:1.6.0, mime@npm:^1.4.1":
+"mime@npm:1.6.0":
   version: 1.6.0
   resolution: "mime@npm:1.6.0"
   bin:
@@ -14062,13 +13990,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"process-nextick-args@npm:~2.0.0":
-  version: 2.0.1
-  resolution: "process-nextick-args@npm:2.0.1"
-  checksum: 10c0/bec089239487833d46b59d80327a1605e1c5287eaad770a291add7f45fda1bb5e28b38e0e061add0a1d0ee0984788ce74fa394d345eed1c420cacf392c554367
-  languageName: node
-  linkType: hard
-
 "process@npm:^0.11.10":
   version: 0.11.10
   resolution: "process@npm:0.11.10"
@@ -14277,7 +14198,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"qs@npm:^6.12.3, qs@npm:^6.5.1":
+"qs@npm:^6.12.3":
   version: 6.13.1
   resolution: "qs@npm:6.13.1"
   dependencies:
@@ -14845,21 +14766,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"readable-stream@npm:^2.3.5":
-  version: 2.3.7
-  resolution: "readable-stream@npm:2.3.7"
-  dependencies:
-    core-util-is: "npm:~1.0.0"
-    inherits: "npm:~2.0.3"
-    isarray: "npm:~1.0.0"
-    process-nextick-args: "npm:~2.0.0"
-    safe-buffer: "npm:~5.1.1"
-    string_decoder: "npm:~1.1.1"
-    util-deprecate: "npm:~1.0.1"
-  checksum: 10c0/1708755e6cf9daff6ff60fa5b4575636472289c5b95d38058a91f94732b8d024a940a0d4d955639195ce42c22cab16973ee8fea8deedd24b5fec3dd596465f86
-  languageName: node
-  linkType: hard
-
 "readable-stream@npm:^3.5.0, readable-stream@npm:^3.6.0, readable-stream@npm:^3.6.2":
   version: 3.6.2
   resolution: "readable-stream@npm:3.6.2"
@@ -15059,13 +14965,6 @@ __metadata:
     invariant: "npm:^2.2.4"
     relay-runtime: "npm:16.0.0"
   checksum: 10c0/4009f8bce91b254d7328c0d03b5bb4e38e0dd3938cb4bee31cd47403de2f99ff085bd39b9e882bb6f79d06bd6be8ddb7f6a0d4e60a7703431f286a779ba6a644
-  languageName: node
-  linkType: hard
-
-"remove-trailing-slash@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "remove-trailing-slash@npm:0.1.0"
-  checksum: 10c0/565076c0a9c2d1753665d4c6e7dda566f622f7a1430e545be8b4f2527c882590691c0ebd522af7e603d0e5b5fefd5b0aed6c03fc7862bf9df16d47efc6bf72a7
   languageName: node
   linkType: hard
 
@@ -15357,7 +15256,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"safe-buffer@npm:5.1.2, safe-buffer@npm:~5.1.0, safe-buffer@npm:~5.1.1":
+"safe-buffer@npm:5.1.2":
   version: 5.1.2
   resolution: "safe-buffer@npm:5.1.2"
   checksum: 10c0/780ba6b5d99cc9a40f7b951d47152297d0e260f0df01472a1b99d4889679a4b94a13d644f7dbc4f022572f09ae9005fa2fbb93bbbd83643316f365a3e9a45b21
@@ -16283,15 +16182,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"string_decoder@npm:~1.1.1":
-  version: 1.1.1
-  resolution: "string_decoder@npm:1.1.1"
-  dependencies:
-    safe-buffer: "npm:~5.1.0"
-  checksum: 10c0/b4f89f3a92fd101b5653ca3c99550e07bdf9e13b35037e9e2a1c7b47cec4e55e06ff3fc468e314a0b5e80bfbaf65c1ca5a84978764884ae9413bec1fc6ca924e
-  languageName: node
-  linkType: hard
-
 "stringify-object@npm:^3.3.0":
   version: 3.3.0
   resolution: "stringify-object@npm:3.3.0"
@@ -16450,33 +16340,6 @@ __metadata:
     eventemitter3: "npm:^5.0.0"
     raf: "npm:^3.0.0"
   checksum: 10c0/177c7fd4cf56a6bbbfa693f4f12798e2a1745f995a7c7cdd815be7bf8ae9a90280ea7306eeeee559df56233863e04c86353cb908ee0cd91fbe5a5e00a0116a2c
-  languageName: node
-  linkType: hard
-
-"superagent-retry@npm:^0.6.0":
-  version: 0.6.0
-  resolution: "superagent-retry@npm:0.6.0"
-  peerDependencies:
-    superagent: "*"
-  checksum: 10c0/49d6e7b07b7be92db5d8319a66e94aa4c7104a9b98765e30fe7f6858e07c9a4e756d8c3a3601e41926112c78089c2f195aaf5457ed6d3430b451e522fea9ab9a
-  languageName: node
-  linkType: hard
-
-"superagent@npm:^3.5.0":
-  version: 3.8.3
-  resolution: "superagent@npm:3.8.3"
-  dependencies:
-    component-emitter: "npm:^1.2.0"
-    cookiejar: "npm:^2.1.0"
-    debug: "npm:^3.1.0"
-    extend: "npm:^3.0.0"
-    form-data: "npm:^2.3.1"
-    formidable: "npm:^1.2.0"
-    methods: "npm:^1.1.1"
-    mime: "npm:^1.4.1"
-    qs: "npm:^6.5.1"
-    readable-stream: "npm:^2.3.5"
-  checksum: 10c0/e467c39aee7aa57dc2e45b5c7c76d70a7ad4fff8d3d2b57a2da0edfaca0e598562fc9f8f74a1383661744f68b3dfd2cca388a3000b41d6c2d8e0e5d031d152fe
   languageName: node
   linkType: hard
 
@@ -17478,7 +17341,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"util-deprecate@npm:^1.0.1, util-deprecate@npm:^1.0.2, util-deprecate@npm:~1.0.1":
+"util-deprecate@npm:^1.0.1, util-deprecate@npm:^1.0.2":
   version: 1.0.2
   resolution: "util-deprecate@npm:1.0.2"
   checksum: 10c0/41a5bdd214df2f6c3ecf8622745e4a366c4adced864bc3c833739791aeeeb1838119af7daed4ba36428114b5c67dcda034a79c882e97e43c03e66a4dd7389942

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,12 +31,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@artsy/cohesion@npm:4.355.0":
-  version: 4.355.0
-  resolution: "@artsy/cohesion@npm:4.355.0"
+"@artsy/cohesion@npm:4.356.0":
+  version: 4.356.0
+  resolution: "@artsy/cohesion@npm:4.356.0"
   dependencies:
     core-js: "npm:3"
-  checksum: 10c0/7594175dbd941f0ca5872ad124bb2c662b686017a2d92b19c62f796123cc2592588551f18459244942336a299ae52e6ec0892a38b59ecd8886f47a683bee5a9f
+  checksum: 10c0/58c85159c0c06567eb9a5667e4cc363372c3cc226ebd8657c240711bd0b31104db0afd07d02b55dc1e996cf863f866b180e6f8d9f5162baa2583fa3e18d94393
   languageName: node
   linkType: hard
 
@@ -9399,7 +9399,7 @@ __metadata:
   resolution: "force@workspace:."
   dependencies:
     "@artaio/arta-browser": "npm:^2.16.1"
-    "@artsy/cohesion": "npm:4.355.0"
+    "@artsy/cohesion": "npm:4.356.0"
     "@artsy/detect-responsive-traits": "npm:^0.2.0"
     "@artsy/dismissible": "npm:^0.8.1"
     "@artsy/express-reloadable": "npm:^1.7.0"


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [DI-291](https://www.notion.so/artsy/6-Force-One-Tap-Basic-Analytics-361cab0764a0804c9a28d989f4c950fe?v=310cab0764a08151b558000cc3bc6840&source=copy_link)

### Description

<!-- Implementation description -->

Social auth analytics were broken in a few ways. 

Tracking was duplicated between client and server side (passport).

### Previously 

**Client Side**
- used a cookie based approach in order to fire events once passport completed authentication
- **broke when we introduced unified auth**, mode became "Welcome" which broke validation and dropped events `action: { Login: "loggedIn", SignUp: "signedUp" }[mode]`
- **could not tell authoritatively if a a log in or a sign up occurred** from client side, at end of server auth got a logged in session either way

**Server Side**
- **tracked redundant analytics to client** but needed a server side lib (analytics node)
- **did not adhere to new cohesion formats**
- **fired created account events (trackSignup) for both log in and sign up for social auth**
- **pointed to a different misconfigured segment destination** so was not reaching analysts

### Now 

**Client Side**
- sends auth dialog analytics context to server via query params
- watches for same cookie to fire auth analytics events

**Server Side**
- now sets the cookie as it can unambiguously tell between a sign up and log in event, includes auth dialog context from request params 




