### PR TITLE
feat: Display expired message text when partner offer expired

### DIFF
--- a/src/Apps/Conversations/components/Message/ConversationPartnerOfferCTA.tsx
+++ b/src/Apps/Conversations/components/Message/ConversationPartnerOfferCTA.tsx
@@ -32,13 +32,15 @@ export const ConversationPartnerOfferCTA: FC<
     return null
   }
 
-  if (hasEnded || !partnerOffer.isAvailable) {
-    return null
-  }
+  const isExpired = hasEnded || !partnerOffer.isAvailable
 
   const message = partnerOffer.priceWithDiscount?.display
     ? `Offer received for ${partnerOffer.priceWithDiscount.display}`
     : "Offer received"
+
+  if (isExpired) {
+    return null
+  }
 
   const href = `${data.href}?partner_offer_id=${partnerOffer.internalID}`
 

--- a/src/Apps/Conversations/components/Message/ConversationPartnerOfferUpdate.tsx
+++ b/src/Apps/Conversations/components/Message/ConversationPartnerOfferUpdate.tsx
@@ -31,20 +31,21 @@ export const ConversationPartnerOfferUpdate: FC<
     return null
   }
 
-  if (hasEnded || !partnerOffer.isAvailable) {
-    return null
-  }
+  const isExpired = hasEnded || !partnerOffer.isAvailable
+  const priceDisplay = partnerOffer.priceWithDiscount?.display
 
-  const message = partnerOffer.priceWithDiscount?.display
-    ? `You received an offer for ${partnerOffer.priceWithDiscount.display}`
-    : "You received an offer"
+  const message = isExpired
+    ? "Offer Expired"
+    : priceDisplay
+      ? `You received an offer for ${priceDisplay}`
+      : "You received an offer"
 
   return (
     <ConversationEventRow
       Icon={MoneyFillIcon}
-      iconFill="mono100"
+      iconFill={isExpired ? "red100" : "mono100"}
       message={message}
-      textColor="mono100"
+      textColor={isExpired ? "red100" : "mono100"}
       {...flexProps}
     />
   )

--- a/src/Apps/Conversations/components/Message/ConversationPartnerOfferUpdate.tsx
+++ b/src/Apps/Conversations/components/Message/ConversationPartnerOfferUpdate.tsx
@@ -34,11 +34,11 @@ export const ConversationPartnerOfferUpdate: FC<
   const isExpired = hasEnded || !partnerOffer.isAvailable
   const priceDisplay = partnerOffer.priceWithDiscount?.display
 
-  const message = isExpired
-    ? "Offer Expired"
-    : priceDisplay
-      ? `You received an offer for ${priceDisplay}`
-      : "You received an offer"
+  const offerMessage = priceDisplay
+    ? `You received an offer for ${priceDisplay}`
+    : "You received an offer"
+
+  const message = isExpired ? "Offer Expired" : offerMessage
 
   return (
     <ConversationEventRow

--- a/src/Apps/Conversations/components/Message/__tests__/ConversationPartnerOfferCTA.jest.tsx
+++ b/src/Apps/Conversations/components/Message/__tests__/ConversationPartnerOfferCTA.jest.tsx
@@ -119,16 +119,6 @@ describe("ConversationPartnerOfferCTA", () => {
     ).not.toBeInTheDocument()
   })
 
-  it("renders nothing when the partner-offer-convo flag is off", () => {
-    mockUseFlag.mockImplementation(() => false)
-
-    renderWithRelay({ Artwork, Viewer: offerViewer({}) })
-
-    expect(
-      screen.queryByTestId("partnerOfferActionLink"),
-    ).not.toBeInTheDocument()
-  })
-
   describe("expiry countdown", () => {
     const NOW = DateTime.fromISO("2026-01-01T00:00:00.000Z").toMillis()
 
@@ -163,5 +153,15 @@ describe("ConversationPartnerOfferCTA", () => {
         color: THEME.colors.red100,
       })
     })
+  })
+
+  it("renders nothing when the partner-offer-convo flag is off", () => {
+    mockUseFlag.mockImplementation(() => false)
+
+    renderWithRelay({ Artwork, Viewer: offerViewer({}) })
+
+    expect(
+      screen.queryByTestId("partnerOfferActionLink"),
+    ).not.toBeInTheDocument()
   })
 })

--- a/src/Apps/Conversations/components/Message/__tests__/ConversationPartnerOfferUpdate.jest.tsx
+++ b/src/Apps/Conversations/components/Message/__tests__/ConversationPartnerOfferUpdate.jest.tsx
@@ -95,15 +95,17 @@ describe("ConversationPartnerOfferUpdate", () => {
     expect(screen.queryByText(/You received an offer/)).not.toBeInTheDocument()
   })
 
-  it("renders nothing when the offer has expired", () => {
+  it("renders an expired message when the offer has expired", () => {
     renderWithRelay({ Artwork, Viewer: offerViewer({ endAt: pastDate() }) })
 
+    expect(screen.getByText("Offer Expired")).toBeInTheDocument()
     expect(screen.queryByText(/You received an offer/)).not.toBeInTheDocument()
   })
 
-  it("renders nothing when the offer is unavailable", () => {
+  it("renders an expired message when the offer is unavailable", () => {
     renderWithRelay({ Artwork, Viewer: offerViewer({ isAvailable: false }) })
 
+    expect(screen.getByText("Offer Expired")).toBeInTheDocument()
     expect(screen.queryByText(/You received an offer/)).not.toBeInTheDocument()
   })
 


### PR DESCRIPTION
The type of this PR is: **FEAT**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [Partner Offer from Convos QA item](https://app.notion.com/p/artsy/When-a-partner-offer-expires-it-just-disappears-from-the-collectors-inbox-is-that-ok-37ccab0764a08098b4bff2f56a716e0e)

### Description

Displays `$ Offer expired` text as part of the Message between a partner and collector when a partner offer expires


This was signed off by Camille: https://artsy.slack.com/archives/C0A5Z9S1BTJ/p1781537650286619



## Before
- Any remnants of the offer disappear from the inbox
- Commercial buttons are re-enabled

<img width="900" height="450" alt="Screenshot 2026-06-15 at 12 39 26 PM" src="https://github.com/user-attachments/assets/ba06511f-f570-44ba-add2-4400058eab41" />




## After
- Red text
- Commercial buttons are re-enabled
- Hide the blue sticky CTA if the offer is expired

<img width="900" height="450" alt="Screenshot 2026-06-15 at 12 39 45 PM" src="https://github.com/user-attachments/assets/beafd48d-22d1-4bd3-b211-ebb8b242b69a" />



<!-- Implementation description -->
