### PR TITLE
fix(ArtistSeries): guard against null artistSeries before destructuring

### DIFF
--- a/src/Apps/ArtistSeries/ArtistSeriesApp.tsx
+++ b/src/Apps/ArtistSeries/ArtistSeriesApp.tsx
@@ -10,12 +10,14 @@ import { ArtistSeriesHeaderFragmentContainer as ArtistSeriesHeader } from "./Com
 import { ArtistSeriesMetaFragmentContainer as ArtistSeriesMeta } from "./Components/ArtistSeriesMeta"
 
 interface ArtistSeriesAppProps {
-  artistSeries: ArtistSeriesApp_artistSeries$data
+  artistSeries: ArtistSeriesApp_artistSeries$data | null
 }
 
 const ArtistSeriesApp: React.FC<
   React.PropsWithChildren<ArtistSeriesAppProps>
 > = ({ artistSeries }) => {
+  if (!artistSeries) return null
+
   const { railArtist, internalID } = artistSeries
 
   return (


### PR DESCRIPTION
## What

When `artistSeries(id: $slug)` returns `null` from Metaphysics (e.g. a non-existent or deleted series), the `@principalField` directive is supposed to redirect to a 404 — but this isn't catching every case. The component received `null` as `artistSeries` and crashed on the destructure `const { railArtist, internalID } = artistSeries`, throwing:

> Cannot destructure property 'railArtist' from null or undefined value

This has been hitting **6,629 events across 5,328 users**.

## Fix

- Updated `ArtistSeriesAppProps.artistSeries` to accept `| null`
- Added an early `if (!artistSeries) return null` guard before the destructure

## Related

- Sentry: https://artsynet.sentry.io/issues/FORCE-PRODUCTION-1ZQZ (should fully resolve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)