### PR TITLE
fix: log correct flag value in Sentry for checkout timeout errors

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Hooks/__tests__/useLoadCheckout.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/__tests__/useLoadCheckout.jest.tsx
@@ -231,6 +231,54 @@ describe("useLoadCheckout", () => {
       )
     })
 
+    it("logs the current loading-gate flags when the timeout fires, not their initial values", async () => {
+      // Simulate the common failure path:
+      //   - minimumLoadingPassed has flipped to true via the 1s timer
+      //   - The Stripe redirect handler has called its callback
+      //   - The order validated synchronously
+      //   - isInitialAutoSaveComplete is true (no autosave needed for this user)
+      //   - expressCheckoutPaymentMethods is still null (Express Checkout never resolved)
+      // The Sentry log should reflect this exact shape so we can diagnose
+      // which flag was actually stuck, instead of always reporting all-false.
+      useCheckoutContext.mockReturnValue({
+        isLoading: true,
+        expressCheckoutPaymentMethods: null,
+        steps: [],
+        setLoadingComplete: mockSetLoadingComplete,
+        isInitialAutoSaveComplete: true,
+      })
+
+      renderHook(() => useLoadCheckout(mockOrder))
+
+      // Pass the minimum-loading gate.
+      act(() => {
+        jest.advanceTimersByTime(MIN_LOADING_MS)
+      })
+
+      // Stripe redirect handler resolves.
+      act(() => {
+        mockStripeCallback?.()
+      })
+
+      // Advance past the 8s deadline; Express Checkout never loaded.
+      act(() => {
+        jest.advanceTimersByTime(MAX_LOADING_MS - MIN_LOADING_MS)
+      })
+
+      await waitFor(() => {
+        expect(mockShowCheckoutErrorModal).toHaveBeenCalledWith({
+          error: "loading_timeout",
+        })
+      })
+
+      const errorMessage = mockLogger.error.mock.calls[0][0].message
+      expect(errorMessage).toContain("minimumLoadingPassed: true")
+      expect(errorMessage).toContain("orderValidated: true")
+      expect(errorMessage).toContain("isExpressCheckoutLoaded: false")
+      expect(errorMessage).toContain("isStripeRedirectHandled: true")
+      expect(errorMessage).toContain("isInitialAutoSaveComplete: true")
+    })
+
     it("does not set timeout error if loading completes before MAX_LOADING_MS", async () => {
       let isLoading = true
       useCheckoutContext.mockImplementation(() => ({

--- a/src/Apps/Order2/Routes/Checkout/Hooks/useLoadCheckout.ts
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/useLoadCheckout.ts
@@ -128,17 +128,39 @@ export const useLoadCheckout = (order: useLoadCheckout_order$key) => {
     loadingErrorRef.current = checkoutModalError
   }, [checkoutModalError])
 
+  // Mirror the loading-gate flags into a ref so the one-shot timeout below
+  // can read their *current* values when it fires. Without this, the timeout
+  // closure captures the values at mount (all false), making the Sentry log
+  // useless for diagnosing which flag was actually stuck.
+  const flagsRef = useRef({
+    minimumLoadingPassed,
+    orderValidated,
+    isExpressCheckoutLoaded,
+    isStripeRedirectHandled,
+    isInitialAutoSaveComplete,
+  })
+  useEffect(() => {
+    flagsRef.current = {
+      minimumLoadingPassed,
+      orderValidated,
+      isExpressCheckoutLoaded,
+      isStripeRedirectHandled,
+      isInitialAutoSaveComplete,
+    }
+  }, [
+    minimumLoadingPassed,
+    orderValidated,
+    isExpressCheckoutLoaded,
+    isStripeRedirectHandled,
+    isInitialAutoSaveComplete,
+  ])
+
   // Set timeout for maximum loading duration
   // biome-ignore lint/correctness/useExhaustiveDependencies: 1-time effect
   useEffect(() => {
     const timeout = setTimeout(() => {
       if (isLoadingRef.current && !loadingErrorRef.current) {
-        const loadingState = Object.entries({
-          minimumLoadingPassed,
-          orderValidated,
-          isExpressCheckoutLoaded,
-          isStripeRedirectHandled,
-        })
+        const loadingState = Object.entries(flagsRef.current)
           .map(([key, value]) => `${key}: ${value}`)
           .join(", ")
 


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [EMI-3203]

### Description

We log gating flags in Sentry ([example](https://artsynet.sentry.io/issues/7403011161/events/d4636dd996f24a06b82c5aad84b18bbc/)) when checkout times out. They all appeared `false` which were incorrect and not helpful. This is the first step to have correct flag reported.

The issue is that we use the values from closure which are static initial values `false`. This updates it to use ref and report the correct current value.


<img width="1449" height="177" alt="Screenshot 2026-06-02 at 3 43 23 PM" src="https://github.com/user-attachments/assets/d2f26aea-5bbc-44cc-966f-439e1e26b006" />


[EMI-3203]: https://artsyproduct.atlassian.net/browse/EMI-3203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ