### PR TITLE
refactor: inject Relay environment into phone-number validation

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
@@ -11,8 +11,8 @@ import { SELECTABLE_TYPES } from "Apps/Order2/Routes/Checkout/Components/Deliver
 import { SavedAddressOptions } from "Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/Order2SavedAddressOptions"
 import { handleError } from "Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/handleError"
 import {
-  deliveryAddressValidationSchema,
   findInitialSelectedAddress,
+  getDeliveryAddressValidationSchema,
   processSavedAddresses,
 } from "Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/utils"
 import { useCheckoutContext } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext"
@@ -37,7 +37,7 @@ import type { Order2DeliveryForm_me$key } from "__generated__/Order2DeliveryForm
 import type { Order2DeliveryForm_order$key } from "__generated__/Order2DeliveryForm_order.graphql"
 import { Form, Formik, type FormikHelpers } from "formik"
 import { useCallback, useMemo, useRef } from "react"
-import { graphql, useFragment } from "react-relay"
+import { graphql, useFragment, useRelayEnvironment } from "react-relay"
 
 interface Order2DeliveryFormProps {
   order: Order2DeliveryForm_order$key
@@ -54,6 +54,12 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
   const meData = useFragment(ME_FRAGMENT, me)
   const createUserAddress = useOrder2CreateUserAddressMutation()
   const logger = createLogger("Order2DeliveryForm")
+
+  const relayEnvironment = useRelayEnvironment()
+  const validationSchema = useMemo(
+    () => getDeliveryAddressValidationSchema(relayEnvironment),
+    [relayEnvironment],
+  )
 
   const { addressConnection, name: meName, phoneNumber: mePhoneNumber } = meData
 
@@ -378,7 +384,7 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
           : initialSelectedAddress || initialValues
       }
       enableReinitialize={true}
-      validationSchema={deliveryAddressValidationSchema}
+      validationSchema={validationSchema}
       onSubmit={onSubmit}
     >
       {({ isSubmitting, setValues, status, submitForm }) => {

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2PickupForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2PickupForm.tsx
@@ -9,8 +9,8 @@ import { useOrder2SetOrderFulfillmentOptionMutation } from "Apps/Order2/Routes/C
 import { useOrder2SetOrderPickupDetailsMutation } from "Apps/Order2/Routes/Checkout/Mutations/useOrder2SetOrderPickupDetailsMutation"
 import {
   phoneInitialValuesFromMe,
+  getRichRequiredPhoneValidators,
   handlePhoneNumberChange,
-  richRequiredPhoneValidators,
 } from "Components/Address/utils"
 import { useInitialLocationValues } from "Components/Address/utils/useInitialLocationValues"
 import { countries as phoneCountryOptions } from "Utils/countries"
@@ -25,7 +25,7 @@ import {
   useFormikContext,
 } from "formik"
 import { useCallback, useMemo } from "react"
-import { graphql, useFragment } from "react-relay"
+import { graphql, useFragment, useRelayEnvironment } from "react-relay"
 import * as Yup from "yup"
 
 const logger = createLogger("Order2PickupForm.tsx")
@@ -46,6 +46,15 @@ export const Order2PickupForm: React.FC<Order2PickupFormProps> = ({
 }) => {
   const orderData = useFragment(ORDER_FRAGMENT, order)
   const meData = useFragment(ME_FRAGMENT, me)
+
+  const relayEnvironment = useRelayEnvironment()
+  const validationSchema = useMemo(
+    () =>
+      Yup.object().shape({
+        ...getRichRequiredPhoneValidators(relayEnvironment),
+      }),
+    [relayEnvironment],
+  )
 
   const { completeStep, checkoutTracking, setCheckoutMode, isOffer } =
     useCheckoutContext()
@@ -170,7 +179,7 @@ export const Order2PickupForm: React.FC<Order2PickupFormProps> = ({
       <Spacer y={[2, 2, 4]} />
       <Formik<PickupFormValues>
         initialValues={initialValues}
-        validationSchema={VALIDATION_SCHEMA}
+        validationSchema={validationSchema}
         onSubmit={handleSubmit}
         enableReinitialize={true}
       >
@@ -235,10 +244,6 @@ const PickupFormInput: React.FC = () => {
     </div>
   )
 }
-
-const VALIDATION_SCHEMA = Yup.object().shape({
-  ...richRequiredPhoneValidators,
-})
 
 const ME_FRAGMENT = graphql`
   fragment Order2PickupForm_me on Me {

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/AddAddressForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/AddAddressForm.tsx
@@ -1,7 +1,7 @@
 import { ContextModule } from "@artsy/cohesion"
 import { Button, Spacer } from "@artsy/palette"
 import { SectionHeading } from "Apps/Order2/Components/SectionHeading"
-import { deliveryAddressValidationSchema } from "Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/utils"
+import { getDeliveryAddressValidationSchema } from "Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/utils"
 import { useCheckoutContext } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext"
 import { useScrollToFieldErrorOnSubmit } from "Apps/Order2/Routes/Checkout/Hooks/useScrollToFieldErrorOnSubmit"
 import { useOrder2CreateUserAddressMutation } from "Apps/Order2/Routes/Checkout/Mutations/useOrder2CreateUserAddressMutation"
@@ -12,6 +12,8 @@ import {
 } from "Components/Address/AddressFormFields"
 import createLogger from "Utils/logger"
 import { Form, Formik } from "formik"
+import { useMemo } from "react"
+import { useRelayEnvironment } from "react-relay"
 
 const logger = createLogger("AddAddressForm")
 
@@ -30,6 +32,12 @@ export const AddAddressForm = ({
   const createUserAddress = useOrder2CreateUserAddressMutation()
   const updateUserDefaultAddress = useOrder2UpdateUserDefaultAddressMutation()
   const { setUserAddressMode, checkoutTracking } = useCheckoutContext()
+
+  const relayEnvironment = useRelayEnvironment()
+  const validationSchema = useMemo(
+    () => getDeliveryAddressValidationSchema(relayEnvironment),
+    [relayEnvironment],
+  )
 
   const handleSetAsDefault = async (addressID: string) => {
     await updateUserDefaultAddress.submitMutation({
@@ -89,7 +97,7 @@ export const AddAddressForm = ({
   return (
     <Formik<FormikContextWithAddress>
       initialValues={initialValues}
-      validationSchema={deliveryAddressValidationSchema}
+      validationSchema={validationSchema}
       onSubmit={handleSubmit}
     >
       {({ isSubmitting }) => {

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/UpdateAddressForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/UpdateAddressForm.tsx
@@ -11,7 +11,7 @@ import {
 import { SectionHeading } from "Apps/Order2/Components/SectionHeading"
 import {
   type ProcessedUserAddress,
-  deliveryAddressValidationSchema,
+  getDeliveryAddressValidationSchema,
 } from "Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/utils"
 import { useCheckoutContext } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext"
 import { useScrollToFieldErrorOnSubmit } from "Apps/Order2/Routes/Checkout/Hooks/useScrollToFieldErrorOnSubmit"
@@ -26,7 +26,8 @@ import {
 import createLogger from "Utils/logger"
 import type { Order2CheckoutContext_order$data } from "__generated__/Order2CheckoutContext_order.graphql"
 import { Form, Formik } from "formik"
-import { useState } from "react"
+import { useMemo, useState } from "react"
+import { useRelayEnvironment } from "react-relay"
 
 const logger = createLogger("UpdateAddressForm")
 
@@ -68,6 +69,11 @@ export const UpdateAddressForm = ({
     useOrder2UnsetOrderFulfillmentOptionMutation()
   const { setUserAddressMode, orderData, checkoutTracking } =
     useCheckoutContext()
+  const relayEnvironment = useRelayEnvironment()
+  const validationSchema = useMemo(
+    () => getDeliveryAddressValidationSchema(relayEnvironment),
+    [relayEnvironment],
+  )
   const [showDeleteDialog, setShowDeleteDialog] = useState(false)
   const [isDeleting, setIsDeleting] = useState(false)
   const [deleteError, setDeleteError] = useState<{
@@ -192,7 +198,7 @@ export const UpdateAddressForm = ({
   return (
     <Formik<FormikContextWithAddress>
       initialValues={initialValues}
-      validationSchema={deliveryAddressValidationSchema}
+      validationSchema={validationSchema}
       onSubmit={handleSubmitAddress}
       validateOnMount
       initialTouched={{

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/AddAddressForm.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/AddAddressForm.jest.tsx
@@ -5,6 +5,13 @@ import { useOrder2CreateUserAddressMutation } from "Apps/Order2/Routes/Checkout/
 import { useOrder2UpdateUserDefaultAddressMutation } from "Apps/Order2/Routes/Checkout/Mutations/useOrder2UpdateUserDefaultAddressMutation"
 import { useCheckoutContext } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext"
 import type { FormikContextWithAddress } from "Components/Address/AddressFormFields"
+import { autoResolvePhoneValidation } from "DevTools/autoResolvePhoneValidation"
+import { RelayEnvironmentProvider } from "react-relay"
+import { createMockEnvironment } from "relay-test-utils"
+
+// The form reads the Relay environment via useRelayEnvironment() for async
+// phone validation, so exercise the real hooks against a mock environment.
+jest.unmock("react-relay")
 
 jest.mock(
   "Apps/Order2/Routes/Checkout/Mutations/useOrder2CreateUserAddressMutation",
@@ -52,6 +59,16 @@ const mockProps = {
   onSaveAddress: mockOnSaveAddress,
 }
 
+const renderAddAddressForm = (props = mockProps) => {
+  const env = createMockEnvironment()
+  autoResolvePhoneValidation(env)
+  return render(
+    <RelayEnvironmentProvider environment={env}>
+      <AddAddressForm {...props} />
+    </RelayEnvironmentProvider>,
+  )
+}
+
 describe("AddAddressForm", () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -73,7 +90,7 @@ describe("AddAddressForm", () => {
   })
 
   it("renders the add address form with setAsDefault checkbox", () => {
-    render(<AddAddressForm {...mockProps} />)
+    renderAddAddressForm()
 
     expect(screen.getByText("Add address")).toBeInTheDocument()
     expect(screen.getByPlaceholderText("Add full name")).toBeInTheDocument()
@@ -98,7 +115,7 @@ describe("AddAddressForm", () => {
       },
     })
 
-    render(<AddAddressForm {...mockProps} />)
+    renderAddAddressForm()
 
     // Fill out the form
     await userEvent.type(
@@ -179,7 +196,7 @@ describe("AddAddressForm", () => {
       },
     })
 
-    render(<AddAddressForm {...mockProps} />)
+    renderAddAddressForm()
 
     // Fill out the form
     await userEvent.type(
@@ -252,7 +269,7 @@ describe("AddAddressForm", () => {
   })
 
   it("allows checking and unchecking the setAsDefault checkbox", async () => {
-    render(<AddAddressForm {...mockProps} />)
+    renderAddAddressForm()
 
     const checkbox = screen.getByTestId("setAsDefault")
 
@@ -269,7 +286,7 @@ describe("AddAddressForm", () => {
   })
 
   it("calls setUserAddressMode(null) when cancel button is clicked", async () => {
-    render(<AddAddressForm {...mockProps} />)
+    renderAddAddressForm()
 
     await userEvent.click(screen.getByText("Cancel"))
 
@@ -286,7 +303,7 @@ describe("AddAddressForm", () => {
       },
     })
 
-    render(<AddAddressForm {...mockProps} />)
+    renderAddAddressForm()
 
     // Fill out the form
     await userEvent.type(
@@ -329,7 +346,7 @@ describe("AddAddressForm", () => {
       },
     })
 
-    render(<AddAddressForm {...mockProps} />)
+    renderAddAddressForm()
 
     // Fill out the form
     await userEvent.type(

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/UpdateAddressForm.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/SavedAddressOptions/__tests__/UpdateAddressForm.jest.tsx
@@ -1,4 +1,5 @@
 import { render, screen, waitFor } from "@testing-library/react"
+import type * as React from "react"
 import userEvent from "@testing-library/user-event"
 import { useCheckoutContext } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutContext"
 import { useOrder2DeleteUserAddressMutation } from "Apps/Order2/Routes/Checkout/Mutations/useOrder2DeleteUserAddressMutation"
@@ -7,6 +8,13 @@ import { useOrder2UpdateUserAddressMutation } from "Apps/Order2/Routes/Checkout/
 import { useOrder2UpdateUserDefaultAddressMutation } from "Apps/Order2/Routes/Checkout/Mutations/useOrder2UpdateUserDefaultAddressMutation"
 import type { ProcessedUserAddress } from "../../utils"
 import { UpdateAddressForm } from "../UpdateAddressForm"
+import { autoResolvePhoneValidation } from "DevTools/autoResolvePhoneValidation"
+import { RelayEnvironmentProvider } from "react-relay"
+import { createMockEnvironment } from "relay-test-utils"
+
+// The form reads the Relay environment via useRelayEnvironment() for async
+// phone validation, so exercise the real hooks against a mock environment.
+jest.unmock("react-relay")
 
 jest.mock(
   "Apps/Order2/Routes/Checkout/Mutations/useOrder2UpdateUserAddressMutation",
@@ -97,6 +105,18 @@ const mockDEProps = {
   onDeleteAddress: jest.fn(),
 }
 
+const renderUpdateAddressForm = (
+  props: React.ComponentProps<typeof UpdateAddressForm> = mockUSProps,
+) => {
+  const env = createMockEnvironment()
+  autoResolvePhoneValidation(env)
+  return render(
+    <RelayEnvironmentProvider environment={env}>
+      <UpdateAddressForm {...props} />
+    </RelayEnvironmentProvider>,
+  )
+}
+
 describe("UpdateAddressForm", () => {
   beforeEach(() => {
     jest.clearAllMocks()
@@ -128,7 +148,7 @@ describe("UpdateAddressForm", () => {
 
   describe("Core form functionality", () => {
     it("renders form with US address data", () => {
-      render(<UpdateAddressForm {...mockUSProps} />)
+      renderUpdateAddressForm()
 
       expect(screen.getByDisplayValue("John Doe")).toBeInTheDocument()
       expect(screen.getByDisplayValue("123 Main St")).toBeInTheDocument()
@@ -136,7 +156,7 @@ describe("UpdateAddressForm", () => {
     })
 
     it("renders form with German address data", () => {
-      render(<UpdateAddressForm {...mockDEProps} />)
+      renderUpdateAddressForm(mockDEProps)
 
       expect(screen.getByDisplayValue("Hans Mueller")).toBeInTheDocument()
       expect(screen.getByDisplayValue("Unter den Linden 1")).toBeInTheDocument()
@@ -154,7 +174,7 @@ describe("UpdateAddressForm", () => {
         },
       })
 
-      render(<UpdateAddressForm {...mockUSProps} />)
+      renderUpdateAddressForm()
 
       const nameField = screen.getByDisplayValue("John Doe")
       await userEvent.clear(nameField)
@@ -169,7 +189,7 @@ describe("UpdateAddressForm", () => {
     })
 
     it("allows editing address fields", async () => {
-      render(<UpdateAddressForm {...mockUSProps} />)
+      renderUpdateAddressForm()
 
       const nameField = screen.getByDisplayValue("John Doe")
       const addressField = screen.getByDisplayValue("123 Main St")
@@ -199,7 +219,7 @@ describe("UpdateAddressForm", () => {
         },
       })
 
-      render(<UpdateAddressForm {...mockUSProps} />)
+      renderUpdateAddressForm()
 
       const nameField = screen.getByDisplayValue("John Doe")
       await userEvent.clear(nameField)
@@ -221,7 +241,7 @@ describe("UpdateAddressForm", () => {
     })
 
     it("handles form validation errors", async () => {
-      render(<UpdateAddressForm {...mockUSProps} />)
+      renderUpdateAddressForm()
 
       const nameField = screen.getByDisplayValue("John Doe")
       await userEvent.clear(nameField)
@@ -237,7 +257,7 @@ describe("UpdateAddressForm", () => {
     })
 
     it("closes form when cancel button is clicked", async () => {
-      render(<UpdateAddressForm {...mockUSProps} />)
+      renderUpdateAddressForm()
 
       const cancelButton = screen.getByText("Cancel")
       await userEvent.click(cancelButton)
@@ -248,13 +268,13 @@ describe("UpdateAddressForm", () => {
 
   describe("Save button disabled state", () => {
     it("disables the Save Address button when no changes are made", () => {
-      render(<UpdateAddressForm {...mockUSProps} />)
+      renderUpdateAddressForm()
 
       expect(screen.getByText("Save Address").closest("button")).toBeDisabled()
     })
 
     it("enables the Save Address button after a field is changed", async () => {
-      render(<UpdateAddressForm {...mockUSProps} />)
+      renderUpdateAddressForm()
 
       const nameField = screen.getByDisplayValue("John Doe")
       await userEvent.clear(nameField)
@@ -266,7 +286,7 @@ describe("UpdateAddressForm", () => {
     })
 
     it("enables the Save Address button when setAsDefault is checked", async () => {
-      render(<UpdateAddressForm {...mockUSProps} />)
+      renderUpdateAddressForm()
 
       await userEvent.click(screen.getByTestId("setAsDefault"))
 
@@ -278,7 +298,7 @@ describe("UpdateAddressForm", () => {
 
   describe("Delete functionality", () => {
     it("shows delete confirmation dialog when delete is clicked", async () => {
-      render(<UpdateAddressForm {...mockUSProps} />)
+      renderUpdateAddressForm()
 
       const deleteButton = screen.getByText("Delete address")
       await userEvent.click(deleteButton)
@@ -301,7 +321,7 @@ describe("UpdateAddressForm", () => {
         },
       })
 
-      render(<UpdateAddressForm {...mockUSProps} />)
+      renderUpdateAddressForm()
 
       const deleteButton = screen.getByText("Delete address")
       await userEvent.click(deleteButton)
@@ -326,7 +346,7 @@ describe("UpdateAddressForm", () => {
         },
       })
 
-      render(<UpdateAddressForm {...mockUSProps} />)
+      renderUpdateAddressForm()
 
       const deleteButton = screen.getByText("Delete address")
       await userEvent.click(deleteButton)
@@ -355,7 +375,7 @@ describe("UpdateAddressForm", () => {
         },
       })
 
-      render(<UpdateAddressForm {...mockUSProps} />)
+      renderUpdateAddressForm()
 
       const deleteButton = screen.getByText("Delete address")
       await userEvent.click(deleteButton)
@@ -379,7 +399,7 @@ describe("UpdateAddressForm", () => {
         },
       })
 
-      render(<UpdateAddressForm {...mockUSProps} />)
+      renderUpdateAddressForm()
 
       const deleteButton = screen.getByText("Delete address")
       await userEvent.click(deleteButton)
@@ -403,7 +423,7 @@ describe("UpdateAddressForm", () => {
         },
       })
 
-      render(<UpdateAddressForm {...mockUSProps} />)
+      renderUpdateAddressForm()
 
       const deleteButton = screen.getByText("Delete address")
       await userEvent.click(deleteButton)
@@ -420,7 +440,7 @@ describe("UpdateAddressForm", () => {
     it("handles network errors gracefully", async () => {
       mockDeleteUserAddress.mockRejectedValue(new Error("Network error"))
 
-      render(<UpdateAddressForm {...mockUSProps} />)
+      renderUpdateAddressForm()
 
       const deleteButton = screen.getByText("Delete address")
       await userEvent.click(deleteButton)
@@ -444,7 +464,7 @@ describe("UpdateAddressForm", () => {
         },
       })
 
-      render(<UpdateAddressForm {...mockUSProps} />)
+      renderUpdateAddressForm()
 
       const deleteButton = screen.getByText("Delete address")
       await userEvent.click(deleteButton)
@@ -481,9 +501,10 @@ describe("UpdateAddressForm", () => {
     })
 
     it("calls unsetOrderFulfillmentOption when the deleted address is the order address", async () => {
-      render(
-        <UpdateAddressForm {...mockUSProps} orderAddressID="address-id-123" />,
-      )
+      renderUpdateAddressForm({
+        ...mockUSProps,
+        orderAddressID: "address-id-123",
+      })
 
       await userEvent.click(screen.getByText("Delete address"))
       await userEvent.click(screen.getByText("Delete"))
@@ -496,12 +517,10 @@ describe("UpdateAddressForm", () => {
     })
 
     it("does not call unsetOrderFulfillmentOption when the deleted address is not the order address", async () => {
-      render(
-        <UpdateAddressForm
-          {...mockUSProps}
-          orderAddressID="different-address-id"
-        />,
-      )
+      renderUpdateAddressForm({
+        ...mockUSProps,
+        orderAddressID: "different-address-id",
+      })
 
       await userEvent.click(screen.getByText("Delete address"))
       await userEvent.click(screen.getByText("Delete"))
@@ -514,7 +533,7 @@ describe("UpdateAddressForm", () => {
     })
 
     it("does not call unsetOrderFulfillmentOption when orderAddressID is not provided", async () => {
-      render(<UpdateAddressForm {...mockUSProps} />)
+      renderUpdateAddressForm()
 
       await userEvent.click(screen.getByText("Delete address"))
       await userEvent.click(screen.getByText("Delete"))
@@ -529,7 +548,7 @@ describe("UpdateAddressForm", () => {
 
   describe("Set as default functionality", () => {
     it("shows setAsDefault checkbox for non-default addresses", () => {
-      render(<UpdateAddressForm {...mockUSProps} />)
+      renderUpdateAddressForm()
 
       const checkbox = screen.getByTestId("setAsDefault")
       expect(checkbox).toBeInTheDocument()
@@ -537,14 +556,14 @@ describe("UpdateAddressForm", () => {
     })
 
     it("does not show setAsDefault checkbox for default addresses", () => {
-      render(<UpdateAddressForm {...mockDEProps} />)
+      renderUpdateAddressForm(mockDEProps)
 
       const checkbox = screen.queryByTestId("setAsDefault")
       expect(checkbox).not.toBeInTheDocument()
     })
 
     it("allows checking and unchecking the setAsDefault checkbox", async () => {
-      render(<UpdateAddressForm {...mockUSProps} />)
+      renderUpdateAddressForm()
 
       const checkbox = screen.getByTestId("setAsDefault")
       expect(checkbox).not.toBeChecked()
@@ -575,7 +594,7 @@ describe("UpdateAddressForm", () => {
         },
       })
 
-      render(<UpdateAddressForm {...mockUSProps} />)
+      renderUpdateAddressForm()
 
       const nameField = screen.getByDisplayValue("John Doe")
       await userEvent.clear(nameField)
@@ -612,7 +631,7 @@ describe("UpdateAddressForm", () => {
         },
       })
 
-      render(<UpdateAddressForm {...mockUSProps} />)
+      renderUpdateAddressForm()
 
       const nameField = screen.getByDisplayValue("John Doe")
       await userEvent.clear(nameField)
@@ -640,7 +659,7 @@ describe("UpdateAddressForm", () => {
 
       mockUpdateUserDefaultAddress.mockRejectedValue(new Error("Network error"))
 
-      render(<UpdateAddressForm {...mockUSProps} />)
+      renderUpdateAddressForm()
 
       const nameField = screen.getByDisplayValue("John Doe")
       await userEvent.clear(nameField)

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/__tests__/Order2DeliveryForm.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/__tests__/Order2DeliveryForm.jest.tsx
@@ -5,6 +5,7 @@ import {
   CheckoutStepState,
 } from "Apps/Order2/Routes/Checkout/CheckoutContext/types"
 import { useSelectDeliveryOption } from "Apps/Order2/Routes/Checkout/Hooks/useSelectDeliveryOption"
+import { autoResolvePhoneValidation } from "DevTools/autoResolvePhoneValidation"
 import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
 import type { Order2DeliveryFormTestQuery } from "__generated__/Order2DeliveryFormTestQuery.graphql"
@@ -54,25 +55,34 @@ beforeEach(() => {
   }
 })
 
-const { renderWithRelay } = setupTestWrapperTL<Order2DeliveryFormTestQuery>({
-  Component: (props: any) => (
-    <Order2DeliveryForm
-      order={props.me.order}
-      me={props.me}
-      hasFulfillmentDetails={false}
-    />
-  ),
-  query: graphql`
-    query Order2DeliveryFormTestQuery @relay_test_operation {
-      me {
-        ...Order2DeliveryForm_me
-        order(id: "order-id") {
-          ...Order2DeliveryForm_order
+const { renderWithRelay: renderWithRelayBase } =
+  setupTestWrapperTL<Order2DeliveryFormTestQuery>({
+    Component: (props: any) => (
+      <Order2DeliveryForm
+        order={props.me.order}
+        me={props.me}
+        hasFulfillmentDetails={false}
+      />
+    ),
+    query: graphql`
+      query Order2DeliveryFormTestQuery @relay_test_operation {
+        me {
+          ...Order2DeliveryForm_me
+          order(id: "order-id") {
+            ...Order2DeliveryForm_order
+          }
         }
       }
-    }
-  `,
-})
+    `,
+  })
+
+// Auto-resolve the async phone-validation query so form submission isn't
+// blocked waiting on it; other operations remain pending for manual resolution.
+const renderWithRelay: typeof renderWithRelayBase = (...args) => {
+  const result = renderWithRelayBase(...args)
+  autoResolvePhoneValidation(result.env)
+  return result
+}
 
 describe("Order2DeliveryForm", () => {
   const baseOrderProps = {

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/utils.ts
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/utils.ts
@@ -6,6 +6,7 @@ import { COUNTRY_CODE_TO_COUNTRY_NAME } from "Components/CountrySelect"
 import { extractNodes } from "Utils/extractNodes"
 import type { ExtractNodeType } from "Utils/typeSupport"
 import type { Order2DeliveryForm_me$data } from "__generated__/Order2DeliveryForm_me.graphql"
+import type { Environment } from "relay-runtime"
 import * as yup from "yup"
 
 type MeAddresses = ExtractNodeType<
@@ -129,6 +130,11 @@ export const findInitialSelectedAddress = (
   return processedAddresses[0]
 }
 
-export const deliveryAddressValidationSchema = yup
-  .object()
-  .shape(addressFormFieldsValidator({ withPhoneNumber: true }))
+export const getDeliveryAddressValidationSchema = (
+  relayEnvironment: Environment,
+) =>
+  yup
+    .object()
+    .shape(
+      addressFormFieldsValidator({ withPhoneNumber: true, relayEnvironment }),
+    )

--- a/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/__tests__/Order2CheckoutRoute.jest.tsx
@@ -162,16 +162,16 @@ jest.mock("Components/Address/utils", () => {
   return {
     ...jest.requireActual("Components/Address/utils"),
     validatePhoneNumber: jest.fn().mockResolvedValue(true),
-    richPhoneValidators: {
+    getRichPhoneValidators: () => ({
       phoneNumber: Yup.string(),
       phoneNumberCountryCode: Yup.string(),
-    },
-    richRequiredPhoneValidators: {
+    }),
+    getRichRequiredPhoneValidators: () => ({
       phoneNumber: Yup.string().required("Phone number is required"),
       phoneNumberCountryCode: Yup.string().required(
         "Phone number country code is required",
       ),
-    },
+    }),
   }
 })
 

--- a/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsInformation.tsx
+++ b/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsInformation.tsx
@@ -21,6 +21,7 @@ import { countries as countryPhoneOptions } from "Utils/countries"
 import type { SettingsEditSettingsInformation_me$data } from "__generated__/SettingsEditSettingsInformation_me.graphql"
 import { Form, Formik } from "formik"
 import type * as React from "react"
+import { useMemo } from "react"
 import {
   createFragmentContainer,
   graphql,
@@ -39,7 +40,6 @@ export const SettingsEditSettingsInformation: React.FC<
   const { sendToast } = useToasts()
   const { submitMutation } = useUpdateSettingsInformation()
   const relayEnvironment = useRelayEnvironment()
-  const richPhoneValidators = getRichPhoneValidators(relayEnvironment)
   const phoneNumber = me.phoneNumber?.display ?? me.phoneNumber?.originalNumber
   const phoneCountryCode = me.phoneNumber?.regionCode
 
@@ -49,6 +49,24 @@ export const SettingsEditSettingsInformation: React.FC<
   const defaultPhoneCountryCode = phoneCountryCode
     ? phoneCountryCode
     : locationBasedInitialValues.phoneNumberCountryCode || "us"
+
+  const validationSchema = useMemo(() => {
+    const richPhoneValidators = getRichPhoneValidators(relayEnvironment)
+
+    return Yup.object().shape({
+      email: Yup.string()
+        .email("Please enter a valid email.")
+        .required("Please enter a valid email."),
+      // Requires password when email is changed
+      password: passwordValidator.when("email", {
+        is: email => email !== me.email,
+        otherwise: field => field.notRequired(),
+      }),
+      phoneNumber: richPhoneValidators.phoneNumber.notRequired(),
+      phoneNumberCountryCode:
+        richPhoneValidators.phoneNumberCountryCode.notRequired(),
+    })
+  }, [relayEnvironment, me.email])
 
   return (
     <>
@@ -66,19 +84,7 @@ export const SettingsEditSettingsInformation: React.FC<
           priceRangeMin: me.priceRangeMin,
           password: "",
         }}
-        validationSchema={Yup.object().shape({
-          email: Yup.string()
-            .email("Please enter a valid email.")
-            .required("Please enter a valid email."),
-          // Requires password when email is changed
-          password: passwordValidator.when("email", {
-            is: email => email !== me.email,
-            otherwise: field => field.notRequired(),
-          }),
-          phoneNumber: richPhoneValidators.phoneNumber.notRequired(),
-          phoneNumberCountryCode:
-            richPhoneValidators.phoneNumberCountryCode.notRequired(),
-        })}
+        validationSchema={validationSchema}
         onSubmit={async (
           {
             email,

--- a/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsInformation.tsx
+++ b/src/Apps/Settings/Routes/EditSettings/Components/SettingsEditSettingsInformation.tsx
@@ -11,8 +11,8 @@ import {
 } from "@artsy/palette"
 import { PRICE_BUCKETS } from "Apps/Settings/Routes/EditProfile/Components/SettingsEditProfileAboutYou"
 import {
+  getRichPhoneValidators,
   handlePhoneNumberChange,
-  richPhoneValidators,
 } from "Components/Address/utils"
 import { sortCountriesForCountryInput } from "Components/Address/utils/sortCountriesForCountryInput"
 import { useInitialLocationValues } from "Components/Address/utils/useInitialLocationValues"
@@ -21,7 +21,11 @@ import { countries as countryPhoneOptions } from "Utils/countries"
 import type { SettingsEditSettingsInformation_me$data } from "__generated__/SettingsEditSettingsInformation_me.graphql"
 import { Form, Formik } from "formik"
 import type * as React from "react"
-import { createFragmentContainer, graphql } from "react-relay"
+import {
+  createFragmentContainer,
+  graphql,
+  useRelayEnvironment,
+} from "react-relay"
 import * as Yup from "yup"
 import { useUpdateSettingsInformation } from "./useUpdateSettingsInformation"
 
@@ -34,6 +38,8 @@ export const SettingsEditSettingsInformation: React.FC<
 > = ({ me }) => {
   const { sendToast } = useToasts()
   const { submitMutation } = useUpdateSettingsInformation()
+  const relayEnvironment = useRelayEnvironment()
+  const richPhoneValidators = getRichPhoneValidators(relayEnvironment)
   const phoneNumber = me.phoneNumber?.display ?? me.phoneNumber?.originalNumber
   const phoneCountryCode = me.phoneNumber?.regionCode
 

--- a/src/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddressForm.tsx
+++ b/src/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddressForm.tsx
@@ -11,11 +11,10 @@ import {
 import { useAddAddress } from "Apps/Settings/Routes/Shipping/useAddAddress"
 import { useEditAddress } from "Apps/Settings/Routes/Shipping/useEditAddress"
 import { useSetDefaultAddress } from "Apps/Settings/Routes/Shipping/useSetDefaultAddress"
-import { AddressFormFields } from "Components/Address/AddressFormFields"
 import {
-  getRichRequiredPhoneValidators,
-  yupAddressValidator,
-} from "Components/Address/utils"
+  AddressFormFields,
+  addressFormFieldsValidator,
+} from "Components/Address/AddressFormFields"
 import { sortCountriesForCountryInput } from "Components/Address/utils/sortCountriesForCountryInput"
 import { useInitialLocationValues } from "Components/Address/utils/useInitialLocationValues"
 import { countries as countryPhoneOptions } from "Utils/countries"
@@ -76,8 +75,10 @@ export const SettingsShippingAddressForm: FC<
   const validationSchema = useMemo(
     () =>
       Yup.object().shape({
-        address: yupAddressValidator,
-        ...getRichRequiredPhoneValidators(relayEnvironment),
+        ...addressFormFieldsValidator({
+          withPhoneNumber: true,
+          relayEnvironment,
+        }),
         setAsDefault: Yup.boolean().optional(),
       }),
     [relayEnvironment],

--- a/src/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddressForm.tsx
+++ b/src/Apps/Settings/Routes/Shipping/Components/SettingsShippingAddressForm.tsx
@@ -13,14 +13,15 @@ import { useEditAddress } from "Apps/Settings/Routes/Shipping/useEditAddress"
 import { useSetDefaultAddress } from "Apps/Settings/Routes/Shipping/useSetDefaultAddress"
 import { AddressFormFields } from "Components/Address/AddressFormFields"
 import {
-  richRequiredPhoneValidators,
+  getRichRequiredPhoneValidators,
   yupAddressValidator,
 } from "Components/Address/utils"
 import { sortCountriesForCountryInput } from "Components/Address/utils/sortCountriesForCountryInput"
 import { useInitialLocationValues } from "Components/Address/utils/useInitialLocationValues"
 import { countries as countryPhoneOptions } from "Utils/countries"
 import { Form, Formik } from "formik"
-import type { FC } from "react"
+import { type FC, useMemo } from "react"
+import { useRelayEnvironment } from "react-relay"
 import * as Yup from "yup"
 
 const DEFAULT_PHONE_COUNTRY_CODE = "us"
@@ -54,12 +55,6 @@ const INITIAL_VALUES = {
 
 type AddressAttributes = typeof INITIAL_ADDRESS
 
-const VALIDATION_SCHEMA = Yup.object().shape({
-  address: yupAddressValidator,
-  ...richRequiredPhoneValidators,
-  setAsDefault: Yup.boolean().optional(),
-})
-
 interface SettingsShippingAddressFormProps {
   onClose(): void
   address?: {
@@ -76,6 +71,17 @@ export const SettingsShippingAddressForm: FC<
   const { submitMutation: submitEditAddress } = useEditAddress()
   const { submitMutation: submitSetDefaultAddress } = useSetDefaultAddress()
   const { sendToast } = useToasts()
+
+  const relayEnvironment = useRelayEnvironment()
+  const validationSchema = useMemo(
+    () =>
+      Yup.object().shape({
+        address: yupAddressValidator,
+        ...getRichRequiredPhoneValidators(relayEnvironment),
+        setAsDefault: Yup.boolean().optional(),
+      }),
+    [relayEnvironment],
+  )
 
   const isEditing = !!address
   const countryInputOptions = sortCountriesForCountryInput(countryPhoneOptions)
@@ -112,7 +118,7 @@ export const SettingsShippingAddressForm: FC<
     <Formik
       validateOnMount
       enableReinitialize={true}
-      validationSchema={VALIDATION_SCHEMA}
+      validationSchema={validationSchema}
       initialValues={getInitialValues()}
       onSubmit={async (
         {

--- a/src/Components/Address/AddressFormFields.tsx
+++ b/src/Components/Address/AddressFormFields.tsx
@@ -56,6 +56,24 @@ interface Props {
 }
 
 /**
+ * Arguments for `addressFormFieldsValidator`. Modeled as a discriminated union
+ * so that requesting rich phone validation (`withPhoneNumber: true`) forces a
+ * Relay `relayEnvironment` to be supplied — otherwise the async phone-number
+ * validation would be silently omitted from the schema.
+ */
+type AddressFormFieldsValidatorArgs =
+  | {
+      withPhoneNumber: true
+      relayEnvironment: Environment
+      withLegacyPhoneInput?: boolean
+    }
+  | {
+      withPhoneNumber?: false
+      relayEnvironment?: Environment
+      withLegacyPhoneInput?: boolean
+    }
+
+/**
  * Validation schema for address form fields. Arguments match the
  * <AddressFormFields/> component - e.g. to include phone number validation
  *
@@ -84,14 +102,11 @@ interface Props {
  * ```
  */
 export const addressFormFieldsValidator = (
-  args: Pick<Props, "withLegacyPhoneInput" | "withPhoneNumber"> & {
-    relayEnvironment?: Environment
-  } = {},
+  args: AddressFormFieldsValidatorArgs = {},
 ) => ({
   address: yupAddressValidator,
   ...(args.withLegacyPhoneInput && basicPhoneValidator),
   ...(args.withPhoneNumber &&
-    args.relayEnvironment &&
     getRichRequiredPhoneValidators(args.relayEnvironment)),
 })
 

--- a/src/Components/Address/AddressFormFields.tsx
+++ b/src/Components/Address/AddressFormFields.tsx
@@ -16,10 +16,10 @@ import { AddressAutocompleteInput } from "Components/Address/AddressAutocomplete
 import {
   type Address,
   basicPhoneValidator,
+  getRichRequiredPhoneValidators,
   handlePhoneNumberChange,
   isPostalCodeRequired,
   isRegionRequired,
-  richRequiredPhoneValidators,
   yupAddressValidator,
 } from "Components/Address/utils"
 import { sortCountriesForCountryInput } from "Components/Address/utils/sortCountriesForCountryInput"
@@ -27,6 +27,7 @@ import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
 import { countries as countryPhoneOptions } from "Utils/countries"
 import { useFormikContext } from "formik"
 import { type ChangeEvent, useMemo, useState } from "react"
+import type { Environment } from "relay-runtime"
 import { useTracking } from "react-tracking"
 
 export interface FormikContextWithAddress {
@@ -58,27 +59,40 @@ interface Props {
  * Validation schema for address form fields. Arguments match the
  * <AddressFormFields/> component - e.g. to include phone number validation
  *
+ * When `withPhoneNumber` is used, pass the Relay `relayEnvironment` (from
+ * `useRelayEnvironment()`) so the async phone-number validation can run; build
+ * the schema in-component (typically memoized on the environment).
+ *
  * @example
  * ```tsx
- * const validationSchema = yup.object().shape({
- *  ...addressFormFieldsValidator({ withLegacyPhoneInput: true }),
- *  saveAddress: boolean
- * })
+ * const relayEnvironment = useRelayEnvironment()
+ * const validationSchema = useMemo(
+ *   () =>
+ *     yup.object().shape({
+ *       ...addressFormFieldsValidator({ withPhoneNumber: true, relayEnvironment }),
+ *       saveAddress: boolean,
+ *     }),
+ *   [relayEnvironment],
+ * )
  * // later...
  *
  * <Formik
  *  validationSchema={validationSchema}
  *  {...otherFormikProps}
  * >
- *   <AddressFormFields<AddressFormValues> withLegacyPhoneInput />
+ *   <AddressFormFields<AddressFormValues> withPhoneNumber />
  * ```
  */
 export const addressFormFieldsValidator = (
-  args: Pick<Props, "withLegacyPhoneInput" | "withPhoneNumber"> = {},
+  args: Pick<Props, "withLegacyPhoneInput" | "withPhoneNumber"> & {
+    relayEnvironment?: Environment
+  } = {},
 ) => ({
   address: yupAddressValidator,
   ...(args.withLegacyPhoneInput && basicPhoneValidator),
-  ...(args.withPhoneNumber && richRequiredPhoneValidators),
+  ...(args.withPhoneNumber &&
+    args.relayEnvironment &&
+    getRichRequiredPhoneValidators(args.relayEnvironment)),
 })
 
 /**

--- a/src/Components/Address/__tests__/AddressFormFields.jest.tsx
+++ b/src/Components/Address/__tests__/AddressFormFields.jest.tsx
@@ -14,6 +14,8 @@ import {
 import { type Address, emptyAddress } from "Components/Address/utils"
 import { flushPromiseQueue } from "DevTools/flushPromiseQueue"
 import { Formik } from "formik"
+import type { Environment } from "relay-runtime"
+import { createMockEnvironment } from "relay-test-utils"
 import * as Yup from "yup"
 
 describe("AddressFormFields", () => {
@@ -112,7 +114,11 @@ describe("AddressFormFields", () => {
             phoneNumber: "",
           }}
           validationSchema={Yup.object().shape({
-            ...addressFormFieldsValidator({ withPhoneNumber: true }),
+            ...addressFormFieldsValidator({
+              withPhoneNumber: true,
+              relayEnvironment:
+                createMockEnvironment() as unknown as Environment,
+            }),
           })}
         >
           {formikBag => (

--- a/src/Components/Address/utils/utils.ts
+++ b/src/Components/Address/utils/utils.ts
@@ -1,8 +1,7 @@
 import type { CreateTokenCardData } from "@stripe/stripe-js"
 import type { utilsValidatePhoneNumberQuery } from "__generated__/utilsValidatePhoneNumberQuery.graphql"
 import { debounce } from "lodash"
-import { useCallback, useEffect, useState } from "react"
-import { fetchQuery, graphql, useRelayEnvironment } from "react-relay"
+import { fetchQuery, graphql } from "react-relay"
 import type { Environment } from "relay-runtime"
 import * as Yup from "yup"
 
@@ -90,38 +89,6 @@ export const validatePhoneNumber = (
   return new Promise(resolve => {
     phoneValidator(phoneNumber, resolve, relayEnvironment)
   })
-}
-
-/**
- * React hook for phone number validation
- * @param national The national phone number
- * @param regionCode The region/country code
- * @returns Boolean indicating if phone number is valid
- */
-export const useValidatePhoneNumber = ({
-  national,
-  regionCode,
-}: PhoneNumber) => {
-  const relayEnvironment = useRelayEnvironment()
-  const [isPhoneNumberValid, setIsPhoneNumberValid] = useState(true)
-
-  const validate = useCallback(async () => {
-    const isValid = await validatePhoneNumber(
-      {
-        national,
-        regionCode,
-      },
-      relayEnvironment,
-    )
-
-    setIsPhoneNumberValid(isValid)
-  }, [national, regionCode, relayEnvironment])
-
-  useEffect(() => {
-    validate()
-  }, [validate])
-
-  return isPhoneNumberValid
 }
 
 export const toStripeAddress = (address: Address): CreateTokenCardData => {

--- a/src/Components/Address/utils/utils.ts
+++ b/src/Components/Address/utils/utils.ts
@@ -1,9 +1,9 @@
 import type { CreateTokenCardData } from "@stripe/stripe-js"
-import { createRelaySSREnvironment } from "System/Relay/createRelaySSREnvironment"
 import type { utilsValidatePhoneNumberQuery } from "__generated__/utilsValidatePhoneNumberQuery.graphql"
 import { debounce } from "lodash"
 import { useCallback, useEffect, useState } from "react"
-import { fetchQuery, graphql } from "react-relay"
+import { fetchQuery, graphql, useRelayEnvironment } from "react-relay"
+import type { Environment } from "relay-runtime"
 import * as Yup from "yup"
 
 export interface Address {
@@ -28,8 +28,6 @@ export const emptyAddress: Address = {
   phoneNumber: "",
 }
 
-const relayEnvironment = createRelaySSREnvironment()
-
 type PhoneNumber = {
   national: string
   regionCode: string
@@ -39,6 +37,7 @@ const phoneValidator = debounce(
   async (
     { national, regionCode }: PhoneNumber,
     resolve: (value: boolean) => void,
+    relayEnvironment: Environment,
   ) => {
     if (!national || national.length < 5 || !regionCode) {
       return resolve(false)
@@ -79,13 +78,17 @@ const phoneValidator = debounce(
 /**
  * Validates a phone number using GraphQL API
  * @param phoneNumber Object with national number and region code
+ * @param relayEnvironment Relay environment used to run the validation query.
+ *   Injected by the caller (e.g. via `useRelayEnvironment()`) so tests can
+ *   supply a mock environment instead of hitting the network.
  * @returns Promise that resolves to boolean indicating if phone number is valid
  */
 export const validatePhoneNumber = (
   phoneNumber: PhoneNumber,
+  relayEnvironment: Environment,
 ): Promise<boolean> => {
   return new Promise(resolve => {
-    phoneValidator(phoneNumber, resolve)
+    phoneValidator(phoneNumber, resolve, relayEnvironment)
   })
 }
 
@@ -99,16 +102,20 @@ export const useValidatePhoneNumber = ({
   national,
   regionCode,
 }: PhoneNumber) => {
+  const relayEnvironment = useRelayEnvironment()
   const [isPhoneNumberValid, setIsPhoneNumberValid] = useState(true)
 
   const validate = useCallback(async () => {
-    const isValid = await validatePhoneNumber({
-      national,
-      regionCode,
-    })
+    const isValid = await validatePhoneNumber(
+      {
+        national,
+        regionCode,
+      },
+      relayEnvironment,
+    )
 
     setIsPhoneNumberValid(isValid)
-  }, [national, regionCode])
+  }, [national, regionCode, relayEnvironment])
 
   useEffect(() => {
     validate()
@@ -142,7 +149,14 @@ export const handlePhoneNumberChange = (
   setFieldValue("phoneNumber", e.target.value.replace(/[a-zA-Z]/g, ""))
 }
 
-export const richPhoneValidators = {
+/**
+ * Builds the rich phone-number Yup validators, closing over the Relay
+ * environment used to run the async validation query. Callers obtain the
+ * environment from React context (`useRelayEnvironment()`) and build the schema
+ * in-component (typically memoized), which keeps validation testable with a
+ * mock environment.
+ */
+export const getRichPhoneValidators = (relayEnvironment: Environment) => ({
   phoneNumber: Yup.string()
     .matches(/^[^a-zA-Z]*$/, "Please enter a valid phone number")
     .test({
@@ -152,14 +166,17 @@ export const richPhoneValidators = {
         if (!national || national.length === 0) {
           return true
         }
-        return validatePhoneNumber({
-          national: `${national}`,
-          regionCode: `${context.parent.phoneNumberCountryCode}`,
-        })
+        return validatePhoneNumber(
+          {
+            national: `${national}`,
+            regionCode: `${context.parent.phoneNumberCountryCode}`,
+          },
+          relayEnvironment,
+        )
       },
     }),
   phoneNumberCountryCode: Yup.string(),
-}
+})
 
 export const phoneInitialValuesFromMe = (
   mePhoneNumber:
@@ -177,13 +194,19 @@ export const phoneInitialValuesFromMe = (
   }
 }
 
-export const richRequiredPhoneValidators = {
-  phoneNumber: richPhoneValidators.phoneNumber.required(
-    "Phone number is required",
-  ),
-  phoneNumberCountryCode: richPhoneValidators.phoneNumberCountryCode.required(
-    "Phone number country code is required",
-  ),
+export const getRichRequiredPhoneValidators = (
+  relayEnvironment: Environment,
+) => {
+  const richPhoneValidators = getRichPhoneValidators(relayEnvironment)
+
+  return {
+    phoneNumber: richPhoneValidators.phoneNumber.required(
+      "Phone number is required",
+    ),
+    phoneNumberCountryCode: richPhoneValidators.phoneNumberCountryCode.required(
+      "Phone number country code is required",
+    ),
+  }
 }
 
 const usPostalCodeRegexp = /^[0-9]{5}(?:-[0-9]{4})?$/

--- a/src/DevTools/autoResolvePhoneValidation.ts
+++ b/src/DevTools/autoResolvePhoneValidation.ts
@@ -29,7 +29,9 @@ export const autoResolvePhoneValidation = (env: MockEnvironment): void => {
     env.mock.queueOperationResolver(makeResolver())
 
     return MockPayloadGenerator.generate(operation, {
-      PhoneNumber: () => ({ isValid: true }),
+      // The field resolves to the `PhoneNumberType` GraphQL type; keying on
+      // anything else silently falls back to a default mock value for `isValid`.
+      PhoneNumberType: () => ({ isValid: true }),
     })
   }
 

--- a/src/DevTools/autoResolvePhoneValidation.ts
+++ b/src/DevTools/autoResolvePhoneValidation.ts
@@ -1,0 +1,37 @@
+import type { OperationDescriptor } from "relay-runtime"
+import { type MockEnvironment, MockPayloadGenerator } from "relay-test-utils"
+
+const PHONE_VALIDATION_QUERY = "utilsValidatePhoneNumberQuery"
+
+/**
+ * Auto-resolves the async phone-number validation query
+ * (`utilsValidatePhoneNumberQuery`) on a mock Relay environment.
+ *
+ * Phone validation runs through `useRelayEnvironment()`, so in tests its query
+ * lands on the same mock environment as the component under test. Left
+ * unresolved it stalls Formik validation (and therefore form submission). Call
+ * this once after rendering so validation resolves deterministically to valid
+ * — without hitting the network or mocking `Components/Address/utils`.
+ *
+ * Other operations (mutations, refetches) fall through untouched and remain
+ * pending for manual resolution via `mockResolveLastOperation`.
+ */
+export const autoResolvePhoneValidation = (env: MockEnvironment): void => {
+  const makeResolver = () => (operation: OperationDescriptor) => {
+    if (operation.request.node.operation.name !== PHONE_VALIDATION_QUERY) {
+      // Returning null leaves the resolver queued and the operation pending,
+      // so non-phone operations are still resolved manually.
+      return null
+    }
+
+    // Re-queue a fresh resolver so later phone-validation queries (e.g. a
+    // re-validation on submit) are also handled.
+    env.mock.queueOperationResolver(makeResolver())
+
+    return MockPayloadGenerator.generate(operation, {
+      PhoneNumber: () => ({ isValid: true }),
+    })
+  }
+
+  env.mock.queueOperationResolver(makeResolver())
+}


### PR DESCRIPTION
The type of this PR is: **refactor**

Phone-number validation previously constructed its own Relay environment at module load and ran a network-backed query during Yup validation. In tests that query failed over the (absent) network - brittle, but only an issue when we needed to explicitly test behavior around it.

This PR makes the behavior consistent by having creating phone validation schemas from a factory that takes a relay environment. As a result tests are more predictable and we can re-use a single environment in our production code. Testing is less brittle and easier thanks to a `DevTools/autoResolvePhoneValidation` helper that resolves the phone query on a mock environment: form submission isn't blocked, leaving other operations for manual resolution.
