### PR TITLE
fix(EMI-3253): disable phone number auto-linking on checkout delivery address

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Order2CheckoutApp.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Order2CheckoutApp.tsx
@@ -156,6 +156,10 @@ export const Order2CheckoutApp: React.FC<Order2CheckoutAppProps> = ({
             : "width=device-width, initial-scale=1, maximum-scale=5 viewport-fit=cover"
         }
       />
+      {/* Prevent mobile browsers (iOS Safari) from auto-linking phone-number
+          text — e.g. the phone on the delivery address — into tappable
+          `tel:` links. Explicit `tel:` links are unaffected. */}
+      <Meta name="format-detection" content="telephone=no" />
       {showLoadingSkeleton && (
         <Order2CheckoutLoadingSkeleton
           order={orderData}


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-3253]

### Description

<!-- Implementation description -->
Disable phone number auto-linking for the whole checkout flow by injecting `<meta name="format-detection" content="telephone=no">` into the document head

**Note:** another way to address this use case would be to add `<meta name="format-detection" content="telephone=no" />` line to `buildHtmlTemplate()` [after line 50 in html.ts file.](https://github.com/artsy/force/blob/main/src/html.ts#L50-L51) This would disable phone number auto-linking for every page on Force. I don't think this is what we need tho as I think some parts of the web might need the phone number auto-linking. So sharing this just in case someone finds it useful

| Before | After |
| --- | --- |
| <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-06-01 at 10 42 26" src="https://github.com/user-attachments/assets/57024205-a532-4022-a33b-ec1755c4a467" /> | <img width="1206" height="2622" alt="Simulator Screenshot - iPhone 16 Pro - 2026-06-01 at 10 42 36" src="https://github.com/user-attachments/assets/3c6b5f21-269a-4c96-94df-a4bc7f6535eb" /> |




[EMI-3253]: https://artsyproduct.atlassian.net/browse/EMI-3253?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ