### PR TITLE
feat(EMI-3174): create offer history component

### DIFF
--- a/src/Apps/Order2/Routes/Respond/Components/Order2OfferHistory.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/Order2OfferHistory.tsx
@@ -1,0 +1,86 @@
+import { Box, Expandable, Flex, Text } from "@artsy/palette"
+import { SectionHeading } from "Apps/Order2/Components/SectionHeading"
+import type { Order2OfferHistory_order$key } from "__generated__/Order2OfferHistory_order.graphql"
+import { graphql, useFragment } from "react-relay"
+
+interface Order2OfferHistoryProps {
+  order: Order2OfferHistory_order$key
+}
+
+// Relative column widths: date · source · offer · incl. shipping & taxes
+const COLUMNS = [1.3, 0.8, 1, 1.7]
+
+const sourceLabel = (fromParticipant: string) => {
+  return fromParticipant === "SELLER" ? "Gallery" : "You"
+}
+
+export const Order2OfferHistory: React.FC<Order2OfferHistoryProps> = ({
+  order,
+}) => {
+  const { submittedOffers } = useFragment(FRAGMENT, order)
+
+  if (!submittedOffers || submittedOffers.length === 0) {
+    return null
+  }
+
+  return (
+    <Box backgroundColor="mono0" py={2} px={[2, 2, 4]}>
+      <Expandable
+        label={<SectionHeading>Offer history</SectionHeading>}
+        borderColor="transparent"
+        backgroundColor="mono0"
+      >
+        <Flex justifyContent="flex-end" mb={1}>
+          <Text variant="xs">Incl. shipping &amp; taxes</Text>
+        </Flex>
+
+        {submittedOffers.map(offer => {
+          const isSeller = offer.fromParticipant === "SELLER"
+          return (
+            <Flex
+              key={offer.internalID}
+              mt={1}
+              backgroundColor={isSeller ? "mono0" : "mono5"}
+            >
+              <Box flex={COLUMNS[0]}>
+                <Text variant="sm" justifySelf="flex-start">
+                  {offer.createdAt}
+                </Text>
+              </Box>
+              <Box flex={COLUMNS[1]}>
+                <Text variant="sm">{sourceLabel(offer.fromParticipant)}</Text>
+              </Box>
+              <Box flex={COLUMNS[2]}>
+                <Text variant="sm" justifySelf="flex-start">
+                  {offer.amount?.display}
+                </Text>
+              </Box>
+              <Box flex={COLUMNS[3]}>
+                {/* buyerTotal is undefined for incomplete (original) offers */}
+                <Text variant="sm" justifySelf="flex-end">
+                  {offer.buyerTotal?.display ?? "INCOMPLETE ORDER"}
+                </Text>
+              </Box>
+            </Flex>
+          )
+        })}
+      </Expandable>
+    </Box>
+  )
+}
+
+const FRAGMENT = graphql`
+  fragment Order2OfferHistory_order on Order {
+    submittedOffers {
+      internalID
+      createdAt(format: "MMMM D, YYYY")
+      fromParticipant
+      amount {
+        display
+      }
+      buyerTotal {
+        display
+      }
+    }
+  }
+`

--- a/src/Apps/Order2/Routes/Respond/Components/Order2OfferHistory.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/Order2OfferHistory.tsx
@@ -11,7 +11,14 @@ interface Order2OfferHistoryProps {
 const COLUMNS = [1, 1, 2, 1]
 
 const sourceLabel = (fromParticipant: string) => {
-  return fromParticipant === "SELLER" ? "Gallery" : "You"
+  switch (fromParticipant) {
+    case "SELLER":
+      return "Gallery"
+    case "BUYER":
+      return "You"
+    default:
+      return "Unknown"
+  }
 }
 
 export const Order2OfferHistory: React.FC<Order2OfferHistoryProps> = ({

--- a/src/Apps/Order2/Routes/Respond/Components/Order2OfferHistory.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/Order2OfferHistory.tsx
@@ -52,24 +52,26 @@ export const Order2OfferHistory: React.FC<Order2OfferHistoryProps> = ({
                 backgroundColor={isSeller ? "mono0" : "mono5"}
               >
                 <Box flex={COLUMNS[0]}>
-                  <Text variant="sm" justifySelf="flex-start">
+                  <Text variant={["xs", "sm"]} justifySelf="flex-start">
                     {offer.createdAt}
                   </Text>
                 </Box>
                 <Box flex={COLUMNS[1]}>
-                  <Text variant="sm">{sourceLabel(offer.fromParticipant)}</Text>
+                  <Text variant={["xs", "sm"]}>
+                    {sourceLabel(offer.fromParticipant)}
+                  </Text>
                 </Box>
                 <Box flex={COLUMNS[2]}>
-                  <Text variant="sm" justifySelf="flex-start">
+                  <Text variant={["xs", "sm"]} justifySelf="flex-start">
                     {offer.amount?.display}
                   </Text>
                 </Box>
-<Box flex={COLUMNS[3]} textAlign="right">
-  {/* buyerTotal is undefined for incomplete (original) offers */}
-  <Text variant="sm">
-    {offer.buyerTotal?.display ?? "INCOMPLETE ORDER"}
-  </Text>
-</Box>
+                <Box flex={COLUMNS[3]} textAlign="right">
+                  {/* buyerTotal is undefined for incomplete (original) offers */}
+                  <Text variant={["xs", "sm"]}>
+                    {offer.buyerTotal?.display ?? "INCOMPLETE ORDER"}
+                  </Text>
+                </Box>
               </Flex>
             )
           })}

--- a/src/Apps/Order2/Routes/Respond/Components/Order2OfferHistory.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/Order2OfferHistory.tsx
@@ -8,7 +8,7 @@ interface Order2OfferHistoryProps {
 }
 
 // Relative column widths: date · source · offer · incl. shipping & taxes
-const COLUMNS = [1.3, 0.8, 1, 1.7]
+const COLUMNS = [1, 1, 2, 1]
 
 const sourceLabel = (fromParticipant: string) => {
   return fromParticipant === "SELLER" ? "Gallery" : "You"
@@ -24,46 +24,49 @@ export const Order2OfferHistory: React.FC<Order2OfferHistoryProps> = ({
   }
 
   return (
-    <Box backgroundColor="mono0" py={2} px={[2, 2, 4]}>
+    <Box backgroundColor="mono0" px={[2, 2, 4]}>
       <Expandable
         label={<SectionHeading>Offer history</SectionHeading>}
         borderColor="transparent"
         backgroundColor="mono0"
+        pb={1}
       >
         <Flex justifyContent="flex-end" mb={1}>
           <Text variant="xs">Incl. shipping &amp; taxes</Text>
         </Flex>
 
-        {submittedOffers.map(offer => {
-          const isSeller = offer.fromParticipant === "SELLER"
-          return (
-            <Flex
-              key={offer.internalID}
-              mt={1}
-              backgroundColor={isSeller ? "mono0" : "mono5"}
-            >
-              <Box flex={COLUMNS[0]}>
-                <Text variant="sm" justifySelf="flex-start">
-                  {offer.createdAt}
-                </Text>
-              </Box>
-              <Box flex={COLUMNS[1]}>
-                <Text variant="sm">{sourceLabel(offer.fromParticipant)}</Text>
-              </Box>
-              <Box flex={COLUMNS[2]}>
-                <Text variant="sm" justifySelf="flex-start">
-                  {offer.amount?.display}
-                </Text>
-              </Box>
-              <Box flex={COLUMNS[3]}>
-                {/* buyerTotal is undefined for incomplete (original) offers */}
-                <Text variant="sm" justifySelf="flex-end">
-                  {offer.buyerTotal?.display ?? "INCOMPLETE ORDER"}
-                </Text>
-              </Box>
-            </Flex>
-          )
-        })}
+        <Box pb={1}>
+          {submittedOffers.map(offer => {
+            const isSeller = offer.fromParticipant === "SELLER"
+            return (
+              <Flex
+                key={offer.internalID}
+                mt={1}
+                backgroundColor={isSeller ? "mono0" : "mono5"}
+              >
+                <Box flex={COLUMNS[0]}>
+                  <Text variant="sm" justifySelf="flex-start">
+                    {offer.createdAt}
+                  </Text>
+                </Box>
+                <Box flex={COLUMNS[1]}>
+                  <Text variant="sm">{sourceLabel(offer.fromParticipant)}</Text>
+                </Box>
+                <Box flex={COLUMNS[2]}>
+                  <Text variant="sm" justifySelf="flex-start">
+                    {offer.amount?.display}
+                  </Text>
+                </Box>
+                <Box flex={COLUMNS[3]}>
+                  {/* buyerTotal is undefined for incomplete (original) offers */}
+                  <Text variant="sm" justifySelf="flex-end">
+                    {offer.buyerTotal?.display ?? "INCOMPLETE ORDER"}
+                  </Text>
+                </Box>
+              </Flex>
+            )
+          })}
+        </Box>
       </Expandable>
     </Box>
   )

--- a/src/Apps/Order2/Routes/Respond/Components/Order2OfferHistory.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/Order2OfferHistory.tsx
@@ -64,12 +64,12 @@ export const Order2OfferHistory: React.FC<Order2OfferHistoryProps> = ({
                     {offer.amount?.display}
                   </Text>
                 </Box>
-                <Box flex={COLUMNS[3]}>
-                  {/* buyerTotal is undefined for incomplete (original) offers */}
-                  <Text variant="sm" justifySelf="flex-end">
-                    {offer.buyerTotal?.display ?? "INCOMPLETE ORDER"}
-                  </Text>
-                </Box>
+<Box flex={COLUMNS[3]} textAlign="right">
+  {/* buyerTotal is undefined for incomplete (original) offers */}
+  <Text variant="sm">
+    {offer.buyerTotal?.display ?? "INCOMPLETE ORDER"}
+  </Text>
+</Box>
               </Flex>
             )
           })}

--- a/src/Apps/Order2/Routes/Respond/Components/__tests__/Order2OfferHistory.jest.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/__tests__/Order2OfferHistory.jest.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, screen } from "@testing-library/react"
+import { Order2OfferHistory } from "Apps/Order2/Routes/Respond/Components/Order2OfferHistory"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
+import type { Order2OfferHistoryTestQuery } from "__generated__/Order2OfferHistoryTestQuery.graphql"
+import { graphql } from "react-relay"
+
+jest.unmock("react-relay")
+
+const { renderWithRelay } = setupTestWrapperTL<Order2OfferHistoryTestQuery>({
+  Component: (props: any) => {
+    return <Order2OfferHistory order={props.me.order} />
+  },
+  query: graphql`
+    query Order2OfferHistoryTestQuery @relay_test_operation {
+      me {
+        order(id: "order-id") {
+          ...Order2OfferHistory_order
+        }
+      }
+    }
+  `,
+})
+
+// A gallery offer (complete) + a buyer offer with no buyerTotal (incomplete).
+const withOffers = {
+  Order: () => ({
+    submittedOffers: [
+      {
+        internalID: "offer-1",
+        createdAt: "January 1, 2026",
+        fromParticipant: "SELLER",
+        amount: { display: "$1,000" },
+        buyerTotal: { display: "$1,100" },
+      },
+      {
+        internalID: "offer-2",
+        createdAt: "January 2, 2026",
+        fromParticipant: "BUYER",
+        amount: { display: "$900" },
+        buyerTotal: null,
+      },
+    ],
+  }),
+}
+
+describe("Order2OfferHistory", () => {
+  it("renders the 'Offer history' expandable", () => {
+    renderWithRelay(withOffers)
+
+    expect(screen.getByText("Offer history")).toBeInTheDocument()
+  })
+
+  it("renders a row per submitted offer with date, source, offer and total", () => {
+    renderWithRelay(withOffers)
+    fireEvent.click(screen.getByText("Offer history"))
+
+    // Gallery (seller) offer
+    expect(screen.getByText("January 1, 2026")).toBeInTheDocument()
+    expect(screen.getByText("Gallery")).toBeInTheDocument()
+    expect(screen.getByText("$1,000")).toBeInTheDocument()
+    expect(screen.getByText("$1,100")).toBeInTheDocument()
+
+    // Buyer ("You") offer
+    expect(screen.getByText("January 2, 2026")).toBeInTheDocument()
+    expect(screen.getByText("You")).toBeInTheDocument()
+    expect(screen.getByText("$900")).toBeInTheDocument()
+  })
+
+  it("shows INCOMPLETE ORDER when an offer has no buyerTotal", () => {
+    renderWithRelay(withOffers)
+    fireEvent.click(screen.getByText("Offer history"))
+
+    expect(screen.getByText("INCOMPLETE ORDER")).toBeInTheDocument()
+  })
+
+  it("renders nothing when there are no submitted offers", () => {
+    renderWithRelay({ Order: () => ({ submittedOffers: [] }) })
+
+    expect(screen.queryByText("Offer history")).not.toBeInTheDocument()
+  })
+})

--- a/src/Apps/Order2/Routes/Respond/Order2RespondApp.tsx
+++ b/src/Apps/Order2/Routes/Respond/Order2RespondApp.tsx
@@ -10,6 +10,7 @@ import {
 import { OrderErrorApp } from "Apps/Order2/Components/Order2ErrorApp"
 import { Order2HelpLinksWithInquiry } from "Apps/Order2/Components/Order2HelpLinks"
 import { Order2CollapsibleOrderSummary } from "Apps/Order2/Routes/Checkout/Components/Order2CollapsibleOrderSummary"
+import { Order2OfferHistory } from "Apps/Order2/Routes/Respond/Components/Order2OfferHistory"
 import { Order2RespondSummary } from "Apps/Order2/Routes/Respond/Components/Order2RespondSummary"
 import { useRespondContext } from "Apps/Order2/Routes/Respond/Hooks/useRespondContext"
 import { NOT_FOUND_ERROR } from "Apps/Order2/constants"
@@ -59,6 +60,8 @@ export const Order2RespondApp: React.FC<Order2RespondAppProps> = ({
             </Box>
             <Spacer y={2} />
             <Box>{/* Respond form will go here */}</Box>
+            <Spacer y={2} />
+            <Order2OfferHistory order={orderData} />
           </Box>
         </Column>
 
@@ -95,6 +98,7 @@ const ORDER_FRAGMENT = graphql`
     }
     ...Order2CollapsibleOrderSummary_order
     ...Order2RespondSummary_order
+    ...Order2OfferHistory_order
     ...Order2HelpLinks_order
   }
 `

--- a/src/__generated__/Order2OfferHistoryTestQuery.graphql.ts
+++ b/src/__generated__/Order2OfferHistoryTestQuery.graphql.ts
@@ -1,0 +1,249 @@
+/**
+ * @generated SignedSource<<61c89ffcdb7ba5663e3df9ad28968dff>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type Order2OfferHistoryTestQuery$variables = Record<PropertyKey, never>;
+export type Order2OfferHistoryTestQuery$data = {
+  readonly me: {
+    readonly order: {
+      readonly " $fragmentSpreads": FragmentRefs<"Order2OfferHistory_order">;
+    } | null | undefined;
+  } | null | undefined;
+};
+export type Order2OfferHistoryTestQuery = {
+  response: Order2OfferHistoryTestQuery$data;
+  variables: Order2OfferHistoryTestQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "order-id"
+  }
+],
+v1 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v4 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "Money"
+},
+v5 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "Order2OfferHistoryTestQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": (v0/*: any*/),
+            "concreteType": "Order",
+            "kind": "LinkedField",
+            "name": "order",
+            "plural": false,
+            "selections": [
+              {
+                "args": null,
+                "kind": "FragmentSpread",
+                "name": "Order2OfferHistory_order"
+              }
+            ],
+            "storageKey": "order(id:\"order-id\")"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "Order2OfferHistoryTestQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": null,
+        "concreteType": "Me",
+        "kind": "LinkedField",
+        "name": "me",
+        "plural": false,
+        "selections": [
+          {
+            "alias": null,
+            "args": (v0/*: any*/),
+            "concreteType": "Order",
+            "kind": "LinkedField",
+            "name": "order",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Offer",
+                "kind": "LinkedField",
+                "name": "submittedOffers",
+                "plural": true,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "internalID",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "format",
+                        "value": "MMMM D, YYYY"
+                      }
+                    ],
+                    "kind": "ScalarField",
+                    "name": "createdAt",
+                    "storageKey": "createdAt(format:\"MMMM D, YYYY\")"
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "fromParticipant",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Money",
+                    "kind": "LinkedField",
+                    "name": "amount",
+                    "plural": false,
+                    "selections": (v1/*: any*/),
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Money",
+                    "kind": "LinkedField",
+                    "name": "buyerTotal",
+                    "plural": false,
+                    "selections": (v1/*: any*/),
+                    "storageKey": null
+                  },
+                  (v2/*: any*/)
+                ],
+                "storageKey": null
+              },
+              (v2/*: any*/)
+            ],
+            "storageKey": "order(id:\"order-id\")"
+          },
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "2eb87e7f2857c3fbf15a149ea5a44f41",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "me": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Me"
+        },
+        "me.id": (v3/*: any*/),
+        "me.order": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Order"
+        },
+        "me.order.id": (v3/*: any*/),
+        "me.order.submittedOffers": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": true,
+          "type": "Offer"
+        },
+        "me.order.submittedOffers.amount": (v4/*: any*/),
+        "me.order.submittedOffers.amount.display": (v5/*: any*/),
+        "me.order.submittedOffers.buyerTotal": (v4/*: any*/),
+        "me.order.submittedOffers.buyerTotal.display": (v5/*: any*/),
+        "me.order.submittedOffers.createdAt": (v5/*: any*/),
+        "me.order.submittedOffers.fromParticipant": {
+          "enumValues": [
+            "BUYER",
+            "SELLER"
+          ],
+          "nullable": false,
+          "plural": false,
+          "type": "FromParticipantEnum"
+        },
+        "me.order.submittedOffers.id": (v3/*: any*/),
+        "me.order.submittedOffers.internalID": (v3/*: any*/)
+      }
+    },
+    "name": "Order2OfferHistoryTestQuery",
+    "operationKind": "query",
+    "text": "query Order2OfferHistoryTestQuery {\n  me {\n    order(id: \"order-id\") {\n      ...Order2OfferHistory_order\n      id\n    }\n    id\n  }\n}\n\nfragment Order2OfferHistory_order on Order {\n  submittedOffers {\n    internalID\n    createdAt(format: \"MMMM D, YYYY\")\n    fromParticipant\n    amount {\n      display\n    }\n    buyerTotal {\n      display\n    }\n    id\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "e85acb333009d768358f35137f91b547";
+
+export default node;

--- a/src/__generated__/Order2OfferHistory_order.graphql.ts
+++ b/src/__generated__/Order2OfferHistory_order.graphql.ts
@@ -1,0 +1,115 @@
+/**
+ * @generated SignedSource<<9b813b3add881acc57525872e59cf295>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+export type FromParticipantEnum = "BUYER" | "SELLER" | "%future added value";
+import { FragmentRefs } from "relay-runtime";
+export type Order2OfferHistory_order$data = {
+  readonly submittedOffers: ReadonlyArray<{
+    readonly amount: {
+      readonly display: string | null | undefined;
+    } | null | undefined;
+    readonly buyerTotal: {
+      readonly display: string | null | undefined;
+    } | null | undefined;
+    readonly createdAt: string | null | undefined;
+    readonly fromParticipant: FromParticipantEnum;
+    readonly internalID: string;
+  }>;
+  readonly " $fragmentType": "Order2OfferHistory_order";
+};
+export type Order2OfferHistory_order$key = {
+  readonly " $data"?: Order2OfferHistory_order$data;
+  readonly " $fragmentSpreads": FragmentRefs<"Order2OfferHistory_order">;
+};
+
+const node: ReaderFragment = (function(){
+var v0 = [
+  {
+    "alias": null,
+    "args": null,
+    "kind": "ScalarField",
+    "name": "display",
+    "storageKey": null
+  }
+];
+return {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "Order2OfferHistory_order",
+  "selections": [
+    {
+      "alias": null,
+      "args": null,
+      "concreteType": "Offer",
+      "kind": "LinkedField",
+      "name": "submittedOffers",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "internalID",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": [
+            {
+              "kind": "Literal",
+              "name": "format",
+              "value": "MMMM D, YYYY"
+            }
+          ],
+          "kind": "ScalarField",
+          "name": "createdAt",
+          "storageKey": "createdAt(format:\"MMMM D, YYYY\")"
+        },
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "fromParticipant",
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Money",
+          "kind": "LinkedField",
+          "name": "amount",
+          "plural": false,
+          "selections": (v0/*: any*/),
+          "storageKey": null
+        },
+        {
+          "alias": null,
+          "args": null,
+          "concreteType": "Money",
+          "kind": "LinkedField",
+          "name": "buyerTotal",
+          "plural": false,
+          "selections": (v0/*: any*/),
+          "storageKey": null
+        }
+      ],
+      "storageKey": null
+    }
+  ],
+  "type": "Order",
+  "abstractKey": null
+};
+})();
+
+(node as any).hash = "11143a85ed0421ef17cdbe210c8c99ae";
+
+export default node;

--- a/src/__generated__/Order2RespondApp_order.graphql.ts
+++ b/src/__generated__/Order2RespondApp_order.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<a21f8b6dffd0edeb6f473767cc4595eb>>
+ * @generated SignedSource<<0c6cc7095430a28b74046e9bd11ab044>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -19,7 +19,7 @@ export type Order2RespondApp_order$data = {
     } | null | undefined;
   } | null | undefined>;
   readonly mode: OrderModeEnum;
-  readonly " $fragmentSpreads": FragmentRefs<"Order2CollapsibleOrderSummary_order" | "Order2HelpLinks_order" | "Order2RespondSummary_order">;
+  readonly " $fragmentSpreads": FragmentRefs<"Order2CollapsibleOrderSummary_order" | "Order2HelpLinks_order" | "Order2OfferHistory_order" | "Order2RespondSummary_order">;
   readonly " $fragmentType": "Order2RespondApp_order";
 };
 export type Order2RespondApp_order$key = {
@@ -89,6 +89,11 @@ const node: ReaderFragment = {
     {
       "args": null,
       "kind": "FragmentSpread",
+      "name": "Order2OfferHistory_order"
+    },
+    {
+      "args": null,
+      "kind": "FragmentSpread",
       "name": "Order2HelpLinks_order"
     }
   ],
@@ -96,6 +101,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "aafa6d84f4f57897a358341ab8b34908";
+(node as any).hash = "8257003f6e8f057d99e01ef621243f17";
 
 export default node;

--- a/src/__generated__/order2Routes_RespondQuery.graphql.ts
+++ b/src/__generated__/order2Routes_RespondQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<c3a9394b8dbe7a7691c7cf5648c3d615>>
+ * @generated SignedSource<<5fa1498046785257bd76804a83bfdc37>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -209,6 +209,16 @@ v18 = [
 v19 = {
   "alias": null,
   "args": null,
+  "concreteType": "Money",
+  "kind": "LinkedField",
+  "name": "amount",
+  "plural": false,
+  "selections": (v18/*: any*/),
+  "storageKey": null
+},
+v20 = {
+  "alias": null,
+  "args": null,
   "concreteType": null,
   "kind": "LinkedField",
   "name": "pricingBreakdownLines",
@@ -241,21 +251,22 @@ v19 = {
       "selections": [
         (v14/*: any*/),
         (v15/*: any*/),
-        {
-          "alias": null,
-          "args": null,
-          "concreteType": "Money",
-          "kind": "LinkedField",
-          "name": "amount",
-          "plural": false,
-          "selections": (v18/*: any*/),
-          "storageKey": null
-        }
+        (v19/*: any*/)
       ],
       "type": "TotalLine",
       "abstractKey": null
     }
   ],
+  "storageKey": null
+},
+v21 = {
+  "alias": null,
+  "args": null,
+  "concreteType": "Money",
+  "kind": "LinkedField",
+  "name": "buyerTotal",
+  "plural": false,
+  "selections": (v18/*: any*/),
   "storageKey": null
 };
 return {
@@ -536,7 +547,7 @@ return {
                     "name": "buyerStateExpiresAt",
                     "storageKey": null
                   },
-                  (v19/*: any*/),
+                  (v20/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -545,21 +556,12 @@ return {
                     "name": "pendingOffer",
                     "plural": false,
                     "selections": [
-                      (v19/*: any*/),
+                      (v20/*: any*/),
                       (v5/*: any*/)
                     ],
                     "storageKey": null
                   },
-                  {
-                    "alias": null,
-                    "args": null,
-                    "concreteType": "Money",
-                    "kind": "LinkedField",
-                    "name": "buyerTotal",
-                    "plural": false,
-                    "selections": (v18/*: any*/),
-                    "storageKey": null
-                  },
+                  (v21/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -589,6 +591,41 @@ return {
                     "plural": false,
                     "selections": (v18/*: any*/),
                     "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "concreteType": "Offer",
+                    "kind": "LinkedField",
+                    "name": "submittedOffers",
+                    "plural": true,
+                    "selections": [
+                      (v2/*: any*/),
+                      {
+                        "alias": null,
+                        "args": [
+                          {
+                            "kind": "Literal",
+                            "name": "format",
+                            "value": "MMMM D, YYYY"
+                          }
+                        ],
+                        "kind": "ScalarField",
+                        "name": "createdAt",
+                        "storageKey": "createdAt(format:\"MMMM D, YYYY\")"
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "fromParticipant",
+                        "storageKey": null
+                      },
+                      (v19/*: any*/),
+                      (v21/*: any*/),
+                      (v5/*: any*/)
+                    ],
+                    "storageKey": null
                   }
                 ],
                 "storageKey": null
@@ -603,12 +640,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "107ff698b239424030edad8e872e5d93",
+    "cacheID": "86207d01ea97fdf2c594289c3645ebeb",
     "id": null,
     "metadata": {},
     "name": "order2Routes_RespondQuery",
     "operationKind": "query",
-    "text": "query order2Routes_RespondQuery(\n  $orderID: ID!\n) {\n  viewer {\n    me {\n      order(id: $orderID) {\n        internalID\n        mode\n        buyerState\n        id\n      }\n      id\n    }\n    ...Order2RespondRoute_viewer_3HPek8\n  }\n}\n\nfragment Order2CheckoutPricingBreakdown_order on Order {\n  source\n  mode\n  buyerStateExpiresAt\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n  pendingOffer {\n    pricingBreakdownLines {\n      __typename\n      ... on ShippingLine {\n        displayName\n        amountFallbackText\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on TaxLine {\n        displayName\n        amountFallbackText\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on SubtotalLine {\n        displayName\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on TotalLine {\n        displayName\n        amountFallbackText\n        amount {\n          display\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Order2CollapsibleOrderSummary_order on Order {\n  ...Order2CheckoutPricingBreakdown_order\n  source\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artworkVersion {\n      title\n      artistNames\n      date\n      thumbnail: image {\n        url\n        resizedSquare: resized(height: 200, version: [\"square\"]) {\n          url\n        }\n      }\n      id\n    }\n    artwork {\n      internalID\n      figures(includeAll: false) {\n        __typename\n        ... on Image {\n          resizedSquare: resized(height: 200, version: [\"square\"]) {\n            url\n          }\n        }\n        ... on Video {\n          id\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment Order2HelpLinks_order on Order {\n  internalID\n  mode\n  source\n}\n\nfragment Order2RespondApp_order on Order {\n  internalID\n  mode\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    id\n  }\n  ...Order2CollapsibleOrderSummary_order\n  ...Order2RespondSummary_order\n  ...Order2HelpLinks_order\n}\n\nfragment Order2RespondContext_order on Order {\n  internalID\n  source\n  mode\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    id\n  }\n}\n\nfragment Order2RespondRoute_viewer_3HPek8 on Viewer {\n  me {\n    order(id: $orderID) {\n      internalID\n      ...Order2RespondContext_order\n      ...Order2RespondApp_order\n      id\n    }\n    id\n  }\n}\n\nfragment Order2RespondSummary_order on Order {\n  ...Order2CheckoutPricingBreakdown_order\n  lineItems {\n    artworkVersion {\n      artistNames\n      title\n      date\n      image {\n        resized(height: 200) {\n          url\n        }\n      }\n      id\n    }\n    artwork {\n      internalID\n      price\n      attributionClass {\n        shortDescription\n        id\n      }\n      dimensions {\n        in\n        cm\n      }\n      framedDimensions {\n        in\n        cm\n      }\n      images(includeAll: false) {\n        resized(height: 200) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n}\n"
+    "text": "query order2Routes_RespondQuery(\n  $orderID: ID!\n) {\n  viewer {\n    me {\n      order(id: $orderID) {\n        internalID\n        mode\n        buyerState\n        id\n      }\n      id\n    }\n    ...Order2RespondRoute_viewer_3HPek8\n  }\n}\n\nfragment Order2CheckoutPricingBreakdown_order on Order {\n  source\n  mode\n  buyerStateExpiresAt\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n  pendingOffer {\n    pricingBreakdownLines {\n      __typename\n      ... on ShippingLine {\n        displayName\n        amountFallbackText\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on TaxLine {\n        displayName\n        amountFallbackText\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on SubtotalLine {\n        displayName\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on TotalLine {\n        displayName\n        amountFallbackText\n        amount {\n          display\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Order2CollapsibleOrderSummary_order on Order {\n  ...Order2CheckoutPricingBreakdown_order\n  source\n  buyerTotal {\n    display\n  }\n  itemsTotal {\n    display\n  }\n  shippingTotal {\n    display\n  }\n  taxTotal {\n    display\n  }\n  lineItems {\n    artworkVersion {\n      title\n      artistNames\n      date\n      thumbnail: image {\n        url\n        resizedSquare: resized(height: 200, version: [\"square\"]) {\n          url\n        }\n      }\n      id\n    }\n    artwork {\n      internalID\n      figures(includeAll: false) {\n        __typename\n        ... on Image {\n          resizedSquare: resized(height: 200, version: [\"square\"]) {\n            url\n          }\n        }\n        ... on Video {\n          id\n        }\n      }\n      id\n    }\n    id\n  }\n}\n\nfragment Order2HelpLinks_order on Order {\n  internalID\n  mode\n  source\n}\n\nfragment Order2OfferHistory_order on Order {\n  submittedOffers {\n    internalID\n    createdAt(format: \"MMMM D, YYYY\")\n    fromParticipant\n    amount {\n      display\n    }\n    buyerTotal {\n      display\n    }\n    id\n  }\n}\n\nfragment Order2RespondApp_order on Order {\n  internalID\n  mode\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    id\n  }\n  ...Order2CollapsibleOrderSummary_order\n  ...Order2RespondSummary_order\n  ...Order2OfferHistory_order\n  ...Order2HelpLinks_order\n}\n\nfragment Order2RespondContext_order on Order {\n  internalID\n  source\n  mode\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    id\n  }\n}\n\nfragment Order2RespondRoute_viewer_3HPek8 on Viewer {\n  me {\n    order(id: $orderID) {\n      internalID\n      ...Order2RespondContext_order\n      ...Order2RespondApp_order\n      id\n    }\n    id\n  }\n}\n\nfragment Order2RespondSummary_order on Order {\n  ...Order2CheckoutPricingBreakdown_order\n  lineItems {\n    artworkVersion {\n      artistNames\n      title\n      date\n      image {\n        resized(height: 200) {\n          url\n        }\n      }\n      id\n    }\n    artwork {\n      internalID\n      price\n      attributionClass {\n        shortDescription\n        id\n      }\n      dimensions {\n        in\n        cm\n      }\n      framedDimensions {\n        in\n        cm\n      }\n      images(includeAll: false) {\n        resized(height: 200) {\n          url\n        }\n      }\n      id\n    }\n    id\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-3174]

### Description

<!-- Implementation description -->

Adds an "Offer history" expandable (Palette Expandable, toggle arrow) to the respond/counteroffer page so a collector can review the full negotiation.

Renders only when there are submitted offers

⚠️ Note - **incomplete offers**: `buyerTotal` (the offer total incl. shipping & taxes) is not defined for incomplete/original offers. Shipping & taxes can't be computed until the order is further along. For those rows the last column renders **"INCOMPLETE ORDER"** instead of an amount. The bare offer amount is still shown. So an offer history can legitimately contain a mix of complete rows (with a total) and incomplete rows (without). I will raise it during the QA or earlier to confirm the approach and/or copy.

| Web folded | Web expanded | Mobile expanded |
| --- | --- | --- |
| <img width="1510" height="673" alt="image" src="https://github.com/user-attachments/assets/1c3dfea3-8826-46e3-9bcf-c43bbb695279" /> | <img width="758" height="350" alt="image" src="https://github.com/user-attachments/assets/65cfc5bc-50c1-441f-92be-e183f070cc01" /> | <img width="408" height="695" alt="image" src="https://github.com/user-attachments/assets/232eee38-a505-4446-a397-1d58ed0480d0" /> |


[EMI-3174]: https://artsyproduct.atlassian.net/browse/EMI-3174?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ