### PR TITLE
fix(auth): fallback preserves email

### DIFF
--- a/src/Components/AuthDialog/AuthDialogContext.tsx
+++ b/src/Components/AuthDialog/AuthDialogContext.tsx
@@ -117,7 +117,7 @@ type Action =
   | { type: "SET"; payload: Partial<State> }
   | { type: "SHOW" }
   | { type: "HIDE" }
-  | { type: "FALLBACK" }
+  | { type: "FALLBACK"; payload: { email: string } }
 
 export const reducer = (state: State, action: Action): State => {
   switch (action.type) {
@@ -139,7 +139,12 @@ export const reducer = (state: State, action: Action): State => {
     }
 
     case "FALLBACK": {
-      return { ...state, mode: "Login", isFallback: true }
+      return {
+        ...state,
+        mode: "Login",
+        isFallback: true,
+        values: { ...state.values, email: action.payload.email },
+      }
     }
 
     default: {

--- a/src/Components/AuthDialog/Views/AuthDialogWelcome.tsx
+++ b/src/Components/AuthDialog/Views/AuthDialogWelcome.tsx
@@ -54,7 +54,7 @@ export const AuthDialogWelcome: FC<
           dispatch({ type: "MODE", payload: { mode } })
         } catch (error) {
           console.error(error)
-          dispatch({ type: "FALLBACK" })
+          dispatch({ type: "FALLBACK", payload: { email } })
         }
       }}
     >

--- a/src/Components/AuthDialog/__tests__/AuthDialogContext.jest.ts
+++ b/src/Components/AuthDialog/__tests__/AuthDialogContext.jest.ts
@@ -1,0 +1,18 @@
+import { INITIAL_STATE, reducer } from "Components/AuthDialog/AuthDialogContext"
+
+describe("AuthDialogContext", () => {
+  describe("FALLBACK", () => {
+    it("retains the submitted email when falling back to login", () => {
+      const state = reducer(INITIAL_STATE, {
+        type: "FALLBACK",
+        payload: { email: "example@example.com" },
+      })
+
+      expect(state).toMatchObject({
+        mode: "Login",
+        isFallback: true,
+        values: { email: "example@example.com" },
+      })
+    })
+  })
+})


### PR DESCRIPTION
Re: https://artsy.slack.com/archives/CP9P4KR35/p1782322569401259

When recaptcha failed we would fallback to login mode, but not preserve the email in the state which left the button disabled since it wasn't a valid payload. This fixes that.

cc @artsy/diamond-devs 