### PR TITLE
fix(EMI-e187): delivery address error message tracked before step is visible

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
@@ -381,7 +381,9 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
       validationSchema={deliveryAddressValidationSchema}
       onSubmit={onSubmit}
     >
-      {({ isSubmitting, setValues, status, submitForm }) => {
+      {({ isSubmitting, setValues, status, submitForm, errors }) => {
+        if (Object.values(errors).length > 0)
+          console.log("Formik errors:", errors)
         return (
           <Flex flexDirection={"column"} mb={2}>
             {fulfillmentDetailsError && (

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
@@ -381,9 +381,7 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
       validationSchema={deliveryAddressValidationSchema}
       onSubmit={onSubmit}
     >
-      {({ isSubmitting, setValues, status, submitForm, errors }) => {
-        if (Object.values(errors).length > 0)
-          console.log("Formik errors:", errors)
+      {({ isSubmitting, setValues, status, submitForm }) => {
         return (
           <Flex flexDirection={"column"} mb={2}>
             {fulfillmentDetailsError && (

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/Order2SavedAddressOptions.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/Order2SavedAddressOptions.tsx
@@ -41,7 +41,8 @@ const getUnableToShipMessage = (
   if (region && isBuyNow) {
     return {
       title: `Ships within ${region}`,
-      message: "Try a different address or contact the gallery for international shipping.",
+      message:
+        "Try a different address or contact the gallery for international shipping.",
     }
   }
   return {
@@ -95,11 +96,14 @@ export const SavedAddressOptions = ({
     step => step.name === CheckoutStepName.FULFILLMENT_DETAILS,
   )
 
+  const isStepActive =
+    fulfillmentDetailsStep?.state === CheckoutStepState.ACTIVE
+
   // Track when saved addresses are viewed (only once when step is active)
   const hasTrackedAddressViewRef = useRef(false)
 
   useCheckoutImpressionEffect(() => {
-    if (fulfillmentDetailsStep?.state !== CheckoutStepState.ACTIVE) {
+    if (!isStepActive) {
       hasTrackedAddressViewRef.current = false
       return
     }
@@ -116,12 +120,7 @@ export const SavedAddressOptions = ({
       checkoutTracking.savedAddressViewed(savedAddresses)
       hasTrackedAddressViewRef.current = true
     }
-  }, [
-    savedAddresses,
-    checkoutTracking,
-    fulfillmentDetailsStep?.state,
-    userAddressMode,
-  ])
+  }, [savedAddresses, checkoutTracking, isStepActive, userAddressMode])
 
   // Scroll to top of step whenever userAddressMode changes
   // This covers: beginning edit, completing edit, canceling edit,
@@ -131,9 +130,6 @@ export const SavedAddressOptions = ({
       scrollToStep(CheckoutStepName.FULFILLMENT_DETAILS)
     }
   }, [userAddressMode, previousUserAddressMode, scrollToStep])
-
-  const isStepActive =
-    fulfillmentDetailsStep?.state === CheckoutStepState.ACTIVE
 
   // Auto-submit the first valid address when no delivery address is confirmed.
   // This covers two cases:
@@ -168,15 +164,12 @@ export const SavedAddressOptions = ({
 
   // Reactively set/clear error banner based on selected address validity and shippability
   useEffect(() => {
-    if (!selectedAddress || userAddressMode) return
+    if (!selectedAddress || userAddressMode || !isStepActive) return
 
     if (!selectedAddress.isShippable && !isOffer) {
       setSectionErrorMessage({
         section: CheckoutStepName.FULFILLMENT_DETAILS,
-        error: getUnableToShipMessage(
-          shippingOriginRegion ?? null,
-          !isOffer,
-        ),
+        error: getUnableToShipMessage(shippingOriginRegion ?? null, !isOffer),
       })
       return
     }
@@ -199,6 +192,7 @@ export const SavedAddressOptions = ({
     isOffer,
     setSectionErrorMessage,
     shippingOriginRegion,
+    isStepActive,
   ])
 
   const onSaveAddress = useCallback(

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/Order2SavedAddressOptions.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/Order2SavedAddressOptions.jest.tsx
@@ -475,10 +475,6 @@ describe("SavedAddressOptions", () => {
       })
     })
 
-    // Regression: in an offer flow the fulfillment-details step is UPCOMING
-    // while the buyer completes the offer step. A pre-selected invalid address
-    // must not surface its error banner (which would fire errorMessageViewed)
-    // until the step actually becomes active and visible.
     it("defers the error banner for an invalid address until the step becomes active", async () => {
       mockUseCheckoutContext.mockReturnValue({
         ...mockCheckoutContext,

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/Order2SavedAddressOptions.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/Order2SavedAddressOptions.jest.tsx
@@ -474,6 +474,64 @@ describe("SavedAddressOptions", () => {
         )
       })
     })
+
+    // Regression: in an offer flow the fulfillment-details step is UPCOMING
+    // while the buyer completes the offer step. A pre-selected invalid address
+    // must not surface its error banner (which would fire errorMessageViewed)
+    // until the step actually becomes active and visible.
+    it("defers the error banner for an invalid address until the step becomes active", async () => {
+      mockUseCheckoutContext.mockReturnValue({
+        ...mockCheckoutContext,
+        isOffer: true,
+        steps: [
+          {
+            name: CheckoutStepName.FULFILLMENT_DETAILS,
+            state: CheckoutStepState.UPCOMING,
+          },
+        ],
+      })
+
+      const { rerender } = renderSavedAddressOptions({
+        savedAddresses: [mockUSAddress1, mockInvalidAddress],
+        initialSelectedAddress: mockInvalidAddress,
+      })
+
+      // While the step is inactive, no error is set — so no banner, no event.
+      await new Promise(resolve => setTimeout(resolve, 50))
+      expect(mockCheckoutContext.setSectionErrorMessage).not.toHaveBeenCalled()
+
+      // Completing the offer step activates fulfillment details...
+      mockUseCheckoutContext.mockReturnValue({
+        ...mockCheckoutContext,
+        isOffer: true,
+        steps: [
+          {
+            name: CheckoutStepName.FULFILLMENT_DETAILS,
+            state: CheckoutStepState.ACTIVE,
+          },
+        ],
+      })
+
+      rerender(
+        buildSavedAddressOptions({
+          savedAddresses: [mockUSAddress1, mockInvalidAddress],
+          initialSelectedAddress: mockInvalidAddress,
+        }),
+      )
+
+      // ...and only then is the error surfaced.
+      await waitFor(() => {
+        expect(mockCheckoutContext.setSectionErrorMessage).toHaveBeenCalledWith(
+          {
+            section: CheckoutStepName.FULFILLMENT_DETAILS,
+            error: {
+              title: "Missing required information",
+              message: "Edit your address and/or phone number to continue.",
+            },
+          },
+        )
+      })
+    })
   })
 
   describe("Address editing validation", () => {

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/__tests__/Order2DeliveryForm.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/__tests__/Order2DeliveryForm.jest.tsx
@@ -43,6 +43,8 @@ beforeEach(() => {
       clickedShippingAddress: jest.fn(),
       clickedAddNewShippingAddress: jest.fn(),
       clickedEditShippingAddress: jest.fn(),
+      errorMessageViewed: jest.fn(),
+      savedAddressViewed: jest.fn(),
     },
     completeStep: jest.fn(),
     setUserAddressMode: jest.fn(),
@@ -50,7 +52,12 @@ beforeEach(() => {
     setIsFulfillmentDetailsSaving: jest.fn(),
     userAddressMode: null,
     messages: {},
-    steps: [],
+    steps: [
+      {
+        name: CheckoutStepName.FULFILLMENT_DETAILS,
+        state: CheckoutStepState.ACTIVE,
+      },
+    ],
   }
 })
 
@@ -240,7 +247,6 @@ describe("Order2DeliveryForm", () => {
             error: { title: "Title", message: "Message", code },
           },
         }
-        mockCheckoutContext.checkoutTracking.errorMessageViewed = jest.fn()
       }
 
       it("renders the section error banner for a non-postal-code error", async () => {

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/__tests__/Order2DeliveryForm.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/__tests__/Order2DeliveryForm.jest.tsx
@@ -27,6 +27,27 @@ jest.mock("Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext", () => ({
   useCheckoutContext: () => mockCheckoutContext,
 }))
 
+// The rich phone validators run an async, debounced Relay query against a real
+// SSR environment. Under fake timers that never resolves, which hangs Formik's
+// submit-time validation. Replace them with synchronous yup validators.
+jest.mock("Components/Address/utils", () => {
+  const Yup = require("yup")
+  return {
+    ...jest.requireActual("Components/Address/utils"),
+    validatePhoneNumber: jest.fn().mockResolvedValue(true),
+    richPhoneValidators: {
+      phoneNumber: Yup.string(),
+      phoneNumberCountryCode: Yup.string(),
+    },
+    richRequiredPhoneValidators: {
+      phoneNumber: Yup.string().required("Phone number is required"),
+      phoneNumberCountryCode: Yup.string().required(
+        "Phone number country code is required",
+      ),
+    },
+  }
+})
+
 beforeEach(() => {
   jest.clearAllMocks()
   jest.runAllTimers()

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/__tests__/Order2DeliveryForm.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/__tests__/Order2DeliveryForm.jest.tsx
@@ -27,26 +27,12 @@ jest.mock("Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext", () => ({
   useCheckoutContext: () => mockCheckoutContext,
 }))
 
-// The rich phone validators run an async, debounced Relay query against a real
-// SSR environment. Under fake timers that never resolves, which hangs Formik's
-// submit-time validation. Replace them with synchronous yup validators.
-jest.mock("Components/Address/utils", () => {
-  const Yup = require("yup")
-  return {
-    ...jest.requireActual("Components/Address/utils"),
-    validatePhoneNumber: jest.fn().mockResolvedValue(true),
-    richPhoneValidators: {
-      phoneNumber: Yup.string(),
-      phoneNumberCountryCode: Yup.string(),
-    },
-    richRequiredPhoneValidators: {
-      phoneNumber: Yup.string().required("Phone number is required"),
-      phoneNumberCountryCode: Yup.string().required(
-        "Phone number country code is required",
-      ),
-    },
-  }
-})
+// Swap the async, debounced, network-backed phone validators for synchronous
+// ones — see mockPhoneValidation for why (otherwise submit-time validation
+// hangs under fake timers).
+jest.mock("Components/Address/utils", () =>
+  require("Components/Address/utils/mockPhoneValidation").mockPhoneValidation(),
+)
 
 beforeEach(() => {
   jest.clearAllMocks()

--- a/src/Components/Address/utils/mockPhoneValidation.ts
+++ b/src/Components/Address/utils/mockPhoneValidation.ts
@@ -1,0 +1,33 @@
+import * as Yup from "yup"
+
+/**
+ * Factory for `jest.mock("Components/Address/utils", ...)` that swaps the async,
+ * debounced, network-backed phone validators for synchronous yup validators.
+ *
+ * The real validators call `validatePhoneNumber`, which debounces (200ms) and
+ * then fires a Relay query against a live SSR environment. In tests that either
+ * hangs forever under `jest.useFakeTimers()` (the debounce timer never fires,
+ * so Formik's submit-time validation never resolves and no mutation is queued)
+ * or silently relies on a real localhost fetch failing under real timers. Any
+ * test that submits an address form should opt in:
+ *
+ *   jest.mock("Components/Address/utils", () =>
+ *     require("Components/Address/utils/mockPhoneValidation").mockPhoneValidation(),
+ *   )
+ */
+export const mockPhoneValidation = () => {
+  return {
+    ...jest.requireActual("Components/Address/utils"),
+    validatePhoneNumber: jest.fn().mockResolvedValue(true),
+    richPhoneValidators: {
+      phoneNumber: Yup.string(),
+      phoneNumberCountryCode: Yup.string(),
+    },
+    richRequiredPhoneValidators: {
+      phoneNumber: Yup.string().required("Phone number is required"),
+      phoneNumberCountryCode: Yup.string().required(
+        "Phone number country code is required",
+      ),
+    },
+  }
+}


### PR DESCRIPTION
The type of this PR is: **fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-3187]

### Description

This PR makes delivery address error messages only appear and fire when the step is active. It includes some other cleanup.
<!-- Implementation description -->


[EMI-3187]: https://artsyproduct.atlassian.net/browse/EMI-3187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ