### PR TITLE
fix(DI-306): Update Title Tag on /categories

### DIFF
--- a/src/Apps/Categories/CategoriesApp.tsx
+++ b/src/Apps/Categories/CategoriesApp.tsx
@@ -20,7 +20,10 @@ const CategoriesApp: React.FC<React.PropsWithChildren<CategoriesAppProps>> = ({
 
   return (
     <>
-      <MetaTags pathname="categories" />
+      <MetaTags
+        pathname="categories"
+        title="Browse and Shop Art by Category | Artsy"
+      />
 
       <Spacer y={[2, 4]} />
 


### PR DESCRIPTION
The type of this PR is: **FIX**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [DI-306](https://www.notion.so/372cab0764a08078b782f58aecd789d5)

### Description

Currently https://www.artsy.net/categories doesn’t have a unique title tag, it uses the default title which is `Artsy — Discover and Buy Fine Art`
Now we are overriding that with `Browse and Shop Art by Category | Artsy`.

<!-- Implementation description -->
Before: 
<img width="474" height="108" alt="Screenshot 2026-06-01 at 2 54 29 PM" src="https://github.com/user-attachments/assets/d189be69-aae7-428f-bd52-c5dc42b2444b" />
After:
<img width="580" height="107" alt="Screenshot 2026-06-01 at 2 55 39 PM" src="https://github.com/user-attachments/assets/ebbc114f-99b3-41e4-a2d6-1226c14819b1" />

cc: @artsy/diamond-devs 
