### PR TITLE
fix: scrolling for streamlined checkout

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Hooks/__tests__/useCheckoutAutoScroll.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/__tests__/useCheckoutAutoScroll.jest.tsx
@@ -38,6 +38,21 @@ const createSteps = (activeStep: CheckoutStepName) => {
   }))
 }
 
+const createStepsWithMultipleActive = (activeSteps: CheckoutStepName[]) => {
+  const activeIndices = activeSteps.map(s => ALL_STEPS.indexOf(s))
+  const firstActive = Math.min(...activeIndices)
+  const lastActive = Math.max(...activeIndices)
+  return ALL_STEPS.map((name, index) => ({
+    name,
+    state:
+      index < firstActive
+        ? CheckoutStepState.COMPLETED
+        : index >= firstActive && index <= lastActive
+          ? CheckoutStepState.ACTIVE
+          : CheckoutStepState.UPCOMING,
+  }))
+}
+
 describe("useCheckoutAutoScroll", () => {
   let mockJumpTo: jest.Mock
 
@@ -157,6 +172,79 @@ describe("useCheckoutAutoScroll", () => {
     expect(mockJumpTo).toHaveBeenCalledWith("fulfillment-details-step", {
       behavior: "smooth",
       offset: 30,
+    })
+  })
+
+  describe("combined FULFILLMENT_DETAILS + DELIVERY_OPTION step", () => {
+    it("scrolls to the first active step (FULFILLMENT_DETAILS) on initial load", () => {
+      const steps = createStepsWithMultipleActive([
+        CheckoutStepName.FULFILLMENT_DETAILS,
+        CheckoutStepName.DELIVERY_OPTION,
+      ])
+
+      mockUseCheckoutContext.mockReturnValue({ isLoading: true, steps })
+
+      const { rerender } = renderHook(() => useCheckoutAutoScroll())
+
+      mockUseCheckoutContext.mockReturnValue({ isLoading: false, steps })
+
+      rerender()
+      jest.runAllTimers()
+
+      expect(mockJumpTo).toHaveBeenCalledWith("fulfillment-details-step", {
+        behavior: "smooth",
+        offset: 30,
+      })
+    })
+
+    it("scrolls to DELIVERY_OPTION when advancing from the combined step to PAYMENT", () => {
+      mockUseCheckoutContext.mockReturnValue({
+        isLoading: false,
+        steps: createStepsWithMultipleActive([
+          CheckoutStepName.FULFILLMENT_DETAILS,
+          CheckoutStepName.DELIVERY_OPTION,
+        ]),
+      })
+
+      const { rerender } = renderHook(() => useCheckoutAutoScroll())
+
+      mockUseCheckoutContext.mockReturnValue({
+        isLoading: false,
+        steps: createSteps(CheckoutStepName.PAYMENT),
+      })
+
+      rerender()
+      jest.runAllTimers()
+
+      expect(mockJumpTo).toHaveBeenCalledWith("delivery-options-step", {
+        behavior: "smooth",
+        offset: 30,
+      })
+    })
+
+    it("scrolls to FULFILLMENT_DETAILS when going back from PAYMENT to the combined step", () => {
+      mockUseCheckoutContext.mockReturnValue({
+        isLoading: false,
+        steps: createSteps(CheckoutStepName.PAYMENT),
+      })
+
+      const { rerender } = renderHook(() => useCheckoutAutoScroll())
+
+      mockUseCheckoutContext.mockReturnValue({
+        isLoading: false,
+        steps: createStepsWithMultipleActive([
+          CheckoutStepName.FULFILLMENT_DETAILS,
+          CheckoutStepName.DELIVERY_OPTION,
+        ]),
+      })
+
+      rerender()
+      jest.runAllTimers()
+
+      expect(mockJumpTo).toHaveBeenCalledWith("fulfillment-details-step", {
+        behavior: "smooth",
+        offset: 30,
+      })
     })
   })
 })

--- a/src/Apps/Order2/Routes/Checkout/Hooks/useCheckoutAutoScroll.ts
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/useCheckoutAutoScroll.ts
@@ -24,10 +24,14 @@ export const useCheckoutAutoScroll = () => {
   const { isLoading, steps } = useCheckoutContext()
   const { scrollToStep } = useScrollToStep()
 
-  const activeStep = steps.find(step => step.state === CheckoutStepState.ACTIVE)
+  const activeSteps = steps.filter(
+    step => step.state === CheckoutStepState.ACTIVE,
+  )
+  const activeStep = activeSteps[0]
+  const trailingActiveStep = activeSteps[activeSteps.length - 1]
   const activeStepIndex = stepWithIndex(activeStep, steps)
 
-  const previousStep = usePrevious(activeStep)
+  const previousStep = usePrevious(trailingActiveStep)
   const previousStepIndex = stepWithIndex(previousStep, steps)
 
   const wasLoading = usePrevious(isLoading)

--- a/src/Apps/Order2/Routes/Checkout/Hooks/useCheckoutAutoScroll.ts
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/useCheckoutAutoScroll.ts
@@ -24,6 +24,8 @@ export const useCheckoutAutoScroll = () => {
   const { isLoading, steps } = useCheckoutContext()
   const { scrollToStep } = useScrollToStep()
 
+  // Combined steps (FULFILLMENT_DETAILS + DELIVERY_OPTION) are ACTIVE
+  // together, use the last one so forward-advance previousStep is correct.
   const activeSteps = steps.filter(
     step => step.state === CheckoutStepState.ACTIVE,
   )


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-3256]

### Description

This fixes the page jump for the streamlined checkout. Now that the fulfillment step and delivery steps are combined, it was scrolling to the fulfillment step on continue to payment, but it should scroll to the delivery step. 


https://github.com/user-attachments/assets/1c09f350-5a37-439b-824e-847a922f7391



<!-- Implementation description -->


[EMI-3256]: https://artsyproduct.atlassian.net/browse/EMI-3256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ