### PR TITLE
fix: coerce numeric search terms to string in prepareVariables

### DIFF
--- a/src/Apps/Search/__tests__/searchRoutes.jest.tsx
+++ b/src/Apps/Search/__tests__/searchRoutes.jest.tsx
@@ -1,0 +1,31 @@
+import { prepareVariables } from "Apps/Search/searchRoutes"
+
+describe("searchRoutes", () => {
+  describe("prepareVariables", () => {
+    it("passes the term through as the keyword", () => {
+      const variables = prepareVariables(
+        {},
+        { location: { query: { term: "andy" } } },
+      )
+
+      expect(variables.keyword).toBe("andy")
+    })
+
+    it("coerces a numeric term to a string", () => {
+      // The router's query-string parser turns `?term=1954` into the number
+      // 1954, which would be rejected by the `String!` query variable.
+      const variables = prepareVariables(
+        {},
+        { location: { query: { term: 1954 } } },
+      )
+
+      expect(variables.keyword).toBe("1954")
+    })
+
+    it("falls back to an empty string when the term is missing", () => {
+      const variables = prepareVariables({}, { location: { query: {} } })
+
+      expect(variables.keyword).toBe("")
+    })
+  })
+})

--- a/src/Apps/Search/searchRoutes.tsx
+++ b/src/Apps/Search/searchRoutes.tsx
@@ -43,7 +43,7 @@ const SearchApp = loadable(
   },
 )
 
-const prepareVariables = (_params, { location }) => {
+export const prepareVariables = (_params, { location }) => {
   const aggregations = [
     "TOTAL",
     "ARTIST_NATIONALITY",
@@ -52,9 +52,14 @@ const prepareVariables = (_params, { location }) => {
     "PARTNER",
   ]
 
+  const { term } = location.query
+
   return {
     ...paramsToCamelCase(omit(location.query, "term")),
-    keyword: location.query.term ?? "",
+    // `term` can be coerced to a number by the router's query-string parser
+    // (e.g. `?term=1954`), so force it back to a string for the `String!` query
+    // variable. The nullish fallback guards against navigation without a term.
+    keyword: term != null ? String(term) : "",
     aggregations,
   }
 }


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

Fixes a 500 error when searching for a purely numeric term, e.g. `/search?term=1954`.

The router's query-string parser coerces any numeric-looking query value into a JS `number`. So `?term=1954` reaches `prepareVariables` as the number `1954` rather than the string `"1954"`.

This was previously masked by an explicit `.toString()`:

```ts
keyword: location.query.term.toString(),
```

PR #17252 (which fixed a real undefined.toString() crash in usePrefetchRoute) changed it to:

```ts
keyword: location.query.term ?? "",
```

The nullish fallback guards against a missing term but no longer coerces the value, so a number is passed to the `$keyword: String!` Relay variable. Metaphysics rejects a number where a non-null String is required, throwing during SSR → 500.