### PR TITLE
feat: do not wait for address auto save when loading checkout; reduce timeout

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/CheckoutContext/Order2CheckoutContext.tsx
+++ b/src/Apps/Order2/Routes/Checkout/CheckoutContext/Order2CheckoutContext.tsx
@@ -115,9 +115,6 @@ export interface Order2CheckoutModel {
     }
   >
   setIsFulfillmentDetailsSaving: Action<this, boolean>
-  /** True once any eager pre-load address auto-save has completed (or is not needed). */
-  isInitialAutoSaveComplete: boolean
-  setInitialAutoSaveComplete: Action<this>
   /** Persists the last-used saved credit card ID. Only relevant for saved card payments. */
   setLastUsedPaymentMethodId: Action<this, string>
 }
@@ -139,7 +136,6 @@ export const Order2CheckoutContext: ReturnType<
   userAddressMode: null,
   messages: {},
   artworkPath: "/",
-  isInitialAutoSaveComplete: true,
 
   // Required runtime props - will be provided by Provider
   // These will be overridden by the Provider with actual values
@@ -258,10 +254,6 @@ export const Order2CheckoutContext: ReturnType<
     state.isFulfillmentDetailsSaving = isFulfillmentDetailsSaving
   }),
 
-  setInitialAutoSaveComplete: action(state => {
-    state.isInitialAutoSaveComplete = true
-  }),
-
   setLastUsedPaymentMethodId: action((_state, id) => {
     setStorageValue(LAST_USED_PAYMENT_ID_KEY, id)
   }),
@@ -284,20 +276,6 @@ export const Order2CheckoutContextProvider: React.FC<
   const hasSavedAddresses = (meData.addressConnection?.edges?.length ?? 0) > 0
 
   const initialSteps = useBuildInitialSteps(orderData)
-
-  // Auto-save is needed when: non-offer, has saved addresses, FD not yet complete,
-  // and FD is the first active step (no offer step before it).
-  const fulfillmentDetailsStep = initialSteps.find(
-    s => s.name === CheckoutStepName.FULFILLMENT_DETAILS,
-  )
-
-  // Autosave of shipping address only applies when it is the first step,
-  // i.e. there is no offer step preceding it.
-  const isOffer = orderData.mode === "OFFER"
-  const needsInitialAutoSave =
-    !isOffer &&
-    hasSavedAddresses &&
-    fulfillmentDetailsStep?.state === CheckoutStepState.ACTIVE
 
   // Initialize the store with the initial state
   const initialState = useMemo(
@@ -333,7 +311,6 @@ export const Order2CheckoutContextProvider: React.FC<
     orderData,
     artworkPath,
     hasSavedAddresses,
-    isInitialAutoSaveComplete: !needsInitialAutoSave,
   } as Order2CheckoutModel
 
   return (

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
@@ -84,8 +84,6 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
     setUserAddressMode,
     setSectionErrorMessage,
     setIsFulfillmentDetailsSaving,
-    setInitialAutoSaveComplete,
-    isInitialAutoSaveComplete,
   } = checkoutContext
 
   const { error: fulfillmentDetailsError } = useFulfillmentDetailsError()
@@ -317,9 +315,6 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
         )
       } finally {
         setIsFulfillmentDetailsSaving(false)
-        if (!isInitialAutoSaveComplete) {
-          setInitialAutoSaveComplete()
-        }
       }
     },
     [
@@ -336,41 +331,31 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
       setUserAddressMode,
       unsetOrderFulfillmentOption,
       setOrderDeliveryAddressMutation,
-      isInitialAutoSaveComplete,
-      setInitialAutoSaveComplete,
     ],
   )
 
   const handleSelectInvalidAddress = useCallback(async () => {
-    try {
-      if (orderData.selectedFulfillmentOption?.type) {
-        try {
-          await unsetOrderFulfillmentOption.submitMutation({
-            variables: {
-              input: { id: orderData.internalID },
-            },
-          })
-        } catch (error) {
-          logger.error(
-            "Error unsetting fulfillment option after invalid address selection:",
-            error,
-          )
-        }
-      }
-      editStep(CheckoutStepName.FULFILLMENT_DETAILS)
-    } finally {
-      if (!isInitialAutoSaveComplete) {
-        setInitialAutoSaveComplete()
+    if (orderData.selectedFulfillmentOption?.type) {
+      try {
+        await unsetOrderFulfillmentOption.submitMutation({
+          variables: {
+            input: { id: orderData.internalID },
+          },
+        })
+      } catch (error) {
+        logger.error(
+          "Error unsetting fulfillment option after invalid address selection:",
+          error,
+        )
       }
     }
+    editStep(CheckoutStepName.FULFILLMENT_DETAILS)
   }, [
     orderData.selectedFulfillmentOption?.type,
     orderData.internalID,
     unsetOrderFulfillmentOption,
     logger,
     editStep,
-    isInitialAutoSaveComplete,
-    setInitialAutoSaveComplete,
   ])
 
   return (

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/Order2SavedAddressOptions.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/Order2SavedAddressOptions.jest.tsx
@@ -221,8 +221,6 @@ describe("SavedAddressOptions", () => {
           state: CheckoutStepState.ACTIVE,
         },
       ],
-      isInitialAutoSaveComplete: true,
-      setInitialAutoSaveComplete: jest.fn(),
     } as any
 
     mockUseCheckoutContext.mockReturnValue(mockCheckoutContext)

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/__tests__/Order2DeliveryForm.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/__tests__/Order2DeliveryForm.jest.tsx
@@ -50,8 +50,6 @@ beforeEach(() => {
     setIsFulfillmentDetailsSaving: jest.fn(),
     userAddressMode: null,
     messages: {},
-    isInitialAutoSaveComplete: true,
-    setInitialAutoSaveComplete: jest.fn(),
     steps: [],
   }
 })

--- a/src/Apps/Order2/Routes/Checkout/Hooks/__tests__/useLoadCheckout.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/__tests__/useLoadCheckout.jest.tsx
@@ -83,7 +83,6 @@ describe("useLoadCheckout", () => {
       steps: [{ state: CheckoutStepState.ACTIVE, name: "PAYMENT" }],
       setLoadingComplete: mockSetLoadingComplete,
       setExpressCheckoutLoaded: mockSetExpressCheckoutLoaded,
-      isInitialAutoSaveComplete: true,
     })
 
     // Mock useCheckoutModal
@@ -210,7 +209,6 @@ describe("useLoadCheckout", () => {
         steps: [],
         setLoadingComplete: mockSetLoadingComplete,
         setExpressCheckoutLoaded: mockSetExpressCheckoutLoaded,
-        isInitialAutoSaveComplete: true,
       })
 
       renderHook(() => useLoadCheckout(mockOrder))
@@ -235,7 +233,6 @@ describe("useLoadCheckout", () => {
       expect(errorMessage).toContain("minimumLoadingPassed: true")
       expect(errorMessage).toContain("orderValidated: true")
       expect(errorMessage).toContain("isExpressCheckoutLoaded: false")
-      expect(errorMessage).toContain("isInitialAutoSaveComplete: true")
 
       // No blocking modal; Express Checkout is force-emptied so the rest of
       // the page can finish loading and the user can complete checkout.
@@ -244,16 +241,15 @@ describe("useLoadCheckout", () => {
     })
 
     it("surfaces the modal when a flag other than Express Checkout is stuck", async () => {
-      // Express Checkout *is* loaded (empty list), but autosave never
-      // completed. This is a genuine problem — not graceful degradation —
-      // so the user should see the blocking modal.
+      // Express Checkout *is* loaded (empty list), but loading is still stuck
+      // for another reason. This is a genuine problem — not graceful
+      // degradation — so the user should see the blocking modal.
       useCheckoutContext.mockReturnValue({
         isLoading: true,
         expressCheckoutPaymentMethods: [],
         steps: [],
         setLoadingComplete: mockSetLoadingComplete,
         setExpressCheckoutLoaded: mockSetExpressCheckoutLoaded,
-        isInitialAutoSaveComplete: false,
       })
 
       renderHook(() => useLoadCheckout(mockOrder))
@@ -284,7 +280,6 @@ describe("useLoadCheckout", () => {
         expressCheckoutPaymentMethods: [],
         steps: [],
         setLoadingComplete: mockSetLoadingComplete,
-        isInitialAutoSaveComplete: true,
       }))
 
       const { rerender } = renderHook(() => useLoadCheckout(mockOrder))
@@ -320,7 +315,6 @@ describe("useLoadCheckout", () => {
         expressCheckoutPaymentMethods: expressCheckoutLoaded ? [] : null,
         steps: [],
         setLoadingComplete: mockSetLoadingComplete,
-        isInitialAutoSaveComplete: true,
       }))
 
       const { rerender } = renderHook(() => useLoadCheckout(mockOrder))

--- a/src/Apps/Order2/Routes/Checkout/Hooks/useLoadCheckout.ts
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/useLoadCheckout.ts
@@ -33,7 +33,6 @@ export const useLoadCheckout = (order: useLoadCheckout_order$key) => {
     expressCheckoutPaymentMethods,
     expressCheckoutState,
     steps,
-    isInitialAutoSaveComplete,
   } = useCheckoutContext()
 
   const { checkoutModalError, showCheckoutErrorModal } = useCheckoutModal()
@@ -130,21 +129,14 @@ export const useLoadCheckout = (order: useLoadCheckout_order$key) => {
     minimumLoadingPassed,
     orderValidated,
     isExpressCheckoutLoaded,
-    isInitialAutoSaveComplete,
   })
   useEffect(() => {
     flagsRef.current = {
       minimumLoadingPassed,
       orderValidated,
       isExpressCheckoutLoaded,
-      isInitialAutoSaveComplete,
     }
-  }, [
-    minimumLoadingPassed,
-    orderValidated,
-    isExpressCheckoutLoaded,
-    isInitialAutoSaveComplete,
-  ])
+  }, [minimumLoadingPassed, orderValidated, isExpressCheckoutLoaded])
 
   // After MAX_LOADING_MS without loading completing, log the stuck flags to
   // Sentry, then either degrade gracefully (Express Checkout-only failure)
@@ -169,8 +161,7 @@ export const useLoadCheckout = (order: useLoadCheckout_order$key) => {
       const onlyExpressCheckoutStuck =
         !flags.isExpressCheckoutLoaded &&
         flags.minimumLoadingPassed &&
-        flags.orderValidated &&
-        flags.isInitialAutoSaveComplete
+        flags.orderValidated
 
       if (onlyExpressCheckoutStuck) {
         setExpressCheckoutLoaded([])
@@ -194,7 +185,6 @@ export const useLoadCheckout = (order: useLoadCheckout_order$key) => {
         minimumLoadingPassed,
         orderValidated,
         isExpressCheckoutLoaded,
-        isInitialAutoSaveComplete,
         isLoading,
         setLoadingComplete,
       ].every(Boolean)
@@ -205,7 +195,6 @@ export const useLoadCheckout = (order: useLoadCheckout_order$key) => {
     minimumLoadingPassed,
     orderValidated,
     isExpressCheckoutLoaded,
-    isInitialAutoSaveComplete,
     isLoading,
     setLoadingComplete,
     checkoutModalError,

--- a/src/Apps/Order2/Routes/Checkout/Hooks/useLoadCheckout.ts
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/useLoadCheckout.ts
@@ -19,7 +19,7 @@ import { graphql, useFragment } from "react-relay"
 const logger = createLogger("useLoadCheckout.tsx")
 
 export const MIN_LOADING_MS = 1000
-export const MAX_LOADING_MS = 6000
+export const MAX_LOADING_MS = 3000
 
 export const useLoadCheckout = (order: useLoadCheckout_order$key) => {
   const [minimumLoadingPassed, setMinimumLoadingPassed] = useState(false)

--- a/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
@@ -126,6 +126,28 @@ jest.mock("Utils/Hooks/useUserLocation", () => ({
   })),
 }))
 
+// Replace the async, network-backed phone-number validators with synchronous
+// Yup schemas. The real ones run a debounced Relay query with retry backoff
+// (~2.2s of timers), which otherwise pushes the saved-address load past the
+// MAX_LOADING_MS watchdog and wedges the loading skeleton.
+jest.mock("Components/Address/utils", () => {
+  const Yup = require("yup")
+  return {
+    ...jest.requireActual("Components/Address/utils"),
+    validatePhoneNumber: jest.fn().mockResolvedValue(true),
+    richPhoneValidators: {
+      phoneNumber: Yup.string(),
+      phoneNumberCountryCode: Yup.string(),
+    },
+    richRequiredPhoneValidators: {
+      phoneNumber: Yup.string().required("Phone number is required"),
+      phoneNumberCountryCode: Yup.string().required(
+        "Phone number country code is required",
+      ),
+    },
+  }
+})
+
 const mockTrackEvent = jest.fn()
 
 beforeEach(() => {


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [EMI-3272]

### Description

Currently the loading skeleton for checkout will wait for the initial auto save (from the streamlined shipping initiative) to complete and then reveal the checkout UI. It's not ideal. The sooner we can show the users the checkout (vs. the loading skeleton), even when the address saving or Arta quote fetching is ongoing, the better experience it is. This drops the `isInitialAutoSaveComplete` check. Also, I reduce the timeout to be 3 seconds.

See below recording for an example. We show the checkout after reduced wait time. If the saving or fetching is not complete, users would see proper loading state of certain section/component.

<img width="1747" height="1037" alt="dont-wait-auto-save" src="https://github.com/user-attachments/assets/60d05ae0-4e0d-4891-869d-647106045ca2" />



[EMI-3272]: https://artsyproduct.atlassian.net/browse/EMI-3272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ