### PR TITLE
chore(EMI-3285): autocomplete country tracking

### DIFF
--- a/src/Apps/Order/Routes/Shipping/Components/__tests__/FulfillmentDetailsForm.jest.tsx
+++ b/src/Apps/Order/Routes/Shipping/Components/__tests__/FulfillmentDetailsForm.jest.tsx
@@ -576,6 +576,7 @@ describe("FulfillmentDetailsForm", () => {
         context_owner_type: "orders-shipping",
         input: "401 Broadway",
         suggested_addresses_results: 1,
+        country: "US",
       })
       expect(mockTrackEvent).toHaveBeenNthCalledWith(2, {
         action: "selectedItemFromAddressAutoCompletion",
@@ -584,6 +585,7 @@ describe("FulfillmentDetailsForm", () => {
         context_owner_type: "orders-shipping",
         input: "401 Broadway",
         item: "401 Broadway, New York NY 10013",
+        country: "US",
       })
     })
   })

--- a/src/Components/Address/AddressAutocompleteInput.tsx
+++ b/src/Components/Address/AddressAutocompleteInput.tsx
@@ -281,6 +281,7 @@ export const AddressAutocompleteInput = ({
       context_owner_id: trackingValues.contextPageOwnerId,
       input,
       suggested_addresses_results: resultCount,
+      country: address.country,
     }
 
     trackEvent(event)
@@ -297,6 +298,7 @@ export const AddressAutocompleteInput = ({
       context_owner_id: trackingValues.contextPageOwnerId,
       input: input,
       item: option.value,
+      country: address.country,
     }
 
     trackEvent(event)

--- a/src/Components/Address/AddressFormFields.tsx
+++ b/src/Components/Address/AddressFormFields.tsx
@@ -154,6 +154,7 @@ export const AddressFormFields = <V extends FormikContextWithAddress>(
       context_owner_type: contextPageOwnerType,
       context_owner_id: contextPageOwnerId || "",
       field,
+      country: values.address.country,
     }
     trackEvent(event)
     setAutocompletedNotYetEdited(false)

--- a/src/Components/Address/__tests__/AddressAutocompleteInput.jest.tsx
+++ b/src/Components/Address/__tests__/AddressAutocompleteInput.jest.tsx
@@ -809,6 +809,7 @@ describe("AddressAutocompleteInput", () => {
         context_owner_type: "orders-shipping",
         input: "401 Broadway",
         suggested_addresses_results: 1,
+        country: "US",
       })
       mockFetch.mockResolvedValue({
         json: jest.fn().mockResolvedValue({
@@ -842,6 +843,7 @@ describe("AddressAutocompleteInput", () => {
           context_owner_type: "orders-shipping",
           input: "156 Quincy",
           suggested_addresses_results: 2,
+          country: "US",
         })
       })
     })
@@ -867,7 +869,56 @@ describe("AddressAutocompleteInput", () => {
         context_owner_type: "orders-shipping",
         input: "401 Broadway",
         item: "401 Broadway, New York NY 10013",
+        country: "US",
       })
+    })
+
+    it("tracks the country code when an international address is selected", async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          json: jest.fn().mockResolvedValue({
+            candidates: [
+              {
+                address_text: "Unter den Linden 1 10117 Berlin",
+                address_id: "de-addr-id",
+                entries: 1,
+              },
+            ],
+          }),
+          ok: true,
+        })
+        .mockResolvedValueOnce({
+          json: jest.fn().mockResolvedValue({
+            candidates: [
+              {
+                country_iso3: "DEU",
+                administrative_area: "Berlin",
+                locality: "Berlin",
+                postal_code: "10117",
+                street: "Unter den Linden 1",
+              },
+            ],
+          }),
+          ok: true,
+        })
+
+      render(<TestImplementation initialAddress={{ country: "DE" }} />)
+
+      const line1Input = screen.getByPlaceholderText("Autocomplete input")
+      await userEvent.paste(line1Input, "Unter den Linden")
+
+      const dropdown = await screen.findByRole("listbox", { hidden: true })
+      await userEvent.click(
+        within(dropdown).getByText("Unter den Linden 1 10117 Berlin"),
+      )
+      await flushPromiseQueue()
+
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: "selectedItemFromAddressAutoCompletion",
+          country: "DE",
+        }),
+      )
     })
   })
 })

--- a/src/Components/Address/__tests__/AddressAutocompleteInput.jest.tsx
+++ b/src/Components/Address/__tests__/AddressAutocompleteInput.jest.tsx
@@ -873,7 +873,7 @@ describe("AddressAutocompleteInput", () => {
       })
     })
 
-    it("tracks the country code when an international address is selected", async () => {
+    it("tracks when an international address is selected", async () => {
       mockFetch
         .mockResolvedValueOnce({
           json: jest.fn().mockResolvedValue({
@@ -888,17 +888,7 @@ describe("AddressAutocompleteInput", () => {
           ok: true,
         })
         .mockResolvedValueOnce({
-          json: jest.fn().mockResolvedValue({
-            candidates: [
-              {
-                country_iso3: "DEU",
-                administrative_area: "Berlin",
-                locality: "Berlin",
-                postal_code: "10117",
-                street: "Unter den Linden 1",
-              },
-            ],
-          }),
+          json: jest.fn().mockResolvedValue({ candidates: [] }),
           ok: true,
         })
 
@@ -913,12 +903,15 @@ describe("AddressAutocompleteInput", () => {
       )
       await flushPromiseQueue()
 
-      expect(mockTrackEvent).toHaveBeenCalledWith(
-        expect.objectContaining({
-          action: "selectedItemFromAddressAutoCompletion",
-          country: "DE",
-        }),
-      )
+      expect(mockTrackEvent).toHaveBeenCalledWith({
+        action: "selectedItemFromAddressAutoCompletion",
+        context_module: "ordersShipping",
+        context_owner_id: "1234",
+        context_owner_type: "orders-shipping",
+        input: "Unter den Linden",
+        item: "Unter den Linden 1 10117 Berlin",
+        country: "DE",
+      })
     })
   })
 })

--- a/src/Components/Address/__tests__/AddressFormFields.tracking.jest.tsx
+++ b/src/Components/Address/__tests__/AddressFormFields.tracking.jest.tsx
@@ -79,6 +79,7 @@ describe("AddressFormFields — editedAutocompletedAddress tracking", () => {
       context_owner_type: undefined,
       context_owner_id: "",
       field: "city",
+      country: "US",
     })
   })
 


### PR DESCRIPTION
The type of this PR is: **Chore**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-3285]

### Description

Adds `country` to address autocomplete tracking. 

<!-- Implementation description -->


[EMI-3285]: https://artsyproduct.atlassian.net/browse/EMI-3285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ