### PR TITLE
feat: limit international autocomplete support to only allowed countries

### DIFF
--- a/src/Components/Address/AddressAutocompleteInput.tsx
+++ b/src/Components/Address/AddressAutocompleteInput.tsx
@@ -78,26 +78,13 @@ const ARTSY_SUPPORTED_ISO3_CODES = [
  * ISO-2 country codes where international address autocomplete is available.
  * This is the intersection of Smarty API support and Artsy's enabled countries.
  */
-export const SUPPORTED_INTERNATIONAL_COUNTRY_CODES: Set<string> = (() => {
-  // Verify ARTSY_SUPPORTED_ISO3_CODES is a subset of SMARTY_SUPPORTED_ISO3_CODES
-  const unsupportedCountries = ARTSY_SUPPORTED_ISO3_CODES.filter(
-    iso3 => !SMARTY_SUPPORTED_ISO3_CODES.includes(iso3),
+export const SUPPORTED_INTERNATIONAL_COUNTRY_CODES: Set<string> = new Set(
+  ARTSY_SUPPORTED_ISO3_CODES.filter(iso3 =>
+    SMARTY_SUPPORTED_ISO3_CODES.includes(iso3),
   )
-
-  if (unsupportedCountries.length > 0) {
-    console.error(
-      `ARTSY_SUPPORTED_ISO3_CODES contains countries not supported by Smarty API: ${unsupportedCountries.join(", ")}`,
-    )
-  }
-
-  return new Set(
-    ARTSY_SUPPORTED_ISO3_CODES.filter(iso3 =>
-      SMARTY_SUPPORTED_ISO3_CODES.includes(iso3),
-    )
-      .map(iso3 => ISO3_TO_ISO2[iso3])
-      .filter(Boolean),
-  )
-})()
+    .map(iso3 => ISO3_TO_ISO2[iso3])
+    .filter(Boolean),
+)
 
 interface AutocompleteTrackingValues {
   contextPageOwnerId: string

--- a/src/Components/Address/AddressAutocompleteInput.tsx
+++ b/src/Components/Address/AddressAutocompleteInput.tsx
@@ -78,13 +78,26 @@ const ARTSY_SUPPORTED_ISO3_CODES = [
  * ISO-2 country codes where international address autocomplete is available.
  * This is the intersection of Smarty API support and Artsy's enabled countries.
  */
-export const SUPPORTED_INTERNATIONAL_COUNTRY_CODES: Set<string> = new Set(
-  ARTSY_SUPPORTED_ISO3_CODES.filter(iso3 =>
-    SMARTY_SUPPORTED_ISO3_CODES.includes(iso3),
+export const SUPPORTED_INTERNATIONAL_COUNTRY_CODES: Set<string> = (() => {
+  // Verify ARTSY_SUPPORTED_ISO3_CODES is a subset of SMARTY_SUPPORTED_ISO3_CODES
+  const unsupportedCountries = ARTSY_SUPPORTED_ISO3_CODES.filter(
+    iso3 => !SMARTY_SUPPORTED_ISO3_CODES.includes(iso3),
   )
-    .map(iso3 => ISO3_TO_ISO2[iso3])
-    .filter(Boolean),
-)
+
+  if (unsupportedCountries.length > 0) {
+    console.error(
+      `ARTSY_SUPPORTED_ISO3_CODES contains countries not supported by Smarty API: ${unsupportedCountries.join(", ")}`,
+    )
+  }
+
+  return new Set(
+    ARTSY_SUPPORTED_ISO3_CODES.filter(iso3 =>
+      SMARTY_SUPPORTED_ISO3_CODES.includes(iso3),
+    )
+      .map(iso3 => ISO3_TO_ISO2[iso3])
+      .filter(Boolean),
+  )
+})()
 
 interface AutocompleteTrackingValues {
   contextPageOwnerId: string

--- a/src/Components/Address/AddressAutocompleteInput.tsx
+++ b/src/Components/Address/AddressAutocompleteInput.tsx
@@ -35,8 +35,8 @@ const SMARTY_INTL_AUTOCOMPLETE_URL =
   "https://international-autocomplete.api.smarty.com/v2/lookup"
 
 /**
- * ISO-2 country codes supported by the Smarty international autocomplete v2 API.
- * Derived from the ISO-3 list at:
+ * ISO-3 country codes supported by the Smarty international autocomplete v2 API.
+ * Derived from the list at:
  * https://www.smarty.com/docs/cloud/international-address-autocomplete-api#supported-countries
  * US territories (GU, PR, VI, MP, AS, UM, MH) are absent — they are covered by the US API.
  */
@@ -62,8 +62,28 @@ const SMARTY_SUPPORTED_ISO3_CODES = [
   "YEM","ZMB","ZWE","ALA",
 ] as const
 
+/**
+ * ISO-3 country codes where Artsy enables international address autocomplete.
+ * Must be a subset of SMARTY_SUPPORTED_ISO3_CODES.
+ */
+const ARTSY_SUPPORTED_ISO3_CODES = [
+  "GBR", // United Kingdom
+  "DEU", // Germany
+  "CHE", // Switzerland
+  "ITA", // Italy
+  "FRA", // France
+] as const
+
+/**
+ * ISO-2 country codes where international address autocomplete is available.
+ * This is the intersection of Smarty API support and Artsy's enabled countries.
+ */
 export const SUPPORTED_INTERNATIONAL_COUNTRY_CODES: Set<string> = new Set(
-  SMARTY_SUPPORTED_ISO3_CODES.map(iso3 => ISO3_TO_ISO2[iso3]).filter(Boolean),
+  ARTSY_SUPPORTED_ISO3_CODES.filter(iso3 =>
+    SMARTY_SUPPORTED_ISO3_CODES.includes(iso3),
+  )
+    .map(iso3 => ISO3_TO_ISO2[iso3])
+    .filter(Boolean),
 )
 
 interface AutocompleteTrackingValues {

--- a/src/Components/Address/__tests__/AddressAutocompleteInput.jest.tsx
+++ b/src/Components/Address/__tests__/AddressAutocompleteInput.jest.tsx
@@ -149,7 +149,7 @@ const TestImplementation: FC<React.PropsWithChildren<ImplementationProps>> = ({
 }
 
 describe("AddressAutocompleteInput", () => {
-  describe("address autocomplete is enabled for US only", () => {
+  describe("US address autocomplete", () => {
     it("renders an autocomplete input for a US address", async () => {
       render(<TestImplementation initialAddress={{ country: "US" }} />)
 
@@ -307,6 +307,32 @@ describe("AddressAutocompleteInput", () => {
       await userEvent.type(line1Input, "40")
       expect(screen.queryByLabelText("Clear input")).not.toBeInTheDocument()
     })
+  })
+
+  describe("International address autocomplete", () => {
+    it("logs error when ARTSY_SUPPORTED_ISO3_CODES contains countries not in SMARTY_SUPPORTED_ISO3_CODES", () => {
+      const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation()
+
+      // Simulate the logic with an unsupported country
+      const mockArtsySupported = ["GBR", "DEU", "CHE", "ITA", "FRA", "XXX"] // XXX is not in Smarty list
+      const mockSmartySupported = ["GBR", "DEU", "CHE", "ITA", "FRA"] // Real Smarty list subset
+
+      const unsupportedCountries = mockArtsySupported.filter(
+        iso3 => !mockSmartySupported.includes(iso3),
+      )
+
+      if (unsupportedCountries.length > 0) {
+        console.error(
+          `ARTSY_SUPPORTED_ISO3_CODES contains countries not supported by Smarty API: ${unsupportedCountries.join(", ")}`,
+        )
+      }
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        "ARTSY_SUPPORTED_ISO3_CODES contains countries not supported by Smarty API: XXX",
+      )
+
+      consoleErrorSpy.mockRestore()
+    })
 
     it("renders a normal input for a non-US address when international flag is off", async () => {
       const { useFlag } = jest.requireMock("@unleash/proxy-client-react")
@@ -336,7 +362,7 @@ describe("AddressAutocompleteInput", () => {
       expect(screen.getByLabelText("Clear input")).toBeInTheDocument()
     })
 
-    it("only makes autocomplete requests for countries in ARTSY_SUPPORTED_ISO3_CODES", async () => {
+    it("only makes autocomplete requests for countries in SUPPORTED_INTERNATIONAL_COUNTRY_CODES", async () => {
       // Test with a supported country (GB)
       const { rerender } = render(
         <TestImplementation initialAddress={{ country: "GB" }} />,
@@ -496,17 +522,6 @@ describe("AddressAutocompleteInput", () => {
         }),
         0,
       )
-    })
-
-    it("does not populate autocomplete for unsupported countries (Netherlands)", async () => {
-      render(<TestImplementation initialAddress={{ country: "NL" }} />)
-
-      const line1Input = screen.getByPlaceholderText("Autocomplete input")
-      await userEvent.type(line1Input, "Herengracht 1")
-
-      // Should render as normal input, not autocomplete
-      expect(screen.queryByLabelText("Clear input")).not.toBeInTheDocument()
-      expect(mockFetch).not.toHaveBeenCalled()
     })
 
     it("filters out international suggestions with entries > 1", async () => {
@@ -730,83 +745,82 @@ describe("AddressAutocompleteInput", () => {
         expect(screen.getByLabelText("Clear input")).toBeInTheDocument()
       })
     })
+  })
 
-    // See TestImplementation for implementation details
-    describe("tracking", () => {
-      it.skip("tracks when autocomplete results are received", async () => {
-        render(<TestImplementation />)
+  describe("Tracking", () => {
+    it.skip("tracks when autocomplete results are received", async () => {
+      render(<TestImplementation />)
 
-        const line1Input = screen.getByPlaceholderText("Autocomplete input")
-        await userEvent.type(line1Input, "401 Broadway")
+      const line1Input = screen.getByPlaceholderText("Autocomplete input")
+      await userEvent.type(line1Input, "401 Broadway")
 
-        await screen.findByRole("listbox", { hidden: true })
+      await screen.findByRole("listbox", { hidden: true })
 
+      expect(mockTrackEvent).toHaveBeenCalledWith({
+        action: "addressAutoCompletionResult",
+        context_module: "ordersShipping",
+        context_owner_id: "1234",
+        context_owner_type: "orders-shipping",
+        input: "401 Broadway",
+        suggested_addresses_results: 1,
+      })
+      mockFetch.mockResolvedValue({
+        json: jest.fn().mockResolvedValue({
+          suggestions: [
+            {
+              city: "New York",
+              entries: 2,
+              secondary: "Fl 25",
+              state: "NY",
+              street_line: "156 Quincy",
+              zipcode: "10013",
+            },
+            {
+              city: "Brooklyn",
+              entries: 2,
+              secondary: "Apt 1",
+              state: "NY",
+              street_line: "156 Quincy",
+              zipcode: "11216",
+            },
+          ],
+        }),
+      })
+      await userEvent.clear(line1Input)
+      await userEvent.type(line1Input, "156 Quincy")
+      await waitFor(() => {
         expect(mockTrackEvent).toHaveBeenCalledWith({
           action: "addressAutoCompletionResult",
           context_module: "ordersShipping",
           context_owner_id: "1234",
           context_owner_type: "orders-shipping",
-          input: "401 Broadway",
-          suggested_addresses_results: 1,
-        })
-        mockFetch.mockResolvedValue({
-          json: jest.fn().mockResolvedValue({
-            suggestions: [
-              {
-                city: "New York",
-                entries: 2,
-                secondary: "Fl 25",
-                state: "NY",
-                street_line: "156 Quincy",
-                zipcode: "10013",
-              },
-              {
-                city: "Brooklyn",
-                entries: 2,
-                secondary: "Apt 1",
-                state: "NY",
-                street_line: "156 Quincy",
-                zipcode: "11216",
-              },
-            ],
-          }),
-        })
-        await userEvent.clear(line1Input)
-        await userEvent.type(line1Input, "156 Quincy")
-        await waitFor(() => {
-          expect(mockTrackEvent).toHaveBeenCalledWith({
-            action: "addressAutoCompletionResult",
-            context_module: "ordersShipping",
-            context_owner_id: "1234",
-            context_owner_type: "orders-shipping",
-            input: "156 Quincy",
-            suggested_addresses_results: 2,
-          })
+          input: "156 Quincy",
+          suggested_addresses_results: 2,
         })
       })
+    })
 
-      it("tracks when an address is selected", async () => {
-        render(<TestImplementation />)
+    it("tracks when an address is selected", async () => {
+      render(<TestImplementation />)
 
-        const line1Input = screen.getByPlaceholderText("Autocomplete input")
-        await userEvent.paste(line1Input, "401 Broadway")
+      const line1Input = screen.getByPlaceholderText("Autocomplete input")
+      await userEvent.paste(line1Input, "401 Broadway")
 
-        const dropdown = await screen.findByRole("listbox", { hidden: true })
-        const option = within(dropdown).getByText(
-          "401 Broadway, New York NY 10013",
-        )
+      const dropdown = await screen.findByRole("listbox", { hidden: true })
+      const option = within(dropdown).getByText(
+        "401 Broadway, New York NY 10013",
+      )
 
-        await userEvent.click(option)
-        await flushPromiseQueue()
+      await userEvent.click(option)
+      await flushPromiseQueue()
 
-        expect(mockTrackEvent).toHaveBeenCalledWith({
-          action: "selectedItemFromAddressAutoCompletion",
-          context_module: "ordersShipping",
-          context_owner_id: "1234",
-          context_owner_type: "orders-shipping",
-          input: "401 Broadway",
-          item: "401 Broadway, New York NY 10013",
-        })
+      expect(mockTrackEvent).toHaveBeenCalledWith({
+        action: "selectedItemFromAddressAutoCompletion",
+        context_module: "ordersShipping",
+        context_owner_id: "1234",
+        context_owner_type: "orders-shipping",
+        input: "401 Broadway",
+        item: "401 Broadway, New York NY 10013",
       })
     })
   })

--- a/src/Components/Address/__tests__/AddressAutocompleteInput.jest.tsx
+++ b/src/Components/Address/__tests__/AddressAutocompleteInput.jest.tsx
@@ -310,28 +310,19 @@ describe("AddressAutocompleteInput", () => {
   })
 
   describe("International address autocomplete", () => {
-    it("logs error when ARTSY_SUPPORTED_ISO3_CODES contains countries not in SMARTY_SUPPORTED_ISO3_CODES", () => {
-      const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation()
-
-      // Simulate the logic with an unsupported country
-      const mockArtsySupported = ["GBR", "DEU", "CHE", "ITA", "FRA", "XXX"] // XXX is not in Smarty list
-      const mockSmartySupported = ["GBR", "DEU", "CHE", "ITA", "FRA"] // Real Smarty list subset
-
-      const unsupportedCountries = mockArtsySupported.filter(
-        iso3 => !mockSmartySupported.includes(iso3),
+    it("contains exactly the expected countries in SUPPORTED_INTERNATIONAL_COUNTRY_CODES", () => {
+      const { SUPPORTED_INTERNATIONAL_COUNTRY_CODES } = jest.requireActual(
+        "Components/Address/AddressAutocompleteInput",
       )
 
-      if (unsupportedCountries.length > 0) {
-        console.error(
-          `ARTSY_SUPPORTED_ISO3_CODES contains countries not supported by Smarty API: ${unsupportedCountries.join(", ")}`,
-        )
-      }
-
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
-        "ARTSY_SUPPORTED_ISO3_CODES contains countries not supported by Smarty API: XXX",
+      const expectedCountries = ["GB", "DE", "CH", "IT", "FR"]
+      expect(SUPPORTED_INTERNATIONAL_COUNTRY_CODES.size).toBe(
+        expectedCountries.length,
       )
 
-      consoleErrorSpy.mockRestore()
+      // Verify the exact counties in SUPPORTED_INTERNATIONAL_COUNTRY_CODES
+      const actualCountries = Array.from(SUPPORTED_INTERNATIONAL_COUNTRY_CODES)
+      expect(actualCountries.sort()).toEqual(expectedCountries.sort())
     })
 
     it("renders a normal input for a non-US address when international flag is off", async () => {

--- a/src/Components/Address/__tests__/AddressAutocompleteInput.jest.tsx
+++ b/src/Components/Address/__tests__/AddressAutocompleteInput.jest.tsx
@@ -336,6 +336,32 @@ describe("AddressAutocompleteInput", () => {
       expect(screen.getByLabelText("Clear input")).toBeInTheDocument()
     })
 
+    it("only makes autocomplete requests for countries in ARTSY_SUPPORTED_ISO3_CODES", async () => {
+      // Test with a supported country (GB)
+      const { rerender } = render(
+        <TestImplementation initialAddress={{ country: "GB" }} />,
+      )
+
+      let line1Input = screen.getByPlaceholderText("Autocomplete input")
+      await userEvent.type(line1Input, "10 Downing")
+
+      await waitFor(() => {
+        expect(mockFetch).toHaveBeenCalled()
+      })
+
+      mockFetch.mockClear()
+
+      // Test with an unsupported but Smarty-supported country (NL)
+      rerender(<TestImplementation initialAddress={{ country: "NL" }} />)
+
+      line1Input = screen.getByPlaceholderText("Autocomplete input")
+      await userEvent.type(line1Input, "Herengracht 1")
+
+      // Should render as normal input, not autocomplete
+      expect(screen.queryByLabelText("Clear input")).not.toBeInTheDocument()
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
     it("shows suggestions for an international address", async () => {
       mockFetch.mockResolvedValue({
         json: jest.fn().mockResolvedValue({
@@ -472,60 +498,15 @@ describe("AddressAutocompleteInput", () => {
       )
     })
 
-    it("populates all fields from structured components on select (Netherlands)", async () => {
-      mockFetch
-        .mockResolvedValueOnce({
-          json: jest.fn().mockResolvedValue({
-            candidates: [
-              {
-                address_text: "Herengracht 1 1015 BA Amsterdam",
-                address_id: "nl-addr-id",
-                entries: 1,
-              },
-            ],
-          }),
-          ok: true,
-        })
-        .mockResolvedValueOnce({
-          json: jest.fn().mockResolvedValue({
-            candidates: [
-              {
-                country_iso3: "NLD",
-                administrative_area: "Noord-Holland",
-                locality: "Amsterdam",
-                postal_code: "1015 BA",
-                street: "Herengracht 1",
-              },
-            ],
-          }),
-          ok: true,
-        })
-
+    it("does not populate autocomplete for unsupported countries (Netherlands)", async () => {
       render(<TestImplementation initialAddress={{ country: "NL" }} />)
 
       const line1Input = screen.getByPlaceholderText("Autocomplete input")
-      await userEvent.paste(line1Input, "Herengracht")
+      await userEvent.type(line1Input, "Herengracht 1")
 
-      const dropdown = await screen.findByRole("listbox", { hidden: true })
-      await userEvent.click(
-        within(dropdown).getByText("Herengracht 1 1015 BA Amsterdam"),
-      )
-      await flushPromiseQueue()
-
-      expect(mockFetch.mock.calls[1][0]).toContain("/v2/lookup/nl-addr-id")
-      expect(mockOnSelect).toHaveBeenCalledWith(
-        expect.objectContaining({
-          address: {
-            addressLine1: "Herengracht 1",
-            addressLine2: "",
-            city: "Amsterdam",
-            region: "Noord-Holland",
-            postalCode: "1015 BA",
-            country: "NL",
-          },
-        }),
-        0,
-      )
+      // Should render as normal input, not autocomplete
+      expect(screen.queryByLabelText("Clear input")).not.toBeInTheDocument()
+      expect(mockFetch).not.toHaveBeenCalled()
     })
 
     it("filters out international suggestions with entries > 1", async () => {
@@ -563,8 +544,8 @@ describe("AddressAutocompleteInput", () => {
           json: jest.fn().mockResolvedValue({
             candidates: [
               {
-                address_text: "1-1 Shibuya Tokyo",
-                address_id: "jp-addr-id",
+                address_text: "Via Roma 1 00100 Roma",
+                address_id: "it-addr-id",
                 entries: 1,
               },
             ],
@@ -576,22 +557,22 @@ describe("AddressAutocompleteInput", () => {
           ok: true,
         })
 
-      render(<TestImplementation initialAddress={{ country: "JP" }} />)
+      render(<TestImplementation initialAddress={{ country: "IT" }} />)
 
       const line1Input = screen.getByPlaceholderText("Autocomplete input")
-      await userEvent.paste(line1Input, "Shibuya")
+      await userEvent.paste(line1Input, "Via Roma")
 
       const dropdown = await screen.findByRole("listbox", { hidden: true })
-      await userEvent.click(within(dropdown).getByText("1-1 Shibuya Tokyo"))
+      await userEvent.click(within(dropdown).getByText("Via Roma 1 00100 Roma"))
       await flushPromiseQueue()
 
       expect(mockOnSelect).toHaveBeenCalledWith(
         expect.objectContaining({
           address: expect.objectContaining({
-            addressLine1: "1-1 Shibuya Tokyo",
+            addressLine1: "Via Roma 1 00100 Roma",
             city: "",
             postalCode: "",
-            country: "JP",
+            country: "IT",
           }),
         }),
         0,


### PR DESCRIPTION
Address https://artsyproduct.atlassian.net/browse/EMI-3246

Was debating if just drop SMARTY_SUPPORTED_ISO3_CODES and have Artsy_codes as the only source here. But feel like it's a good thing to be explicit in the logic that we only support subset of the counties and it's out Artsy limitation.

Alternatively we might want to move this list to be env variable so that we can do expansion without code updates but that is probably unrealistic anyways as we would need to do bunch of testing anyways. So opted for the simplest solution here for now.
