### PR TITLE
feat(settings): disables account linking when 2fa is enabled

### DIFF
--- a/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsLinkedAccounts.tsx
+++ b/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsLinkedAccounts.tsx
@@ -1,7 +1,7 @@
 import AppleIcon from "@artsy/icons/AppleIcon"
 import FacebookIcon from "@artsy/icons/FacebookIcon"
 import GoogleIcon from "@artsy/icons/GoogleIcon"
-import { Button, Join, Spacer, Text, useToasts } from "@artsy/palette"
+import { Button, Join, Message, Spacer, Text, useToasts } from "@artsy/palette"
 import { useRouter } from "System/Hooks/useRouter"
 import { useMode } from "Utils/Hooks/useMode"
 import { getENV } from "Utils/getENV"
@@ -54,11 +54,20 @@ export const SettingsEditSettingsLinkedAccounts: FC<
       </Text>
 
       <Join separator={<Spacer y={2} />}>
+        {me.hasSecondFactorEnabled && (
+          <Message variant="info">
+            Linked accounts are unavailable while two-factor authentication is
+            enabled. Disable two-factor authentication to manage your linked
+            accounts.
+          </Message>
+        )}
+
         <SettingsEditSettingsLinkedAccountsButton
           me={me}
           provider="FACEBOOK"
           href={authenticationPaths?.facebookPath}
           Icon={FacebookIcon}
+          disabled={me.hasSecondFactorEnabled}
         />
 
         <SettingsEditSettingsLinkedAccountsButton
@@ -66,6 +75,7 @@ export const SettingsEditSettingsLinkedAccounts: FC<
           provider="APPLE"
           href={authenticationPaths?.applePath}
           Icon={AppleIcon}
+          disabled={me.hasSecondFactorEnabled}
         />
 
         <SettingsEditSettingsLinkedAccountsButton
@@ -73,6 +83,7 @@ export const SettingsEditSettingsLinkedAccounts: FC<
           provider="GOOGLE"
           href={authenticationPaths?.googlePath}
           Icon={GoogleIcon}
+          disabled={me.hasSecondFactorEnabled}
         />
       </Join>
     </>
@@ -83,6 +94,7 @@ export const SettingsEditSettingsLinkedAccountsFragmentContainer =
   createFragmentContainer(SettingsEditSettingsLinkedAccounts, {
     me: graphql`
       fragment SettingsEditSettingsLinkedAccounts_me on Me {
+        hasSecondFactorEnabled
         authentications {
           provider
         }
@@ -95,13 +107,14 @@ interface SettingsEditSettingsLinkedAccountsButtonProps {
   me: SettingsEditSettingsLinkedAccounts_me$data
   href?: string
   provider: AuthenticationProvider
+  disabled?: boolean
 }
 
 type Mode = "Disconnected" | "Connecting" | "Connected" | "Disconnecting"
 
 const SettingsEditSettingsLinkedAccountsButton: FC<
   React.PropsWithChildren<SettingsEditSettingsLinkedAccountsButtonProps>
-> = ({ Icon, me, href, provider }) => {
+> = ({ Icon, me, href, provider, disabled }) => {
   const isConnected = me.authentications.find(
     authentication => authentication.provider === provider,
   )
@@ -158,8 +171,9 @@ const SettingsEditSettingsLinkedAccountsButton: FC<
   return (
     <Button
       onClick={handleClick}
+      disabled={disabled}
       loading={mode === "Connecting" || mode === "Disconnecting"}
-      {...(mode === "Connected"
+      {...(mode === "Connected" || disabled
         ? { variant: "secondaryBlack" }
         : {
             variant: "primaryBlack",

--- a/src/Apps/Settings/Routes/EditSettings/Components/__tests__/SettingsEditSettingsLinkedAccounts.jest.tsx
+++ b/src/Apps/Settings/Routes/EditSettings/Components/__tests__/SettingsEditSettingsLinkedAccounts.jest.tsx
@@ -35,7 +35,7 @@ describe("SettingsEditSettingsLinkedAccounts", () => {
 
   it("renders the link if the accounts are disconnected", () => {
     renderWithRelay({
-      Me: () => ({ authentications: [] }),
+      Me: () => ({ hasSecondFactorEnabled: false, authentications: [] }),
     })
 
     const links = screen.getAllByRole("link")
@@ -48,6 +48,7 @@ describe("SettingsEditSettingsLinkedAccounts", () => {
   it("renders the buttons if the accounts are connected", () => {
     renderWithRelay({
       Me: () => ({
+        hasSecondFactorEnabled: false,
         authentications: [
           { provider: "FACEBOOK" },
           { provider: "APPLE" },
@@ -59,5 +60,26 @@ describe("SettingsEditSettingsLinkedAccounts", () => {
     expect(screen.getByText("Disconnect Facebook Account")).toBeInTheDocument()
     expect(screen.getByText("Disconnect Apple Account")).toBeInTheDocument()
     expect(screen.getByText("Disconnect Google Account")).toBeInTheDocument()
+  })
+
+  it("disables the buttons and explains why when two-factor is enabled", () => {
+    renderWithRelay({
+      Me: () => ({
+        hasSecondFactorEnabled: true,
+        authentications: [],
+      }),
+    })
+
+    expect(
+      screen.getByText(
+        /Linked accounts are unavailable while two-factor authentication is enabled/,
+      ),
+    ).toBeInTheDocument()
+
+    expect(screen.queryAllByRole("link")).toHaveLength(0)
+
+    for (const button of screen.getAllByRole("button")) {
+      expect(button).toBeDisabled()
+    }
   })
 })

--- a/src/__generated__/SettingsEditSettingsLinkedAccounts_Test_Query.graphql.ts
+++ b/src/__generated__/SettingsEditSettingsLinkedAccounts_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<e9f8abfbb58660d8fa2bf03ea031b235>>
+ * @generated SignedSource<<11b86879403f0bfd337ad495b36b35ef>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -73,6 +73,13 @@ return {
           {
             "alias": null,
             "args": null,
+            "kind": "ScalarField",
+            "name": "hasSecondFactorEnabled",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
             "concreteType": "AuthenticationType",
             "kind": "LinkedField",
             "name": "authentications",
@@ -96,12 +103,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "80873362a12b6f0256e1534d3b35f5d2",
+    "cacheID": "e533c0c3c4c29315de10523831031490",
     "id": null,
     "metadata": {},
     "name": "SettingsEditSettingsLinkedAccounts_Test_Query",
     "operationKind": "query",
-    "text": "query SettingsEditSettingsLinkedAccounts_Test_Query {\n  me {\n    ...SettingsEditSettingsLinkedAccounts_me\n    id\n  }\n}\n\nfragment SettingsEditSettingsLinkedAccounts_me on Me {\n  authentications {\n    provider\n    id\n  }\n}\n"
+    "text": "query SettingsEditSettingsLinkedAccounts_Test_Query {\n  me {\n    ...SettingsEditSettingsLinkedAccounts_me\n    id\n  }\n}\n\nfragment SettingsEditSettingsLinkedAccounts_me on Me {\n  hasSecondFactorEnabled\n  authentications {\n    provider\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SettingsEditSettingsLinkedAccounts_me.graphql.ts
+++ b/src/__generated__/SettingsEditSettingsLinkedAccounts_me.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<f0bf487151d5769d663a9efd8990522a>>
+ * @generated SignedSource<<fdefbc915d408dcff4dd0a4211377af4>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -15,6 +15,7 @@ export type SettingsEditSettingsLinkedAccounts_me$data = {
   readonly authentications: ReadonlyArray<{
     readonly provider: AuthenticationProvider;
   }>;
+  readonly hasSecondFactorEnabled: boolean;
   readonly " $fragmentType": "SettingsEditSettingsLinkedAccounts_me";
 };
 export type SettingsEditSettingsLinkedAccounts_me$key = {
@@ -28,6 +29,13 @@ const node: ReaderFragment = {
   "metadata": null,
   "name": "SettingsEditSettingsLinkedAccounts_me",
   "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "hasSecondFactorEnabled",
+      "storageKey": null
+    },
     {
       "alias": null,
       "args": null,
@@ -51,6 +59,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "a55e6069851be3fddb81897ba96a6c80";
+(node as any).hash = "c3d3db28bb68992831f613763c072521";
 
 export default node;

--- a/src/__generated__/settingsRoutes_SettingsEditSettingsRouteQuery.graphql.ts
+++ b/src/__generated__/settingsRoutes_SettingsEditSettingsRouteQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<d15cbf4f8b19d1ca679ec1a42713deba>>
+ * @generated SignedSource<<18c1d6d6c6cda7dfa61e73705b09ed8a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -296,12 +296,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "74cf6e7419fc63d359180abc9df405ad",
+    "cacheID": "d8bd0d5073b03fc0a181e13cf4197489",
     "id": null,
     "metadata": {},
     "name": "settingsRoutes_SettingsEditSettingsRouteQuery",
     "operationKind": "query",
-    "text": "query settingsRoutes_SettingsEditSettingsRouteQuery {\n  me {\n    ...SettingsEditSettingsRoute_me\n    id\n  }\n}\n\nfragment AppSecondFactor_me on Me {\n  hasSecondFactorEnabled\n  appSecondFactors: secondFactors(kinds: [app]) {\n    __typename\n    ... on AppSecondFactor {\n      __typename\n      internalID\n      name\n    }\n  }\n}\n\nfragment SettingsEditSettingsInformation_me on Me {\n  email\n  name\n  paddleNumber\n  phoneNumber {\n    regionCode\n    display(format: NATIONAL)\n    originalNumber\n  }\n  priceRange\n  priceRangeMin\n  priceRangeMax\n}\n\nfragment SettingsEditSettingsLinkedAccounts_me on Me {\n  authentications {\n    provider\n    id\n  }\n}\n\nfragment SettingsEditSettingsPassword_me on Me {\n  hasPassword\n}\n\nfragment SettingsEditSettingsRoute_me on Me {\n  ...SettingsEditSettingsInformation_me\n  ...SettingsEditSettingsPassword_me\n  ...SettingsEditSettingsTwoFactor_me\n  ...SettingsEditSettingsLinkedAccounts_me\n}\n\nfragment SettingsEditSettingsTwoFactorBackupCodes_me on Me {\n  backupSecondFactors: secondFactors(kinds: [backup]) {\n    __typename\n    ... on BackupSecondFactor {\n      __typename\n    }\n  }\n}\n\nfragment SettingsEditSettingsTwoFactor_me on Me {\n  hasSecondFactorEnabled\n  ...AppSecondFactor_me\n  ...SmsSecondFactor_me\n  ...SettingsEditSettingsTwoFactorBackupCodes_me\n}\n\nfragment SmsSecondFactor_me on Me {\n  email\n  hasSecondFactorEnabled\n  isEmailConfirmed\n  smsSecondFactors: secondFactors(kinds: [sms]) {\n    __typename\n    ... on SmsSecondFactor {\n      __typename\n      internalID\n      formattedPhoneNumber\n    }\n  }\n}\n"
+    "text": "query settingsRoutes_SettingsEditSettingsRouteQuery {\n  me {\n    ...SettingsEditSettingsRoute_me\n    id\n  }\n}\n\nfragment AppSecondFactor_me on Me {\n  hasSecondFactorEnabled\n  appSecondFactors: secondFactors(kinds: [app]) {\n    __typename\n    ... on AppSecondFactor {\n      __typename\n      internalID\n      name\n    }\n  }\n}\n\nfragment SettingsEditSettingsInformation_me on Me {\n  email\n  name\n  paddleNumber\n  phoneNumber {\n    regionCode\n    display(format: NATIONAL)\n    originalNumber\n  }\n  priceRange\n  priceRangeMin\n  priceRangeMax\n}\n\nfragment SettingsEditSettingsLinkedAccounts_me on Me {\n  hasSecondFactorEnabled\n  authentications {\n    provider\n    id\n  }\n}\n\nfragment SettingsEditSettingsPassword_me on Me {\n  hasPassword\n}\n\nfragment SettingsEditSettingsRoute_me on Me {\n  ...SettingsEditSettingsInformation_me\n  ...SettingsEditSettingsPassword_me\n  ...SettingsEditSettingsTwoFactor_me\n  ...SettingsEditSettingsLinkedAccounts_me\n}\n\nfragment SettingsEditSettingsTwoFactorBackupCodes_me on Me {\n  backupSecondFactors: secondFactors(kinds: [backup]) {\n    __typename\n    ... on BackupSecondFactor {\n      __typename\n    }\n  }\n}\n\nfragment SettingsEditSettingsTwoFactor_me on Me {\n  hasSecondFactorEnabled\n  ...AppSecondFactor_me\n  ...SmsSecondFactor_me\n  ...SettingsEditSettingsTwoFactorBackupCodes_me\n}\n\nfragment SmsSecondFactor_me on Me {\n  email\n  hasSecondFactorEnabled\n  isEmailConfirmed\n  smsSecondFactors: secondFactors(kinds: [sms]) {\n    __typename\n    ... on SmsSecondFactor {\n      __typename\n      internalID\n      formattedPhoneNumber\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/useUnlinkSettingsLinkedAccountMutation.graphql.ts
+++ b/src/__generated__/useUnlinkSettingsLinkedAccountMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<cf884282bed4e2abc136278b1a49370e>>
+ * @generated SignedSource<<3077f390ef86ddce9d6a7557fb280acc>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -115,6 +115,13 @@ return {
               {
                 "alias": null,
                 "args": null,
+                "kind": "ScalarField",
+                "name": "hasSecondFactorEnabled",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
                 "concreteType": "AuthenticationType",
                 "kind": "LinkedField",
                 "name": "authentications",
@@ -141,12 +148,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "0d93dd39b9e7eb1a49d2b4c73bd27579",
+    "cacheID": "cdde76258fc053765ad6faef429a63e3",
     "id": null,
     "metadata": {},
     "name": "useUnlinkSettingsLinkedAccountMutation",
     "operationKind": "mutation",
-    "text": "mutation useUnlinkSettingsLinkedAccountMutation(\n  $input: UnlinkAuthenticationMutationInput!\n) {\n  unlinkAuthentication(input: $input) {\n    me {\n      ...SettingsEditSettingsLinkedAccounts_me\n      id\n    }\n  }\n}\n\nfragment SettingsEditSettingsLinkedAccounts_me on Me {\n  authentications {\n    provider\n    id\n  }\n}\n"
+    "text": "mutation useUnlinkSettingsLinkedAccountMutation(\n  $input: UnlinkAuthenticationMutationInput!\n) {\n  unlinkAuthentication(input: $input) {\n    me {\n      ...SettingsEditSettingsLinkedAccounts_me\n      id\n    }\n  }\n}\n\nfragment SettingsEditSettingsLinkedAccounts_me on Me {\n  hasSecondFactorEnabled\n  authentications {\n    provider\n    id\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
If you've tried to test account linking with your artsymail.com account, I'm sure you've been slightly surprised that you can't because of 2FA being enabled. Rather than going through the dance to get to the error message, we can just check to see if it's enabled and disable the buttons with an explanation.

<img width="1986" height="930" alt="image" src="https://github.com/user-attachments/assets/21625919-c7ff-4558-b9a6-fa3f7f3bdc53" />

cc @artsy/diamond-devs 