### PR TITLE
chore: trace Smarty autocomplete requests as root transaction on Sentry

### DIFF
--- a/src/Apps/Order/Routes/Shipping/Components/__tests__/FulfillmentDetailsForm.jest.tsx
+++ b/src/Apps/Order/Routes/Shipping/Components/__tests__/FulfillmentDetailsForm.jest.tsx
@@ -502,6 +502,7 @@ describe("FulfillmentDetailsForm", () => {
 
     beforeEach(() => {
       mockFetch = jest.fn().mockResolvedValue({
+        ok: true,
         json: jest.fn().mockResolvedValue({
           suggestions: [
             {

--- a/src/Components/Address/AddressAutocompleteInput.tsx
+++ b/src/Components/Address/AddressAutocompleteInput.tsx
@@ -18,6 +18,7 @@ import {
   ISO2_TO_ISO3,
   ISO3_TO_ISO2,
 } from "Components/Address/utils/countryISO3Codes"
+import { traceFetch } from "System/Utils/setupSentryClient"
 import { getENV } from "Utils/getENV"
 import { throttle, uniqBy } from "lodash"
 import { useCallback, useEffect, useReducer } from "react"
@@ -538,9 +539,13 @@ const fetchSuggestionsWithThrottle = throttle(
 
     const url = `${SMARTY_US_AUTOCOMPLETE_URL}?${new URLSearchParams(params).toString()}`
 
-    const response = await fetch(url)
-    const json = await response.json()
-    return json
+    return traceFetch({ name: "smarty.autocomplete.us", url }, async () => {
+      const response = await fetch(url)
+      if (!response.ok) {
+        throw new Error(`US autocomplete request failed: ${response.status}`)
+      }
+      return response.json()
+    })
   },
   THROTTLE_DELAY,
   {
@@ -569,13 +574,18 @@ const fetchInternationalSuggestionsWithThrottle = throttle(
 
     const url = `${SMARTY_INTL_AUTOCOMPLETE_URL}?${new URLSearchParams(params).toString()}`
 
-    const response = await fetch(url)
-    if (!response.ok) {
-      throw new Error(
-        `International autocomplete request failed: ${response.status}`,
-      )
-    }
-    return response.json()
+    return traceFetch(
+      { name: "smarty.autocomplete.international", url },
+      async () => {
+        const response = await fetch(url)
+        if (!response.ok) {
+          throw new Error(
+            `International autocomplete request failed: ${response.status}`,
+          )
+        }
+        return response.json()
+      },
+    )
   },
   THROTTLE_DELAY,
   {

--- a/src/System/Utils/__tests__/setupSentryClient.jest.ts
+++ b/src/System/Utils/__tests__/setupSentryClient.jest.ts
@@ -1,0 +1,73 @@
+import * as Sentry from "@sentry/browser"
+import { traceFetch } from "System/Utils/setupSentryClient"
+
+jest.mock("@sentry/browser", () => ({
+  startSpan: jest.fn((_options, callback) => callback()),
+}))
+
+const startSpanMock = Sentry.startSpan as jest.Mock
+
+describe("traceFetch", () => {
+  beforeEach(() => {
+    startSpanMock.mockClear()
+    startSpanMock.mockImplementation((_options, callback) => callback())
+  })
+
+  it("wraps the callback in startSpan with the expected span context", async () => {
+    await traceFetch(
+      { name: "smarty.autocomplete.us", url: "https://example.com/lookup" },
+      async () => "ok",
+    )
+
+    expect(startSpanMock).toHaveBeenCalledTimes(1)
+    expect(startSpanMock).toHaveBeenCalledWith(
+      {
+        name: "smarty.autocomplete.us",
+        op: "http.client",
+        forceTransaction: true,
+        attributes: {
+          "http.method": "GET",
+          "http.url": "https://example.com/lookup",
+        },
+      },
+      expect.any(Function),
+    )
+  })
+
+  it("defaults the http.method attribute to GET", async () => {
+    await traceFetch(
+      { name: "foo", url: "https://example.com" },
+      async () => null,
+    )
+
+    const [spanContext] = startSpanMock.mock.calls[0]
+    expect(spanContext.attributes["http.method"]).toBe("GET")
+  })
+
+  it("respects a custom http method", async () => {
+    await traceFetch(
+      { name: "foo", url: "https://example.com", method: "POST" },
+      async () => null,
+    )
+
+    const [spanContext] = startSpanMock.mock.calls[0]
+    expect(spanContext.attributes["http.method"]).toBe("POST")
+  })
+
+  it("returns the value resolved by the callback", async () => {
+    const result = await traceFetch(
+      { name: "foo", url: "https://example.com" },
+      async () => ({ data: 42 }),
+    )
+
+    expect(result).toEqual({ data: 42 })
+  })
+
+  it("propagates errors thrown by the callback", async () => {
+    await expect(
+      traceFetch({ name: "foo", url: "https://example.com" }, async () => {
+        throw new Error("boom")
+      }),
+    ).rejects.toThrow("boom")
+  })
+})

--- a/src/System/Utils/setupSentryClient.ts
+++ b/src/System/Utils/setupSentryClient.ts
@@ -8,6 +8,7 @@ import {
   init,
   startBrowserTracingNavigationSpan,
   startBrowserTracingPageLoadSpan,
+  startSpan,
 } from "@sentry/browser"
 import {
   ALLOWED_URLS,
@@ -124,3 +125,35 @@ function routeMatchToParamSpanAttributes(
 
   return paramAttributes
 }
+
+/**
+ * Wraps an async HTTP call in a Sentry span that is forced to be a root
+ * transaction. Useful for interaction-triggered requests that fire outside of
+ * an active pageload/navigation transaction — without `forceTransaction: true`
+ * those calls would attach to a non-recording span and never be sent.
+ *
+ * @example
+ * await traceFetch(
+ *   { name: "smarty.autocomplete.us", url },
+ *   async () => {
+ *     const response = await fetch(url)
+ *     return response.json()
+ *   },
+ * )
+ */
+export const traceFetch = <T>(
+  { name, url, method = "GET" }: { name: string; url: string; method?: string },
+  fn: () => Promise<T>,
+): Promise<T> =>
+  startSpan(
+    {
+      name,
+      op: "http.client",
+      forceTransaction: true,
+      attributes: {
+        "http.method": method,
+        "http.url": url,
+      },
+    },
+    fn,
+  )


### PR DESCRIPTION
The type of this PR is: **Chore**

This PR solves [EMI-3252]

### Description

## The problem
In production, Smarty address autocomplete requests have produced [zero Sentry traces over the past 90 days](https://artsynet.sentry.io/explore/traces/?aggregateField=%7B%22yAxes%22%3A%5B%22count%28span.duration%29%22%5D%7D&aggregateField=%7B%22yAxes%22%3A%5B%22p75%28span.duration%29%22%5D%7D&aggregateField=%7B%22groupBy%22%3A%22http.response_status_code%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22p90%28span.duration%29%22%5D%7D&field=id&field=span.name&field=span.description&field=span.duration&field=transaction&field=timestamp&field=span.domain&field=http.response_status_code&groupBy=http.response_status_code&id=1458460&interval=3h&mode=aggregate&project=28316&query=span.op%3Ahttp.client%20span.domain%3A%EF%80%8DContains%EF%80%8D%2A.smarty.com&sort=-timestamp&statsPeriod=90d&title=Address%20Autocomplete%20Performance&visualize=%7B%22yAxes%22%3A%5B%22count%28span.duration%29%22%5D%7D&visualize=%7B%22yAxes%22%3A%5B%22p75%28span.duration%29%22%5D%7D&visualize=%7B%22yAxes%22%3A%5B%22p90%28span.duration%29%22%5D%7D), despite the network calls firing normally on the Order2 checkout page.

<img width="1548" height="939" alt="Screenshot 2026-05-26 at 8 34 02 PM" src="https://github.com/user-attachments/assets/d3a13166-5ea3-470b-ae4b-39cff45d11e6" />


## Root Cause

Force's Sentry browser tracing only opens root transactions on [pageload and navigation](https://github.com/artsy/force/blob/06272f009fc0d3aaf6891ce174f80187c0c24dc5/src/System/Utils/setupSentryClient.ts#L26-L53) — these are idle spans that auto-close ~1s after the last child span finishes. The Smarty fetches fire later, when the user clicks into the street-address field and types, typically many seconds after the navigation transaction has already closed. In staging, some requests are traced and I think it's due to automated tests performing quick interactions.

<img width="1282" height="122" alt="Screenshot 2026-05-27 at 9 50 35 AM" src="https://github.com/user-attachments/assets/b3b88986-e55c-4199-9b20-5fdc1ffd64cb" />


## Solution

Wrap interaction-triggered Smarty fetches in an explicit `startSpan` with `forceTransaction: true`, so they emit their own root span regardless of whether a pageload/navigation transaction is open. Added a reusable `traceFetch` helper in `src/System/Utils/setupSentryClient.ts` so the same pattern can be applied to other interaction-driven fetches. Will add some details inline.

[EMI-3252]: https://artsyproduct.atlassian.net/browse/EMI-3252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ