### PR TITLE
fix(EMI-3158): clicked payment method tracking

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
@@ -459,7 +459,10 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({
   }
 
   const handleCardPaymentSelect = () => {
-    if (selectedPaymentMethod !== "stripe-card") {
+    if (
+      selectedPaymentMethod !== null &&
+      selectedPaymentMethod !== "stripe-card"
+    ) {
       trackPaymentMethodSelection("CREDIT_CARD")
     }
     unsetStepError()
@@ -470,7 +473,10 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({
     paymentType: "sepa_debit" | "us_bank_account",
     methodType: "stripe-sepa" | "stripe-ach",
   ) => {
-    if (selectedPaymentMethod !== methodType) {
+    if (
+      selectedPaymentMethod !== null &&
+      selectedPaymentMethod !== methodType
+    ) {
       const trackingMethod =
         paymentType === "sepa_debit" ? "SEPA_DEBIT" : "US_BANK_ACCOUNT"
       trackPaymentMethodSelection(trackingMethod)

--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/__tests__/Order2PaymentForm.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/__tests__/Order2PaymentForm.jest.tsx
@@ -702,9 +702,22 @@ describe("Order2PaymentForm", () => {
   })
 
   describe("payment method tracking", () => {
+    it("does not track on Stripe element's initial onChange (load event)", async () => {
+      renderPaymentForm()
+      await waitForPaymentElement()
+
+      await userEvent.click(screen.getByTestId("mock-credit-card"))
+
+      expect(
+        mockCheckoutContext.checkoutTracking.clickedPaymentMethod,
+      ).not.toHaveBeenCalled()
+    })
+
     it("tracks payment method selection for credit card", async () => {
       renderPaymentForm()
       await waitForPaymentElement()
+
+      await userEvent.click(screen.getByTestId("mock-sepa"))
 
       await userEvent.click(screen.getByTestId("mock-credit-card"))
 
@@ -720,6 +733,8 @@ describe("Order2PaymentForm", () => {
     it("tracks payment method selection for ACH", async () => {
       renderPaymentForm()
       await waitForPaymentElement()
+
+      await userEvent.click(screen.getByTestId("mock-credit-card"))
 
       await userEvent.click(screen.getByTestId("mock-ach"))
 
@@ -750,6 +765,8 @@ describe("Order2PaymentForm", () => {
     it("tracks payment method selection for SEPA", async () => {
       renderPaymentForm()
       await waitForPaymentElement()
+
+      await userEvent.click(screen.getByTestId("mock-credit-card"))
 
       await userEvent.click(screen.getByTestId("mock-sepa"))
 

--- a/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
@@ -1313,10 +1313,6 @@ describe("Order2CheckoutRoute", () => {
           context_module: "ordersPayment",
         },
         {
-          action: "clickedPaymentMethod",
-          payment_method: "CREDIT_CARD",
-        },
-        {
           action: "clickedOrderProgression",
           context_module: "ordersPayment",
         },


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-3158]

### Description
Do not fire `clickedPaymentMethod` when the payment element is auto-expanded / default selected, only track payment method clicks when the user actively selects a new payment method. 

<!-- Implementation description -->


[EMI-3158]: https://artsyproduct.atlassian.net/browse/EMI-3158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ