### PR TITLE
fix(system): recover from transient null-data crashes during route navigation

### DIFF
--- a/src/Apps/Components/AppShell.tsx
+++ b/src/Apps/Components/AppShell.tsx
@@ -1,6 +1,7 @@
 import { Layout } from "Apps/Components/Layouts"
 import { ContentErrorBoundary } from "System/Components/ContentErrorBoundary"
 import { PageLoadingBar } from "System/Components/PageLoadingBar"
+import { TransientRouteErrorBoundary } from "System/Components/TransientRouteErrorBoundary"
 import { AnalyticsContextProvider } from "System/Contexts/AnalyticsContext"
 import { NavigationHistoryProvider } from "System/Contexts/NavigationHistoryContext"
 import { findCurrentRoute } from "System/Router/Utils/routeUtils"
@@ -69,7 +70,13 @@ export const AppShell: React.FC<
                 nav/footer. Re-throws chunk load errors to the outer boundary in
                 Boot.tsx. See docs/error-handling.md for the two-tier system. */}
             <ContentErrorBoundary pathname={match?.location?.pathname}>
-              {children}
+              {/* Swallows transient null-data crashes during route navigation
+                  and recovers when the next route commits; re-throws genuine
+                  errors to ContentErrorBoundary above. Remove this wrapper to
+                  disable that behavior. */}
+              <TransientRouteErrorBoundary pathname={match?.location?.pathname}>
+                {children}
+              </TransientRouteErrorBoundary>
             </ContentErrorBoundary>
           </Layout>
 

--- a/src/System/Components/TransientRouteErrorBoundary.tsx
+++ b/src/System/Components/TransientRouteErrorBoundary.tsx
@@ -1,0 +1,107 @@
+import { HttpError } from "found"
+import * as React from "react"
+
+interface TransientRouteErrorBoundaryProps {
+  children?: React.ReactNode
+  pathname?: string
+}
+
+interface TransientRouteErrorBoundaryState {
+  caughtError: Error | HttpError | null
+  rethrow: boolean
+}
+
+/**
+ * Swallows transient null-data crashes that occur *while a route navigation is
+ * in flight* and recovers automatically once the next route commits.
+ *
+ * Top-level route components read their principal entity from Relay and access
+ * its fields directly (the generated types say it is non-null because
+ * `@principalField` guarantees it at fetch time). During a navigation
+ * transition that data can briefly resolve to `null`, and the component throws.
+ * Those crashes are transient — the app recovers as soon as the next route
+ * renders — so surfacing the error page + reporting to Sentry is just noise.
+ *
+ * This boundary owns *only* that concern:
+ *
+ * - A crash that coincides with an in-flight navigation: render nothing and
+ *   recover when the next route commits (componentDidUpdate, on pathname
+ *   change).
+ * - Anything else (genuine errors on the current page, HttpErrors, chunk-load
+ *   errors): re-thrown to the surrounding `ContentErrorBoundary`, which is
+ *   unchanged and still owns all error UI and Sentry reporting.
+ *
+ * To remove this behavior entirely: delete this file and unwrap it in
+ * `AppShell`. Nothing else depends on it.
+ */
+export class TransientRouteErrorBoundary extends React.Component<
+  TransientRouteErrorBoundaryProps,
+  TransientRouteErrorBoundaryState
+> {
+  state: TransientRouteErrorBoundaryState = {
+    caughtError: null,
+    rethrow: false,
+  }
+
+  static getDerivedStateFromError(
+    error: Error | HttpError,
+  ): Partial<TransientRouteErrorBoundaryState> {
+    // Hold the error; the swallow-vs-rethrow decision is made in
+    // componentDidCatch (which has access to props) and frozen into state so
+    // render() never re-derives it.
+    return { caughtError: error }
+  }
+
+  componentDidCatch(error: Error | HttpError): void {
+    // Transient mid-navigation crash: do nothing — render nothing and let the
+    // next route recover us. Anything else is handed off to
+    // ContentErrorBoundary on the next render.
+    if (!this.shouldSwallow(error)) {
+      this.setState({ rethrow: true })
+    }
+  }
+
+  componentDidUpdate(prevProps: TransientRouteErrorBoundaryProps): void {
+    // The next route committed: recover and render it.
+    if (prevProps.pathname !== this.props.pathname && this.state.caughtError) {
+      this.setState({ caughtError: null, rethrow: false })
+    }
+  }
+
+  /**
+   * A navigation is in flight when the live URL has already advanced to the
+   * destination but this boundary's committed `pathname` prop (frozen by the
+   * router's StaticContainer during the pending transition) still reflects the
+   * route we are leaving.
+   */
+  private isNavigating(): boolean {
+    if (typeof window === "undefined") return false
+    return window.location.pathname !== this.props.pathname
+  }
+
+  private shouldSwallow(error: Error | HttpError): boolean {
+    // Deliberate router errors and chunk-load failures are not transient.
+    if (error instanceof HttpError) return false
+    if (error.message?.match(/Loading chunk .* failed/)) return false
+
+    // Only a crash that coincides with an in-flight navigation is treated as a
+    // transient teardown.
+    return this.isNavigating()
+  }
+
+  render(): React.ReactNode {
+    const { caughtError, rethrow } = this.state
+
+    if (caughtError) {
+      // Genuine errors bubble to ContentErrorBoundary.
+      if (rethrow) {
+        throw caughtError
+      }
+
+      // Transient: render nothing until the next route commits.
+      return null
+    }
+
+    return this.props.children
+  }
+}

--- a/src/System/Components/__tests__/TransientRouteErrorBoundary.jest.tsx
+++ b/src/System/Components/__tests__/TransientRouteErrorBoundary.jest.tsx
@@ -1,0 +1,124 @@
+import { TransientRouteErrorBoundary } from "System/Components/TransientRouteErrorBoundary"
+import { render, screen } from "@testing-library/react"
+import { HttpError } from "found"
+import * as React from "react"
+
+// Stand-in for the surrounding ContentErrorBoundary: records anything the
+// transient boundary re-throws.
+class OuterBoundary extends React.Component<
+  { children?: React.ReactNode },
+  { caught: boolean }
+> {
+  state = { caught: false }
+
+  static getDerivedStateFromError(): { caught: boolean } {
+    return { caught: true }
+  }
+
+  render(): React.ReactNode {
+    if (this.state.caught) {
+      return <div>Outer boundary caught</div>
+    }
+    return this.props.children
+  }
+}
+
+const Throw: React.FC<{ error: Error | HttpError }> = ({ error }) => {
+  throw error
+}
+
+const renderWithin = (
+  pathname: string,
+  child: React.ReactNode,
+): ReturnType<typeof render> => {
+  return render(
+    <OuterBoundary>
+      <TransientRouteErrorBoundary pathname={pathname}>
+        {child}
+      </TransientRouteErrorBoundary>
+    </OuterBoundary>,
+  )
+}
+
+const setLocation = (pathname: string): void => {
+  window.history.replaceState({}, "", pathname)
+}
+
+describe("TransientRouteErrorBoundary", () => {
+  const errorLog = console.error
+
+  beforeAll(() => {
+    console.error = jest.fn()
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+    setLocation("/")
+  })
+
+  afterAll(() => {
+    console.error = errorLog
+  })
+
+  it("renders children when there is no error", () => {
+    setLocation("/page-1")
+
+    renderWithin("/page-1", <div>Route content</div>)
+
+    expect(screen.getByText("Route content")).toBeInTheDocument()
+    expect(screen.queryByText("Outer boundary caught")).not.toBeInTheDocument()
+  })
+
+  it("swallows a transient crash during navigation and recovers on the next route", () => {
+    // URL already advanced to the destination; committed pathname still old.
+    setLocation("/page-2")
+
+    const { rerender } = renderWithin(
+      "/page-1",
+      <Throw error={new Error("transient null")} />,
+    )
+
+    // Rendered nothing, did not bubble to the outer boundary.
+    expect(screen.queryByText("Outer boundary caught")).not.toBeInTheDocument()
+
+    // The new route commits.
+    rerender(
+      <OuterBoundary>
+        <TransientRouteErrorBoundary pathname="/page-2">
+          <div>Recovered content</div>
+        </TransientRouteErrorBoundary>
+      </OuterBoundary>,
+    )
+
+    expect(screen.getByText("Recovered content")).toBeInTheDocument()
+    expect(screen.queryByText("Outer boundary caught")).not.toBeInTheDocument()
+  })
+
+  it("re-throws a genuine crash (not navigating) to the outer boundary", () => {
+    // URL matches committed pathname -> not navigating.
+    setLocation("/page-1")
+
+    renderWithin("/page-1", <Throw error={new Error("genuine crash")} />)
+
+    expect(screen.getByText("Outer boundary caught")).toBeInTheDocument()
+  })
+
+  it("re-throws HttpErrors to the outer boundary even mid-navigation", () => {
+    setLocation("/page-2")
+
+    renderWithin("/page-1", <Throw error={new HttpError(404)} />)
+
+    expect(screen.getByText("Outer boundary caught")).toBeInTheDocument()
+  })
+
+  it("re-throws chunk-load errors to the outer boundary even mid-navigation", () => {
+    setLocation("/page-2")
+
+    renderWithin(
+      "/page-1",
+      <Throw error={new Error("Loading chunk abc.js failed")} />,
+    )
+
+    expect(screen.getByText("Outer boundary caught")).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
So, I wired up the Sentry MCP and was exploring errors. A big class is comprised of null access errors (`Cannot read properties of null (reading '...')`, etc). After fixing a few of these, I noticed the same pattern repeating itself: we were accessing a property on a type that Metaphysics reports as non-nullable. This is unusual and typically should 404, because they tend to be principal fields. The fact that they were coming up null some of the time suggests some other problem rather than them being null at fetch and rendering anyway.

It seems that during a client-side route transition the component can be re-rendered for a moment with that data `null`, and it throws. Today `ContentErrorBoundary` catches the throw, flashes the "Something Went Wrong" page mid-navigation, and reports it to Sentry, even though the app recovers when the next route commits. This is a property of how the router keeps the outgoing page mounted during the pending transition while Relay store activity briefly resolves the principal field to null.

This is a weird one to fix, as it seems like ultimately it originates from within `found-relay` (see trade-offs, below). 

Ultimately this treats the symptom for now. We introduce a new error boundary, `TransientRouteErrorBoundary`, between `ContentErrorBoundary` and the route content in `AppShell`. It owns *only* this transient-recovery concern.

- **Mid-navigation crash** (the live URL has already advanced, but the boundary's committed `pathname` prop, frozen by the router's `StaticContainer` during the pending transition, still points at the route we're leaving): treat it as a transient teardown. Render nothing and recover automatically when the next route commits. (No error page, no Sentry reporting).

- **Everything else** (genuine errors on the current page, `HttpError`s, chunk-load failures): re-thrown to `ContentErrorBoundary`, which is unchanged and still owns all error UI + Sentry reporting. Errors surface immediately.

These are the types of issues that this should mitigate:

- [`Cannot read properties of null …`](https://artsynet.sentry.io/explore/discover/homepage/?dataset=errors&queryDataset=error-events&query=errorBoundary%3Acontent+message%3A%22*Cannot+read+properties+of+null*%22&project=28316&field=count%28%29&statsPeriod=90d&mode=aggregate&yAxis=count%28%29)
- [`null is not an object …`](https://artsynet.sentry.io/explore/discover/homepage/?dataset=errors&queryDataset=error-events&query=errorBoundary%3Acontent+message%3A%22*null+is+not+an+object*%22&project=28316&field=count%28%29&statsPeriod=90d&mode=aggregate&yAxis=count%28%29)
- [`… as it is null`](https://artsynet.sentry.io/explore/discover/homepage/?dataset=errors&queryDataset=error-events&query=errorBoundary%3Acontent+message%3A%22*as+it+is+null*%22&project=28316&field=count%28%29&statsPeriod=90d&mode=aggregate&yAxis=count%28%29)

Possibly addressed (a null-guarded component renders a different number of hooks; mitigated only when mid-navigation):

- [`Rendered fewer hooks than expected …`](https://artsynet.sentry.io/explore/discover/homepage/?dataset=errors&queryDataset=error-events&query=errorBoundary%3Acontent+message%3A%22*Rendered+fewer+hooks*%22&project=28316&field=count%28%29&statsPeriod=90d&mode=aggregate&yAxis=count%28%29) 

### Trade-offs

- This catches the transient at the boundary rather than preventing the null at the data layer. The exact operation that publishes the null principal field isn't pinned down (it would need runtime store instrumentation and likely a `found-relay` patch); the boundary neutralizes the whole class regardless of the precise trigger.
- Some genuine errors may go unreported. A real error that the user navigates away from within the transition looks identical to a transient and won't be reported.

### After deploy

Watch [`errorBoundary:content "Cannot read properties of null"`](https://artsynet.sentry.io/explore/discover/homepage/?dataset=errors&queryDataset=error-events&query=errorBoundary%3Acontent+message%3A%22*Cannot+read+properties+of+null*%22&project=28316&field=count%28%29&statsPeriod=90d&mode=aggregate&yAxis=count%28%29) and the Safari `null is not an object` variant. Transient navigation nulls should drop; genuine same-page crashes should still report.

cc @artsy/diamond-devs 