### PR TITLE
feat(TOP-319): add tracking for partner CTA convo impression

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "sha.js": "^2.4.12"
   },
   "dependencies": {
-    "@artsy/cohesion": "4.360.0",
+    "@artsy/cohesion": "4.361.0",
     "@artsy/detect-responsive-traits": "^0.2.0",
     "@artsy/dismissible": "^0.8.1",
     "@artsy/express-reloadable": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "sha.js": "^2.4.12"
   },
   "dependencies": {
-    "@artsy/cohesion": "4.357.0",
+    "@artsy/cohesion": "4.360.0",
     "@artsy/detect-responsive-traits": "^0.2.0",
     "@artsy/dismissible": "^0.8.1",
     "@artsy/express-reloadable": "^1.7.0",

--- a/src/Apps/Conversations/components/Message/ConversationPartnerOfferCTA.tsx
+++ b/src/Apps/Conversations/components/Message/ConversationPartnerOfferCTA.tsx
@@ -2,12 +2,13 @@ import ChevronRightIcon from "@artsy/icons/ChevronRightIcon"
 import { Clickable, Flex, Message, Text } from "@artsy/palette"
 import { useFlag } from "@unleash/proxy-client-react"
 import { useConversationsContext } from "Apps/Conversations/ConversationsContext"
+import { useConversationsTracking } from "Apps/Conversations/hooks/useConversationsTracking"
 import { isPartnerOfferActive } from "Apps/Conversations/utils/isPartnerOfferActive"
 import { ExpiresInTimer } from "Components/Notifications/ExpiresInTimer"
 import { RouterLink } from "System/Components/RouterLink"
 import { extractNodes } from "Utils/extractNodes"
 import type { ConversationPartnerOfferCTA_conversation$key } from "__generated__/ConversationPartnerOfferCTA_conversation.graphql"
-import type { FC } from "react"
+import { type FC, useEffect } from "react"
 import { graphql, useFragment } from "react-relay"
 
 interface ConversationPartnerOfferCTAProps {
@@ -20,6 +21,7 @@ export const ConversationPartnerOfferCTA: FC<
   const isPartnerOfferConvoEnabled = useFlag("topaz_partner-offer-convo")
 
   const data = useFragment(CONVERSATION_FRAGMENT, conversation)
+  const { trackPartnerOfferCTAViewed } = useConversationsTracking()
 
   const { findPartnerOffer } = useConversationsContext()
 
@@ -29,17 +31,21 @@ export const ConversationPartnerOfferCTA: FC<
   const partnerOffer = artwork?.internalID
     ? findPartnerOffer(artwork.internalID)
     : null
+  const hasActivePartnerOffer = isPartnerOfferActive(partnerOffer)
+
+  useEffect(() => {
+    if (hasActivePartnerOffer && data?.internalID) {
+      trackPartnerOfferCTAViewed(data.internalID)
+    }
+  }, [hasActivePartnerOffer, data?.internalID, trackPartnerOfferCTAViewed])
 
   if (
     !isPartnerOfferConvoEnabled ||
     !partnerOffer ||
     !artwork?.href ||
-    activeOrder
+    activeOrder ||
+    !hasActivePartnerOffer
   ) {
-    return null
-  }
-
-  if (!isPartnerOfferActive(partnerOffer)) {
     return null
   }
 

--- a/src/Apps/Conversations/components/Message/__tests__/ConversationPartnerOfferCTA.jest.tsx
+++ b/src/Apps/Conversations/components/Message/__tests__/ConversationPartnerOfferCTA.jest.tsx
@@ -6,13 +6,22 @@ import { ConversationPartnerOfferCTA } from "Apps/Conversations/components/Messa
 import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
 import { DateTime, Settings } from "luxon"
 import { graphql } from "react-relay"
+import { useTracking } from "react-tracking"
 
 jest.unmock("react-relay")
+jest.mock("react-tracking")
 
 const mockUseFlag = useFlag as jest.Mock
+const mockUseTracking = useTracking as jest.Mock
+const trackingSpy = jest.fn()
 
 beforeEach(() => {
   mockUseFlag.mockImplementation(() => true)
+  mockUseTracking.mockImplementation(() => ({ trackEvent: trackingSpy }))
+})
+
+afterEach(() => {
+  jest.clearAllMocks()
 })
 
 const futureDate = () => {
@@ -48,6 +57,7 @@ const { renderWithRelay } = setupTestWrapperTL({
 })
 
 const Conversation = () => ({
+  internalID: "conversation-id",
   items: [
     {
       item: {
@@ -91,6 +101,12 @@ describe("ConversationPartnerOfferCTA", () => {
         /^\/artwork\/some-artwork\?partner_offer_id=partner-offer-id&conversation_id=.+$/,
       ),
     )
+
+    expect(trackingSpy).toHaveBeenCalledWith({
+      action: "partnerOfferInConversationViewed",
+      context_owner_id: "conversation-id",
+      context_owner_type: "conversation",
+    })
   })
 
   it("falls back to a generic message when there is no discounted price", () => {
@@ -113,6 +129,8 @@ describe("ConversationPartnerOfferCTA", () => {
     expect(
       screen.queryByTestId("partnerOfferActionLink"),
     ).not.toBeInTheDocument()
+
+    expect(trackingSpy).not.toHaveBeenCalled()
   })
 
   it("renders nothing when the offer has expired", () => {

--- a/src/Apps/Conversations/hooks/__tests__/useConversationsTracking.jest.ts
+++ b/src/Apps/Conversations/hooks/__tests__/useConversationsTracking.jest.ts
@@ -1,0 +1,40 @@
+import { renderHook } from "@testing-library/react-hooks"
+import { useConversationsTracking } from "Apps/Conversations/hooks/useConversationsTracking"
+import { useTracking } from "react-tracking"
+
+jest.mock("react-tracking")
+
+describe("useConversationsTracking", () => {
+  const mockUseTracking = useTracking as jest.Mock
+  const trackingSpy = jest.fn()
+
+  const setupHook = () => {
+    const { result } = renderHook(() => useConversationsTracking())
+
+    if (result.error) {
+      throw result.error
+    }
+
+    return result.current
+  }
+
+  beforeEach(() => {
+    mockUseTracking.mockImplementation(() => ({ trackEvent: trackingSpy }))
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  describe("#trackPartnerOfferCTAViewed", () => {
+    it("tracks the partner offer in conversation viewed event", () => {
+      setupHook().trackPartnerOfferCTAViewed("conversation-id")
+
+      expect(trackingSpy).toHaveBeenCalledWith({
+        action: "partnerOfferInConversationViewed",
+        context_owner_id: "conversation-id",
+        context_owner_type: "conversation",
+      })
+    })
+  })
+})

--- a/src/Apps/Conversations/hooks/useConversationsTracking.ts
+++ b/src/Apps/Conversations/hooks/useConversationsTracking.ts
@@ -1,0 +1,26 @@
+import {
+  ActionType,
+  OwnerType,
+  type PartnerOfferInConversationViewed,
+} from "@artsy/cohesion"
+import { useCallback } from "react"
+import { useTracking } from "react-tracking"
+
+export const useConversationsTracking = () => {
+  const { trackEvent } = useTracking()
+
+  const trackPartnerOfferCTAViewed = useCallback(
+    (conversationID: string) => {
+      const payload: PartnerOfferInConversationViewed = {
+        action: ActionType.partnerOfferInConversationViewed,
+        context_owner_id: conversationID,
+        context_owner_type: OwnerType.conversation,
+      }
+
+      trackEvent(payload)
+    },
+    [trackEvent],
+  )
+
+  return { trackPartnerOfferCTAViewed }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,12 +21,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@artsy/cohesion@npm:4.357.0":
-  version: 4.357.0
-  resolution: "@artsy/cohesion@npm:4.357.0"
+"@artsy/cohesion@npm:4.360.0":
+  version: 4.360.0
+  resolution: "@artsy/cohesion@npm:4.360.0"
   dependencies:
     core-js: "npm:3"
-  checksum: 10c0/1291b6abe71531355a808c29598daccc7c349cac2783f49e46353532f0cda73a4bc4a092c08e70bf6194b1ecd4e24726c4b9c7d43d0b6331ab3801f042d957dc
+  checksum: 10c0/622d3790842c080606a9eff9d9f59a6df0aa2874d7132fb24a7416341c8739828bbbd8645b01d12d79b549de0b872fd2ea892e41074109ec2a69bc39021fd211
   languageName: node
   linkType: hard
 
@@ -9324,7 +9324,7 @@ __metadata:
   resolution: "force@workspace:."
   dependencies:
     "@artaio/arta-browser": "npm:^2.16.1"
-    "@artsy/cohesion": "npm:4.357.0"
+    "@artsy/cohesion": "npm:4.360.0"
     "@artsy/detect-responsive-traits": "npm:^0.2.0"
     "@artsy/dismissible": "npm:^0.8.1"
     "@artsy/express-reloadable": "npm:^1.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -21,12 +21,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@artsy/cohesion@npm:4.360.0":
-  version: 4.360.0
-  resolution: "@artsy/cohesion@npm:4.360.0"
+"@artsy/cohesion@npm:4.361.0":
+  version: 4.361.0
+  resolution: "@artsy/cohesion@npm:4.361.0"
   dependencies:
     core-js: "npm:3"
-  checksum: 10c0/622d3790842c080606a9eff9d9f59a6df0aa2874d7132fb24a7416341c8739828bbbd8645b01d12d79b549de0b872fd2ea892e41074109ec2a69bc39021fd211
+  checksum: 10c0/01b4e235464f5a59b66df98ab18258dbb22f4912bb9ae7c2b5b73abdf119e90e87ccb653345d7f0485c8adfca728d330c569d5812f7288ecad02571d618f0f80
   languageName: node
   linkType: hard
 
@@ -9324,7 +9324,7 @@ __metadata:
   resolution: "force@workspace:."
   dependencies:
     "@artaio/arta-browser": "npm:^2.16.1"
-    "@artsy/cohesion": "npm:4.360.0"
+    "@artsy/cohesion": "npm:4.361.0"
     "@artsy/detect-responsive-traits": "npm:^0.2.0"
     "@artsy/dismissible": "npm:^0.8.1"
     "@artsy/express-reloadable": "npm:^1.7.0"


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

Last one of [TOP-319]

### Description

Add viewed tracking when the partner offer CTA is visible in a convo.

cc @artsy/topaz-devs 

Note: Cohesion type-check is gonna yell, the schema is in a broken state, will wait for the hotfix to bump the module here but we can already review the PR.


[TOP-319]: https://artsyproduct.atlassian.net/browse/TOP-319?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ