### PR TITLE
fix: do not block checkout if only express checkout fails to load

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Hooks/__tests__/useLoadCheckout.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/__tests__/useLoadCheckout.jest.tsx
@@ -40,6 +40,7 @@ const mockLogger = loggerFactory()
 jest.useFakeTimers()
 
 const mockSetLoadingComplete = jest.fn()
+const mockSetExpressCheckoutLoaded = jest.fn()
 const mockShowCheckoutErrorModal = jest.fn()
 
 const { useFragment } = jest.requireMock("react-relay")
@@ -94,6 +95,7 @@ describe("useLoadCheckout", () => {
       expressCheckoutPaymentMethods: null,
       steps: [{ state: CheckoutStepState.ACTIVE, name: "PAYMENT" }],
       setLoadingComplete: mockSetLoadingComplete,
+      setExpressCheckoutLoaded: mockSetExpressCheckoutLoaded,
       isInitialAutoSaveComplete: true,
     })
 
@@ -211,40 +213,16 @@ describe("useLoadCheckout", () => {
   })
 
   describe("loading timeout", () => {
-    it("sets loading_timeout error when MAX_LOADING_MS is exceeded", async () => {
-      renderHook(() => useLoadCheckout(mockOrder))
-
-      act(() => {
-        jest.advanceTimersByTime(MAX_LOADING_MS)
-      })
-
-      await waitFor(() => {
-        expect(mockShowCheckoutErrorModal).toHaveBeenCalledWith({
-          error: "loading_timeout",
-        })
-      })
-
-      expect(mockLogger.error).toHaveBeenCalled()
-      const errorCall = mockLogger.error.mock.calls[0][0]
-      expect(errorCall.message).toContain(
-        `Checkout loading state exceeded ${MAX_LOADING_MS}ms timeout`,
-      )
-    })
-
-    it("logs the current loading-gate flags when the timeout fires, not their initial values", async () => {
-      // Simulate the common failure path:
-      //   - minimumLoadingPassed has flipped to true via the 1s timer
-      //   - The Stripe redirect handler has called its callback
-      //   - The order validated synchronously
-      //   - isInitialAutoSaveComplete is true (no autosave needed for this user)
-      //   - expressCheckoutPaymentMethods is still null (Express Checkout never resolved)
-      // The Sentry log should reflect this exact shape so we can diagnose
-      // which flag was actually stuck, instead of always reporting all-false.
+    it("degrades gracefully without a modal when only Express Checkout is stuck", async () => {
+      // All other flags are good — only expressCheckoutPaymentMethods stays null.
+      // This is the Eigen-webview shape: Stripe.js never resolves the
+      // Express Checkout element, but the rest of the checkout is healthy.
       useCheckoutContext.mockReturnValue({
         isLoading: true,
         expressCheckoutPaymentMethods: null,
         steps: [],
         setLoadingComplete: mockSetLoadingComplete,
+        setExpressCheckoutLoaded: mockSetExpressCheckoutLoaded,
         isInitialAutoSaveComplete: true,
       })
 
@@ -266,17 +244,61 @@ describe("useLoadCheckout", () => {
       })
 
       await waitFor(() => {
-        expect(mockShowCheckoutErrorModal).toHaveBeenCalledWith({
-          error: "loading_timeout",
-        })
+        expect(mockLogger.error).toHaveBeenCalled()
       })
 
+      // Log fires with the *current* flag state so we can diagnose which
+      // flag was stuck, instead of always reporting all-false.
       const errorMessage = mockLogger.error.mock.calls[0][0].message
       expect(errorMessage).toContain("minimumLoadingPassed: true")
       expect(errorMessage).toContain("orderValidated: true")
       expect(errorMessage).toContain("isExpressCheckoutLoaded: false")
       expect(errorMessage).toContain("isStripeRedirectHandled: true")
       expect(errorMessage).toContain("isInitialAutoSaveComplete: true")
+
+      // No blocking modal; Express Checkout is force-emptied so the rest of
+      // the page can finish loading and the user can complete checkout.
+      expect(mockShowCheckoutErrorModal).not.toHaveBeenCalled()
+      expect(mockSetExpressCheckoutLoaded).toHaveBeenCalledWith([])
+    })
+
+    it("surfaces the modal when a flag other than Express Checkout is stuck", async () => {
+      // Express Checkout *is* loaded (empty list), but autosave never
+      // completed. This is a genuine problem — not graceful degradation —
+      // so the user should see the blocking modal.
+      useCheckoutContext.mockReturnValue({
+        isLoading: true,
+        expressCheckoutPaymentMethods: [],
+        steps: [],
+        setLoadingComplete: mockSetLoadingComplete,
+        setExpressCheckoutLoaded: mockSetExpressCheckoutLoaded,
+        isInitialAutoSaveComplete: false,
+      })
+
+      renderHook(() => useLoadCheckout(mockOrder))
+
+      // Pass the minimum-loading gate.
+      act(() => {
+        jest.advanceTimersByTime(MIN_LOADING_MS)
+      })
+
+      // Stripe redirect handler resolves.
+      act(() => {
+        mockStripeCallback?.()
+      })
+
+      act(() => {
+        jest.advanceTimersByTime(MAX_LOADING_MS - MIN_LOADING_MS)
+      })
+
+      await waitFor(() => {
+        expect(mockShowCheckoutErrorModal).toHaveBeenCalledWith({
+          error: "loading_timeout",
+        })
+      })
+
+      expect(mockLogger.error).toHaveBeenCalled()
+      expect(mockSetExpressCheckoutLoaded).not.toHaveBeenCalled()
     })
 
     it("does not set timeout error if loading completes before MAX_LOADING_MS", async () => {

--- a/src/Apps/Order2/Routes/Checkout/Hooks/useLoadCheckout.ts
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/useLoadCheckout.ts
@@ -31,6 +31,7 @@ export const useLoadCheckout = (order: useLoadCheckout_order$key) => {
   const {
     isLoading,
     setLoadingComplete,
+    setExpressCheckoutLoaded,
     expressCheckoutPaymentMethods,
     expressCheckoutState,
     steps,
@@ -155,20 +156,36 @@ export const useLoadCheckout = (order: useLoadCheckout_order$key) => {
     isInitialAutoSaveComplete,
   ])
 
-  // Set timeout for maximum loading duration
+  // After MAX_LOADING_MS without loading completing, log the stuck flags to
+  // Sentry, then either degrade gracefully (Express Checkout-only failure)
+  // or surface a blocking modal (anything else is stuck).
+  //
   // biome-ignore lint/correctness/useExhaustiveDependencies: 1-time effect
   useEffect(() => {
     const timeout = setTimeout(() => {
-      if (isLoadingRef.current && !loadingErrorRef.current) {
-        const loadingState = Object.entries(flagsRef.current)
-          .map(([key, value]) => `${key}: ${value}`)
-          .join(", ")
+      if (!isLoadingRef.current || loadingErrorRef.current) return
 
-        const error = new Error(
+      const flags = flagsRef.current
+      const loadingState = Object.entries(flags)
+        .map(([key, value]) => `${key}: ${value}`)
+        .join(", ")
+
+      logger.error(
+        new Error(
           `Checkout loading state exceeded ${MAX_LOADING_MS}ms timeout: ${loadingState}`,
-        )
+        ),
+      )
 
-        logger.error(error)
+      const onlyExpressCheckoutStuck =
+        !flags.isExpressCheckoutLoaded &&
+        flags.minimumLoadingPassed &&
+        flags.orderValidated &&
+        flags.isStripeRedirectHandled &&
+        flags.isInitialAutoSaveComplete
+
+      if (onlyExpressCheckoutStuck) {
+        setExpressCheckoutLoaded([])
+      } else {
         showCheckoutErrorModal({
           error: CheckoutModalError.LOADING_TIMEOUT,
         })

--- a/src/Apps/Order2/Routes/Checkout/Hooks/useLoadCheckout.ts
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/useLoadCheckout.ts
@@ -20,7 +20,7 @@ import { graphql, useFragment } from "react-relay"
 const logger = createLogger("useLoadCheckout.tsx")
 
 export const MIN_LOADING_MS = 1000
-export const MAX_LOADING_MS = 8000
+export const MAX_LOADING_MS = 6000
 
 export const useLoadCheckout = (order: useLoadCheckout_order$key) => {
   const [minimumLoadingPassed, setMinimumLoadingPassed] = useState(false)


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [EMI-3203]

### Description

After https://github.com/artsy/force/pull/17296, we started to log real flag values when the timeout happens, and from the [first few instances](https://artsynet.sentry.io/issues/7403011161/events/c2497974f179479bb63cd7ac7c5304a3/) they were indeed the express checkout.

<img width="1244" height="208" alt="Screenshot 2026-06-03 at 9 36 24 AM" src="https://github.com/user-attachments/assets/6002db4d-9ea6-4136-a0da-7e3706de18fb" />

We'll need to investigate further why express checkout fails (or are very slow) to load in those cases, but the first step is to continue rendering the rest of the checkout, without blocking the regular flow. Users would be able to continue with regular checkout when express checkout is not available.

### Before (simulated by blocking stripe.com domain in the browser)

<img width="1737" height="1004" alt="blocking-express-checkout" src="https://github.com/user-attachments/assets/dd89be2b-41b6-4e3b-ae9e-ba7076999b3c" />

### After

<img width="1737" height="1004" alt="no-blocking-express-checkout" src="https://github.com/user-attachments/assets/0af84607-0c64-4f34-b3b1-00f8dce6c1d6" />


[EMI-3203]: https://artsyproduct.atlassian.net/browse/EMI-3203?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ