### PR TITLE
Revert "feat: do not wait for address auto save when loading checkout; reduce timeout"

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/CheckoutContext/Order2CheckoutContext.tsx
+++ b/src/Apps/Order2/Routes/Checkout/CheckoutContext/Order2CheckoutContext.tsx
@@ -115,6 +115,9 @@ export interface Order2CheckoutModel {
     }
   >
   setIsFulfillmentDetailsSaving: Action<this, boolean>
+  /** True once any eager pre-load address auto-save has completed (or is not needed). */
+  isInitialAutoSaveComplete: boolean
+  setInitialAutoSaveComplete: Action<this>
   /** Persists the last-used saved credit card ID. Only relevant for saved card payments. */
   setLastUsedPaymentMethodId: Action<this, string>
 }
@@ -136,6 +139,7 @@ export const Order2CheckoutContext: ReturnType<
   userAddressMode: null,
   messages: {},
   artworkPath: "/",
+  isInitialAutoSaveComplete: true,
 
   // Required runtime props - will be provided by Provider
   // These will be overridden by the Provider with actual values
@@ -254,6 +258,10 @@ export const Order2CheckoutContext: ReturnType<
     state.isFulfillmentDetailsSaving = isFulfillmentDetailsSaving
   }),
 
+  setInitialAutoSaveComplete: action(state => {
+    state.isInitialAutoSaveComplete = true
+  }),
+
   setLastUsedPaymentMethodId: action((_state, id) => {
     setStorageValue(LAST_USED_PAYMENT_ID_KEY, id)
   }),
@@ -276,6 +284,20 @@ export const Order2CheckoutContextProvider: React.FC<
   const hasSavedAddresses = (meData.addressConnection?.edges?.length ?? 0) > 0
 
   const initialSteps = useBuildInitialSteps(orderData)
+
+  // Auto-save is needed when: non-offer, has saved addresses, FD not yet complete,
+  // and FD is the first active step (no offer step before it).
+  const fulfillmentDetailsStep = initialSteps.find(
+    s => s.name === CheckoutStepName.FULFILLMENT_DETAILS,
+  )
+
+  // Autosave of shipping address only applies when it is the first step,
+  // i.e. there is no offer step preceding it.
+  const isOffer = orderData.mode === "OFFER"
+  const needsInitialAutoSave =
+    !isOffer &&
+    hasSavedAddresses &&
+    fulfillmentDetailsStep?.state === CheckoutStepState.ACTIVE
 
   // Initialize the store with the initial state
   const initialState = useMemo(
@@ -311,6 +333,7 @@ export const Order2CheckoutContextProvider: React.FC<
     orderData,
     artworkPath,
     hasSavedAddresses,
+    isInitialAutoSaveComplete: !needsInitialAutoSave,
   } as Order2CheckoutModel
 
   return (

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
@@ -84,6 +84,8 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
     setUserAddressMode,
     setSectionErrorMessage,
     setIsFulfillmentDetailsSaving,
+    setInitialAutoSaveComplete,
+    isInitialAutoSaveComplete,
   } = checkoutContext
 
   const { error: fulfillmentDetailsError } = useFulfillmentDetailsError()
@@ -315,6 +317,9 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
         )
       } finally {
         setIsFulfillmentDetailsSaving(false)
+        if (!isInitialAutoSaveComplete) {
+          setInitialAutoSaveComplete()
+        }
       }
     },
     [
@@ -331,31 +336,41 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
       setUserAddressMode,
       unsetOrderFulfillmentOption,
       setOrderDeliveryAddressMutation,
+      isInitialAutoSaveComplete,
+      setInitialAutoSaveComplete,
     ],
   )
 
   const handleSelectInvalidAddress = useCallback(async () => {
-    if (orderData.selectedFulfillmentOption?.type) {
-      try {
-        await unsetOrderFulfillmentOption.submitMutation({
-          variables: {
-            input: { id: orderData.internalID },
-          },
-        })
-      } catch (error) {
-        logger.error(
-          "Error unsetting fulfillment option after invalid address selection:",
-          error,
-        )
+    try {
+      if (orderData.selectedFulfillmentOption?.type) {
+        try {
+          await unsetOrderFulfillmentOption.submitMutation({
+            variables: {
+              input: { id: orderData.internalID },
+            },
+          })
+        } catch (error) {
+          logger.error(
+            "Error unsetting fulfillment option after invalid address selection:",
+            error,
+          )
+        }
+      }
+      editStep(CheckoutStepName.FULFILLMENT_DETAILS)
+    } finally {
+      if (!isInitialAutoSaveComplete) {
+        setInitialAutoSaveComplete()
       }
     }
-    editStep(CheckoutStepName.FULFILLMENT_DETAILS)
   }, [
     orderData.selectedFulfillmentOption?.type,
     orderData.internalID,
     unsetOrderFulfillmentOption,
     logger,
     editStep,
+    isInitialAutoSaveComplete,
+    setInitialAutoSaveComplete,
   ])
 
   return (

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/Order2SavedAddressOptions.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/Order2SavedAddressOptions.jest.tsx
@@ -221,6 +221,8 @@ describe("SavedAddressOptions", () => {
           state: CheckoutStepState.ACTIVE,
         },
       ],
+      isInitialAutoSaveComplete: true,
+      setInitialAutoSaveComplete: jest.fn(),
     } as any
 
     mockUseCheckoutContext.mockReturnValue(mockCheckoutContext)

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/__tests__/Order2DeliveryForm.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/__tests__/Order2DeliveryForm.jest.tsx
@@ -50,6 +50,8 @@ beforeEach(() => {
     setIsFulfillmentDetailsSaving: jest.fn(),
     userAddressMode: null,
     messages: {},
+    isInitialAutoSaveComplete: true,
+    setInitialAutoSaveComplete: jest.fn(),
     steps: [],
   }
 })

--- a/src/Apps/Order2/Routes/Checkout/Hooks/__tests__/useLoadCheckout.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/__tests__/useLoadCheckout.jest.tsx
@@ -83,6 +83,7 @@ describe("useLoadCheckout", () => {
       steps: [{ state: CheckoutStepState.ACTIVE, name: "PAYMENT" }],
       setLoadingComplete: mockSetLoadingComplete,
       setExpressCheckoutLoaded: mockSetExpressCheckoutLoaded,
+      isInitialAutoSaveComplete: true,
     })
 
     // Mock useCheckoutModal
@@ -209,6 +210,7 @@ describe("useLoadCheckout", () => {
         steps: [],
         setLoadingComplete: mockSetLoadingComplete,
         setExpressCheckoutLoaded: mockSetExpressCheckoutLoaded,
+        isInitialAutoSaveComplete: true,
       })
 
       renderHook(() => useLoadCheckout(mockOrder))
@@ -233,6 +235,7 @@ describe("useLoadCheckout", () => {
       expect(errorMessage).toContain("minimumLoadingPassed: true")
       expect(errorMessage).toContain("orderValidated: true")
       expect(errorMessage).toContain("isExpressCheckoutLoaded: false")
+      expect(errorMessage).toContain("isInitialAutoSaveComplete: true")
 
       // No blocking modal; Express Checkout is force-emptied so the rest of
       // the page can finish loading and the user can complete checkout.
@@ -241,15 +244,16 @@ describe("useLoadCheckout", () => {
     })
 
     it("surfaces the modal when a flag other than Express Checkout is stuck", async () => {
-      // Express Checkout *is* loaded (empty list), but loading is still stuck
-      // for another reason. This is a genuine problem — not graceful
-      // degradation — so the user should see the blocking modal.
+      // Express Checkout *is* loaded (empty list), but autosave never
+      // completed. This is a genuine problem — not graceful degradation —
+      // so the user should see the blocking modal.
       useCheckoutContext.mockReturnValue({
         isLoading: true,
         expressCheckoutPaymentMethods: [],
         steps: [],
         setLoadingComplete: mockSetLoadingComplete,
         setExpressCheckoutLoaded: mockSetExpressCheckoutLoaded,
+        isInitialAutoSaveComplete: false,
       })
 
       renderHook(() => useLoadCheckout(mockOrder))
@@ -280,6 +284,7 @@ describe("useLoadCheckout", () => {
         expressCheckoutPaymentMethods: [],
         steps: [],
         setLoadingComplete: mockSetLoadingComplete,
+        isInitialAutoSaveComplete: true,
       }))
 
       const { rerender } = renderHook(() => useLoadCheckout(mockOrder))
@@ -315,6 +320,7 @@ describe("useLoadCheckout", () => {
         expressCheckoutPaymentMethods: expressCheckoutLoaded ? [] : null,
         steps: [],
         setLoadingComplete: mockSetLoadingComplete,
+        isInitialAutoSaveComplete: true,
       }))
 
       const { rerender } = renderHook(() => useLoadCheckout(mockOrder))

--- a/src/Apps/Order2/Routes/Checkout/Hooks/useLoadCheckout.ts
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/useLoadCheckout.ts
@@ -19,7 +19,7 @@ import { graphql, useFragment } from "react-relay"
 const logger = createLogger("useLoadCheckout.tsx")
 
 export const MIN_LOADING_MS = 1000
-export const MAX_LOADING_MS = 3000
+export const MAX_LOADING_MS = 6000
 
 export const useLoadCheckout = (order: useLoadCheckout_order$key) => {
   const [minimumLoadingPassed, setMinimumLoadingPassed] = useState(false)
@@ -33,6 +33,7 @@ export const useLoadCheckout = (order: useLoadCheckout_order$key) => {
     expressCheckoutPaymentMethods,
     expressCheckoutState,
     steps,
+    isInitialAutoSaveComplete,
   } = useCheckoutContext()
 
   const { checkoutModalError, showCheckoutErrorModal } = useCheckoutModal()
@@ -129,14 +130,21 @@ export const useLoadCheckout = (order: useLoadCheckout_order$key) => {
     minimumLoadingPassed,
     orderValidated,
     isExpressCheckoutLoaded,
+    isInitialAutoSaveComplete,
   })
   useEffect(() => {
     flagsRef.current = {
       minimumLoadingPassed,
       orderValidated,
       isExpressCheckoutLoaded,
+      isInitialAutoSaveComplete,
     }
-  }, [minimumLoadingPassed, orderValidated, isExpressCheckoutLoaded])
+  }, [
+    minimumLoadingPassed,
+    orderValidated,
+    isExpressCheckoutLoaded,
+    isInitialAutoSaveComplete,
+  ])
 
   // After MAX_LOADING_MS without loading completing, log the stuck flags to
   // Sentry, then either degrade gracefully (Express Checkout-only failure)
@@ -161,7 +169,8 @@ export const useLoadCheckout = (order: useLoadCheckout_order$key) => {
       const onlyExpressCheckoutStuck =
         !flags.isExpressCheckoutLoaded &&
         flags.minimumLoadingPassed &&
-        flags.orderValidated
+        flags.orderValidated &&
+        flags.isInitialAutoSaveComplete
 
       if (onlyExpressCheckoutStuck) {
         setExpressCheckoutLoaded([])
@@ -185,6 +194,7 @@ export const useLoadCheckout = (order: useLoadCheckout_order$key) => {
         minimumLoadingPassed,
         orderValidated,
         isExpressCheckoutLoaded,
+        isInitialAutoSaveComplete,
         isLoading,
         setLoadingComplete,
       ].every(Boolean)
@@ -195,6 +205,7 @@ export const useLoadCheckout = (order: useLoadCheckout_order$key) => {
     minimumLoadingPassed,
     orderValidated,
     isExpressCheckoutLoaded,
+    isInitialAutoSaveComplete,
     isLoading,
     setLoadingComplete,
     checkoutModalError,

--- a/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
@@ -126,28 +126,6 @@ jest.mock("Utils/Hooks/useUserLocation", () => ({
   })),
 }))
 
-// Replace the async, network-backed phone-number validators with synchronous
-// Yup schemas. The real ones run a debounced Relay query with retry backoff
-// (~2.2s of timers), which otherwise pushes the saved-address load past the
-// MAX_LOADING_MS watchdog and wedges the loading skeleton.
-jest.mock("Components/Address/utils", () => {
-  const Yup = require("yup")
-  return {
-    ...jest.requireActual("Components/Address/utils"),
-    validatePhoneNumber: jest.fn().mockResolvedValue(true),
-    richPhoneValidators: {
-      phoneNumber: Yup.string(),
-      phoneNumberCountryCode: Yup.string(),
-    },
-    richRequiredPhoneValidators: {
-      phoneNumber: Yup.string().required("Phone number is required"),
-      phoneNumberCountryCode: Yup.string().required(
-        "Phone number country code is required",
-      ),
-    },
-  }
-})
-
 const mockTrackEvent = jest.fn()
 
 beforeEach(() => {


### PR DESCRIPTION
Reverts artsy/force#17333

Integrity caught that Express Checkout breaks when there is a saved address.