### PR TITLE
fix: pre-approve artsy git repos

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,8 @@
+# Yarn ≥4.12 blocks git-hosted dependencies unless approved (lockfile v9+).
+# approve only the artsy org.
+approvedGitRepositories:
+  - "https://github.com/artsy/**"
+
 nodeLinker: node-modules
 
 yarnPath: .yarn/releases/yarn-4.17.1.cjs


### PR DESCRIPTION
The type of this PR is: **fix**

### Description

This PR fixes this [issue](https://app.circleci.com/pipelines/github/artsy/force/81547/workflows/e4624836-48be-4942-9119-c7d9292f29b5/jobs/555711) that we started getting after renovate upgrade [PR](https://github.com/artsy/force/pull/17448)

<!-- Implementation description -->
