### PR TITLE
fix(ArtworkStructuredData): move useMemo calls before early return

### DIFF
--- a/src/Apps/Artwork/Components/ArtworkStructuredData.tsx
+++ b/src/Apps/Artwork/Components/ArtworkStructuredData.tsx
@@ -26,8 +26,6 @@ export const ArtworkStructuredData: React.FC<ArtworkStructuredDataProps> = ({
     { fetchPolicy: "store-or-network" },
   )
 
-  if (!artwork) return null
-
   const partner: ArtGallery | undefined = useMemo(() => {
     if (!artwork?.partner?.name) return
     const partner = artwork.partner
@@ -90,6 +88,8 @@ export const ArtworkStructuredData: React.FC<ArtworkStructuredDataProps> = ({
     artwork?.availability,
     partner,
   ])
+
+  if (!artwork) return null
 
   const artworkUrl = `${getENV("APP_URL")}${artwork.href}`
   const artistUrl = `${getENV("APP_URL")}${artwork.artists?.[0]?.href}`


### PR DESCRIPTION
## What

PR #17245 intended to fix a React Rules of Hooks violation in `ArtworkStructuredData` but was a no-op — it moved non-hook constants around but left the two `useMemo` calls still after `if (!artwork) return null`. React requires hooks to be called unconditionally on every render; calling them after a conditional return means they're skipped when `artwork` is null, causing a hook count mismatch if the component later re-renders with artwork data.

## Fix

Move both `useMemo` calls above the early return. The callbacks already guard against null values with optional chaining, so they're safe to run unconditionally.

## Why tests didn't catch this

The tests mount the component fresh for each case and never transition a single instance from null to non-null data, so React never sees a differing hook count between renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)