### PR TITLE
feat: lint AGENTS.md and auto-sync agent wrappers

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,102 @@
+<!-- Auto-generated from AGENTS.md — do not edit directly. Run: curl -sS https://raw.githubusercontent.com/artsy/duchamp/main/scripts/sync-agent-wrappers.sh | bash -->
+
+# Agent Guidelines
+
+Force is Artsy's public-facing web application.
+
+Our best practices are documented in detail in @docs/best_practices.md
+
+## Tech Stack
+
+- **React** - Component framework
+- **TypeScript** - Strict type checking (no migration flags)
+- **Relay** - GraphQL client for Metaphysics API
+- **Palette** - Artsy's design system ([docs](https://palette.artsy.net/))
+- **Found** - Routing framework (SSR-enabled)
+- **Jest + @testing-library/react** - Testing
+
+## Common commands
+
+Use the following commands to verify the quality of uncommitted code:
+
+- **Type-checking**
+  - `yarn type-check`
+- **Relay compiler**
+  - `yarn relay`
+- **Linting** (on changed files)
+  - `yarn lint $(git ls-files --modified --others --exclude-standard)`
+- **Running tests** (on changed files)
+  - `yarn jest $(git ls-files --modified --others --exclude-standard)`
+
+## Code Style
+
+- Write tests for any new functionality; ensure tests pass
+- Write correctly typed code; avoid adding `@ts-expect-error`
+- Prefer named exports; avoid default exports
+- Prefer explicit returns; avoid implicit returns
+- Force follows conventional typographical style and prefers curly typographic single quotes(`‘` and `’`) and double quotes (`“` and `”`) in user-facing texts. Consider this when generating or updating code, including tests
+
+## Commit Style
+
+**CRITICAL: Before every commit, you MUST verify code quality:**
+
+Ensure the following commands produce no warnings or errors for pending files:
+
+```sh
+yarn type-check
+yarn jest $(git ls-files --modified --others --exclude-standard)
+yarn lint $(git ls-files --modified --others --exclude-standard)
+```
+
+**Only after all checks pass** should you create the commit:
+
+- Use Conventional Commits style when writing commit messages
+- Add yourself as co-author
+
+**Never commit code that fails type-checking or linting, or has failing tests.**
+
+## Common Patterns
+
+- **UI**: Use Artsy's design system `@artsy/palette` for UI components
+- **Data**: Use Relay hooks for data fetching
+- **Analytics**: Use react-tracking with Artsy's event schema `@artsy/cohesion`
+- **Tests**
+  - Use Jest, but avoid snapshot tests
+  - Use React Testing Library to test user-facing behavior rather than implementation details
+  - Use Playwright for high-level smoke tests in `playwright/e2e`
+
+## File Organization
+
+- Apps go in `src/Apps/`
+- Shared components in top-level `/Components`
+- Avoid index files (breaks VSCode auto-import)
+- Routes mounted in [src/routes.tsx](src/routes.tsx)
+
+```
+src/
+├── Apps/                    # Sub-applications
+│   └── MyApp/
+│       ├── routes.tsx       # Route definitions
+│       ├── Components/      # Shared within app
+│       └── Routes/          # Route-specific code
+│           └── Home/
+│               ├── HomeApp.tsx
+│               ├── Components/
+│               └── Utils/
+├── Components/              # Shared across apps
+└── System/                  # Framework code
+```
+
+## Skills
+
+If you have a matching skill for a user request, be sure to use it.
+
+The documentation below may augment your knowledge, but the skill should be your first resort.
+
+## Further documentation
+
+- [Best Practices (Full)](docs/best_practices.md)
+- [Adding New Apps](docs/adding_new_app.md)
+- [Architecture](docs/architecture.md)
+- [Caching](docs/architecture-caching.md)
+- And more in @docs

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,102 @@
+<!-- Auto-generated from AGENTS.md — do not edit directly. Run: curl -sS https://raw.githubusercontent.com/artsy/duchamp/main/scripts/sync-agent-wrappers.sh | bash -->
+
+# Agent Guidelines
+
+Force is Artsy's public-facing web application.
+
+Our best practices are documented in detail in @docs/best_practices.md
+
+## Tech Stack
+
+- **React** - Component framework
+- **TypeScript** - Strict type checking (no migration flags)
+- **Relay** - GraphQL client for Metaphysics API
+- **Palette** - Artsy's design system ([docs](https://palette.artsy.net/))
+- **Found** - Routing framework (SSR-enabled)
+- **Jest + @testing-library/react** - Testing
+
+## Common commands
+
+Use the following commands to verify the quality of uncommitted code:
+
+- **Type-checking**
+  - `yarn type-check`
+- **Relay compiler**
+  - `yarn relay`
+- **Linting** (on changed files)
+  - `yarn lint $(git ls-files --modified --others --exclude-standard)`
+- **Running tests** (on changed files)
+  - `yarn jest $(git ls-files --modified --others --exclude-standard)`
+
+## Code Style
+
+- Write tests for any new functionality; ensure tests pass
+- Write correctly typed code; avoid adding `@ts-expect-error`
+- Prefer named exports; avoid default exports
+- Prefer explicit returns; avoid implicit returns
+- Force follows conventional typographical style and prefers curly typographic single quotes(`‘` and `’`) and double quotes (`“` and `”`) in user-facing texts. Consider this when generating or updating code, including tests
+
+## Commit Style
+
+**CRITICAL: Before every commit, you MUST verify code quality:**
+
+Ensure the following commands produce no warnings or errors for pending files:
+
+```sh
+yarn type-check
+yarn jest $(git ls-files --modified --others --exclude-standard)
+yarn lint $(git ls-files --modified --others --exclude-standard)
+```
+
+**Only after all checks pass** should you create the commit:
+
+- Use Conventional Commits style when writing commit messages
+- Add yourself as co-author
+
+**Never commit code that fails type-checking or linting, or has failing tests.**
+
+## Common Patterns
+
+- **UI**: Use Artsy's design system `@artsy/palette` for UI components
+- **Data**: Use Relay hooks for data fetching
+- **Analytics**: Use react-tracking with Artsy's event schema `@artsy/cohesion`
+- **Tests**
+  - Use Jest, but avoid snapshot tests
+  - Use React Testing Library to test user-facing behavior rather than implementation details
+  - Use Playwright for high-level smoke tests in `playwright/e2e`
+
+## File Organization
+
+- Apps go in `src/Apps/`
+- Shared components in top-level `/Components`
+- Avoid index files (breaks VSCode auto-import)
+- Routes mounted in [src/routes.tsx](src/routes.tsx)
+
+```
+src/
+├── Apps/                    # Sub-applications
+│   └── MyApp/
+│       ├── routes.tsx       # Route definitions
+│       ├── Components/      # Shared within app
+│       └── Routes/          # Route-specific code
+│           └── Home/
+│               ├── HomeApp.tsx
+│               ├── Components/
+│               └── Utils/
+├── Components/              # Shared across apps
+└── System/                  # Framework code
+```
+
+## Skills
+
+If you have a matching skill for a user request, be sure to use it.
+
+The documentation below may augment your knowledge, but the skill should be your first resort.
+
+## Further documentation
+
+- [Best Practices (Full)](docs/best_practices.md)
+- [Adding New Apps](docs/adding_new_app.md)
+- [Architecture](docs/architecture.md)
+- [Caching](docs/architecture-caching.md)
+- And more in @docs

--- a/.github/workflows/lint-agents-md.yml
+++ b/.github/workflows/lint-agents-md.yml
@@ -1,0 +1,12 @@
+name: Lint AGENTS.md (via artsy/duchamp)
+
+on:
+  pull_request:
+    paths:
+      - AGENTS.md
+      - .cursorrules
+      - .github/copilot-instructions.md
+
+jobs:
+  lint:
+    uses: artsy/duchamp/.github/workflows/lint-agents-md.yml@main

--- a/.github/workflows/sync-agent-wrappers.yml
+++ b/.github/workflows/sync-agent-wrappers.yml
@@ -1,0 +1,17 @@
+name: Sync agent wrappers
+
+# After AGENTS.md is merged to main, regenerate the agent wrapper files
+# (.cursorrules, .github/copilot-instructions.md) and open an auto-merging
+# PR with the changes (handled by the duchamp reusable workflow). This
+# keeps AGENTS.md PRs free of generated-file churn.
+on:
+  push:
+    branches: [main]
+    paths:
+      - AGENTS.md
+
+jobs:
+  sync:
+    uses: artsy/duchamp/.github/workflows/open-agent-wrappers-pr.yml@main
+    secrets:
+      sync-token: ${{ secrets.CONVENTIONS_SYNC_TOKEN }}


### PR DESCRIPTION
Brings the AGENTS.md tooling from `artsy/duchamp` to force, matching what `artsy/agent-tooling` uses.

## What's included
- **`.github/workflows/lint-agents-md.yml`** — on PRs touching `AGENTS.md` or the wrappers, runs the duchamp reusable lint: (1) rejects Claude-specific patterns in `AGENTS.md` (they belong in `CLAUDE.md`), and (2) rejects hand-edits to the generated wrapper files.
- **`.github/workflows/sync-agent-wrappers.yml`** — after an `AGENTS.md` change merges to `main`, regenerates the wrappers and opens an auto-merging PR with the result (via the duchamp reusable workflow, using `CONVENTIONS_SYNC_TOKEN`).
- **`.cursorrules`** + **`.github/copilot-instructions.md`** — initial generated wrappers (header + current `AGENTS.md`), so Cursor and Copilot pick up the same guidance.

## How it works going forward
Edit `AGENTS.md` → merge → the wrappers are regenerated and synced automatically via an auto-merging PR. Don't edit the wrappers by hand; the lint guard will reject it and point you back to `AGENTS.md`.

## ⚠️ Note on this PR's CI
The `Check agent wrappers are not hand-edited` check is expected to **fail on this PR**, because it introduces the wrapper files for the first time and the guard can't distinguish first-time generation from a manual edit. See the merge note in the PR discussion for how to land it cleanly.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YYAoVcr13ruwsWDe2ou236)_