### PR TITLE
chore: suppress one tap if download footer shows #trivial

### DIFF
--- a/src/Components/AppDownloadFooter.tsx
+++ b/src/Components/AppDownloadFooter.tsx
@@ -21,6 +21,8 @@ import { useTracking } from "react-tracking"
 import styled from "styled-components"
 
 const APP_DOWNLOAD_FOOTER_KEY = "AppDownloadFooter"
+const ONE_TAP_SUPPRESS_COOKIE = "g_one_tap_suppress"
+const ONE_TAP_SUPPRESS_DURATION_SECONDS = 30 * 60
 
 type AppDownloadFooterProps = {}
 
@@ -62,13 +64,22 @@ export const AppDownloadFooter: FC<
     Cookies.set(APP_DOWNLOAD_FOOTER_KEY, 1, { expires: 0 })
   }
 
-  if (
-    !isMounted ||
-    Cookies.get(APP_DOWNLOAD_FOOTER_KEY) ||
-    mode === "Dismissed" ||
-    match?.location?.pathname === "/" ||
-    routeChanges.current < 2
-  ) {
+  const shouldShow =
+    isMounted &&
+    !Cookies.get(APP_DOWNLOAD_FOOTER_KEY) &&
+    mode !== "Dismissed" &&
+    match?.location?.pathname !== "/" &&
+    routeChanges.current >= 2
+
+  useEffect(() => {
+    if (shouldShow) {
+      Cookies.set(ONE_TAP_SUPPRESS_COOKIE, "1", {
+        expires: ONE_TAP_SUPPRESS_DURATION_SECONDS,
+      })
+    }
+  }, [shouldShow])
+
+  if (!shouldShow) {
     return null
   }
 


### PR DESCRIPTION
The type of this PR is: **chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [DI-398](https://app.notion.com/p/artsy/Force-Make-sure-one-tap-does-not-interfere-with-app-download-footer-381cab0764a0807fac85e12e9a8da91a?source=copy_link)

### Description

Sets one tap suppression cookie to suppress one tap banner in case when AppDownloadFooter is showing to avoid competing UI. In practice think this should be rare since the only time the footer shows is after changing routes 2 times which should mean one tap should have autodismissed...but just to be on safe side, might both show if you stay on a page for a while after one tap dismiss expires.


Assisted-By: Claude <noreply@anthropic.com>