### PR TITLE
fix(EMI-3275): do not trigger impression events during checkout load

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/Order2DeliveryOptionsForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/Order2DeliveryOptionsForm.tsx
@@ -26,12 +26,13 @@ import {
 } from "Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/utils"
 import { useCompleteFulfillmentDetailsData } from "Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/useCompleteFulfillmentDetailsData"
 import { useCheckoutContext } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext"
+import { useCheckoutImpressionEffect } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutImpressionEffect"
 import { useScrollToErrorBanner } from "Apps/Order2/Routes/Checkout/Hooks/useScrollToErrorBanner"
 import { useSelectDeliveryOption } from "Apps/Order2/Routes/Checkout/Hooks/useSelectDeliveryOption"
 import { SHIPPING_AND_RETURNS_FAQS_URL } from "Apps/Order2/constants"
 import { RouterLink } from "System/Components/RouterLink"
 import type { Order2DeliveryOptionsForm_order$key } from "__generated__/Order2DeliveryOptionsForm_order.graphql"
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useState } from "react"
 import { graphql, useFragment } from "react-relay"
 
 interface Order2DeliveryOptionsFormProps {
@@ -44,7 +45,6 @@ export const Order2DeliveryOptionsForm: React.FC<
 > = ({ order, refreshingOptions = false }) => {
   const orderData = useFragment(FRAGMENT, order)
   const {
-    isLoading,
     checkoutTracking,
     completeStep,
     messages,
@@ -111,16 +111,15 @@ export const Order2DeliveryOptionsForm: React.FC<
           }),
         )
 
-  useEffect(() => {
+  useCheckoutImpressionEffect(() => {
     if (
-      isLoading ||
       deliveryOptionsStep?.state !== CheckoutStepState.ACTIVE ||
       !artaQuotesJson
     ) {
       return
     }
     checkoutTracking.shippingQuoteViewed(JSON.parse(artaQuotesJson))
-  }, [artaQuotesJson, checkoutTracking, deliveryOptionsStep?.state, isLoading])
+  }, [artaQuotesJson, checkoutTracking, deliveryOptionsStep?.state])
 
   const handleContinue = useCallback(async () => {
     checkoutTracking.clickedOrderProgression(

--- a/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/Order2DeliveryOptionsForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/Order2DeliveryOptionsForm.tsx
@@ -44,6 +44,7 @@ export const Order2DeliveryOptionsForm: React.FC<
 > = ({ order, refreshingOptions = false }) => {
   const orderData = useFragment(FRAGMENT, order)
   const {
+    isLoading,
     checkoutTracking,
     completeStep,
     messages,
@@ -112,13 +113,14 @@ export const Order2DeliveryOptionsForm: React.FC<
 
   useEffect(() => {
     if (
+      isLoading ||
       deliveryOptionsStep?.state !== CheckoutStepState.ACTIVE ||
       !artaQuotesJson
     ) {
       return
     }
     checkoutTracking.shippingQuoteViewed(JSON.parse(artaQuotesJson))
-  }, [artaQuotesJson, checkoutTracking, deliveryOptionsStep?.state])
+  }, [artaQuotesJson, checkoutTracking, deliveryOptionsStep?.state, isLoading])
 
   const handleContinue = useCallback(async () => {
     checkoutTracking.clickedOrderProgression(

--- a/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/__tests__/Order2DeliveryOptionsForm.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/__tests__/Order2DeliveryOptionsForm.jest.tsx
@@ -32,6 +32,7 @@ const mockShippingQuoteViewed = jest.fn()
 beforeEach(() => {
   jest.clearAllMocks()
   mockCheckoutContext = {
+    isLoading: false,
     checkoutTracking: {
       clickedOrderProgression: jest.fn(),
       clickedBuyerProtection: jest.fn(),
@@ -554,6 +555,22 @@ describe("Order2DeliveryOptionsForm", () => {
         {
           name: CheckoutStepName.DELIVERY_OPTION,
           state: CheckoutStepState.UPCOMING,
+        },
+      ]
+
+      renderWithRelay(artaOptionsData)
+
+      await waitFor(() => {
+        expect(mockShippingQuoteViewed).not.toHaveBeenCalled()
+      })
+    })
+
+    it("does not track shippingQuoteViewed while the checkout is loading", async () => {
+      mockCheckoutContext.isLoading = true
+      mockCheckoutContext.steps = [
+        {
+          name: CheckoutStepName.DELIVERY_OPTION,
+          state: CheckoutStepState.ACTIVE,
         },
       ]
 

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/Order2SavedAddressOptions.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/Order2SavedAddressOptions.tsx
@@ -71,6 +71,7 @@ export const SavedAddressOptions = ({
   shippingOriginRegion,
 }: SavedAddressOptionsProps) => {
   const {
+    isLoading,
     setUserAddressMode,
     userAddressMode,
     setSectionErrorMessage,
@@ -101,6 +102,10 @@ export const SavedAddressOptions = ({
   const hasTrackedAddressViewRef = useRef(false)
 
   useEffect(() => {
+    if (isLoading) {
+      return
+    }
+
     if (fulfillmentDetailsStep?.state !== CheckoutStepState.ACTIVE) {
       hasTrackedAddressViewRef.current = false
       return
@@ -123,6 +128,7 @@ export const SavedAddressOptions = ({
     checkoutTracking,
     fulfillmentDetailsStep?.state,
     userAddressMode,
+    isLoading,
   ])
 
   // Scroll to top of step whenever userAddressMode changes

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/Order2SavedAddressOptions.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/Order2SavedAddressOptions.tsx
@@ -21,6 +21,7 @@ import {
   validateAddressFields,
 } from "Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/utils"
 import { useCheckoutContext } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext"
+import { useCheckoutImpressionEffect } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutImpressionEffect"
 import { useFulfillmentDetailsError } from "Apps/Order2/Routes/Checkout/Hooks/useFulfillmentDetailsError"
 import { useScrollToStep } from "Apps/Order2/Routes/Checkout/Hooks/useScrollToStep"
 import type { FormikContextWithAddress } from "Components/Address/AddressFormFields"
@@ -71,7 +72,6 @@ export const SavedAddressOptions = ({
   shippingOriginRegion,
 }: SavedAddressOptionsProps) => {
   const {
-    isLoading,
     setUserAddressMode,
     userAddressMode,
     setSectionErrorMessage,
@@ -101,11 +101,7 @@ export const SavedAddressOptions = ({
   // Track when saved addresses are viewed (only once when step is active)
   const hasTrackedAddressViewRef = useRef(false)
 
-  useEffect(() => {
-    if (isLoading) {
-      return
-    }
-
+  useCheckoutImpressionEffect(() => {
     if (fulfillmentDetailsStep?.state !== CheckoutStepState.ACTIVE) {
       hasTrackedAddressViewRef.current = false
       return
@@ -128,7 +124,6 @@ export const SavedAddressOptions = ({
     checkoutTracking,
     fulfillmentDetailsStep?.state,
     userAddressMode,
-    isLoading,
   ])
 
   // Scroll to top of step whenever userAddressMode changes

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/Order2SavedAddressOptions.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/Order2SavedAddressOptions.jest.tsx
@@ -178,10 +178,10 @@ const TestWrapper = ({
 
 type SavedAddressOptionsProps = React.ComponentProps<typeof SavedAddressOptions>
 
-const renderSavedAddressOptions = (
+const buildSavedAddressOptions = (
   props: Partial<SavedAddressOptionsProps> = {},
 ) => {
-  return render(
+  return (
     <TestWrapper>
       <SavedAddressOptions
         hasDeliveryAddress={true}
@@ -192,8 +192,14 @@ const renderSavedAddressOptions = (
         newAddressInitialValues={mockNewAddressInitialValues}
         {...props}
       />
-    </TestWrapper>,
+    </TestWrapper>
   )
+}
+
+const renderSavedAddressOptions = (
+  props: Partial<SavedAddressOptionsProps> = {},
+) => {
+  return render(buildSavedAddressOptions(props))
 }
 
 describe("SavedAddressOptions", () => {
@@ -204,6 +210,7 @@ describe("SavedAddressOptions", () => {
     onSelectInvalidAddress = jest.fn()
 
     mockCheckoutContext = {
+      isLoading: false,
       setUserAddressMode: jest.fn(),
       userAddressMode: null,
       setSectionErrorMessage: jest.fn(),
@@ -886,10 +893,14 @@ describe("SavedAddressOptions", () => {
   })
 
   describe("Tracking", () => {
-    const setupTrackingContext = (stepState: CheckoutStepState) => {
+    const setupTrackingContext = (
+      stepState: CheckoutStepState,
+      { isLoading = false }: { isLoading?: boolean } = {},
+    ) => {
       const mockSavedAddressViewed = jest.fn()
       mockCheckoutContext = {
         ...mockCheckoutContext,
+        isLoading,
         checkoutTracking: {
           ...mockCheckoutContext.checkoutTracking,
           savedAddressViewed: mockSavedAddressViewed,
@@ -928,6 +939,47 @@ describe("SavedAddressOptions", () => {
 
       await waitFor(() => {
         expect(mockSavedAddressViewed).not.toHaveBeenCalled()
+      })
+    })
+
+    it("does not track savedAddressViewed while the checkout is loading", async () => {
+      const mockSavedAddressViewed = setupTrackingContext(
+        CheckoutStepState.ACTIVE,
+        { isLoading: true },
+      )
+
+      renderSavedAddressOptions()
+
+      await waitFor(() => {
+        expect(mockSavedAddressViewed).not.toHaveBeenCalled()
+      })
+    })
+
+    it("tracks savedAddressViewed once after the checkout finishes loading", async () => {
+      const mockSavedAddressViewed = setupTrackingContext(
+        CheckoutStepState.ACTIVE,
+        { isLoading: true },
+      )
+
+      const { rerender } = renderSavedAddressOptions()
+
+      await waitFor(() => {
+        expect(mockSavedAddressViewed).not.toHaveBeenCalled()
+      })
+
+      mockUseCheckoutContext.mockReturnValue({
+        ...mockCheckoutContext,
+        isLoading: false,
+      })
+
+      rerender(buildSavedAddressOptions())
+
+      await waitFor(() => {
+        expect(mockSavedAddressViewed).toHaveBeenCalledTimes(1)
+        expect(mockSavedAddressViewed).toHaveBeenCalledWith([
+          mockUSAddress1,
+          mockUSAddress2,
+        ])
       })
     })
 

--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
@@ -227,6 +227,7 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({
   const setPaymentMutation = useOrder2SetOrderPaymentMutation()
 
   const {
+    isLoading,
     setConfirmationToken,
     checkoutTracking,
     completeStep,
@@ -295,7 +296,11 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({
 
   // Default to saved payment method when available and track that it has been viewed
   useEffect(() => {
-    if (!checkoutTracking || paymentStep?.state !== CheckoutStepState.ACTIVE) {
+    if (
+      isLoading ||
+      !checkoutTracking ||
+      paymentStep?.state !== CheckoutStepState.ACTIVE
+    ) {
       return
     }
 
@@ -334,6 +339,7 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({
     paymentStep?.state,
     savedCreditCards,
     allowedSavedBankAccounts,
+    isLoading,
   ])
 
   const resetElementsToInitialParams = useCallback(() => {

--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
@@ -28,6 +28,7 @@ import {
   fallbackError,
 } from "Apps/Order2/Routes/Checkout/Components/CheckoutErrorBanner"
 import { useCheckoutContext } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext"
+import { useCheckoutImpressionEffect } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutImpressionEffect"
 import { useScrollToErrorBanner } from "Apps/Order2/Routes/Checkout/Hooks/useScrollToErrorBanner"
 import { useOrder2SetOrderPaymentMutation } from "Apps/Order2/Routes/Checkout/Mutations/useOrder2SetOrderPaymentMutation"
 import { fetchAndSetConfirmationToken } from "Apps/Order2/Utils/confirmationTokenUtils"
@@ -44,7 +45,7 @@ import type {
   Order2PaymentForm_order$key,
 } from "__generated__/Order2PaymentForm_order.graphql"
 import type React from "react"
-import { useCallback, useEffect, useMemo, useRef, useState } from "react"
+import { useCallback, useMemo, useRef, useState } from "react"
 import { graphql, useFragment, useRelayEnvironment } from "react-relay"
 import { SavedPaymentMethodOption } from "./SavedPaymentMethodOption"
 import { StripePaymentCheckboxes } from "./StripePaymentCheckboxes"
@@ -227,7 +228,6 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({
   const setPaymentMutation = useOrder2SetOrderPaymentMutation()
 
   const {
-    isLoading,
     setConfirmationToken,
     checkoutTracking,
     completeStep,
@@ -295,9 +295,8 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({
   const billingFormRef = useRef<any>(null)
 
   // Default to saved payment method when available and track that it has been viewed
-  useEffect(() => {
+  useCheckoutImpressionEffect(() => {
     if (
-      isLoading ||
       !checkoutTracking ||
       paymentStep?.state !== CheckoutStepState.ACTIVE
     ) {
@@ -339,7 +338,6 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({
     paymentStep?.state,
     savedCreditCards,
     allowedSavedBankAccounts,
-    isLoading,
   ])
 
   const resetElementsToInitialParams = useCallback(() => {

--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/__tests__/Order2PaymentForm.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/__tests__/Order2PaymentForm.jest.tsx
@@ -103,6 +103,7 @@ jest.mock("react-relay", () => {
 })
 
 const mockCheckoutContext = {
+  isLoading: false,
   setConfirmationToken: jest.fn(),
   setSavePaymentMethod: jest.fn(),
   completeStep: jest.fn(),
@@ -247,6 +248,7 @@ const waitForPaymentElement = async () => {
 
 beforeEach(() => {
   jest.clearAllMocks()
+  mockCheckoutContext.isLoading = false
   mockOnBalanceCheckComplete = null
   mockLastUsedPaymentMethodId = null
   ;(useTracking as jest.Mock).mockImplementation(() => ({
@@ -804,6 +806,34 @@ describe("Order2PaymentForm", () => {
       expect(
         mockCheckoutContext.checkoutTracking.savedPaymentMethodViewed,
       ).toHaveBeenCalledWith(["CREDIT_CARD"], ["card-1"])
+    })
+
+    it("does not track savedPaymentMethodViewed while the checkout is loading", async () => {
+      mockCheckoutContext.isLoading = true
+
+      const savedCards = [
+        {
+          id: "card-1",
+          internalID: "card-1",
+          brand: "Visa",
+          last4: "1234",
+        },
+      ]
+
+      renderWithRelay({
+        Me: () => ({
+          ...baseMeProps,
+          creditCards: { edges: savedCards.map(card => ({ node: card })) },
+        }),
+      })
+
+      await waitFor(() => {
+        expect(screen.getByTestId("payment-element")).toBeInTheDocument()
+      })
+
+      expect(
+        mockCheckoutContext.checkoutTracking.savedPaymentMethodViewed,
+      ).not.toHaveBeenCalled()
     })
 
     it("tracks payment method selection for saved credit card", async () => {

--- a/src/Apps/Order2/Routes/Checkout/Hooks/useCheckoutImpressionEffect.ts
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/useCheckoutImpressionEffect.ts
@@ -1,0 +1,19 @@
+import { useCheckoutContext } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext"
+import { useEffect } from "react"
+import type { DependencyList, EffectCallback } from "react"
+
+export const useCheckoutImpressionEffect = (
+  effect: EffectCallback,
+  deps: DependencyList,
+) => {
+  const { isLoading } = useCheckoutContext()
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: effect deps are supplied by the caller
+  useEffect(() => {
+    if (isLoading) {
+      return
+    }
+
+    return effect()
+  }, [...deps, isLoading])
+}

--- a/src/Apps/Order2/Routes/Checkout/Order2CheckoutApp.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Order2CheckoutApp.tsx
@@ -101,6 +101,8 @@ export const Order2CheckoutApp: React.FC<Order2CheckoutAppProps> = ({
   )
 
   useEffect(() => {
+    if (isLoading) return
+
     activeStepNames.split(",").forEach(name => {
       switch (name) {
         case CheckoutStepName.CONFIRMATION:
@@ -119,7 +121,7 @@ export const Order2CheckoutApp: React.FC<Order2CheckoutAppProps> = ({
           break
       }
     })
-  }, [activeStepNames, checkoutTracking])
+  }, [activeStepNames, checkoutTracking, isLoading])
 
   // DELIVERY_OPTION is tracked in a separate effect so its expansion signal
   // (which can flip while FULFILLMENT_DETAILS is still ACTIVE) doesn't cause
@@ -129,12 +131,12 @@ export const Order2CheckoutApp: React.FC<Order2CheckoutAppProps> = ({
     isDeliveryOptionExpanded
 
   useEffect(() => {
-    if (isDeliveryOptionVisible) {
+    if (!isLoading && isDeliveryOptionVisible) {
       checkoutTracking.orderProgressionViewed(
         ContextModule.ordersShippingMethods,
       )
     }
-  }, [isDeliveryOptionVisible, checkoutTracking])
+  }, [isDeliveryOptionVisible, checkoutTracking, isLoading])
 
   // Scroll to top when returning to standard checkout mode (and at load time)
   useEffect(() => {

--- a/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
@@ -437,6 +437,34 @@ describe("Order2CheckoutRoute", () => {
     expect(artworkTitles).toHaveLength(3)
   })
 
+  it("does not fire impression tracking events while the loading skeleton is visible", async () => {
+    renderWithRelay({ Viewer: () => ({ ...baseProps }) })
+
+    // Skeleton is visible and loading has not completed yet.
+    expect(
+      screen.getByLabelText("Checkout loading skeleton"),
+    ).toBeInTheDocument()
+
+    const trackedViewedActions = () =>
+      mockTrackEvent.mock.calls
+        .map(([event]) => event.action)
+        .filter(action =>
+          [
+            "orderProgressionViewed",
+            "savedAddressViewed",
+            "savedPaymentMethodViewed",
+            "shippingQuoteViewed",
+          ].includes(action),
+        )
+
+    expect(trackedViewedActions()).toHaveLength(0)
+
+    // Once loading completes, progression tracking resumes.
+    await helpers.waitForLoadingComplete()
+
+    expect(trackedViewedActions()).toContain("orderProgressionViewed")
+  })
+
   it("renders the error page when order is not found", async () => {
     await renderWithRelay({
       Viewer: () => ({


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-3275]

### Description
This PR ensures that impression tracking events such as `orderProgressionViewed` until after the checkout is fully loaded. 

<!-- Implementation description -->


[EMI-3275]: https://artsyproduct.atlassian.net/browse/EMI-3275?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ