### PR TITLE
feat: one tap inline errors, pre-fill email in account link errors

### DIFF
--- a/src/Apps/Authentication/Components/AuthenticationInlineDialog.tsx
+++ b/src/Apps/Authentication/Components/AuthenticationInlineDialog.tsx
@@ -7,6 +7,7 @@ import { AuthDialogTitle } from "Components/AuthDialog/AuthDialogTitle"
 import { MetaTags } from "Components/MetaTags"
 import { useRouter } from "System/Hooks/useRouter"
 import { useRecaptcha } from "Utils/EnableRecaptcha"
+import { AUTH_ERROR_CODES, AUTH_PROVIDERS } from "Utils/authConstants"
 import { type FC, useEffect } from "react"
 
 const AuthenticationInlineDialogContents: FC<
@@ -26,8 +27,8 @@ const AuthenticationInlineDialogContents: FC<
     if (!location.query.error_code) return
 
     const message = (
-      ERROR_CODES[location.query.error_code] || ERROR_CODES.UNKNOWN
-    ).replace(/{provider}/g, PROVIDERS[location.query.provider] || "—")
+      AUTH_ERROR_CODES[location.query.error_code] || AUTH_ERROR_CODES.UNKNOWN
+    ).replace(/{provider}/g, AUTH_PROVIDERS[location.query.provider] || "—")
 
     if (location.query.error) {
       console.error(location.query.error)
@@ -84,24 +85,4 @@ export const AuthenticationInlineDialog: FC<
       <AuthenticationInlineDialogContents />
     </AuthenticationInlineDialogProvider>
   )
-}
-
-const ERROR_CODES = {
-  ALREADY_EXISTS:
-    "A user with this email address already exists. Log in to Artsy via email and password and link {provider} in your settings instead.",
-  PREVIOUSLY_LINKED_SETTINGS:
-    "{provider} account previously linked to Artsy. Log in to your Artsy account via email and password and link {provider} in your settings instead.",
-  PREVIOUSLY_LINKED: "{provider} account previously linked to Artsy.",
-  IP_BLOCKED: "Your IP address was blocked by {provider}.",
-  TWO_FACTOR_AUTHENTICATION_REQUIRED:
-    "Please log in with email and password to use two-factor authentication.",
-  TWO_FACTOR_AUTHENTICATION_ENABLED:
-    "Social account linking is not available while two-factor authentication is enabled on your Artsy account.",
-  UNKNOWN: "An unknown error occurred. Please try again.",
-}
-
-const PROVIDERS = {
-  facebook: "Facebook",
-  google: "Google",
-  apple: "Apple",
 }

--- a/src/Apps/Authentication/Hooks/__tests__/useAuthDialogOptions.jest.tsx
+++ b/src/Apps/Authentication/Hooks/__tests__/useAuthDialogOptions.jest.tsx
@@ -35,9 +35,8 @@ describe("useAuthDialogOptions", () => {
       payload: {
         analytics: { intent: "signup" },
         mode: "Welcome",
-        options: {
-          title: "Sign up or log in",
-        },
+        options: { title: "Sign up or log in" },
+        values: { email: undefined },
       },
       type: "SET",
     })
@@ -63,9 +62,8 @@ describe("useAuthDialogOptions", () => {
       payload: {
         analytics: { intent: "signup" },
         mode: "Welcome",
-        options: {
-          title: "Sign up or log in",
-        },
+        options: { title: "Sign up or log in" },
+        values: { email: undefined },
       },
       type: "SET",
     })
@@ -112,6 +110,7 @@ describe("useAuthDialogOptions", () => {
           title: "Example Title",
           redirectTo: "/example-redirect",
         },
+        values: { email: undefined },
       },
       type: "SET",
     })
@@ -149,9 +148,7 @@ describe("useAuthDialogOptions", () => {
 
     expect(dispatch).toHaveBeenCalledWith({
       payload: {
-        analytics: {
-          intent: "signup",
-        },
+        analytics: { intent: "signup" },
         mode: "Welcome",
         options: {
           title: "Sign up or log in",
@@ -161,8 +158,36 @@ describe("useAuthDialogOptions", () => {
             objectId: "exampleId",
           },
         },
+        values: { email: undefined },
       },
       type: "SET",
     })
+  })
+
+  it("pre-fills email from query param", () => {
+    const dispatch = jest.fn()
+
+    mockUseAuthDialogContext.mockImplementation(() => ({
+      state: { mode: "Login" },
+      dispatch,
+    }))
+
+    mockUseRouter.mockImplementation(() => ({
+      match: {
+        location: {
+          query: { email: "user@example.com" },
+        },
+      },
+    }))
+
+    renderHook(useAuthDialogOptions)
+
+    expect(dispatch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          values: { email: "user@example.com" },
+        }),
+      }),
+    )
   })
 })

--- a/src/Apps/Authentication/Hooks/useAuthDialogOptions.tsx
+++ b/src/Apps/Authentication/Hooks/useAuthDialogOptions.tsx
@@ -73,6 +73,9 @@ export const useAuthDialogOptions = () => {
           afterAuthAction,
           redirectTo: query.redirectTo,
         },
+        values: {
+          email: query.email,
+        },
       },
     })
   }, [
@@ -80,6 +83,7 @@ export const useAuthDialogOptions = () => {
     dispatch,
     mode,
     query.contextModule,
+    query.email,
     query.intent,
     query.redirectTo,
     title,

--- a/src/Components/AuthDialog/Hooks/__tests__/useSocialAuthTracking.jest.ts
+++ b/src/Components/AuthDialog/Hooks/__tests__/useSocialAuthTracking.jest.ts
@@ -5,7 +5,9 @@ import { useRouter } from "System/Hooks/useRouter"
 import Cookies from "cookies-js"
 
 jest.mock("System/Hooks/useRouter", () => ({
-  useRouter: jest.fn().mockImplementation(() => ({ match: { location: {} } })),
+  useRouter: jest
+    .fn()
+    .mockImplementation(() => ({ match: { location: { pathname: "/" } } })),
 }))
 
 jest.mock("System/Hooks/useSystemContext", () => ({
@@ -31,9 +33,12 @@ describe("useSocialAuthTracking", () => {
     jest.clearAllMocks()
   })
 
-  it("calls the correct tracking function with the correct data and expires the cookie", () => {
+  it("calls loggedIn with the correct data and expires the cookie", () => {
     const loggedIn = jest.fn()
-    mockUseAuthDialogTracking.mockImplementation(() => ({ loggedIn }))
+    mockUseAuthDialogTracking.mockImplementation(() => ({
+      loggedIn,
+      signedUp: jest.fn(),
+    }))
     mockCookiesExpire.mockImplementation(jest.fn())
 
     mockCookiesGet.mockImplementation(() =>
@@ -55,6 +60,66 @@ describe("useSocialAuthTracking", () => {
     })
 
     expect(mockCookiesExpire).toBeCalledWith("useSocialAuthTracking")
+  })
+
+  it("calls signedUp with onboarding=true when the URL param is present", () => {
+    const signedUp = jest.fn()
+    mockUseAuthDialogTracking.mockImplementation(() => ({
+      loggedIn: jest.fn(),
+      signedUp,
+    }))
+
+    mockCookiesGet.mockImplementation(() =>
+      JSON.stringify({
+        action: "signedUp",
+        service: "google",
+        analytics: {
+          contextModule: "header",
+          intent: "signup",
+        },
+      }),
+    )
+
+    mockUseRouter.mockImplementation(() => ({
+      match: { location: { pathname: "/", search: "?onboarding=true" } },
+    }))
+
+    renderHook(useSocialAuthTracking)
+
+    expect(signedUp).toBeCalledWith({
+      contextModule: "header",
+      intent: "signup",
+      onboarding: true,
+      service: "google",
+      userId: "example",
+    })
+  })
+
+  it("calls signedUp with onboarding=false when the URL param is absent", () => {
+    const signedUp = jest.fn()
+    mockUseAuthDialogTracking.mockImplementation(() => ({
+      loggedIn: jest.fn(),
+      signedUp,
+    }))
+
+    mockCookiesGet.mockImplementation(() =>
+      JSON.stringify({
+        action: "signedUp",
+        service: "google",
+      }),
+    )
+
+    mockUseRouter.mockImplementation(() => ({
+      match: { location: { pathname: "/" } },
+    }))
+
+    renderHook(useSocialAuthTracking)
+
+    expect(signedUp).toBeCalledWith({
+      onboarding: false,
+      service: "google",
+      userId: "example",
+    })
   })
 
   it("passes method to the tracking function when present", () => {

--- a/src/Components/AuthDialog/Hooks/useAuthDialogTracking.ts
+++ b/src/Components/AuthDialog/Hooks/useAuthDialogTracking.ts
@@ -80,6 +80,7 @@ export const useAuthDialogTracking = () => {
         userId,
         intent = analytics.intent || Intent.signup,
         trigger = analytics.trigger || "click",
+        onboarding = isElligibleForOnboarding,
       }: {
         contextModule?: CreatedAccount["context_module"]
         method?: CreatedAccount["method"]
@@ -87,6 +88,7 @@ export const useAuthDialogTracking = () => {
         userId: CreatedAccount["user_id"]
         intent?: CreatedAccount["intent"]
         trigger?: CreatedAccount["trigger"]
+        onboarding?: CreatedAccount["onboarding"]
       }) => {
         const payload: CreatedAccount = {
           action: ActionType.createdAccount,
@@ -94,7 +96,7 @@ export const useAuthDialogTracking = () => {
           context_module: contextModule,
           intent,
           method,
-          onboarding: isElligibleForOnboarding,
+          onboarding,
           service,
           trigger,
           type: AuthModalType.signup,

--- a/src/Components/AuthDialog/Hooks/useSocialAuthTracking.ts
+++ b/src/Components/AuthDialog/Hooks/useSocialAuthTracking.ts
@@ -50,15 +50,25 @@ export const useSocialAuthTracking = () => {
       return
     }
 
-    track[value.action]({
+    const params = {
       service: value.service,
       userId: user.id,
       ...(value.method ? { method: value.method } : {}),
       ...(value.analytics ?? {}),
-    })
+    }
+
+    if (value.action === "signedUp") {
+      // for social auth, tracking fires after a full-page redirect, so the
+      // dialog context is gone. We read onboarding from the URL instead
+      const onboarding =
+        new URLSearchParams(location.search).get("onboarding") === "true"
+      track.signedUp({ ...params, onboarding })
+    } else {
+      track.loggedIn(params)
+    }
 
     Cookies.expire(USE_SOCIAL_AUTH_TRACKING_KEY)
-  }, [location.pathname, track, user])
+  }, [location.pathname, location.search, track, user])
 }
 
 const schema = Yup.object({
@@ -73,10 +83,15 @@ const schema = Yup.object({
   trigger: Yup.string().oneOf(["click", "tap", "timed", "scroll"]),
 })
 
-type Payload = Omit<Yup.InferType<typeof schema>, "analytics"> & {
+type Payload = Omit<
+  Yup.InferType<typeof schema>,
+  "analytics" | "method" | "service"
+> & {
   // We assume that the unions are valid because it would
   // be difficult to get the runtime values from Cohesion
   analytics?: AuthDialogAnalytics
+  method?: "one-tap"
+  service: "apple" | "facebook" | "google"
 }
 
 const isValid = (value: any): value is Payload => {

--- a/src/Components/AuthDialog/Views/AuthDialogWelcome.tsx
+++ b/src/Components/AuthDialog/Views/AuthDialogWelcome.tsx
@@ -24,6 +24,7 @@ export const AuthDialogWelcome: FC<
 
   return (
     <Formik
+      enableReinitialize
       validateOnBlur={false}
       validationSchema={VALIDATION_SCHEMA}
       initialValues={{ email: values.email || "", mode: "Pending" }}

--- a/src/Server/passport/lib/app/__tests__/lifecycle.jest.ts
+++ b/src/Server/passport/lib/app/__tests__/lifecycle.jest.ts
@@ -489,13 +489,77 @@ describe("lifecycle", () => {
         expect(res.cookie).not.toHaveBeenCalled()
       })
 
-      it("uses google as the provider in error redirects", () => {
-        passport.authenticate.mockReturnValueOnce((_req, _res, next) => {
-          next(new Error("Unauthorized source IP address"))
-        })
+      it("redirects IP_BLOCKED inline to the originating page", () => {
+        passport.authenticate.mockReturnValueOnce(
+          (_req: any, _res: any, next: any) =>
+            next(new Error("Unauthorized source IP address")),
+        )
         lifecycle.afterSocialAuth("google", "one-tap")(req, res, next)
         expect(res.redirect).toHaveBeenCalledWith(
-          "/login?error_code=IP_BLOCKED&provider=google",
+          "/?g_one_tap_error=IP_BLOCKED&g_one_tap_provider=google",
+        )
+      })
+
+      it("redirects IP_BLOCKED inline to redirectTo when set", () => {
+        req.session.redirectTo = "/artist/andy-warhol"
+        passport.authenticate.mockReturnValueOnce(
+          (_req: any, _res: any, next: any) =>
+            next(new Error("Unauthorized source IP address")),
+        )
+        lifecycle.afterSocialAuth("google", "one-tap")(req, res, next)
+        expect(res.redirect).toHaveBeenCalledWith(
+          "/artist/andy-warhol?g_one_tap_error=IP_BLOCKED&g_one_tap_provider=google",
+        )
+      })
+
+      it("redirects TWO_FACTOR_AUTHENTICATION_REQUIRED inline", () => {
+        passport.authenticate.mockReturnValueOnce(
+          (_req: any, _res: any, next: any) =>
+            next(new Error("missing two-factor authentication code")),
+        )
+        lifecycle.afterSocialAuth("google", "one-tap")(req, res, next)
+        expect(res.redirect).toHaveBeenCalledWith(
+          "/?g_one_tap_error=TWO_FACTOR_AUTHENTICATION_REQUIRED&g_one_tap_provider=google",
+        )
+      })
+
+      it("redirects unknown errors inline", () => {
+        passport.authenticate.mockReturnValueOnce(
+          (_req: any, _res: any, next: any) =>
+            next(new Error("some unexpected error")),
+        )
+        lifecycle.afterSocialAuth("google", "one-tap")(req, res, next)
+        expect(res.redirect).toHaveBeenCalledWith(
+          "/?g_one_tap_error=UNKNOWN&g_one_tap_provider=google",
+        )
+      })
+
+      it("still redirects ALREADY_EXISTS to the login page", () => {
+        passport.authenticate.mockReturnValueOnce(
+          (_req: any, _res: any, next: any) => {
+            const err: any = new Error()
+            err.response = { body: { error: "User Already Exists" } }
+            req.socialProfileEmail = "user@example.com"
+            next(err)
+          },
+        )
+        lifecycle.afterSocialAuth("google", "one-tap")(req, res, next)
+        expect(res.redirect).toHaveBeenCalledWith(
+          expect.stringContaining("/login"),
+        )
+      })
+
+      it("still redirects PREVIOUSLY_LINKED_SETTINGS to the login page", () => {
+        passport.authenticate.mockReturnValueOnce(
+          (_req: any, _res: any, next: any) => {
+            const err: any = new Error()
+            err.response = { body: { error: "User Already Exists" } }
+            next(err)
+          },
+        )
+        lifecycle.afterSocialAuth("google", "one-tap")(req, res, next)
+        expect(res.redirect).toHaveBeenCalledWith(
+          expect.stringContaining("/login"),
         )
       })
     })

--- a/src/Server/passport/lib/app/__tests__/lifecycle.jest.ts
+++ b/src/Server/passport/lib/app/__tests__/lifecycle.jest.ts
@@ -339,7 +339,7 @@ describe("lifecycle", () => {
       )
       lifecycle.afterSocialAuth("facebook")(req, res, next)
       expect(res.redirect).toHaveBeenCalledWith(
-        "/login?error=An+unknown+error+occurred.+Please+try+again.&error_code=UNKNOWN",
+        "/login?error=An+unknown+error+occurred.+Please+try+again.&error_code=UNKNOWN&provider=facebook",
       )
       expect(warn).toHaveBeenCalledWith(
         "Error authenticating with facebook: Facebook authorization failed",

--- a/src/Server/passport/lib/app/__tests__/lifecycle.jest.ts
+++ b/src/Server/passport/lib/app/__tests__/lifecycle.jest.ts
@@ -496,7 +496,7 @@ describe("lifecycle", () => {
         )
         lifecycle.afterSocialAuth("google", "one-tap")(req, res, next)
         expect(res.redirect).toHaveBeenCalledWith(
-          "/?g_one_tap_error=IP_BLOCKED&g_one_tap_provider=google",
+          "/?g_one_tap_error=IP_BLOCKED",
         )
       })
 
@@ -508,7 +508,7 @@ describe("lifecycle", () => {
         )
         lifecycle.afterSocialAuth("google", "one-tap")(req, res, next)
         expect(res.redirect).toHaveBeenCalledWith(
-          "/artist/andy-warhol?g_one_tap_error=IP_BLOCKED&g_one_tap_provider=google",
+          "/artist/andy-warhol?g_one_tap_error=IP_BLOCKED",
         )
       })
 
@@ -519,7 +519,7 @@ describe("lifecycle", () => {
         )
         lifecycle.afterSocialAuth("google", "one-tap")(req, res, next)
         expect(res.redirect).toHaveBeenCalledWith(
-          "/?g_one_tap_error=TWO_FACTOR_AUTHENTICATION_REQUIRED&g_one_tap_provider=google",
+          "/?g_one_tap_error=TWO_FACTOR_AUTHENTICATION_REQUIRED",
         )
       })
 
@@ -529,9 +529,7 @@ describe("lifecycle", () => {
             next(new Error("some unexpected error")),
         )
         lifecycle.afterSocialAuth("google", "one-tap")(req, res, next)
-        expect(res.redirect).toHaveBeenCalledWith(
-          "/?g_one_tap_error=UNKNOWN&g_one_tap_provider=google",
-        )
+        expect(res.redirect).toHaveBeenCalledWith("/?g_one_tap_error=UNKNOWN")
       })
 
       it("still redirects ALREADY_EXISTS to the login page", () => {

--- a/src/Server/passport/lib/app/lifecycle.ts
+++ b/src/Server/passport/lib/app/lifecycle.ts
@@ -187,16 +187,38 @@ const redirectWithQuery = (
   return `${path}?${query.toString()}`
 }
 
-const oneTapInlineRedirect = (
+const redirectSocialAuthError = (
   req: Req,
   res: ArtsyResponse,
-  errorCode: string,
-  provider: Provider,
+  {
+    isOneTap,
+    redirectPath,
+    errorCode,
+    provider,
+    errorMessage,
+  }: {
+    isOneTap: boolean
+    redirectPath: string
+    errorCode: string
+    provider: Provider
+    errorMessage?: string
+  },
 ) => {
+  if (isOneTap) {
+    // One-tap errors are handled inline via toast on page that initialized flow
+    return res.redirect(
+      redirectWithQuery(req.session.redirectTo || "/", {
+        g_one_tap_error: errorCode,
+        g_one_tap_provider: provider,
+      }),
+    )
+  }
+  // All other social auth errors redirect to login page
   return res.redirect(
-    redirectWithQuery(req.session.redirectTo || "/", {
-      g_one_tap_error: errorCode,
-      g_one_tap_provider: provider,
+    redirectWithQuery(redirectPath, {
+      ...(errorMessage != null ? { error: errorMessage } : {}),
+      error_code: errorCode,
+      provider,
     }),
   )
 }
@@ -292,37 +314,25 @@ export const afterSocialAuth =
       }
 
       if (err?.message?.match("Unauthorized source IP address")) {
-        if (isOneTap) {
-          return oneTapInlineRedirect(req, res, "IP_BLOCKED", provider)
-        }
-        // Your IP address was blocked by the provider. Redirect back to login page.
-        return res.redirect(
-          redirectWithQuery(redirectPath, {
-            error_code: "IP_BLOCKED",
-            provider,
-          }),
-        )
+        return redirectSocialAuthError(req, res, {
+          isOneTap,
+          redirectPath,
+          errorCode: "IP_BLOCKED",
+          provider,
+        })
       }
 
       if (err != null) {
         const message = extractError(err)
 
         if (message.includes("missing two-factor authentication code")) {
-          if (isOneTap) {
-            return oneTapInlineRedirect(
-              req,
-              res,
-              "TWO_FACTOR_AUTHENTICATION_REQUIRED",
-              provider,
-            )
-          }
-          return res.redirect(
-            redirectWithQuery(redirectPath, {
-              error: SOCIAL_LOGIN_TWO_FACTOR_AUTH_ERROR,
-              error_code: "TWO_FACTOR_AUTHENTICATION_REQUIRED",
-              provider,
-            }),
-          )
+          return redirectSocialAuthError(req, res, {
+            isOneTap,
+            redirectPath,
+            errorCode: "TWO_FACTOR_AUTHENTICATION_REQUIRED",
+            provider,
+            errorMessage: SOCIAL_LOGIN_TWO_FACTOR_AUTH_ERROR,
+          })
         }
 
         if (
@@ -341,15 +351,13 @@ export const afterSocialAuth =
 
         // Unknown error. Do not show error message to user; log to console.
         console.warn(`Error authenticating with ${provider}: ${message}`)
-        if (isOneTap) {
-          return oneTapInlineRedirect(req, res, "UNKNOWN", provider)
-        }
-        return res.redirect(
-          redirectWithQuery(redirectPath, {
-            error: UNKNOWN_AUTH_ERROR,
-            error_code: "UNKNOWN",
-          }),
-        )
+        return redirectSocialAuthError(req, res, {
+          isOneTap,
+          redirectPath,
+          errorCode: "UNKNOWN",
+          provider,
+          errorMessage: UNKNOWN_AUTH_ERROR,
+        })
       }
 
       if (linkingAccount) {

--- a/src/Server/passport/lib/app/lifecycle.ts
+++ b/src/Server/passport/lib/app/lifecycle.ts
@@ -209,7 +209,6 @@ const redirectSocialAuthError = (
     return res.redirect(
       redirectWithQuery(req.session.redirectTo || "/", {
         g_one_tap_error: errorCode,
-        g_one_tap_provider: provider,
       }),
     )
   }

--- a/src/Server/passport/lib/app/lifecycle.ts
+++ b/src/Server/passport/lib/app/lifecycle.ts
@@ -187,6 +187,20 @@ const redirectWithQuery = (
   return `${path}?${query.toString()}`
 }
 
+const oneTapInlineRedirect = (
+  req: Req,
+  res: ArtsyResponse,
+  errorCode: string,
+  provider: Provider,
+) => {
+  return res.redirect(
+    redirectWithQuery(req.session.redirectTo || "/", {
+      g_one_tap_error: errorCode,
+      g_one_tap_provider: provider,
+    }),
+  )
+}
+
 export const beforeSocialAuth =
   (provider: Provider) =>
   (req: Req, res: ArtsyResponse, next: NextFunction) => {
@@ -278,6 +292,9 @@ export const afterSocialAuth =
       }
 
       if (err?.message?.match("Unauthorized source IP address")) {
+        if (isOneTap) {
+          return oneTapInlineRedirect(req, res, "IP_BLOCKED", provider)
+        }
         // Your IP address was blocked by the provider. Redirect back to login page.
         return res.redirect(
           redirectWithQuery(redirectPath, {
@@ -291,6 +308,14 @@ export const afterSocialAuth =
         const message = extractError(err)
 
         if (message.includes("missing two-factor authentication code")) {
+          if (isOneTap) {
+            return oneTapInlineRedirect(
+              req,
+              res,
+              "TWO_FACTOR_AUTHENTICATION_REQUIRED",
+              provider,
+            )
+          }
           return res.redirect(
             redirectWithQuery(redirectPath, {
               error: SOCIAL_LOGIN_TWO_FACTOR_AUTH_ERROR,
@@ -314,8 +339,11 @@ export const afterSocialAuth =
           )
         }
 
-        // Unknown error. Redirect back to login page. Do not show error message to user; log to console.
+        // Unknown error. Do not show error message to user; log to console.
         console.warn(`Error authenticating with ${provider}: ${message}`)
+        if (isOneTap) {
+          return oneTapInlineRedirect(req, res, "UNKNOWN", provider)
+        }
         return res.redirect(
           redirectWithQuery(redirectPath, {
             error: UNKNOWN_AUTH_ERROR,

--- a/src/Server/passport/lib/passport/__tests__/callbacks.jest.ts
+++ b/src/Server/passport/lib/passport/__tests__/callbacks.jest.ts
@@ -107,15 +107,6 @@ describe("passport callbacks", () => {
     expect(req.socialProfileEmail).toEqual("user@example.com")
   })
 
-  it("clears socialProfileEmail when google profile has no email", () => {
-    mockRequestGravity.mockResolvedValue(
-      gravityResponse({ access_token: "access-token" }),
-    )
-    req.socialProfileEmail = "previous@example.com"
-    cbs.google(req, "foo-token", "refresh-token", {}, jest.fn())
-    expect(req.socialProfileEmail).toBeUndefined()
-  })
-
   it("gets a user with an access token via google one tap", done => {
     req.body = { credential: "google-jwt-credential" }
     mockRequestGravity.mockResolvedValue(
@@ -139,16 +130,6 @@ describe("passport callbacks", () => {
     const profile = { emails: [{ value: "user@example.com" }] }
     cbs.googleOneTap(req, profile, jest.fn())
     expect(req.socialProfileEmail).toEqual("user@example.com")
-  })
-
-  it("clears socialProfileEmail when google one tap profile has no email", () => {
-    mockRequestGravity.mockResolvedValue(
-      gravityResponse({ access_token: "access-token" }),
-    )
-    req.body = { credential: "google-jwt-credential" }
-    req.socialProfileEmail = "previous@example.com"
-    cbs.googleOneTap(req, {}, jest.fn())
-    expect(req.socialProfileEmail).toBeUndefined()
   })
 
   it("passes the user agent through google one tap", async () => {

--- a/src/Server/passport/lib/passport/__tests__/callbacks.jest.ts
+++ b/src/Server/passport/lib/passport/__tests__/callbacks.jest.ts
@@ -98,6 +98,24 @@ describe("passport callbacks", () => {
     expect(sendArgs.oauth_token).toEqual("foo-token")
   })
 
+  it("sets socialProfileEmail from google profile", () => {
+    mockRequestGravity.mockResolvedValue(
+      gravityResponse({ access_token: "access-token" }),
+    )
+    const profile = { emails: [{ value: "user@example.com" }] }
+    cbs.google(req, "foo-token", "refresh-token", profile, jest.fn())
+    expect(req.socialProfileEmail).toEqual("user@example.com")
+  })
+
+  it("clears socialProfileEmail when google profile has no email", () => {
+    mockRequestGravity.mockResolvedValue(
+      gravityResponse({ access_token: "access-token" }),
+    )
+    req.socialProfileEmail = "previous@example.com"
+    cbs.google(req, "foo-token", "refresh-token", {}, jest.fn())
+    expect(req.socialProfileEmail).toBeUndefined()
+  })
+
   it("gets a user with an access token via google one tap", done => {
     req.body = { credential: "google-jwt-credential" }
     mockRequestGravity.mockResolvedValue(
@@ -111,6 +129,26 @@ describe("passport callbacks", () => {
     expect(sendArgs.grant_type).toEqual("jwt")
     expect(sendArgs.jwt).toEqual("google-jwt-credential")
     expect(sendArgs.oauth_provider).toEqual("google")
+  })
+
+  it("sets socialProfileEmail from google one tap profile", () => {
+    mockRequestGravity.mockResolvedValue(
+      gravityResponse({ access_token: "access-token" }),
+    )
+    req.body = { credential: "google-jwt-credential" }
+    const profile = { emails: [{ value: "user@example.com" }] }
+    cbs.googleOneTap(req, profile, jest.fn())
+    expect(req.socialProfileEmail).toEqual("user@example.com")
+  })
+
+  it("clears socialProfileEmail when google one tap profile has no email", () => {
+    mockRequestGravity.mockResolvedValue(
+      gravityResponse({ access_token: "access-token" }),
+    )
+    req.body = { credential: "google-jwt-credential" }
+    req.socialProfileEmail = "previous@example.com"
+    cbs.googleOneTap(req, {}, jest.fn())
+    expect(req.socialProfileEmail).toBeUndefined()
   })
 
   it("passes the user agent through google one tap", async () => {

--- a/src/Server/passport/lib/passport/callbacks.ts
+++ b/src/Server/passport/lib/passport/callbacks.ts
@@ -99,8 +99,6 @@ export const facebook = (
 ) => {
   if (profile && profile.emails && profile.emails[0]) {
     req.socialProfileEmail = profile.emails[0].value
-  } else {
-    req.socialProfileEmail = undefined
   }
   // Link Facebook account
   if (req.user) {
@@ -160,8 +158,6 @@ export const google = (
 ) => {
   if (profile?.emails?.[0]) {
     req.socialProfileEmail = profile.emails[0].value
-  } else {
-    req.socialProfileEmail = undefined
   }
 
   // Link Google account
@@ -220,8 +216,6 @@ export const googleOneTap = (
 ) => {
   if (profile?.emails?.[0]) {
     req.socialProfileEmail = profile.emails[0].value
-  } else {
-    req.socialProfileEmail = undefined
   }
 
   requestGravity({

--- a/src/Server/passport/lib/passport/callbacks.ts
+++ b/src/Server/passport/lib/passport/callbacks.ts
@@ -158,6 +158,12 @@ export const google = (
   profile: OAuthProfile,
   done?: PassportDone,
 ) => {
+  if (profile?.emails?.[0]) {
+    req.socialProfileEmail = profile.emails[0].value
+  } else {
+    req.socialProfileEmail = undefined
+  }
+
   // Link Google account
   if (req.user) {
     return requestGravity({
@@ -212,6 +218,12 @@ export const googleOneTap = (
   profile: OAuthProfile,
   done?: PassportDone,
 ) => {
+  if (profile?.emails?.[0]) {
+    req.socialProfileEmail = profile.emails[0].value
+  } else {
+    req.socialProfileEmail = undefined
+  }
+
   requestGravity({
     body: {
       client_id: opts.ARTSY_ID,

--- a/src/Utils/GoogleOneTapContainer.tsx
+++ b/src/Utils/GoogleOneTapContainer.tsx
@@ -1,7 +1,7 @@
 import { useToasts } from "@artsy/palette"
 import { useFlag } from "@unleash/proxy-client-react"
 import { useSystemContext } from "System/Hooks/useSystemContext"
-import { AUTH_ERROR_CODES, AUTH_PROVIDERS } from "Utils/authConstants"
+import { AUTH_ERROR_CODES } from "Utils/authConstants"
 import { getENV } from "Utils/getENV"
 import { useEffect } from "react"
 
@@ -33,21 +33,16 @@ export const GoogleOneTapContainer = () => {
   useEffect(() => {
     const params = new URLSearchParams(window.location.search)
     const errorCode = params.get("g_one_tap_error")
-    const providerKey = params.get("g_one_tap_provider")
 
     if (!errorCode) return
 
     const template = AUTH_ERROR_CODES[errorCode] ?? AUTH_ERROR_CODES.UNKNOWN
-    const message = template.replace(
-      "{provider}",
-      AUTH_PROVIDERS[providerKey ?? ""] ?? "provider",
-    )
+    const message = template.replace("{provider}", "Google")
 
     sendToast({ message, variant: "error", ttl: Number.POSITIVE_INFINITY })
 
     const cleanUrl = new URL(window.location.href)
     cleanUrl.searchParams.delete("g_one_tap_error")
-    cleanUrl.searchParams.delete("g_one_tap_provider")
     window.history.replaceState({}, "", cleanUrl.toString())
   }, [sendToast])
 

--- a/src/Utils/GoogleOneTapContainer.tsx
+++ b/src/Utils/GoogleOneTapContainer.tsx
@@ -1,7 +1,21 @@
+import { useToasts } from "@artsy/palette"
 import { useFlag } from "@unleash/proxy-client-react"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import { getENV } from "Utils/getENV"
 import { useEffect } from "react"
+
+const ONE_TAP_ERROR_MESSAGES: Record<string, string> = {
+  IP_BLOCKED: "Your IP address was blocked by {provider}.",
+  TWO_FACTOR_AUTHENTICATION_REQUIRED:
+    "Please log in with email and password to use two-factor authentication.",
+  UNKNOWN: "An unknown error occurred. Please try again.",
+}
+
+const PROVIDERS: Record<string, string> = {
+  facebook: "Facebook",
+  google: "Google",
+  apple: "Apple",
+}
 
 const AUTH_PATHS = [
   "/log_in",
@@ -20,12 +34,35 @@ export const GoogleOneTapContainer = () => {
   const { isLoggedIn } = useSystemContext()
   const isGoogleOneTapEnabled = !!useFlag("diamond_google-one-tap")
   const googleClientId = getENV("GOOGLE_CLIENT_ID")
+  const { sendToast } = useToasts()
 
   const enabled =
     !isLoggedIn &&
     isGoogleOneTapEnabled &&
     !!googleClientId &&
     !isAuthPath(window.location.pathname)
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search)
+    const errorCode = params.get("g_one_tap_error")
+    const providerKey = params.get("g_one_tap_provider")
+
+    if (!errorCode) return
+
+    const template =
+      ONE_TAP_ERROR_MESSAGES[errorCode] ?? ONE_TAP_ERROR_MESSAGES.UNKNOWN
+    const message = template.replace(
+      "{provider}",
+      PROVIDERS[providerKey ?? ""] ?? "provider",
+    )
+
+    sendToast({ message, variant: "error", ttl: Number.POSITIVE_INFINITY })
+
+    const cleanUrl = new URL(window.location.href)
+    cleanUrl.searchParams.delete("g_one_tap_error")
+    cleanUrl.searchParams.delete("g_one_tap_provider")
+    window.history.replaceState({}, "", cleanUrl.toString())
+  }, [sendToast])
 
   useEffect(() => {
     if (!enabled) {

--- a/src/Utils/GoogleOneTapContainer.tsx
+++ b/src/Utils/GoogleOneTapContainer.tsx
@@ -1,21 +1,9 @@
 import { useToasts } from "@artsy/palette"
 import { useFlag } from "@unleash/proxy-client-react"
 import { useSystemContext } from "System/Hooks/useSystemContext"
+import { AUTH_ERROR_CODES, AUTH_PROVIDERS } from "Utils/authConstants"
 import { getENV } from "Utils/getENV"
 import { useEffect } from "react"
-
-const ONE_TAP_ERROR_MESSAGES: Record<string, string> = {
-  IP_BLOCKED: "Your IP address was blocked by {provider}.",
-  TWO_FACTOR_AUTHENTICATION_REQUIRED:
-    "Please log in with email and password to use two-factor authentication.",
-  UNKNOWN: "An unknown error occurred. Please try again.",
-}
-
-const PROVIDERS: Record<string, string> = {
-  facebook: "Facebook",
-  google: "Google",
-  apple: "Apple",
-}
 
 const AUTH_PATHS = [
   "/log_in",
@@ -49,11 +37,10 @@ export const GoogleOneTapContainer = () => {
 
     if (!errorCode) return
 
-    const template =
-      ONE_TAP_ERROR_MESSAGES[errorCode] ?? ONE_TAP_ERROR_MESSAGES.UNKNOWN
+    const template = AUTH_ERROR_CODES[errorCode] ?? AUTH_ERROR_CODES.UNKNOWN
     const message = template.replace(
       "{provider}",
-      PROVIDERS[providerKey ?? ""] ?? "provider",
+      AUTH_PROVIDERS[providerKey ?? ""] ?? "provider",
     )
 
     sendToast({ message, variant: "error", ttl: Number.POSITIVE_INFINITY })

--- a/src/Utils/__tests__/GoogleOneTapContainer.jest.tsx
+++ b/src/Utils/__tests__/GoogleOneTapContainer.jest.tsx
@@ -1,13 +1,19 @@
 import { render } from "@testing-library/react"
+import { useToasts } from "@artsy/palette"
 import { useFlag } from "@unleash/proxy-client-react"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import { GoogleOneTapContainer } from "Utils/GoogleOneTapContainer"
 import { getENV } from "Utils/getENV"
 
 const mockCaptureException = jest.fn()
+const mockSendToast = jest.fn()
 
 jest.mock("@sentry/browser", () => ({
   captureException: (...args: unknown[]) => mockCaptureException(...args),
+}))
+
+jest.mock("@artsy/palette", () => ({
+  useToasts: jest.fn(),
 }))
 
 jest.mock("Utils/getENV", () => ({
@@ -26,6 +32,7 @@ describe("GoogleOneTapContainer", () => {
   const mockUseFlag = useFlag as jest.Mock
   const mockGetENV = getENV as jest.Mock
   const mockUseSystemContext = useSystemContext as jest.Mock
+  const mockUseToasts = useToasts as jest.Mock
 
   const enableOneTap = () => {
     mockUseFlag.mockReturnValue(true)
@@ -42,6 +49,8 @@ describe("GoogleOneTapContainer", () => {
     mockUseSystemContext.mockReturnValue({ isLoggedIn: false })
     mockGetENV.mockReturnValue(null)
     mockCaptureException.mockClear()
+    mockSendToast.mockClear()
+    mockUseToasts.mockReturnValue({ sendToast: mockSendToast })
   })
 
   afterEach(() => {
@@ -151,6 +160,101 @@ describe("GoogleOneTapContainer", () => {
       mockGetENV.mockReturnValue("test-client-id")
       render(<GoogleOneTapContainer />)
       expect(gsiScript()).not.toBeInTheDocument()
+    })
+  })
+
+  describe("inline error toasts", () => {
+    const originalLocation = window.location
+
+    afterEach(() => {
+      Object.defineProperty(window, "location", {
+        value: originalLocation,
+        writable: true,
+      })
+    })
+
+    const setLocation = (search: string) => {
+      Object.defineProperty(window, "location", {
+        value: {
+          pathname: "/artist/andy-warhol",
+          search,
+          href: `http://localhost/artist/andy-warhol${search}`,
+        },
+        writable: true,
+      })
+    }
+
+    it("shows a toast for IP_BLOCKED", () => {
+      setLocation("?g_one_tap_error=IP_BLOCKED&g_one_tap_provider=google")
+      enableOneTap()
+      render(<GoogleOneTapContainer />)
+      expect(mockSendToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "Your IP address was blocked by Google.",
+          variant: "error",
+        }),
+      )
+    })
+
+    it("shows a toast for TWO_FACTOR_AUTHENTICATION_REQUIRED", () => {
+      setLocation(
+        "?g_one_tap_error=TWO_FACTOR_AUTHENTICATION_REQUIRED&g_one_tap_provider=google",
+      )
+      enableOneTap()
+      render(<GoogleOneTapContainer />)
+      expect(mockSendToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message:
+            "Please log in with email and password to use two-factor authentication.",
+          variant: "error",
+        }),
+      )
+    })
+
+    it("shows a generic toast for UNKNOWN", () => {
+      setLocation("?g_one_tap_error=UNKNOWN&g_one_tap_provider=google")
+      enableOneTap()
+      render(<GoogleOneTapContainer />)
+      expect(mockSendToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "An unknown error occurred. Please try again.",
+          variant: "error",
+        }),
+      )
+    })
+
+    it("falls back to the generic message for unrecognized error codes", () => {
+      setLocation("?g_one_tap_error=SOMETHING_NEW&g_one_tap_provider=google")
+      enableOneTap()
+      render(<GoogleOneTapContainer />)
+      expect(mockSendToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: "An unknown error occurred. Please try again.",
+          variant: "error",
+        }),
+      )
+    })
+
+    it("cleans up error params from the URL after showing the toast", () => {
+      setLocation("?g_one_tap_error=IP_BLOCKED&g_one_tap_provider=google")
+      const replaceStateSpy = jest
+        .spyOn(window.history, "replaceState")
+        .mockImplementation(() => {})
+      enableOneTap()
+      render(<GoogleOneTapContainer />)
+      expect(replaceStateSpy).toHaveBeenCalledWith(
+        {},
+        "",
+        "http://localhost/artist/andy-warhol",
+      )
+      replaceStateSpy.mockRestore()
+    })
+
+    it("does not show a toast when no error params are present", () => {
+      setLocation("")
+      enableOneTap()
+      render(<GoogleOneTapContainer />)
+      expect(mockSendToast).not.toHaveBeenCalled()
     })
   })
 })

--- a/src/Utils/__tests__/GoogleOneTapContainer.jest.tsx
+++ b/src/Utils/__tests__/GoogleOneTapContainer.jest.tsx
@@ -185,7 +185,7 @@ describe("GoogleOneTapContainer", () => {
     }
 
     it("shows a toast for IP_BLOCKED", () => {
-      setLocation("?g_one_tap_error=IP_BLOCKED&g_one_tap_provider=google")
+      setLocation("?g_one_tap_error=IP_BLOCKED")
       enableOneTap()
       render(<GoogleOneTapContainer />)
       expect(mockSendToast).toHaveBeenCalledWith(
@@ -197,9 +197,7 @@ describe("GoogleOneTapContainer", () => {
     })
 
     it("shows a toast for TWO_FACTOR_AUTHENTICATION_REQUIRED", () => {
-      setLocation(
-        "?g_one_tap_error=TWO_FACTOR_AUTHENTICATION_REQUIRED&g_one_tap_provider=google",
-      )
+      setLocation("?g_one_tap_error=TWO_FACTOR_AUTHENTICATION_REQUIRED")
       enableOneTap()
       render(<GoogleOneTapContainer />)
       expect(mockSendToast).toHaveBeenCalledWith(
@@ -212,7 +210,7 @@ describe("GoogleOneTapContainer", () => {
     })
 
     it("shows a generic toast for UNKNOWN", () => {
-      setLocation("?g_one_tap_error=UNKNOWN&g_one_tap_provider=google")
+      setLocation("?g_one_tap_error=UNKNOWN")
       enableOneTap()
       render(<GoogleOneTapContainer />)
       expect(mockSendToast).toHaveBeenCalledWith(
@@ -224,7 +222,7 @@ describe("GoogleOneTapContainer", () => {
     })
 
     it("falls back to the generic message for unrecognized error codes", () => {
-      setLocation("?g_one_tap_error=SOMETHING_NEW&g_one_tap_provider=google")
+      setLocation("?g_one_tap_error=SOMETHING_NEW")
       enableOneTap()
       render(<GoogleOneTapContainer />)
       expect(mockSendToast).toHaveBeenCalledWith(
@@ -236,7 +234,7 @@ describe("GoogleOneTapContainer", () => {
     })
 
     it("cleans up error params from the URL after showing the toast", () => {
-      setLocation("?g_one_tap_error=IP_BLOCKED&g_one_tap_provider=google")
+      setLocation("?g_one_tap_error=IP_BLOCKED")
       const replaceStateSpy = jest
         .spyOn(window.history, "replaceState")
         .mockImplementation(() => {})

--- a/src/Utils/authConstants.ts
+++ b/src/Utils/authConstants.ts
@@ -1,0 +1,19 @@
+export const AUTH_ERROR_CODES: Record<string, string> = {
+  ALREADY_EXISTS:
+    "A user with this email address already exists. Log in to Artsy via email and password and link {provider} in your settings instead.",
+  PREVIOUSLY_LINKED_SETTINGS:
+    "{provider} account previously linked to Artsy. Log in to your Artsy account via email and password and link {provider} in your settings instead.",
+  PREVIOUSLY_LINKED: "{provider} account previously linked to Artsy.",
+  IP_BLOCKED: "Your IP address was blocked by {provider}.",
+  TWO_FACTOR_AUTHENTICATION_REQUIRED:
+    "Please log in with email and password to use two-factor authentication.",
+  TWO_FACTOR_AUTHENTICATION_ENABLED:
+    "Social account linking is not available while two-factor authentication is enabled on your Artsy account.",
+  UNKNOWN: "An unknown error occurred. Please try again.",
+}
+
+export const AUTH_PROVIDERS: Record<string, string> = {
+  facebook: "Facebook",
+  google: "Google",
+  apple: "Apple",
+}


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [DI-299](https://www.notion.so/artsy/Force-Inline-Errors-for-One-Tap-36ccab0764a080c3ae6dcb7e6697701a?source=copy_link)

### Description

<!-- Implementation description -->

This does 2 things:

### Inline Errors for One Tap

- for one tap which is meant to be a low friction sign in option, handles most errors via inline toasts on the page the user is on rather than redirecting to log in page:


<img width="1512" height="945" alt="2fa-required" src="https://github.com/user-attachments/assets/04f2fb29-34c8-45b2-8670-7569629510c7" />
<img width="1512" height="945" alt="unknown" src="https://github.com/user-attachments/assets/3e871213-39d6-4036-a5f6-99a29fe23733" />
<img width="1512" height="945" alt="ipblocked" src="https://github.com/user-attachments/assets/0d7d13c7-974a-4e01-b669-201a97fb5237" />

- Errors that request account linking still redirect to login:
<img width="1512" height="945" alt="link_instead" src="https://github.com/user-attachments/assets/8058b15e-f8d8-4dd8-9119-d9517349b08e" />



### Pre-fill email on account link errors

- pre-fills email for social auth errors that request account linking, think this was previous intention because we are passing the email back for facebook but was never completed

<img width="1920" height="1080" alt="email-link" src="https://github.com/user-attachments/assets/cb25ce01-fb57-4246-91c4-657c80b84235" />



