### PR TITLE
test(PhotoDropzone): wrap async assertions in waitFor to fix flake

### DIFF
--- a/src/Components/PhotoUpload/__tests__/PhotoDropzone.jest.tsx
+++ b/src/Components/PhotoUpload/__tests__/PhotoDropzone.jest.tsx
@@ -76,12 +76,14 @@ describe("PhotoDropzone", () => {
 
       await flushPromiseQueue()
 
-      expect(onDropMock).toHaveBeenCalled()
-      expect(onDropMock).toHaveBeenCalledWith([
-        validImage,
-        validImage,
-        validImage,
-      ])
+      await waitFor(() => {
+        expect(onDropMock).toHaveBeenCalled()
+        expect(onDropMock).toHaveBeenCalledWith([
+          validImage,
+          validImage,
+          validImage,
+        ])
+      })
     })
 
     it("rejects not image files", async () => {
@@ -99,20 +101,22 @@ describe("PhotoDropzone", () => {
 
       await flushPromiseQueue()
 
-      expect(onDropMock).not.toHaveBeenCalled()
-      expect(onRejectMock).toHaveBeenCalled()
-      expect(onRejectMock).toHaveBeenCalledWith(
-        [...Array(3)].map(() => ({
-          file: pdfFile,
-          errors: [
-            {
-              message:
-                "File type must be one of image/jpeg, image/png, image/heic",
-              code: "file-invalid-type",
-            },
-          ],
-        })),
-      )
+      await waitFor(() => {
+        expect(onDropMock).not.toHaveBeenCalled()
+        expect(onRejectMock).toHaveBeenCalled()
+        expect(onRejectMock).toHaveBeenCalledWith(
+          [...Array(3)].map(() => ({
+            file: pdfFile,
+            errors: [
+              {
+                message:
+                  "File type must be one of image/jpeg, image/png, image/heic",
+                code: "file-invalid-type",
+              },
+            ],
+          })),
+        )
+      })
     })
 
     it("rejects too big files", async () => {
@@ -239,12 +243,14 @@ describe("PhotoDropzone", () => {
 
       await flushPromiseQueue()
 
-      expect(onDropMock).toHaveBeenCalled()
-      expect(onDropMock).toHaveBeenCalledWith([
-        validImage,
-        validImage,
-        validImage,
-      ])
+      await waitFor(() => {
+        expect(onDropMock).toHaveBeenCalled()
+        expect(onDropMock).toHaveBeenCalledWith([
+          validImage,
+          validImage,
+          validImage,
+        ])
+      })
     })
 
     it("rejects not image files", async () => {


### PR DESCRIPTION
The type of this PR is: **Test**

### Description

Noticing the PhotoDropzone tests are [flaky](https://app.circleci.com/pipelines/github/artsy/force/80327/workflows/8af08a49-ad31-4c13-a356-1507645edc9c/jobs/549281), with the error below.

This wraps the assertions, following the pattern of other tests, in `waitFor` to address when a single `flushPromiseQueue` is not sufficient.

```
FAIL src/Components/PhotoUpload/__tests__/PhotoDropzone.jest.tsx
  ● PhotoDropzone › md breakpoint › rejects not image files

    expect(jest.fn()).toHaveBeenCalledWith(...expected)

    - Expected
    + Received

    - Array [
    -   Object {
    -     "errors": Array [
    -       Object {
    -         "code": "file-invalid-type",
    -         "message": "File type must be one of image/jpeg, image/png, image/heic",
    -       },
    -     ],
    -     "file": Object {
    -       "name": "foo.pdf",
    -       "path": "foo.pdf",
    -       "size": 2000000,
    -       "type": "application/pdf",
    -     },
    -   },
    -   Object {
    -     "errors": Array [
    -       Object {
    -         "code": "file-invalid-type",
    -         "message": "File type must be one of image/jpeg, image/png, image/heic",
    -       },
    -     ],
    -     "file": Object {
    -       "name": "foo.pdf",
    -       "path": "foo.pdf",
    -       "size": 2000000,
    -       "type": "application/pdf",
    -     },
    -   },
    -   Object {
    -     "errors": Array [
    -       Object {
    -         "code": "file-invalid-type",
    -         "message": "File type must be one of image/jpeg, image/png, image/heic",
    -       },
    -     ],
    -     "file": Object {
    -       "name": "foo.pdf",
    -       "path": "foo.pdf",
    -       "size": 2000000,
    -       "type": "application/pdf",
    -     },
    -   },
    - ]
    + Array [],

    Number of calls: 1

      102 |       expect(onDropMock).not.toHaveBeenCalled()
      103 |       expect(onRejectMock).toHaveBeenCalled()
    > 104 |       expect(onRejectMock).toHaveBeenCalledWith(
          |                            ^
      105 |         [...Array(3)].map(() => ({
      106 |           file: pdfFile,
      107 |           errors: [

      at Object.toHaveBeenCalledWith (src/Components/PhotoUpload/__tests__/PhotoDropzone.jest.tsx:104:28)
```
