### PR TITLE
chore: preapprove our own package for npm minimal age gate

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,3 +5,8 @@ yarnPath: .yarn/releases/yarn-4.15.0.cjs
 # Disable postinstall scripts from 3rd parties. In 2025, libraries really
 # shouldn't need this, and if they do we should evaulate them one-by-one.
 enableScripts: false
+
+# Bypass the default 24h npm release-age gate for our own packages.
+# Third-party transitives are still gated.
+npmPreapprovedPackages:
+  - "@artsy/*"

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,7 +6,8 @@ yarnPath: .yarn/releases/yarn-4.15.0.cjs
 # shouldn't need this, and if they do we should evaulate them one-by-one.
 enableScripts: false
 
-# Bypass the default 24h npm release-age gate for our own packages.
-# Third-party transitives are still gated.
+# Quarantine third-party packages for 10 days after publish.
+npmMinimalAgeGate: 14400
+# Preapprove our own.
 npmPreapprovedPackages:
   - "@artsy/*"


### PR DESCRIPTION
The type of this PR is: **Chore**

### Description

Yarn 4.15 (updated [~1 week ago](https://github.com/artsy/force/commit/0d002dea96)) ships a default `npmMinimalAgeGate: 1440` (24h) that blocks installs of packages published less than a day ago. 

However, it blocks our own packages like [Cohesion](https://app.circleci.com/pipelines/github/artsy/force/80428/workflows/b17e197e-625f-4e0f-b7cf-09c451276436/jobs/549890). Third-party transitives are still gated, and I think it would be safe to pre-approve Artsy packages. Curious how you think!

<img width="1144" height="648" alt="Screenshot 2026-06-01 at 5 06 12 PM" src="https://github.com/user-attachments/assets/9259cbb3-e529-4f14-8a2f-f3c34b4c8b9b" />
