### PR TITLE
feat(artist): adds compact editorial module to control artist header

### DIFF
--- a/src/Apps/Artist/Components/ArtistHeader/ArtistHeader.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/ArtistHeader.tsx
@@ -20,6 +20,7 @@ import {
   Stack,
   Text,
 } from "@artsy/palette"
+import { ArtistHeaderEditorial } from "Apps/Artist/Components/ArtistHeader/ArtistHeaderEditorial"
 import {
   ArtistHeaderImageFragmentContainer,
   isValidImage,
@@ -58,7 +59,9 @@ const ArtistHeader: React.FC<React.PropsWithChildren<ArtistHeaderProps>> = ({
       : biographyText
   const hasVerifiedRepresentatives = artist?.verifiedRepresentatives?.length > 0
   const hasInsights = artist.insights.length > 0
-  const hasRightDetails = hasVerifiedRepresentatives || hasInsights
+  const hasEditorial = (artist.articlesConnection?.totalCount ?? 0) > 0
+  const hasRightDetails =
+    hasVerifiedRepresentatives || hasInsights || hasEditorial
   const hasSomething = hasImage || hasBio || hasRightDetails
 
   const trackToggledArtistBio = (expand: boolean) => {
@@ -285,19 +288,23 @@ const ArtistHeader: React.FC<React.PropsWithChildren<ArtistHeaderProps>> = ({
             </>
           )}
 
-          <Box display={["none", "block"]}>
-            {artist.insights
-              .slice(0, ARTIST_HEADER_NUMBER_OF_INSIGHTS)
-              .map((insight, index) => {
-                return (
-                  <ArtistCareerHighlightFragmentContainer
-                    key={insight.kind ?? index}
-                    insight={insight}
-                    contextModule={ContextModule.artistHeader}
-                  />
-                )
-              })}
-          </Box>
+          {hasInsights && (
+            <Box display={["none", "block"]}>
+              {artist.insights
+                .slice(0, getArtistHeaderNumberOfInsights({ hasEditorial }))
+                .map((insight, index) => {
+                  return (
+                    <ArtistCareerHighlightFragmentContainer
+                      key={insight.kind ?? index}
+                      insight={insight}
+                      contextModule={ContextModule.artistHeader}
+                    />
+                  )
+                })}
+            </Box>
+          )}
+
+          {hasEditorial && <ArtistHeaderEditorial artist={artist} />}
         </Column>
       )}
     </GridColumns>
@@ -324,6 +331,10 @@ export const ArtistHeaderFragmentContainer = createFragmentContainer(
           kind
           ...ArtistCareerHighlight_insight
         }
+        articlesConnection(first: 3, sort: PUBLISHED_AT_DESC) {
+          totalCount
+        }
+        ...ArtistHeaderEditorial_artist
         verifiedRepresentatives {
           partner {
             internalID
@@ -372,3 +383,19 @@ const CV = styled(RouterLink)`
 `
 
 export const ARTIST_HEADER_NUMBER_OF_INSIGHTS = 4
+
+// When the editorial module is present, fewer insights are displayed in the
+// header to limit how far the artwork grid is pushed down. The remainder is
+// picked up by ArtistCareerHighlights in the about section, which must slice
+// from the same offset.
+export const ARTIST_HEADER_NUMBER_OF_INSIGHTS_WITH_EDITORIAL = 2
+
+export const getArtistHeaderNumberOfInsights = ({
+  hasEditorial,
+}: {
+  hasEditorial: boolean
+}): number => {
+  return hasEditorial
+    ? ARTIST_HEADER_NUMBER_OF_INSIGHTS_WITH_EDITORIAL
+    : ARTIST_HEADER_NUMBER_OF_INSIGHTS
+}

--- a/src/Apps/Artist/Components/ArtistHeader/ArtistHeaderEditorial.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/ArtistHeaderEditorial.tsx
@@ -1,0 +1,124 @@
+import {
+  type BoxProps,
+  ProgressDots,
+  Stack,
+  Swiper,
+  SwiperCell,
+  SwiperRail,
+  Text,
+} from "@artsy/palette"
+import { ArtistHeaderEditorialItem } from "Apps/Artist/Components/ArtistHeader/ArtistHeaderEditorialItem"
+import { RouterLink } from "System/Components/RouterLink"
+import { extractNodes } from "Utils/extractNodes"
+import type { ArtistHeaderEditorial_artist$key } from "__generated__/ArtistHeaderEditorial_artist.graphql"
+import { type ForwardRefExoticComponent, forwardRef, useState } from "react"
+import { graphql, useFragment } from "react-relay"
+
+interface ArtistHeaderEditorialProps {
+  artist: ArtistHeaderEditorial_artist$key
+}
+
+export const ArtistHeaderEditorial: React.FC<ArtistHeaderEditorialProps> = ({
+  artist: artistRef,
+}) => {
+  const artist = useFragment(fragment, artistRef)
+
+  const articles = extractNodes(artist.articlesConnection)
+  const totalCount = artist.articlesConnection?.totalCount ?? 0
+
+  const [activeIndex, setActiveIndex] = useState(0)
+
+  if (articles.length === 0) return null
+
+  return (
+    <Stack gap={2}>
+      <Stack
+        gap={1}
+        flexDirection="row"
+        justifyContent="space-between"
+        alignItems="top"
+        borderTop="solid 1px"
+        borderColor={["mono10", "mono60"]}
+        pt={2}
+      >
+        <Text variant="sm-display">
+          Artsy Editorial Featuring {artist.name}
+        </Text>
+
+        {totalCount > 1 && (
+          <Text
+            variant="xs"
+            color="mono60"
+            flexShrink={0}
+            as={RouterLink}
+            to={`${artist.href}/articles`}
+          >
+            View All
+          </Text>
+        )}
+      </Stack>
+
+      <Stack gap={1}>
+        <Swiper
+          snap="center"
+          Cell={ArtistHeaderEditorialSwiperCell}
+          Rail={ArtistHeaderEditorialSwiperRail}
+          initialIndex={activeIndex}
+          onChange={setActiveIndex}
+        >
+          {articles.map(article => {
+            return (
+              <ArtistHeaderEditorialItem
+                key={article.internalID}
+                article={article}
+              />
+            )
+          })}
+        </Swiper>
+
+        {articles.length > 1 && (
+          <ProgressDots
+            amount={articles.length}
+            activeIndex={activeIndex}
+            onClick={setActiveIndex}
+          />
+        )}
+      </Stack>
+    </Stack>
+  )
+}
+
+const fragment = graphql`
+  fragment ArtistHeaderEditorial_artist on Artist {
+    name
+    href
+    articlesConnection(first: 3, sort: PUBLISHED_AT_DESC) {
+      totalCount
+      edges {
+        node {
+          ...ArtistHeaderEditorialItem_article
+          internalID
+        }
+      }
+    }
+  }
+`
+
+const ArtistHeaderEditorialSwiperCell: ForwardRefExoticComponent<BoxProps> =
+  forwardRef((props, ref) => {
+    return (
+      <SwiperCell
+        {...props}
+        ref={ref as any}
+        display="inline-flex"
+        width="100%"
+        pr={0}
+      />
+    )
+  })
+
+const ArtistHeaderEditorialSwiperRail: React.FC<
+  React.PropsWithChildren
+> = props => {
+  return <SwiperRail {...props} display="block" style={{ lineHeight: 0 }} />
+}

--- a/src/Apps/Artist/Components/ArtistHeader/ArtistHeaderEditorialItem.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/ArtistHeaderEditorialItem.tsx
@@ -1,0 +1,104 @@
+import {
+  ActionType,
+  type ClickedArticleGroup,
+  ContextModule,
+  OwnerType,
+} from "@artsy/cohesion"
+import { Box, Image, ResponsiveBox, Stack, Text } from "@artsy/palette"
+import { RouterLink } from "System/Components/RouterLink"
+import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
+import type { ArtistHeaderEditorialItem_article$key } from "__generated__/ArtistHeaderEditorialItem_article.graphql"
+import { graphql, useFragment } from "react-relay"
+import { useTracking } from "react-tracking"
+
+interface ArtistHeaderEditorialItemProps {
+  article: ArtistHeaderEditorialItem_article$key
+}
+
+export const ArtistHeaderEditorialItem: React.FC<
+  ArtistHeaderEditorialItemProps
+> = ({ article: articleRef }) => {
+  const article = useFragment(fragment, articleRef)
+
+  const { trackEvent } = useTracking()
+
+  const { contextPageOwnerId, contextPageOwnerSlug, contextPageOwnerType } =
+    useAnalyticsContext()
+
+  const thumbnail = article.thumbnailImage?.small
+
+  return (
+    <Stack
+      flexDirection="row"
+      gap={[1, 2]}
+      pr={[1, 0]}
+      as={RouterLink}
+      to={article.href}
+      textDecoration="none"
+      onClick={() => {
+        const trackingEvent: ClickedArticleGroup = {
+          action: ActionType.clickedArticleGroup,
+          context_module: ContextModule.artistHeader,
+          context_page_owner_type: contextPageOwnerType!,
+          context_page_owner_id: contextPageOwnerId,
+          context_page_owner_slug: contextPageOwnerSlug,
+          destination_page_owner_type: OwnerType.article,
+          type: "thumbnail",
+        }
+
+        trackEvent(trackingEvent)
+      }}
+    >
+      <Box width={[125, 100]} flexShrink={0} bg="mono10">
+        {thumbnail && (
+          <ResponsiveBox
+            aspectWidth={1}
+            aspectHeight={1}
+            maxWidth="100%"
+            bg="mono10"
+          >
+            <Image
+              src={thumbnail.src}
+              srcSet={thumbnail.srcSet}
+              width="100%"
+              height="100%"
+              lazyLoad
+              alt=""
+            />
+          </ResponsiveBox>
+        )}
+      </Box>
+
+      <Box>
+        <Text
+          variant={["sm-display", "sm-display", "sm-display", "md"]}
+          lineClamp={2}
+        >
+          {article.title}
+        </Text>
+
+        <Text variant={["xs", "xs", "xs", "sm"]}>By {article.byline}</Text>
+
+        <Text variant={["xs", "xs", "xs", "sm"]} color="mono60">
+          {article.publishedAt}
+        </Text>
+      </Box>
+    </Stack>
+  )
+}
+
+const fragment = graphql`
+  fragment ArtistHeaderEditorialItem_article on Article {
+    internalID
+    href
+    byline
+    title
+    publishedAt(format: "MMM D, YYYY")
+    thumbnailImage {
+      small: cropped(width: 125, height: 125) {
+        src
+        srcSet
+      }
+    }
+  }
+`

--- a/src/Apps/Artist/Components/ArtistHeader/__tests__/ArtistHeader.jest.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/__tests__/ArtistHeader.jest.tsx
@@ -435,6 +435,63 @@ describe("ArtistHeaderFragmentContainer", () => {
 
       // Only first 4 insights should be rendered (ARTIST_HEADER_NUMBER_OF_INSIGHTS = 4)
     })
+
+    it("shows up to 4 insights when there is no editorial", () => {
+      renderWithRelay({
+        Artist: () => ({
+          name: "Pablo Picasso",
+          articlesConnection: { totalCount: 0, edges: [] },
+          insights: [
+            { kind: "COLLECTED", label: "Insight 0", entities: ["MoMA"] },
+            { kind: "REVIEWED", label: "Insight 1", entities: ["MoMA"] },
+            { kind: "SOLO_SHOW", label: "Insight 2", entities: ["MoMA"] },
+            { kind: "GROUP_SHOW", label: "Insight 3", entities: ["MoMA"] },
+            { kind: "TRENDING_NOW", label: "Insight 4", entities: ["MoMA"] },
+          ],
+        }),
+      })
+
+      expect(screen.getByText("Insight 0")).toBeInTheDocument()
+      expect(screen.getByText("Insight 3")).toBeInTheDocument()
+      expect(screen.queryByText("Insight 4")).not.toBeInTheDocument()
+    })
+
+    it("shows only 2 insights when the editorial module is present", () => {
+      renderWithRelay({
+        Artist: () => ({
+          name: "Pablo Picasso",
+          articlesConnection: {
+            totalCount: 1,
+            edges: [
+              {
+                node: {
+                  internalID: "article-1",
+                  href: "/article/article-1",
+                  title: "Article 1",
+                  byline: "Artsy Editorial",
+                  publishedAt: "Jan 1, 2026",
+                  thumbnailImage: null,
+                },
+              },
+            ],
+          },
+          insights: [
+            { kind: "COLLECTED", label: "Insight 0", entities: ["MoMA"] },
+            { kind: "REVIEWED", label: "Insight 1", entities: ["MoMA"] },
+            { kind: "SOLO_SHOW", label: "Insight 2", entities: ["MoMA"] },
+            { kind: "GROUP_SHOW", label: "Insight 3", entities: ["MoMA"] },
+          ],
+        }),
+      })
+
+      expect(
+        screen.getByText("Artsy Editorial Featuring Pablo Picasso"),
+      ).toBeInTheDocument()
+      expect(screen.getByText("Insight 0")).toBeInTheDocument()
+      expect(screen.getByText("Insight 1")).toBeInTheDocument()
+      expect(screen.queryByText("Insight 2")).not.toBeInTheDocument()
+      expect(screen.queryByText("Insight 3")).not.toBeInTheDocument()
+    })
   })
 
   describe("CV link", () => {

--- a/src/Apps/Artist/Components/ArtistHeader/__tests__/ArtistHeaderEditorial.jest.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/__tests__/ArtistHeaderEditorial.jest.tsx
@@ -1,0 +1,115 @@
+import { screen } from "@testing-library/react"
+import { ArtistHeaderEditorial } from "Apps/Artist/Components/ArtistHeader/ArtistHeaderEditorial"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
+import { useRouter } from "System/Hooks/useRouter"
+import { graphql } from "react-relay"
+import { useTracking } from "react-tracking"
+
+jest.unmock("react-relay")
+jest.mock("react-tracking")
+jest.mock("System/Hooks/useRouter")
+jest.mock("System/Hooks/useAnalyticsContext", () => ({
+  useAnalyticsContext: jest.fn(() => ({
+    contextPageOwnerId: "4d8b92b34eb68a1b2c0003f4",
+    contextPageOwnerSlug: "pablo-picasso",
+    contextPageOwnerType: "artist",
+  })),
+}))
+
+const mockUseTracking = useTracking as jest.Mock
+const trackEvent = jest.fn()
+
+beforeAll(() => {
+  mockUseTracking.mockImplementation(() => ({ trackEvent }))
+  ;(useRouter as jest.Mock).mockImplementation(() => ({
+    match: {
+      location: {
+        query: {},
+      },
+    },
+  }))
+})
+
+beforeEach(() => {
+  trackEvent.mockClear()
+})
+
+const { renderWithRelay } = setupTestWrapperTL({
+  Component: (props: any) => {
+    return <ArtistHeaderEditorial artist={props.artist} />
+  },
+  query: graphql`
+    query ArtistHeaderEditorial_Test_Query @relay_test_operation {
+      artist(id: "example") {
+        ...ArtistHeaderEditorial_artist
+      }
+    }
+  `,
+})
+
+const article = (index: number) => ({
+  node: {
+    internalID: `article-${index}`,
+    href: `/article/article-${index}`,
+    title: `Article ${index}`,
+    byline: "Artsy Editorial",
+    publishedAt: "Jan 1, 2026",
+    thumbnailImage: null,
+  },
+})
+
+describe("ArtistHeaderEditorial", () => {
+  it("renders nothing when there are no articles", () => {
+    renderWithRelay({
+      Artist: () => ({
+        name: "Pablo Picasso",
+        articlesConnection: {
+          totalCount: 0,
+          edges: [],
+        },
+      }),
+    })
+
+    expect(
+      screen.queryByText("Artsy Editorial Featuring Pablo Picasso"),
+    ).not.toBeInTheDocument()
+  })
+
+  it("renders the heading and articles", () => {
+    renderWithRelay({
+      Artist: () => ({
+        name: "Pablo Picasso",
+        articlesConnection: {
+          totalCount: 1,
+          edges: [article(1)],
+        },
+      }),
+    })
+
+    expect(
+      screen.getByText("Artsy Editorial Featuring Pablo Picasso"),
+    ).toBeInTheDocument()
+    expect(screen.getByText("Article 1")).toBeInTheDocument()
+    expect(screen.queryByText("View All")).not.toBeInTheDocument()
+  })
+
+  it("renders a View All link when there are more than one article", () => {
+    renderWithRelay({
+      Artist: () => ({
+        name: "Pablo Picasso",
+        href: "/artist/pablo-picasso",
+        articlesConnection: {
+          totalCount: 2,
+          edges: [article(1), article(2)],
+        },
+      }),
+    })
+
+    const viewAll = screen.getByText("View All")
+    expect(viewAll).toBeInTheDocument()
+    expect(viewAll.closest("a")).toHaveAttribute(
+      "href",
+      "/artist/pablo-picasso/articles",
+    )
+  })
+})

--- a/src/Apps/Artist/Routes/Overview/Components/ArtistCareerHighlights.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtistCareerHighlights.tsx
@@ -6,7 +6,7 @@ import {
   GridColumns,
   SkeletonText,
 } from "@artsy/palette"
-import { ARTIST_HEADER_NUMBER_OF_INSIGHTS } from "Apps/Artist/Components/ArtistHeader/ArtistHeader"
+import { getArtistHeaderNumberOfInsights } from "Apps/Artist/Components/ArtistHeader/ArtistHeader"
 import { ArtistCareerHighlightFragmentContainer } from "Apps/Artist/Routes/Overview/Components/ArtistCareerHighlight"
 import { RailHeader } from "Components/Rail/RailHeader"
 import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
@@ -34,7 +34,10 @@ const ArtistCareerHighlights: FC<
     return null
   }
 
-  const insights = artist.insights.slice(ARTIST_HEADER_NUMBER_OF_INSIGHTS)
+  const hasEditorial = (artist.articlesConnection?.totalCount ?? 0) > 0
+  const insights = artist.insights.slice(
+    getArtistHeaderNumberOfInsights({ hasEditorial }),
+  )
   const numOfColumns = insights.length > 4 ? 2 : 1
   const mid = Math.ceil(insights.length / 2)
   const columns =
@@ -126,6 +129,9 @@ export const ArtistCareerHighlightsFragmentContainer = createFragmentContainer(
       fragment ArtistCareerHighlights_artist on Artist {
         name
         href
+        articlesConnection(first: 1) {
+          totalCount
+        }
         insights {
           ...ArtistCareerHighlight_insight
           kind

--- a/src/Apps/Artist/Routes/Overview/Components/ArtistOverview.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/ArtistOverview.tsx
@@ -1,6 +1,6 @@
 import { ActionType, type ClickedCV, ContextModule } from "@artsy/cohesion"
 import { Stack } from "@artsy/palette"
-import { ARTIST_HEADER_NUMBER_OF_INSIGHTS } from "Apps/Artist/Components/ArtistHeader/ArtistHeader"
+import { getArtistHeaderNumberOfInsights } from "Apps/Artist/Components/ArtistHeader/ArtistHeader"
 import {
   ArtistSeriesRailPlaceholder,
   ArtistSeriesRailQueryRenderer,
@@ -78,9 +78,10 @@ export const ArtistOverview: React.FC<
   const { contextPageOwnerType, contextPageOwnerId, contextPageOwnerSlug } =
     useAnalyticsContext()
 
+  const hasEditorial = (artist.articlesConnection?.totalCount ?? 0) > 0
   const hasCareerHighlights =
     Array.isArray(artist.insights) &&
-    artist.insights.length > ARTIST_HEADER_NUMBER_OF_INSIGHTS
+    artist.insights.length > getArtistHeaderNumberOfInsights({ hasEditorial })
   const hasArtistSeries = (artist.artistSeriesConnection?.totalCount ?? 0) > 0
   const hasCurrentShows = (artist.showsConnection?.totalCount ?? 0) > 0
   const hasRelatedArtists = (artist.counts?.relatedArtists ?? 0) > 0
@@ -160,6 +161,9 @@ export const ArtistOverviewFragmentContainer = createFragmentContainer(
         name
         insights {
           __typename
+        }
+        articlesConnection(first: 1) {
+          totalCount
         }
         artistSeriesConnection(first: 0) {
           totalCount

--- a/src/Apps/Artist/Routes/Overview/Components/__tests__/ArtistCareerHighlights.jest.tsx
+++ b/src/Apps/Artist/Routes/Overview/Components/__tests__/ArtistCareerHighlights.jest.tsx
@@ -10,6 +10,7 @@ jest.mock("react-tracking")
 
 jest.mock("Apps/Artist/Components/ArtistHeader/ArtistHeader", () => ({
   ARTIST_HEADER_NUMBER_OF_INSIGHTS: 0,
+  getArtistHeaderNumberOfInsights: () => 0,
 }))
 
 jest.mock("System/Hooks/useAnalyticsContext", () => ({

--- a/src/__generated__/ArtistAppTestQuery.graphql.ts
+++ b/src/__generated__/ArtistAppTestQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a348749f7394fc7cc6c74327221d8421>>
+ * @generated SignedSource<<e64d1364aa780bcc7bdbc4dcaa5b6efb>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -99,30 +99,31 @@ v10 = [
 v11 = [
   (v5/*: any*/)
 ],
-v12 = [
+v12 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "title",
+  "storageKey": null
+},
+v13 = [
   {
     "kind": "Literal",
     "name": "format",
     "value": "HTML"
   }
 ],
-v13 = {
+v14 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Artist"
 },
-v14 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "String"
-},
 v15 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "ArtistBlurb"
+  "type": "String"
 },
 v16 = {
   "enumValues": null,
@@ -146,17 +147,23 @@ v19 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
-  "type": "Int"
+  "type": "String"
 },
 v20 = {
   "enumValues": null,
-  "nullable": false,
+  "nullable": true,
   "plural": false,
-  "type": "String"
+  "type": "Int"
 },
 v21 = {
   "enumValues": null,
   "nullable": true,
+  "plural": false,
+  "type": "ArtistBlurb"
+},
+v22 = {
+  "enumValues": null,
+  "nullable": false,
   "plural": false,
   "type": "Int"
 };
@@ -484,13 +491,7 @@ return {
             "name": "notableArtworks",
             "plural": true,
             "selections": [
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "title",
-                "storageKey": null
-              },
+              (v12/*: any*/),
               (v3/*: any*/),
               {
                 "alias": null,
@@ -547,7 +548,7 @@ return {
           },
           {
             "alias": null,
-            "args": (v12/*: any*/),
+            "args": (v13/*: any*/),
             "concreteType": "ArtistBlurb",
             "kind": "LinkedField",
             "name": "biographyBlurb",
@@ -595,13 +596,129 @@ return {
               },
               {
                 "alias": null,
-                "args": (v12/*: any*/),
+                "args": (v13/*: any*/),
                 "kind": "ScalarField",
                 "name": "description",
                 "storageKey": "description(format:\"HTML\")"
               }
             ],
             "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 3
+              },
+              {
+                "kind": "Literal",
+                "name": "sort",
+                "value": "PUBLISHED_AT_DESC"
+              }
+            ],
+            "concreteType": "ArticleConnection",
+            "kind": "LinkedField",
+            "name": "articlesConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "totalCount",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ArticleEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Article",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v9/*: any*/),
+                      (v3/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "byline",
+                        "storageKey": null
+                      },
+                      (v12/*: any*/),
+                      {
+                        "alias": null,
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "format",
+                            "value": "MMM D, YYYY"
+                          }
+                        ],
+                        "kind": "ScalarField",
+                        "name": "publishedAt",
+                        "storageKey": "publishedAt(format:\"MMM D, YYYY\")"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "thumbnailImage",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "small",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "height",
+                                "value": 125
+                              },
+                              {
+                                "kind": "Literal",
+                                "name": "width",
+                                "value": 125
+                              }
+                            ],
+                            "concreteType": "CroppedImageUrl",
+                            "kind": "LinkedField",
+                            "name": "cropped",
+                            "plural": false,
+                            "selections": [
+                              (v5/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "srcSet",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": "cropped(height:125,width:125)"
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      (v8/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "articlesConnection(first:3,sort:\"PUBLISHED_AT_DESC\")"
           },
           (v8/*: any*/)
         ],
@@ -610,24 +727,53 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4f40692ef1405bae3b2a698b26374ae9",
+    "cacheID": "790ed8f925b6dda9f3145138317b79a8",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
-        "artist": (v13/*: any*/),
+        "artist": (v14/*: any*/),
         "artist.alternateNames": {
           "enumValues": null,
           "nullable": true,
           "plural": true,
           "type": "String"
         },
-        "artist.awards": (v14/*: any*/),
-        "artist.biographyBlurb": (v15/*: any*/),
-        "artist.biographyBlurb.credit": (v14/*: any*/),
-        "artist.biographyBlurb.text": (v14/*: any*/),
-        "artist.biographyBlurbPlain": (v15/*: any*/),
-        "artist.biographyBlurbPlain.text": (v14/*: any*/),
-        "artist.birthday": (v14/*: any*/),
+        "artist.articlesConnection": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArticleConnection"
+        },
+        "artist.articlesConnection.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "ArticleEdge"
+        },
+        "artist.articlesConnection.edges.node": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Article"
+        },
+        "artist.articlesConnection.edges.node.byline": (v15/*: any*/),
+        "artist.articlesConnection.edges.node.href": (v15/*: any*/),
+        "artist.articlesConnection.edges.node.id": (v16/*: any*/),
+        "artist.articlesConnection.edges.node.internalID": (v16/*: any*/),
+        "artist.articlesConnection.edges.node.publishedAt": (v15/*: any*/),
+        "artist.articlesConnection.edges.node.thumbnailImage": (v17/*: any*/),
+        "artist.articlesConnection.edges.node.thumbnailImage.small": (v18/*: any*/),
+        "artist.articlesConnection.edges.node.thumbnailImage.small.src": (v19/*: any*/),
+        "artist.articlesConnection.edges.node.thumbnailImage.small.srcSet": (v19/*: any*/),
+        "artist.articlesConnection.edges.node.title": (v15/*: any*/),
+        "artist.articlesConnection.totalCount": (v20/*: any*/),
+        "artist.awards": (v15/*: any*/),
+        "artist.biographyBlurb": (v21/*: any*/),
+        "artist.biographyBlurb.credit": (v15/*: any*/),
+        "artist.biographyBlurb.text": (v15/*: any*/),
+        "artist.biographyBlurbPlain": (v21/*: any*/),
+        "artist.biographyBlurbPlain.text": (v15/*: any*/),
+        "artist.birthday": (v15/*: any*/),
         "artist.counts": {
           "enumValues": null,
           "nullable": true,
@@ -646,26 +792,26 @@ return {
           "plural": false,
           "type": "Artwork"
         },
-        "artist.coverArtwork.fallbackArtist": (v13/*: any*/),
+        "artist.coverArtwork.fallbackArtist": (v14/*: any*/),
         "artist.coverArtwork.fallbackArtist.id": (v16/*: any*/),
-        "artist.coverArtwork.fallbackArtist.name": (v14/*: any*/),
-        "artist.coverArtwork.href": (v14/*: any*/),
+        "artist.coverArtwork.fallbackArtist.name": (v15/*: any*/),
+        "artist.coverArtwork.href": (v15/*: any*/),
         "artist.coverArtwork.id": (v16/*: any*/),
         "artist.coverArtwork.image": (v17/*: any*/),
         "artist.coverArtwork.image.cropped": (v18/*: any*/),
-        "artist.coverArtwork.image.cropped.height": (v19/*: any*/),
-        "artist.coverArtwork.image.cropped.src": (v20/*: any*/),
-        "artist.coverArtwork.image.cropped.width": (v19/*: any*/),
-        "artist.coverArtwork.image.height": (v21/*: any*/),
-        "artist.coverArtwork.image.large": (v14/*: any*/),
-        "artist.coverArtwork.image.src": (v14/*: any*/),
-        "artist.coverArtwork.image.width": (v21/*: any*/),
-        "artist.coverArtwork.imageTitle": (v14/*: any*/),
+        "artist.coverArtwork.image.cropped.height": (v22/*: any*/),
+        "artist.coverArtwork.image.cropped.src": (v19/*: any*/),
+        "artist.coverArtwork.image.cropped.width": (v22/*: any*/),
+        "artist.coverArtwork.image.height": (v20/*: any*/),
+        "artist.coverArtwork.image.large": (v15/*: any*/),
+        "artist.coverArtwork.image.src": (v15/*: any*/),
+        "artist.coverArtwork.image.width": (v20/*: any*/),
+        "artist.coverArtwork.imageTitle": (v15/*: any*/),
         "artist.coverArtwork.internalID": (v16/*: any*/),
         "artist.coverArtwork.slug": (v16/*: any*/),
-        "artist.deathday": (v14/*: any*/),
-        "artist.formattedNationalityAndBirthday": (v14/*: any*/),
-        "artist.gender": (v14/*: any*/),
+        "artist.deathday": (v15/*: any*/),
+        "artist.formattedNationalityAndBirthday": (v15/*: any*/),
+        "artist.gender": (v15/*: any*/),
         "artist.genes": {
           "enumValues": null,
           "nullable": false,
@@ -673,9 +819,9 @@ return {
           "type": "Gene"
         },
         "artist.genes.id": (v16/*: any*/),
-        "artist.genes.name": (v14/*: any*/),
-        "artist.hometown": (v14/*: any*/),
-        "artist.href": (v14/*: any*/),
+        "artist.genes.name": (v15/*: any*/),
+        "artist.hometown": (v15/*: any*/),
+        "artist.href": (v15/*: any*/),
         "artist.id": (v16/*: any*/),
         "artist.insights": {
           "enumValues": null,
@@ -683,7 +829,7 @@ return {
           "plural": true,
           "type": "ArtistInsight"
         },
-        "artist.insights.description": (v14/*: any*/),
+        "artist.insights.description": (v15/*: any*/),
         "artist.insights.entities": {
           "enumValues": null,
           "nullable": false,
@@ -714,20 +860,20 @@ return {
           "plural": false,
           "type": "ArtistInsightKind"
         },
-        "artist.insights.label": (v20/*: any*/),
+        "artist.insights.label": (v19/*: any*/),
         "artist.internalID": (v16/*: any*/),
-        "artist.name": (v14/*: any*/),
-        "artist.nationality": (v14/*: any*/),
+        "artist.name": (v15/*: any*/),
+        "artist.nationality": (v15/*: any*/),
         "artist.notableArtworks": {
           "enumValues": null,
           "nullable": false,
           "plural": true,
           "type": "Artwork"
         },
-        "artist.notableArtworks.date": (v14/*: any*/),
-        "artist.notableArtworks.href": (v14/*: any*/),
+        "artist.notableArtworks.date": (v15/*: any*/),
+        "artist.notableArtworks.href": (v15/*: any*/),
         "artist.notableArtworks.id": (v16/*: any*/),
-        "artist.notableArtworks.title": (v14/*: any*/),
+        "artist.notableArtworks.title": (v15/*: any*/),
         "artist.slug": (v16/*: any*/),
         "artist.verifiedRepresentatives": {
           "enumValues": null,
@@ -742,10 +888,10 @@ return {
           "plural": false,
           "type": "Partner"
         },
-        "artist.verifiedRepresentatives.partner.href": (v14/*: any*/),
+        "artist.verifiedRepresentatives.partner.href": (v15/*: any*/),
         "artist.verifiedRepresentatives.partner.id": (v16/*: any*/),
         "artist.verifiedRepresentatives.partner.internalID": (v16/*: any*/),
-        "artist.verifiedRepresentatives.partner.name": (v14/*: any*/),
+        "artist.verifiedRepresentatives.partner.name": (v15/*: any*/),
         "artist.verifiedRepresentatives.partner.profile": {
           "enumValues": null,
           "nullable": true,
@@ -754,15 +900,15 @@ return {
         },
         "artist.verifiedRepresentatives.partner.profile.icon": (v17/*: any*/),
         "artist.verifiedRepresentatives.partner.profile.icon.src1x": (v18/*: any*/),
-        "artist.verifiedRepresentatives.partner.profile.icon.src1x.src": (v20/*: any*/),
+        "artist.verifiedRepresentatives.partner.profile.icon.src1x.src": (v19/*: any*/),
         "artist.verifiedRepresentatives.partner.profile.icon.src2x": (v18/*: any*/),
-        "artist.verifiedRepresentatives.partner.profile.icon.src2x.src": (v20/*: any*/),
+        "artist.verifiedRepresentatives.partner.profile.icon.src2x.src": (v19/*: any*/),
         "artist.verifiedRepresentatives.partner.profile.id": (v16/*: any*/)
       }
     },
     "name": "ArtistAppTestQuery",
     "operationKind": "query",
-    "text": "query ArtistAppTestQuery {\n  artist(id: \"example\") {\n    ...ArtistApp_artist\n    id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  internalID\n  slug\n  name\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  kind\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistHeaderImage_artwork on Artwork {\n  imageTitle\n  image {\n    src: url(version: [\"larger\", \"larger\"])\n    width\n    height\n  }\n  fallbackArtist: artist {\n    name\n    id\n  }\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  insights {\n    kind\n    ...ArtistCareerHighlight_insight\n  }\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          src1x: cropped(width: 30, height: 30) {\n            src\n          }\n          src2x: cropped(width: 60, height: 60) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n  coverArtwork {\n    internalID\n    slug\n    href\n    image {\n      src: url(version: [\"larger\", \"larger\"])\n      width\n      height\n    }\n    ...ArtistHeaderImage_artwork\n    id\n  }\n}\n\nfragment ArtistMeta_artist on Artist {\n  ...ArtistStructuredData_artist\n  name\n  nationality\n  birthday\n  deathday\n  alternateNames\n  biographyBlurbPlain: biographyBlurb(format: PLAIN) {\n    text\n  }\n  coverArtwork {\n    image {\n      large: url(version: \"large\")\n    }\n    id\n  }\n}\n\nfragment ArtistStructuredData_artist on Artist {\n  slug\n  name\n  alternateNames\n  awards\n  birthday\n  deathday\n  gender\n  hometown\n  nationality\n  href\n  biographyBlurbPlain: biographyBlurb(format: PLAIN) {\n    text\n  }\n  coverArtwork {\n    image {\n      cropped(width: 1200, height: 900, version: [\"larger\", \"large\"]) {\n        src\n        width\n        height\n      }\n    }\n    id\n  }\n  verifiedRepresentatives {\n    partner {\n      name\n      href\n      id\n    }\n    id\n  }\n  notableArtworks(size: 3) {\n    title\n    href\n    date\n    id\n  }\n  genes(size: 10) {\n    name\n    id\n  }\n}\n"
+    "text": "query ArtistAppTestQuery {\n  artist(id: \"example\") {\n    ...ArtistApp_artist\n    id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  internalID\n  slug\n  name\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  kind\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistHeaderEditorialItem_article on Article {\n  internalID\n  href\n  byline\n  title\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    small: cropped(width: 125, height: 125) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtistHeaderEditorial_artist on Artist {\n  name\n  href\n  articlesConnection(first: 3, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        ...ArtistHeaderEditorialItem_article\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistHeaderImage_artwork on Artwork {\n  imageTitle\n  image {\n    src: url(version: [\"larger\", \"larger\"])\n    width\n    height\n  }\n  fallbackArtist: artist {\n    name\n    id\n  }\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  insights {\n    kind\n    ...ArtistCareerHighlight_insight\n  }\n  articlesConnection(first: 3, sort: PUBLISHED_AT_DESC) {\n    totalCount\n  }\n  ...ArtistHeaderEditorial_artist\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          src1x: cropped(width: 30, height: 30) {\n            src\n          }\n          src2x: cropped(width: 60, height: 60) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n  coverArtwork {\n    internalID\n    slug\n    href\n    image {\n      src: url(version: [\"larger\", \"larger\"])\n      width\n      height\n    }\n    ...ArtistHeaderImage_artwork\n    id\n  }\n}\n\nfragment ArtistMeta_artist on Artist {\n  ...ArtistStructuredData_artist\n  name\n  nationality\n  birthday\n  deathday\n  alternateNames\n  biographyBlurbPlain: biographyBlurb(format: PLAIN) {\n    text\n  }\n  coverArtwork {\n    image {\n      large: url(version: \"large\")\n    }\n    id\n  }\n}\n\nfragment ArtistStructuredData_artist on Artist {\n  slug\n  name\n  alternateNames\n  awards\n  birthday\n  deathday\n  gender\n  hometown\n  nationality\n  href\n  biographyBlurbPlain: biographyBlurb(format: PLAIN) {\n    text\n  }\n  coverArtwork {\n    image {\n      cropped(width: 1200, height: 900, version: [\"larger\", \"large\"]) {\n        src\n        width\n        height\n      }\n    }\n    id\n  }\n  verifiedRepresentatives {\n    partner {\n      name\n      href\n      id\n    }\n    id\n  }\n  notableArtworks(size: 3) {\n    title\n    href\n    date\n    id\n  }\n  genes(size: 10) {\n    name\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistCareerHighlightsQuery.graphql.ts
+++ b/src/__generated__/ArtistCareerHighlightsQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1bc897d4d57d1b7ce668efa70bca7e80>>
+ * @generated SignedSource<<b2f19da90e2c11dbc32b84994b299708>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -95,6 +95,30 @@ return {
           },
           {
             "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 1
+              }
+            ],
+            "concreteType": "ArticleConnection",
+            "kind": "LinkedField",
+            "name": "articlesConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "totalCount",
+                "storageKey": null
+              }
+            ],
+            "storageKey": "articlesConnection(first:1)"
+          },
+          {
+            "alias": null,
             "args": null,
             "concreteType": "ArtistInsight",
             "kind": "LinkedField",
@@ -151,12 +175,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "6383a5abf9e38d885c4ceb612ac368e4",
+    "cacheID": "a4031d4fa18c977e04f9eeb8a56ededc",
     "id": null,
     "metadata": {},
     "name": "ArtistCareerHighlightsQuery",
     "operationKind": "query",
-    "text": "query ArtistCareerHighlightsQuery(\n  $id: String!\n) {\n  artist(id: $id) {\n    ...ArtistCareerHighlights_artist\n    id\n  }\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  kind\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistCareerHighlights_artist on Artist {\n  name\n  href\n  insights {\n    ...ArtistCareerHighlight_insight\n    kind\n    entities\n    description(format: HTML)\n  }\n}\n"
+    "text": "query ArtistCareerHighlightsQuery(\n  $id: String!\n) {\n  artist(id: $id) {\n    ...ArtistCareerHighlights_artist\n    id\n  }\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  kind\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistCareerHighlights_artist on Artist {\n  name\n  href\n  articlesConnection(first: 1) {\n    totalCount\n  }\n  insights {\n    ...ArtistCareerHighlight_insight\n    kind\n    entities\n    description(format: HTML)\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistCareerHighlights_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistCareerHighlights_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<8588b35a320770e98107fa9399e1d4e7>>
+ * @generated SignedSource<<8ac2e9e4974f796e3a93034847d22561>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -92,6 +92,30 @@ return {
           },
           {
             "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 1
+              }
+            ],
+            "concreteType": "ArticleConnection",
+            "kind": "LinkedField",
+            "name": "articlesConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "totalCount",
+                "storageKey": null
+              }
+            ],
+            "storageKey": "articlesConnection(first:1)"
+          },
+          {
+            "alias": null,
             "args": null,
             "concreteType": "ArtistInsight",
             "kind": "LinkedField",
@@ -148,7 +172,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "4231d35ab562fa8dda6322c8f9fee94c",
+    "cacheID": "80d1d260c3fc6e4adeb9a3f4382e5ffa",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -157,6 +181,18 @@ return {
           "nullable": true,
           "plural": false,
           "type": "Artist"
+        },
+        "artist.articlesConnection": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArticleConnection"
+        },
+        "artist.articlesConnection.totalCount": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Int"
         },
         "artist.href": (v1/*: any*/),
         "artist.id": {
@@ -213,7 +249,7 @@ return {
     },
     "name": "ArtistCareerHighlights_Test_Query",
     "operationKind": "query",
-    "text": "query ArtistCareerHighlights_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistCareerHighlights_artist\n    id\n  }\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  kind\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistCareerHighlights_artist on Artist {\n  name\n  href\n  insights {\n    ...ArtistCareerHighlight_insight\n    kind\n    entities\n    description(format: HTML)\n  }\n}\n"
+    "text": "query ArtistCareerHighlights_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistCareerHighlights_artist\n    id\n  }\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  kind\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistCareerHighlights_artist on Artist {\n  name\n  href\n  articlesConnection(first: 1) {\n    totalCount\n  }\n  insights {\n    ...ArtistCareerHighlight_insight\n    kind\n    entities\n    description(format: HTML)\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistCareerHighlights_artist.graphql.ts
+++ b/src/__generated__/ArtistCareerHighlights_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<90f725d1d25b8ee8df2549347cd53386>>
+ * @generated SignedSource<<a4758319ad30ddbd33c58e8fa0bb7326>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,9 @@ import { ReaderFragment } from 'relay-runtime';
 export type ArtistInsightKind = "ACTIVE_SECONDARY_MARKET" | "ARTSY_VANGUARD_YEAR" | "AWARDS" | "BIENNIAL" | "COLLECTED" | "CRITICALLY_ACCLAIMED" | "CURATORS_PICK_EMERGING" | "FOUNDATIONS" | "GAINING_FOLLOWERS" | "GROUP_SHOW" | "HIGH_AUCTION_RECORD" | "PRIVATE_COLLECTIONS" | "RECENT_CAREER_EVENT" | "RESIDENCIES" | "REVIEWED" | "SOLO_SHOW" | "TRENDING_NOW" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type ArtistCareerHighlights_artist$data = {
+  readonly articlesConnection: {
+    readonly totalCount: number | null | undefined;
+  } | null | undefined;
   readonly href: string | null | undefined;
   readonly insights: ReadonlyArray<{
     readonly description: string | null | undefined;
@@ -46,6 +49,30 @@ const node: ReaderFragment = {
       "kind": "ScalarField",
       "name": "href",
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 1
+        }
+      ],
+      "concreteType": "ArticleConnection",
+      "kind": "LinkedField",
+      "name": "articlesConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "totalCount",
+          "storageKey": null
+        }
+      ],
+      "storageKey": "articlesConnection(first:1)"
     },
     {
       "alias": null,
@@ -95,6 +122,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "fe1ae82aedf825b87d4bb8d944f5e3f9";
+(node as any).hash = "700ca6b21df6819b4758b21cbb1b2f87";
 
 export default node;

--- a/src/__generated__/ArtistHeaderEditorialItem_article.graphql.ts
+++ b/src/__generated__/ArtistHeaderEditorialItem_article.graphql.ts
@@ -1,0 +1,133 @@
+/**
+ * @generated SignedSource<<1f02584d46530b70851831aea03035b7>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ArtistHeaderEditorialItem_article$data = {
+  readonly byline: string | null | undefined;
+  readonly href: string | null | undefined;
+  readonly internalID: string;
+  readonly publishedAt: string | null | undefined;
+  readonly thumbnailImage: {
+    readonly small: {
+      readonly src: string;
+      readonly srcSet: string;
+    } | null | undefined;
+  } | null | undefined;
+  readonly title: string | null | undefined;
+  readonly " $fragmentType": "ArtistHeaderEditorialItem_article";
+};
+export type ArtistHeaderEditorialItem_article$key = {
+  readonly " $data"?: ArtistHeaderEditorialItem_article$data;
+  readonly " $fragmentSpreads": FragmentRefs<"ArtistHeaderEditorialItem_article">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ArtistHeaderEditorialItem_article",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "internalID",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "href",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "byline",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "title",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "format",
+          "value": "MMM D, YYYY"
+        }
+      ],
+      "kind": "ScalarField",
+      "name": "publishedAt",
+      "storageKey": "publishedAt(format:\"MMM D, YYYY\")"
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Image",
+      "kind": "LinkedField",
+      "name": "thumbnailImage",
+      "plural": false,
+      "selections": [
+        {
+          "alias": "small",
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "height",
+              "value": 125
+            },
+            {
+              "kind": "Literal",
+              "name": "width",
+              "value": 125
+            }
+          ],
+          "concreteType": "CroppedImageUrl",
+          "kind": "LinkedField",
+          "name": "cropped",
+          "plural": false,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "src",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "srcSet",
+              "storageKey": null
+            }
+          ],
+          "storageKey": "cropped(height:125,width:125)"
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Article",
+  "abstractKey": null
+};
+
+(node as any).hash = "b1980e299d766d96a40b49aa38ef22e1";
+
+export default node;

--- a/src/__generated__/ArtistHeaderEditorial_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistHeaderEditorial_Test_Query.graphql.ts
@@ -1,0 +1,322 @@
+/**
+ * @generated SignedSource<<d60690dc7d19f0dc985d72611b0a85d2>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ArtistHeaderEditorial_Test_Query$variables = Record<PropertyKey, never>;
+export type ArtistHeaderEditorial_Test_Query$data = {
+  readonly artist: {
+    readonly " $fragmentSpreads": FragmentRefs<"ArtistHeaderEditorial_artist">;
+  } | null | undefined;
+};
+export type ArtistHeaderEditorial_Test_Query = {
+  response: ArtistHeaderEditorial_Test_Query$data;
+  variables: ArtistHeaderEditorial_Test_Query$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "example"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "href",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v4 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v5 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "String"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ArtistHeaderEditorial_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Artist",
+        "kind": "LinkedField",
+        "name": "artist",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ArtistHeaderEditorial_artist"
+          }
+        ],
+        "storageKey": "artist(id:\"example\")"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "ArtistHeaderEditorial_Test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Artist",
+        "kind": "LinkedField",
+        "name": "artist",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "name",
+            "storageKey": null
+          },
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 3
+              },
+              {
+                "kind": "Literal",
+                "name": "sort",
+                "value": "PUBLISHED_AT_DESC"
+              }
+            ],
+            "concreteType": "ArticleConnection",
+            "kind": "LinkedField",
+            "name": "articlesConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "totalCount",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ArticleEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Article",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "internalID",
+                        "storageKey": null
+                      },
+                      (v1/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "byline",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "title",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "format",
+                            "value": "MMM D, YYYY"
+                          }
+                        ],
+                        "kind": "ScalarField",
+                        "name": "publishedAt",
+                        "storageKey": "publishedAt(format:\"MMM D, YYYY\")"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "thumbnailImage",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "small",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "height",
+                                "value": 125
+                              },
+                              {
+                                "kind": "Literal",
+                                "name": "width",
+                                "value": 125
+                              }
+                            ],
+                            "concreteType": "CroppedImageUrl",
+                            "kind": "LinkedField",
+                            "name": "cropped",
+                            "plural": false,
+                            "selections": [
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "src",
+                                "storageKey": null
+                              },
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "srcSet",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": "cropped(height:125,width:125)"
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      (v2/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "articlesConnection(first:3,sort:\"PUBLISHED_AT_DESC\")"
+          },
+          (v2/*: any*/)
+        ],
+        "storageKey": "artist(id:\"example\")"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "6b638b45cee9960246caed14e0c21bfc",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "artist": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Artist"
+        },
+        "artist.articlesConnection": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArticleConnection"
+        },
+        "artist.articlesConnection.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "ArticleEdge"
+        },
+        "artist.articlesConnection.edges.node": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Article"
+        },
+        "artist.articlesConnection.edges.node.byline": (v3/*: any*/),
+        "artist.articlesConnection.edges.node.href": (v3/*: any*/),
+        "artist.articlesConnection.edges.node.id": (v4/*: any*/),
+        "artist.articlesConnection.edges.node.internalID": (v4/*: any*/),
+        "artist.articlesConnection.edges.node.publishedAt": (v3/*: any*/),
+        "artist.articlesConnection.edges.node.thumbnailImage": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Image"
+        },
+        "artist.articlesConnection.edges.node.thumbnailImage.small": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "CroppedImageUrl"
+        },
+        "artist.articlesConnection.edges.node.thumbnailImage.small.src": (v5/*: any*/),
+        "artist.articlesConnection.edges.node.thumbnailImage.small.srcSet": (v5/*: any*/),
+        "artist.articlesConnection.edges.node.title": (v3/*: any*/),
+        "artist.articlesConnection.totalCount": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Int"
+        },
+        "artist.href": (v3/*: any*/),
+        "artist.id": (v4/*: any*/),
+        "artist.name": (v3/*: any*/)
+      }
+    },
+    "name": "ArtistHeaderEditorial_Test_Query",
+    "operationKind": "query",
+    "text": "query ArtistHeaderEditorial_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistHeaderEditorial_artist\n    id\n  }\n}\n\nfragment ArtistHeaderEditorialItem_article on Article {\n  internalID\n  href\n  byline\n  title\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    small: cropped(width: 125, height: 125) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtistHeaderEditorial_artist on Artist {\n  name\n  href\n  articlesConnection(first: 3, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        ...ArtistHeaderEditorialItem_article\n        internalID\n        id\n      }\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "1b2eb2a4757af3c15b3b5e69654f4825";
+
+export default node;

--- a/src/__generated__/ArtistHeaderEditorial_artist.graphql.ts
+++ b/src/__generated__/ArtistHeaderEditorial_artist.graphql.ts
@@ -1,0 +1,122 @@
+/**
+ * @generated SignedSource<<0a2a1009abe66d80e2d58084bbf9d0ba>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ArtistHeaderEditorial_artist$data = {
+  readonly articlesConnection: {
+    readonly edges: ReadonlyArray<{
+      readonly node: {
+        readonly internalID: string;
+        readonly " $fragmentSpreads": FragmentRefs<"ArtistHeaderEditorialItem_article">;
+      } | null | undefined;
+    } | null | undefined> | null | undefined;
+    readonly totalCount: number | null | undefined;
+  } | null | undefined;
+  readonly href: string | null | undefined;
+  readonly name: string | null | undefined;
+  readonly " $fragmentType": "ArtistHeaderEditorial_artist";
+};
+export type ArtistHeaderEditorial_artist$key = {
+  readonly " $data"?: ArtistHeaderEditorial_artist$data;
+  readonly " $fragmentSpreads": FragmentRefs<"ArtistHeaderEditorial_artist">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ArtistHeaderEditorial_artist",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "name",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "href",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 3
+        },
+        {
+          "kind": "Literal",
+          "name": "sort",
+          "value": "PUBLISHED_AT_DESC"
+        }
+      ],
+      "concreteType": "ArticleConnection",
+      "kind": "LinkedField",
+      "name": "articlesConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "totalCount",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "ArticleEdge",
+          "kind": "LinkedField",
+          "name": "edges",
+          "plural": true,
+          "selections": [
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Article",
+              "kind": "LinkedField",
+              "name": "node",
+              "plural": false,
+              "selections": [
+                {
+                  "args": null,
+                  "kind": "FragmentSpread",
+                  "name": "ArtistHeaderEditorialItem_article"
+                },
+                {
+                  "alias": null,
+                  "args": null,
+                  "kind": "ScalarField",
+                  "name": "internalID",
+                  "storageKey": null
+                }
+              ],
+              "storageKey": null
+            }
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": "articlesConnection(first:3,sort:\"PUBLISHED_AT_DESC\")"
+    }
+  ],
+  "type": "Artist",
+  "abstractKey": null
+};
+
+(node as any).hash = "2989a92b71193f16bbd5f873cf16608c";
+
+export default node;

--- a/src/__generated__/ArtistHeader_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistHeader_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<74bf378969e373c758d917c5e560dc0a>>
+ * @generated SignedSource<<680e021d788dc3b076dc753c3e15813c>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -64,15 +64,13 @@ v5 = {
   "name": "href",
   "storageKey": null
 },
-v6 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "src",
-    "storageKey": null
-  }
-],
+v6 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "src",
+  "storageKey": null
+},
 v7 = {
   "alias": null,
   "args": null,
@@ -80,47 +78,50 @@ v7 = {
   "name": "id",
   "storageKey": null
 },
-v8 = {
+v8 = [
+  (v6/*: any*/)
+],
+v9 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Artist"
 },
-v9 = {
+v10 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v10 = {
+v11 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v11 = {
+v12 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Image"
 },
-v12 = {
+v13 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Int"
+  "type": "CroppedImageUrl"
 },
-v13 = {
+v14 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v14 = {
+v15 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "CroppedImageUrl"
+  "type": "Int"
 };
 return {
   "fragment": {
@@ -257,6 +258,129 @@ return {
           },
           {
             "alias": null,
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "first",
+                "value": 3
+              },
+              {
+                "kind": "Literal",
+                "name": "sort",
+                "value": "PUBLISHED_AT_DESC"
+              }
+            ],
+            "concreteType": "ArticleConnection",
+            "kind": "LinkedField",
+            "name": "articlesConnection",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "totalCount",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "ArticleEdge",
+                "kind": "LinkedField",
+                "name": "edges",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Article",
+                    "kind": "LinkedField",
+                    "name": "node",
+                    "plural": false,
+                    "selections": [
+                      (v1/*: any*/),
+                      (v5/*: any*/),
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "byline",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "title",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "format",
+                            "value": "MMM D, YYYY"
+                          }
+                        ],
+                        "kind": "ScalarField",
+                        "name": "publishedAt",
+                        "storageKey": "publishedAt(format:\"MMM D, YYYY\")"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "concreteType": "Image",
+                        "kind": "LinkedField",
+                        "name": "thumbnailImage",
+                        "plural": false,
+                        "selections": [
+                          {
+                            "alias": "small",
+                            "args": [
+                              {
+                                "kind": "Literal",
+                                "name": "height",
+                                "value": 125
+                              },
+                              {
+                                "kind": "Literal",
+                                "name": "width",
+                                "value": 125
+                              }
+                            ],
+                            "concreteType": "CroppedImageUrl",
+                            "kind": "LinkedField",
+                            "name": "cropped",
+                            "plural": false,
+                            "selections": [
+                              (v6/*: any*/),
+                              {
+                                "alias": null,
+                                "args": null,
+                                "kind": "ScalarField",
+                                "name": "srcSet",
+                                "storageKey": null
+                              }
+                            ],
+                            "storageKey": "cropped(height:125,width:125)"
+                          }
+                        ],
+                        "storageKey": null
+                      },
+                      (v7/*: any*/)
+                    ],
+                    "storageKey": null
+                  }
+                ],
+                "storageKey": null
+              }
+            ],
+            "storageKey": "articlesConnection(first:3,sort:\"PUBLISHED_AT_DESC\")"
+          },
+          (v5/*: any*/),
+          {
+            "alias": null,
             "args": null,
             "concreteType": "VerifiedRepresentative",
             "kind": "LinkedField",
@@ -308,7 +432,7 @@ return {
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v8/*: any*/),
                             "storageKey": "cropped(height:30,width:30)"
                           },
                           {
@@ -329,7 +453,7 @@ return {
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v6/*: any*/),
+                            "selections": (v8/*: any*/),
                             "storageKey": "cropped(height:60,width:60)"
                           }
                         ],
@@ -430,19 +554,48 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a519d4ea488321cfaadb9d104d806164",
+    "cacheID": "f5f1281980bd5b1c93ce00fb67961781",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
-        "artist": (v8/*: any*/),
+        "artist": (v9/*: any*/),
+        "artist.articlesConnection": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "ArticleConnection"
+        },
+        "artist.articlesConnection.edges": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": true,
+          "type": "ArticleEdge"
+        },
+        "artist.articlesConnection.edges.node": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Article"
+        },
+        "artist.articlesConnection.edges.node.byline": (v10/*: any*/),
+        "artist.articlesConnection.edges.node.href": (v10/*: any*/),
+        "artist.articlesConnection.edges.node.id": (v11/*: any*/),
+        "artist.articlesConnection.edges.node.internalID": (v11/*: any*/),
+        "artist.articlesConnection.edges.node.publishedAt": (v10/*: any*/),
+        "artist.articlesConnection.edges.node.thumbnailImage": (v12/*: any*/),
+        "artist.articlesConnection.edges.node.thumbnailImage.small": (v13/*: any*/),
+        "artist.articlesConnection.edges.node.thumbnailImage.small.src": (v14/*: any*/),
+        "artist.articlesConnection.edges.node.thumbnailImage.small.srcSet": (v14/*: any*/),
+        "artist.articlesConnection.edges.node.title": (v10/*: any*/),
+        "artist.articlesConnection.totalCount": (v15/*: any*/),
         "artist.biographyBlurb": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtistBlurb"
         },
-        "artist.biographyBlurb.credit": (v9/*: any*/),
-        "artist.biographyBlurb.text": (v9/*: any*/),
+        "artist.biographyBlurb.credit": (v10/*: any*/),
+        "artist.biographyBlurb.text": (v10/*: any*/),
         "artist.counts": {
           "enumValues": null,
           "nullable": true,
@@ -461,27 +614,28 @@ return {
           "plural": false,
           "type": "Artwork"
         },
-        "artist.coverArtwork.fallbackArtist": (v8/*: any*/),
-        "artist.coverArtwork.fallbackArtist.id": (v10/*: any*/),
-        "artist.coverArtwork.fallbackArtist.name": (v9/*: any*/),
-        "artist.coverArtwork.href": (v9/*: any*/),
-        "artist.coverArtwork.id": (v10/*: any*/),
-        "artist.coverArtwork.image": (v11/*: any*/),
-        "artist.coverArtwork.image.height": (v12/*: any*/),
-        "artist.coverArtwork.image.src": (v9/*: any*/),
-        "artist.coverArtwork.image.width": (v12/*: any*/),
-        "artist.coverArtwork.imageTitle": (v9/*: any*/),
-        "artist.coverArtwork.internalID": (v10/*: any*/),
-        "artist.coverArtwork.slug": (v10/*: any*/),
-        "artist.formattedNationalityAndBirthday": (v9/*: any*/),
-        "artist.id": (v10/*: any*/),
+        "artist.coverArtwork.fallbackArtist": (v9/*: any*/),
+        "artist.coverArtwork.fallbackArtist.id": (v11/*: any*/),
+        "artist.coverArtwork.fallbackArtist.name": (v10/*: any*/),
+        "artist.coverArtwork.href": (v10/*: any*/),
+        "artist.coverArtwork.id": (v11/*: any*/),
+        "artist.coverArtwork.image": (v12/*: any*/),
+        "artist.coverArtwork.image.height": (v15/*: any*/),
+        "artist.coverArtwork.image.src": (v10/*: any*/),
+        "artist.coverArtwork.image.width": (v15/*: any*/),
+        "artist.coverArtwork.imageTitle": (v10/*: any*/),
+        "artist.coverArtwork.internalID": (v11/*: any*/),
+        "artist.coverArtwork.slug": (v11/*: any*/),
+        "artist.formattedNationalityAndBirthday": (v10/*: any*/),
+        "artist.href": (v10/*: any*/),
+        "artist.id": (v11/*: any*/),
         "artist.insights": {
           "enumValues": null,
           "nullable": false,
           "plural": true,
           "type": "ArtistInsight"
         },
-        "artist.insights.description": (v9/*: any*/),
+        "artist.insights.description": (v10/*: any*/),
         "artist.insights.entities": {
           "enumValues": null,
           "nullable": false,
@@ -512,44 +666,44 @@ return {
           "plural": false,
           "type": "ArtistInsightKind"
         },
-        "artist.insights.label": (v13/*: any*/),
-        "artist.internalID": (v10/*: any*/),
-        "artist.name": (v9/*: any*/),
-        "artist.slug": (v10/*: any*/),
+        "artist.insights.label": (v14/*: any*/),
+        "artist.internalID": (v11/*: any*/),
+        "artist.name": (v10/*: any*/),
+        "artist.slug": (v11/*: any*/),
         "artist.verifiedRepresentatives": {
           "enumValues": null,
           "nullable": false,
           "plural": true,
           "type": "VerifiedRepresentative"
         },
-        "artist.verifiedRepresentatives.id": (v10/*: any*/),
+        "artist.verifiedRepresentatives.id": (v11/*: any*/),
         "artist.verifiedRepresentatives.partner": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "Partner"
         },
-        "artist.verifiedRepresentatives.partner.href": (v9/*: any*/),
-        "artist.verifiedRepresentatives.partner.id": (v10/*: any*/),
-        "artist.verifiedRepresentatives.partner.internalID": (v10/*: any*/),
-        "artist.verifiedRepresentatives.partner.name": (v9/*: any*/),
+        "artist.verifiedRepresentatives.partner.href": (v10/*: any*/),
+        "artist.verifiedRepresentatives.partner.id": (v11/*: any*/),
+        "artist.verifiedRepresentatives.partner.internalID": (v11/*: any*/),
+        "artist.verifiedRepresentatives.partner.name": (v10/*: any*/),
         "artist.verifiedRepresentatives.partner.profile": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Profile"
         },
-        "artist.verifiedRepresentatives.partner.profile.icon": (v11/*: any*/),
-        "artist.verifiedRepresentatives.partner.profile.icon.src1x": (v14/*: any*/),
-        "artist.verifiedRepresentatives.partner.profile.icon.src1x.src": (v13/*: any*/),
-        "artist.verifiedRepresentatives.partner.profile.icon.src2x": (v14/*: any*/),
-        "artist.verifiedRepresentatives.partner.profile.icon.src2x.src": (v13/*: any*/),
-        "artist.verifiedRepresentatives.partner.profile.id": (v10/*: any*/)
+        "artist.verifiedRepresentatives.partner.profile.icon": (v12/*: any*/),
+        "artist.verifiedRepresentatives.partner.profile.icon.src1x": (v13/*: any*/),
+        "artist.verifiedRepresentatives.partner.profile.icon.src1x.src": (v14/*: any*/),
+        "artist.verifiedRepresentatives.partner.profile.icon.src2x": (v13/*: any*/),
+        "artist.verifiedRepresentatives.partner.profile.icon.src2x.src": (v14/*: any*/),
+        "artist.verifiedRepresentatives.partner.profile.id": (v11/*: any*/)
       }
     },
     "name": "ArtistHeader_Test_Query",
     "operationKind": "query",
-    "text": "query ArtistHeader_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistHeader_artist\n    id\n  }\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  kind\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistHeaderImage_artwork on Artwork {\n  imageTitle\n  image {\n    src: url(version: [\"larger\", \"larger\"])\n    width\n    height\n  }\n  fallbackArtist: artist {\n    name\n    id\n  }\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  insights {\n    kind\n    ...ArtistCareerHighlight_insight\n  }\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          src1x: cropped(width: 30, height: 30) {\n            src\n          }\n          src2x: cropped(width: 60, height: 60) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n  coverArtwork {\n    internalID\n    slug\n    href\n    image {\n      src: url(version: [\"larger\", \"larger\"])\n      width\n      height\n    }\n    ...ArtistHeaderImage_artwork\n    id\n  }\n}\n"
+    "text": "query ArtistHeader_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistHeader_artist\n    id\n  }\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  kind\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistHeaderEditorialItem_article on Article {\n  internalID\n  href\n  byline\n  title\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    small: cropped(width: 125, height: 125) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtistHeaderEditorial_artist on Artist {\n  name\n  href\n  articlesConnection(first: 3, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        ...ArtistHeaderEditorialItem_article\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistHeaderImage_artwork on Artwork {\n  imageTitle\n  image {\n    src: url(version: [\"larger\", \"larger\"])\n    width\n    height\n  }\n  fallbackArtist: artist {\n    name\n    id\n  }\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  insights {\n    kind\n    ...ArtistCareerHighlight_insight\n  }\n  articlesConnection(first: 3, sort: PUBLISHED_AT_DESC) {\n    totalCount\n  }\n  ...ArtistHeaderEditorial_artist\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          src1x: cropped(width: 30, height: 30) {\n            src\n          }\n          src2x: cropped(width: 60, height: 60) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n  coverArtwork {\n    internalID\n    slug\n    href\n    image {\n      src: url(version: [\"larger\", \"larger\"])\n      width\n      height\n    }\n    ...ArtistHeaderImage_artwork\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistHeader_artist.graphql.ts
+++ b/src/__generated__/ArtistHeader_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<387ca1b99a33dc3e275ee03df64f9feb>>
+ * @generated SignedSource<<8afc4d30f95d7e3fc3cef27c7766285f>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -12,6 +12,9 @@ import { ReaderFragment } from 'relay-runtime';
 export type ArtistInsightKind = "ACTIVE_SECONDARY_MARKET" | "ARTSY_VANGUARD_YEAR" | "AWARDS" | "BIENNIAL" | "COLLECTED" | "CRITICALLY_ACCLAIMED" | "CURATORS_PICK_EMERGING" | "FOUNDATIONS" | "GAINING_FOLLOWERS" | "GROUP_SHOW" | "HIGH_AUCTION_RECORD" | "PRIVATE_COLLECTIONS" | "RECENT_CAREER_EVENT" | "RESIDENCIES" | "REVIEWED" | "SOLO_SHOW" | "TRENDING_NOW" | "%future added value";
 import { FragmentRefs } from "relay-runtime";
 export type ArtistHeader_artist$data = {
+  readonly articlesConnection: {
+    readonly totalCount: number | null | undefined;
+  } | null | undefined;
   readonly biographyBlurb: {
     readonly credit: string | null | undefined;
     readonly text: string | null | undefined;
@@ -55,6 +58,7 @@ export type ArtistHeader_artist$data = {
       } | null | undefined;
     };
   }>;
+  readonly " $fragmentSpreads": FragmentRefs<"ArtistHeaderEditorial_artist">;
   readonly " $fragmentType": "ArtistHeader_artist";
 };
 export type ArtistHeader_artist$key = {
@@ -187,6 +191,40 @@ return {
         }
       ],
       "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "first",
+          "value": 3
+        },
+        {
+          "kind": "Literal",
+          "name": "sort",
+          "value": "PUBLISHED_AT_DESC"
+        }
+      ],
+      "concreteType": "ArticleConnection",
+      "kind": "LinkedField",
+      "name": "articlesConnection",
+      "plural": false,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "totalCount",
+          "storageKey": null
+        }
+      ],
+      "storageKey": "articlesConnection(first:3,sort:\"PUBLISHED_AT_DESC\")"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
+      "name": "ArtistHeaderEditorial_artist"
     },
     {
       "alias": null,
@@ -343,6 +381,6 @@ return {
 };
 })();
 
-(node as any).hash = "e646f8af0d12b8682664e738c4add32b";
+(node as any).hash = "6dd03d32de23ecef8c5dc53dde4f5d01";
 
 export default node;

--- a/src/__generated__/ArtistOverviewQueryRendererQuery.graphql.ts
+++ b/src/__generated__/ArtistOverviewQueryRendererQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c3592a0847fd1809e5e05b84817e1ca6>>
+ * @generated SignedSource<<81c74c2c738c1dc3ebd76fbd4dfff729>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -45,11 +45,13 @@ v2 = {
   "name": "__typename",
   "storageKey": null
 },
-v3 = {
-  "kind": "Literal",
-  "name": "first",
-  "value": 0
-},
+v3 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 1
+  }
+],
 v4 = [
   {
     "alias": null,
@@ -60,6 +62,11 @@ v4 = [
   }
 ],
 v5 = {
+  "kind": "Literal",
+  "name": "first",
+  "value": 0
+},
+v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
@@ -142,8 +149,18 @@ return {
           },
           {
             "alias": null,
+            "args": (v3/*: any*/),
+            "concreteType": "ArticleConnection",
+            "kind": "LinkedField",
+            "name": "articlesConnection",
+            "plural": false,
+            "selections": (v4/*: any*/),
+            "storageKey": "articlesConnection(first:1)"
+          },
+          {
+            "alias": null,
             "args": [
-              (v3/*: any*/)
+              (v5/*: any*/)
             ],
             "concreteType": "ArtistSeriesConnection",
             "kind": "LinkedField",
@@ -155,7 +172,7 @@ return {
           {
             "alias": null,
             "args": [
-              (v3/*: any*/),
+              (v5/*: any*/),
               {
                 "kind": "Literal",
                 "name": "status",
@@ -197,13 +214,7 @@ return {
             "selections": [
               {
                 "alias": null,
-                "args": [
-                  {
-                    "kind": "Literal",
-                    "name": "first",
-                    "value": 1
-                  }
-                ],
+                "args": (v3/*: any*/),
                 "concreteType": "GeneConnection",
                 "kind": "LinkedField",
                 "name": "genes",
@@ -226,7 +237,7 @@ return {
                         "plural": false,
                         "selections": [
                           (v2/*: any*/),
-                          (v5/*: any*/)
+                          (v6/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -239,19 +250,19 @@ return {
             ],
             "storageKey": null
           },
-          (v5/*: any*/)
+          (v6/*: any*/)
         ],
         "storageKey": null
       }
     ]
   },
   "params": {
-    "cacheID": "b501bf05149587dcc3d5c0466ac3b12c",
+    "cacheID": "e65a279d198c5d6a1e6cb6ef56819877",
     "id": null,
     "metadata": {},
     "name": "ArtistOverviewQueryRendererQuery",
     "operationKind": "query",
-    "text": "query ArtistOverviewQueryRendererQuery(\n  $artistID: String!\n) @cacheable {\n  artist(id: $artistID) {\n    ...ArtistOverview_artist\n    id\n  }\n}\n\nfragment ArtistOverview_artist on Artist {\n  internalID\n  href\n  name\n  insights {\n    __typename\n  }\n  artistSeriesConnection(first: 0) {\n    totalCount\n  }\n  showsConnection(first: 0, status: \"running\") {\n    totalCount\n  }\n  counts {\n    relatedArtists\n  }\n  related {\n    genes(first: 1) {\n      edges {\n        node {\n          __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
+    "text": "query ArtistOverviewQueryRendererQuery(\n  $artistID: String!\n) @cacheable {\n  artist(id: $artistID) {\n    ...ArtistOverview_artist\n    id\n  }\n}\n\nfragment ArtistOverview_artist on Artist {\n  internalID\n  href\n  name\n  insights {\n    __typename\n  }\n  articlesConnection(first: 1) {\n    totalCount\n  }\n  artistSeriesConnection(first: 0) {\n    totalCount\n  }\n  showsConnection(first: 0, status: \"running\") {\n    totalCount\n  }\n  counts {\n    relatedArtists\n  }\n  related {\n    genes(first: 1) {\n      edges {\n        node {\n          __typename\n          id\n        }\n      }\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistOverview_artist.graphql.ts
+++ b/src/__generated__/ArtistOverview_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<40d5af569085b05b2f6dc01c5a31c75a>>
+ * @generated SignedSource<<d5dd02083222e2182319baf802d7fce3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -11,6 +11,9 @@
 import { ReaderFragment } from 'relay-runtime';
 import { FragmentRefs } from "relay-runtime";
 export type ArtistOverview_artist$data = {
+  readonly articlesConnection: {
+    readonly totalCount: number | null | undefined;
+  } | null | undefined;
   readonly artistSeriesConnection: {
     readonly totalCount: number;
   } | null | undefined;
@@ -52,11 +55,13 @@ var v0 = [
     "storageKey": null
   }
 ],
-v1 = {
-  "kind": "Literal",
-  "name": "first",
-  "value": 0
-},
+v1 = [
+  {
+    "kind": "Literal",
+    "name": "first",
+    "value": 1
+  }
+],
 v2 = [
   {
     "alias": null,
@@ -65,7 +70,12 @@ v2 = [
     "name": "totalCount",
     "storageKey": null
   }
-];
+],
+v3 = {
+  "kind": "Literal",
+  "name": "first",
+  "value": 0
+};
 return {
   "argumentDefinitions": [],
   "kind": "Fragment",
@@ -105,8 +115,18 @@ return {
     },
     {
       "alias": null,
+      "args": (v1/*: any*/),
+      "concreteType": "ArticleConnection",
+      "kind": "LinkedField",
+      "name": "articlesConnection",
+      "plural": false,
+      "selections": (v2/*: any*/),
+      "storageKey": "articlesConnection(first:1)"
+    },
+    {
+      "alias": null,
       "args": [
-        (v1/*: any*/)
+        (v3/*: any*/)
       ],
       "concreteType": "ArtistSeriesConnection",
       "kind": "LinkedField",
@@ -118,7 +138,7 @@ return {
     {
       "alias": null,
       "args": [
-        (v1/*: any*/),
+        (v3/*: any*/),
         {
           "kind": "Literal",
           "name": "status",
@@ -160,13 +180,7 @@ return {
       "selections": [
         {
           "alias": null,
-          "args": [
-            {
-              "kind": "Literal",
-              "name": "first",
-              "value": 1
-            }
-          ],
+          "args": (v1/*: any*/),
           "concreteType": "GeneConnection",
           "kind": "LinkedField",
           "name": "genes",
@@ -205,6 +219,6 @@ return {
 };
 })();
 
-(node as any).hash = "d045ac74566d56916833c64576a0d522";
+(node as any).hash = "423f8b1ac84a9c7b27d18ab8c1950caa";
 
 export default node;

--- a/src/__generated__/artistRoutes_ArtistAppQuery.graphql.ts
+++ b/src/__generated__/artistRoutes_ArtistAppQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b1b1497cfeab4daef8d235bdc565f323>>
+ * @generated SignedSource<<06e71965f6b22e9828f751d9ff063847>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -203,7 +203,113 @@ v22 = [
 ],
 v23 = [
   (v6/*: any*/)
-];
+],
+v24 = {
+  "alias": null,
+  "args": [
+    (v18/*: any*/),
+    {
+      "kind": "Literal",
+      "name": "sort",
+      "value": "PUBLISHED_AT_DESC"
+    }
+  ],
+  "concreteType": "ArticleConnection",
+  "kind": "LinkedField",
+  "name": "articlesConnection",
+  "plural": false,
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "kind": "ScalarField",
+      "name": "totalCount",
+      "storageKey": null
+    },
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "ArticleEdge",
+      "kind": "LinkedField",
+      "name": "edges",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Article",
+          "kind": "LinkedField",
+          "name": "node",
+          "plural": false,
+          "selections": [
+            (v14/*: any*/),
+            (v4/*: any*/),
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "byline",
+              "storageKey": null
+            },
+            (v12/*: any*/),
+            {
+              "alias": null,
+              "args": [
+                {
+                  "kind": "Literal",
+                  "name": "format",
+                  "value": "MMM D, YYYY"
+                }
+              ],
+              "kind": "ScalarField",
+              "name": "publishedAt",
+              "storageKey": "publishedAt(format:\"MMM D, YYYY\")"
+            },
+            {
+              "alias": null,
+              "args": null,
+              "concreteType": "Image",
+              "kind": "LinkedField",
+              "name": "thumbnailImage",
+              "plural": false,
+              "selections": [
+                {
+                  "alias": "small",
+                  "args": [
+                    {
+                      "kind": "Literal",
+                      "name": "height",
+                      "value": 125
+                    },
+                    {
+                      "kind": "Literal",
+                      "name": "width",
+                      "value": 125
+                    }
+                  ],
+                  "concreteType": "CroppedImageUrl",
+                  "kind": "LinkedField",
+                  "name": "cropped",
+                  "plural": false,
+                  "selections": [
+                    (v6/*: any*/),
+                    (v17/*: any*/)
+                  ],
+                  "storageKey": "cropped(height:125,width:125)"
+                }
+              ],
+              "storageKey": null
+            },
+            (v9/*: any*/)
+          ],
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "storageKey": "articlesConnection(first:3,sort:\"PUBLISHED_AT_DESC\")"
+};
 return {
   "fragment": {
     "argumentDefinitions": (v0/*: any*/),
@@ -685,112 +791,7 @@ return {
                 ],
                 "storageKey": null
               },
-              {
-                "alias": null,
-                "args": [
-                  (v18/*: any*/),
-                  {
-                    "kind": "Literal",
-                    "name": "sort",
-                    "value": "PUBLISHED_AT_DESC"
-                  }
-                ],
-                "concreteType": "ArticleConnection",
-                "kind": "LinkedField",
-                "name": "articlesConnection",
-                "plural": false,
-                "selections": [
-                  {
-                    "alias": null,
-                    "args": null,
-                    "kind": "ScalarField",
-                    "name": "totalCount",
-                    "storageKey": null
-                  },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "ArticleEdge",
-                    "kind": "LinkedField",
-                    "name": "edges",
-                    "plural": true,
-                    "selections": [
-                      {
-                        "alias": null,
-                        "args": null,
-                        "concreteType": "Article",
-                        "kind": "LinkedField",
-                        "name": "node",
-                        "plural": false,
-                        "selections": [
-                          (v14/*: any*/),
-                          (v4/*: any*/),
-                          {
-                            "alias": null,
-                            "args": null,
-                            "kind": "ScalarField",
-                            "name": "byline",
-                            "storageKey": null
-                          },
-                          (v12/*: any*/),
-                          {
-                            "alias": null,
-                            "args": [
-                              {
-                                "kind": "Literal",
-                                "name": "format",
-                                "value": "MMM D, YYYY"
-                              }
-                            ],
-                            "kind": "ScalarField",
-                            "name": "publishedAt",
-                            "storageKey": "publishedAt(format:\"MMM D, YYYY\")"
-                          },
-                          {
-                            "alias": null,
-                            "args": null,
-                            "concreteType": "Image",
-                            "kind": "LinkedField",
-                            "name": "thumbnailImage",
-                            "plural": false,
-                            "selections": [
-                              {
-                                "alias": "small",
-                                "args": [
-                                  {
-                                    "kind": "Literal",
-                                    "name": "height",
-                                    "value": 125
-                                  },
-                                  {
-                                    "kind": "Literal",
-                                    "name": "width",
-                                    "value": 125
-                                  }
-                                ],
-                                "concreteType": "CroppedImageUrl",
-                                "kind": "LinkedField",
-                                "name": "cropped",
-                                "plural": false,
-                                "selections": [
-                                  (v6/*: any*/),
-                                  (v17/*: any*/)
-                                ],
-                                "storageKey": "cropped(height:125,width:125)"
-                              }
-                            ],
-                            "storageKey": null
-                          },
-                          (v9/*: any*/)
-                        ],
-                        "storageKey": null
-                      }
-                    ],
-                    "storageKey": null
-                  }
-                ],
-                "storageKey": "articlesConnection(first:3,sort:\"PUBLISHED_AT_DESC\")"
-              }
+              (v24/*: any*/)
             ]
           },
           {
@@ -840,6 +841,7 @@ return {
                 ],
                 "storageKey": null
               },
+              (v24/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -996,12 +998,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f2abd9fdbf9116242f9315d10dac2195",
+    "cacheID": "b19f5fa9b0664bd20c9e15ed8798a348",
     "id": null,
     "metadata": {},
     "name": "artistRoutes_ArtistAppQuery",
     "operationKind": "query",
-    "text": "query artistRoutes_ArtistAppQuery(\n  $artistID: String!\n  $shouldShowExperiment: Boolean!\n) @cacheable {\n  artist(id: $artistID) @principalField {\n    slug\n    ...ArtistApp_artist_3dhG1i\n    ...ArtistCombinedRoute_artist\n    id\n  }\n}\n\nfragment ArtistAbout_artist on Artist {\n  name\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  movementGenes: genes(geneFamilyID: \"styles-and-movements\", minValue: 50, size: 3) {\n    internalID\n    name\n    slug\n    id\n  }\n  mediumGenes: genes(geneFamilyID: \"medium-and-techniques\", minValue: 50, size: 3) {\n    internalID\n    name\n    slug\n    id\n  }\n}\n\nfragment ArtistAbove_artist on Artist {\n  ...ArtistBreadcrumb_artist\n  ...ArtistTombstone_artist\n  ...ArtistNotableWorks_artist\n  ...ArtistAbout_artist\n  ...ArtistRepresentation_artist\n  ...ArtistEditorial_artist\n}\n\nfragment ArtistApp_artist_3dhG1i on Artist {\n  ...ArtistMeta_artist\n  ...ArtistAbove_artist @include(if: $shouldShowExperiment)\n  ...ArtistHeader_artist @skip(if: $shouldShowExperiment)\n  internalID\n  slug\n  name\n}\n\nfragment ArtistBreadcrumb_artist on Artist {\n  name\n  href\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  kind\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistCombinedRoute_artist on Artist {\n  internalID\n}\n\nfragment ArtistEditorialItem_article on Article {\n  internalID\n  href\n  byline\n  title\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    small: cropped(width: 125, height: 125) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtistEditorial_artist on Artist {\n  name\n  href\n  articlesConnection(first: 3, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        ...ArtistEditorialItem_article\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistHeaderImage_artwork on Artwork {\n  imageTitle\n  image {\n    src: url(version: [\"larger\", \"larger\"])\n    width\n    height\n  }\n  fallbackArtist: artist {\n    name\n    id\n  }\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  insights {\n    kind\n    ...ArtistCareerHighlight_insight\n  }\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          src1x: cropped(width: 30, height: 30) {\n            src\n          }\n          src2x: cropped(width: 60, height: 60) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n  coverArtwork {\n    internalID\n    slug\n    href\n    image {\n      src: url(version: [\"larger\", \"larger\"])\n      width\n      height\n    }\n    ...ArtistHeaderImage_artwork\n    id\n  }\n}\n\nfragment ArtistMeta_artist on Artist {\n  ...ArtistStructuredData_artist\n  name\n  nationality\n  birthday\n  deathday\n  alternateNames\n  biographyBlurbPlain: biographyBlurb(format: PLAIN) {\n    text\n  }\n  coverArtwork {\n    image {\n      large: url(version: \"large\")\n    }\n    id\n  }\n}\n\nfragment ArtistNotableWorksArtworks_artist on Artist {\n  notableArtworks(size: 3) {\n    internalID\n    slug\n    href\n    title\n    date\n    image {\n      resized(width: 420, height: 420) {\n        width\n        height\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArtistNotableWorks_artist on Artist {\n  ...ArtistNotableWorksArtworks_artist\n  artworksConnection(first: 3, sort: ICONICITY_DESC) {\n    edges {\n      node {\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistRepresentation_artist on Artist {\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          _1x: cropped(width: 45, height: 45) {\n            src\n          }\n          _2x: cropped(width: 90, height: 90) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment ArtistStructuredData_artist on Artist {\n  slug\n  name\n  alternateNames\n  awards\n  birthday\n  deathday\n  gender\n  hometown\n  nationality\n  href\n  biographyBlurbPlain: biographyBlurb(format: PLAIN) {\n    text\n  }\n  coverArtwork {\n    image {\n      cropped(width: 1200, height: 900, version: [\"larger\", \"large\"]) {\n        src\n        width\n        height\n      }\n    }\n    id\n  }\n  verifiedRepresentatives {\n    partner {\n      name\n      href\n      id\n    }\n    id\n  }\n  notableArtworks(size: 3) {\n    title\n    href\n    date\n    id\n  }\n  genes(size: 10) {\n    name\n    id\n  }\n}\n\nfragment ArtistTombstone_artist on Artist {\n  internalID\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n}\n"
+    "text": "query artistRoutes_ArtistAppQuery(\n  $artistID: String!\n  $shouldShowExperiment: Boolean!\n) @cacheable {\n  artist(id: $artistID) @principalField {\n    slug\n    ...ArtistApp_artist_3dhG1i\n    ...ArtistCombinedRoute_artist\n    id\n  }\n}\n\nfragment ArtistAbout_artist on Artist {\n  name\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  movementGenes: genes(geneFamilyID: \"styles-and-movements\", minValue: 50, size: 3) {\n    internalID\n    name\n    slug\n    id\n  }\n  mediumGenes: genes(geneFamilyID: \"medium-and-techniques\", minValue: 50, size: 3) {\n    internalID\n    name\n    slug\n    id\n  }\n}\n\nfragment ArtistAbove_artist on Artist {\n  ...ArtistBreadcrumb_artist\n  ...ArtistTombstone_artist\n  ...ArtistNotableWorks_artist\n  ...ArtistAbout_artist\n  ...ArtistRepresentation_artist\n  ...ArtistEditorial_artist\n}\n\nfragment ArtistApp_artist_3dhG1i on Artist {\n  ...ArtistMeta_artist\n  ...ArtistAbove_artist @include(if: $shouldShowExperiment)\n  ...ArtistHeader_artist @skip(if: $shouldShowExperiment)\n  internalID\n  slug\n  name\n}\n\nfragment ArtistBreadcrumb_artist on Artist {\n  name\n  href\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  kind\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistCombinedRoute_artist on Artist {\n  internalID\n}\n\nfragment ArtistEditorialItem_article on Article {\n  internalID\n  href\n  byline\n  title\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    small: cropped(width: 125, height: 125) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtistEditorial_artist on Artist {\n  name\n  href\n  articlesConnection(first: 3, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        ...ArtistEditorialItem_article\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistHeaderEditorialItem_article on Article {\n  internalID\n  href\n  byline\n  title\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    small: cropped(width: 125, height: 125) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtistHeaderEditorial_artist on Artist {\n  name\n  href\n  articlesConnection(first: 3, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        ...ArtistHeaderEditorialItem_article\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistHeaderImage_artwork on Artwork {\n  imageTitle\n  image {\n    src: url(version: [\"larger\", \"larger\"])\n    width\n    height\n  }\n  fallbackArtist: artist {\n    name\n    id\n  }\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  insights {\n    kind\n    ...ArtistCareerHighlight_insight\n  }\n  articlesConnection(first: 3, sort: PUBLISHED_AT_DESC) {\n    totalCount\n  }\n  ...ArtistHeaderEditorial_artist\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          src1x: cropped(width: 30, height: 30) {\n            src\n          }\n          src2x: cropped(width: 60, height: 60) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n  coverArtwork {\n    internalID\n    slug\n    href\n    image {\n      src: url(version: [\"larger\", \"larger\"])\n      width\n      height\n    }\n    ...ArtistHeaderImage_artwork\n    id\n  }\n}\n\nfragment ArtistMeta_artist on Artist {\n  ...ArtistStructuredData_artist\n  name\n  nationality\n  birthday\n  deathday\n  alternateNames\n  biographyBlurbPlain: biographyBlurb(format: PLAIN) {\n    text\n  }\n  coverArtwork {\n    image {\n      large: url(version: \"large\")\n    }\n    id\n  }\n}\n\nfragment ArtistNotableWorksArtworks_artist on Artist {\n  notableArtworks(size: 3) {\n    internalID\n    slug\n    href\n    title\n    date\n    image {\n      resized(width: 420, height: 420) {\n        width\n        height\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArtistNotableWorks_artist on Artist {\n  ...ArtistNotableWorksArtworks_artist\n  artworksConnection(first: 3, sort: ICONICITY_DESC) {\n    edges {\n      node {\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistRepresentation_artist on Artist {\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          _1x: cropped(width: 45, height: 45) {\n            src\n          }\n          _2x: cropped(width: 90, height: 90) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment ArtistStructuredData_artist on Artist {\n  slug\n  name\n  alternateNames\n  awards\n  birthday\n  deathday\n  gender\n  hometown\n  nationality\n  href\n  biographyBlurbPlain: biographyBlurb(format: PLAIN) {\n    text\n  }\n  coverArtwork {\n    image {\n      cropped(width: 1200, height: 900, version: [\"larger\", \"large\"]) {\n        src\n        width\n        height\n      }\n    }\n    id\n  }\n  verifiedRepresentatives {\n    partner {\n      name\n      href\n      id\n    }\n    id\n  }\n  notableArtworks(size: 3) {\n    title\n    href\n    date\n    id\n  }\n  genes(size: 10) {\n    name\n    id\n  }\n}\n\nfragment ArtistTombstone_artist on Artist {\n  internalID\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Re: [Artist Top of Page: Editorial Component inclusion](https://app.notion.com/p/artsy/Artist-Top-of-Page-Editorial-Component-inclusion-379cab0764a08162a4aefe1952884582)

Here we take the mobile version of the editorial module we used in the artist header experiment branch and adapt it for desktop usage, then include it on the control branch.

| Desktop | Mobile |
| ---- | ---- |
| <img width="3022" height="1628" alt="image" src="https://github.com/user-attachments/assets/492bd7f9-5f4d-4136-a4cd-de6289d2e92d" /> | <img width="990" height="1646" alt="image" src="https://github.com/user-attachments/assets/9d1fc20e-e814-4341-b6e5-502223aca4c2" /> |

cc @artsy/diamond-devs 

