### PR TITLE
fix: pass destination location to prepareVariables in usePrefetchRoute

### DIFF
--- a/src/Apps/Search/searchRoutes.tsx
+++ b/src/Apps/Search/searchRoutes.tsx
@@ -54,7 +54,7 @@ const prepareVariables = (_params, { location }) => {
 
   return {
     ...paramsToCamelCase(omit(location.query, "term")),
-    keyword: String(location.query.term ?? ""),
+    keyword: location.query.term ?? "",
     aggregations,
   }
 }

--- a/src/Apps/Search/searchRoutes.tsx
+++ b/src/Apps/Search/searchRoutes.tsx
@@ -54,7 +54,7 @@ const prepareVariables = (_params, { location }) => {
 
   return {
     ...paramsToCamelCase(omit(location.query, "term")),
-    keyword: location.query.term.toString(),
+    keyword: String(location.query.term ?? ""),
     aggregations,
   }
 }

--- a/src/System/Hooks/__tests__/usePrefetchRoute.jest.tsx
+++ b/src/System/Hooks/__tests__/usePrefetchRoute.jest.tsx
@@ -207,6 +207,44 @@ describe("usePrefetchRoute", () => {
     expect(onComplete).toHaveBeenCalled()
   })
 
+  it("should pass the destination location to prepareVariables, not the current page location", () => {
+    const mockPrepareVariables = jest.fn().mockReturnValue({ keyword: "cats" })
+    const mockRoute = {
+      match: { params: {} },
+      route: {
+        path: "/search",
+        query: "SearchQuery",
+        prepareVariables: mockPrepareVariables,
+      },
+    }
+    const mockSubscription = { unsubscribe: jest.fn() }
+    const destinationLocation = { pathname: "/search", query: { term: "cats" } }
+
+    mockUseRouter.mockReturnValue({
+      match: { ...mockMatch, location: { pathname: "/artists", query: {} } },
+      router: {
+        createLocation: jest.fn().mockReturnValue(destinationLocation),
+      },
+    })
+    mockFindRoutesByPath.mockReturnValue([mockRoute])
+    mockTake.mockReturnValue([mockRoute])
+    mockFetchQuery.mockReturnValue({
+      subscribe: jest.fn(() => mockSubscription),
+    })
+
+    const { result } = renderHook(() =>
+      usePrefetchRoute({ initialPath: "/search?term=cats" }),
+    )
+    result.current.prefetch()
+
+    // prepareVariables should receive the destination /search?term=cats location,
+    // not the current /artists page location
+    expect(mockPrepareVariables).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ location: destinationLocation }),
+    )
+  })
+
   it("should pass along route TTLs to fetchQuery metadata", () => {
     const mockRoute = {
       match: { params: { id: "bar" } },

--- a/src/System/Hooks/__tests__/usePrefetchRoute.jest.tsx
+++ b/src/System/Hooks/__tests__/usePrefetchRoute.jest.tsx
@@ -237,8 +237,7 @@ describe("usePrefetchRoute", () => {
     )
     result.current.prefetch()
 
-    // prepareVariables should receive the destination /search?term=cats location,
-    // not the current /artists page location
+    // prepareVariables should receive the destination location, not the current page's
     expect(mockPrepareVariables).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ location: destinationLocation }),

--- a/src/System/Hooks/__tests__/usePrefetchRoute.jest.tsx
+++ b/src/System/Hooks/__tests__/usePrefetchRoute.jest.tsx
@@ -219,9 +219,14 @@ describe("usePrefetchRoute", () => {
     }
     const mockSubscription = { unsubscribe: jest.fn() }
     const destinationLocation = { pathname: "/search", query: { term: "cats" } }
+    const mockContext = { user: { id: "user-123" } }
 
     mockUseRouter.mockReturnValue({
-      match: { ...mockMatch, location: { pathname: "/artists", query: {} } },
+      match: {
+        ...mockMatch,
+        location: { pathname: "/artists", query: {} },
+        context: mockContext,
+      },
       router: {
         createLocation: jest.fn().mockReturnValue(destinationLocation),
       },
@@ -237,11 +242,11 @@ describe("usePrefetchRoute", () => {
     )
     result.current.prefetch()
 
-    // prepareVariables should receive the destination location, not the current page's
-    expect(mockPrepareVariables).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ location: destinationLocation }),
-    )
+    // destination location (not current page's) and current app context
+    expect(mockPrepareVariables).toHaveBeenCalledWith(expect.anything(), {
+      location: destinationLocation,
+      context: mockContext,
+    })
   })
 
   it("should pass along route TTLs to fetchQuery metadata", () => {

--- a/src/System/Hooks/usePrefetchRoute.tsx
+++ b/src/System/Hooks/usePrefetchRoute.tsx
@@ -21,7 +21,7 @@ export const usePrefetchRoute = ({
 } => {
   const { relayEnvironment } = useSystemContext()
 
-  const { match } = useRouter()
+  const { match, router } = useRouter()
 
   const prefetchFeatureFlagEnabled = getENV("ENABLE_PREFETCH")
 
@@ -60,7 +60,14 @@ export const usePrefetchRoute = ({
             return params
           }
 
-          return prepareVariables(params, match) as OperationType["variables"]
+          const prefetchLocation = router?.createLocation?.(path as string) ?? {
+            pathname: path,
+            query: {},
+          }
+          return prepareVariables(params, {
+            ...match,
+            location: prefetchLocation,
+          }) as OperationType["variables"]
         })()
 
         const isPrefetchable = !!(query && variables)

--- a/src/System/Hooks/usePrefetchRoute.tsx
+++ b/src/System/Hooks/usePrefetchRoute.tsx
@@ -65,8 +65,8 @@ export const usePrefetchRoute = ({
             query: {},
           }
           return prepareVariables(params, {
-            ...match,
             location: prefetchLocation,
+            context: match.context,
           }) as OperationType["variables"]
         })()
 


### PR DESCRIPTION
This PR addresses the following issue that I am seeing a lot in Sentry:

> **TypeError**
> undefined is not an object (evaluating 'n.query.term.toString')

This can be reproduced by using the search functionality and hovering over the "See full results for..." text at the bottom of the search autocomplete.

https://github.com/user-attachments/assets/28559ab6-8764-4d8d-b93e-266b67068a97

## Cause

`RouterLink` fires `prefetch()` on `mouseover` for every link, including `SuggestionItemLink` in the search autocomplete. `usePrefetchRoute` found the matching route (e.g. `/search`) and called its `prepareVariables(params, match)` — but `match` was the **current page's** match, not the destination route's. On any page other than `/search`, `match.location.query.term` is `undefined`. `searchRoutes.tsx` called `location.query.term.toString()` without a null guard, causing a `TypeError` that surfaced an error in the console and in Sentry.

## Fix

1. **`usePrefetchRoute.tsx`** — create the location for the prefetch path using `router.createLocation(path)` (the same approach `RouterLink` uses for its own location), then pass it to `prepareVariables` instead of the current page's location. This ensures query params like `?term=foo` are correctly parsed for the destination route.

2. **`searchRoutes.tsx`** — add a defensive `?? ""` guard as a fallback for any direct navigation to `/search` without a `term` param.

3. **New test** in `usePrefetchRoute.jest.tsx` — verifies that `prepareVariables` receives the destination route's location (not the current page's) when a `router.createLocation` mock is provided.

## Related

- Sentry: https://artsynet.sentry.io/issues/FORCE-PRODUCTION-1ZR3 (7,812 events, 5,672 users)
- Sentry: https://artsynet.sentry.io/issues/FORCE-PRODUCTION-1ZR8 (2,596 events, 2,086 users)
- Sentry: https://artsynet.sentry.io/issues/FORCE-PRODUCTION-2088 (599 events, 515 users)
- Sentry: https://artsynet.sentry.io/issues/FORCE-PRODUCTION-1ZRM (451 events, 361 users)

These four issues share the same root cause and should all be resolved by this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)