### PR TITLE
chore: update no quotes error message for new checkout

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/__tests__/Order2DeliveryForm.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/__tests__/Order2DeliveryForm.jest.tsx
@@ -1047,7 +1047,7 @@ describe("Order2DeliveryForm", () => {
         expect(mockCheckoutContext.setSectionErrorMessage).toHaveBeenCalledWith(
           {
             error: expect.objectContaining({
-              title: "Unable to provide shipping quote",
+              title: "Shipping quote unavailable",
             }),
             section: "FULFILLMENT_DETAILS",
           },
@@ -1266,7 +1266,7 @@ describe("Order2DeliveryForm", () => {
         expect(mockCheckoutContext.setSectionErrorMessage).toHaveBeenCalledWith(
           {
             error: expect.objectContaining({
-              title: "Unable to provide shipping quote",
+              title: "Shipping quote unavailable",
             }),
             section: "FULFILLMENT_DETAILS",
           },

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/handleError.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/handleError.tsx
@@ -43,14 +43,13 @@ export const handleError = (
     }),
     no_shipping_options: code => ({
       errorBanner: {
-        title: "Unable to provide shipping quote",
+        title: "Shipping quote unavailable",
         message: (
           <>
-            Please contact <MailtoOrderSupport /> so we can assist you with your
-            purchase.
+            Try a different address, or contact the gallery or <MailtoOrderSupport /> to arrange shipping.
           </>
         ),
-        displayText: `Please contact ${ORDER_SUPPORT_EMAIL} so we can assist you with your purchase.`,
+        displayText: `Try a different address, or contact the gallery or ${ORDER_SUPPORT_EMAIL} to arrange shipping.`,
         code,
       },
     }),


### PR DESCRIPTION
Addresses https://artsyproduct.atlassian.net/browse/EMI-3265

Decided not to rename the error code and keep it as `no_shipping_options` as this error is only thrown when options are expected but none received. The error is generic(not mentioning arta) so think it's good that the definition of it - quote expected but none received. Confusingly this error is also mentioned in Express checkout flow but don't think this code would ever be reached in reality. Decided to keep that as is as we need to look at Express Checkout errors separately. Don't think they are handled by our code anyways.

For this change.
Before:
<img width="1262" height="873" alt="Screenshot 2026-06-23 at 11 13 51 AM" src="https://github.com/user-attachments/assets/92f5e893-1d75-47d0-81eb-f161b49e61e5" />

After:
<img width="1454" height="932" alt="Screenshot 2026-06-23 at 10 47 13 AM" src="https://github.com/user-attachments/assets/ef5889da-f983-479f-bc91-137138b655fb" />


