### PR TITLE
feat: trigger event for the first edit after address autocomplete selection

### DIFF
--- a/src/Components/Address/AddressFormFields.tsx
+++ b/src/Components/Address/AddressFormFields.tsx
@@ -1,4 +1,8 @@
-import type { ContextModule } from "@artsy/cohesion"
+import {
+  ActionType,
+  type ContextModule,
+  type EditedAutocompletedAddress,
+} from "@artsy/cohesion"
 import {
   Checkbox,
   Column,
@@ -22,7 +26,8 @@ import { sortCountriesForCountryInput } from "Components/Address/utils/sortCount
 import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
 import { countries as countryPhoneOptions } from "Utils/countries"
 import { useFormikContext } from "formik"
-import { useMemo } from "react"
+import { type ChangeEvent, useMemo, useState } from "react"
+import { useTracking } from "react-tracking"
 
 export interface FormikContextWithAddress {
   address: Address
@@ -136,6 +141,30 @@ export const AddressFormFields = <V extends FormikContextWithAddress>(
     contextPageOwnerId: contextPageOwnerId || "",
   }
 
+  const [autocompletedNotYetEdited, setAutocompletedNotYetEdited] =
+    useState(false)
+  const { trackEvent } = useTracking()
+
+  const trackEditOnce = (field: keyof Address) => {
+    if (!autocompletedNotYetEdited) return
+
+    const event: EditedAutocompletedAddress = {
+      action: ActionType.editedAutocompletedAddress,
+      context_module: props.contextModule,
+      context_owner_type: contextPageOwnerType,
+      context_owner_id: contextPageOwnerId || "",
+      field,
+    }
+    trackEvent(event)
+    setAutocompletedNotYetEdited(false)
+  }
+
+  const handleAddressFieldChange =
+    (field: keyof Address) => (e: ChangeEvent<HTMLInputElement>) => {
+      handleChange(e)
+      trackEditOnce(field)
+    }
+
   const phoneInputType = useMemo(() => {
     if (props.withLegacyPhoneInput) {
       return "legacy"
@@ -194,6 +223,7 @@ export const AddressFormFields = <V extends FormikContextWithAddress>(
                 e.target.value.toLowerCase(),
               )
             }
+            trackEditOnce("country")
           }}
           onBlur={handleBlur}
           error={touchedAddress?.country && errorsAddress?.country}
@@ -216,7 +246,7 @@ export const AddressFormFields = <V extends FormikContextWithAddress>(
           placeholder="Add street address"
           title="Street address"
           value={values.address.addressLine1}
-          onChange={handleChange}
+          onChange={handleAddressFieldChange("addressLine1")}
           onSelect={option => {
             const selectedAddress = option.address
             setValues({
@@ -231,6 +261,7 @@ export const AddressFormFields = <V extends FormikContextWithAddress>(
                 country: selectedAddress.country,
               },
             })
+            setAutocompletedNotYetEdited(true)
           }}
           error={touchedAddress?.addressLine1 && errorsAddress?.addressLine1}
           onClear={() => {
@@ -248,7 +279,7 @@ export const AddressFormFields = <V extends FormikContextWithAddress>(
           placeholder="Add apartment, floor, suite, etc."
           autoComplete="address-line2"
           value={values.address?.addressLine2}
-          onChange={handleChange}
+          onChange={handleAddressFieldChange("addressLine2")}
           onBlur={handleBlur}
           error={touchedAddress?.addressLine2 && errorsAddress?.addressLine2}
         />
@@ -263,7 +294,7 @@ export const AddressFormFields = <V extends FormikContextWithAddress>(
           placeholder="Add city"
           autoComplete="address-level2"
           value={values.address?.city}
-          onChange={handleChange}
+          onChange={handleAddressFieldChange("city")}
           onBlur={handleBlur}
           error={touchedAddress?.city && errorsAddress?.city}
           required
@@ -279,7 +310,7 @@ export const AddressFormFields = <V extends FormikContextWithAddress>(
           placeholder="Add state, region or province"
           autoComplete="address-level1"
           value={values.address?.region}
-          onChange={handleChange}
+          onChange={handleAddressFieldChange("region")}
           onBlur={handleBlur}
           error={touchedAddress?.region && errorsAddress?.region}
           required={isRegionRequired(values.address.country)}
@@ -295,7 +326,7 @@ export const AddressFormFields = <V extends FormikContextWithAddress>(
           placeholder="Add ZIP/Postal code"
           autoComplete="postal-code"
           value={values.address?.postalCode}
-          onChange={handleChange}
+          onChange={handleAddressFieldChange("postalCode")}
           onBlur={handleBlur}
           error={touchedAddress?.postalCode && errorsAddress?.postalCode}
           required={isPostalCodeRequired(values.address.country)}

--- a/src/Components/Address/__tests__/AddressFormFields.tracking.jest.tsx
+++ b/src/Components/Address/__tests__/AddressFormFields.tracking.jest.tsx
@@ -1,0 +1,143 @@
+import { ContextModule } from "@artsy/cohesion"
+import { render, screen } from "@testing-library/react"
+import userEvent from "@testing-library/user-event"
+import { AddressFormFields } from "Components/Address/AddressFormFields"
+import { emptyAddress } from "Components/Address/utils"
+import { Formik } from "formik"
+import { useTracking } from "react-tracking"
+
+// Replace AddressAutocompleteInput with a stub: a plain input that mirrors
+// the field semantics, plus a button that fires `onSelect` with a fixture
+// address. This lets us drive the autocomplete selection deterministically
+// without hitting Smarty or wiring up suggestion UI.
+jest.mock("Components/Address/AddressAutocompleteInput", () => ({
+  AddressAutocompleteInput: ({ name, value, onChange, onSelect }: any) => (
+    <div>
+      <input
+        aria-label="Street address"
+        name={name}
+        value={value || ""}
+        onChange={onChange}
+        data-testid="autocomplete-input"
+      />
+      <button
+        type="button"
+        data-testid="select-autocomplete"
+        onClick={() =>
+          onSelect(
+            {
+              address: {
+                addressLine1: "123 Test St",
+                addressLine2: "",
+                city: "Test City",
+                region: "TS",
+                postalCode: "12345",
+                country: "US",
+              },
+            },
+            0,
+          )
+        }
+      >
+        Select suggestion
+      </button>
+    </div>
+  ),
+}))
+
+const mockTrackEvent = jest.fn()
+;(useTracking as jest.Mock).mockImplementation(() => ({
+  trackEvent: mockTrackEvent,
+}))
+
+const renderForm = () =>
+  render(
+    <Formik
+      onSubmit={jest.fn()}
+      initialValues={{ address: { ...emptyAddress, country: "US" } }}
+    >
+      <AddressFormFields contextModule={ContextModule.ordersFulfillment} />
+    </Formik>,
+  )
+
+describe("AddressFormFields — editedAutocompletedAddress tracking", () => {
+  beforeEach(() => {
+    mockTrackEvent.mockClear()
+  })
+
+  it("fires editedAutocompletedAddress on the first edit after a suggestion is selected", async () => {
+    renderForm()
+
+    await userEvent.click(screen.getByTestId("select-autocomplete"))
+
+    const city = screen.getByLabelText("City")
+    await userEvent.type(city, "X")
+
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      action: "editedAutocompletedAddress",
+      context_module: ContextModule.ordersFulfillment,
+      context_owner_type: undefined,
+      context_owner_id: "",
+      field: "city",
+    })
+  })
+
+  it("does not fire when the user edits a field without first selecting a suggestion", async () => {
+    renderForm()
+
+    const city = screen.getByLabelText("City")
+    await userEvent.type(city, "X")
+
+    expect(mockTrackEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ action: "editedAutocompletedAddress" }),
+    )
+  })
+
+  it("fires only once across multiple edits after a single selection", async () => {
+    renderForm()
+
+    await userEvent.click(screen.getByTestId("select-autocomplete"))
+
+    await userEvent.type(screen.getByLabelText("City"), "X")
+    await userEvent.type(
+      screen.getByLabelText("State, region or province"),
+      "Y",
+    )
+    await userEvent.type(screen.getByLabelText("ZIP/Postal code"), "Z")
+
+    const editEvents = mockTrackEvent.mock.calls.filter(
+      ([event]) => event.action === "editedAutocompletedAddress",
+    )
+    expect(editEvents).toHaveLength(1)
+    expect(editEvents[0][0].field).toBe("city")
+  })
+
+  it("re-enabled after a second selection so a later edit fires again", async () => {
+    renderForm()
+
+    await userEvent.click(screen.getByTestId("select-autocomplete"))
+    await userEvent.type(screen.getByLabelText("City"), "X")
+    await userEvent.click(screen.getByTestId("select-autocomplete"))
+    await userEvent.type(
+      screen.getByLabelText("State, region or province"),
+      "Y",
+    )
+
+    const editEvents = mockTrackEvent.mock.calls.filter(
+      ([event]) => event.action === "editedAutocompletedAddress",
+    )
+    expect(editEvents).toHaveLength(2)
+    expect(editEvents.map(([e]) => e.field)).toEqual(["city", "region"])
+  })
+
+  it("does not fire when the user edits the `name` field after a selection", async () => {
+    renderForm()
+
+    await userEvent.click(screen.getByTestId("select-autocomplete"))
+    await userEvent.type(screen.getByLabelText("Full name"), "Jane")
+
+    expect(mockTrackEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ action: "editedAutocompletedAddress" }),
+    )
+  })
+})


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves https://artsyproduct.atlassian.net/browse/EMI-3247

### Description

This implements the missing tracking event `EditedAutocompletedAddress` in order2. It's triggered for the first edit of any address input after selecting an autocomplete suggestion.

<img width="2548" height="1279" alt="Screenshot 2026-06-03 at 1 18 10 PM" src="https://github.com/user-attachments/assets/cc95e68d-fb88-49b7-b5ff-2b07d7291c57" />
