### PR TITLE
feat: fetch 10 intl. suggestions to surface more single entry suggestions

### DIFF
--- a/src/Components/Address/AddressAutocompleteInput.tsx
+++ b/src/Components/Address/AddressAutocompleteInput.tsx
@@ -30,6 +30,7 @@ const { key: API_KEY } = getENV("SMARTY_EMBEDDED_KEY_JSON") || { key: "" }
 
 const THROTTLE_DELAY = 500
 const INTERNATIONAL_LICENSE = "international-autocomplete-v2-cloud"
+const INTERNATIONAL_MAX_RESULTS = 10
 const SMARTY_US_AUTOCOMPLETE_URL =
   "https://us-autocomplete-pro.api.smarty.com/lookup"
 const SMARTY_INTL_AUTOCOMPLETE_URL =
@@ -384,7 +385,7 @@ export const AddressAutocompleteInput = ({
               // Multiple entry suggestions require secondary address selection which we
               // don't have a UI for yet.
               .filter((c: ProviderSuggestionInternational) => c.entries === 1)
-              .slice(0, 5),
+              .slice(0, INTERNATIONAL_MAX_RESULTS),
           })
         }
       } catch (e) {
@@ -596,7 +597,7 @@ const fetchInternationalSuggestionsWithThrottle = throttle(
       key: apiKey,
       search,
       country,
-      max_results: "5",
+      max_results: String(INTERNATIONAL_MAX_RESULTS),
       license: INTERNATIONAL_LICENSE,
     }
 


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [EMI-3182]

### Description

Smarty recommended to implement secondary info autocomplete for international addresses by only showing the suggestions with a single entry and letting users keep typing until it's shown. The filtering approach might show fewer than 5 suggestions that's currently fetched/displayed. This changes it to 10 suggestions with the goal of narrowing down matches more quickly.

Will need to test it out on smaller viewports like the app and see how the interaction looks like.

[EMI-3182]: https://artsyproduct.atlassian.net/browse/EMI-3182?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ