### PR TITLE
fix: include SENTRY_RELEASE in release stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,9 @@ COPY --chown=deploy:deploy --from=builder-base /app/.yarn ./.yarn
 
 ENTRYPOINT ["/usr/bin/dumb-init", "./scripts/load_secrets_and_run.sh"]
 
+ARG SENTRY_RELEASE
 ENV NODE_PATH=/app/src
+ENV SENTRY_RELEASE=$SENTRY_RELEASE
 
 # TODO: Reduce production memory, this is not a concern
 CMD ["node", "--max_old_space_size=2048", "--heapsnapshot-signal=SIGUSR2", "--no-experimental-fetch", "-r @swc-node/register", "./src/prod.ts"]


### PR DESCRIPTION
This PR fixes a bug with "releases" that I noticed in Sentry after configuring production builds to upload source maps. 

For context, each build gets tagged with a release version that can be matched with events in Sentry so that we can easily see which version of Force first introduced an issue.

However, it doesn't seem like these release versions are being sent to Sentry. I suspect that the release version is missing because the "production" stage of our Dockerfile clears the `SENTRY_RELEASE` env var (which is set during the "builder-base" stage) when it calls `FROM node:22.14.0-alpine as production`.

cc: @artsy/diamond-devs 