### PR TITLE
chore: cleaned up additional conditioning for availableShippingCountries

### DIFF
--- a/src/Apps/Order2/Utils/__tests__/addressUtils.jest.ts
+++ b/src/Apps/Order2/Utils/__tests__/addressUtils.jest.ts
@@ -1,4 +1,3 @@
-import { COUNTRIES } from "Utils/countries"
 import {
   countryCodePrefix,
   getShippableCountries,
@@ -21,10 +20,9 @@ describe("addressUtils", () => {
       ).toBe(true)
     })
 
-    it("returns all countries when shipping countries list is empty", () => {
+    it("returns empty array when shipping countries list is empty", () => {
       const result = getShippableCountries([])
-      expect(result).toEqual(COUNTRIES)
-      expect(result.length).toBeGreaterThan(0)
+      expect(result.length).toBe(0)
     })
 
     it("handles case-insensitive matching", () => {

--- a/src/Apps/Order2/Utils/addressUtils.ts
+++ b/src/Apps/Order2/Utils/addressUtils.ts
@@ -9,12 +9,6 @@ import { COUNTRIES, type CountryData } from "Utils/countries"
 export function getShippableCountries(
   availableShippingCountries: ReadonlyArray<string>,
 ): CountryData[] {
-  // If there are no available shipping countries (ex. no artwork location),
-  // then just return all shippalbe countries and let the partner choose to
-  // approve or reject the offer
-  if (availableShippingCountries.length === 0) {
-    return COUNTRIES
-  }
   const lowercaseCountryCodes = availableShippingCountries.map(code =>
     code.toLowerCase(),
   )


### PR DESCRIPTION
The source of truth for `availableShippingCountries` should be Exchange. We should not need any special casing on Force side now. If the list has is not properly set - the changes should be done in Exchange.

This change made possible by updates done here: https://github.com/artsy/exchange/pull/3068


One thing to note here - we do not seem to limit to this 'available countries' when address is added inline in checkout flow by clicking 'Add new address' button. Trying to remember if this is intentional @rquartararo ?