### PR TITLE
chore: Remove subheader on all partner offer activity notifications

### DIFF
--- a/src/Components/Notifications/PartnerOfferCreatedNotification.tsx
+++ b/src/Components/Notifications/PartnerOfferCreatedNotification.tsx
@@ -30,8 +30,8 @@ export const PartnerOfferCreatedNotification: FC<
   const { hasEnded } = useTimer(partnerOffer?.endAt || "")
   const isOfferFromSaves = partnerOffer?.source === "SAVE"
 
-  let subtitle = isOfferFromSaves
-    ? "Review the offer on your saved artwork"
+  let subtitle: string | null = isOfferFromSaves
+    ? null
     : "Review the offer before it expires"
 
   if (hasEnded)
@@ -69,7 +69,7 @@ export const PartnerOfferCreatedNotification: FC<
         </Flex>
       </Flex>
 
-      <Text variant="sm-display">{subtitle}</Text>
+      {subtitle && <Text variant="sm-display">{subtitle}</Text>}
 
       <Spacer y={0.5} />
 

--- a/src/Components/Notifications/__tests__/PartnerOfferCreatedNotification.jest.tsx
+++ b/src/Components/Notifications/__tests__/PartnerOfferCreatedNotification.jest.tsx
@@ -38,9 +38,6 @@ describe("PartnerOfferCreatedNotification", () => {
 
     // header
     expect(screen.getByText("Saved work by Damon Zucconi")).toBeInTheDocument()
-    expect(
-      screen.getByText("Review the offer on your saved artwork"),
-    ).toBeInTheDocument()
     expect(screen.getByTestId("manage-saves-link")).toHaveAttribute(
       "href",
       "/favorites/saves",


### PR DESCRIPTION
The type of this PR is: **CHORE**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [TOP-301](https://artsyproduct.atlassian.net/browse/TOP-301)

### Description

chore: Remove subheader on all partner offer activity notifications
This should be removed for all partner offer either from `saves` or the soon in the future `conversations`


## Before
<img width="1917" height="819" alt="Screenshot 2026-06-03 at 5 36 44 PM" src="https://github.com/user-attachments/assets/f4ea8d53-45e7-435d-b63a-1315bac345e2" />


## After
<img width="1917" height="921" alt="Screenshot 2026-06-03 at 5 34 31 PM" src="https://github.com/user-attachments/assets/85663449-b240-4fa1-af7e-dddeaa1b1274" />

<!-- Implementation description -->


[TOP-301]: https://artsyproduct.atlassian.net/browse/TOP-301?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ