### PR TITLE
fix: hide one tap for auth dialog, don't steal focus

### DIFF
--- a/src/Utils/GoogleOneTapContainer.tsx
+++ b/src/Utils/GoogleOneTapContainer.tsx
@@ -1,5 +1,6 @@
 import { useToasts } from "@artsy/palette"
 import { useFlag } from "@unleash/proxy-client-react"
+import { useAuthDialogContext } from "Components/AuthDialog/AuthDialogContext"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import { AUTH_ERROR_CODES } from "Utils/authConstants"
 import { getENV } from "Utils/getENV"
@@ -18,17 +19,29 @@ const AUTH_PATHS = [
 const isAuthPath = (pathname: string) =>
   AUTH_PATHS.some(path => pathname.startsWith(path))
 
+const isInputFocused = () => {
+  const el = document.activeElement
+  return (
+    el instanceof HTMLInputElement ||
+    el instanceof HTMLTextAreaElement ||
+    el instanceof HTMLSelectElement ||
+    (el instanceof HTMLElement && el.isContentEditable)
+  )
+}
+
 export const GoogleOneTapContainer = () => {
   const { isLoggedIn } = useSystemContext()
   const isGoogleOneTapEnabled = !!useFlag("diamond_google-one-tap")
   const googleClientId = getENV("GOOGLE_CLIENT_ID")
   const { sendToast } = useToasts()
+  const { state: authDialogState } = useAuthDialogContext()
 
   const enabled =
     !isLoggedIn &&
     isGoogleOneTapEnabled &&
     !!googleClientId &&
-    !isAuthPath(window.location.pathname)
+    !isAuthPath(window.location.pathname) &&
+    !authDialogState.isVisible
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search)
@@ -47,6 +60,12 @@ export const GoogleOneTapContainer = () => {
   }, [sendToast])
 
   useEffect(() => {
+    if (!authDialogState.isVisible)
+      return // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(window as any).google?.accounts?.id?.cancel?.()
+  }, [authDialogState.isVisible])
+
+  useEffect(() => {
     if (!enabled) {
       return
     }
@@ -55,12 +74,25 @@ export const GoogleOneTapContainer = () => {
       return
     }
 
-    const script = document.createElement("script")
-    script.id = "google-one-tap-script"
-    script.src = "https://accounts.google.com/gsi/client"
-    script.async = true
-    script.defer = true
-    document.body.appendChild(script)
+    const appendScript = () => {
+      const script = document.createElement("script")
+      script.id = "google-one-tap-script"
+      script.src = "https://accounts.google.com/gsi/client"
+      script.async = true
+      script.defer = true
+      document.body.appendChild(script)
+    }
+
+    if (isInputFocused()) {
+      const handleFocusOut = () => {
+        document.removeEventListener("focusout", handleFocusOut)
+        appendScript()
+      }
+      document.addEventListener("focusout", handleFocusOut)
+      return () => document.removeEventListener("focusout", handleFocusOut)
+    }
+
+    appendScript()
   }, [enabled])
 
   if (!enabled) {

--- a/src/Utils/__tests__/GoogleOneTapContainer.jest.tsx
+++ b/src/Utils/__tests__/GoogleOneTapContainer.jest.tsx
@@ -1,6 +1,7 @@
-import { render } from "@testing-library/react"
+import { act, render } from "@testing-library/react"
 import { useToasts } from "@artsy/palette"
 import { useFlag } from "@unleash/proxy-client-react"
+import { useAuthDialogContext } from "Components/AuthDialog/AuthDialogContext"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import { GoogleOneTapContainer } from "Utils/GoogleOneTapContainer"
 import { getENV } from "Utils/getENV"
@@ -28,15 +29,21 @@ jest.mock("System/Hooks/useSystemContext", () => ({
   useSystemContext: jest.fn(),
 }))
 
+jest.mock("Components/AuthDialog/AuthDialogContext", () => ({
+  useAuthDialogContext: jest.fn(),
+}))
+
 describe("GoogleOneTapContainer", () => {
   const mockUseFlag = useFlag as jest.Mock
   const mockGetENV = getENV as jest.Mock
   const mockUseSystemContext = useSystemContext as jest.Mock
   const mockUseToasts = useToasts as jest.Mock
+  const mockUseAuthDialogContext = useAuthDialogContext as jest.Mock
 
   const enableOneTap = () => {
     mockUseFlag.mockReturnValue(true)
     mockUseSystemContext.mockReturnValue({ isLoggedIn: false })
+    mockUseAuthDialogContext.mockReturnValue({ state: { isVisible: false } })
     mockGetENV.mockImplementation((key: string) => {
       if (key === "GOOGLE_CLIENT_ID") return "test-client-id"
       if (key === "APP_URL") return "https://artsy.net"
@@ -47,6 +54,7 @@ describe("GoogleOneTapContainer", () => {
   beforeEach(() => {
     mockUseFlag.mockReturnValue(false)
     mockUseSystemContext.mockReturnValue({ isLoggedIn: false })
+    mockUseAuthDialogContext.mockReturnValue({ state: { isVisible: false } })
     mockGetENV.mockReturnValue(null)
     mockCaptureException.mockClear()
     mockSendToast.mockClear()
@@ -138,6 +146,24 @@ describe("GoogleOneTapContainer", () => {
       expect(gsiScript()).toBeInTheDocument()
     })
 
+    it("defers script injection until the focused input is blurred", () => {
+      enableOneTap()
+
+      const input = document.createElement("input")
+      document.body.appendChild(input)
+      input.focus()
+
+      render(<GoogleOneTapContainer />)
+      expect(gsiScript()).not.toBeInTheDocument()
+
+      act(() => {
+        input.dispatchEvent(new FocusEvent("focusout", { bubbles: true }))
+      })
+
+      expect(gsiScript()).toBeInTheDocument()
+      input.remove()
+    })
+
     it("does not append script when feature flag is off", () => {
       mockUseFlag.mockReturnValue(false)
       mockUseSystemContext.mockReturnValue({ isLoggedIn: false })
@@ -160,6 +186,30 @@ describe("GoogleOneTapContainer", () => {
       mockGetENV.mockReturnValue("test-client-id")
       render(<GoogleOneTapContainer />)
       expect(gsiScript()).not.toBeInTheDocument()
+    })
+
+    it("does not append script when the auth dialog is open", () => {
+      enableOneTap()
+      mockUseAuthDialogContext.mockReturnValue({ state: { isVisible: true } })
+      render(<GoogleOneTapContainer />)
+      expect(gsiScript()).not.toBeInTheDocument()
+    })
+  })
+
+  describe("auth dialog interaction", () => {
+    it("cancels One Tap when the auth dialog opens", () => {
+      const mockCancel = jest.fn()
+      ;(window as any).google = { accounts: { id: { cancel: mockCancel } } }
+
+      enableOneTap()
+      const { rerender } = render(<GoogleOneTapContainer />)
+
+      mockUseAuthDialogContext.mockReturnValue({ state: { isVisible: true } })
+      rerender(<GoogleOneTapContainer />)
+
+      expect(mockCancel).toHaveBeenCalled()
+
+      delete (window as any).google
     })
   })
 


### PR DESCRIPTION

The type of this PR is: **Fix**


### Description

- checks if any input is focused and delays appending one tap div if so
- checks for auth dialog visibility when appending div and in useEffect to avoid showing one tap


Assisted-By: Claude <noreply@anthropic.com>
