### PR TITLE
fix: clear fields on address form when they are not included in Smarty suggestions

### DIFF
--- a/src/Components/Address/AddressAutocompleteInput.tsx
+++ b/src/Components/Address/AddressAutocompleteInput.tsx
@@ -647,9 +647,19 @@ const fetchInternationalComponents = async ({
     throw new Error(`Address component lookup failed: ${response.status}`)
   }
   const json = (await response.json()) as {
-    candidates: InternationalAddressComponents[]
+    candidates: Array<Partial<InternationalAddressComponents>>
   }
-  return json.candidates?.[0] ?? null
+  const candidate = json.candidates?.[0]
+  if (!candidate) return null
+
+  return {
+    country_iso3: "",
+    administrative_area: "",
+    locality: "",
+    postal_code: "",
+    street: "",
+    ...candidate,
+  }
 }
 
 /**

--- a/src/Components/Address/__tests__/AddressAutocompleteInput.jest.tsx
+++ b/src/Components/Address/__tests__/AddressAutocompleteInput.jest.tsx
@@ -642,6 +642,61 @@ describe("AddressAutocompleteInput", () => {
       )
     })
 
+    it("defaults fields Smarty omits to empty strings on selection", async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          json: jest.fn().mockResolvedValue({
+            candidates: [
+              {
+                address_text: "10 Downing Street London SW1A 2AA",
+                address_id: "gb-addr-id",
+                entries: 1,
+              },
+            ],
+          }),
+          ok: true,
+        })
+        .mockResolvedValueOnce({
+          json: jest.fn().mockResolvedValue({
+            // Smarty omits administrative_area when it has no value for it.
+            candidates: [
+              {
+                country_iso3: "GBR",
+                locality: "London",
+                postal_code: "SW1A 2AA",
+                street: "10 Downing Street",
+              },
+            ],
+          }),
+          ok: true,
+        })
+
+      render(<TestImplementation initialAddress={{ country: "GB" }} />)
+
+      const line1Input = screen.getByPlaceholderText("Autocomplete input")
+      await userEvent.paste(line1Input, "10 Downing")
+
+      const dropdown = await screen.findByRole("listbox", { hidden: true })
+      await userEvent.click(
+        within(dropdown).getByText("10 Downing Street London SW1A 2AA"),
+      )
+      await flushPromiseQueue()
+
+      expect(mockOnSelect).toHaveBeenCalledWith(
+        expect.objectContaining({
+          address: {
+            addressLine1: "10 Downing Street",
+            addressLine2: "",
+            city: "London",
+            region: "",
+            postalCode: "SW1A 2AA",
+            country: "GB",
+          },
+        }),
+        0,
+      )
+    })
+
     it("falls back to full address_text in addressLine1 when components endpoint returns no components", async () => {
       mockFetch
         .mockResolvedValueOnce({


### PR DESCRIPTION


The type of this PR is: **Fix**
This PR solves [EMI-3271]

### Description

Smarty suggestions for UK addresses might not have the `administrative_area` in the response, which we use for region. 

| UK | Italy |
|--------|--------|
| <img width="547" height="172" alt="Screenshot 2026-06-03 at 2 22 30 PM" src="https://github.com/user-attachments/assets/f05a3f57-3826-499a-854b-9073f755a571" /> | <img width="549" height="239" alt="Screenshot 2026-06-03 at 2 23 24 PM" src="https://github.com/user-attachments/assets/eaef3091-bcac-4bdc-a96d-c42df0f24634" /> |

That `undefined` flowed through the form's `setValues`, which turned the input from controlled to uncontrolled. React left the previously typed/selected value sitting in the DOM instead of clearing it. The fix preserves the required fields and defaults to empty string when any is missing from the Smarty responses.

<details><summary>Recording for before</summary>
<p>

<img width="1916" height="1164" alt="clear-state" src="https://github.com/user-attachments/assets/5dc44ec6-f854-4b6f-9691-59477f771c0d" />


</p>
</details> 

<details><summary>Recording for after</summary>
<p>

<img width="1916" height="1164" alt="clear-state-correctly" src="https://github.com/user-attachments/assets/18cb43ac-92ad-42b2-8128-2dfff4584fb2" />

</p>
</details> 

[EMI-3271]: https://artsyproduct.atlassian.net/browse/EMI-3271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ