### PR TITLE
feat(EMI-3283): add terms and conditions copy and tracking

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/Order2ReviewStep.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2ReviewStep.tsx
@@ -11,6 +11,7 @@ import {
 import type { CheckoutErrorBannerMessage } from "Apps/Order2/Routes/Checkout/Components/CheckoutErrorBanner"
 import { CheckoutModalError } from "Apps/Order2/Routes/Checkout/Components/CheckoutModal"
 import { Order2CheckoutPricingBreakdown } from "Apps/Order2/Routes/Checkout/Components/Order2CheckoutPricingBreakdown"
+import { TermsAndConditions } from "Apps/Order2/Routes/Checkout/Components/TermsAndConditions"
 import { useCheckoutContext } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext"
 import { useCheckoutModal } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutModal"
 import { useOrder2SubmitOrderMutation } from "Apps/Order2/Routes/Checkout/Mutations/useOrder2SubmitOrderMutation"
@@ -311,6 +312,9 @@ export const Order2ReviewStep: React.FC<Order2ReviewStepProps> = ({
           >
             Submit
           </Button>
+          <Spacer y={2} />
+          <TermsAndConditions />
+          <Spacer y={2} />
         </>
       )}
     </Flex>

--- a/src/Apps/Order2/Routes/Checkout/Components/TermsAndConditions.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/TermsAndConditions.tsx
@@ -1,0 +1,22 @@
+import { Text } from "@artsy/palette"
+import { useCheckoutContext } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext"
+import { RouterLink } from "System/Components/RouterLink"
+import type React from "react"
+
+export const TermsAndConditions: React.FC = () => {
+  const { checkoutTracking } = useCheckoutContext()
+
+  return (
+    <Text variant="xs" color="mono60">
+      By clicking Submit, I agree to Artsy’s{" "}
+      <RouterLink
+        inline
+        to="/terms"
+        target="_blank"
+        onClick={() => checkoutTracking.clickedTermsAndConditions()}
+      >
+        General Terms and Conditions of Sale.
+      </RouterLink>
+    </Text>
+  )
+}

--- a/src/Apps/Order2/Routes/Checkout/Hooks/__tests__/useCheckoutTracking.jest.ts
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/__tests__/useCheckoutTracking.jest.ts
@@ -117,6 +117,28 @@ describe("useCheckoutTracking", () => {
     })
   })
 
+  describe("clickedTermsAndConditions", () => {
+    it("tracks click", () => {
+      const { result } = renderHook(() =>
+        useCheckoutTracking({
+          source: "artwork",
+          mode: "BUY",
+        }),
+      )
+
+      act(() => {
+        result.current.clickedTermsAndConditions()
+      })
+
+      assertTracked({
+        action: "clickedTermsAndConditions",
+        context_module: "ordersReview",
+        context_page_owner_type: "orders-checkout",
+        context_page_owner_id: "order-id",
+      })
+    })
+  })
+
   describe("clickedPaymentMethod", () => {
     it("tracks clicked payment method passing amountMinor and currency values through", () => {
       const { result } = renderHook(() =>

--- a/src/Apps/Order2/Routes/Checkout/Hooks/useCheckoutTracking.ts
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/useCheckoutTracking.ts
@@ -15,6 +15,7 @@ import {
   type ClickedPaymentMethod,
   type ClickedSelectShippingOption,
   type ClickedShippingAddress,
+  type ClickedTermsAndConditions,
   ContextModule,
   type ErrorMessageViewed,
   type ExpressCheckoutViewed,
@@ -237,6 +238,16 @@ export const useCheckoutTracking = ({
         const payload: ClickedChangeShippingMethod = {
           action: ActionType.clickedChangeShippingMethod,
           context_module: ContextModule.ordersCheckout,
+          context_page_owner_type: contextPageOwnerType,
+          context_page_owner_id: contextPageOwnerId,
+        }
+        trackEvent(payload)
+      },
+
+      clickedTermsAndConditions: () => {
+        const payload: ClickedTermsAndConditions = {
+          action: ActionType.clickedTermsAndConditions,
+          context_module: ContextModule.ordersReview,
           context_page_owner_type: contextPageOwnerType,
           context_page_owner_id: contextPageOwnerId,
         }


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-3283]

### Description

This adds the terms and conditions copy and tracking to the submit step in the new checkout.

<img width="1402" height="856" alt="Screenshot 2026-06-25 at 9 43 09 AM" src="https://github.com/user-attachments/assets/8cbd5c3b-435c-4093-8565-1af9d5a8622c" />


<!-- Implementation description -->


[EMI-3283]: https://artsyproduct.atlassian.net/browse/EMI-3283?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ