### PR TITLE
feat(EMI-3298): add terms and conditions link

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/Order2ReviewStep.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2ReviewStep.tsx
@@ -245,7 +245,11 @@ export const Order2ReviewStep: React.FC<Order2ReviewStepProps> = ({
             Submit
           </Button>
           <Spacer y={2} />
-          <TermsAndConditions />
+          <TermsAndConditions
+            onClickTermsAndConditions={() =>
+              checkoutTracking.clickedTermsAndConditions()
+            }
+          />
           <Spacer y={2} />
         </>
       )}

--- a/src/Apps/Order2/Routes/Checkout/Components/TermsAndConditions.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/TermsAndConditions.tsx
@@ -1,11 +1,14 @@
 import { Text } from "@artsy/palette"
-import { useCheckoutContext } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext"
 import { RouterLink } from "System/Components/RouterLink"
 import type React from "react"
 
-export const TermsAndConditions: React.FC = () => {
-  const { checkoutTracking } = useCheckoutContext()
+interface TermsAndConditionsProps {
+  onClickTermsAndConditions?: () => void
+}
 
+export const TermsAndConditions: React.FC<TermsAndConditionsProps> = ({
+  onClickTermsAndConditions,
+}) => {
   return (
     <Text variant="xs" color="mono60">
       By clicking Submit, I agree to Artsy’s{" "}
@@ -13,7 +16,7 @@ export const TermsAndConditions: React.FC = () => {
         inline
         to="/terms"
         target="_blank"
-        onClick={() => checkoutTracking.clickedTermsAndConditions()}
+        onClick={onClickTermsAndConditions}
       >
         General Terms and Conditions of Sale.
       </RouterLink>

--- a/src/Apps/Order2/Routes/Respond/Components/Order2RespondSummary.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/Order2RespondSummary.tsx
@@ -3,6 +3,7 @@ import { Button, Message, Spacer, Text } from "@artsy/palette"
 import { useStripe } from "@stripe/react-stripe-js"
 import { useArtworkDimensions } from "Apps/Artwork/useArtworkDimensions"
 import { Order2OrderSummary } from "Apps/Order2/Components/Order2OrderSummary"
+import { TermsAndConditions } from "Apps/Order2/Routes/Checkout/Components/TermsAndConditions"
 import { useRespondContext } from "Apps/Order2/Routes/Respond/Hooks/useRespondContext"
 import { useOrder2AcceptOfferMutation } from "Apps/Order2/Routes/Respond/Mutations/useOrder2AcceptOfferMutation"
 import { useOrder2DeclineOfferMutation } from "Apps/Order2/Routes/Respond/Mutations/useOrder2DeclineOfferMutation"
@@ -226,6 +227,16 @@ export const Order2RespondSummary: React.FC<Order2RespondSummaryProps> = ({
           >
             Submit
           </Button>
+
+          <Spacer y={2} />
+
+          <TermsAndConditions
+            onClickTermsAndConditions={() =>
+              checkoutTracking.clickedTermsAndConditions()
+            }
+          />
+
+          <Spacer y={2} />
 
           {errorMessage && (
             <>

--- a/src/Apps/Order2/Routes/Respond/Components/__tests__/Order2RespondSummary.jest.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/__tests__/Order2RespondSummary.jest.tsx
@@ -282,6 +282,25 @@ describe("Order2RespondSummary", () => {
         })
       })
     })
+
+    it("tracks clickedTermsAndConditions when the terms link is clicked", async () => {
+      renderWithRelay(defaultResolvers)
+
+      fireEvent.click(screen.getByText("Accept gallery offer"))
+      fireEvent.click(continueButton())
+      mockTrackEvent.mockClear()
+
+      fireEvent.click(
+        await screen.findByText("General Terms and Conditions of Sale."),
+      )
+
+      expect(mockTrackEvent).toHaveBeenCalledWith({
+        action: "clickedTermsAndConditions",
+        context_module: "ordersReview",
+        context_page_owner_id: "order-id",
+        context_page_owner_type: "orders-respond",
+      })
+    })
   })
 
   it("hides the Submit CTA again when the response is edited", () => {


### PR DESCRIPTION
The type of this PR is: **feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-3298]

### Description
This adds the terms and conditions link and tracking for counteroffer submit step. 

<img width="552" height="711" alt="Screenshot 2026-07-09 at 9 28 39 AM" src="https://github.com/user-attachments/assets/bcaea0d7-5413-4885-963c-ef9d4b13c2ed" />



<!-- Implementation description -->


[EMI-3298]: https://artsyproduct.atlassian.net/browse/EMI-3298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ