### PR TITLE
fix: get onboarding value from url to fix social tracking + minor cleanup

### DIFF
--- a/src/Components/AuthDialog/Hooks/__tests__/useSocialAuthTracking.jest.ts
+++ b/src/Components/AuthDialog/Hooks/__tests__/useSocialAuthTracking.jest.ts
@@ -5,7 +5,9 @@ import { useRouter } from "System/Hooks/useRouter"
 import Cookies from "cookies-js"
 
 jest.mock("System/Hooks/useRouter", () => ({
-  useRouter: jest.fn().mockImplementation(() => ({ match: { location: {} } })),
+  useRouter: jest
+    .fn()
+    .mockImplementation(() => ({ match: { location: { pathname: "/" } } })),
 }))
 
 jest.mock("System/Hooks/useSystemContext", () => ({
@@ -31,9 +33,12 @@ describe("useSocialAuthTracking", () => {
     jest.clearAllMocks()
   })
 
-  it("calls the correct tracking function with the correct data and expires the cookie", () => {
+  it("calls loggedIn with the correct data and expires the cookie", () => {
     const loggedIn = jest.fn()
-    mockUseAuthDialogTracking.mockImplementation(() => ({ loggedIn }))
+    mockUseAuthDialogTracking.mockImplementation(() => ({
+      loggedIn,
+      signedUp: jest.fn(),
+    }))
     mockCookiesExpire.mockImplementation(jest.fn())
 
     mockCookiesGet.mockImplementation(() =>
@@ -55,6 +60,66 @@ describe("useSocialAuthTracking", () => {
     })
 
     expect(mockCookiesExpire).toBeCalledWith("useSocialAuthTracking")
+  })
+
+  it("calls signedUp with onboarding=true when the URL param is present", () => {
+    const signedUp = jest.fn()
+    mockUseAuthDialogTracking.mockImplementation(() => ({
+      loggedIn: jest.fn(),
+      signedUp,
+    }))
+
+    mockCookiesGet.mockImplementation(() =>
+      JSON.stringify({
+        action: "signedUp",
+        service: "google",
+        analytics: {
+          contextModule: "header",
+          intent: "signup",
+        },
+      }),
+    )
+
+    mockUseRouter.mockImplementation(() => ({
+      match: { location: { pathname: "/", search: "?onboarding=true" } },
+    }))
+
+    renderHook(useSocialAuthTracking)
+
+    expect(signedUp).toBeCalledWith({
+      contextModule: "header",
+      intent: "signup",
+      onboarding: true,
+      service: "google",
+      userId: "example",
+    })
+  })
+
+  it("calls signedUp with onboarding=false when the URL param is absent", () => {
+    const signedUp = jest.fn()
+    mockUseAuthDialogTracking.mockImplementation(() => ({
+      loggedIn: jest.fn(),
+      signedUp,
+    }))
+
+    mockCookiesGet.mockImplementation(() =>
+      JSON.stringify({
+        action: "signedUp",
+        service: "google",
+      }),
+    )
+
+    mockUseRouter.mockImplementation(() => ({
+      match: { location: { pathname: "/" } },
+    }))
+
+    renderHook(useSocialAuthTracking)
+
+    expect(signedUp).toBeCalledWith({
+      onboarding: false,
+      service: "google",
+      userId: "example",
+    })
   })
 
   it("passes method to the tracking function when present", () => {

--- a/src/Components/AuthDialog/Hooks/useAuthDialogTracking.ts
+++ b/src/Components/AuthDialog/Hooks/useAuthDialogTracking.ts
@@ -80,6 +80,7 @@ export const useAuthDialogTracking = () => {
         userId,
         intent = analytics.intent || Intent.signup,
         trigger = analytics.trigger || "click",
+        onboarding = isElligibleForOnboarding,
       }: {
         contextModule?: CreatedAccount["context_module"]
         method?: CreatedAccount["method"]
@@ -87,6 +88,7 @@ export const useAuthDialogTracking = () => {
         userId: CreatedAccount["user_id"]
         intent?: CreatedAccount["intent"]
         trigger?: CreatedAccount["trigger"]
+        onboarding?: CreatedAccount["onboarding"]
       }) => {
         const payload: CreatedAccount = {
           action: ActionType.createdAccount,
@@ -94,7 +96,7 @@ export const useAuthDialogTracking = () => {
           context_module: contextModule,
           intent,
           method,
-          onboarding: isElligibleForOnboarding,
+          onboarding,
           service,
           trigger,
           type: AuthModalType.signup,

--- a/src/Components/AuthDialog/Hooks/useSocialAuthTracking.ts
+++ b/src/Components/AuthDialog/Hooks/useSocialAuthTracking.ts
@@ -109,7 +109,3 @@ const parse = (value: any): Payload | null => {
     return null
   }
 }
-
-export const setSocialAuthTracking = (payload: Payload) => {
-  Cookies.set(USE_SOCIAL_AUTH_TRACKING_KEY, JSON.stringify(payload))
-}

--- a/src/Components/AuthDialog/Hooks/useSocialAuthTracking.ts
+++ b/src/Components/AuthDialog/Hooks/useSocialAuthTracking.ts
@@ -50,15 +50,25 @@ export const useSocialAuthTracking = () => {
       return
     }
 
-    track[value.action]({
+    const params = {
       service: value.service,
       userId: user.id,
       ...(value.method ? { method: value.method } : {}),
       ...(value.analytics ?? {}),
-    })
+    }
+
+    if (value.action === "signedUp") {
+      // for social auth, tracking fires after a full-page redirect, so the
+      // dialog context is gone. We read onboarding from the URL instead
+      const onboarding =
+        new URLSearchParams(location.search).get("onboarding") === "true"
+      track.signedUp({ ...params, onboarding })
+    } else {
+      track.loggedIn(params)
+    }
 
     Cookies.expire(USE_SOCIAL_AUTH_TRACKING_KEY)
-  }, [location.pathname, track, user])
+  }, [location.pathname, location.search, track, user])
 }
 
 const schema = Yup.object({
@@ -73,10 +83,15 @@ const schema = Yup.object({
   trigger: Yup.string().oneOf(["click", "tap", "timed", "scroll"]),
 })
 
-type Payload = Omit<Yup.InferType<typeof schema>, "analytics"> & {
+type Payload = Omit<
+  Yup.InferType<typeof schema>,
+  "analytics" | "method" | "service"
+> & {
   // We assume that the unions are valid because it would
   // be difficult to get the runtime values from Cohesion
   analytics?: AuthDialogAnalytics
+  method?: "one-tap"
+  service: "apple" | "facebook" | "google"
 }
 
 const isValid = (value: any): value is Payload => {


### PR DESCRIPTION
The type of this PR is: **fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PROJECT-XX]

### Description

<!-- Implementation description -->

Fixes bug found in [QA](https://www.notion.so/artsy/1-intent-is-login-but-I-expected-it-to-be-signup-Does-this-happen-because-the-mixed-login-sign-36dcab0764a08013a613d695fb51256a?source=copy_link).

The onboarding flag was not being populated properly for social auth case due to losing dialog context when going through server and redirecting. 

This reads the value from the url which should be reliably set. 
