### PR TITLE
fix: don't stringify absent keyword/period filters

### DIFF
--- a/src/Components/ArtworkFilter/Utils/__tests__/allowedFilters.jest.ts
+++ b/src/Components/ArtworkFilter/Utils/__tests__/allowedFilters.jest.ts
@@ -56,6 +56,18 @@ describe("allowedFilters", () => {
     })
   })
 
+  it("keeps string inputs as strings but omits absent ones", () => {
+    // Numeric-looking values are coerced back to strings...
+    expect(allowedFilters({ keyword: 2010, period: 1990 })).toEqual({
+      keyword: "2010",
+      period: "1990",
+    })
+
+    // ...but undefined/null are omitted entirely, so we never send the literal
+    // string "undefined"/"null" (which would filter to zero results).
+    expect(allowedFilters({ keyword: undefined, period: null })).toEqual({})
+  })
+
   it("allows auction-specific sort values", () => {
     expect(
       allowedFilters({

--- a/src/Components/ArtworkFilter/Utils/allowedFilters.ts
+++ b/src/Components/ArtworkFilter/Utils/allowedFilters.ts
@@ -33,9 +33,13 @@ export const allowedFilters = (
     }
 
     // Coerce strings (query-string parsing may turn numeric-looking values
-    // like "2010" into numbers, so ensure string-typed inputs stay strings)
+    // like "2010" into numbers, so ensure string-typed inputs stay strings).
+    // Skip absent values — String(undefined) === "undefined" would otherwise
+    // filter by the literal keyword "undefined" and return no results.
     if (STRING_INPUT_ARGS.includes(key)) {
-      obj[key] = String(filterParams[key])
+      const value = filterParams[key]
+      if (value == null) return obj
+      obj[key] = String(value)
       return obj
     }
 


### PR DESCRIPTION
The type of this PR is: **TYPE**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [this slack issue](https://artsy.slack.com/archives/C05EEBNEF71/p1783628389271589)

### Description

In a recent [PR](https://github.com/artsy/force/pull/17454), I identified an issue where we treat strings that look like intergers as numbers (`"2010"` as `2010`). Sending those strings to MP led to failed queries. 

**What went wrong?**
I was stringifying the string params as they come, so for example `2010` would become `"2010"`, but I didn't factor in mind that the default value might be `undefined` instead of `""`. Leading to sending a string value of `"undefined"` which obviously would fail.

**Fix?**
Making sure that the values are not `null` or `undefined`

**Screen recording**

<video src="https://github.com/user-attachments/assets/306c686a-9882-4815-8e4b-fe81af39bf5c" />

`Assisted-by: Opus`

<!-- Implementation description -->
