### PR TITLE
fix: use proper context module in address form

### DIFF
--- a/src/Apps/Auction/Components/Form/AddressFormWithCreditCard.tsx
+++ b/src/Apps/Auction/Components/Form/AddressFormWithCreditCard.tsx
@@ -1,3 +1,4 @@
+import { ContextModule } from "@artsy/cohesion"
 import { Join, Spacer, Text } from "@artsy/palette"
 import type { AuctionFormValues } from "Apps/Auction/Components/Form/Utils/initialValues"
 import { useAuctionFormContext } from "Apps/Auction/Hooks/useAuctionFormContext"
@@ -42,7 +43,10 @@ export const AddressFormWithCreditCard: React.FC<
         required
       />
 
-      <AddressFormFields<AuctionFormValues> withLegacyPhoneInput />
+      <AddressFormFields<AuctionFormValues>
+        contextModule={ContextModule.auctionRegistration}
+        withLegacyPhoneInput
+      />
     </Join>
   )
 }

--- a/src/Apps/Invoice/Components/AddressFormWithCreditCard.tsx
+++ b/src/Apps/Invoice/Components/AddressFormWithCreditCard.tsx
@@ -39,12 +39,8 @@ export const AddressFormWithCreditCard: React.FC<
         required
       />
 
-      {/* TODO: switch to a dedicated `invoice` ContextModule once one is
-          added to @artsy/cohesion. Keeping `auctionRegistration` preserves
-          the existing (incorrect) analytics value until then so we don't
-          churn the dimension twice. */}
       <AddressFormFields<AddressFormValues>
-        contextModule={ContextModule.auctionRegistration}
+        contextModule={ContextModule.invoice}
       />
     </Join>
   )

--- a/src/Apps/Invoice/Components/AddressFormWithCreditCard.tsx
+++ b/src/Apps/Invoice/Components/AddressFormWithCreditCard.tsx
@@ -1,3 +1,4 @@
+import { ContextModule } from "@artsy/cohesion"
 import { Join, Spacer } from "@artsy/palette"
 import { useFormContext } from "Apps/Invoice/Hooks/useFormContext"
 import { AddressFormFields } from "Components/Address/AddressFormFields"
@@ -38,7 +39,13 @@ export const AddressFormWithCreditCard: React.FC<
         required
       />
 
-      <AddressFormFields<AddressFormValues> />
+      {/* TODO: switch to a dedicated `invoice` ContextModule once one is
+          added to @artsy/cohesion. Keeping `auctionRegistration` preserves
+          the existing (incorrect) analytics value until then so we don't
+          churn the dimension twice. */}
+      <AddressFormFields<AddressFormValues>
+        contextModule={ContextModule.auctionRegistration}
+      />
     </Join>
   )
 }

--- a/src/Apps/Order/Routes/Shipping/Components/AddressModal.tsx
+++ b/src/Apps/Order/Routes/Shipping/Components/AddressModal.tsx
@@ -1,3 +1,4 @@
+import { ContextModule } from "@artsy/cohesion"
 import {
   Banner,
   Button,
@@ -234,7 +235,10 @@ const AddressModalForm: FC<
             </Banner>
           )}
 
-          <AddressFormFields<FormValues> withLegacyPhoneInput />
+          <AddressFormFields<FormValues>
+            contextModule={ContextModule.ordersShipping}
+            withLegacyPhoneInput
+          />
 
           <Spacer y={2} />
 

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
@@ -461,6 +461,7 @@ const DeliveryFormFields: React.FC<DeliveryFormFieldsProps> = ({
   return (
     <div ref={formRef}>
       <AddressFormFields
+        contextModule={ContextModule.ordersFulfillment}
         withPhoneNumber
         syncPhoneCountryCode
         shippableCountries={shippableCountries as any}

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/AddAddressForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/AddAddressForm.tsx
@@ -139,7 +139,11 @@ const AddAddressFormFields: React.FC = () => {
 
   return (
     <div ref={formRef}>
-      <AddressFormFields withPhoneNumber withSetAsDefault />
+      <AddressFormFields
+        contextModule={ContextModule.ordersFulfillment}
+        withPhoneNumber
+        withSetAsDefault
+      />
     </div>
   )
 }

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/UpdateAddressForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/UpdateAddressForm.tsx
@@ -321,6 +321,7 @@ const UpdateAddressFormFields: React.FC<UpdateAddressFormFieldsProps> = ({
   return (
     <div ref={formRef}>
       <AddressFormFields
+        contextModule={ContextModule.ordersFulfillment}
         withPhoneNumber
         withSetAsDefault={!address.isDefault}
       />

--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/StripePaymentCheckboxes.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/StripePaymentCheckboxes.tsx
@@ -1,3 +1,4 @@
+import { ContextModule } from "@artsy/cohesion"
 import InfoIcon from "@artsy/icons/InfoIcon"
 import {
   Box,
@@ -159,7 +160,7 @@ const BillingAddressFormFields: React.FC = () => {
 
   return (
     <div ref={formRef}>
-      <AddressFormFields />
+      <AddressFormFields contextModule={ContextModule.ordersPayment} />
     </div>
   )
 }

--- a/src/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddressForm.tsx
+++ b/src/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddressForm.tsx
@@ -1,3 +1,4 @@
+import { ContextModule } from "@artsy/cohesion"
 import {
   Button,
   Column,
@@ -199,6 +200,7 @@ export const SettingsShippingAddressForm: FC<
           >
             <Form>
               <AddressFormFields
+                contextModule={ContextModule.accountSettings}
                 withPhoneNumber
                 withSetAsDefault={!address?.isDefault}
               />

--- a/src/Components/Address/AddressFormFields.tsx
+++ b/src/Components/Address/AddressFormFields.tsx
@@ -1,4 +1,4 @@
-import { ContextModule } from "@artsy/cohesion"
+import type { ContextModule } from "@artsy/cohesion"
 import {
   Checkbox,
   Column,
@@ -34,6 +34,9 @@ export interface FormikContextWithAddress {
 type CountryData = (typeof countryPhoneOptions)[number]
 
 interface Props {
+  /** Cohesion ContextModule for the surface hosting this form. Used as the
+   * `context_module` on address-autocomplete analytics events. */
+  contextModule: ContextModule
   /** Whether to include rich phone number input */
   withPhoneNumber?: boolean
   /* @deprecated - legacy plain-text phone input */
@@ -65,7 +68,9 @@ interface Props {
  *   <AddressFormFields<AddressFormValues> withLegacyPhoneInput />
  * ```
  */
-export const addressFormFieldsValidator = (args: Props = {}) => ({
+export const addressFormFieldsValidator = (
+  args: Pick<Props, "withLegacyPhoneInput" | "withPhoneNumber"> = {},
+) => ({
   address: yupAddressValidator,
   ...(args.withLegacyPhoneInput && basicPhoneValidator),
   ...(args.withPhoneNumber && richRequiredPhoneValidators),
@@ -126,7 +131,7 @@ export const AddressFormFields = <V extends FormikContextWithAddress>(
   const { contextPageOwnerId, contextPageOwnerType } = useAnalyticsContext()
 
   const autocompleteTrackingValues = {
-    contextModule: ContextModule.auctionRegistration,
+    contextModule: props.contextModule,
     contextOwnerType: contextPageOwnerType,
     contextPageOwnerId: contextPageOwnerId || "",
   }

--- a/src/Components/Address/__tests__/AddressFormFields.jest.tsx
+++ b/src/Components/Address/__tests__/AddressFormFields.jest.tsx
@@ -1,3 +1,4 @@
+import { ContextModule } from "@artsy/cohesion"
 import { Button } from "@artsy/palette"
 import { render, screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
@@ -35,7 +36,7 @@ describe("AddressFormFields", () => {
         >
           {formikBag => (
             <>
-              <AddressFormFields />
+              <AddressFormFields contextModule={ContextModule.ordersShipping} />
               <Button type="submit" onClick={() => formikBag.handleSubmit()}>
                 Submit
               </Button>
@@ -116,7 +117,10 @@ describe("AddressFormFields", () => {
         >
           {formikBag => (
             <>
-              <AddressFormFields withPhoneNumber />
+              <AddressFormFields
+                contextModule={ContextModule.ordersShipping}
+                withPhoneNumber
+              />
               <Button type="submit" onClick={() => formikBag.handleSubmit()}>
                 Submit
               </Button>
@@ -171,7 +175,10 @@ describe("AddressFormFields", () => {
         >
           {formikBag => (
             <>
-              <AddressFormFields withLegacyPhoneInput />
+              <AddressFormFields
+                contextModule={ContextModule.ordersShipping}
+                withLegacyPhoneInput
+              />
               <Button type="submit" onClick={() => formikBag.handleSubmit()}>
                 Submit
               </Button>


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [EMI-3247]

### Description

`AddressFormFields` was hardcoding `context_module: auctionRegistration` on the autocomplete analytics events it forwarded to `AddressAutocompleteInput`, so every surface using it (Order2 shipping/payment, Auction reg, Invoice, Settings, legacy Order) reported the wrong context.

- Made `contextModule: ContextModule` a required prop on `AddressFormFields` so the value cannot drift again.
- Updated callers to pass the correct module:
    - Order2 fulfillment forms → `ordersFulfillment`
    - Order2 billing addresses → `ordersPayment`
    - Auction reg → `auctionRegistration`
    - Settings shipping → `accountSettings`
    - Legacy Order shipping → `ordersShipping`
 - Kept Invoice as is:
    - Invoice → kept on `auctionRegistration` with a TODO (no dedicated `invoice` Cohesion value yet; deferring to avoid a churn-then-rechurn)


<img width="2558" height="1323" alt="Screenshot 2026-06-01 at 9 35 57 AM" src="https://github.com/user-attachments/assets/6593184f-cda3-4247-baa9-16b77b007370" />


[EMI-3247]: https://artsyproduct.atlassian.net/browse/EMI-3247?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ