### PR TITLE
fix: add error state for account link attempts with 2fa enabled

### DIFF
--- a/src/Components/AuthDialog/Views/AuthDialogLinkAccounts.tsx
+++ b/src/Components/AuthDialog/Views/AuthDialogLinkAccounts.tsx
@@ -11,14 +11,15 @@ import {
   Stack,
   Text,
 } from "@artsy/palette"
+import { useAuthDialogContext } from "Components/AuthDialog/AuthDialogContext"
 import { useAfterAuthentication } from "Components/AuthDialog/Hooks/useAfterAuthentication"
 import { formatErrorMessage } from "Components/AuthDialog/Utils/formatErrorMessage"
 import { useRouter } from "System/Hooks/useRouter"
-import { AUTH_PROVIDERS } from "Utils/authConstants"
 import { login } from "Utils/auth"
+import { AUTH_ERROR_CODES, AUTH_PROVIDERS } from "Utils/authConstants"
 import { getENV } from "Utils/getENV"
-import { stringify } from "qs"
 import { Form, Formik } from "formik"
+import { stringify } from "qs"
 import { type FC, useState } from "react"
 import * as Yup from "yup"
 
@@ -158,6 +159,7 @@ const PasswordForm: FC<PasswordFormProps> = ({
   onBack,
 }) => {
   const { runAfterAuthentication } = useAfterAuthentication()
+  const { dispatch } = useAuthDialogContext()
 
   return (
     <Formik
@@ -186,6 +188,17 @@ const PasswordForm: FC<PasswordFormProps> = ({
             runAfterAuthentication({ accessToken: res.user?.accessToken })
           }, 1500)
         } catch (err) {
+          if (
+            err.message === "missing two-factor authentication code" ||
+            err.message === "missing on-demand authentication code"
+          ) {
+            setFieldValue("mode", "TwoFactorBlocked")
+            setStatus({
+              error: AUTH_ERROR_CODES.TWO_FACTOR_AUTHENTICATION_ENABLED,
+            })
+            return
+          }
+
           setFieldValue("mode", "Error")
           setStatus({ error: formatErrorMessage(err) })
         }
@@ -240,16 +253,29 @@ const PasswordForm: FC<PasswordFormProps> = ({
               )}
 
               <Stack gap={1}>
-                <Button
-                  type="submit"
-                  width="100%"
-                  loading={values.mode === "Loading"}
-                  disabled={!isValid || !dirty || values.mode === "Success"}
-                >
-                  {emailOnly ? "Yes, Link Accounts" : "Link Accounts"}
-                </Button>
+                {values.mode === "TwoFactorBlocked" ? (
+                  <Button
+                    variant="secondaryBlack"
+                    width="100%"
+                    type="button"
+                    onClick={() => {
+                      dispatch({ type: "MODE", payload: { mode: "Login" } })
+                    }}
+                  >
+                    Go Back
+                  </Button>
+                ) : (
+                  <Button
+                    type="submit"
+                    width="100%"
+                    loading={values.mode === "Loading"}
+                    disabled={!isValid || !dirty || values.mode === "Success"}
+                  >
+                    {emailOnly ? "Yes, Link Accounts" : "Link Accounts"}
+                  </Button>
+                )}
 
-                {onBack && (
+                {onBack && values.mode !== "TwoFactorBlocked" && (
                   <Button
                     variant="secondaryBlack"
                     width="100%"
@@ -279,7 +305,13 @@ const PasswordForm: FC<PasswordFormProps> = ({
   )
 }
 
-type FormMode = "Pending" | "Loading" | "Success" | "Error" | "LinkError"
+type FormMode =
+  | "Pending"
+  | "Loading"
+  | "Success"
+  | "Error"
+  | "LinkError"
+  | "TwoFactorBlocked"
 
 const VALIDATION_SCHEMA = Yup.object().shape({
   password: Yup.string().required("Password required"),

--- a/src/Components/AuthDialog/Views/__tests__/AuthDialogLinkAccounts.jest.tsx
+++ b/src/Components/AuthDialog/Views/__tests__/AuthDialogLinkAccounts.jest.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { useAuthDialogContext } from "Components/AuthDialog/AuthDialogContext"
+import { AuthDialogLinkAccounts } from "Components/AuthDialog/Views/AuthDialogLinkAccounts"
+import { login } from "Utils/auth"
+
+jest.mock("System/Hooks/useRouter", () => ({
+  useRouter: jest.fn(() => ({
+    match: {
+      location: {
+        query: {
+          email: "user@example.com",
+          provider: "google",
+          existing_providers: "email",
+        },
+      },
+    },
+  })),
+}))
+
+jest.mock("Utils/auth", () => ({
+  login: jest.fn(),
+}))
+
+jest.mock("Components/AuthDialog/Hooks/useAfterAuthentication", () => ({
+  useAfterAuthentication: jest.fn().mockReturnValue({
+    runAfterAuthentication: jest.fn(),
+  }),
+}))
+
+jest.mock("Utils/getENV", () => ({
+  getENV: jest.fn().mockReturnValue({
+    applePath: "/users/auth/apple",
+    facebookPath: "/users/auth/facebook",
+    googlePath: "/users/auth/google",
+  }),
+}))
+
+jest.mock("Components/AuthDialog/AuthDialogContext", () => ({
+  useAuthDialogContext: jest.fn(),
+}))
+
+describe("AuthDialogLinkAccounts", () => {
+  const mockDispatch = jest.fn()
+
+  beforeEach(() => {
+    mockDispatch.mockClear()
+    ;(useAuthDialogContext as jest.Mock).mockReturnValue({
+      dispatch: mockDispatch,
+      state: { values: {}, options: {} },
+    })
+  })
+
+  it("renders the password form when only email provider is available", () => {
+    render(<AuthDialogLinkAccounts />)
+
+    expect(
+      screen.getByPlaceholderText("Enter your password"),
+    ).toBeInTheDocument()
+    expect(screen.getByText("Yes, Link Accounts")).toBeInTheDocument()
+  })
+
+  it("submits the password and calls login", async () => {
+    render(<AuthDialogLinkAccounts />)
+
+    const loginMock = jest
+      .fn()
+      .mockResolvedValue({ user: { accessToken: "token" } })
+    ;(login as jest.Mock).mockImplementationOnce(loginMock)
+
+    const passwordInput = screen.getByPlaceholderText("Enter your password")
+    fireEvent.change(passwordInput, { target: { value: "secret" } })
+
+    // eslint-disable-next-line testing-library/no-node-access
+    const button = screen.getByText("Yes, Link Accounts").parentNode!
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(loginMock).toHaveBeenCalledWith({
+        email: "user@example.com",
+        password: "secret",
+        authenticationCode: "",
+      })
+    })
+  })
+
+  it("shows a 2FA-disabled error and Go Back button when the account has two-factor authentication enabled", async () => {
+    render(<AuthDialogLinkAccounts />)
+    ;(login as jest.Mock).mockRejectedValueOnce(
+      new Error("missing two-factor authentication code"),
+    )
+
+    const passwordInput = screen.getByPlaceholderText("Enter your password")
+    fireEvent.change(passwordInput, { target: { value: "secret" } })
+
+    // eslint-disable-next-line testing-library/no-node-access
+    const button = screen.getByText("Yes, Link Accounts").parentNode!
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          "Social account linking is not available while two-factor authentication is enabled on your Artsy account.",
+        ),
+      ).toBeInTheDocument()
+    })
+
+    expect(screen.queryByText("Yes, Link Accounts")).not.toBeInTheDocument()
+
+    fireEvent.click(screen.getByText("Go Back"))
+
+    expect(mockDispatch).toHaveBeenCalledWith({
+      type: "MODE",
+      payload: { mode: "Login" },
+    })
+  })
+
+  it("shows a 2FA-disabled error when the account requires on-demand authentication", async () => {
+    render(<AuthDialogLinkAccounts />)
+    ;(login as jest.Mock).mockRejectedValueOnce(
+      new Error("missing on-demand authentication code"),
+    )
+
+    const passwordInput = screen.getByPlaceholderText("Enter your password")
+    fireEvent.change(passwordInput, { target: { value: "secret" } })
+
+    // eslint-disable-next-line testing-library/no-node-access
+    const button = screen.getByText("Yes, Link Accounts").parentNode!
+    fireEvent.click(button)
+
+    await waitFor(() => {
+      expect(screen.getByText("Go Back")).toBeInTheDocument()
+    })
+  })
+})


### PR DESCRIPTION


The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [PROJECT-XX]

### Description

<!-- Implementation description -->

Adds an error state for inline account linking attempts with 2fa, which are not allowed. 


Assisted-By: Claude <noreply@anthropic.com>