### PR TITLE
fix: navigate to unified login page on mobile rather than new signup #trivial

### DIFF
--- a/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuAuthentication.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenuAuthentication.tsx
@@ -58,7 +58,7 @@ const NavBarMobileMenuLoggedOut: React.FC<
   return (
     <>
       <NavBarMobileMenuItemLink
-        to={`/signup?intent=${Intent.signup}&contextModule=${ContextModule.header}`}
+        to={`/login?intent=${Intent.signup}&contextModule=${ContextModule.header}`}
       >
         Sign Up
       </NavBarMobileMenuItemLink>

--- a/src/Components/NavBar/NavBarMobileMenu/__tests__/NavBarMobileMenu.jest.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/__tests__/NavBarMobileMenu.jest.tsx
@@ -1,10 +1,10 @@
-import type * as React from "react"
-import { NavBarMobileMenu } from "Components/NavBar/NavBarMobileMenu/NavBarMobileMenu"
-import { SystemContextProvider } from "System/Contexts/SystemContext"
-import type { buildAppRoutesQuery } from "__generated__/buildAppRoutesQuery.graphql"
-import { logout } from "Utils/auth"
 import { render, screen } from "@testing-library/react"
 import { fireEvent } from "@testing-library/react"
+import { NavBarMobileMenu } from "Components/NavBar/NavBarMobileMenu/NavBarMobileMenu"
+import { SystemContextProvider } from "System/Contexts/SystemContext"
+import { logout } from "Utils/auth"
+import type { buildAppRoutesQuery } from "__generated__/buildAppRoutesQuery.graphql"
+import type * as React from "react"
 import { useTracking } from "react-tracking"
 
 jest.mock("react-tracking")
@@ -129,7 +129,7 @@ describe("NavBarMobileMenu", () => {
         ["/institutions", "Museums"],
         ["/price-database", "Price Database"],
         ["/articles", "Editorial"],
-        ["/signup?intent=signup&contextModule=header", "Sign Up"],
+        ["/login?intent=signup&contextModule=header", "Sign Up"],
         ["/login?intent=login&contextModule=header", "Log In"],
       ].map(link => link.join(""))
 


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [DI-292](https://app.notion.com/p/artsy/Change-Mobile-routing-on-Sign-Up-to-login-364cab0764a0804f9cd0eb384ebae7b6?source=copy_link)

### Description

<!-- Implementation description -->

Navigates to old unified login / sign up page instead of new /signup route from mobile "Sign Up" tap in hamburger menu.

### Before

<img width="412" height="1274" alt="before-signup" src="https://github.com/user-attachments/assets/bbba84a4-3e54-46ab-be5f-6cfeb2c09246" />

### After

<img width="412" height="1285" alt="after-signup" src="https://github.com/user-attachments/assets/21ad70e6-ea1c-4af9-8819-682e12963641" />



