### PR TITLE
fix(nav): ensures desktop and mobile nav items are in sync

### DIFF
--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -33,6 +33,7 @@ import { usePrefetchRoute } from "System/Hooks/usePrefetchRoute"
 import { Media } from "Utils/Responsive"
 import { track } from "react-tracking"
 import styled from "styled-components"
+import { GALLERY_PARTNERSHIPS_URL } from "./constants"
 import { NavBarItemButton, NavBarItemLink } from "./NavBarItem"
 import { NavBarLoggedInActionsQueryRenderer } from "./NavBarLoggedInActions"
 import { NavBarMobileMenuNotificationsIndicatorQueryRenderer } from "./NavBarMobileMenu/NavBarMobileMenuNotificationsIndicator"
@@ -77,9 +78,6 @@ export const NavBar: React.FC<React.PropsWithChildren<unknown>> = track(
   const isMobile = xs || sm
   const isLoggedIn = Boolean(user)
   const showNotificationCount = isLoggedIn && mode !== "More"
-
-  const GALLERY_PARTNERSHIPS_URL =
-    "https://partners.artsy.net/gallery-partnerships/?utm_medium=internal-banner&utm_source=artsy&utm_campaign=b2b-2025-gallery-partnerships-application-banner-link&utm_sfc=701Hu000001jeLjIAI"
 
   // Close mobile menu if dragging window from small size to desktop
   useEffect(() => {

--- a/src/Components/NavBar/NavBar.tsx
+++ b/src/Components/NavBar/NavBar.tsx
@@ -23,7 +23,12 @@ import {
 } from "./NavBarMobileMenu/NavBarMobileMenu"
 
 import { AppDownloadBanner } from "Components/AppDownloadBanner"
-import { NavBarDropdownPanel } from "Components/NavBar/NavBarDropdownPanel"
+import { NavBarDesktopItem } from "Components/NavBar/NavBarDesktopItem"
+import {
+  DESKTOP_SECOND_TIER,
+  DESKTOP_TOP_TIER,
+  NAV_ITEMS,
+} from "Components/NavBar/navItems"
 import { NavBarMobileMenuProfile } from "Components/NavBar/NavBarMobileMenu/NavBarMobileMenuProfile"
 import { ProgressiveOnboardingAlertFind } from "Components/ProgressiveOnboarding/ProgressiveOnboardingAlertFind"
 import { ProgressiveOnboardingFollowFind } from "Components/ProgressiveOnboarding/ProgressiveOnboardingFollowFind"
@@ -32,8 +37,6 @@ import { SearchBar } from "Components/Search/SearchBar"
 import { usePrefetchRoute } from "System/Hooks/usePrefetchRoute"
 import { Media } from "Utils/Responsive"
 import { track } from "react-tracking"
-import styled from "styled-components"
-import { GALLERY_PARTNERSHIPS_URL } from "./constants"
 import { NavBarItemButton, NavBarItemLink } from "./NavBarItem"
 import { NavBarLoggedInActionsQueryRenderer } from "./NavBarLoggedInActions"
 import { NavBarMobileMenuNotificationsIndicatorQueryRenderer } from "./NavBarMobileMenu/NavBarMobileMenuNotificationsIndicator"
@@ -199,48 +202,16 @@ export const NavBar: React.FC<React.PropsWithChildren<unknown>> = track(
               {/* Desktop. Collapses into mobile at `xs` breakpoint. */}
               <Flex display={["none", "flex"]} ml={2} alignItems="stretch">
                 <Text variant="sm" lineHeight={1} display={["none", "flex"]}>
-                  <Flex alignItems="center" display={["none", "flex"]}>
-                    <NavBarItemLink
-                      href="/collect"
-                      onMouseOver={() => prefetch("/collect")}
-                      textDecoration="none"
-                      onClick={handleClick}
-                      data-label="Buy"
-                    >
-                      Buy
-                    </NavBarItemLink>
-                  </Flex>
-
-                  <NavBarItemLink
-                    href={GALLERY_PARTNERSHIPS_URL}
-                    textDecoration="none"
-                    onClick={handleClick}
-                    data-label="Artsy for Galleries"
-                  >
-                    Artsy for Galleries
-                  </NavBarItemLink>
-
-                  <NavBarItemLink
-                    href="/price-database"
-                    onMouseOver={() => prefetch("/price-database")}
-                    textDecoration="none"
-                    onClick={handleClick}
-                    data-label="Price Database"
-                  >
-                    Price Database
-                  </NavBarItemLink>
-
-                  <Flex alignItems="center" display={["none", "flex"]}>
-                    <NavBarItemLink
-                      href="/articles"
-                      onMouseOver={() => prefetch("/articles")}
-                      textDecoration="none"
-                      onClick={handleClick}
-                      data-label="Articles"
-                    >
-                      Editorial
-                    </NavBarItemLink>
-                  </Flex>
+                  {DESKTOP_TOP_TIER.map(id => {
+                    return (
+                      <NavBarDesktopItem
+                        key={id}
+                        item={NAV_ITEMS[id]}
+                        navigationData={navigationData}
+                        handleClick={handleClick}
+                      />
+                    )
+                  })}
                 </Text>
 
                 {isLoggedIn ? (
@@ -344,110 +315,16 @@ export const NavBar: React.FC<React.PropsWithChildren<unknown>> = track(
             >
               <NavBarDropdownProvider>
                 <NavBarDropdownArea>
-                  {navigationData?.whatsNewNavigation && (
-                    <NavBarDropdownPanel
-                      navigationData={navigationData.whatsNewNavigation}
-                      label="What’s New"
-                      href="/collection/new-this-week"
-                      contextModule={
-                        DeprecatedAnalyticsSchema.ContextModule
-                          .HeaderWhatsNewDropdown
-                      }
-                      menuType="whatsNew"
-                      handleClick={handleClick}
-                    />
-                  )}
-
-                  {navigationData?.artistsNavigation && (
-                    <NavBarDropdownPanel
-                      navigationData={navigationData.artistsNavigation}
-                      label="Artists"
-                      href="/artists"
-                      contextModule={
-                        DeprecatedAnalyticsSchema.ContextModule
-                          .HeaderArtistsDropdown
-                      }
-                      menuType="artists"
-                      handleClick={handleClick}
-                    />
-                  )}
-
-                  {navigationData?.artworksNavigation && (
-                    <NavBarDropdownPanel
-                      navigationData={navigationData.artworksNavigation}
-                      label="Artworks"
-                      href="/collect"
-                      contextModule={
-                        DeprecatedAnalyticsSchema.ContextModule
-                          .HeaderArtworksDropdown
-                      }
-                      menuType="artworks"
-                      handleClick={handleClick}
-                    />
-                  )}
-
-                  <NavBarItemLink
-                    href="/auctions"
-                    onMouseOver={() => prefetch("/auctions")}
-                    onClick={handleClick}
-                    data-label="Auctions"
-                  >
-                    Auctions
-                  </NavBarItemLink>
-
-                  <NavBarItemLink
-                    href="/viewing-rooms"
-                    onMouseOver={() => prefetch("/viewing-rooms")}
-                    onClick={handleClick}
-                    data-label="Viewing Rooms"
-                  >
-                    Viewing Rooms
-                  </NavBarItemLink>
-
-                  <NavBarItemLink
-                    href="/galleries"
-                    onMouseOver={() => prefetch("/galleries")}
-                    onClick={handleClick}
-                    data-label="Galleries"
-                  >
-                    Galleries
-                  </NavBarItemLink>
-
-                  <NavBarItemFairsLink
-                    href="/art-fairs"
-                    onMouseOver={() => prefetch("/art-fairs")}
-                    onClick={handleClick}
-                    data-label="Fairs & Events"
-                  >
-                    Fairs & Events
-                  </NavBarItemFairsLink>
-
-                  <NavBarItemLink
-                    href="/shows"
-                    onMouseOver={() => prefetch("/shows")}
-                    onClick={handleClick}
-                    data-label="Shows"
-                  >
-                    Shows
-                  </NavBarItemLink>
-
-                  <NavBarItemInstitutionsLink
-                    href="/institutions"
-                    onMouseOver={() => prefetch("/institutions")}
-                    onClick={handleClick}
-                    data-label="Institutions"
-                  >
-                    Museums
-                  </NavBarItemInstitutionsLink>
-
-                  <NavBarItemLink
-                    href="/feature/how-to-buy-art"
-                    onMouseOver={() => prefetch("/feature/how-to-buy-art")}
-                    onClick={handleClick}
-                    data-label="Collecting 101"
-                  >
-                    Collecting 101
-                  </NavBarItemLink>
+                  {DESKTOP_SECOND_TIER.map(id => {
+                    return (
+                      <NavBarDesktopItem
+                        key={id}
+                        item={NAV_ITEMS[id]}
+                        navigationData={navigationData}
+                        handleClick={handleClick}
+                      />
+                    )
+                  })}
                 </NavBarDropdownArea>
               </NavBarDropdownProvider>
             </Text>
@@ -485,17 +362,3 @@ const NavBarDropdownArea: React.FC<React.PropsWithChildren> = ({
     </Flex>
   )
 }
-
-// Hide these links earlier to ensure "Collecting 101" has space on smaller widths
-
-const NavBarItemFairsLink = styled(NavBarItemLink)`
-  @media (max-width: 1000px) {
-    display: none;
-  }
-`
-const NavBarItemInstitutionsLink = styled(NavBarItemLink)`
-  // Can no longer fit on screen @ 900px
-  @media (max-width: 900px) {
-    display: none;
-  }
-`

--- a/src/Components/NavBar/NavBarDesktopItem.tsx
+++ b/src/Components/NavBar/NavBarDesktopItem.tsx
@@ -1,0 +1,76 @@
+import { usePrefetchRoute } from "System/Hooks/usePrefetchRoute"
+import type { NavigationData } from "System/Contexts/NavigationDataContext"
+import type * as React from "react"
+import styled from "styled-components"
+import { NavBarDropdownPanel } from "./NavBarDropdownPanel"
+import { NavBarItemLink } from "./NavBarItem"
+import type { NavItem, NavItemId } from "./navItems"
+
+// Hide these links earlier to ensure "Collecting 101" has space on smaller widths.
+const NavBarItemFairsLink = styled(NavBarItemLink)`
+  @media (max-width: 1000px) {
+    display: none;
+  }
+`
+const NavBarItemInstitutionsLink = styled(NavBarItemLink)`
+  // Can no longer fit on screen @ 900px
+  @media (max-width: 900px) {
+    display: none;
+  }
+`
+
+// Links that collapse at wider breakpoints; all others use NavBarItemLink.
+const DESKTOP_LINK_COMPONENT: Partial<
+  Record<NavItemId, typeof NavBarItemLink>
+> = {
+  fairs: NavBarItemFairsLink,
+  museums: NavBarItemInstitutionsLink,
+}
+
+interface NavBarDesktopItemProps {
+  item: NavItem
+  navigationData: NavigationData | null
+  handleClick: (event: React.MouseEvent<HTMLAnchorElement, MouseEvent>) => void
+}
+
+export const NavBarDesktopItem: React.FC<NavBarDesktopItemProps> = ({
+  item,
+  navigationData,
+  handleClick,
+}) => {
+  const { prefetch } = usePrefetchRoute()
+
+  if (item.type === "dropdown") {
+    const navigationVersion = navigationData?.[item.navigationKey]
+
+    if (!navigationVersion) {
+      return null
+    }
+
+    return (
+      <NavBarDropdownPanel
+        navigationData={navigationVersion}
+        label={item.label}
+        href={item.href}
+        contextModule={item.contextModule}
+        menuType={item.menuType}
+        handleClick={handleClick}
+      />
+    )
+  }
+
+  const LinkComponent =
+    DESKTOP_LINK_COMPONENT[item.id as NavItemId] ?? NavBarItemLink
+
+  return (
+    <LinkComponent
+      href={item.href}
+      data-label={item.dataLabel ?? item.label}
+      textDecoration="none"
+      onClick={handleClick}
+      onMouseOver={item.prefetch ? () => prefetch(item.href) : undefined}
+    >
+      {item.label}
+    </LinkComponent>
+  )
+}

--- a/src/Components/NavBar/NavBarMobileMenu/NavBarMobileItem.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/NavBarMobileItem.tsx
@@ -1,0 +1,58 @@
+import { Separator } from "@artsy/palette"
+import type { NavigationData } from "System/Contexts/NavigationDataContext"
+import type * as React from "react"
+import {
+  MOBILE_EMPHASIZED,
+  NAV_ITEMS,
+  type NavItemId,
+  SEPARATOR,
+} from "../navItems"
+import { NavBarMobileMenuItemLink } from "./NavBarMobileMenuItem"
+import { NavBarMobileSubMenu } from "./NavBarMobileSubMenu"
+
+interface NavBarMobileItemProps {
+  entry: NavItemId | typeof SEPARATOR
+  navigationData?: NavigationData | null
+  handleClick: (
+    event: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement, MouseEvent>,
+  ) => void
+}
+
+export const NavBarMobileItem: React.FC<NavBarMobileItemProps> = ({
+  entry,
+  navigationData,
+  handleClick,
+}) => {
+  if (entry === SEPARATOR) {
+    return <Separator my={1} />
+  }
+
+  const item = NAV_ITEMS[entry]
+
+  if (item.type === "dropdown") {
+    const navigationVersion = navigationData?.[item.navigationKey]
+
+    if (!navigationVersion) {
+      return null
+    }
+
+    return (
+      <NavBarMobileSubMenu
+        navigationVersion={navigationVersion}
+        menuType={item.menuType}
+      >
+        {item.label}
+      </NavBarMobileSubMenu>
+    )
+  }
+
+  return (
+    <NavBarMobileMenuItemLink
+      to={item.href}
+      color={MOBILE_EMPHASIZED.includes(entry) ? "mono100" : undefined}
+      onClick={handleClick}
+    >
+      {item.label}
+    </NavBarMobileMenuItemLink>
+  )
+}

--- a/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenu.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenu.tsx
@@ -5,6 +5,7 @@ import { useSystemContext } from "System/Hooks/useSystemContext"
 import { useDeviceDetection } from "Utils/Hooks/useDeviceDetection"
 import { logout } from "Utils/auth"
 import type * as React from "react"
+import { GALLERY_PARTNERSHIPS_URL } from "Components/NavBar/constants"
 import { NavBarMobileMenuAuthentication } from "./NavBarMobileMenuAuthentication"
 import { useNavBarTracking } from "../useNavBarTracking"
 import {
@@ -140,6 +141,14 @@ export const NavBarMobileMenu: React.FC<
               </NavBarMobileMenuItemLink>
 
               <Separator my={1} />
+
+              <NavBarMobileMenuItemLink
+                to={GALLERY_PARTNERSHIPS_URL}
+                color="mono100"
+                onClick={handleClick}
+              >
+                Artsy for Galleries
+              </NavBarMobileMenuItemLink>
 
               <NavBarMobileMenuItemLink
                 to="/price-database"

--- a/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenu.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenu.tsx
@@ -140,6 +140,13 @@ export const NavBarMobileMenu: React.FC<
                 Museums
               </NavBarMobileMenuItemLink>
 
+              <NavBarMobileMenuItemLink
+                to="/feature/how-to-buy-art"
+                onClick={handleClick}
+              >
+                Collecting 101
+              </NavBarMobileMenuItemLink>
+
               <Separator my={1} />
 
               <NavBarMobileMenuItemLink

--- a/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenu.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/NavBarMobileMenu.tsx
@@ -5,7 +5,8 @@ import { useSystemContext } from "System/Hooks/useSystemContext"
 import { useDeviceDetection } from "Utils/Hooks/useDeviceDetection"
 import { logout } from "Utils/auth"
 import type * as React from "react"
-import { GALLERY_PARTNERSHIPS_URL } from "Components/NavBar/constants"
+import { MOBILE_NAV_LAYOUT, SEPARATOR } from "../navItems"
+import { NavBarMobileItem } from "./NavBarMobileItem"
 import { NavBarMobileMenuAuthentication } from "./NavBarMobileMenuAuthentication"
 import { useNavBarTracking } from "../useNavBarTracking"
 import {
@@ -13,7 +14,6 @@ import {
   NavBarMobileMenuItemLink,
 } from "./NavBarMobileMenuItem"
 import { NavBarMobileMenuNavigationProvider } from "./NavBarMobileMenuNavigation"
-import { NavBarMobileSubMenu } from "Components/NavBar/NavBarMobileMenu/NavBarMobileSubMenu"
 import { NavBarMobileMenuTransition } from "./NavBarMobileMenuTransition"
 import type { buildAppRoutesQuery } from "__generated__/buildAppRoutesQuery.graphql"
 
@@ -75,103 +75,16 @@ export const NavBarMobileMenu: React.FC<
             </NavBarMobileMenuItemButton>
 
             <NavBarMobileMenuTransition isOpen={isOpen} py={2}>
-              <NavBarMobileMenuItemLink
-                to="/collect"
-                color="mono100"
-                onClick={handleClick}
-              >
-                Buy
-              </NavBarMobileMenuItemLink>
-
-              {navigationData?.whatsNewNavigation && (
-                <NavBarMobileSubMenu
-                  navigationVersion={navigationData.whatsNewNavigation}
-                  menuType="whatsNew"
-                >
-                  What’s New
-                </NavBarMobileSubMenu>
-              )}
-
-              {navigationData?.artistsNavigation && (
-                <NavBarMobileSubMenu
-                  navigationVersion={navigationData.artistsNavigation}
-                  menuType="artists"
-                >
-                  Artists
-                </NavBarMobileSubMenu>
-              )}
-
-              {navigationData?.artworksNavigation && (
-                <NavBarMobileSubMenu
-                  navigationVersion={navigationData.artworksNavigation}
-                  menuType="artworks"
-                >
-                  Artworks
-                </NavBarMobileSubMenu>
-              )}
-
-              <NavBarMobileMenuItemLink to="/auctions" onClick={handleClick}>
-                Auctions
-              </NavBarMobileMenuItemLink>
-
-              <NavBarMobileMenuItemLink
-                to="/viewing-rooms"
-                onClick={handleClick}
-              >
-                Viewing Rooms
-              </NavBarMobileMenuItemLink>
-
-              <NavBarMobileMenuItemLink to="/galleries" onClick={handleClick}>
-                Galleries
-              </NavBarMobileMenuItemLink>
-
-              <NavBarMobileMenuItemLink to="/art-fairs" onClick={handleClick}>
-                Fairs & Events
-              </NavBarMobileMenuItemLink>
-
-              <NavBarMobileMenuItemLink to="/shows" onClick={handleClick}>
-                Shows
-              </NavBarMobileMenuItemLink>
-
-              <NavBarMobileMenuItemLink
-                to="/institutions"
-                onClick={handleClick}
-              >
-                Museums
-              </NavBarMobileMenuItemLink>
-
-              <NavBarMobileMenuItemLink
-                to="/feature/how-to-buy-art"
-                onClick={handleClick}
-              >
-                Collecting 101
-              </NavBarMobileMenuItemLink>
-
-              <Separator my={1} />
-
-              <NavBarMobileMenuItemLink
-                to={GALLERY_PARTNERSHIPS_URL}
-                color="mono100"
-                onClick={handleClick}
-              >
-                Artsy for Galleries
-              </NavBarMobileMenuItemLink>
-
-              <NavBarMobileMenuItemLink
-                to="/price-database"
-                color="mono100"
-                onClick={handleClick}
-              >
-                Price Database
-              </NavBarMobileMenuItemLink>
-
-              <NavBarMobileMenuItemLink
-                to="/articles"
-                color="mono100"
-                onClick={handleClick}
-              >
-                Editorial
-              </NavBarMobileMenuItemLink>
+              {MOBILE_NAV_LAYOUT.map((entry, index) => {
+                return (
+                  <NavBarMobileItem
+                    key={entry === SEPARATOR ? `separator-${index}` : entry}
+                    entry={entry}
+                    navigationData={navigationData}
+                    handleClick={handleClick}
+                  />
+                )
+              })}
 
               <Separator my={1} />
 

--- a/src/Components/NavBar/NavBarMobileMenu/__tests__/NavBarMobileMenu.jest.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/__tests__/NavBarMobileMenu.jest.tsx
@@ -127,6 +127,10 @@ describe("NavBarMobileMenu", () => {
         ["/art-fairs", "Fairs & Events"],
         ["/shows", "Shows"],
         ["/institutions", "Museums"],
+        [
+          "https://partners.artsy.net/gallery-partnerships/?utm_medium=internal-banner&utm_source=artsy&utm_campaign=b2b-2025-gallery-partnerships-application-banner-link&utm_sfc=701Hu000001jeLjIAI",
+          "Artsy for Galleries",
+        ],
         ["/price-database", "Price Database"],
         ["/articles", "Editorial"],
         ["/login?intent=signup&contextModule=header", "Sign Up"],

--- a/src/Components/NavBar/NavBarMobileMenu/__tests__/NavBarMobileMenu.jest.tsx
+++ b/src/Components/NavBar/NavBarMobileMenu/__tests__/NavBarMobileMenu.jest.tsx
@@ -127,6 +127,7 @@ describe("NavBarMobileMenu", () => {
         ["/art-fairs", "Fairs & Events"],
         ["/shows", "Shows"],
         ["/institutions", "Museums"],
+        ["/feature/how-to-buy-art", "Collecting 101"],
         [
           "https://partners.artsy.net/gallery-partnerships/?utm_medium=internal-banner&utm_source=artsy&utm_campaign=b2b-2025-gallery-partnerships-application-banner-link&utm_sfc=701Hu000001jeLjIAI",
           "Artsy for Galleries",

--- a/src/Components/NavBar/__tests__/navItems.jest.ts
+++ b/src/Components/NavBar/__tests__/navItems.jest.ts
@@ -1,0 +1,29 @@
+import {
+  DESKTOP_SECOND_TIER,
+  DESKTOP_TOP_TIER,
+  MOBILE_NAV_LAYOUT,
+  NAV_ITEMS,
+  SEPARATOR,
+} from "Components/NavBar/navItems"
+
+describe("nav items parity", () => {
+  const desktopIds = [...DESKTOP_TOP_TIER, ...DESKTOP_SECOND_TIER]
+  const mobileIds = MOBILE_NAV_LAYOUT.filter(entry => entry !== SEPARATOR)
+  const registryIds = Object.keys(NAV_ITEMS)
+
+  it("renders the same set of items on desktop and mobile", () => {
+    // If this fails, a link was added to one platform's layout but not the
+    // other. Add it to both DESKTOP_* and MOBILE_NAV_LAYOUT in navItems.ts.
+    expect(new Set(desktopIds)).toEqual(new Set(mobileIds))
+  })
+
+  it("places every registry item in both layouts (no orphaned definitions)", () => {
+    expect(new Set(desktopIds)).toEqual(new Set(registryIds))
+    expect(new Set(mobileIds)).toEqual(new Set(registryIds))
+  })
+
+  it("does not place an item more than once within a platform", () => {
+    expect(desktopIds.length).toBe(new Set(desktopIds).size)
+    expect(mobileIds.length).toBe(new Set(mobileIds).size)
+  })
+})

--- a/src/Components/NavBar/constants.ts
+++ b/src/Components/NavBar/constants.ts
@@ -13,3 +13,6 @@ export const DESKTOP_NAV_BAR_HEIGHT =
 export const MOBILE_APP_DOWNLOAD_BANNER_HEIGHT = 40
 export const MOBILE_NAV_HEIGHT =
   MOBILE_APP_DOWNLOAD_BANNER_HEIGHT + DESKTOP_NAV_BAR_TOP_TIER_HEIGHT
+
+export const GALLERY_PARTNERSHIPS_URL =
+  "https://partners.artsy.net/gallery-partnerships/?utm_medium=internal-banner&utm_source=artsy&utm_campaign=b2b-2025-gallery-partnerships-application-banner-link&utm_sfc=701Hu000001jeLjIAI"

--- a/src/Components/NavBar/constants.ts
+++ b/src/Components/NavBar/constants.ts
@@ -13,6 +13,3 @@ export const DESKTOP_NAV_BAR_HEIGHT =
 export const MOBILE_APP_DOWNLOAD_BANNER_HEIGHT = 40
 export const MOBILE_NAV_HEIGHT =
   MOBILE_APP_DOWNLOAD_BANNER_HEIGHT + DESKTOP_NAV_BAR_TOP_TIER_HEIGHT
-
-export const GALLERY_PARTNERSHIPS_URL =
-  "https://partners.artsy.net/gallery-partnerships/?utm_medium=internal-banner&utm_source=artsy&utm_campaign=b2b-2025-gallery-partnerships-application-banner-link&utm_sfc=701Hu000001jeLjIAI"

--- a/src/Components/NavBar/navItems.ts
+++ b/src/Components/NavBar/navItems.ts
@@ -1,0 +1,211 @@
+import * as DeprecatedAnalyticsSchema from "@artsy/cohesion/dist/DeprecatedSchema"
+
+/**
+ * A single source of truth for the desktop and mobile navigation menus.
+ *
+ * Each platform composes its own layout (see the layout arrays below) and renders
+ * items via its own subcomponent (`NavBarDesktopItem` / `NavBarMobileItem`), so
+ * presentation and hierarchy remain platform-specific while the set of links stays
+ * in sync. A parity test (`__tests__/navItems.jest.ts`) enforces that both platforms
+ * cover the same items.
+ */
+
+interface LinkNavItem {
+  type: "link"
+  id: string
+  label: string
+  href: string
+  /** Desktop prefetches the route on hover. */
+  prefetch?: boolean
+  /** External URL — not a router-aware route, so it isn't prefetched. */
+  external?: boolean
+  /** Desktop `data-label` for tracking; defaults to `label` when omitted. */
+  dataLabel?: string
+}
+
+interface DropdownNavItem {
+  type: "dropdown"
+  id: string
+  label: string
+  href: string
+  menuType: "whatsNew" | "artists" | "artworks"
+  navigationKey:
+    | "whatsNewNavigation"
+    | "artistsNavigation"
+    | "artworksNavigation"
+  /** Desktop-only: analytics context module for the dropdown. */
+  contextModule: string
+}
+
+export type NavItem = LinkNavItem | DropdownNavItem
+
+export const NAV_ITEMS = {
+  buy: {
+    type: "link",
+    id: "buy",
+    label: "Buy",
+    href: "/collect",
+    prefetch: true,
+  },
+  whatsNew: {
+    type: "dropdown",
+    id: "whatsNew",
+    label: "What’s New",
+    href: "/collection/new-this-week",
+    menuType: "whatsNew",
+    navigationKey: "whatsNewNavigation",
+    contextModule:
+      DeprecatedAnalyticsSchema.ContextModule.HeaderWhatsNewDropdown,
+  },
+  artists: {
+    type: "dropdown",
+    id: "artists",
+    label: "Artists",
+    href: "/artists",
+    menuType: "artists",
+    navigationKey: "artistsNavigation",
+    contextModule:
+      DeprecatedAnalyticsSchema.ContextModule.HeaderArtistsDropdown,
+  },
+  artworks: {
+    type: "dropdown",
+    id: "artworks",
+    label: "Artworks",
+    href: "/collect",
+    menuType: "artworks",
+    navigationKey: "artworksNavigation",
+    contextModule:
+      DeprecatedAnalyticsSchema.ContextModule.HeaderArtworksDropdown,
+  },
+  auctions: {
+    type: "link",
+    id: "auctions",
+    label: "Auctions",
+    href: "/auctions",
+    prefetch: true,
+  },
+  viewingRooms: {
+    type: "link",
+    id: "viewingRooms",
+    label: "Viewing Rooms",
+    href: "/viewing-rooms",
+    prefetch: true,
+  },
+  galleries: {
+    type: "link",
+    id: "galleries",
+    label: "Galleries",
+    href: "/galleries",
+    prefetch: true,
+  },
+  fairs: {
+    type: "link",
+    id: "fairs",
+    label: "Fairs & Events",
+    href: "/art-fairs",
+    prefetch: true,
+  },
+  shows: {
+    type: "link",
+    id: "shows",
+    label: "Shows",
+    href: "/shows",
+    prefetch: true,
+  },
+  museums: {
+    type: "link",
+    id: "museums",
+    label: "Museums",
+    href: "/institutions",
+    dataLabel: "Institutions",
+    prefetch: true,
+  },
+  collecting101: {
+    type: "link",
+    id: "collecting101",
+    label: "Collecting 101",
+    href: "/feature/how-to-buy-art",
+    prefetch: true,
+  },
+  galleryPartnerships: {
+    type: "link",
+    id: "galleryPartnerships",
+    label: "Artsy for Galleries",
+    href: "https://partners.artsy.net/gallery-partnerships/?utm_medium=internal-banner&utm_source=artsy&utm_campaign=b2b-2025-gallery-partnerships-application-banner-link&utm_sfc=701Hu000001jeLjIAI",
+    external: true,
+  },
+  priceDatabase: {
+    type: "link",
+    id: "priceDatabase",
+    label: "Price Database",
+    href: "/price-database",
+    prefetch: true,
+  },
+  editorial: {
+    type: "link",
+    id: "editorial",
+    label: "Editorial",
+    href: "/articles",
+    dataLabel: "Articles",
+    prefetch: true,
+  },
+} satisfies Record<string, NavItem>
+
+export type NavItemId = keyof typeof NAV_ITEMS
+
+export const SEPARATOR = "—separator—" as const
+
+/**
+ * Desktop layout. The top tier sits alongside the search bar; the second tier is
+ * the row of browse links and dropdown panels below it.
+ */
+export const DESKTOP_TOP_TIER: NavItemId[] = [
+  "buy",
+  "galleryPartnerships",
+  "priceDatabase",
+  "editorial",
+]
+
+export const DESKTOP_SECOND_TIER: NavItemId[] = [
+  "whatsNew",
+  "artists",
+  "artworks",
+  "auctions",
+  "viewingRooms",
+  "galleries",
+  "fairs",
+  "shows",
+  "museums",
+  "collecting101",
+]
+
+/**
+ * Mobile layout. A single ordered list; `SEPARATOR` renders a divider. The
+ * mobile-only actions below the final divider (auth, "Get the app", "Log out")
+ * are not nav links and live directly in `NavBarMobileMenu`.
+ */
+export const MOBILE_NAV_LAYOUT: Array<NavItemId | typeof SEPARATOR> = [
+  "buy",
+  "whatsNew",
+  "artists",
+  "artworks",
+  "auctions",
+  "viewingRooms",
+  "galleries",
+  "fairs",
+  "shows",
+  "museums",
+  "collecting101",
+  SEPARATOR,
+  "galleryPartnerships",
+  "priceDatabase",
+  "editorial",
+]
+
+/** Mobile items rendered with emphasized (`mono100`) text. */
+export const MOBILE_EMPHASIZED: NavItemId[] = [
+  "buy",
+  "galleryPartnerships",
+  "priceDatabase",
+  "editorial",
+]


### PR DESCRIPTION
The dropdown menus (What's New / Artists / Artworks) are already shared via the `buildAppRoutesQuery` GraphQL query. The flat static links, however, were hand-coded separately in `NavBar.tsx` and `NavBarMobileMenu.tsx`, which let them drift apart. Mobile was missing 2 links: "Collecting 101" and "Artsy for Galleries". They are now defined a single time in `navItems.ts` and enforced with a simple spec.

I retained all the other differences. In particular one does look like an oversight to me but I'm not sure: some of the mobile nav links are black, while the others are grey. It's modeled here as `MOBILE_EMPHASIZED` [but I posed a question to #design](https://artsy.slack.com/archives/C02BGC5PW/p1782128720171379) about it.

cc @artsy/diamond-devs 