### PR TITLE
fix(auth): prevents loading spinner flash on welcome transition

### DIFF
--- a/src/Components/AuthDialog/Views/AuthDialogWelcome.tsx
+++ b/src/Components/AuthDialog/Views/AuthDialogWelcome.tsx
@@ -33,8 +33,6 @@ export const AuthDialogWelcome: FC<
         mode: AUTHENTICATION_MODES.Pending,
       }}
       onSubmit={async ({ email }) => {
-        dispatch({ type: "SET", payload: { values: { email } } })
-
         try {
           const recaptchaToken = await recaptcha("verify_user")
 
@@ -52,6 +50,7 @@ export const AuthDialogWelcome: FC<
 
           const mode = verifyUser.exists ? "Login" : "SignUp"
 
+          dispatch({ type: "SET", payload: { values: { email } } })
           dispatch({ type: "MODE", payload: { mode } })
         } catch (error) {
           console.error(error)


### PR DESCRIPTION
Noticed this while logging in the other day: the "Continue" button on the `Welcome` step of `AuthDialog` was visibly dropping out of its loading state for a moment before the dialog transitioned to the `Login` or `SignUp` view. Made it feel like the click had failed briefly.

This move the `SET` dispatch, so the context update batches with the view swap and we no longer see it drop out of that state.

cc @artsy/diamond-devs 