### PR TITLE
chore: sample Smarty autocomplete requests at 100%

### DIFF
--- a/src/Components/Address/AddressAutocompleteInput.tsx
+++ b/src/Components/Address/AddressAutocompleteInput.tsx
@@ -35,6 +35,11 @@ const SMARTY_US_AUTOCOMPLETE_URL =
 const SMARTY_INTL_AUTOCOMPLETE_URL =
   "https://international-autocomplete.api.smarty.com/v2/lookup"
 
+// Prefix used by Sentry client to adjust traces sampling rate
+export const SMARTY_TRACE_PREFIX = "smarty.autocomplete"
+const SMARTY_US_AUTOCOMPLETE_SPAN_NAME = `${SMARTY_TRACE_PREFIX}.us`
+const SMARTY_INTL_AUTOCOMPLETE_SPAN_NAME = `${SMARTY_TRACE_PREFIX}.international`
+
 /**
  * ISO-3 country codes supported by the Smarty international autocomplete v2 API.
  * Derived from the list at:
@@ -559,13 +564,16 @@ const fetchSuggestionsWithThrottle = throttle(
 
     const url = `${SMARTY_US_AUTOCOMPLETE_URL}?${new URLSearchParams(params).toString()}`
 
-    return traceFetch({ name: "smarty.autocomplete.us", url }, async () => {
-      const response = await fetch(url)
-      if (!response.ok) {
-        throw new Error(`US autocomplete request failed: ${response.status}`)
-      }
-      return response.json()
-    })
+    return traceFetch(
+      { name: SMARTY_US_AUTOCOMPLETE_SPAN_NAME, url },
+      async () => {
+        const response = await fetch(url)
+        if (!response.ok) {
+          throw new Error(`US autocomplete request failed: ${response.status}`)
+        }
+        return response.json()
+      },
+    )
   },
   THROTTLE_DELAY,
   {
@@ -595,7 +603,7 @@ const fetchInternationalSuggestionsWithThrottle = throttle(
     const url = `${SMARTY_INTL_AUTOCOMPLETE_URL}?${new URLSearchParams(params).toString()}`
 
     return traceFetch(
-      { name: "smarty.autocomplete.international", url },
+      { name: SMARTY_INTL_AUTOCOMPLETE_SPAN_NAME, url },
       async () => {
         const response = await fetch(url)
         if (!response.ok) {

--- a/src/System/Utils/setupSentryClient.ts
+++ b/src/System/Utils/setupSentryClient.ts
@@ -10,6 +10,7 @@ import {
   startBrowserTracingPageLoadSpan,
   startSpan,
 } from "@sentry/browser"
+import { SMARTY_TRACE_PREFIX } from "Components/Address/AddressAutocompleteInput"
 import {
   ALLOWED_URLS,
   DENIED_URLS,
@@ -24,6 +25,14 @@ let initialPageLoadSpan: Span | undefined | null
 // For use in router RenderStates callback hooks
 export let sentryRouterTracing
 
+const tracesSampler = (samplingContext: { name?: string }): number => {
+  // Sample Smarty autocomplete traces at 100%
+  if (samplingContext.name?.startsWith(SMARTY_TRACE_PREFIX)) {
+    return 1
+  }
+  return 0.08
+}
+
 export function setupSentryClient() {
   if (getENV("NODE_ENV") !== "production") {
     return
@@ -35,7 +44,7 @@ export function setupSentryClient() {
     dsn: getENV("SENTRY_PUBLIC_DSN"),
     ignoreErrors: IGNORED_ERRORS,
     release: getENV("SENTRY_RELEASE"),
-    tracesSampleRate: 0.08,
+    tracesSampler,
     integrations: [
       browserTracingIntegration({
         // See sentry router tracing below


### PR DESCRIPTION
The type of this PR is: **Chore**

This PR solves [EMI-3252]

### Description

Following https://github.com/artsy/force/pull/17274, we started to observe Smarty autocomplete requests coming in. This samples them at 100% (as opposed to the default 8%) so we can better monitor to begin with. The volume is low so hopefully not a significant impact on cost, and I'll monitor too.


<img width="1628" height="1134" alt="Screenshot 2026-05-28 at 7 31 25 AM" src="https://github.com/user-attachments/assets/28b45a40-23a2-4434-ba94-b8de52b78408" />


[EMI-3252]: https://artsyproduct.atlassian.net/browse/EMI-3252?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ