### PR TITLE
fix: require selected fulfillment option to complete shipping step

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/__tests__/Order2DeliveryOptionsForm.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/__tests__/Order2DeliveryOptionsForm.jest.tsx
@@ -381,15 +381,14 @@ describe("Order2DeliveryOptionsForm", () => {
         name: "Continue to Payment",
       })
 
-      await userEvent.click(continueButton)
+      // Button should be disabled because BUY orders require a valid fulfillment option
+      expect(continueButton).toBeDisabled()
 
       // Should not call the mutation for BUY orders
       expect(mockSetOrderFulfillmentOption).not.toHaveBeenCalled()
 
-      // Should still complete the step
-      expect(mockCheckoutContext.completeStep).toHaveBeenCalledWith(
-        CheckoutStepName.DELIVERY_OPTION,
-      )
+      // Should not complete the step since no valid option is selected
+      expect(mockCheckoutContext.completeStep).not.toHaveBeenCalled()
     })
   })
 

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/useCompleteFulfillmentDetailsData.ts
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/useCompleteFulfillmentDetailsData.ts
@@ -5,7 +5,6 @@ import { graphql, useFragment } from "react-relay"
 /**
  * Hook that returns props for the completed fulfillment details view if the step is complete.
  * Returns null if fulfillment details are not complete.
- * Fulfillment details is complete if the backend has saved minimal address data.
  */
 export const useCompleteFulfillmentDetailsData = (
   order: useCompleteFulfillmentDetailsData_order$key,
@@ -17,41 +16,58 @@ export const useCompleteFulfillmentDetailsData = (
   if (!fulfillmentDetails) {
     return null
   }
-  switch (orderData.selectedFulfillmentOption?.type) {
-    case "PICKUP":
-      return {
-        isPickup: true,
-        fulfillmentDetails: {
-          name: fulfillmentDetails?.name,
-          phoneNumber: orderData.fulfillmentDetails?.phoneNumber?.display,
-        },
-        isOffer,
-      }
-    default:
-      const isComplete = ["addressLine1", "country", "name"].every(field => {
-        return (
-          fulfillmentDetails[field as keyof typeof fulfillmentDetails] != null
-        )
-      })
 
-      if (!isComplete) {
-        return null
-      }
+  const selectedType = orderData.selectedFulfillmentOption?.type
 
-      return {
-        isPickup: false,
-        fulfillmentDetails: {
-          name: fulfillmentDetails?.name || null,
-          addressLine1: fulfillmentDetails?.addressLine1 || null,
-          addressLine2: fulfillmentDetails?.addressLine2 || null,
-          city: fulfillmentDetails?.city || null,
-          region: fulfillmentDetails?.region || null,
-          postalCode: fulfillmentDetails?.postalCode || null,
-          country: orderData.fulfillmentDetails?.country || null,
-          phoneNumber:
-            orderData.fulfillmentDetails?.phoneNumber?.display || null,
-        },
-      }
+  // For pickup: step is complete if name and phone number exist and PICKUP is selected.
+  if (selectedType === "PICKUP") {
+    return {
+      isPickup: true,
+      fulfillmentDetails: {
+        name: fulfillmentDetails?.name,
+        phoneNumber: orderData.fulfillmentDetails?.phoneNumber?.display,
+      },
+      isOffer,
+    }
+  }
+
+  /**
+   * For delivery addresses:
+   * - In BUY mode: requires both address data AND a valid fulfillment option to be selected.
+   *   If address exists but no fulfillment option is set, this indicates an error state
+   *   (e.g., missing postal code, unsupported region) and the step should remain active.
+   * - In OFFER mode: address data alone is sufficient since shipping is determined later (TBD).
+   *   However, we still validate that basic required fields are present.
+   *
+   * For pickup: step is complete if name and phone number exist and PICKUP is selected.
+   */
+  const isComplete = ["addressLine1", "country", "name"].every(field => {
+    return fulfillmentDetails[field as keyof typeof fulfillmentDetails] != null
+  })
+
+  if (!isComplete) {
+    return null
+  }
+
+  // In BUY mode fulfillment option has to be selected.
+  // If address exists but no option is selected, step is incomplete.
+  if (!isOffer && !selectedType) {
+    return null
+  }
+
+  // Step is complete - return the view props
+  return {
+    isPickup: false,
+    fulfillmentDetails: {
+      name: fulfillmentDetails?.name || null,
+      addressLine1: fulfillmentDetails?.addressLine1 || null,
+      addressLine2: fulfillmentDetails?.addressLine2 || null,
+      city: fulfillmentDetails?.city || null,
+      region: fulfillmentDetails?.region || null,
+      postalCode: fulfillmentDetails?.postalCode || null,
+      country: orderData.fulfillmentDetails?.country || null,
+      phoneNumber: orderData.fulfillmentDetails?.phoneNumber?.display || null,
+    },
   }
 }
 

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/useCompleteFulfillmentDetailsData.ts
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/useCompleteFulfillmentDetailsData.ts
@@ -38,8 +38,6 @@ export const useCompleteFulfillmentDetailsData = (
    *   (e.g., missing postal code, unsupported region) and the step should remain active.
    * - In OFFER mode: address data alone is sufficient since shipping is determined later (TBD).
    *   However, we still validate that basic required fields are present.
-   *
-   * For pickup: step is complete if name and phone number exist and PICKUP is selected.
    */
   const isComplete = ["addressLine1", "country", "name"].every(field => {
     return fulfillmentDetails[field as keyof typeof fulfillmentDetails] != null


### PR DESCRIPTION
Hopefully addresses: https://artsyproduct.atlassian.net/browse/EMI-3266

  The issue was that we only considered the presence of `addressLine1`, `country`, and `name` as requirements for completing the step. This
  worked fine when the step only handled shipping addresses, but now that it's been expanded to "fulfillment details" (including delivery
  option selection), those rules have become insufficient.

  The step completion logic is encapsulated in `useCompleteFulfillmentDetailsData`, which is good for maintainability. However, I'm not
  entirely happy with how much business logic lives in the frontend. Ideally, we could move this logic to Metaphysics, but that refactor
  doesn't seem worth it at this point.

  This fix adds the requirement that BUY orders must have a `selectedFulfillmentOption` before the step can complete. I don't have high
  confidence that this won't break some edge case flows, but our test coverage is extensive and should catch most issues.