### PR TITLE
feat: upload source maps to sentry for ssr

### DIFF
--- a/rsbuild.config.ts
+++ b/rsbuild.config.ts
@@ -66,6 +66,7 @@ export default defineConfig({
         distPath: {
           root: "dist/server",
         },
+        sourceMap: isProduction ? { js: "hidden-source-map" } : false,
       },
       source: {
         entry: {
@@ -81,6 +82,20 @@ export default defineConfig({
           node: {
             __dirname: true,
           },
+          plugins: [
+            ...(isProduction && process.env.SENTRY_AUTH_TOKEN
+              ? [
+                  sentryWebpackPlugin({
+                    org: "artsynet",
+                    project: "force-production",
+                    release: { name: process.env.SENTRY_RELEASE },
+                    sourcemaps: {
+                      filesToDeleteAfterUpload: ["dist/server/**/*.map"],
+                    },
+                  }),
+                ]
+              : []),
+          ],
         },
         swc: {
           module: {

--- a/src/instrument.ts
+++ b/src/instrument.ts
@@ -1,7 +1,11 @@
 import * as Sentry from "@sentry/node"
 import { nodeProfilingIntegration } from "@sentry/profiling-node"
 import { IGNORED_ERRORS } from "Server/analytics/sentryFilters"
-import { SENTRY_PRIVATE_DSN, SENTRY_TRACING_ENABLED } from "Server/config"
+import {
+  SENTRY_PRIVATE_DSN,
+  SENTRY_RELEASE,
+  SENTRY_TRACING_ENABLED,
+} from "Server/config"
 
 const TRACING_CONFIG: Sentry.NodeOptions = {
   integrations: [nodeProfilingIntegration()],
@@ -13,6 +17,7 @@ if (SENTRY_PRIVATE_DSN) {
   Sentry.init({
     dsn: SENTRY_PRIVATE_DSN,
     ignoreErrors: IGNORED_ERRORS,
+    release: SENTRY_RELEASE,
     ...(SENTRY_TRACING_ENABLED ? TRACING_CONFIG : {}),
   })
 }


### PR DESCRIPTION
This PR is a follow-up to #17233 that configures the server-side Rsbuild environment to generate hidden source maps during production builds and upload them to Sentry. (We only configured the client-side in the previous PR.)

It also adds `release: SENTRY_RELEASE` to the server-side Sentry init call so that Sentry can match stacktraces in its evens to the correct "version" of Force (identified by its git commit SHA). 

cc: @artsy/diamond-devs 