### PR TITLE
fix(artist): gracefully handle errors and timeouts in artist page section readiness

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -660,6 +660,7 @@ export const ArtistAuctionResultsQueryRenderer: React.FC<
       }}
       render={({ error, props }) => {
         if (error) {
+          handleReady()
           console.error(
             "[ArtistAuctionResults]: Error loading auction results",
             error,

--- a/src/Apps/Artist/Routes/AuctionResults/Components/MarketStats.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/Components/MarketStats.tsx
@@ -329,6 +329,7 @@ export const MarketStatsQueryRenderer: FC<
       `}
       render={({ props, error }) => {
         if (error) {
+          handleReady()
           onRender(false)
           console.error(error)
           return null

--- a/src/Apps/Artist/Routes/Overview/Components/ArtistOverview.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtistOverview.tsx
@@ -49,6 +49,7 @@ export const ArtistOverviewQueryRenderer: React.FC<
       variables={{ artistID: id }}
       render={({ error, props }) => {
         if (error) {
+          handleReady()
           console.error("[ArtistOverview]: Error loading overview", error)
           return null
         }

--- a/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
+++ b/src/Apps/Artist/Routes/WorksForSale/Components/ArtistArtworkFilter.tsx
@@ -239,6 +239,7 @@ export const ArtistArtworkFilterQueryRenderer: FC<
       placeholder={<ArtworkFilterPlaceholder showCreateAlert />}
       render={({ error, props }) => {
         if (error) {
+          handleReady()
           console.error(
             "[ArtistArtworkFilter]: Error loading artwork grid",
             error,

--- a/src/Utils/Hooks/__tests__/useSectionReadiness.jest.tsx
+++ b/src/Utils/Hooks/__tests__/useSectionReadiness.jest.tsx
@@ -1,5 +1,95 @@
 import { act, renderHook } from "@testing-library/react-hooks"
-import { useSectionReady } from "../useSectionReadiness"
+import { useSectionReadiness, useSectionReady } from "../useSectionReadiness"
+
+describe("useSectionReadiness", () => {
+  let warnSpy: jest.SpyInstance
+
+  beforeEach(() => {
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    warnSpy.mockRestore()
+  })
+
+  it("waitFor resolves when the section becomes ready", async () => {
+    const { result } = renderHook(() =>
+      useSectionReadiness(["a", "b"] as const),
+    )
+
+    let resolved = false
+    const promise = result.current.waitFor(["a"]).then(() => {
+      resolved = true
+    })
+
+    expect(resolved).toBe(false)
+
+    act(() => {
+      result.current.markReady("a")
+    })
+
+    await promise
+
+    expect(resolved).toBe(true)
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+
+  it("waitFor resolves after the timeout when a section never reports ready, and warns", async () => {
+    const { result } = renderHook(() =>
+      useSectionReadiness(["a", "b"] as const),
+    )
+
+    await result.current.waitFor(["a"], { timeoutMs: 50 })
+
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0][0]).toMatch(/did not become ready/)
+    expect(result.current.mode.a).toBe("Ready")
+  })
+
+  it("waitUntil resolves via timeout if a prior section never reports ready", async () => {
+    const { result } = renderHook(() =>
+      useSectionReadiness(["a", "b", "c"] as const),
+    )
+
+    await result.current.waitUntil("c", { timeoutMs: 50 })
+
+    expect(result.current.navigating.c).toBe(false)
+    expect(result.current.mode.a).toBe("Ready")
+    expect(result.current.mode.b).toBe("Ready")
+  })
+
+  it("a subsequent waitFor on a timed-out section resolves immediately", async () => {
+    const { result } = renderHook(() => useSectionReadiness(["a"] as const))
+
+    await result.current.waitFor(["a"], { timeoutMs: 25 })
+
+    expect(result.current.mode.a).toBe("Ready")
+
+    let secondResolved = false
+    await result.current.waitFor(["a"], { timeoutMs: 25 })
+    secondResolved = true
+
+    expect(secondResolved).toBe(true)
+  })
+
+  it("disables the timeout when timeoutMs <= 0", async () => {
+    const { result } = renderHook(() => useSectionReadiness(["a"] as const))
+
+    let resolved = false
+    const promise = result.current.waitFor(["a"], { timeoutMs: 0 }).then(() => {
+      resolved = true
+    })
+
+    await new Promise(r => setTimeout(r, 50))
+    expect(resolved).toBe(false)
+
+    act(() => {
+      result.current.markReady("a")
+    })
+    await promise
+    expect(resolved).toBe(true)
+  })
+})
 
 describe("useSectionReady", () => {
   it("does not call onReady synchronously when handleReady is invoked", () => {

--- a/src/Utils/Hooks/useSectionReadiness.ts
+++ b/src/Utils/Hooks/useSectionReadiness.ts
@@ -82,6 +82,26 @@ const reducer = <TSectionKey extends string>(
   }
 }
 
+/**
+ * Default timeout (ms) applied to {@link UseSectionReadinessReturn.waitFor} and
+ * {@link UseSectionReadinessReturn.waitUntil}. Prevents a section whose
+ * `onReady` callback never fires (e.g. a query that errors out or never
+ * resolves) from blocking navigation and loading UI indefinitely.
+ */
+export const DEFAULT_SECTION_READINESS_TIMEOUT_MS = 8000
+
+type WaitOptions = {
+  /**
+   * Maximum time (in ms) to wait for the section(s) to become ready before
+   * giving up and resolving anyway. When a wait times out, the affected
+   * section is force-marked as ready so subsequent waits don't re-hang.
+   *
+   * Defaults to {@link DEFAULT_SECTION_READINESS_TIMEOUT_MS}. Pass `0` or a
+   * negative number to disable the timeout (not recommended in production).
+   */
+  timeoutMs?: number
+}
+
 type UseSectionReadinessReturn<TSectionKey extends string> = {
   /** Maps each section key to whether it should be lazily loaded (true) or eagerly loaded (false) */
   lazy: SectionMap<TSectionKey, boolean>
@@ -91,14 +111,14 @@ type UseSectionReadinessReturn<TSectionKey extends string> = {
   navigating: SectionMap<TSectionKey, boolean>
   /** Callback function to mark a section as ready. Call this when a section finishes loading. */
   markReady: (key: TSectionKey) => void
-  /** Wait for one or more sections to become ready. Returns a promise that resolves when all specified sections are ready. */
-  waitFor: (keys: TSectionKey[]) => Promise<void>
+  /** Wait for one or more sections to become ready. Returns a promise that resolves when all specified sections are ready, or when the timeout elapses. */
+  waitFor: (keys: TSectionKey[], options?: WaitOptions) => Promise<void>
   /** Get all section keys that come before the target section in the order */
   priorTo: (target: TSectionKey) => TSectionKey[]
   /** Wait for all sections up to (and optionally including) a target section to be ready. This will trigger eager loading of those sections. */
   waitUntil: (
     target: TSectionKey,
-    options?: { includeTarget?: boolean },
+    options?: WaitOptions & { includeTarget?: boolean },
   ) => Promise<void>
   /** The original ordered array of section keys */
   order: TSectionKey[]
@@ -139,18 +159,43 @@ export const useSectionReadiness = <TSectionKey extends string>(
   )
 
   const waitFor = useCallback(
-    async (keys: TSectionKey[]) => {
+    async (keys: TSectionKey[], options?: WaitOptions) => {
+      const timeoutMs =
+        options?.timeoutMs ?? DEFAULT_SECTION_READINESS_TIMEOUT_MS
+
       await Promise.all(
         keys.map(key => {
           return new Promise<void>(resolve => {
             if (mode[key] === "Ready") return resolve()
 
-            waitersRef.current[key].push(resolve)
+            let settled = false
+            let timer: ReturnType<typeof setTimeout> | null = null
+
+            const settle = () => {
+              if (settled) return
+              settled = true
+              if (timer !== null) clearTimeout(timer)
+              resolve()
+            }
+
+            if (timeoutMs > 0) {
+              timer = setTimeout(() => {
+                console.warn(
+                  `[useSectionReadiness] Section "${String(
+                    key,
+                  )}" did not become ready within ${timeoutMs}ms; resolving to avoid an indefinite hang.`,
+                )
+                markReady(key)
+                settle()
+              }, timeoutMs)
+            }
+
+            waitersRef.current[key].push(settle)
           })
         }),
       )
     },
-    [mode],
+    [mode, markReady],
   )
 
   const priorTo = useCallback(
@@ -163,7 +208,10 @@ export const useSectionReadiness = <TSectionKey extends string>(
   }, [])
 
   const waitUntil = useCallback(
-    async (target: TSectionKey, options?: { includeTarget?: boolean }) => {
+    async (
+      target: TSectionKey,
+      options?: WaitOptions & { includeTarget?: boolean },
+    ) => {
       const index = orderedKeys.indexOf(target)
       const end = index + (options?.includeTarget ? 1 : 0)
       const keys = orderedKeys.slice(0, Math.max(0, end))
@@ -174,7 +222,7 @@ export const useSectionReadiness = <TSectionKey extends string>(
       eagerLoad(keys)
 
       try {
-        await waitFor(keys)
+        await waitFor(keys, { timeoutMs: options?.timeoutMs })
       } finally {
         dispatch({ type: "END_NAVIGATION" })
       }


### PR DESCRIPTION
Noticed when I was testing the page before I had turned on the VPN that the requests to Diffusion were hung, which resulted in a perpetual spinner for the sections. This adds a timeout and also marks the section 'ready' if we error completely (since it will simply be skipped).

I also wound up making a ticket to add a global retry and timeout middleware to our Relay setup, which seems like a strangely obvious absence.

cc @artsy/diamond-devs 