### PR TITLE
chore:: Upgrade TypeScript to 7.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "scan": "npx react-scan@latest",
     "start": "scripts/start.sh",
     "start:prod": "yarn build && SESSION_LOCAL_INSECURE=true NODE_ENV=production yarn start",
-    "start:prod:debug": "SESSION_LOCAL_INSECURE=true NODE_ENV=production NODE_PATH=src node --inspect --max_old_space_size=3072 -r @swc-node/register ./src/prod.ts",
+    "start:prod:debug": "SESSION_LOCAL_INSECURE=true NODE_ENV=production NODE_PATH=src node --inspect --max_old_space_size=3072 -r ./scripts/swcNodeTypescript5.js -r @swc-node/register ./src/prod.ts",
     "sync-env": "aws s3 cp s3://artsy-citadel/force/.env.shared ./ && echo 'ENV sync complete.'",
     "sync-schema": "scripts/sync-schema-pull.sh",
     "sync-schema-local": "scripts/sync-schema-local.sh",
@@ -255,6 +255,7 @@
     "storybook-states": "1.2.0",
     "typescript": "^7.0.2",
     "typescript-styled-plugin": "0.15.0",
+    "typescript5": "npm:typescript@~5.9.3",
     "webpack": "^5.106.2",
     "webpack-node-externals": "3.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -253,7 +253,7 @@
     "storybook": "^8.6.17",
     "storybook-react-rsbuild": "^0.1.8",
     "storybook-states": "1.2.0",
-    "typescript": "^5.6.3",
+    "typescript": "^7.0.2",
     "typescript-styled-plugin": "0.15.0",
     "webpack": "^5.106.2",
     "webpack-node-externals": "3.0.0"

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "check-npm-vulnerabilities": "yarn npm audit --severity critical --recursive",
     "clean": "scripts/clean.sh",
     "clean:relay": "rm -rf '$TMPDIR'/RelayFindGraphQLTags-*",
-    "danger:ci": "yarn danger ci --verbose",
+    "danger:ci": "NODE_OPTIONS=\"--require ./scripts/swcNodeTypescript5.js\" yarn danger ci --verbose",
     "dead-code": "./scripts/check-dead-code.sh",
     "dead-code:production": "./scripts/check-dead-code.sh production",
     "delete-review-app": "~/.local/bin/kubectl --context staging delete namespace",

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -13,13 +13,13 @@ if [ "${NODE_ENV}" != "production" ]; then
 
   # Smoke Tests
   if [ "$CIRCLECI" = "true" ]; then
-    exec node --max_old_space_size=3072 -r @swc-node/register ./src/dev.ts
+    exec node --max_old_space_size=3072 -r ./scripts/swcNodeTypescript5.js -r @swc-node/register ./src/dev.ts
   # Dev
   else
-    yarn concurrently --raw --kill-others 'yarn relay --watch' "node --max_old_space_size=3072 -r @swc-node/register ./src/dev.ts $@"
+    yarn concurrently --raw --kill-others 'yarn relay --watch' "node --max_old_space_size=3072 -r ./scripts/swcNodeTypescript5.js -r @swc-node/register ./src/dev.ts $@"
   fi
 # Prod
 else
   export NODE_PATH=src
-  exec  node "${OPT[@]}" --no-experimental-fetch -r @swc-node/register ./src/prod.ts
+  exec  node "${OPT[@]}" --no-experimental-fetch -r ./scripts/swcNodeTypescript5.js -r @swc-node/register ./src/prod.ts
 fi

--- a/scripts/swcNodeTypescript5.js
+++ b/scripts/swcNodeTypescript5.js
@@ -1,0 +1,18 @@
+// @swc-node/register reads the legacy TypeScript compiler API (ts.Extension,
+// ts.parseJsonConfigFileContent, ...) at load time, which typescript@7's
+// native compiler package no longer exposes — requiring it crashes the server
+// boot. Until @swc-node ships TS 7 support, preload this file (node -r) before
+// @swc-node/register so that require("typescript") resolves to the TS 5
+// compiler API (installed as the "typescript5" alias package). @swc-node only
+// uses it to parse tsconfig.json and map options for SWC — the actual
+// transpilation is done by SWC itself, and type-checking (yarn type-check)
+// still runs on typescript@7.
+const Module = require("module")
+
+const ts5 = require("typescript5")
+const ts7Path = require.resolve("typescript")
+
+const shim = new Module(ts7Path)
+shim.exports = ts5
+shim.loaded = true
+require.cache[ts7Path] = shim

--- a/scripts/swcNodeTypescript5.js
+++ b/scripts/swcNodeTypescript5.js
@@ -1,12 +1,12 @@
-// @swc-node/register reads the legacy TypeScript compiler API (ts.Extension,
-// ts.parseJsonConfigFileContent, ...) at load time, which typescript@7's
-// native compiler package no longer exposes — requiring it crashes the server
-// boot. Until @swc-node ships TS 7 support, preload this file (node -r) before
-// @swc-node/register so that require("typescript") resolves to the TS 5
-// compiler API (installed as the "typescript5" alias package). @swc-node only
-// uses it to parse tsconfig.json and map options for SWC — the actual
-// transpilation is done by SWC itself, and type-checking (yarn type-check)
-// still runs on typescript@7.
+// Some tools read the legacy TypeScript compiler API (ts.Extension,
+// ts.parseJsonConfigFileContent, ts.transpileModule, ...), which
+// typescript@7's native compiler package no longer exposes — requiring it
+// crashes them. Known cases: @swc-node/register (boots the dev/prod server;
+// only parses tsconfig.json for SWC) and danger (transpiles dangerfile.ts).
+// Until they ship TS 7 support, preload this file (node -r / NODE_OPTIONS)
+// so that require("typescript") resolves to the TS 5 compiler API, installed
+// as the "typescript5" alias package. Type-checking (yarn type-check) still
+// runs on typescript@7.
 const Module = require("module")
 
 const ts5 = require("typescript5")

--- a/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/__tests__/helpers.jest.ts
+++ b/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsTwoFactor/TwoFactorAuthentication/__tests__/helpers.jest.ts
@@ -8,7 +8,7 @@ describe("afterUpdateRedirect", () => {
     delete window.location
   })
   afterEach(() => {
-    window.location = originalLocation
+    window.location = originalLocation as string & Location
   })
 
   it("returns host for trusted domain", () => {

--- a/src/System/Router/__tests__/serverRouter.jest.tsx
+++ b/src/System/Router/__tests__/serverRouter.jest.tsx
@@ -62,7 +62,7 @@ describe("serverRouter", () => {
   const mockFindRoutesByPath = findRoutesByPath as jest.Mock
   let res: ArtsyResponse
   let req: Request
-  let next: NextFunction
+  const next: NextFunction = jest.fn()
   // @ts-ignore
   let options: any = { req, res, next }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,6 @@
   "compilerOptions": {
     "allowJs": true,
     "allowSyntheticDefaultImports": true,
-    "baseUrl": "./src",
-    "downlevelIteration": true,
     "declaration": true,
     "emitDeclarationOnly": true,
     "esModuleInterop": true,
@@ -11,10 +9,11 @@
     "forceConsistentCasingInFileNames": true,
     "incremental": true,
     "jsx": "react-jsx",
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "preserve",
+    "moduleResolution": "bundler",
     "noUnusedLocals": true,
     "outDir": ".cache/tsc", // Need output directory for incremental type-checking
+    "rootDir": "./src",
     "pretty": true,
     "noErrorTruncation": true,
     "skipLibCheck": true,
@@ -24,7 +23,7 @@
     "types": ["node", "jest", "express", "google-maps"],
     "paths": {
       "package.json": ["./package.json"],
-      "*": ["./*"]
+      "*": ["./src/*"]
     },
     "plugins": [
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -9639,6 +9639,7 @@ __metadata:
     tti-polyfill: "npm:0.2.2"
     typescript: "npm:^7.0.2"
     typescript-styled-plugin: "npm:0.15.0"
+    typescript5: "npm:typescript@~5.9.3"
     underscore.string: "npm:3.3.5"
     unleash-client: "npm:^6.5.0"
     unleash-proxy-client: "npm:^3.7.3"
@@ -17862,6 +17863,16 @@ __metadata:
   version: 2.2.0
   resolution: "typescript-template-language-service-decorator@npm:2.2.0"
   checksum: 10c0/5502ae0f688ca5e1560af2e68c7e574fe8a09bca97a8c07e05fe6cf4123a9470119a095874d31c19233d04e267ecfc9347456127f64745371a88c30956505c01
+  languageName: node
+  linkType: hard
+
+"typescript5@npm:typescript@~5.9.3":
+  version: 5.9.3
+  resolution: "typescript@npm:5.9.3"
+  bin:
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10c0/6bd7552ce39f97e711db5aa048f6f9995b53f1c52f7d8667c1abdc1700c68a76a308f579cd309ce6b53646deb4e9a1be7c813a93baaf0a28ccd536a30270e1c5
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5032,6 +5032,146 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@typescript/typescript-aix-ppc64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-aix-ppc64@npm:7.0.2"
+  conditions: os=aix & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-darwin-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-darwin-arm64@npm:7.0.2"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-darwin-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-darwin-x64@npm:7.0.2"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-freebsd-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-freebsd-arm64@npm:7.0.2"
+  conditions: os=freebsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-freebsd-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-freebsd-x64@npm:7.0.2"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-arm64@npm:7.0.2"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-arm@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-arm@npm:7.0.2"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-loong64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-loong64@npm:7.0.2"
+  conditions: os=linux & cpu=loong64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-mips64el@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-mips64el@npm:7.0.2"
+  conditions: os=linux & cpu=mips64el
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-ppc64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-ppc64@npm:7.0.2"
+  conditions: os=linux & cpu=ppc64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-riscv64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-riscv64@npm:7.0.2"
+  conditions: os=linux & cpu=riscv64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-s390x@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-s390x@npm:7.0.2"
+  conditions: os=linux & cpu=s390x
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-linux-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-linux-x64@npm:7.0.2"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-netbsd-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-netbsd-arm64@npm:7.0.2"
+  conditions: os=netbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-netbsd-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-netbsd-x64@npm:7.0.2"
+  conditions: os=netbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-openbsd-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-openbsd-arm64@npm:7.0.2"
+  conditions: os=openbsd & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-openbsd-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-openbsd-x64@npm:7.0.2"
+  conditions: os=openbsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-sunos-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-sunos-x64@npm:7.0.2"
+  conditions: os=sunos & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-win32-arm64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-win32-arm64@npm:7.0.2"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@typescript/typescript-win32-x64@npm:7.0.2":
+  version: 7.0.2
+  resolution: "@typescript/typescript-win32-x64@npm:7.0.2"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
 "@unleash/proxy-client-react@npm:^4.5.2":
   version: 4.5.2
   resolution: "@unleash/proxy-client-react@npm:4.5.2"
@@ -9497,7 +9637,7 @@ __metadata:
     styled-components: "npm:^6.1.13"
     styled-system: "npm:5.1.5"
     tti-polyfill: "npm:0.2.2"
-    typescript: "npm:^5.6.3"
+    typescript: "npm:^7.0.2"
     typescript-styled-plugin: "npm:0.15.0"
     underscore.string: "npm:3.3.5"
     unleash-client: "npm:^6.5.0"
@@ -17725,23 +17865,145 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:^5.6.3":
-  version: 5.6.3
-  resolution: "typescript@npm:5.6.3"
+"typescript@npm:^7.0.2":
+  version: 7.0.2
+  resolution: "typescript@npm:7.0.2"
+  dependencies:
+    "@typescript/typescript-aix-ppc64": "npm:7.0.2"
+    "@typescript/typescript-darwin-arm64": "npm:7.0.2"
+    "@typescript/typescript-darwin-x64": "npm:7.0.2"
+    "@typescript/typescript-freebsd-arm64": "npm:7.0.2"
+    "@typescript/typescript-freebsd-x64": "npm:7.0.2"
+    "@typescript/typescript-linux-arm": "npm:7.0.2"
+    "@typescript/typescript-linux-arm64": "npm:7.0.2"
+    "@typescript/typescript-linux-loong64": "npm:7.0.2"
+    "@typescript/typescript-linux-mips64el": "npm:7.0.2"
+    "@typescript/typescript-linux-ppc64": "npm:7.0.2"
+    "@typescript/typescript-linux-riscv64": "npm:7.0.2"
+    "@typescript/typescript-linux-s390x": "npm:7.0.2"
+    "@typescript/typescript-linux-x64": "npm:7.0.2"
+    "@typescript/typescript-netbsd-arm64": "npm:7.0.2"
+    "@typescript/typescript-netbsd-x64": "npm:7.0.2"
+    "@typescript/typescript-openbsd-arm64": "npm:7.0.2"
+    "@typescript/typescript-openbsd-x64": "npm:7.0.2"
+    "@typescript/typescript-sunos-x64": "npm:7.0.2"
+    "@typescript/typescript-win32-arm64": "npm:7.0.2"
+    "@typescript/typescript-win32-x64": "npm:7.0.2"
+  dependenciesMeta:
+    "@typescript/typescript-aix-ppc64":
+      optional: true
+    "@typescript/typescript-darwin-arm64":
+      optional: true
+    "@typescript/typescript-darwin-x64":
+      optional: true
+    "@typescript/typescript-freebsd-arm64":
+      optional: true
+    "@typescript/typescript-freebsd-x64":
+      optional: true
+    "@typescript/typescript-linux-arm":
+      optional: true
+    "@typescript/typescript-linux-arm64":
+      optional: true
+    "@typescript/typescript-linux-loong64":
+      optional: true
+    "@typescript/typescript-linux-mips64el":
+      optional: true
+    "@typescript/typescript-linux-ppc64":
+      optional: true
+    "@typescript/typescript-linux-riscv64":
+      optional: true
+    "@typescript/typescript-linux-s390x":
+      optional: true
+    "@typescript/typescript-linux-x64":
+      optional: true
+    "@typescript/typescript-netbsd-arm64":
+      optional: true
+    "@typescript/typescript-netbsd-x64":
+      optional: true
+    "@typescript/typescript-openbsd-arm64":
+      optional: true
+    "@typescript/typescript-openbsd-x64":
+      optional: true
+    "@typescript/typescript-sunos-x64":
+      optional: true
+    "@typescript/typescript-win32-arm64":
+      optional: true
+    "@typescript/typescript-win32-x64":
+      optional: true
   bin:
     tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/44f61d3fb15c35359bc60399cb8127c30bae554cd555b8e2b46d68fa79d680354b83320ad419ff1b81a0bdf324197b29affe6cc28988cd6a74d4ac60c94f9799
+  checksum: 10c0/3dcee51ec8c332492325bcdbf7df48b66668751f127e622ae7d41b6c716eb19184424a45e14f7750f50f340232388b69e6287859155f06a5ce2df76f12cb31cf
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A^5.6.3#optional!builtin<compat/typescript>":
-  version: 5.6.3
-  resolution: "typescript@patch:typescript@npm%3A5.6.3#optional!builtin<compat/typescript>::version=5.6.3&hash=8c6c40"
+"typescript@patch:typescript@npm%3A^7.0.2#optional!builtin<compat/typescript>":
+  version: 7.0.2
+  resolution: "typescript@patch:typescript@npm%3A7.0.2#optional!builtin<compat/typescript>::version=7.0.2&hash=3bafbf"
+  dependencies:
+    "@typescript/typescript-aix-ppc64": "npm:7.0.2"
+    "@typescript/typescript-darwin-arm64": "npm:7.0.2"
+    "@typescript/typescript-darwin-x64": "npm:7.0.2"
+    "@typescript/typescript-freebsd-arm64": "npm:7.0.2"
+    "@typescript/typescript-freebsd-x64": "npm:7.0.2"
+    "@typescript/typescript-linux-arm": "npm:7.0.2"
+    "@typescript/typescript-linux-arm64": "npm:7.0.2"
+    "@typescript/typescript-linux-loong64": "npm:7.0.2"
+    "@typescript/typescript-linux-mips64el": "npm:7.0.2"
+    "@typescript/typescript-linux-ppc64": "npm:7.0.2"
+    "@typescript/typescript-linux-riscv64": "npm:7.0.2"
+    "@typescript/typescript-linux-s390x": "npm:7.0.2"
+    "@typescript/typescript-linux-x64": "npm:7.0.2"
+    "@typescript/typescript-netbsd-arm64": "npm:7.0.2"
+    "@typescript/typescript-netbsd-x64": "npm:7.0.2"
+    "@typescript/typescript-openbsd-arm64": "npm:7.0.2"
+    "@typescript/typescript-openbsd-x64": "npm:7.0.2"
+    "@typescript/typescript-sunos-x64": "npm:7.0.2"
+    "@typescript/typescript-win32-arm64": "npm:7.0.2"
+    "@typescript/typescript-win32-x64": "npm:7.0.2"
+  dependenciesMeta:
+    "@typescript/typescript-aix-ppc64":
+      optional: true
+    "@typescript/typescript-darwin-arm64":
+      optional: true
+    "@typescript/typescript-darwin-x64":
+      optional: true
+    "@typescript/typescript-freebsd-arm64":
+      optional: true
+    "@typescript/typescript-freebsd-x64":
+      optional: true
+    "@typescript/typescript-linux-arm":
+      optional: true
+    "@typescript/typescript-linux-arm64":
+      optional: true
+    "@typescript/typescript-linux-loong64":
+      optional: true
+    "@typescript/typescript-linux-mips64el":
+      optional: true
+    "@typescript/typescript-linux-ppc64":
+      optional: true
+    "@typescript/typescript-linux-riscv64":
+      optional: true
+    "@typescript/typescript-linux-s390x":
+      optional: true
+    "@typescript/typescript-linux-x64":
+      optional: true
+    "@typescript/typescript-netbsd-arm64":
+      optional: true
+    "@typescript/typescript-netbsd-x64":
+      optional: true
+    "@typescript/typescript-openbsd-arm64":
+      optional: true
+    "@typescript/typescript-openbsd-x64":
+      optional: true
+    "@typescript/typescript-sunos-x64":
+      optional: true
+    "@typescript/typescript-win32-arm64":
+      optional: true
+    "@typescript/typescript-win32-x64":
+      optional: true
   bin:
     tsc: bin/tsc
-    tsserver: bin/tsserver
-  checksum: 10c0/7c9d2e07c81226d60435939618c91ec2ff0b75fbfa106eec3430f0fcf93a584bc6c73176676f532d78c3594fe28a54b36eb40b3d75593071a7ec91301533ace7
+  checksum: 10c0/6b3cdc369cd829d46e00734ea64233ee84419c2825ad8fe408915adde77abced4b7a2401f7eed517d54a7a4f5d1c1869753cb99018df1c2159c761d9f33483a6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
FYI: I am keeping this as a draft just a couple more days until ts 7 gets some usage

### Description

This PR upgrades TypeScript from 5.6.3 to **7.0.2** — the new native (Go-based) compiler — keeping the same checking semantics (0 errors before and after; the two new errors TS 7 surfaced were real and are fixed here).

**Type-check performance on the same machine:**

| | TS 5.6.3 | TS 7.0.2 | Speedup |
|---|---|---|---|
| Cold `yarn type-check` (incl. full declaration emit to `.cache/tsc`) | 81.2s | 19.7s | **4.1×** |
| Incremental (warm) | 9.0s | 3.3s | 2.7× |

**Config migration** (equivalence-preserving; these options were removed in TS 7):

- `baseUrl` → `paths` values now resolve from the tsconfig dir: `{ "package.json": ["./package.json"], "*": ["./src/*"] }`
- `downlevelIteration` removed (a no-op at `target: es2019`)
- `moduleResolution: node` (node10, removed) → `module: preserve` + `moduleResolution: bundler`, the modern equivalent for a webpack-bundled app (tsc here only type-checks and emits declarations)
- Declaration emit now requires an explicit `rootDir` → `./src`

TS 7 relocates the incremental buildinfo to `.cache/tsconfig.tsbuildinfo`; the `.cache/tsc` emit workaround still functions. Follow-up idea: TS 7 supports `noEmit` + `incremental` natively, so declaration emit could be dropped entirely, taking cold runs to ~3s.

**Code fixes** for TS 7's stricter checks (type-level only; all 26 tests in the touched files pass, lint clean):

- `serverRouter.jest.tsx`: `next` was declared but never assigned — TS 7's use-before-assigned analysis now catches this across closures; initialized with `jest.fn()`
- `helpers.jest.ts`: `window.location` mock restore cast to `string & Location` to match TS 7's new `lib.dom` setter type

### CI fixes (legacy TS compiler API consumers)

Two tools load the legacy TypeScript compiler API at runtime, which `typescript@7`'s native package no longer exposes — both crashed with TS 7 installed:

- **`@swc-node/register`** (boots the dev/smoke-test/**prod** server via `scripts/start.sh`) crashed on `ts.Extension` before the server could listen — this is what broke the `smoke-tests` job, and it would have broken production boot the same way. No `@swc-node` release supports TS 7 yet (1.11.1 crashes identically).
- **danger** (`check-pr` job) crashed on `ts.transpileModule` while transpiling `dangerfile.ts`.

Fix: `scripts/swcNodeTypescript5.js` — preloaded via `node -r` / `NODE_OPTIONS` in the affected entry points — seeds `require.cache` so `require("typescript")` resolves to a TS 5 compiler API (`typescript5` alias package). These tools only use it for tsconfig parsing / dangerfile transpiling; SWC still does the server transpilation, and `yarn type-check` runs on TS 7. Verified locally: the server boots via `scripts/start.sh` and the 404/about smoke-spec assertions pass against it; the dangerfile transpiles through the shimmed path. The shim is deletable once @swc-node and danger support TS 7.

**Heads-up:** `typescript@7.0.2` was published 2026-07-08. Installs that re-resolve it need `YARN_NPM_MINIMAL_AGE_GATE=0` until it clears the 10-day `npmMinimalAgeGate`; immutable CI installs from the committed lockfile are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDuwNGgkcESgEa8E1ADWJi