### PR TITLE
feat: do not wait for address auto save when loading checkout; reduce timeout (take II)

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/CheckoutContext/Order2CheckoutContext.tsx
+++ b/src/Apps/Order2/Routes/Checkout/CheckoutContext/Order2CheckoutContext.tsx
@@ -148,7 +148,10 @@ export const Order2CheckoutContext: ReturnType<
 
   // Actions
   setExpressCheckoutLoaded: action((state, availablePaymentMethods) => {
-    if (state.isLoading && state.expressCheckoutPaymentMethods === null) {
+    // Record the first express-checkout result (wallets or empty). The element
+    // can resolve *after* page loading has completed, so this is intentionally
+    // NOT gated on isLoading.
+    if (state.expressCheckoutPaymentMethods === null) {
       state.expressCheckoutPaymentMethods = availablePaymentMethods
     }
   }),

--- a/src/Apps/Order2/Routes/Checkout/CheckoutContext/Order2CheckoutContext.tsx
+++ b/src/Apps/Order2/Routes/Checkout/CheckoutContext/Order2CheckoutContext.tsx
@@ -115,9 +115,6 @@ export interface Order2CheckoutModel {
     }
   >
   setIsFulfillmentDetailsSaving: Action<this, boolean>
-  /** True once any eager pre-load address auto-save has completed (or is not needed). */
-  isInitialAutoSaveComplete: boolean
-  setInitialAutoSaveComplete: Action<this>
   /** Persists the last-used saved credit card ID. Only relevant for saved card payments. */
   setLastUsedPaymentMethodId: Action<this, string>
 }
@@ -139,7 +136,6 @@ export const Order2CheckoutContext: ReturnType<
   userAddressMode: null,
   messages: {},
   artworkPath: "/",
-  isInitialAutoSaveComplete: true,
 
   // Required runtime props - will be provided by Provider
   // These will be overridden by the Provider with actual values
@@ -258,10 +254,6 @@ export const Order2CheckoutContext: ReturnType<
     state.isFulfillmentDetailsSaving = isFulfillmentDetailsSaving
   }),
 
-  setInitialAutoSaveComplete: action(state => {
-    state.isInitialAutoSaveComplete = true
-  }),
-
   setLastUsedPaymentMethodId: action((_state, id) => {
     setStorageValue(LAST_USED_PAYMENT_ID_KEY, id)
   }),
@@ -284,20 +276,6 @@ export const Order2CheckoutContextProvider: React.FC<
   const hasSavedAddresses = (meData.addressConnection?.edges?.length ?? 0) > 0
 
   const initialSteps = useBuildInitialSteps(orderData)
-
-  // Auto-save is needed when: non-offer, has saved addresses, FD not yet complete,
-  // and FD is the first active step (no offer step before it).
-  const fulfillmentDetailsStep = initialSteps.find(
-    s => s.name === CheckoutStepName.FULFILLMENT_DETAILS,
-  )
-
-  // Autosave of shipping address only applies when it is the first step,
-  // i.e. there is no offer step preceding it.
-  const isOffer = orderData.mode === "OFFER"
-  const needsInitialAutoSave =
-    !isOffer &&
-    hasSavedAddresses &&
-    fulfillmentDetailsStep?.state === CheckoutStepState.ACTIVE
 
   // Initialize the store with the initial state
   const initialState = useMemo(
@@ -333,7 +311,6 @@ export const Order2CheckoutContextProvider: React.FC<
     orderData,
     artworkPath,
     hasSavedAddresses,
-    isInitialAutoSaveComplete: !needsInitialAutoSave,
   } as Order2CheckoutModel
 
   return (

--- a/src/Apps/Order2/Routes/Checkout/CheckoutContext/__tests__/Order2CheckoutContext.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/CheckoutContext/__tests__/Order2CheckoutContext.jest.tsx
@@ -284,20 +284,34 @@ describe("Order2CheckoutContext", () => {
         expect(getState().expressCheckoutPaymentMethods).toEqual(paymentMethods)
       })
 
-      it("does not set payment methods when not loading", async () => {
+      it("records the express result even after loading has completed (not gated on isLoading)", async () => {
         const { getState, actions } = await setup()
 
+        // The express element can resolve after loading has completed (e.g. timeout)
         act(() => {
           actions.setLoadingComplete()
         })
 
         const paymentMethods = [{ type: "apple_pay" }]
-
         act(() => {
           actions.setExpressCheckoutLoaded(paymentMethods as any)
         })
 
-        expect(getState().expressCheckoutPaymentMethods).toBe(null)
+        expect(getState().expressCheckoutPaymentMethods).toEqual(paymentMethods)
+      })
+
+      it("does not let an empty result override already-loaded wallets", async () => {
+        const { getState, actions } = await setup()
+
+        const paymentMethods = [{ type: "apple_pay" }]
+        act(() => {
+          actions.setExpressCheckoutLoaded(paymentMethods as any)
+        })
+        act(() => {
+          actions.setExpressCheckoutLoaded([])
+        })
+
+        expect(getState().expressCheckoutPaymentMethods).toEqual(paymentMethods)
       })
     })
 

--- a/src/Apps/Order2/Routes/Checkout/Components/ExpressCheckout/Order2ExpressCheckout.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/ExpressCheckout/Order2ExpressCheckout.tsx
@@ -1,4 +1,3 @@
-import { Flex } from "@artsy/palette"
 import { Elements, useStripe } from "@stripe/react-stripe-js"
 import type {
   StripeElementsOptions,
@@ -80,11 +79,9 @@ export const Order2ExpressCheckout: React.FC<Order2ExpressCheckoutProps> = ({
   }
 
   return (
-    <Flex flexDirection="column" backgroundColor="mono0" py={2} px={[2, 2, 4]}>
-      <Elements stripe={stripe} options={options}>
-        <Order2ExpressCheckoutUI order={orderData} />
-      </Elements>
-    </Flex>
+    <Elements stripe={stripe} options={options}>
+      <Order2ExpressCheckoutUI order={orderData} />
+    </Elements>
   )
 }
 

--- a/src/Apps/Order2/Routes/Checkout/Components/ExpressCheckout/Order2ExpressCheckoutUI.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/ExpressCheckout/Order2ExpressCheckoutUI.tsx
@@ -99,9 +99,16 @@ export const Order2ExpressCheckoutUI: React.FC<
     editStep,
     setSectionErrorMessage,
     messages,
+    expressCheckoutPaymentMethods,
   } = useCheckoutContext()
 
   const error = messages["EXPRESS_CHECKOUT"]?.error
+
+  // Only show the express-checkout chrome (heading, terms) once Stripe has
+  // resolved at least one wallet. The <ExpressCheckoutElement> is always
+  // rendered so it can fire onReady — but while it's loading or unavailable
+  // it stays an empty, effectively invisible container.
+  const hasWallets = (expressCheckoutPaymentMethods?.length ?? 0) > 0
 
   const unsetStepError = () => {
     setSectionErrorMessage({
@@ -593,8 +600,32 @@ export const Order2ExpressCheckoutUI: React.FC<
     }
   }
 
+  const expressCheckoutElement = (
+    <Box minWidth="240px" maxWidth="100%" paddingX="1px">
+      <ExpressCheckoutElement
+        options={expressCheckoutOptions}
+        onClick={handleOpenExpressCheckout}
+        onCancel={handleCancel}
+        onReady={handleReady}
+        onShippingAddressChange={handleShippingAddressChange}
+        onShippingRateChange={handleShippingRateChange}
+        onLoadError={e => {
+          logger.error("Express checkout element load error", e)
+          setExpressCheckoutLoaded([])
+        }}
+        onConfirm={handleConfirm}
+      />
+    </Box>
+  )
+
+  // Until Stripe resolves at least one wallet, render only the (empty,
+  // effectively invisible) element
+  if (!hasWallets) {
+    return expressCheckoutElement
+  }
+
   return (
-    <Box>
+    <Box backgroundColor="mono0" py={2} px={[2, 2, 4]}>
       <SectionHeading>Express checkout</SectionHeading>
       <Spacer y={[1, 1, 2]} />
       {error && (
@@ -608,21 +639,7 @@ export const Order2ExpressCheckoutUI: React.FC<
           <Spacer y={1} />
         </>
       )}
-      <Box minWidth="240px" maxWidth="100%" paddingX="1px">
-        <ExpressCheckoutElement
-          options={expressCheckoutOptions}
-          onClick={handleOpenExpressCheckout}
-          onCancel={handleCancel}
-          onReady={handleReady}
-          onShippingAddressChange={handleShippingAddressChange}
-          onShippingRateChange={handleShippingRateChange}
-          onLoadError={e => {
-            logger.error("Express checkout element load error", e)
-            setExpressCheckoutLoaded([])
-          }}
-          onConfirm={handleConfirm}
-        />
-      </Box>
+      {expressCheckoutElement}
       <Text variant="xs" color="mono60" mt={[1, 1, 2]}>
         <>By clicking Pay, I agree to Artsy's </>
         <RouterLink

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
@@ -84,8 +84,6 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
     setUserAddressMode,
     setSectionErrorMessage,
     setIsFulfillmentDetailsSaving,
-    setInitialAutoSaveComplete,
-    isInitialAutoSaveComplete,
   } = checkoutContext
 
   const { error: fulfillmentDetailsError } = useFulfillmentDetailsError()
@@ -317,9 +315,6 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
         )
       } finally {
         setIsFulfillmentDetailsSaving(false)
-        if (!isInitialAutoSaveComplete) {
-          setInitialAutoSaveComplete()
-        }
       }
     },
     [
@@ -336,41 +331,31 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
       setUserAddressMode,
       unsetOrderFulfillmentOption,
       setOrderDeliveryAddressMutation,
-      isInitialAutoSaveComplete,
-      setInitialAutoSaveComplete,
     ],
   )
 
   const handleSelectInvalidAddress = useCallback(async () => {
-    try {
-      if (orderData.selectedFulfillmentOption?.type) {
-        try {
-          await unsetOrderFulfillmentOption.submitMutation({
-            variables: {
-              input: { id: orderData.internalID },
-            },
-          })
-        } catch (error) {
-          logger.error(
-            "Error unsetting fulfillment option after invalid address selection:",
-            error,
-          )
-        }
-      }
-      editStep(CheckoutStepName.FULFILLMENT_DETAILS)
-    } finally {
-      if (!isInitialAutoSaveComplete) {
-        setInitialAutoSaveComplete()
+    if (orderData.selectedFulfillmentOption?.type) {
+      try {
+        await unsetOrderFulfillmentOption.submitMutation({
+          variables: {
+            input: { id: orderData.internalID },
+          },
+        })
+      } catch (error) {
+        logger.error(
+          "Error unsetting fulfillment option after invalid address selection:",
+          error,
+        )
       }
     }
+    editStep(CheckoutStepName.FULFILLMENT_DETAILS)
   }, [
     orderData.selectedFulfillmentOption?.type,
     orderData.internalID,
     unsetOrderFulfillmentOption,
     logger,
     editStep,
-    isInitialAutoSaveComplete,
-    setInitialAutoSaveComplete,
   ])
 
   return (

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/Order2SavedAddressOptions.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/Order2SavedAddressOptions.jest.tsx
@@ -221,8 +221,6 @@ describe("SavedAddressOptions", () => {
           state: CheckoutStepState.ACTIVE,
         },
       ],
-      isInitialAutoSaveComplete: true,
-      setInitialAutoSaveComplete: jest.fn(),
     } as any
 
     mockUseCheckoutContext.mockReturnValue(mockCheckoutContext)

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/__tests__/Order2DeliveryForm.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/__tests__/Order2DeliveryForm.jest.tsx
@@ -50,8 +50,6 @@ beforeEach(() => {
     setIsFulfillmentDetailsSaving: jest.fn(),
     userAddressMode: null,
     messages: {},
-    isInitialAutoSaveComplete: true,
-    setInitialAutoSaveComplete: jest.fn(),
     steps: [],
   }
 })

--- a/src/Apps/Order2/Routes/Checkout/Hooks/__tests__/useLoadCheckout.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/__tests__/useLoadCheckout.jest.tsx
@@ -83,7 +83,6 @@ describe("useLoadCheckout", () => {
       steps: [{ state: CheckoutStepState.ACTIVE, name: "PAYMENT" }],
       setLoadingComplete: mockSetLoadingComplete,
       setExpressCheckoutLoaded: mockSetExpressCheckoutLoaded,
-      isInitialAutoSaveComplete: true,
     })
 
     // Mock useCheckoutModal
@@ -210,7 +209,6 @@ describe("useLoadCheckout", () => {
         steps: [],
         setLoadingComplete: mockSetLoadingComplete,
         setExpressCheckoutLoaded: mockSetExpressCheckoutLoaded,
-        isInitialAutoSaveComplete: true,
       })
 
       renderHook(() => useLoadCheckout(mockOrder))
@@ -235,7 +233,6 @@ describe("useLoadCheckout", () => {
       expect(errorMessage).toContain("minimumLoadingPassed: true")
       expect(errorMessage).toContain("orderValidated: true")
       expect(errorMessage).toContain("isExpressCheckoutLoaded: false")
-      expect(errorMessage).toContain("isInitialAutoSaveComplete: true")
 
       // No blocking modal; Express Checkout is force-emptied so the rest of
       // the page can finish loading and the user can complete checkout.
@@ -244,16 +241,15 @@ describe("useLoadCheckout", () => {
     })
 
     it("surfaces the modal when a flag other than Express Checkout is stuck", async () => {
-      // Express Checkout *is* loaded (empty list), but autosave never
-      // completed. This is a genuine problem — not graceful degradation —
-      // so the user should see the blocking modal.
+      // Express Checkout *is* loaded (empty list), but loading is still stuck
+      // for another reason. This is a genuine problem — not graceful
+      // degradation — so the user should see the blocking modal.
       useCheckoutContext.mockReturnValue({
         isLoading: true,
         expressCheckoutPaymentMethods: [],
         steps: [],
         setLoadingComplete: mockSetLoadingComplete,
         setExpressCheckoutLoaded: mockSetExpressCheckoutLoaded,
-        isInitialAutoSaveComplete: false,
       })
 
       renderHook(() => useLoadCheckout(mockOrder))
@@ -284,7 +280,6 @@ describe("useLoadCheckout", () => {
         expressCheckoutPaymentMethods: [],
         steps: [],
         setLoadingComplete: mockSetLoadingComplete,
-        isInitialAutoSaveComplete: true,
       }))
 
       const { rerender } = renderHook(() => useLoadCheckout(mockOrder))
@@ -320,7 +315,6 @@ describe("useLoadCheckout", () => {
         expressCheckoutPaymentMethods: expressCheckoutLoaded ? [] : null,
         steps: [],
         setLoadingComplete: mockSetLoadingComplete,
-        isInitialAutoSaveComplete: true,
       }))
 
       const { rerender } = renderHook(() => useLoadCheckout(mockOrder))

--- a/src/Apps/Order2/Routes/Checkout/Hooks/__tests__/useLoadCheckout.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/__tests__/useLoadCheckout.jest.tsx
@@ -234,10 +234,13 @@ describe("useLoadCheckout", () => {
       expect(errorMessage).toContain("orderValidated: true")
       expect(errorMessage).toContain("isExpressCheckoutLoaded: false")
 
-      // No blocking modal; Express Checkout is force-emptied so the rest of
-      // the page can finish loading and the user can complete checkout.
+      // No blocking modal. The timeout stops blocking the page on express
+      // checkout via an internal timeout flag (it completes loading) WITHOUT
+      // emptying express checkout — so its element stays mounted and can still
+      // resolve its wallets later.
       expect(mockShowCheckoutErrorModal).not.toHaveBeenCalled()
-      expect(mockSetExpressCheckoutLoaded).toHaveBeenCalledWith([])
+      expect(mockSetExpressCheckoutLoaded).not.toHaveBeenCalled()
+      expect(mockSetLoadingComplete).toHaveBeenCalled()
     })
 
     it("surfaces the modal when a flag other than Express Checkout is stuck", async () => {

--- a/src/Apps/Order2/Routes/Checkout/Hooks/useLoadCheckout.ts
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/useLoadCheckout.ts
@@ -24,12 +24,16 @@ export const MAX_LOADING_MS = 3000
 export const useLoadCheckout = (order: useLoadCheckout_order$key) => {
   const [minimumLoadingPassed, setMinimumLoadingPassed] = useState(false)
   const [orderValidated, setOrderValidated] = useState(false)
+  // Set by the hook when express checkout is not done loading by the max loading time.
+  // This unblocks page loading *without* touching expressCheckoutPaymentMethods,
+  // so the express element stays mounted and can still resolve its wallets.
+  const [expressCheckoutLoadTimedOut, setExpressCheckoutLoadTimedOut] =
+    useState(false)
   const orderData = useFragment(ORDER_FRAGMENT, order)
 
   const {
     isLoading,
     setLoadingComplete,
-    setExpressCheckoutLoaded,
     expressCheckoutPaymentMethods,
     expressCheckoutState,
     steps,
@@ -37,9 +41,12 @@ export const useLoadCheckout = (order: useLoadCheckout_order$key) => {
 
   const { checkoutModalError, showCheckoutErrorModal } = useCheckoutModal()
 
-  // Express Checkout is considered "loaded" if:
+  // Express Checkout is considered "loaded" (for the purpose of the loading
+  // gate) if:
   // 1. It's actually loaded (not null), OR
-  // 2. We're in post-payment state where Express Checkout should be hidden
+  // 2. We're in post-payment state where Express Checkout should be hidden, OR
+  // 3. It exceeded the max loading time (it may still resolve later — we just
+  //    stop blocking the page on it).
   const expressCheckoutPaymentMethodsReady =
     expressCheckoutPaymentMethods !== null
   const activeStep = steps.find(step => step.state === CheckoutStepState.ACTIVE)
@@ -47,7 +54,9 @@ export const useLoadCheckout = (order: useLoadCheckout_order$key) => {
     activeStep?.name === CheckoutStepName.CONFIRMATION
 
   const isExpressCheckoutLoaded =
-    expressCheckoutPaymentMethodsReady || isInPostPaymentState
+    expressCheckoutPaymentMethodsReady ||
+    isInPostPaymentState ||
+    expressCheckoutLoadTimedOut
 
   // Scroll lock during loading.
   // Pad the body by the scrollbar width while locked so the layout doesn't shift
@@ -164,7 +173,9 @@ export const useLoadCheckout = (order: useLoadCheckout_order$key) => {
         flags.orderValidated
 
       if (onlyExpressCheckoutStuck) {
-        setExpressCheckoutLoaded([])
+        // Stop blocking the page on express checkout, but leave its element
+        // mounted so it can still resolve and render once Stripe is ready.
+        setExpressCheckoutLoadTimedOut(true)
       } else {
         showCheckoutErrorModal({
           error: CheckoutModalError.LOADING_TIMEOUT,

--- a/src/Apps/Order2/Routes/Checkout/Hooks/useLoadCheckout.ts
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/useLoadCheckout.ts
@@ -19,7 +19,7 @@ import { graphql, useFragment } from "react-relay"
 const logger = createLogger("useLoadCheckout.tsx")
 
 export const MIN_LOADING_MS = 1000
-export const MAX_LOADING_MS = 6000
+export const MAX_LOADING_MS = 3000
 
 export const useLoadCheckout = (order: useLoadCheckout_order$key) => {
   const [minimumLoadingPassed, setMinimumLoadingPassed] = useState(false)
@@ -33,7 +33,6 @@ export const useLoadCheckout = (order: useLoadCheckout_order$key) => {
     expressCheckoutPaymentMethods,
     expressCheckoutState,
     steps,
-    isInitialAutoSaveComplete,
   } = useCheckoutContext()
 
   const { checkoutModalError, showCheckoutErrorModal } = useCheckoutModal()
@@ -130,21 +129,14 @@ export const useLoadCheckout = (order: useLoadCheckout_order$key) => {
     minimumLoadingPassed,
     orderValidated,
     isExpressCheckoutLoaded,
-    isInitialAutoSaveComplete,
   })
   useEffect(() => {
     flagsRef.current = {
       minimumLoadingPassed,
       orderValidated,
       isExpressCheckoutLoaded,
-      isInitialAutoSaveComplete,
     }
-  }, [
-    minimumLoadingPassed,
-    orderValidated,
-    isExpressCheckoutLoaded,
-    isInitialAutoSaveComplete,
-  ])
+  }, [minimumLoadingPassed, orderValidated, isExpressCheckoutLoaded])
 
   // After MAX_LOADING_MS without loading completing, log the stuck flags to
   // Sentry, then either degrade gracefully (Express Checkout-only failure)
@@ -169,8 +161,7 @@ export const useLoadCheckout = (order: useLoadCheckout_order$key) => {
       const onlyExpressCheckoutStuck =
         !flags.isExpressCheckoutLoaded &&
         flags.minimumLoadingPassed &&
-        flags.orderValidated &&
-        flags.isInitialAutoSaveComplete
+        flags.orderValidated
 
       if (onlyExpressCheckoutStuck) {
         setExpressCheckoutLoaded([])
@@ -194,7 +185,6 @@ export const useLoadCheckout = (order: useLoadCheckout_order$key) => {
         minimumLoadingPassed,
         orderValidated,
         isExpressCheckoutLoaded,
-        isInitialAutoSaveComplete,
         isLoading,
         setLoadingComplete,
       ].every(Boolean)
@@ -205,7 +195,6 @@ export const useLoadCheckout = (order: useLoadCheckout_order$key) => {
     minimumLoadingPassed,
     orderValidated,
     isExpressCheckoutLoaded,
-    isInitialAutoSaveComplete,
     isLoading,
     setLoadingComplete,
     checkoutModalError,

--- a/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
@@ -9,11 +9,21 @@ import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
 import mockStripe from "DevTools/mockStripe"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
 import type { Order2CheckoutRouteTestQuery } from "__generated__/Order2CheckoutRouteTestQuery.graphql"
+import {
+  MAX_LOADING_MS,
+  MIN_LOADING_MS,
+} from "Apps/Order2/Routes/Checkout/Hooks/useLoadCheckout"
 import { useEffect } from "react"
 import { graphql } from "react-relay"
 import { useTracking } from "react-tracking"
 import { Order2ExpressCheckout as MockExpressCheckout } from "../Components/ExpressCheckout/Order2ExpressCheckout"
 import { Order2CheckoutRoute } from "../Order2CheckoutRoute"
+
+// Controls when the mocked express checkout reports its wallets:
+// - null (default): report "no wallets" instantly (existing behavior).
+// - <number>: report a wallet after this many ms, to exercise the race
+//   between express loading and the loading watchdog (MAX_LOADING_MS).
+let mockExpressCheckoutLoadDelayMs: number | null = null
 
 jest.setTimeout(15000)
 
@@ -102,16 +112,33 @@ jest.mock("System/Hooks/useRouter", () => ({
 jest.mock(
   "Apps/Order2/Routes/Checkout/Components/ExpressCheckout/Order2ExpressCheckout",
   () => {
-    const MockExpressCheckout = jest.fn(() => {
-      const { setExpressCheckoutLoaded, expressCheckoutPaymentMethods } =
-        useCheckoutContext()
+    // The load (setExpressCheckoutLoaded) lives in a child that mirrors the real
+    // <ExpressCheckoutElement>: it is unmounted when express is hidden, which
+    // cancels any in-flight load — exactly like Stripe's element being torn down.
+    const MockExpressCheckoutElement = () => {
+      const { setExpressCheckoutLoaded } = useCheckoutContext()
       // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
       useEffect(() => {
-        setExpressCheckoutLoaded([])
+        if (mockExpressCheckoutLoadDelayMs == null) {
+          setExpressCheckoutLoaded([])
+          return
+        }
+        const id = setTimeout(() => {
+          setExpressCheckoutLoaded(["applePay"])
+        }, mockExpressCheckoutLoadDelayMs)
+        return () => clearTimeout(id)
       }, [])
-      return expressCheckoutPaymentMethods == null ? (
-        <div>MockExpressCheckout</div>
-      ) : null
+      return <div>MockExpressCheckout</div>
+    }
+
+    const MockExpressCheckout = jest.fn(() => {
+      const { expressCheckoutPaymentMethods } = useCheckoutContext()
+      // Mirror the real Order2ExpressCheckout guard: an empty result unmounts
+      // the element subtree (and thus its loader); rendered while pending (null)
+      // or once wallets are available.
+      return expressCheckoutPaymentMethods?.length === 0 ? null : (
+        <MockExpressCheckoutElement />
+      )
     })
 
     return {
@@ -151,11 +178,16 @@ jest.mock("Components/Address/utils", () => {
 const mockTrackEvent = jest.fn()
 
 beforeEach(() => {
+  // Clear any timers left pending by a previous test so their callbacks don't
+  // fire inside the next test's timer advances (the loading min/max watchdogs
+  // and the express-load delay are all timer-driven).
+  jest.clearAllTimers()
   mockTrackEvent.mockClear()
   ;(useTracking as jest.Mock).mockImplementation(() => ({
     trackEvent: mockTrackEvent,
   }))
   ;(MockExpressCheckout as jest.Mock).mockClear()
+  mockExpressCheckoutLoadDelayMs = null
 })
 
 const { renderWithRelay } = setupTestWrapperTL<Order2CheckoutRouteTestQuery>({
@@ -440,6 +472,62 @@ describe("Order2CheckoutRoute", () => {
       ).toBeInTheDocument()
 
       expect(MockExpressCheckout).not.toHaveBeenCalled()
+    })
+
+    it("renders express checkout when its load wins the race against the loading timeout", async () => {
+      // Wallets resolve well before the watchdog at MAX_LOADING_MS.
+      mockExpressCheckoutLoadDelayMs = 500
+
+      const props = { ...baseProps }
+      props.me.order.lineItems[0].artwork.isFixedShippingFeeOnly = true // express-eligible
+      renderWithRelay({ Viewer: () => props })
+
+      await helpers.waitForLoadingComplete()
+
+      expect(screen.getByText("MockExpressCheckout")).toBeInTheDocument()
+    })
+
+    it("renders express checkout even when its load lands after the loading timeout", async () => {
+      // Regression guard. In production a saved-address auto-save adds latency,
+      // so the express element can report its wallets only AFTER the loading
+      // watchdog (MAX_LOADING_MS) fires. The watchdog must unblock loading
+      // WITHOUT unmounting/emptying express, so the element stays mounted and
+      // can still render once its wallets resolve. (A previous regression
+      // force-emptied express on timeout, which unmounted it and dropped the
+      // late result.)
+      mockExpressCheckoutLoadDelayMs = MAX_LOADING_MS + 100
+
+      const props = { ...baseProps }
+      props.me.order.lineItems[0].artwork.isFixedShippingFeeOnly = true // express-eligible
+      renderWithRelay({ Viewer: () => props })
+
+      // Let the minimum-loading gate pass and flush, so the watchdog reads an
+      // up-to-date flag state (and thus takes the graceful-degrade branch).
+      await act(async () => {
+        jest.advanceTimersByTime(MIN_LOADING_MS)
+        await flushPromiseQueue()
+      })
+
+      // Watchdog fires while express is still unresolved → unblocks loading
+      // (via the timeout flag) while leaving express mounted.
+      await act(async () => {
+        jest.advanceTimersByTime(MAX_LOADING_MS - MIN_LOADING_MS)
+        await flushPromiseQueue()
+      })
+
+      await waitFor(() => {
+        expect(
+          screen.queryByLabelText("Checkout loading skeleton"),
+        ).not.toBeInTheDocument()
+      })
+
+      // The (late) real express load now fires and reports a wallet.
+      await act(async () => {
+        jest.advanceTimersByTime(200)
+        await flushPromiseQueue()
+      })
+
+      expect(screen.getByText("MockExpressCheckout")).toBeInTheDocument()
     })
   })
 

--- a/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
@@ -126,6 +126,28 @@ jest.mock("Utils/Hooks/useUserLocation", () => ({
   })),
 }))
 
+// Replace the async, network-backed phone-number validators with synchronous
+// Yup schemas. The real ones run a debounced Relay query with retry backoff
+// (~2.2s of timers), which otherwise pushes the saved-address load past the
+// MAX_LOADING_MS watchdog and wedges the loading skeleton.
+jest.mock("Components/Address/utils", () => {
+  const Yup = require("yup")
+  return {
+    ...jest.requireActual("Components/Address/utils"),
+    validatePhoneNumber: jest.fn().mockResolvedValue(true),
+    richPhoneValidators: {
+      phoneNumber: Yup.string(),
+      phoneNumberCountryCode: Yup.string(),
+    },
+    richRequiredPhoneValidators: {
+      phoneNumber: Yup.string().required("Phone number is required"),
+      phoneNumberCountryCode: Yup.string().required(
+        "Phone number country code is required",
+      ),
+    },
+  }
+})
+
 const mockTrackEvent = jest.fn()
 
 beforeEach(() => {


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [EMI-3272]

### Description

[Previous attempt](https://github.com/artsy/force/pull/17333) was reverted because it [prevented Express Checkout from being rendered](https://artsy.slack.com/archives/C02JHHHKP5K/p1781189522173589?thread_ts=1781188235.549719&cid=C02JHHHKP5K) when Express Checkout loads _after_ the reduced timeout (3 seconds). This PR reapplies the previous attempt and fixes 2 things:

- 308a8c72fc59f3f335f913772c4d50be0bc87d02: Render Express Checkout when it loads after the timeout.
- 1e5eb6a8d2a3ce613e88337fea6fd3e29c7c10f5: Now Express Checkout can be loaded after revealing the checkout, we make sure the section only appears when Stripe resolves eligible payment methods.

See the following recordings for different conditions:

<details><summary>Express Checkout loads normally (before the 3-second timeout)</summary>
<p>

<img width="1710" height="1135" alt="express-checkout-normal" src="https://github.com/user-attachments/assets/538aa980-20c6-4f2c-8a5f-9e420795a223" />


</p>
</details> 

<details><summary>Express Checkout loads slowly (after the 3-second timeout)</summary>
<p>

<img width="1710" height="1135" alt="express-checkout-after-loading" src="https://github.com/user-attachments/assets/913cfbbc-2396-4407-a76b-25907941c953" />


</p>
</details> 

<details><summary>Express Checkout does not load</summary>
<p>

<img width="1710" height="1135" alt="express-checkout-not-loaded" src="https://github.com/user-attachments/assets/313f3d85-3d35-460f-a3c2-7bcb91e506f8" />

</p>
</details> 

[EMI-3272]: https://artsyproduct.atlassian.net/browse/EMI-3272?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ