### PR TITLE
feat: production to use HPAv2

### DIFF
--- a/hokusai/production.yml
+++ b/hokusai/production.yml
@@ -246,7 +246,7 @@ spec:
         emptyDir: {}
 
 ---
-apiVersion: autoscaling/v2beta2
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: force-web-spotty


### PR DESCRIPTION
HPAv2 is at GA status as of Kubernetes v1.23 which is our current version. v2 adds the ability to scale by memory, by custom metrics, and by combination of metrics. Let us switch to v2.

Jira: PHIRE-3107