### PR TITLE
fix: Adds defensive check to wait for access to unleash flags

### DIFF
--- a/src/Apps/Conversations/components/ConversationCTA/ConversationCTA.tsx
+++ b/src/Apps/Conversations/components/ConversationCTA/ConversationCTA.tsx
@@ -1,7 +1,7 @@
 import VerifiedIcon from "@artsy/icons/VerifiedIcon"
 import { Box, Flex, type FlexProps, Spacer, Text } from "@artsy/palette"
 import { themeGet } from "@styled-system/theme-get"
-import { useFlag } from "@unleash/proxy-client-react"
+import { useFlag, useFlagsStatus } from "@unleash/proxy-client-react"
 import { useConversationsContext } from "Apps/Conversations/ConversationsContext"
 import { ConversationConfirmModal } from "Apps/Conversations/components/ConversationCTA/ConversationConfirmModal"
 import { ConversationMakeOfferButton } from "Apps/Conversations/components/ConversationCTA/ConversationMakeOfferButton"
@@ -23,6 +23,7 @@ export const ConversationCTA: React.FC<
 > = ({ conversation, ...flexProps }) => {
   const data = useFragment(FRAGMENT, conversation)
   const { findPartnerOffer } = useConversationsContext()
+  const { flagsReady } = useFlagsStatus()
 
   const liveArtwork = data?.items?.[0]?.liveArtwork
   const artwork = liveArtwork?.__typename === "Artwork" ? liveArtwork : null
@@ -30,7 +31,9 @@ export const ConversationCTA: React.FC<
   const partnerOffer = artwork ? findPartnerOffer(artwork.internalID) : null
   const isPartnerOfferConvoEnabled = useFlag("topaz_partner-offer-convo")
   const hasOpenPartnerOffer =
-    isPartnerOfferConvoEnabled && isPartnerOfferActive(partnerOffer)
+    flagsReady &&
+    isPartnerOfferConvoEnabled &&
+    isPartnerOfferActive(partnerOffer)
 
   const activeOrder = extractNodes(data.activeOrderCTA)[0]
   const activePartnerOffer =
@@ -50,6 +53,7 @@ export const ConversationCTA: React.FC<
   const canPurchase = artwork.isAcquireable || !!activePartnerOffer
   const canMakeOffer = artwork.isOfferable || artwork.isOfferableFromInquiry
   const showTransactionButtons =
+    flagsReady &&
     !activeOrder &&
     !hasOpenPartnerOffer &&
     artwork.published &&


### PR DESCRIPTION
The type of this PR is: **FIX**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [QA-item](https://www.notion.so/artsy/Purchase-buttons-at-the-bottom-flicker-before-replaced-with-offer-received-banner-382cab0764a080d79284e6b9275940b5?source=copy_link)

### Description

fix: Adds defensive check to wait for access to unleash flags

`useFlag` from Unleash is asynchronous — on first render it returns false while the flags are still loading, then flips to true. So on the first render isPartnerOfferConvoEnabled is false, making hasOpenPartnerOffer false, so the transaction buttons briefly appear. Then Unleash resolves the flag to true and they disappear.


Adding a defensive check to ensure flags are ready to load before rendering the CTAs


## Example

https://github.com/user-attachments/assets/7f3eff0c-5769-4d88-bc5a-30c5a777caa0



## Fix

https://github.com/user-attachments/assets/231cff22-16dc-47b8-b025-96deac4392ad



cc @artsy/topaz-devs 

<!-- Implementation description -->
