### PR TITLE
chore: update sentry fingerprints

### DIFF
--- a/src/System/Components/ContentErrorBoundary.tsx
+++ b/src/System/Components/ContentErrorBoundary.tsx
@@ -60,11 +60,7 @@ export class ContentErrorBoundary extends React.Component<
         componentStack: errorInfo.componentStack,
       })
       scope.setTag("errorBoundary", "content")
-      scope.setFingerprint([
-        "ContentErrorBoundary",
-        "{{ error.type }}",
-        "{{ default }}",
-      ])
+      scope.setFingerprint(["ContentErrorBoundary", String(message)])
       captureException(error)
     })
   }

--- a/src/System/Components/ErrorBoundary.tsx
+++ b/src/System/Components/ErrorBoundary.tsx
@@ -41,11 +41,7 @@ export class ErrorBoundary extends React.Component<Props, State> {
         componentStack: errorInfo.componentStack,
       })
       scope.setTag("errorBoundary", "outer")
-      scope.setFingerprint([
-        "ErrorBoundary",
-        "{{ error.type }}",
-        "{{ default }}",
-      ])
+      scope.setFingerprint(["ErrorBoundary", String(message)])
       captureException(error)
     })
 

--- a/src/System/Components/__tests__/ContentErrorBoundary.jest.tsx
+++ b/src/System/Components/__tests__/ContentErrorBoundary.jest.tsx
@@ -193,8 +193,7 @@ describe("ContentErrorBoundary", () => {
     expect(mockSetTag).toHaveBeenCalledWith("errorBoundary", "content")
     expect(mockSetFingerprint).toHaveBeenCalledWith([
       "ContentErrorBoundary",
-      "{{ error.type }}",
-      "{{ default }}",
+      "sentry test error",
     ])
     expect(mockCaptureException).toHaveBeenCalled()
   })

--- a/src/System/Components/__tests__/ErrorBoundary.jest.tsx
+++ b/src/System/Components/__tests__/ErrorBoundary.jest.tsx
@@ -189,8 +189,7 @@ describe("ErrorBoundary", () => {
     expect(mockSetTag).toHaveBeenCalledWith("errorBoundary", "outer")
     expect(mockSetFingerprint).toHaveBeenCalledWith([
       "ErrorBoundary",
-      "{{ error.type }}",
-      "{{ default }}",
+      "sentry test error",
     ])
     expect(mockCaptureException).toHaveBeenCalled()
   })


### PR DESCRIPTION
This PR updates the Sentry fingerprints that group error boundary events in Sentry, replacing a coarse per-error-class grouping (ex., Error, TypeError, NotFoundError, etc.) with per-message grouping so that each distinct failure mode produces its own issue rather than collapsing all errors caught by the same boundary into one.

cc: @artsy/diamond-devs 