### PR TITLE
fix(sentry): suppress Cloudflare challenge errors

### DIFF
--- a/src/System/Utils/__tests__/sentryBeforeSend.jest.ts
+++ b/src/System/Utils/__tests__/sentryBeforeSend.jest.ts
@@ -1,0 +1,39 @@
+import type { ErrorEvent } from "@sentry/browser"
+import { sentryBeforeSend } from "../sentryBeforeSend"
+
+const CLOUDFLARE_HTML =
+  '<!DOCTYPE html><html lang="en-US"><head><title>Just a moment...</title></head></html>'
+
+const makeEvent = (
+  type: string | undefined,
+  value: string | undefined,
+): ErrorEvent =>
+  ({
+    exception: { values: [{ type, value }] },
+  }) as ErrorEvent
+
+describe("sentryBeforeSend", () => {
+  it("suppresses RRNLRequestError containing Cloudflare HTML", () => {
+    const event = makeEvent(
+      "RRNLRequestError",
+      `Relay request for \`ArtistEditorialNewsGridQuery\` failed by the following reasons:\n\n${CLOUDFLARE_HTML}`,
+    )
+    expect(sentryBeforeSend(event)).toBeNull()
+  })
+
+  it("passes through RRNLRequestError with non-HTML body", () => {
+    const event = makeEvent(
+      "RRNLRequestError",
+      "Relay request for `SomeQuery` failed by the following reasons:\n\nNetwork error",
+    )
+    expect(sentryBeforeSend(event)).toBe(event)
+  })
+
+  it("passes through RRNLRequestError with HTML that is not a Cloudflare challenge", () => {
+    const event = makeEvent(
+      "RRNLRequestError",
+      "Relay request failed:\n\n<!DOCTYPE html><html><head><title>500 Internal Server Error</title>",
+    )
+    expect(sentryBeforeSend(event)).toBe(event)
+  })
+})

--- a/src/System/Utils/sentryBeforeSend.ts
+++ b/src/System/Utils/sentryBeforeSend.ts
@@ -1,0 +1,22 @@
+import type { ErrorEvent } from "@sentry/browser"
+
+export function sentryBeforeSend(event: ErrorEvent): ErrorEvent | null {
+  const exception = event.exception?.values?.[0]
+
+  if (isCloudflareChallenge(exception?.type, exception?.value)) {
+    return null
+  }
+
+  return event
+}
+
+function isCloudflareChallenge(
+  type: string | undefined,
+  value: string | undefined,
+): boolean {
+  return (
+    type === "RRNLRequestError" &&
+    (value?.includes("<!DOCTYPE html>") ?? false) &&
+    (value?.includes("Just a moment...") ?? false)
+  )
+}

--- a/src/System/Utils/setupSentryClient.ts
+++ b/src/System/Utils/setupSentryClient.ts
@@ -9,6 +9,7 @@ import {
   startBrowserTracingNavigationSpan,
   startBrowserTracingPageLoadSpan,
 } from "@sentry/browser"
+import { sentryBeforeSend } from "./sentryBeforeSend"
 import {
   ALLOWED_URLS,
   DENIED_URLS,
@@ -35,6 +36,7 @@ export function setupSentryClient() {
     ignoreErrors: IGNORED_ERRORS,
     release: getENV("SENTRY_RELEASE"),
     tracesSampleRate: 0.08,
+    beforeSend: sentryBeforeSend,
     integrations: [
       browserTracingIntegration({
         // See sentry router tracing below


### PR DESCRIPTION
## What

`RRNLRequestError` events where Cloudflare returned an HTML challenge page instead of a JSON GraphQL response were being logged to Sentry as distinct issues — one per request, because each Cloudflare response contains unique session tokens that produce a unique fingerprint. These originate from datacenter IPs being challenged by Cloudflare and are not actionable from client-side code.

## Fix

Adds a `beforeSend` hook to the client-side Sentry initialization that drops events where all three conditions are true:

- Error type is `RRNLRequestError` (Relay network request that failed to parse as JSON)
- Response body contains `<!DOCTYPE html>` (API returned HTML instead of JSON)
- Response body contains `Just a moment...` (Cloudflare-specific challenge page title)

The three-way check ensures we only suppress Cloudflare challenges specifically — not other HTML responses (e.g. server 500 pages) or other `RRNLRequestError` causes.

The `beforeSend` logic lives in a new `sentryBeforeSend.ts` module so it can be extended as we identify more suppressible error patterns.

## Related

Suppresses the pattern of `RRNLRequestError` events caused by Cloudflare bot challenges returning HTML instead of JSON for secondary GraphQL queries (e.g. `ArtistEditorialNewsGridQuery`, `ArtworkStructuredDataQuery`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)