### PR TITLE
fix: defer useSectionReady onReady callback to effect phase

### DIFF
--- a/src/Utils/Hooks/useSectionReadiness.ts
+++ b/src/Utils/Hooks/useSectionReadiness.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useReducer, useRef } from "react"
+import { useCallback, useEffect, useMemo, useReducer, useRef } from "react"
 
 type SectionMap<TSectionKey extends string, TValue> = Record<
   TSectionKey,
@@ -211,11 +211,18 @@ type UseSectionReadyProps = {
 
 export const useSectionReady = ({ onReady }: UseSectionReadyProps) => {
   const rendered = useRef(false)
+  const pending = useRef(false)
+
+  useEffect(() => {
+    if (!pending.current) return
+    pending.current = false
+    onReady?.()
+  })
 
   const handleReady = () => {
     if (rendered.current) return
     rendered.current = true
-    onReady?.()
+    pending.current = true
   }
 
   return { handleReady }


### PR DESCRIPTION
## What

`useSectionReady` is a small hook used on the artist combined route to signal that a section has finished loading. The `handleReady` callback was being called inside `SystemQueryRenderer`'s `render` prop, which runs synchronously during React's render phase.

Calling `onReady()` there (which ultimately dispatches to a `useReducer`) is a state mutation during render. React detects this, emits a "Cannot update a component while rendering a different component" warning, and then SSR hydration goes wrong — the client React tree diverges from the server-rendered HTML, causing `removeChild` crashes.

## Fix

`handleReady` now only sets a `pending` ref instead of calling `onReady` directly. A `useEffect` (no deps, runs after every commit) checks the ref and fires `onReady` in the effects phase, where state mutations are safe.

## Related

Should reduce crashes on `/artist` pages appearing in [FORCE-PRODUCTION-2083](https://artsynet.sentry.io/issues/FORCE-PRODUCTION-2083).

🤖 Generated with [Claude Code](https://claude.com/claude-code)