### PR TITLE
fix: coerce auction-results filter params before sending to metaphysics

### DIFF
--- a/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
+++ b/src/Apps/Artist/Routes/AuctionResults/ArtistAuctionResults.tsx
@@ -347,9 +347,16 @@ export const ArtistAuctionResultsRefetchContainer = createRefetchContainer(
 
     const { match } = useRouter()
     const { userPreferences } = useSystemContext()
-    const filters = paramsToCamelCase(
-      // Expect auction results params to be nested under `auction`
-      (match?.location.query?.auction as any) ?? {},
+    // Coerce string URL params (e.g. "true", "2020") to their proper Boolean/Int
+    // types before seeding the filter context, mirroring the query renderer
+    // above. Without this, the refetch query sends string values for Boolean/Int
+    // variables and metaphysics rejects them (e.g. `Boolean cannot represent a
+    // non boolean value: "true"`).
+    const filters = allowedAuctionResultFilters(
+      paramsToCamelCase(
+        // Expect auction results params to be nested under `auction`
+        (match?.location.query?.auction as any) ?? {},
+      ),
     )
 
     return (

--- a/src/Components/ArtworkFilter/Utils/allowedFilters.ts
+++ b/src/Components/ArtworkFilter/Utils/allowedFilters.ts
@@ -32,12 +32,21 @@ export const allowedFilters = (
       return obj
     }
 
+    // Coerce strings (query-string parsing may turn numeric-looking values
+    // like "2010" into numbers, so ensure string-typed inputs stay strings)
+    if (STRING_INPUT_ARGS.includes(key)) {
+      obj[key] = String(filterParams[key])
+      return obj
+    }
+
     obj[key] = filterParams[key]
     return obj
   }, {})
 }
 
 const INTEGER_INPUT_ARGS = ["first", "last", "page", "size"]
+
+const STRING_INPUT_ARGS = ["keyword", "period"]
 
 const BOOLEAN_INPUT_ARGS = [
   "acquireable",


### PR DESCRIPTION
The type of this PR is: **Fix**

### Description

After the metaphysics graphql 15 → 16 upgrade, stricter input coercion started rejecting query variables that v15 tolerated. Datadog error-tracking surfaced these on the MP canary. This PR fixes the Force-originated ones for the Artist Auction Results page.

**`ArtistAuctionResults.tsx`** — the query-renderer path already coerced URL params via `allowedAuctionResultFilters`, but the **refetch** path (`ArtistAuctionResultsQuery`) seeded the filter context with raw string params from `?auction[...]`. That sent string values to `Boolean`/`Int` variables, producing:
- `Boolean cannot represent a non boolean value: "true"` (vars `allowUnspecifiedSaleDates`, `includeEstimateRange`, `includeUnknownPrices`, `allowEmptyCreatedDates`)
- `Int cannot represent non-integer value: "81"` (year/page vars)

Fix: run the refetch path's params through `allowedAuctionResultFilters` too (which already does the string→Boolean/Int coercion), mirroring the renderer path.

**`allowedFilters.ts`** — query-string parsing can turn numeric-looking string args (e.g. `keyword`, `period` = `"2010"`) into numbers; coerce them back to strings so string-typed inputs stay strings.

### Verification
- `yarn type-check` passes ✅
- Changes mirror existing coercion already used on the initial-render path.

### Manual verification by me 🤚🏽 

https://github.com/user-attachments/assets/e6ebbf3d-4184-4df8-b72b-65615a22596d



Assisted-by: Claude:Opus-4.8