### PR TITLE
fix: don't show no-shipping error for offers when shipping is not configured

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
@@ -78,7 +78,6 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
 
   const {
     isOffer,
-    isInternationalShipping,
     setCheckoutMode,
     checkoutTracking,
     completeStep,
@@ -254,19 +253,21 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
             },
           })
 
-        const newOrder = validateAndExtractOrderResponse(
+        const updatedOrder = validateAndExtractOrderResponse(
           setOrderDeliveryAddressResult.updateOrderShippingAddress
             ?.orderOrError,
         ).order
 
-        const isMissingShippingOption = newOrder.fulfillmentOptions.every(
+        const isMissingShippingOption = updatedOrder.fulfillmentOptions.every(
           option => ["PICKUP", "SHIPPING_TBD"].includes(option.type),
         )
 
         const artwork = orderData.lineItems?.[0]?.artwork
-        const artaConfiguredForShipping = isInternationalShipping
-          ? !!artwork?.artsyShippingInternational
-          : !!artwork?.processWithArtsyShippingDomestic
+        const artaConfiguredForShipping =
+          !!updatedOrder.shippingRadius &&
+          (updatedOrder.shippingRadius === "domestic"
+            ? !!artwork?.processWithArtsyShippingDomestic
+            : !!artwork?.artsyShippingInternational)
 
         if (
           isMissingShippingOption &&
@@ -294,7 +295,7 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
         // Always select a delivery option after saving the address — re-using the
         // previously selected type if still available, otherwise the first option.
         // For new-address users with a single option, also auto-advance.
-        const selectable = newOrder.fulfillmentOptions.filter(o =>
+        const selectable = updatedOrder.fulfillmentOptions.filter(o =>
           SELECTABLE_TYPES.includes(o.type),
         )
         if (selectable.length > 0) {
@@ -329,7 +330,6 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
     },
     [
       hasSavedAddresses,
-      isInternationalShipping,
       isOffer,
       orderData.internalID,
       orderData.lineItems,

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/__tests__/Order2DeliveryForm.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/__tests__/Order2DeliveryForm.jest.tsx
@@ -1274,6 +1274,312 @@ describe("Order2DeliveryForm", () => {
         expect(mockCheckoutContext.completeStep).not.toHaveBeenCalled()
       })
 
+      it("allows OFFER mode with international address to proceed when Arta international is not configured", async () => {
+        mockCheckoutContext.isOffer = true
+        const { mockResolveLastOperation } = renderWithRelay({
+          Me: () => ({
+            ...baseMeProps,
+            order: {
+              ...baseOrderProps,
+              mode: "OFFER",
+              lineItems: [
+                {
+                  artwork: {
+                    processWithArtsyShippingDomestic: false,
+                    artsyShippingInternational: false,
+                  },
+                },
+              ],
+              fulfillmentDetails: {
+                name: "",
+                addressLine1: "",
+                addressLine2: "",
+                city: "",
+                region: "",
+                postalCode: "",
+                country: "DE",
+                phoneNumber: {
+                  regionCode: "de",
+                  originalNumber: "",
+                },
+              },
+            },
+          }),
+        })
+
+        await waitFor(() => {
+          expect(screen.getByText("Delivery address")).toBeInTheDocument()
+        })
+
+        await userEvent.type(
+          screen.getByPlaceholderText("Add full name"),
+          "Jane Smith",
+        )
+        await userEvent.type(
+          screen.getByLabelText("Street address"),
+          "456 Oak Ave",
+        )
+        await userEvent.type(screen.getByLabelText("City"), "Berlin")
+        await userEvent.type(screen.getByLabelText("ZIP/Postal code"), "10115")
+        await userEvent.type(
+          screen.getByTestId("addressFormFields.phoneNumber"),
+          "5559876543",
+        )
+
+        act(() => {
+          userEvent.click(screen.getByText("Save and Continue"))
+        })
+
+        await waitFor(() => {
+          mockResolveLastOperation({
+            updateOrderShippingAddressPayload: () =>
+              orderMutationSuccess(
+                { ...baseOrderProps, mode: "OFFER" },
+                {
+                  shippingRadius: "international",
+                  fulfillmentDetails: {
+                    name: "Jane Smith",
+                    addressLine1: "456 Oak Ave",
+                    addressLine2: "",
+                    city: "Berlin",
+                    region: "",
+                    postalCode: "10115",
+                    country: "DE",
+                    phoneNumber: {
+                      regionCode: "de",
+                      originalNumber: "5559876543",
+                    },
+                  },
+                  fulfillmentOptions: [{ type: "SHIPPING_TBD" }],
+                },
+              ),
+          })
+        })
+        await flushPromiseQueue()
+
+        await waitFor(() => {
+          mockResolveLastOperation({
+            CreateUserAddressPayload: () => ({
+              userAddressOrErrors: {
+                __typename: "UserAddress",
+                internalID: "new-address-id",
+              },
+            }),
+          })
+        })
+        await flushPromiseQueue()
+
+        // Arta international not configured — OFFER mode proceeds without error
+        expect(mockCheckoutContext.setSectionErrorMessage).toHaveBeenCalledWith(
+          {
+            error: null,
+            section: "FULFILLMENT_DETAILS",
+          },
+        )
+        expect(mockCheckoutContext.completeStep).not.toHaveBeenCalled()
+      })
+
+      it("shows error for OFFER mode with international address when Arta international is configured but no quotes are returned", async () => {
+        mockCheckoutContext.isOffer = true
+        const { mockResolveLastOperation } = renderWithRelay({
+          Me: () => ({
+            ...baseMeProps,
+            order: {
+              ...baseOrderProps,
+              mode: "OFFER",
+              lineItems: [
+                {
+                  artwork: {
+                    processWithArtsyShippingDomestic: false,
+                    artsyShippingInternational: true,
+                  },
+                },
+              ],
+              fulfillmentDetails: {
+                name: "",
+                addressLine1: "",
+                addressLine2: "",
+                city: "",
+                region: "",
+                postalCode: "",
+                country: "DE",
+                phoneNumber: {
+                  regionCode: "de",
+                  originalNumber: "",
+                },
+              },
+            },
+          }),
+        })
+
+        await waitFor(() => {
+          expect(screen.getByText("Delivery address")).toBeInTheDocument()
+        })
+
+        await userEvent.type(
+          screen.getByPlaceholderText("Add full name"),
+          "Jane Smith",
+        )
+        await userEvent.type(
+          screen.getByLabelText("Street address"),
+          "456 Oak Ave",
+        )
+        await userEvent.type(screen.getByLabelText("City"), "Berlin")
+        await userEvent.type(screen.getByLabelText("ZIP/Postal code"), "10115")
+        await userEvent.type(
+          screen.getByTestId("addressFormFields.phoneNumber"),
+          "5559876543",
+        )
+
+        act(() => {
+          userEvent.click(screen.getByText("Save and Continue"))
+        })
+
+        await waitFor(() => {
+          mockResolveLastOperation({
+            updateOrderShippingAddressPayload: () =>
+              orderMutationSuccess(
+                { ...baseOrderProps, mode: "OFFER" },
+                {
+                  shippingRadius: "international",
+                  fulfillmentDetails: {
+                    name: "Jane Smith",
+                    addressLine1: "456 Oak Ave",
+                    addressLine2: "",
+                    city: "Berlin",
+                    region: "",
+                    postalCode: "10115",
+                    country: "DE",
+                    phoneNumber: {
+                      regionCode: "de",
+                      originalNumber: "5559876543",
+                    },
+                  },
+                  fulfillmentOptions: [{ type: "SHIPPING_TBD" }],
+                },
+              ),
+          })
+        })
+        await flushPromiseQueue()
+
+        // Arta international configured — OFFER mode shows error
+        expect(mockSelectDeliveryOption).not.toHaveBeenCalled()
+        expect(mockCheckoutContext.setSectionErrorMessage).toHaveBeenCalledWith(
+          {
+            error: expect.objectContaining({
+              title: "Shipping quote unavailable",
+            }),
+            section: "FULFILLMENT_DETAILS",
+          },
+        )
+        expect(mockCheckoutContext.completeStep).not.toHaveBeenCalled()
+      })
+
+      it("allows OFFER mode to proceed when shippingRadius is null", async () => {
+        mockCheckoutContext.isOffer = true
+        const { mockResolveLastOperation } = renderWithRelay({
+          Me: () => ({
+            ...baseMeProps,
+            order: {
+              ...baseOrderProps,
+              mode: "OFFER",
+              lineItems: [
+                {
+                  artwork: {
+                    processWithArtsyShippingDomestic: true,
+                    artsyShippingInternational: true,
+                  },
+                },
+              ],
+              fulfillmentDetails: {
+                name: "",
+                addressLine1: "",
+                addressLine2: "",
+                city: "",
+                region: "",
+                postalCode: "",
+                country: "DE",
+                phoneNumber: {
+                  regionCode: "de",
+                  originalNumber: "",
+                },
+              },
+            },
+          }),
+        })
+
+        await waitFor(() => {
+          expect(screen.getByText("Delivery address")).toBeInTheDocument()
+        })
+
+        await userEvent.type(
+          screen.getByPlaceholderText("Add full name"),
+          "Jane Smith",
+        )
+        await userEvent.type(
+          screen.getByLabelText("Street address"),
+          "456 Oak Ave",
+        )
+        await userEvent.type(screen.getByLabelText("City"), "Berlin")
+        await userEvent.type(screen.getByLabelText("ZIP/Postal code"), "10115")
+        await userEvent.type(
+          screen.getByTestId("addressFormFields.phoneNumber"),
+          "5559876543",
+        )
+
+        act(() => {
+          userEvent.click(screen.getByText("Save and Continue"))
+        })
+
+        await waitFor(() => {
+          mockResolveLastOperation({
+            updateOrderShippingAddressPayload: () =>
+              orderMutationSuccess(
+                { ...baseOrderProps, mode: "OFFER" },
+                {
+                  shippingRadius: null,
+                  fulfillmentDetails: {
+                    name: "Jane Smith",
+                    addressLine1: "456 Oak Ave",
+                    addressLine2: "",
+                    city: "Berlin",
+                    region: "",
+                    postalCode: "10115",
+                    country: "DE",
+                    phoneNumber: {
+                      regionCode: "de",
+                      originalNumber: "5559876543",
+                    },
+                  },
+                  fulfillmentOptions: [{ type: "SHIPPING_TBD" }],
+                },
+              ),
+          })
+        })
+        await flushPromiseQueue()
+
+        await waitFor(() => {
+          mockResolveLastOperation({
+            CreateUserAddressPayload: () => ({
+              userAddressOrErrors: {
+                __typename: "UserAddress",
+                internalID: "new-address-id",
+              },
+            }),
+          })
+        })
+        await flushPromiseQueue()
+
+        // shippingRadius null — artaConfiguredForShipping is false, OFFER proceeds without error
+        expect(mockCheckoutContext.setSectionErrorMessage).toHaveBeenCalledWith(
+          {
+            error: null,
+            section: "FULFILLMENT_DETAILS",
+          },
+        )
+        expect(mockCheckoutContext.completeStep).not.toHaveBeenCalled()
+      })
+
       it("saves address to user profile when user has no saved addresses", async () => {
         const { mockResolveLastOperation } = renderWithRelay({
           Me: () => ({

--- a/src/Apps/Order2/Routes/Checkout/Mutations/useOrder2SetOrderDeliveryAddressMutation.ts
+++ b/src/Apps/Order2/Routes/Checkout/Mutations/useOrder2SetOrderDeliveryAddressMutation.ts
@@ -14,6 +14,7 @@ export const useOrder2SetOrderDeliveryAddressMutation = () => {
             ... on OrderMutationSuccess {
               order {
                 internalID
+                shippingRadius
                 ...Order2CheckoutContext_order
                 ...Order2CheckoutApp_order
                 fulfillmentOptions {

--- a/src/__generated__/useOrder2SetOrderDeliveryAddressMutation.graphql.ts
+++ b/src/__generated__/useOrder2SetOrderDeliveryAddressMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<b363de63654e796f49b2043cc927b972>>
+ * @generated SignedSource<<38e7cfb66cef35a93e724f36a11214d7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -46,6 +46,7 @@ export type useOrder2SetOrderDeliveryAddressMutation$data = {
           readonly type: FulfillmentOptionTypeEnum;
         }>;
         readonly internalID: string;
+        readonly shippingRadius: string | null | undefined;
         readonly " $fragmentSpreads": FragmentRefs<"Order2CheckoutApp_order" | "Order2CheckoutContext_order">;
       };
     } | {
@@ -93,24 +94,31 @@ v4 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "type",
+  "name": "shippingRadius",
   "storageKey": null
 },
 v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "selected",
+  "name": "type",
   "storageKey": null
 },
 v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "display",
+  "name": "selected",
   "storageKey": null
 },
 v7 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "display",
+  "storageKey": null
+},
+v8 = {
   "alias": null,
   "args": null,
   "concreteType": "Money",
@@ -118,25 +126,25 @@ v7 = {
   "name": "amount",
   "plural": false,
   "selections": [
-    (v6/*: any*/)
+    (v7/*: any*/)
   ],
-  "storageKey": null
-},
-v8 = {
-  "alias": null,
-  "args": null,
-  "kind": "ScalarField",
-  "name": "message",
   "storageKey": null
 },
 v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "code",
+  "name": "message",
   "storageKey": null
 },
 v10 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "code",
+  "storageKey": null
+},
+v11 = {
   "kind": "InlineFragment",
   "selections": [
     {
@@ -147,8 +155,8 @@ v10 = {
       "name": "mutationError",
       "plural": false,
       "selections": [
-        (v8/*: any*/),
-        (v9/*: any*/)
+        (v9/*: any*/),
+        (v10/*: any*/)
       ],
       "storageKey": null
     }
@@ -156,49 +164,49 @@ v10 = {
   "type": "OrderMutationError",
   "abstractKey": null
 },
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "minor",
   "storageKey": null
 },
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "major",
   "storageKey": null
 },
-v13 = {
+v14 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "id",
   "storageKey": null
 },
-v14 = {
+v15 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "displayName",
   "storageKey": null
 },
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "amountFallbackText",
   "storageKey": null
 },
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "currencySymbol",
   "storageKey": null
 },
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "concreteType": "Money",
@@ -213,16 +221,16 @@ v17 = {
       "name": "amount",
       "storageKey": null
     },
-    (v16/*: any*/)
+    (v17/*: any*/)
   ],
   "storageKey": null
 },
-v18 = [
-  (v14/*: any*/),
+v19 = [
   (v15/*: any*/),
-  (v17/*: any*/)
+  (v16/*: any*/),
+  (v18/*: any*/)
 ],
-v19 = {
+v20 = {
   "alias": null,
   "args": null,
   "concreteType": null,
@@ -233,21 +241,21 @@ v19 = {
     (v2/*: any*/),
     {
       "kind": "InlineFragment",
-      "selections": (v18/*: any*/),
+      "selections": (v19/*: any*/),
       "type": "ShippingLine",
       "abstractKey": null
     },
     {
       "kind": "InlineFragment",
-      "selections": (v18/*: any*/),
+      "selections": (v19/*: any*/),
       "type": "TaxLine",
       "abstractKey": null
     },
     {
       "kind": "InlineFragment",
       "selections": [
-        (v14/*: any*/),
-        (v17/*: any*/)
+        (v15/*: any*/),
+        (v18/*: any*/)
       ],
       "type": "SubtotalLine",
       "abstractKey": null
@@ -255,9 +263,9 @@ v19 = {
     {
       "kind": "InlineFragment",
       "selections": [
-        (v14/*: any*/),
         (v15/*: any*/),
-        (v7/*: any*/)
+        (v16/*: any*/),
+        (v8/*: any*/)
       ],
       "type": "TotalLine",
       "abstractKey": null
@@ -265,17 +273,17 @@ v19 = {
   ],
   "storageKey": null
 },
-v20 = {
+v21 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "url",
   "storageKey": null
 },
-v21 = [
-  (v20/*: any*/)
+v22 = [
+  (v21/*: any*/)
 ],
-v22 = {
+v23 = {
   "alias": "resizedSquare",
   "args": [
     {
@@ -295,10 +303,10 @@ v22 = {
   "kind": "LinkedField",
   "name": "resized",
   "plural": false,
-  "selections": (v21/*: any*/),
+  "selections": (v22/*: any*/),
   "storageKey": "resized(height:200,version:[\"square\"])"
 },
-v23 = {
+v24 = {
   "alias": null,
   "args": [
     {
@@ -316,16 +324,16 @@ v23 = {
   "kind": "LinkedField",
   "name": "resized",
   "plural": false,
-  "selections": (v21/*: any*/),
+  "selections": (v22/*: any*/),
   "storageKey": "resized(height:138,width:185)"
 },
-v24 = [
+v25 = [
+  (v14/*: any*/)
+],
+v26 = [
   (v13/*: any*/)
 ],
-v25 = [
-  (v12/*: any*/)
-],
-v26 = {
+v27 = {
   "alias": null,
   "args": null,
   "concreteType": null,
@@ -344,7 +352,7 @@ v26 = {
           "kind": "LinkedField",
           "name": "maxPrice",
           "plural": false,
-          "selections": (v25/*: any*/),
+          "selections": (v26/*: any*/),
           "storageKey": null
         },
         {
@@ -354,7 +362,7 @@ v26 = {
           "kind": "LinkedField",
           "name": "minPrice",
           "plural": false,
-          "selections": (v25/*: any*/),
+          "selections": (v26/*: any*/),
           "storageKey": null
         }
       ],
@@ -364,14 +372,14 @@ v26 = {
   ],
   "storageKey": null
 },
-v27 = {
+v28 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "price",
   "storageKey": null
 },
-v28 = [
+v29 = [
   {
     "alias": null,
     "args": null,
@@ -387,47 +395,47 @@ v28 = [
     "storageKey": null
   }
 ],
-v29 = {
+v30 = {
   "alias": null,
   "args": null,
   "concreteType": "dimensions",
   "kind": "LinkedField",
   "name": "dimensions",
   "plural": false,
-  "selections": (v28/*: any*/),
+  "selections": (v29/*: any*/),
   "storageKey": null
 },
-v30 = {
+v31 = {
   "alias": null,
   "args": null,
   "concreteType": "dimensions",
   "kind": "LinkedField",
   "name": "framedDimensions",
   "plural": false,
-  "selections": (v28/*: any*/),
+  "selections": (v29/*: any*/),
   "storageKey": null
 },
-v31 = {
+v32 = {
   "kind": "InlineFragment",
-  "selections": (v24/*: any*/),
+  "selections": (v25/*: any*/),
   "type": "Node",
   "abstractKey": "__isNode"
 },
-v32 = {
+v33 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "currencyCode",
   "storageKey": null
 },
-v33 = [
-  (v11/*: any*/),
-  (v32/*: any*/),
-  (v6/*: any*/)
-],
 v34 = [
-  (v11/*: any*/),
-  (v6/*: any*/)
+  (v12/*: any*/),
+  (v33/*: any*/),
+  (v7/*: any*/)
+],
+v35 = [
+  (v12/*: any*/),
+  (v7/*: any*/)
 ];
 return {
   "fragment": {
@@ -465,6 +473,7 @@ return {
                     "plural": false,
                     "selections": [
                       (v3/*: any*/),
+                      (v4/*: any*/),
                       {
                         "args": null,
                         "kind": "FragmentSpread",
@@ -483,9 +492,9 @@ return {
                         "name": "fulfillmentOptions",
                         "plural": true,
                         "selections": [
-                          (v4/*: any*/),
                           (v5/*: any*/),
-                          (v7/*: any*/)
+                          (v6/*: any*/),
+                          (v8/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -496,7 +505,7 @@ return {
                 "type": "OrderMutationSuccess",
                 "abstractKey": null
               },
-              (v10/*: any*/)
+              (v11/*: any*/)
             ],
             "storageKey": null
           }
@@ -542,6 +551,7 @@ return {
                     "plural": false,
                     "selections": [
                       (v3/*: any*/),
+                      (v4/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -572,14 +582,14 @@ return {
                             "name": "amount",
                             "plural": false,
                             "selections": [
-                              (v11/*: any*/),
-                              (v6/*: any*/),
-                              (v12/*: any*/)
+                              (v12/*: any*/),
+                              (v7/*: any*/),
+                              (v13/*: any*/)
                             ],
                             "storageKey": null
                           },
-                          (v13/*: any*/),
-                          (v19/*: any*/),
+                          (v14/*: any*/),
+                          (v20/*: any*/),
                           (v3/*: any*/)
                         ],
                         "storageKey": null
@@ -697,7 +707,7 @@ return {
                         "name": "selectedFulfillmentOption",
                         "plural": false,
                         "selections": [
-                          (v4/*: any*/),
+                          (v5/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -706,10 +716,10 @@ return {
                             "name": "amount",
                             "plural": false,
                             "selections": [
-                              (v11/*: any*/),
-                              (v6/*: any*/),
-                              (v16/*: any*/),
-                              (v12/*: any*/)
+                              (v12/*: any*/),
+                              (v7/*: any*/),
+                              (v17/*: any*/),
+                              (v13/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -721,13 +731,6 @@ return {
                         "args": null,
                         "kind": "ScalarField",
                         "name": "shippingOrigin",
-                        "storageKey": null
-                      },
-                      {
-                        "alias": null,
-                        "args": null,
-                        "kind": "ScalarField",
-                        "name": "shippingRadius",
                         "storageKey": null
                       },
                       {
@@ -750,7 +753,7 @@ return {
                             "kind": "InlineFragment",
                             "selections": [
                               (v3/*: any*/),
-                              (v13/*: any*/),
+                              (v14/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -787,7 +790,7 @@ return {
                             "kind": "InlineFragment",
                             "selections": [
                               (v3/*: any*/),
-                              (v13/*: any*/),
+                              (v14/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -860,7 +863,7 @@ return {
                                 "name": "slug",
                                 "storageKey": null
                               },
-                              (v13/*: any*/),
+                              (v14/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -894,15 +897,15 @@ return {
                                   {
                                     "kind": "InlineFragment",
                                     "selections": [
-                                      (v22/*: any*/),
-                                      (v23/*: any*/)
+                                      (v23/*: any*/),
+                                      (v24/*: any*/)
                                     ],
                                     "type": "Image",
                                     "abstractKey": null
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v24/*: any*/),
+                                    "selections": (v25/*: any*/),
                                     "type": "Video",
                                     "abstractKey": null
                                   }
@@ -965,7 +968,7 @@ return {
                             ],
                             "storageKey": null
                           },
-                          (v13/*: any*/),
+                          (v14/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -975,7 +978,7 @@ return {
                             "plural": false,
                             "selections": [
                               (v3/*: any*/),
-                              (v13/*: any*/),
+                              (v14/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -1005,8 +1008,8 @@ return {
                                 "name": "image",
                                 "plural": false,
                                 "selections": [
-                                  (v20/*: any*/),
-                                  (v22/*: any*/)
+                                  (v21/*: any*/),
+                                  (v23/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -1025,7 +1028,7 @@ return {
                                     "name": "shortDescription",
                                     "storageKey": null
                                   },
-                                  (v13/*: any*/)
+                                  (v14/*: any*/)
                                 ],
                                 "storageKey": null
                               },
@@ -1037,8 +1040,8 @@ return {
                                 "name": "image",
                                 "plural": false,
                                 "selections": [
-                                  (v20/*: any*/),
-                                  (v23/*: any*/)
+                                  (v21/*: any*/),
+                                  (v24/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -1054,8 +1057,8 @@ return {
                             "plural": false,
                             "selections": [
                               (v2/*: any*/),
-                              (v12/*: any*/),
-                              (v6/*: any*/)
+                              (v13/*: any*/),
+                              (v7/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -1071,10 +1074,10 @@ return {
                               {
                                 "kind": "InlineFragment",
                                 "selections": [
-                                  (v26/*: any*/),
                                   (v27/*: any*/),
-                                  (v29/*: any*/),
-                                  (v30/*: any*/)
+                                  (v28/*: any*/),
+                                  (v30/*: any*/),
+                                  (v31/*: any*/)
                                 ],
                                 "type": "Artwork",
                                 "abstractKey": null
@@ -1082,16 +1085,16 @@ return {
                               {
                                 "kind": "InlineFragment",
                                 "selections": [
-                                  (v26/*: any*/),
-                                  (v13/*: any*/),
                                   (v27/*: any*/),
-                                  (v29/*: any*/),
-                                  (v30/*: any*/)
+                                  (v14/*: any*/),
+                                  (v28/*: any*/),
+                                  (v30/*: any*/),
+                                  (v31/*: any*/)
                                 ],
                                 "type": "EditionSet",
                                 "abstractKey": null
                               },
-                              (v31/*: any*/)
+                              (v32/*: any*/)
                             ],
                             "storageKey": null
                           }
@@ -1105,7 +1108,7 @@ return {
                         "kind": "LinkedField",
                         "name": "buyerTotal",
                         "plural": false,
-                        "selections": (v33/*: any*/),
+                        "selections": (v34/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -1115,7 +1118,7 @@ return {
                         "kind": "LinkedField",
                         "name": "itemsTotal",
                         "plural": false,
-                        "selections": (v33/*: any*/),
+                        "selections": (v34/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -1125,7 +1128,7 @@ return {
                         "kind": "LinkedField",
                         "name": "shippingTotal",
                         "plural": false,
-                        "selections": (v34/*: any*/),
+                        "selections": (v35/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -1135,7 +1138,7 @@ return {
                         "kind": "LinkedField",
                         "name": "taxTotal",
                         "plural": false,
-                        "selections": (v34/*: any*/),
+                        "selections": (v35/*: any*/),
                         "storageKey": null
                       },
                       {
@@ -1153,7 +1156,7 @@ return {
                         "name": "fulfillmentOptions",
                         "plural": true,
                         "selections": [
-                          (v4/*: any*/),
+                          (v5/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1161,10 +1164,10 @@ return {
                             "kind": "LinkedField",
                             "name": "amount",
                             "plural": false,
-                            "selections": (v33/*: any*/),
+                            "selections": (v34/*: any*/),
                             "storageKey": null
                           },
-                          (v5/*: any*/),
+                          (v6/*: any*/),
                           {
                             "alias": null,
                             "args": null,
@@ -1209,7 +1212,7 @@ return {
                             "type": "Partner",
                             "abstractKey": null
                           },
-                          (v31/*: any*/)
+                          (v32/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -1220,11 +1223,11 @@ return {
                         "name": "buyerStateExpiresAt",
                         "storageKey": null
                       },
-                      (v19/*: any*/),
-                      (v16/*: any*/),
-                      (v32/*: any*/),
-                      (v13/*: any*/),
-                      (v9/*: any*/),
+                      (v20/*: any*/),
+                      (v17/*: any*/),
+                      (v33/*: any*/),
+                      (v14/*: any*/),
+                      (v10/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -1254,7 +1257,7 @@ return {
                             "name": "result",
                             "storageKey": null
                           },
-                          (v8/*: any*/)
+                          (v9/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -1265,7 +1268,7 @@ return {
                 "type": "OrderMutationSuccess",
                 "abstractKey": null
               },
-              (v10/*: any*/)
+              (v11/*: any*/)
             ],
             "storageKey": null
           }
@@ -1275,16 +1278,16 @@ return {
     ]
   },
   "params": {
-    "cacheID": "45cb4459554fa6fd7901f689f84d34aa",
+    "cacheID": "51cc2af890b19ec54f2dcddeacf9a24c",
     "id": null,
     "metadata": {},
     "name": "useOrder2SetOrderDeliveryAddressMutation",
     "operationKind": "mutation",
-    "text": "mutation useOrder2SetOrderDeliveryAddressMutation(\n  $input: updateOrderShippingAddressInput!\n) {\n  updateOrderShippingAddress(input: $input) {\n    orderOrError {\n      __typename\n      ... on OrderMutationSuccess {\n        order {\n          internalID\n          ...Order2CheckoutContext_order\n          ...Order2CheckoutApp_order\n          fulfillmentOptions {\n            type\n            selected\n            amount {\n              display\n            }\n          }\n          id\n        }\n      }\n      ... on OrderMutationError {\n        mutationError {\n          message\n          code\n        }\n      }\n    }\n  }\n}\n\nfragment OfferInput_order on Order {\n  currencySymbol\n}\n\nfragment Order2CheckoutApp_order on Order {\n  internalID\n  selectedFulfillmentOption {\n    type\n  }\n  lineItems {\n    artwork {\n      slug\n      isFixedShippingFeeOnly\n      id\n    }\n    id\n  }\n  ...useIsDeliveryOptionExpanded_order\n  ...useLoadCheckout_order\n  ...Order2ExpressCheckout_order\n  ...Order2CollapsibleOrderSummary_order\n  ...Order2OfferStep_order\n  ...Order2FulfillmentDetailsStep_order\n  ...Order2DeliveryOptionsStep_order\n  ...Order2PaymentStep_order\n  ...Order2ReviewStep_order\n  ...Order2CheckoutLoadingSkeleton_order\n  ...Order2HelpLinks_order\n}\n\nfragment Order2CheckoutContext_order on Order {\n  ...useBuildInitialSteps_order\n  internalID\n  mode\n  shippingRadius\n  source\n  stripeConfirmationToken\n  selectedFulfillmentOption {\n    type\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    id\n  }\n}\n\nfragment Order2CheckoutLoadingSkeleton_order on Order {\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  lineItems {\n    artworkVersion {\n      title\n      artistNames\n      date\n      id\n    }\n    id\n  }\n}\n\nfragment Order2CheckoutPricingBreakdown_order on Order {\n  source\n  mode\n  buyerStateExpiresAt\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n  pendingOffer {\n    pricingBreakdownLines {\n      __typename\n      ... on ShippingLine {\n        displayName\n        amountFallbackText\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on TaxLine {\n        displayName\n        amountFallbackText\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on SubtotalLine {\n        displayName\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on TotalLine {\n        displayName\n        amountFallbackText\n        amount {\n          display\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Order2CollapsibleOrderSummary_order on Order {\n  ...Order2CheckoutPricingBreakdown_order\n  source\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artworkVersion {\n      title\n      artistNames\n      date\n      thumbnail: image {\n        url\n        resizedSquare: resized(height: 200, version: [\"square\"]) {\n          url\n        }\n      }\n      id\n    }\n    artwork {\n      internalID\n      figures(includeAll: false) {\n        __typename\n        ... on Image {\n          resizedSquare: resized(height: 200, version: [\"square\"]) {\n            url\n          }\n        }\n        ... on Video {\n          id\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment Order2DeliveryForm_order on Order {\n  internalID\n  selectedFulfillmentOption {\n    type\n  }\n  availableShippingCountries\n  fulfillmentDetails {\n    addressLine1\n    addressLine2\n    city\n    region\n    postalCode\n    country\n    name\n    phoneNumber {\n      originalNumber\n      regionCode\n      countryCode\n    }\n  }\n  lineItems {\n    artwork {\n      shippingOriginRegion\n      processWithArtsyShippingDomestic\n      artsyShippingInternational\n      id\n    }\n    id\n  }\n}\n\nfragment Order2DeliveryOptionsForm_order on Order {\n  ...useCompleteFulfillmentDetailsData_order\n  internalID\n  fulfillmentOptions {\n    amount {\n      display\n      minor\n      currencyCode\n    }\n    type\n    selected\n    shippingQuoteId\n  }\n  selectedFulfillmentOption {\n    type\n  }\n  shippingOrigin\n}\n\nfragment Order2DeliveryOptionsStep_order on Order {\n  ...useCompleteDeliveryOptionData_order\n  ...useIsDeliveryOptionExpanded_order\n  ...Order2DeliveryOptionsForm_order\n  internalID\n  fulfillmentOptions {\n    type\n  }\n  selectedFulfillmentOption {\n    type\n    amount {\n      display\n    }\n  }\n}\n\nfragment Order2ExpressCheckoutUI_order on Order {\n  internalID\n  source\n  mode\n  buyerTotal {\n    minor\n    currencyCode\n  }\n  itemsTotal {\n    minor\n  }\n  shippingTotal {\n    minor\n  }\n  taxTotal {\n    minor\n  }\n  availableShippingCountries\n  fulfillmentOptions {\n    type\n    amount {\n      minor\n      currencyCode\n    }\n    selected\n  }\n  fulfillmentDetails {\n    addressLine1\n    addressLine2\n    city\n    postalCode\n    region\n    country\n    name\n  }\n  lineItems {\n    artwork {\n      internalID\n      slug\n      id\n    }\n    id\n  }\n}\n\nfragment Order2ExpressCheckout_order on Order {\n  ...Order2ExpressCheckoutUI_order\n  availableShippingCountries\n  buyerTotal {\n    minor\n    currencyCode\n  }\n  itemsTotal {\n    minor\n    currencyCode\n  }\n  seller {\n    __typename\n    ... on Partner {\n      merchantAccount {\n        externalId\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment Order2FulfillmentDetailsStep_order on Order {\n  ...useCompleteFulfillmentDetailsData_order\n  ...Order2PickupForm_order\n  ...Order2DeliveryForm_order\n  id\n  internalID\n  fulfillmentDetails {\n    phoneNumber {\n      countryCode\n      regionCode\n      originalNumber\n      display(format: INTERNATIONAL)\n    }\n    addressLine1\n    addressLine2\n    city\n    country\n    name\n    postalCode\n    region\n  }\n  selectedFulfillmentOption {\n    type\n  }\n  fulfillmentOptions {\n    type\n    selected\n  }\n  availableShippingCountries\n}\n\nfragment Order2HelpLinks_order on Order {\n  internalID\n  mode\n  source\n}\n\nfragment Order2OfferOptions_order on Order {\n  ...OfferInput_order\n  source\n  buyerStateExpiresAt\n  currencyCode\n  lineItems {\n    listPrice {\n      __typename\n      major\n    }\n    artworkOrEditionSet {\n      __typename\n      ... on Artwork {\n        listPrice {\n          __typename\n          ... on PriceRange {\n            maxPrice {\n              major\n            }\n            minPrice {\n              major\n            }\n          }\n        }\n      }\n      ... on EditionSet {\n        listPrice {\n          __typename\n          ... on PriceRange {\n            maxPrice {\n              major\n            }\n            minPrice {\n              major\n            }\n          }\n        }\n        id\n      }\n      ... on Node {\n        __isNode: __typename\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Order2OfferStep_order on Order {\n  ...useCompleteOfferData_order\n  ...Order2OfferOptions_order\n  ...OfferInput_order\n  internalID\n  mode\n  source\n  currencyCode\n  selectedFulfillmentOption {\n    type\n  }\n  pendingOffer {\n    amount {\n      display\n      major\n    }\n    note\n    id\n  }\n  lineItems {\n    artwork {\n      isPriceHidden\n      id\n    }\n    artworkOrEditionSet {\n      __typename\n      ... on Artwork {\n        listPrice {\n          __typename\n          ... on PriceRange {\n            maxPrice {\n              major\n            }\n            minPrice {\n              major\n            }\n          }\n        }\n      }\n      ... on EditionSet {\n        listPrice {\n          __typename\n          ... on PriceRange {\n            maxPrice {\n              major\n            }\n            minPrice {\n              major\n            }\n          }\n        }\n        id\n      }\n      ... on Node {\n        __isNode: __typename\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Order2PaymentCompletedView_order on Order {\n  paymentMethod\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      brand\n      lastDigits\n      expirationYear\n      expirationMonth\n      id\n    }\n    ... on BankAccount {\n      last4\n      bankName\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n}\n\nfragment Order2PaymentForm_order on Order {\n  ...WireTransferOption_order\n  code\n  mode\n  source\n  internalID\n  currencyCode\n  availablePaymentMethods\n  availableStripePaymentMethodTypes\n  bankAccountBalanceCheck {\n    result\n    message\n  }\n  buyerTotal {\n    minor\n    currencyCode\n  }\n  seller {\n    __typename\n    ... on Partner {\n      merchantAccount {\n        externalId\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  fulfillmentDetails {\n    name\n    addressLine1\n    addressLine2\n    city\n    region\n    postalCode\n    country\n  }\n}\n\nfragment Order2PaymentStep_order on Order {\n  ...useCompletePaymentData_order\n  ...Order2PaymentForm_order\n  ...Order2PaymentCompletedView_order\n  internalID\n  paymentMethod\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      internalID\n      id\n    }\n    ... on BankAccount {\n      internalID\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  buyerTotal {\n    minor\n    currencyCode\n  }\n  itemsTotal {\n    minor\n    currencyCode\n  }\n  shippingTotal {\n    minor\n  }\n  taxTotal {\n    minor\n  }\n  seller {\n    __typename\n    ... on Partner {\n      merchantAccount {\n        externalId\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment Order2PickupForm_order on Order {\n  internalID\n  fulfillmentOptions {\n    type\n  }\n  selectedFulfillmentOption {\n    type\n  }\n  fulfillmentDetails {\n    phoneNumber {\n      countryCode\n      regionCode\n      originalNumber\n    }\n  }\n  shippingOrigin\n}\n\nfragment Order2ReviewStep_order on Order {\n  ...Order2CheckoutPricingBreakdown_order\n  internalID\n  source\n  buyerStateExpiresAt\n  stripeConfirmationToken\n  paymentMethod\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    listPrice {\n      __typename\n      display\n    }\n    artworkOrEditionSet {\n      __typename\n      ... on Artwork {\n        price\n        dimensions {\n          in\n          cm\n        }\n        framedDimensions {\n          in\n          cm\n        }\n      }\n      ... on EditionSet {\n        price\n        dimensions {\n          in\n          cm\n        }\n        framedDimensions {\n          in\n          cm\n        }\n        id\n      }\n      ... on Node {\n        __isNode: __typename\n        id\n      }\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      attributionClass {\n        shortDescription\n        id\n      }\n      image {\n        url\n        resized(width: 185, height: 138) {\n          url\n        }\n      }\n      id\n    }\n    artwork {\n      internalID\n      figures(includeAll: false) {\n        __typename\n        ... on Image {\n          resized(width: 185, height: 138) {\n            url\n          }\n        }\n        ... on Video {\n          id\n        }\n      }\n      id\n    }\n    id\n  }\n  pendingOffer {\n    internalID\n    id\n  }\n}\n\nfragment WireTransferOption_order on Order {\n  code\n  lineItems {\n    artwork {\n      href\n      meta {\n        share\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment useBuildInitialSteps_order on Order {\n  ...useCompleteOfferData_order\n  ...useCompleteFulfillmentDetailsData_order\n  ...useCompleteDeliveryOptionData_order\n  ...useCompletePaymentData_order\n  mode\n  selectedFulfillmentOption {\n    type\n  }\n}\n\nfragment useCompleteDeliveryOptionData_order on Order {\n  shippingOrigin\n  shippingRadius\n  selectedFulfillmentOption {\n    type\n    amount {\n      minor\n      display\n      currencySymbol\n      major\n    }\n  }\n}\n\nfragment useCompleteFulfillmentDetailsData_order on Order {\n  mode\n  fulfillmentDetails {\n    addressLine1\n    addressLine2\n    city\n    country\n    name\n    postalCode\n    region\n    phoneNumber {\n      display(format: INTERNATIONAL)\n    }\n  }\n  selectedFulfillmentOption {\n    type\n  }\n}\n\nfragment useCompleteOfferData_order on Order {\n  mode\n  pendingOffer {\n    note\n    amount {\n      minor\n      display\n    }\n    id\n  }\n}\n\nfragment useCompletePaymentData_order on Order {\n  paymentMethod\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      internalID\n      id\n    }\n    ... on BankAccount {\n      internalID\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n}\n\nfragment useIsDeliveryOptionExpanded_order on Order {\n  ...useCompleteFulfillmentDetailsData_order\n  selectedFulfillmentOption {\n    type\n  }\n}\n\nfragment useLoadCheckout_order on Order {\n  internalID\n  lineItems {\n    artwork {\n      isAcquireable\n      id\n    }\n    artworkVersion {\n      internalID\n      id\n    }\n    id\n  }\n}\n"
+    "text": "mutation useOrder2SetOrderDeliveryAddressMutation(\n  $input: updateOrderShippingAddressInput!\n) {\n  updateOrderShippingAddress(input: $input) {\n    orderOrError {\n      __typename\n      ... on OrderMutationSuccess {\n        order {\n          internalID\n          shippingRadius\n          ...Order2CheckoutContext_order\n          ...Order2CheckoutApp_order\n          fulfillmentOptions {\n            type\n            selected\n            amount {\n              display\n            }\n          }\n          id\n        }\n      }\n      ... on OrderMutationError {\n        mutationError {\n          message\n          code\n        }\n      }\n    }\n  }\n}\n\nfragment OfferInput_order on Order {\n  currencySymbol\n}\n\nfragment Order2CheckoutApp_order on Order {\n  internalID\n  selectedFulfillmentOption {\n    type\n  }\n  lineItems {\n    artwork {\n      slug\n      isFixedShippingFeeOnly\n      id\n    }\n    id\n  }\n  ...useIsDeliveryOptionExpanded_order\n  ...useLoadCheckout_order\n  ...Order2ExpressCheckout_order\n  ...Order2CollapsibleOrderSummary_order\n  ...Order2OfferStep_order\n  ...Order2FulfillmentDetailsStep_order\n  ...Order2DeliveryOptionsStep_order\n  ...Order2PaymentStep_order\n  ...Order2ReviewStep_order\n  ...Order2CheckoutLoadingSkeleton_order\n  ...Order2HelpLinks_order\n}\n\nfragment Order2CheckoutContext_order on Order {\n  ...useBuildInitialSteps_order\n  internalID\n  mode\n  shippingRadius\n  source\n  stripeConfirmationToken\n  selectedFulfillmentOption {\n    type\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    id\n  }\n}\n\nfragment Order2CheckoutLoadingSkeleton_order on Order {\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  lineItems {\n    artworkVersion {\n      title\n      artistNames\n      date\n      id\n    }\n    id\n  }\n}\n\nfragment Order2CheckoutPricingBreakdown_order on Order {\n  source\n  mode\n  buyerStateExpiresAt\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n  pendingOffer {\n    pricingBreakdownLines {\n      __typename\n      ... on ShippingLine {\n        displayName\n        amountFallbackText\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on TaxLine {\n        displayName\n        amountFallbackText\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on SubtotalLine {\n        displayName\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on TotalLine {\n        displayName\n        amountFallbackText\n        amount {\n          display\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Order2CollapsibleOrderSummary_order on Order {\n  ...Order2CheckoutPricingBreakdown_order\n  source\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artworkVersion {\n      title\n      artistNames\n      date\n      thumbnail: image {\n        url\n        resizedSquare: resized(height: 200, version: [\"square\"]) {\n          url\n        }\n      }\n      id\n    }\n    artwork {\n      internalID\n      figures(includeAll: false) {\n        __typename\n        ... on Image {\n          resizedSquare: resized(height: 200, version: [\"square\"]) {\n            url\n          }\n        }\n        ... on Video {\n          id\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment Order2DeliveryForm_order on Order {\n  internalID\n  selectedFulfillmentOption {\n    type\n  }\n  availableShippingCountries\n  fulfillmentDetails {\n    addressLine1\n    addressLine2\n    city\n    region\n    postalCode\n    country\n    name\n    phoneNumber {\n      originalNumber\n      regionCode\n      countryCode\n    }\n  }\n  lineItems {\n    artwork {\n      shippingOriginRegion\n      processWithArtsyShippingDomestic\n      artsyShippingInternational\n      id\n    }\n    id\n  }\n}\n\nfragment Order2DeliveryOptionsForm_order on Order {\n  ...useCompleteFulfillmentDetailsData_order\n  internalID\n  fulfillmentOptions {\n    amount {\n      display\n      minor\n      currencyCode\n    }\n    type\n    selected\n    shippingQuoteId\n  }\n  selectedFulfillmentOption {\n    type\n  }\n  shippingOrigin\n}\n\nfragment Order2DeliveryOptionsStep_order on Order {\n  ...useCompleteDeliveryOptionData_order\n  ...useIsDeliveryOptionExpanded_order\n  ...Order2DeliveryOptionsForm_order\n  internalID\n  fulfillmentOptions {\n    type\n  }\n  selectedFulfillmentOption {\n    type\n    amount {\n      display\n    }\n  }\n}\n\nfragment Order2ExpressCheckoutUI_order on Order {\n  internalID\n  source\n  mode\n  buyerTotal {\n    minor\n    currencyCode\n  }\n  itemsTotal {\n    minor\n  }\n  shippingTotal {\n    minor\n  }\n  taxTotal {\n    minor\n  }\n  availableShippingCountries\n  fulfillmentOptions {\n    type\n    amount {\n      minor\n      currencyCode\n    }\n    selected\n  }\n  fulfillmentDetails {\n    addressLine1\n    addressLine2\n    city\n    postalCode\n    region\n    country\n    name\n  }\n  lineItems {\n    artwork {\n      internalID\n      slug\n      id\n    }\n    id\n  }\n}\n\nfragment Order2ExpressCheckout_order on Order {\n  ...Order2ExpressCheckoutUI_order\n  availableShippingCountries\n  buyerTotal {\n    minor\n    currencyCode\n  }\n  itemsTotal {\n    minor\n    currencyCode\n  }\n  seller {\n    __typename\n    ... on Partner {\n      merchantAccount {\n        externalId\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment Order2FulfillmentDetailsStep_order on Order {\n  ...useCompleteFulfillmentDetailsData_order\n  ...Order2PickupForm_order\n  ...Order2DeliveryForm_order\n  id\n  internalID\n  fulfillmentDetails {\n    phoneNumber {\n      countryCode\n      regionCode\n      originalNumber\n      display(format: INTERNATIONAL)\n    }\n    addressLine1\n    addressLine2\n    city\n    country\n    name\n    postalCode\n    region\n  }\n  selectedFulfillmentOption {\n    type\n  }\n  fulfillmentOptions {\n    type\n    selected\n  }\n  availableShippingCountries\n}\n\nfragment Order2HelpLinks_order on Order {\n  internalID\n  mode\n  source\n}\n\nfragment Order2OfferOptions_order on Order {\n  ...OfferInput_order\n  source\n  buyerStateExpiresAt\n  currencyCode\n  lineItems {\n    listPrice {\n      __typename\n      major\n    }\n    artworkOrEditionSet {\n      __typename\n      ... on Artwork {\n        listPrice {\n          __typename\n          ... on PriceRange {\n            maxPrice {\n              major\n            }\n            minPrice {\n              major\n            }\n          }\n        }\n      }\n      ... on EditionSet {\n        listPrice {\n          __typename\n          ... on PriceRange {\n            maxPrice {\n              major\n            }\n            minPrice {\n              major\n            }\n          }\n        }\n        id\n      }\n      ... on Node {\n        __isNode: __typename\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Order2OfferStep_order on Order {\n  ...useCompleteOfferData_order\n  ...Order2OfferOptions_order\n  ...OfferInput_order\n  internalID\n  mode\n  source\n  currencyCode\n  selectedFulfillmentOption {\n    type\n  }\n  pendingOffer {\n    amount {\n      display\n      major\n    }\n    note\n    id\n  }\n  lineItems {\n    artwork {\n      isPriceHidden\n      id\n    }\n    artworkOrEditionSet {\n      __typename\n      ... on Artwork {\n        listPrice {\n          __typename\n          ... on PriceRange {\n            maxPrice {\n              major\n            }\n            minPrice {\n              major\n            }\n          }\n        }\n      }\n      ... on EditionSet {\n        listPrice {\n          __typename\n          ... on PriceRange {\n            maxPrice {\n              major\n            }\n            minPrice {\n              major\n            }\n          }\n        }\n        id\n      }\n      ... on Node {\n        __isNode: __typename\n        id\n      }\n    }\n    id\n  }\n}\n\nfragment Order2PaymentCompletedView_order on Order {\n  paymentMethod\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      brand\n      lastDigits\n      expirationYear\n      expirationMonth\n      id\n    }\n    ... on BankAccount {\n      last4\n      bankName\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n}\n\nfragment Order2PaymentForm_order on Order {\n  ...WireTransferOption_order\n  code\n  mode\n  source\n  internalID\n  currencyCode\n  availablePaymentMethods\n  availableStripePaymentMethodTypes\n  bankAccountBalanceCheck {\n    result\n    message\n  }\n  buyerTotal {\n    minor\n    currencyCode\n  }\n  seller {\n    __typename\n    ... on Partner {\n      merchantAccount {\n        externalId\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  fulfillmentDetails {\n    name\n    addressLine1\n    addressLine2\n    city\n    region\n    postalCode\n    country\n  }\n}\n\nfragment Order2PaymentStep_order on Order {\n  ...useCompletePaymentData_order\n  ...Order2PaymentForm_order\n  ...Order2PaymentCompletedView_order\n  internalID\n  paymentMethod\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      internalID\n      id\n    }\n    ... on BankAccount {\n      internalID\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n  buyerTotal {\n    minor\n    currencyCode\n  }\n  itemsTotal {\n    minor\n    currencyCode\n  }\n  shippingTotal {\n    minor\n  }\n  taxTotal {\n    minor\n  }\n  seller {\n    __typename\n    ... on Partner {\n      merchantAccount {\n        externalId\n      }\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n}\n\nfragment Order2PickupForm_order on Order {\n  internalID\n  fulfillmentOptions {\n    type\n  }\n  selectedFulfillmentOption {\n    type\n  }\n  fulfillmentDetails {\n    phoneNumber {\n      countryCode\n      regionCode\n      originalNumber\n    }\n  }\n  shippingOrigin\n}\n\nfragment Order2ReviewStep_order on Order {\n  ...Order2CheckoutPricingBreakdown_order\n  internalID\n  source\n  buyerStateExpiresAt\n  stripeConfirmationToken\n  paymentMethod\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    listPrice {\n      __typename\n      display\n    }\n    artworkOrEditionSet {\n      __typename\n      ... on Artwork {\n        price\n        dimensions {\n          in\n          cm\n        }\n        framedDimensions {\n          in\n          cm\n        }\n      }\n      ... on EditionSet {\n        price\n        dimensions {\n          in\n          cm\n        }\n        framedDimensions {\n          in\n          cm\n        }\n        id\n      }\n      ... on Node {\n        __isNode: __typename\n        id\n      }\n    }\n    artworkVersion {\n      title\n      artistNames\n      date\n      attributionClass {\n        shortDescription\n        id\n      }\n      image {\n        url\n        resized(width: 185, height: 138) {\n          url\n        }\n      }\n      id\n    }\n    artwork {\n      internalID\n      figures(includeAll: false) {\n        __typename\n        ... on Image {\n          resized(width: 185, height: 138) {\n            url\n          }\n        }\n        ... on Video {\n          id\n        }\n      }\n      id\n    }\n    id\n  }\n  pendingOffer {\n    internalID\n    id\n  }\n}\n\nfragment WireTransferOption_order on Order {\n  code\n  lineItems {\n    artwork {\n      href\n      meta {\n        share\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment useBuildInitialSteps_order on Order {\n  ...useCompleteOfferData_order\n  ...useCompleteFulfillmentDetailsData_order\n  ...useCompleteDeliveryOptionData_order\n  ...useCompletePaymentData_order\n  mode\n  selectedFulfillmentOption {\n    type\n  }\n}\n\nfragment useCompleteDeliveryOptionData_order on Order {\n  shippingOrigin\n  shippingRadius\n  selectedFulfillmentOption {\n    type\n    amount {\n      minor\n      display\n      currencySymbol\n      major\n    }\n  }\n}\n\nfragment useCompleteFulfillmentDetailsData_order on Order {\n  mode\n  fulfillmentDetails {\n    addressLine1\n    addressLine2\n    city\n    country\n    name\n    postalCode\n    region\n    phoneNumber {\n      display(format: INTERNATIONAL)\n    }\n  }\n  selectedFulfillmentOption {\n    type\n  }\n}\n\nfragment useCompleteOfferData_order on Order {\n  mode\n  pendingOffer {\n    note\n    amount {\n      minor\n      display\n    }\n    id\n  }\n}\n\nfragment useCompletePaymentData_order on Order {\n  paymentMethod\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      internalID\n      id\n    }\n    ... on BankAccount {\n      internalID\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n}\n\nfragment useIsDeliveryOptionExpanded_order on Order {\n  ...useCompleteFulfillmentDetailsData_order\n  selectedFulfillmentOption {\n    type\n  }\n}\n\nfragment useLoadCheckout_order on Order {\n  internalID\n  lineItems {\n    artwork {\n      isAcquireable\n      id\n    }\n    artworkVersion {\n      internalID\n      id\n    }\n    id\n  }\n}\n"
   }
 };
 })();
 
-(node as any).hash = "6c8bb0068b69c27fc7fcbccfdc61ada0";
+(node as any).hash = "c8b817df0fcf3783022bc316ff34999b";
 
 export default node;


### PR DESCRIPTION
Should fix a bug found for https://artsyproduct.atlassian.net/browse/EMI-3278

Discovered an issue where the error message was showing for Offer orders with no shipping configured, even though that's not an error state — we allow 'incomplete offers':  https://artsy.slack.com/archives/C02JHHHKP5K/p1782318915101859?thread_ts=1782318826.143139&cid=C02JHHHKP5K

Tricky stuff but boils down to 2 parts:
Boils down to 2 parts:
- `isInternationalShipping` read from context was stale: the address had just been updated via mutation but the context value was captured at render time (stale closure). Fixed by reading `shippingRadius` directly from `updatedOrder` returned by the mutation.
- When shipping is not configured on the artwork, `shippingRadius` returns nil from Exchange. Treating nil as "no Arta shipping configured" is the right defensive behavior — even if we later update Exchange to calculate shippingRadius from to/from address, some artworks have no location defined and nil is still possible.

Assisted by Claude in some debugging and it wrote specs.