### PR TITLE
test(useSectionReady): add tests for deferred onReady behavior

### DIFF
--- a/src/Utils/Hooks/__tests__/useSectionReadiness.jest.tsx
+++ b/src/Utils/Hooks/__tests__/useSectionReadiness.jest.tsx
@@ -1,0 +1,45 @@
+import { act, renderHook } from "@testing-library/react-hooks"
+import { useSectionReady } from "../useSectionReadiness"
+
+describe("useSectionReady", () => {
+  it("does not call onReady synchronously when handleReady is invoked", () => {
+    const onReady = jest.fn()
+    const { result } = renderHook(() => useSectionReady({ onReady }))
+
+    result.current.handleReady()
+
+    expect(onReady).not.toHaveBeenCalled()
+  })
+
+  it("calls onReady after the next render following handleReady", () => {
+    const onReady = jest.fn()
+    const { result, rerender } = renderHook(() => useSectionReady({ onReady }))
+
+    result.current.handleReady()
+    expect(onReady).not.toHaveBeenCalled()
+
+    // Simulates the re-render that happens in production when the Relay query
+    // resolves and SystemQueryRenderer re-renders with data
+    act(() => {
+      rerender()
+    })
+
+    expect(onReady).toHaveBeenCalledTimes(1)
+  })
+
+  it("calls onReady only once even if handleReady is called multiple times", () => {
+    const onReady = jest.fn()
+    const { result, rerender } = renderHook(() => useSectionReady({ onReady }))
+
+    // handleReady may be called on every render pass of the render prop
+    result.current.handleReady()
+    result.current.handleReady()
+    result.current.handleReady()
+
+    act(() => {
+      rerender()
+    })
+
+    expect(onReady).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## What

Adds unit tests for `useSectionReady` that were missing from the original fix in #17250.

The three cases covered:

- `onReady` is not called synchronously when `handleReady` is invoked (the core invariant — it must be deferred to the effects phase)
- `onReady` is called after the next render following `handleReady`
- `onReady` is called only once even if `handleReady` is called multiple times

🤖 Generated with [Claude Code](https://claude.com/claude-code)