### PR TITLE
fix: redirecting to home page after one tap login

### DIFF
--- a/src/Server/passport/lib/app/__tests__/lifecycle.jest.ts
+++ b/src/Server/passport/lib/app/__tests__/lifecycle.jest.ts
@@ -444,6 +444,21 @@ describe("lifecycle", () => {
         expect(passport.authenticate).toHaveBeenCalledWith("google-one-tap")
       })
 
+      it("sets redirectTo from the Referer header when not already set", () => {
+        req.headers = { referer: "https://www.artsy.net/artist/andy-warhol" }
+        lifecycle.afterSocialAuth("google", "one-tap")(req, res, next)
+        expect(req.session.redirectTo).toBe(
+          "https://www.artsy.net/artist/andy-warhol",
+        )
+      })
+
+      it("does not override an existing redirectTo with the Referer header", () => {
+        req.session.redirectTo = "/collect"
+        req.headers = { referer: "https://www.artsy.net/artist/andy-warhol" }
+        lifecycle.afterSocialAuth("google", "one-tap")(req, res, next)
+        expect(req.session.redirectTo).toBe("/collect")
+      })
+
       it("sets the suppress cookie on auth error", () => {
         passport.authenticate.mockReturnValueOnce((_req, _res, next) =>
           next(new Error("auth error")),

--- a/src/Server/passport/lib/app/lifecycle.ts
+++ b/src/Server/passport/lib/app/lifecycle.ts
@@ -217,6 +217,12 @@ export const afterSocialAuth =
     const isOneTap = provider === "google" && mode === "one-tap"
     const strategyName = isOneTap ? "google-one-tap" : provider
 
+    // One-tap has no beforeSocialAuth step to capture redirect-to, so fall back
+    // to the Referer header to return the user to the page they were on.
+    if (isOneTap && !req.session.redirectTo && req.headers?.referer) {
+      req.session.redirectTo = req.headers.referer
+    }
+
     if (req.query.denied) {
       return next(new Error(`${provider} denied`))
     }


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [DI-290](https://www.notion.so/artsy/Signing-in-with-one-tap-from-subpage-redirects-back-to-home-page-361cab0764a0802694cdf55c0a243fe2?v=310cab0764a08156aa73000cda8f267f&source=copy_link)

### Description

<!-- Implementation description -->

Our other sign in providers have a beforeSocialAuth function that grabs redirect from request values set in authModal in order to redirect back after sign in. One Tap doesn't have this but does send a referer header with originating url we can use for same purpose. 

https://github.com/user-attachments/assets/aa9c6367-619d-4fd4-84c2-dbc19ebb3cb3




