### PR TITLE
feat(relay): wires up retry middleware

### DIFF
--- a/src/System/Relay/__tests__/createRelaySSREnvironment.jest.ts
+++ b/src/System/Relay/__tests__/createRelaySSREnvironment.jest.ts
@@ -1,6 +1,20 @@
 import { hydrateCacheFromSSR } from "System/Relay/createRelaySSREnvironment"
 import { QueryResponseCache } from "relay-runtime"
 
+const retryMiddlewareMock = jest.fn(
+  (_options: Record<string, unknown>) => next => req => next(req),
+)
+
+jest.mock("react-relay-network-modern/node8", () => {
+  const actual = jest.requireActual("react-relay-network-modern/node8")
+
+  return {
+    ...actual,
+    retryMiddleware: (options: Record<string, unknown>) =>
+      retryMiddlewareMock(options),
+  }
+})
+
 describe("#hydrateCacheFromSSR", () => {
   const relayResponseCache = new QueryResponseCache({
     size: 250,
@@ -29,5 +43,31 @@ describe("#hydrateCacheFromSSR", () => {
     expect(relayResponseCache._responses.size).toBe(2)
     expect(relayResponseCache._responses.get(request[0][0]).payload.id).toBe(0)
     expect(relayResponseCache._responses.get(request[1][0]).payload.id).toBe(1)
+  })
+})
+
+describe("#createRelaySSREnvironment", () => {
+  beforeEach(() => {
+    retryMiddlewareMock.mockClear()
+    jest.resetModules()
+  })
+
+  it("configures retryMiddleware with the client retry policy", () => {
+    const {
+      createRelaySSREnvironment,
+    } = require("System/Relay/createRelaySSREnvironment")
+
+    createRelaySSREnvironment()
+
+    expect(retryMiddlewareMock).toHaveBeenCalledTimes(1)
+
+    const options = retryMiddlewareMock.mock.calls[0][0]
+
+    expect(options).toMatchObject({
+      fetchTimeout: 15000,
+      retryDelays: [500, 1500],
+      statusCodes: [502, 503, 504],
+    })
+    expect(typeof options.beforeRetry).toBe("function")
   })
 })

--- a/src/System/Relay/createRelaySSREnvironment.ts
+++ b/src/System/Relay/createRelaySSREnvironment.ts
@@ -20,6 +20,7 @@ import {
   cacheMiddleware,
   errorMiddleware,
   loggerMiddleware,
+  retryMiddleware,
   urlMiddleware,
 } from "react-relay-network-modern/node8"
 import { Environment, type INetwork, RecordSource, Store } from "relay-runtime"
@@ -142,6 +143,21 @@ export function createRelaySSREnvironment(config: Config = {}) {
     loggingEnabled && loggerMiddleware(),
     loggingEnabled && metaphysicsExtensionsLoggerMiddleware(),
     loggingEnabled && errorMiddleware({ disableServerMiddlewareTip: true }),
+    // Keep retries closest to fetch so cache/SSR/error middlewares only see the final response.
+    // SSR gets a tighter budget because it shares the request timeout with route matching and rendering.
+    retryMiddleware({
+      fetchTimeout: isServer ? 8000 : 15000,
+      retryDelays: isServer ? [500] : [500, 1500],
+      statusCodes: [502, 503, 504],
+      beforeRetry: ({ attempt, delay, lastError, req }) => {
+        const operationName =
+          "operation" in req ? req.operation.name : "batched request"
+
+        logger.warn(
+          `Relay retry attempt=${attempt} delay=${delay}ms op=${operationName} reason=${lastError?.message ?? "status"}`,
+        )
+      },
+    }),
   ]
 
   // TODO: The `noThrow` option is used since we do our own error handling,


### PR DESCRIPTION
The artist page subnav requires a set of requests to succeed in order to navigate and auto scroll to the section. I noticed some slowness and network failures on some pages in staging the other day that would hang it. [I addressed those directly here](https://github.com/artsy/force/pull/17286), but it seems like a global retry would be a good idea. There's already a `retryMiddleware` in our packages to use here.

Just went with what seemed conservatively reasonable for the configuration values. Notable that we have a [global timeout of 29 seconds here](https://github.com/artsy/force/blob/5600aaece70157e96e9b981def33b1eaec77dcb6/src/middleware.ts#L76) (which makes me wonder if that is left over from Heroku days or something).

cc @artsy/diamond-devs 