### PR TITLE
feat(artist): adds artwork title to primary artwork image

### DIFF
--- a/src/Apps/Artist/Components/ArtistHeader/ArtistHeader.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/ArtistHeader.tsx
@@ -129,12 +129,20 @@ const ArtistHeader: React.FC<React.PropsWithChildren<ArtistHeaderProps>> = ({
         >
           <RouterLink
             to={artist.coverArtwork.href}
-            display="block"
+            display="flex"
+            flexDirection="column"
+            gap={1}
             textDecoration="none"
+            width="fit-content"
             maxWidth="100%"
             onClick={trackClickedArtistArtworkImage}
           >
             <ArtistHeaderImageFragmentContainer artwork={artist.coverArtwork} />
+
+            <Text variant="xs" color="mono60" textAlign="left" overflowEllipsis>
+              <em>{artist.coverArtwork.title}</em>
+              {artist.coverArtwork.date && `, ${artist.coverArtwork.date}`}
+            </Text>
           </RouterLink>
         </Column>
       )}
@@ -376,6 +384,8 @@ export const ArtistHeaderFragmentContainer = createFragmentContainer(
           internalID
           slug
           href
+          title
+          date
           image {
             src: url(version: ["larger", "larger"])
             width

--- a/src/Apps/Artist/Components/ArtistHeader/ArtistHeaderEditorial.tsx
+++ b/src/Apps/Artist/Components/ArtistHeader/ArtistHeaderEditorial.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   type BoxProps,
   ProgressDots,
   Stack,
@@ -77,11 +78,15 @@ export const ArtistHeaderEditorial: React.FC<ArtistHeaderEditorialProps> = ({
         </Swiper>
 
         {articles.length > 1 && (
-          <ProgressDots
-            amount={articles.length}
-            activeIndex={activeIndex}
-            onClick={setActiveIndex}
-          />
+          // This component is primarily whitespace so we can neutralize
+          // the height of the dots to visually balance
+          <Box mb={[0, -25]}>
+            <ProgressDots
+              amount={articles.length}
+              activeIndex={activeIndex}
+              onClick={setActiveIndex}
+            />
+          </Box>
         )}
       </Stack>
     </Stack>

--- a/src/Apps/Artist/Routes/Combined/ArtistCombinedRoute.tsx
+++ b/src/Apps/Artist/Routes/Combined/ArtistCombinedRoute.tsx
@@ -102,7 +102,7 @@ const ArtistCombinedRoute: React.FC<
 
       <ArtistCombinedNav waitUntil={waitUntil} navigating={navigating} />
 
-      <Spacer y={[2, 4]} />
+      <Spacer y={2} />
 
       <Section id="artistArtworksTop">
         <Text variant="lg-display" as="h2">

--- a/src/__generated__/ArtistAppTestQuery.graphql.ts
+++ b/src/__generated__/ArtistAppTestQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c5d72e1a3da9ca964338ed4ff7843293>>
+ * @generated SignedSource<<fe43186447b2c44c26a410cde9477bf8>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -92,98 +92,105 @@ v9 = {
   "name": "internalID",
   "storageKey": null
 },
-v10 = [
-  (v2/*: any*/),
-  (v8/*: any*/)
-],
-v11 = [
-  (v5/*: any*/)
-],
-v12 = {
-  "kind": "Literal",
-  "name": "size",
-  "value": 3
-},
-v13 = {
+v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "title",
   "storageKey": null
 },
-v14 = [
+v11 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "date",
+  "storageKey": null
+},
+v12 = [
+  (v2/*: any*/),
+  (v8/*: any*/)
+],
+v13 = [
+  (v5/*: any*/)
+],
+v14 = {
+  "kind": "Literal",
+  "name": "size",
+  "value": 3
+},
+v15 = [
   {
     "kind": "Literal",
     "name": "format",
     "value": "HTML"
   }
 ],
-v15 = {
+v16 = {
   "kind": "Literal",
   "name": "minValue",
   "value": 50
 },
-v16 = [
+v17 = [
   (v9/*: any*/),
   (v2/*: any*/),
   (v1/*: any*/),
   (v8/*: any*/)
 ],
-v17 = {
+v18 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Artist"
 },
-v18 = {
+v19 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v19 = {
+v20 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v20 = {
+v21 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Image"
 },
-v21 = {
+v22 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "CroppedImageUrl"
 },
-v22 = {
+v23 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v23 = {
+v24 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v24 = {
+v25 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "ArtistBlurb"
 },
-v25 = {
+v26 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "Int"
 },
-v26 = {
+v27 = {
   "enumValues": null,
   "nullable": false,
   "plural": true,
@@ -387,6 +394,8 @@ return {
               (v9/*: any*/),
               (v1/*: any*/),
               (v3/*: any*/),
+              (v10/*: any*/),
+              (v11/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -401,7 +410,7 @@ return {
                 "kind": "LinkedField",
                 "name": "artist",
                 "plural": false,
-                "selections": (v10/*: any*/),
+                "selections": (v12/*: any*/),
                 "storageKey": null
               }
             ],
@@ -461,7 +470,7 @@ return {
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v11/*: any*/),
+                            "selections": (v13/*: any*/),
                             "storageKey": "cropped(height:30,width:30)"
                           },
                           {
@@ -482,7 +491,7 @@ return {
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v11/*: any*/),
+                            "selections": (v13/*: any*/),
                             "storageKey": "cropped(height:60,width:60)"
                           }
                         ],
@@ -502,22 +511,16 @@ return {
           {
             "alias": null,
             "args": [
-              (v12/*: any*/)
+              (v14/*: any*/)
             ],
             "concreteType": "Artwork",
             "kind": "LinkedField",
             "name": "notableArtworks",
             "plural": true,
             "selections": [
-              (v13/*: any*/),
+              (v10/*: any*/),
               (v3/*: any*/),
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "date",
-                "storageKey": null
-              },
+              (v11/*: any*/),
               (v8/*: any*/)
             ],
             "storageKey": "notableArtworks(size:3)"
@@ -535,7 +538,7 @@ return {
             "kind": "LinkedField",
             "name": "genes",
             "plural": true,
-            "selections": (v10/*: any*/),
+            "selections": (v12/*: any*/),
             "storageKey": "genes(size:10)"
           },
           (v9/*: any*/),
@@ -566,7 +569,7 @@ return {
           },
           {
             "alias": null,
-            "args": (v14/*: any*/),
+            "args": (v15/*: any*/),
             "concreteType": "ArtistBlurb",
             "kind": "LinkedField",
             "name": "biographyBlurb",
@@ -607,7 +610,7 @@ return {
               },
               {
                 "alias": null,
-                "args": (v14/*: any*/),
+                "args": (v15/*: any*/),
                 "kind": "ScalarField",
                 "name": "description",
                 "storageKey": "description(format:\"HTML\")"
@@ -673,7 +676,7 @@ return {
                         "name": "byline",
                         "storageKey": null
                       },
-                      (v13/*: any*/),
+                      (v10/*: any*/),
                       {
                         "alias": null,
                         "args": [
@@ -746,14 +749,14 @@ return {
                 "name": "geneFamilyID",
                 "value": "styles-and-movements"
               },
-              (v15/*: any*/),
-              (v12/*: any*/)
+              (v16/*: any*/),
+              (v14/*: any*/)
             ],
             "concreteType": "Gene",
             "kind": "LinkedField",
             "name": "genes",
             "plural": true,
-            "selections": (v16/*: any*/),
+            "selections": (v17/*: any*/),
             "storageKey": "genes(geneFamilyID:\"styles-and-movements\",minValue:50,size:3)"
           },
           {
@@ -764,14 +767,14 @@ return {
                 "name": "geneFamilyID",
                 "value": "medium-and-techniques"
               },
-              (v15/*: any*/),
-              (v12/*: any*/)
+              (v16/*: any*/),
+              (v14/*: any*/)
             ],
             "concreteType": "Gene",
             "kind": "LinkedField",
             "name": "genes",
             "plural": true,
-            "selections": (v16/*: any*/),
+            "selections": (v17/*: any*/),
             "storageKey": "genes(geneFamilyID:\"medium-and-techniques\",minValue:50,size:3)"
           },
           (v8/*: any*/)
@@ -781,11 +784,11 @@ return {
     ]
   },
   "params": {
-    "cacheID": "0f0616311fb225602acf5bc053ee992a",
+    "cacheID": "75a4e2ba415d062c2285f0cd67cb43b3",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
-        "artist": (v17/*: any*/),
+        "artist": (v18/*: any*/),
         "artist.alternateNames": {
           "enumValues": null,
           "nullable": true,
@@ -810,24 +813,24 @@ return {
           "plural": false,
           "type": "Article"
         },
-        "artist.articlesConnection.edges.node.byline": (v18/*: any*/),
-        "artist.articlesConnection.edges.node.href": (v18/*: any*/),
-        "artist.articlesConnection.edges.node.id": (v19/*: any*/),
-        "artist.articlesConnection.edges.node.internalID": (v19/*: any*/),
-        "artist.articlesConnection.edges.node.publishedAt": (v18/*: any*/),
-        "artist.articlesConnection.edges.node.thumbnailImage": (v20/*: any*/),
-        "artist.articlesConnection.edges.node.thumbnailImage.small": (v21/*: any*/),
-        "artist.articlesConnection.edges.node.thumbnailImage.small.src": (v22/*: any*/),
-        "artist.articlesConnection.edges.node.thumbnailImage.small.srcSet": (v22/*: any*/),
-        "artist.articlesConnection.edges.node.title": (v18/*: any*/),
-        "artist.articlesConnection.totalCount": (v23/*: any*/),
-        "artist.awards": (v18/*: any*/),
-        "artist.biographyBlurb": (v24/*: any*/),
-        "artist.biographyBlurb.credit": (v18/*: any*/),
-        "artist.biographyBlurb.text": (v18/*: any*/),
-        "artist.biographyBlurbPlain": (v24/*: any*/),
-        "artist.biographyBlurbPlain.text": (v18/*: any*/),
-        "artist.birthday": (v18/*: any*/),
+        "artist.articlesConnection.edges.node.byline": (v19/*: any*/),
+        "artist.articlesConnection.edges.node.href": (v19/*: any*/),
+        "artist.articlesConnection.edges.node.id": (v20/*: any*/),
+        "artist.articlesConnection.edges.node.internalID": (v20/*: any*/),
+        "artist.articlesConnection.edges.node.publishedAt": (v19/*: any*/),
+        "artist.articlesConnection.edges.node.thumbnailImage": (v21/*: any*/),
+        "artist.articlesConnection.edges.node.thumbnailImage.small": (v22/*: any*/),
+        "artist.articlesConnection.edges.node.thumbnailImage.small.src": (v23/*: any*/),
+        "artist.articlesConnection.edges.node.thumbnailImage.small.srcSet": (v23/*: any*/),
+        "artist.articlesConnection.edges.node.title": (v19/*: any*/),
+        "artist.articlesConnection.totalCount": (v24/*: any*/),
+        "artist.awards": (v19/*: any*/),
+        "artist.biographyBlurb": (v25/*: any*/),
+        "artist.biographyBlurb.credit": (v19/*: any*/),
+        "artist.biographyBlurb.text": (v19/*: any*/),
+        "artist.biographyBlurbPlain": (v25/*: any*/),
+        "artist.biographyBlurbPlain.text": (v19/*: any*/),
+        "artist.birthday": (v19/*: any*/),
         "artist.counts": {
           "enumValues": null,
           "nullable": true,
@@ -846,39 +849,41 @@ return {
           "plural": false,
           "type": "Artwork"
         },
-        "artist.coverArtwork.fallbackArtist": (v17/*: any*/),
-        "artist.coverArtwork.fallbackArtist.id": (v19/*: any*/),
-        "artist.coverArtwork.fallbackArtist.name": (v18/*: any*/),
-        "artist.coverArtwork.href": (v18/*: any*/),
-        "artist.coverArtwork.id": (v19/*: any*/),
-        "artist.coverArtwork.image": (v20/*: any*/),
-        "artist.coverArtwork.image.cropped": (v21/*: any*/),
-        "artist.coverArtwork.image.cropped.height": (v25/*: any*/),
-        "artist.coverArtwork.image.cropped.src": (v22/*: any*/),
-        "artist.coverArtwork.image.cropped.width": (v25/*: any*/),
-        "artist.coverArtwork.image.height": (v23/*: any*/),
-        "artist.coverArtwork.image.large": (v18/*: any*/),
-        "artist.coverArtwork.image.src": (v18/*: any*/),
-        "artist.coverArtwork.image.width": (v23/*: any*/),
-        "artist.coverArtwork.imageTitle": (v18/*: any*/),
-        "artist.coverArtwork.internalID": (v19/*: any*/),
-        "artist.coverArtwork.slug": (v19/*: any*/),
-        "artist.deathday": (v18/*: any*/),
-        "artist.formattedNationalityAndBirthday": (v18/*: any*/),
-        "artist.gender": (v18/*: any*/),
-        "artist.genes": (v26/*: any*/),
-        "artist.genes.id": (v19/*: any*/),
-        "artist.genes.name": (v18/*: any*/),
-        "artist.hometown": (v18/*: any*/),
-        "artist.href": (v18/*: any*/),
-        "artist.id": (v19/*: any*/),
+        "artist.coverArtwork.date": (v19/*: any*/),
+        "artist.coverArtwork.fallbackArtist": (v18/*: any*/),
+        "artist.coverArtwork.fallbackArtist.id": (v20/*: any*/),
+        "artist.coverArtwork.fallbackArtist.name": (v19/*: any*/),
+        "artist.coverArtwork.href": (v19/*: any*/),
+        "artist.coverArtwork.id": (v20/*: any*/),
+        "artist.coverArtwork.image": (v21/*: any*/),
+        "artist.coverArtwork.image.cropped": (v22/*: any*/),
+        "artist.coverArtwork.image.cropped.height": (v26/*: any*/),
+        "artist.coverArtwork.image.cropped.src": (v23/*: any*/),
+        "artist.coverArtwork.image.cropped.width": (v26/*: any*/),
+        "artist.coverArtwork.image.height": (v24/*: any*/),
+        "artist.coverArtwork.image.large": (v19/*: any*/),
+        "artist.coverArtwork.image.src": (v19/*: any*/),
+        "artist.coverArtwork.image.width": (v24/*: any*/),
+        "artist.coverArtwork.imageTitle": (v19/*: any*/),
+        "artist.coverArtwork.internalID": (v20/*: any*/),
+        "artist.coverArtwork.slug": (v20/*: any*/),
+        "artist.coverArtwork.title": (v19/*: any*/),
+        "artist.deathday": (v19/*: any*/),
+        "artist.formattedNationalityAndBirthday": (v19/*: any*/),
+        "artist.gender": (v19/*: any*/),
+        "artist.genes": (v27/*: any*/),
+        "artist.genes.id": (v20/*: any*/),
+        "artist.genes.name": (v19/*: any*/),
+        "artist.hometown": (v19/*: any*/),
+        "artist.href": (v19/*: any*/),
+        "artist.id": (v20/*: any*/),
         "artist.insights": {
           "enumValues": null,
           "nullable": false,
           "plural": true,
           "type": "ArtistInsight"
         },
-        "artist.insights.description": (v18/*: any*/),
+        "artist.insights.description": (v19/*: any*/),
         "artist.insights.entities": {
           "enumValues": null,
           "nullable": false,
@@ -909,65 +914,65 @@ return {
           "plural": false,
           "type": "ArtistInsightKind"
         },
-        "artist.insights.label": (v22/*: any*/),
-        "artist.internalID": (v19/*: any*/),
-        "artist.mediumGenes": (v26/*: any*/),
-        "artist.mediumGenes.id": (v19/*: any*/),
-        "artist.mediumGenes.internalID": (v19/*: any*/),
-        "artist.mediumGenes.name": (v18/*: any*/),
-        "artist.mediumGenes.slug": (v19/*: any*/),
-        "artist.movementGenes": (v26/*: any*/),
-        "artist.movementGenes.id": (v19/*: any*/),
-        "artist.movementGenes.internalID": (v19/*: any*/),
-        "artist.movementGenes.name": (v18/*: any*/),
-        "artist.movementGenes.slug": (v19/*: any*/),
-        "artist.name": (v18/*: any*/),
-        "artist.nationality": (v18/*: any*/),
+        "artist.insights.label": (v23/*: any*/),
+        "artist.internalID": (v20/*: any*/),
+        "artist.mediumGenes": (v27/*: any*/),
+        "artist.mediumGenes.id": (v20/*: any*/),
+        "artist.mediumGenes.internalID": (v20/*: any*/),
+        "artist.mediumGenes.name": (v19/*: any*/),
+        "artist.mediumGenes.slug": (v20/*: any*/),
+        "artist.movementGenes": (v27/*: any*/),
+        "artist.movementGenes.id": (v20/*: any*/),
+        "artist.movementGenes.internalID": (v20/*: any*/),
+        "artist.movementGenes.name": (v19/*: any*/),
+        "artist.movementGenes.slug": (v20/*: any*/),
+        "artist.name": (v19/*: any*/),
+        "artist.nationality": (v19/*: any*/),
         "artist.notableArtworks": {
           "enumValues": null,
           "nullable": false,
           "plural": true,
           "type": "Artwork"
         },
-        "artist.notableArtworks.date": (v18/*: any*/),
-        "artist.notableArtworks.href": (v18/*: any*/),
-        "artist.notableArtworks.id": (v19/*: any*/),
-        "artist.notableArtworks.title": (v18/*: any*/),
-        "artist.slug": (v19/*: any*/),
+        "artist.notableArtworks.date": (v19/*: any*/),
+        "artist.notableArtworks.href": (v19/*: any*/),
+        "artist.notableArtworks.id": (v20/*: any*/),
+        "artist.notableArtworks.title": (v19/*: any*/),
+        "artist.slug": (v20/*: any*/),
         "artist.verifiedRepresentatives": {
           "enumValues": null,
           "nullable": false,
           "plural": true,
           "type": "VerifiedRepresentative"
         },
-        "artist.verifiedRepresentatives.id": (v19/*: any*/),
+        "artist.verifiedRepresentatives.id": (v20/*: any*/),
         "artist.verifiedRepresentatives.partner": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "Partner"
         },
-        "artist.verifiedRepresentatives.partner.href": (v18/*: any*/),
-        "artist.verifiedRepresentatives.partner.id": (v19/*: any*/),
-        "artist.verifiedRepresentatives.partner.internalID": (v19/*: any*/),
-        "artist.verifiedRepresentatives.partner.name": (v18/*: any*/),
+        "artist.verifiedRepresentatives.partner.href": (v19/*: any*/),
+        "artist.verifiedRepresentatives.partner.id": (v20/*: any*/),
+        "artist.verifiedRepresentatives.partner.internalID": (v20/*: any*/),
+        "artist.verifiedRepresentatives.partner.name": (v19/*: any*/),
         "artist.verifiedRepresentatives.partner.profile": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Profile"
         },
-        "artist.verifiedRepresentatives.partner.profile.icon": (v20/*: any*/),
-        "artist.verifiedRepresentatives.partner.profile.icon.src1x": (v21/*: any*/),
-        "artist.verifiedRepresentatives.partner.profile.icon.src1x.src": (v22/*: any*/),
-        "artist.verifiedRepresentatives.partner.profile.icon.src2x": (v21/*: any*/),
-        "artist.verifiedRepresentatives.partner.profile.icon.src2x.src": (v22/*: any*/),
-        "artist.verifiedRepresentatives.partner.profile.id": (v19/*: any*/)
+        "artist.verifiedRepresentatives.partner.profile.icon": (v21/*: any*/),
+        "artist.verifiedRepresentatives.partner.profile.icon.src1x": (v22/*: any*/),
+        "artist.verifiedRepresentatives.partner.profile.icon.src1x.src": (v23/*: any*/),
+        "artist.verifiedRepresentatives.partner.profile.icon.src2x": (v22/*: any*/),
+        "artist.verifiedRepresentatives.partner.profile.icon.src2x.src": (v23/*: any*/),
+        "artist.verifiedRepresentatives.partner.profile.id": (v20/*: any*/)
       }
     },
     "name": "ArtistAppTestQuery",
     "operationKind": "query",
-    "text": "query ArtistAppTestQuery {\n  artist(id: \"example\") {\n    ...ArtistApp_artist\n    id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  internalID\n  slug\n  name\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  kind\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistGenesRow_genes on Gene {\n  internalID\n  name\n  slug\n}\n\nfragment ArtistHeaderEditorialItem_article on Article {\n  internalID\n  href\n  byline\n  title\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    small: cropped(width: 125, height: 125) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtistHeaderEditorial_artist on Artist {\n  name\n  href\n  articlesConnection(first: 3, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        ...ArtistHeaderEditorialItem_article\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistHeaderImage_artwork on Artwork {\n  imageTitle\n  image {\n    src: url(version: [\"larger\", \"larger\"])\n    width\n    height\n  }\n  fallbackArtist: artist {\n    name\n    id\n  }\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  insights {\n    kind\n    entities\n    description(format: HTML)\n    ...ArtistCareerHighlight_insight\n  }\n  articlesConnection(first: 3, sort: PUBLISHED_AT_DESC) {\n    totalCount\n  }\n  ...ArtistHeaderEditorial_artist\n  ...ArtistStylesAndTechniques_artist\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          src1x: cropped(width: 30, height: 30) {\n            src\n          }\n          src2x: cropped(width: 60, height: 60) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n  coverArtwork {\n    internalID\n    slug\n    href\n    image {\n      src: url(version: [\"larger\", \"larger\"])\n      width\n      height\n    }\n    ...ArtistHeaderImage_artwork\n    id\n  }\n}\n\nfragment ArtistMeta_artist on Artist {\n  ...ArtistStructuredData_artist\n  name\n  nationality\n  birthday\n  deathday\n  alternateNames\n  biographyBlurbPlain: biographyBlurb(format: PLAIN) {\n    text\n  }\n  coverArtwork {\n    image {\n      large: url(version: \"large\")\n    }\n    id\n  }\n}\n\nfragment ArtistStructuredData_artist on Artist {\n  slug\n  name\n  alternateNames\n  awards\n  birthday\n  deathday\n  gender\n  hometown\n  nationality\n  href\n  biographyBlurbPlain: biographyBlurb(format: PLAIN) {\n    text\n  }\n  coverArtwork {\n    image {\n      cropped(width: 1200, height: 900, version: [\"larger\", \"large\"]) {\n        src\n        width\n        height\n      }\n    }\n    id\n  }\n  verifiedRepresentatives {\n    partner {\n      name\n      href\n      id\n    }\n    id\n  }\n  notableArtworks(size: 3) {\n    title\n    href\n    date\n    id\n  }\n  genes(size: 10) {\n    name\n    id\n  }\n}\n\nfragment ArtistStylesAndTechniques_artist on Artist {\n  movementGenes: genes(geneFamilyID: \"styles-and-movements\", minValue: 50, size: 3) {\n    ...ArtistGenesRow_genes\n    id\n  }\n  mediumGenes: genes(geneFamilyID: \"medium-and-techniques\", minValue: 50, size: 3) {\n    ...ArtistGenesRow_genes\n    id\n  }\n}\n"
+    "text": "query ArtistAppTestQuery {\n  artist(id: \"example\") {\n    ...ArtistApp_artist\n    id\n  }\n}\n\nfragment ArtistApp_artist on Artist {\n  ...ArtistMeta_artist\n  ...ArtistHeader_artist\n  internalID\n  slug\n  name\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  kind\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistGenesRow_genes on Gene {\n  internalID\n  name\n  slug\n}\n\nfragment ArtistHeaderEditorialItem_article on Article {\n  internalID\n  href\n  byline\n  title\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    small: cropped(width: 125, height: 125) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtistHeaderEditorial_artist on Artist {\n  name\n  href\n  articlesConnection(first: 3, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        ...ArtistHeaderEditorialItem_article\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistHeaderImage_artwork on Artwork {\n  imageTitle\n  image {\n    src: url(version: [\"larger\", \"larger\"])\n    width\n    height\n  }\n  fallbackArtist: artist {\n    name\n    id\n  }\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  insights {\n    kind\n    entities\n    description(format: HTML)\n    ...ArtistCareerHighlight_insight\n  }\n  articlesConnection(first: 3, sort: PUBLISHED_AT_DESC) {\n    totalCount\n  }\n  ...ArtistHeaderEditorial_artist\n  ...ArtistStylesAndTechniques_artist\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          src1x: cropped(width: 30, height: 30) {\n            src\n          }\n          src2x: cropped(width: 60, height: 60) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n  coverArtwork {\n    internalID\n    slug\n    href\n    title\n    date\n    image {\n      src: url(version: [\"larger\", \"larger\"])\n      width\n      height\n    }\n    ...ArtistHeaderImage_artwork\n    id\n  }\n}\n\nfragment ArtistMeta_artist on Artist {\n  ...ArtistStructuredData_artist\n  name\n  nationality\n  birthday\n  deathday\n  alternateNames\n  biographyBlurbPlain: biographyBlurb(format: PLAIN) {\n    text\n  }\n  coverArtwork {\n    image {\n      large: url(version: \"large\")\n    }\n    id\n  }\n}\n\nfragment ArtistStructuredData_artist on Artist {\n  slug\n  name\n  alternateNames\n  awards\n  birthday\n  deathday\n  gender\n  hometown\n  nationality\n  href\n  biographyBlurbPlain: biographyBlurb(format: PLAIN) {\n    text\n  }\n  coverArtwork {\n    image {\n      cropped(width: 1200, height: 900, version: [\"larger\", \"large\"]) {\n        src\n        width\n        height\n      }\n    }\n    id\n  }\n  verifiedRepresentatives {\n    partner {\n      name\n      href\n      id\n    }\n    id\n  }\n  notableArtworks(size: 3) {\n    title\n    href\n    date\n    id\n  }\n  genes(size: 10) {\n    name\n    id\n  }\n}\n\nfragment ArtistStylesAndTechniques_artist on Artist {\n  movementGenes: genes(geneFamilyID: \"styles-and-movements\", minValue: 50, size: 3) {\n    ...ArtistGenesRow_genes\n    id\n  }\n  mediumGenes: genes(geneFamilyID: \"medium-and-techniques\", minValue: 50, size: 3) {\n    ...ArtistGenesRow_genes\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistHeader_Test_Query.graphql.ts
+++ b/src/__generated__/ArtistHeader_Test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<199b74a9cb3c2c460bb6c3cfb2fafd02>>
+ * @generated SignedSource<<4c2f75fd60ca8852d8402aa9c0cf5ad3>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -68,78 +68,85 @@ v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "src",
+  "name": "title",
   "storageKey": null
 },
 v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "id",
+  "name": "src",
   "storageKey": null
 },
 v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v9 = {
   "kind": "Literal",
   "name": "minValue",
   "value": 50
 },
-v9 = {
+v10 = {
   "kind": "Literal",
   "name": "size",
   "value": 3
 },
-v10 = [
+v11 = [
   (v1/*: any*/),
   (v3/*: any*/),
   (v2/*: any*/),
+  (v8/*: any*/)
+],
+v12 = [
   (v7/*: any*/)
 ],
-v11 = [
-  (v6/*: any*/)
-],
-v12 = {
+v13 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Artist"
 },
-v13 = {
+v14 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "String"
 },
-v14 = {
+v15 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v15 = {
+v16 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Image"
 },
-v16 = {
+v17 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "CroppedImageUrl"
 },
-v17 = {
+v18 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "String"
 },
-v18 = {
+v19 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
   "type": "Int"
 },
-v19 = {
+v20 = {
   "enumValues": null,
   "nullable": false,
   "plural": true,
@@ -329,13 +336,7 @@ return {
                         "name": "byline",
                         "storageKey": null
                       },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "title",
-                        "storageKey": null
-                      },
+                      (v6/*: any*/),
                       {
                         "alias": null,
                         "args": [
@@ -376,7 +377,7 @@ return {
                             "name": "cropped",
                             "plural": false,
                             "selections": [
-                              (v6/*: any*/),
+                              (v7/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -390,7 +391,7 @@ return {
                         ],
                         "storageKey": null
                       },
-                      (v7/*: any*/)
+                      (v8/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -409,14 +410,14 @@ return {
                 "name": "geneFamilyID",
                 "value": "styles-and-movements"
               },
-              (v8/*: any*/),
-              (v9/*: any*/)
+              (v9/*: any*/),
+              (v10/*: any*/)
             ],
             "concreteType": "Gene",
             "kind": "LinkedField",
             "name": "genes",
             "plural": true,
-            "selections": (v10/*: any*/),
+            "selections": (v11/*: any*/),
             "storageKey": "genes(geneFamilyID:\"styles-and-movements\",minValue:50,size:3)"
           },
           {
@@ -427,14 +428,14 @@ return {
                 "name": "geneFamilyID",
                 "value": "medium-and-techniques"
               },
-              (v8/*: any*/),
-              (v9/*: any*/)
+              (v9/*: any*/),
+              (v10/*: any*/)
             ],
             "concreteType": "Gene",
             "kind": "LinkedField",
             "name": "genes",
             "plural": true,
-            "selections": (v10/*: any*/),
+            "selections": (v11/*: any*/),
             "storageKey": "genes(geneFamilyID:\"medium-and-techniques\",minValue:50,size:3)"
           },
           {
@@ -490,7 +491,7 @@ return {
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v11/*: any*/),
+                            "selections": (v12/*: any*/),
                             "storageKey": "cropped(height:30,width:30)"
                           },
                           {
@@ -511,21 +512,21 @@ return {
                             "kind": "LinkedField",
                             "name": "cropped",
                             "plural": false,
-                            "selections": (v11/*: any*/),
+                            "selections": (v12/*: any*/),
                             "storageKey": "cropped(height:60,width:60)"
                           }
                         ],
                         "storageKey": null
                       },
-                      (v7/*: any*/)
+                      (v8/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  (v7/*: any*/)
+                  (v8/*: any*/)
                 ],
                 "storageKey": null
               },
-              (v7/*: any*/)
+              (v8/*: any*/)
             ],
             "storageKey": null
           },
@@ -540,6 +541,14 @@ return {
               (v1/*: any*/),
               (v2/*: any*/),
               (v5/*: any*/),
+              (v6/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "date",
+                "storageKey": null
+              },
               {
                 "alias": null,
                 "args": null,
@@ -597,26 +606,26 @@ return {
                 "plural": false,
                 "selections": [
                   (v3/*: any*/),
-                  (v7/*: any*/)
+                  (v8/*: any*/)
                 ],
                 "storageKey": null
               },
-              (v7/*: any*/)
+              (v8/*: any*/)
             ],
             "storageKey": null
           },
-          (v7/*: any*/)
+          (v8/*: any*/)
         ],
         "storageKey": "artist(id:\"example\")"
       }
     ]
   },
   "params": {
-    "cacheID": "b1c5ec2183d224840531383c666bc196",
+    "cacheID": "8b9ba8e2cea3a0f6cf60c7153b77e845",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
-        "artist": (v12/*: any*/),
+        "artist": (v13/*: any*/),
         "artist.articlesConnection": {
           "enumValues": null,
           "nullable": true,
@@ -635,25 +644,25 @@ return {
           "plural": false,
           "type": "Article"
         },
-        "artist.articlesConnection.edges.node.byline": (v13/*: any*/),
-        "artist.articlesConnection.edges.node.href": (v13/*: any*/),
-        "artist.articlesConnection.edges.node.id": (v14/*: any*/),
-        "artist.articlesConnection.edges.node.internalID": (v14/*: any*/),
-        "artist.articlesConnection.edges.node.publishedAt": (v13/*: any*/),
-        "artist.articlesConnection.edges.node.thumbnailImage": (v15/*: any*/),
-        "artist.articlesConnection.edges.node.thumbnailImage.small": (v16/*: any*/),
-        "artist.articlesConnection.edges.node.thumbnailImage.small.src": (v17/*: any*/),
-        "artist.articlesConnection.edges.node.thumbnailImage.small.srcSet": (v17/*: any*/),
-        "artist.articlesConnection.edges.node.title": (v13/*: any*/),
-        "artist.articlesConnection.totalCount": (v18/*: any*/),
+        "artist.articlesConnection.edges.node.byline": (v14/*: any*/),
+        "artist.articlesConnection.edges.node.href": (v14/*: any*/),
+        "artist.articlesConnection.edges.node.id": (v15/*: any*/),
+        "artist.articlesConnection.edges.node.internalID": (v15/*: any*/),
+        "artist.articlesConnection.edges.node.publishedAt": (v14/*: any*/),
+        "artist.articlesConnection.edges.node.thumbnailImage": (v16/*: any*/),
+        "artist.articlesConnection.edges.node.thumbnailImage.small": (v17/*: any*/),
+        "artist.articlesConnection.edges.node.thumbnailImage.small.src": (v18/*: any*/),
+        "artist.articlesConnection.edges.node.thumbnailImage.small.srcSet": (v18/*: any*/),
+        "artist.articlesConnection.edges.node.title": (v14/*: any*/),
+        "artist.articlesConnection.totalCount": (v19/*: any*/),
         "artist.biographyBlurb": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtistBlurb"
         },
-        "artist.biographyBlurb.credit": (v13/*: any*/),
-        "artist.biographyBlurb.text": (v13/*: any*/),
+        "artist.biographyBlurb.credit": (v14/*: any*/),
+        "artist.biographyBlurb.text": (v14/*: any*/),
         "artist.counts": {
           "enumValues": null,
           "nullable": true,
@@ -672,28 +681,30 @@ return {
           "plural": false,
           "type": "Artwork"
         },
-        "artist.coverArtwork.fallbackArtist": (v12/*: any*/),
-        "artist.coverArtwork.fallbackArtist.id": (v14/*: any*/),
-        "artist.coverArtwork.fallbackArtist.name": (v13/*: any*/),
-        "artist.coverArtwork.href": (v13/*: any*/),
-        "artist.coverArtwork.id": (v14/*: any*/),
-        "artist.coverArtwork.image": (v15/*: any*/),
-        "artist.coverArtwork.image.height": (v18/*: any*/),
-        "artist.coverArtwork.image.src": (v13/*: any*/),
-        "artist.coverArtwork.image.width": (v18/*: any*/),
-        "artist.coverArtwork.imageTitle": (v13/*: any*/),
-        "artist.coverArtwork.internalID": (v14/*: any*/),
-        "artist.coverArtwork.slug": (v14/*: any*/),
-        "artist.formattedNationalityAndBirthday": (v13/*: any*/),
-        "artist.href": (v13/*: any*/),
-        "artist.id": (v14/*: any*/),
+        "artist.coverArtwork.date": (v14/*: any*/),
+        "artist.coverArtwork.fallbackArtist": (v13/*: any*/),
+        "artist.coverArtwork.fallbackArtist.id": (v15/*: any*/),
+        "artist.coverArtwork.fallbackArtist.name": (v14/*: any*/),
+        "artist.coverArtwork.href": (v14/*: any*/),
+        "artist.coverArtwork.id": (v15/*: any*/),
+        "artist.coverArtwork.image": (v16/*: any*/),
+        "artist.coverArtwork.image.height": (v19/*: any*/),
+        "artist.coverArtwork.image.src": (v14/*: any*/),
+        "artist.coverArtwork.image.width": (v19/*: any*/),
+        "artist.coverArtwork.imageTitle": (v14/*: any*/),
+        "artist.coverArtwork.internalID": (v15/*: any*/),
+        "artist.coverArtwork.slug": (v15/*: any*/),
+        "artist.coverArtwork.title": (v14/*: any*/),
+        "artist.formattedNationalityAndBirthday": (v14/*: any*/),
+        "artist.href": (v14/*: any*/),
+        "artist.id": (v15/*: any*/),
         "artist.insights": {
           "enumValues": null,
           "nullable": false,
           "plural": true,
           "type": "ArtistInsight"
         },
-        "artist.insights.description": (v13/*: any*/),
+        "artist.insights.description": (v14/*: any*/),
         "artist.insights.entities": {
           "enumValues": null,
           "nullable": false,
@@ -724,54 +735,54 @@ return {
           "plural": false,
           "type": "ArtistInsightKind"
         },
-        "artist.insights.label": (v17/*: any*/),
-        "artist.internalID": (v14/*: any*/),
-        "artist.mediumGenes": (v19/*: any*/),
-        "artist.mediumGenes.id": (v14/*: any*/),
-        "artist.mediumGenes.internalID": (v14/*: any*/),
-        "artist.mediumGenes.name": (v13/*: any*/),
-        "artist.mediumGenes.slug": (v14/*: any*/),
-        "artist.movementGenes": (v19/*: any*/),
-        "artist.movementGenes.id": (v14/*: any*/),
-        "artist.movementGenes.internalID": (v14/*: any*/),
-        "artist.movementGenes.name": (v13/*: any*/),
-        "artist.movementGenes.slug": (v14/*: any*/),
-        "artist.name": (v13/*: any*/),
-        "artist.slug": (v14/*: any*/),
+        "artist.insights.label": (v18/*: any*/),
+        "artist.internalID": (v15/*: any*/),
+        "artist.mediumGenes": (v20/*: any*/),
+        "artist.mediumGenes.id": (v15/*: any*/),
+        "artist.mediumGenes.internalID": (v15/*: any*/),
+        "artist.mediumGenes.name": (v14/*: any*/),
+        "artist.mediumGenes.slug": (v15/*: any*/),
+        "artist.movementGenes": (v20/*: any*/),
+        "artist.movementGenes.id": (v15/*: any*/),
+        "artist.movementGenes.internalID": (v15/*: any*/),
+        "artist.movementGenes.name": (v14/*: any*/),
+        "artist.movementGenes.slug": (v15/*: any*/),
+        "artist.name": (v14/*: any*/),
+        "artist.slug": (v15/*: any*/),
         "artist.verifiedRepresentatives": {
           "enumValues": null,
           "nullable": false,
           "plural": true,
           "type": "VerifiedRepresentative"
         },
-        "artist.verifiedRepresentatives.id": (v14/*: any*/),
+        "artist.verifiedRepresentatives.id": (v15/*: any*/),
         "artist.verifiedRepresentatives.partner": {
           "enumValues": null,
           "nullable": false,
           "plural": false,
           "type": "Partner"
         },
-        "artist.verifiedRepresentatives.partner.href": (v13/*: any*/),
-        "artist.verifiedRepresentatives.partner.id": (v14/*: any*/),
-        "artist.verifiedRepresentatives.partner.internalID": (v14/*: any*/),
-        "artist.verifiedRepresentatives.partner.name": (v13/*: any*/),
+        "artist.verifiedRepresentatives.partner.href": (v14/*: any*/),
+        "artist.verifiedRepresentatives.partner.id": (v15/*: any*/),
+        "artist.verifiedRepresentatives.partner.internalID": (v15/*: any*/),
+        "artist.verifiedRepresentatives.partner.name": (v14/*: any*/),
         "artist.verifiedRepresentatives.partner.profile": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Profile"
         },
-        "artist.verifiedRepresentatives.partner.profile.icon": (v15/*: any*/),
-        "artist.verifiedRepresentatives.partner.profile.icon.src1x": (v16/*: any*/),
-        "artist.verifiedRepresentatives.partner.profile.icon.src1x.src": (v17/*: any*/),
-        "artist.verifiedRepresentatives.partner.profile.icon.src2x": (v16/*: any*/),
-        "artist.verifiedRepresentatives.partner.profile.icon.src2x.src": (v17/*: any*/),
-        "artist.verifiedRepresentatives.partner.profile.id": (v14/*: any*/)
+        "artist.verifiedRepresentatives.partner.profile.icon": (v16/*: any*/),
+        "artist.verifiedRepresentatives.partner.profile.icon.src1x": (v17/*: any*/),
+        "artist.verifiedRepresentatives.partner.profile.icon.src1x.src": (v18/*: any*/),
+        "artist.verifiedRepresentatives.partner.profile.icon.src2x": (v17/*: any*/),
+        "artist.verifiedRepresentatives.partner.profile.icon.src2x.src": (v18/*: any*/),
+        "artist.verifiedRepresentatives.partner.profile.id": (v15/*: any*/)
       }
     },
     "name": "ArtistHeader_Test_Query",
     "operationKind": "query",
-    "text": "query ArtistHeader_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistHeader_artist\n    id\n  }\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  kind\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistGenesRow_genes on Gene {\n  internalID\n  name\n  slug\n}\n\nfragment ArtistHeaderEditorialItem_article on Article {\n  internalID\n  href\n  byline\n  title\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    small: cropped(width: 125, height: 125) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtistHeaderEditorial_artist on Artist {\n  name\n  href\n  articlesConnection(first: 3, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        ...ArtistHeaderEditorialItem_article\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistHeaderImage_artwork on Artwork {\n  imageTitle\n  image {\n    src: url(version: [\"larger\", \"larger\"])\n    width\n    height\n  }\n  fallbackArtist: artist {\n    name\n    id\n  }\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  insights {\n    kind\n    entities\n    description(format: HTML)\n    ...ArtistCareerHighlight_insight\n  }\n  articlesConnection(first: 3, sort: PUBLISHED_AT_DESC) {\n    totalCount\n  }\n  ...ArtistHeaderEditorial_artist\n  ...ArtistStylesAndTechniques_artist\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          src1x: cropped(width: 30, height: 30) {\n            src\n          }\n          src2x: cropped(width: 60, height: 60) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n  coverArtwork {\n    internalID\n    slug\n    href\n    image {\n      src: url(version: [\"larger\", \"larger\"])\n      width\n      height\n    }\n    ...ArtistHeaderImage_artwork\n    id\n  }\n}\n\nfragment ArtistStylesAndTechniques_artist on Artist {\n  movementGenes: genes(geneFamilyID: \"styles-and-movements\", minValue: 50, size: 3) {\n    ...ArtistGenesRow_genes\n    id\n  }\n  mediumGenes: genes(geneFamilyID: \"medium-and-techniques\", minValue: 50, size: 3) {\n    ...ArtistGenesRow_genes\n    id\n  }\n}\n"
+    "text": "query ArtistHeader_Test_Query {\n  artist(id: \"example\") {\n    ...ArtistHeader_artist\n    id\n  }\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  kind\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistGenesRow_genes on Gene {\n  internalID\n  name\n  slug\n}\n\nfragment ArtistHeaderEditorialItem_article on Article {\n  internalID\n  href\n  byline\n  title\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    small: cropped(width: 125, height: 125) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtistHeaderEditorial_artist on Artist {\n  name\n  href\n  articlesConnection(first: 3, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        ...ArtistHeaderEditorialItem_article\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistHeaderImage_artwork on Artwork {\n  imageTitle\n  image {\n    src: url(version: [\"larger\", \"larger\"])\n    width\n    height\n  }\n  fallbackArtist: artist {\n    name\n    id\n  }\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  insights {\n    kind\n    entities\n    description(format: HTML)\n    ...ArtistCareerHighlight_insight\n  }\n  articlesConnection(first: 3, sort: PUBLISHED_AT_DESC) {\n    totalCount\n  }\n  ...ArtistHeaderEditorial_artist\n  ...ArtistStylesAndTechniques_artist\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          src1x: cropped(width: 30, height: 30) {\n            src\n          }\n          src2x: cropped(width: 60, height: 60) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n  coverArtwork {\n    internalID\n    slug\n    href\n    title\n    date\n    image {\n      src: url(version: [\"larger\", \"larger\"])\n      width\n      height\n    }\n    ...ArtistHeaderImage_artwork\n    id\n  }\n}\n\nfragment ArtistStylesAndTechniques_artist on Artist {\n  movementGenes: genes(geneFamilyID: \"styles-and-movements\", minValue: 50, size: 3) {\n    ...ArtistGenesRow_genes\n    id\n  }\n  mediumGenes: genes(geneFamilyID: \"medium-and-techniques\", minValue: 50, size: 3) {\n    ...ArtistGenesRow_genes\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArtistHeader_artist.graphql.ts
+++ b/src/__generated__/ArtistHeader_artist.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c8ca9f717a89c42e6cfb767c9570739b>>
+ * @generated SignedSource<<2dcb604ad25d0de3d6aa35f848bacb6a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -23,6 +23,7 @@ export type ArtistHeader_artist$data = {
     readonly follows: any | null | undefined;
   } | null | undefined;
   readonly coverArtwork: {
+    readonly date: string | null | undefined;
     readonly href: string | null | undefined;
     readonly image: {
       readonly height: number | null | undefined;
@@ -31,6 +32,7 @@ export type ArtistHeader_artist$data = {
     } | null | undefined;
     readonly internalID: string;
     readonly slug: string;
+    readonly title: string | null | undefined;
     readonly " $fragmentSpreads": FragmentRefs<"ArtistHeaderImage_artwork">;
   } | null | undefined;
   readonly formattedNationalityAndBirthday: string | null | undefined;
@@ -351,6 +353,20 @@ return {
         {
           "alias": null,
           "args": null,
+          "kind": "ScalarField",
+          "name": "title",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "date",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
           "concreteType": "Image",
           "kind": "LinkedField",
           "name": "image",
@@ -403,6 +419,6 @@ return {
 };
 })();
 
-(node as any).hash = "7d8e7d17a63c0946ca56820ca97c34ea";
+(node as any).hash = "cbd8c3e51f3b6a26b6aa060f49a9ca90";
 
 export default node;

--- a/src/__generated__/artistRoutes_ArtistAppQuery.graphql.ts
+++ b/src/__generated__/artistRoutes_ArtistAppQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<662ab0b0c34d1a360b4100ca3935dea8>>
+ * @generated SignedSource<<5cc9ceecb6d9ee249dbf1bb2f9876a7a>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -116,25 +116,32 @@ v12 = {
   "name": "title",
   "storageKey": null
 },
-v13 = [
+v13 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "date",
+  "storageKey": null
+},
+v14 = [
   (v3/*: any*/),
   (v9/*: any*/)
 ],
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "internalID",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "formattedNationalityAndBirthday",
   "storageKey": null
 },
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "concreteType": "ArtistCounts",
@@ -152,28 +159,28 @@ v16 = {
   ],
   "storageKey": null
 },
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "srcSet",
   "storageKey": null
 },
-v18 = {
+v19 = {
   "kind": "Literal",
   "name": "first",
   "value": 3
 },
-v19 = [
+v20 = [
   {
     "kind": "Literal",
     "name": "format",
     "value": "HTML"
   }
 ],
-v20 = {
+v21 = {
   "alias": null,
-  "args": (v19/*: any*/),
+  "args": (v20/*: any*/),
   "concreteType": "ArtistBlurb",
   "kind": "LinkedField",
   "name": "biographyBlurb",
@@ -190,18 +197,18 @@ v20 = {
   ],
   "storageKey": "biographyBlurb(format:\"HTML\")"
 },
-v21 = {
+v22 = {
   "kind": "Literal",
   "name": "minValue",
   "value": 50
 },
-v22 = [
-  (v14/*: any*/),
+v23 = [
+  (v15/*: any*/),
   (v3/*: any*/),
   (v2/*: any*/),
   (v9/*: any*/)
 ],
-v23 = {
+v24 = {
   "alias": "movementGenes",
   "args": [
     {
@@ -209,17 +216,17 @@ v23 = {
       "name": "geneFamilyID",
       "value": "styles-and-movements"
     },
-    (v21/*: any*/),
+    (v22/*: any*/),
     (v10/*: any*/)
   ],
   "concreteType": "Gene",
   "kind": "LinkedField",
   "name": "genes",
   "plural": true,
-  "selections": (v22/*: any*/),
+  "selections": (v23/*: any*/),
   "storageKey": "genes(geneFamilyID:\"styles-and-movements\",minValue:50,size:3)"
 },
-v24 = {
+v25 = {
   "alias": "mediumGenes",
   "args": [
     {
@@ -227,23 +234,23 @@ v24 = {
       "name": "geneFamilyID",
       "value": "medium-and-techniques"
     },
-    (v21/*: any*/),
+    (v22/*: any*/),
     (v10/*: any*/)
   ],
   "concreteType": "Gene",
   "kind": "LinkedField",
   "name": "genes",
   "plural": true,
-  "selections": (v22/*: any*/),
+  "selections": (v23/*: any*/),
   "storageKey": "genes(geneFamilyID:\"medium-and-techniques\",minValue:50,size:3)"
 },
-v25 = [
+v26 = [
   (v6/*: any*/)
 ],
-v26 = {
+v27 = {
   "alias": null,
   "args": [
-    (v18/*: any*/),
+    (v19/*: any*/),
     {
       "kind": "Literal",
       "name": "sort",
@@ -278,7 +285,7 @@ v26 = {
           "name": "node",
           "plural": false,
           "selections": [
-            (v14/*: any*/),
+            (v15/*: any*/),
             (v4/*: any*/),
             {
               "alias": null,
@@ -329,7 +336,7 @@ v26 = {
                   "plural": false,
                   "selections": [
                     (v6/*: any*/),
-                    (v17/*: any*/)
+                    (v18/*: any*/)
                   ],
                   "storageKey": "cropped(height:125,width:125)"
                 }
@@ -574,13 +581,7 @@ return {
             "selections": [
               (v12/*: any*/),
               (v4/*: any*/),
-              {
-                "alias": null,
-                "args": null,
-                "kind": "ScalarField",
-                "name": "date",
-                "storageKey": null
-              },
+              (v13/*: any*/),
               (v9/*: any*/)
             ],
             "storageKey": "notableArtworks(size:3)"
@@ -598,18 +599,18 @@ return {
             "kind": "LinkedField",
             "name": "genes",
             "plural": true,
-            "selections": (v13/*: any*/),
+            "selections": (v14/*: any*/),
             "storageKey": "genes(size:10)"
           },
-          (v14/*: any*/),
+          (v15/*: any*/),
           (v9/*: any*/),
           {
             "condition": "shouldShowExperiment",
             "kind": "Condition",
             "passingValue": true,
             "selections": [
-              (v15/*: any*/),
               (v16/*: any*/),
+              (v17/*: any*/),
               {
                 "alias": null,
                 "args": (v11/*: any*/),
@@ -618,7 +619,7 @@ return {
                 "name": "notableArtworks",
                 "plural": true,
                 "selections": [
-                  (v14/*: any*/),
+                  (v15/*: any*/),
                   (v2/*: any*/),
                   {
                     "alias": null,
@@ -650,7 +651,7 @@ return {
                           (v7/*: any*/),
                           (v8/*: any*/),
                           (v6/*: any*/),
-                          (v17/*: any*/)
+                          (v18/*: any*/)
                         ],
                         "storageKey": "resized(height:420,width:420)"
                       }
@@ -663,7 +664,7 @@ return {
               {
                 "alias": null,
                 "args": [
-                  (v18/*: any*/),
+                  (v19/*: any*/),
                   {
                     "kind": "Literal",
                     "name": "sort",
@@ -691,7 +692,7 @@ return {
                         "name": "node",
                         "plural": false,
                         "selections": [
-                          (v14/*: any*/),
+                          (v15/*: any*/),
                           (v9/*: any*/)
                         ],
                         "storageKey": null
@@ -702,9 +703,9 @@ return {
                 ],
                 "storageKey": "artworksConnection(first:3,sort:\"ICONICITY_DESC\")"
               },
-              (v20/*: any*/),
-              (v23/*: any*/),
+              (v21/*: any*/),
               (v24/*: any*/),
+              (v25/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -721,7 +722,7 @@ return {
                     "name": "partner",
                     "plural": false,
                     "selections": [
-                      (v14/*: any*/),
+                      (v15/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -756,7 +757,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "cropped",
                                 "plural": false,
-                                "selections": (v25/*: any*/),
+                                "selections": (v26/*: any*/),
                                 "storageKey": "cropped(height:45,width:45)"
                               },
                               {
@@ -777,7 +778,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "cropped",
                                 "plural": false,
-                                "selections": (v25/*: any*/),
+                                "selections": (v26/*: any*/),
                                 "storageKey": "cropped(height:90,width:90)"
                               }
                             ],
@@ -793,7 +794,7 @@ return {
                 ],
                 "storageKey": null
               },
-              (v26/*: any*/)
+              (v27/*: any*/)
             ]
           },
           {
@@ -801,9 +802,9 @@ return {
             "kind": "Condition",
             "passingValue": false,
             "selections": [
-              (v15/*: any*/),
               (v16/*: any*/),
-              (v20/*: any*/),
+              (v17/*: any*/),
+              (v21/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -828,7 +829,7 @@ return {
                   },
                   {
                     "alias": null,
-                    "args": (v19/*: any*/),
+                    "args": (v20/*: any*/),
                     "kind": "ScalarField",
                     "name": "description",
                     "storageKey": "description(format:\"HTML\")"
@@ -843,9 +844,9 @@ return {
                 ],
                 "storageKey": null
               },
-              (v26/*: any*/),
-              (v23/*: any*/),
+              (v27/*: any*/),
               (v24/*: any*/),
+              (v25/*: any*/),
               {
                 "alias": null,
                 "args": null,
@@ -862,7 +863,7 @@ return {
                     "name": "partner",
                     "plural": false,
                     "selections": [
-                      (v14/*: any*/),
+                      (v15/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -897,7 +898,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "cropped",
                                 "plural": false,
-                                "selections": (v25/*: any*/),
+                                "selections": (v26/*: any*/),
                                 "storageKey": "cropped(height:30,width:30)"
                               },
                               {
@@ -918,7 +919,7 @@ return {
                                 "kind": "LinkedField",
                                 "name": "cropped",
                                 "plural": false,
-                                "selections": (v25/*: any*/),
+                                "selections": (v26/*: any*/),
                                 "storageKey": "cropped(height:60,width:60)"
                               }
                             ],
@@ -942,9 +943,11 @@ return {
                 "name": "coverArtwork",
                 "plural": false,
                 "selections": [
-                  (v14/*: any*/),
+                  (v15/*: any*/),
                   (v2/*: any*/),
                   (v4/*: any*/),
+                  (v12/*: any*/),
+                  (v13/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -988,7 +991,7 @@ return {
                     "kind": "LinkedField",
                     "name": "artist",
                     "plural": false,
-                    "selections": (v13/*: any*/),
+                    "selections": (v14/*: any*/),
                     "storageKey": null
                   }
                 ],
@@ -1002,12 +1005,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "2c3350d29917b77c51631577c728ef38",
+    "cacheID": "727475c2a35bdc3acd1b265897e3c53c",
     "id": null,
     "metadata": {},
     "name": "artistRoutes_ArtistAppQuery",
     "operationKind": "query",
-    "text": "query artistRoutes_ArtistAppQuery(\n  $artistID: String!\n  $shouldShowExperiment: Boolean!\n) @cacheable {\n  artist(id: $artistID) @principalField {\n    slug\n    ...ArtistApp_artist_3dhG1i\n    ...ArtistCombinedRoute_artist\n    id\n  }\n}\n\nfragment ArtistAbout_artist on Artist {\n  name\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  movementGenes: genes(geneFamilyID: \"styles-and-movements\", minValue: 50, size: 3) {\n    internalID\n    name\n    slug\n    id\n  }\n  mediumGenes: genes(geneFamilyID: \"medium-and-techniques\", minValue: 50, size: 3) {\n    internalID\n    name\n    slug\n    id\n  }\n}\n\nfragment ArtistAbove_artist on Artist {\n  ...ArtistBreadcrumb_artist\n  ...ArtistTombstone_artist\n  ...ArtistNotableWorks_artist\n  ...ArtistAbout_artist\n  ...ArtistRepresentation_artist\n  ...ArtistEditorial_artist\n}\n\nfragment ArtistApp_artist_3dhG1i on Artist {\n  ...ArtistMeta_artist\n  ...ArtistAbove_artist @include(if: $shouldShowExperiment)\n  ...ArtistHeader_artist @skip(if: $shouldShowExperiment)\n  internalID\n  slug\n  name\n}\n\nfragment ArtistBreadcrumb_artist on Artist {\n  name\n  href\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  kind\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistCombinedRoute_artist on Artist {\n  internalID\n}\n\nfragment ArtistEditorialItem_article on Article {\n  internalID\n  href\n  byline\n  title\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    small: cropped(width: 125, height: 125) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtistEditorial_artist on Artist {\n  name\n  href\n  articlesConnection(first: 3, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        ...ArtistEditorialItem_article\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistGenesRow_genes on Gene {\n  internalID\n  name\n  slug\n}\n\nfragment ArtistHeaderEditorialItem_article on Article {\n  internalID\n  href\n  byline\n  title\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    small: cropped(width: 125, height: 125) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtistHeaderEditorial_artist on Artist {\n  name\n  href\n  articlesConnection(first: 3, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        ...ArtistHeaderEditorialItem_article\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistHeaderImage_artwork on Artwork {\n  imageTitle\n  image {\n    src: url(version: [\"larger\", \"larger\"])\n    width\n    height\n  }\n  fallbackArtist: artist {\n    name\n    id\n  }\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  insights {\n    kind\n    entities\n    description(format: HTML)\n    ...ArtistCareerHighlight_insight\n  }\n  articlesConnection(first: 3, sort: PUBLISHED_AT_DESC) {\n    totalCount\n  }\n  ...ArtistHeaderEditorial_artist\n  ...ArtistStylesAndTechniques_artist\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          src1x: cropped(width: 30, height: 30) {\n            src\n          }\n          src2x: cropped(width: 60, height: 60) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n  coverArtwork {\n    internalID\n    slug\n    href\n    image {\n      src: url(version: [\"larger\", \"larger\"])\n      width\n      height\n    }\n    ...ArtistHeaderImage_artwork\n    id\n  }\n}\n\nfragment ArtistMeta_artist on Artist {\n  ...ArtistStructuredData_artist\n  name\n  nationality\n  birthday\n  deathday\n  alternateNames\n  biographyBlurbPlain: biographyBlurb(format: PLAIN) {\n    text\n  }\n  coverArtwork {\n    image {\n      large: url(version: \"large\")\n    }\n    id\n  }\n}\n\nfragment ArtistNotableWorksArtworks_artist on Artist {\n  notableArtworks(size: 3) {\n    internalID\n    slug\n    href\n    title\n    date\n    image {\n      resized(width: 420, height: 420) {\n        width\n        height\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArtistNotableWorks_artist on Artist {\n  ...ArtistNotableWorksArtworks_artist\n  artworksConnection(first: 3, sort: ICONICITY_DESC) {\n    edges {\n      node {\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistRepresentation_artist on Artist {\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          _1x: cropped(width: 45, height: 45) {\n            src\n          }\n          _2x: cropped(width: 90, height: 90) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment ArtistStructuredData_artist on Artist {\n  slug\n  name\n  alternateNames\n  awards\n  birthday\n  deathday\n  gender\n  hometown\n  nationality\n  href\n  biographyBlurbPlain: biographyBlurb(format: PLAIN) {\n    text\n  }\n  coverArtwork {\n    image {\n      cropped(width: 1200, height: 900, version: [\"larger\", \"large\"]) {\n        src\n        width\n        height\n      }\n    }\n    id\n  }\n  verifiedRepresentatives {\n    partner {\n      name\n      href\n      id\n    }\n    id\n  }\n  notableArtworks(size: 3) {\n    title\n    href\n    date\n    id\n  }\n  genes(size: 10) {\n    name\n    id\n  }\n}\n\nfragment ArtistStylesAndTechniques_artist on Artist {\n  movementGenes: genes(geneFamilyID: \"styles-and-movements\", minValue: 50, size: 3) {\n    ...ArtistGenesRow_genes\n    id\n  }\n  mediumGenes: genes(geneFamilyID: \"medium-and-techniques\", minValue: 50, size: 3) {\n    ...ArtistGenesRow_genes\n    id\n  }\n}\n\nfragment ArtistTombstone_artist on Artist {\n  internalID\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n}\n"
+    "text": "query artistRoutes_ArtistAppQuery(\n  $artistID: String!\n  $shouldShowExperiment: Boolean!\n) @cacheable {\n  artist(id: $artistID) @principalField {\n    slug\n    ...ArtistApp_artist_3dhG1i\n    ...ArtistCombinedRoute_artist\n    id\n  }\n}\n\nfragment ArtistAbout_artist on Artist {\n  name\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  movementGenes: genes(geneFamilyID: \"styles-and-movements\", minValue: 50, size: 3) {\n    internalID\n    name\n    slug\n    id\n  }\n  mediumGenes: genes(geneFamilyID: \"medium-and-techniques\", minValue: 50, size: 3) {\n    internalID\n    name\n    slug\n    id\n  }\n}\n\nfragment ArtistAbove_artist on Artist {\n  ...ArtistBreadcrumb_artist\n  ...ArtistTombstone_artist\n  ...ArtistNotableWorks_artist\n  ...ArtistAbout_artist\n  ...ArtistRepresentation_artist\n  ...ArtistEditorial_artist\n}\n\nfragment ArtistApp_artist_3dhG1i on Artist {\n  ...ArtistMeta_artist\n  ...ArtistAbove_artist @include(if: $shouldShowExperiment)\n  ...ArtistHeader_artist @skip(if: $shouldShowExperiment)\n  internalID\n  slug\n  name\n}\n\nfragment ArtistBreadcrumb_artist on Artist {\n  name\n  href\n}\n\nfragment ArtistCareerHighlight_insight on ArtistInsight {\n  kind\n  label\n  entities\n  description(format: HTML)\n}\n\nfragment ArtistCombinedRoute_artist on Artist {\n  internalID\n}\n\nfragment ArtistEditorialItem_article on Article {\n  internalID\n  href\n  byline\n  title\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    small: cropped(width: 125, height: 125) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtistEditorial_artist on Artist {\n  name\n  href\n  articlesConnection(first: 3, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        ...ArtistEditorialItem_article\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistGenesRow_genes on Gene {\n  internalID\n  name\n  slug\n}\n\nfragment ArtistHeaderEditorialItem_article on Article {\n  internalID\n  href\n  byline\n  title\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    small: cropped(width: 125, height: 125) {\n      src\n      srcSet\n    }\n  }\n}\n\nfragment ArtistHeaderEditorial_artist on Artist {\n  name\n  href\n  articlesConnection(first: 3, sort: PUBLISHED_AT_DESC) {\n    totalCount\n    edges {\n      node {\n        ...ArtistHeaderEditorialItem_article\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistHeaderImage_artwork on Artwork {\n  imageTitle\n  image {\n    src: url(version: [\"larger\", \"larger\"])\n    width\n    height\n  }\n  fallbackArtist: artist {\n    name\n    id\n  }\n}\n\nfragment ArtistHeader_artist on Artist {\n  internalID\n  slug\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n  biographyBlurb(format: HTML) {\n    text\n    credit\n  }\n  insights {\n    kind\n    entities\n    description(format: HTML)\n    ...ArtistCareerHighlight_insight\n  }\n  articlesConnection(first: 3, sort: PUBLISHED_AT_DESC) {\n    totalCount\n  }\n  ...ArtistHeaderEditorial_artist\n  ...ArtistStylesAndTechniques_artist\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          src1x: cropped(width: 30, height: 30) {\n            src\n          }\n          src2x: cropped(width: 60, height: 60) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n  coverArtwork {\n    internalID\n    slug\n    href\n    title\n    date\n    image {\n      src: url(version: [\"larger\", \"larger\"])\n      width\n      height\n    }\n    ...ArtistHeaderImage_artwork\n    id\n  }\n}\n\nfragment ArtistMeta_artist on Artist {\n  ...ArtistStructuredData_artist\n  name\n  nationality\n  birthday\n  deathday\n  alternateNames\n  biographyBlurbPlain: biographyBlurb(format: PLAIN) {\n    text\n  }\n  coverArtwork {\n    image {\n      large: url(version: \"large\")\n    }\n    id\n  }\n}\n\nfragment ArtistNotableWorksArtworks_artist on Artist {\n  notableArtworks(size: 3) {\n    internalID\n    slug\n    href\n    title\n    date\n    image {\n      resized(width: 420, height: 420) {\n        width\n        height\n        src\n        srcSet\n      }\n    }\n    id\n  }\n}\n\nfragment ArtistNotableWorks_artist on Artist {\n  ...ArtistNotableWorksArtworks_artist\n  artworksConnection(first: 3, sort: ICONICITY_DESC) {\n    edges {\n      node {\n        internalID\n        id\n      }\n    }\n  }\n}\n\nfragment ArtistRepresentation_artist on Artist {\n  verifiedRepresentatives {\n    partner {\n      internalID\n      name\n      href\n      profile {\n        icon {\n          _1x: cropped(width: 45, height: 45) {\n            src\n          }\n          _2x: cropped(width: 90, height: 90) {\n            src\n          }\n        }\n        id\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment ArtistStructuredData_artist on Artist {\n  slug\n  name\n  alternateNames\n  awards\n  birthday\n  deathday\n  gender\n  hometown\n  nationality\n  href\n  biographyBlurbPlain: biographyBlurb(format: PLAIN) {\n    text\n  }\n  coverArtwork {\n    image {\n      cropped(width: 1200, height: 900, version: [\"larger\", \"large\"]) {\n        src\n        width\n        height\n      }\n    }\n    id\n  }\n  verifiedRepresentatives {\n    partner {\n      name\n      href\n      id\n    }\n    id\n  }\n  notableArtworks(size: 3) {\n    title\n    href\n    date\n    id\n  }\n  genes(size: 10) {\n    name\n    id\n  }\n}\n\nfragment ArtistStylesAndTechniques_artist on Artist {\n  movementGenes: genes(geneFamilyID: \"styles-and-movements\", minValue: 50, size: 3) {\n    ...ArtistGenesRow_genes\n    id\n  }\n  mediumGenes: genes(geneFamilyID: \"medium-and-techniques\", minValue: 50, size: 3) {\n    ...ArtistGenesRow_genes\n    id\n  }\n}\n\nfragment ArtistTombstone_artist on Artist {\n  internalID\n  name\n  formattedNationalityAndBirthday\n  counts {\n    follows\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Adds the artwork title underneath the primary artwork image and some small whitespace adjustments.

| Before | After |
| ---- | ---- |
| <img width="3840" height="2550" alt="staging artsy net_artist_roni-horn" src="https://github.com/user-attachments/assets/9e4ddf4b-b5c9-481e-8bfd-33d3f9c1daf3" /> | <img width="3840" height="2550" alt="localhost_5000_artist_roni-horn" src="https://github.com/user-attachments/assets/db0d4c35-4136-4afd-93ed-376a6c7ecede" /> |

cc @artsy/diamond-devs 