### PR TITLE
feat: add related articles to News layout

### DIFF
--- a/src/Apps/Article/ArticleApp.tsx
+++ b/src/Apps/Article/ArticleApp.tsx
@@ -10,6 +10,7 @@ import { ArticleBodyFragmentContainer } from "./Components/ArticleBody"
 import { ArticleChannelRelatedArticlesQueryRenderer } from "./Components/ArticleChannelRelatedArticles"
 import { ArticleInfiniteScrollQueryRenderer } from "./Components/ArticleInfiniteScroll"
 import { ArticleMetaTagsFragmentContainer } from "./Components/ArticleMetaTags"
+import { ArticleNewsRelatedArticlesQueryRenderer } from "./Components/ArticleNewsRelatedArticles"
 import { ArticleSeriesFragmentContainer } from "./Components/ArticleSeries"
 import { ArticleVerticalRelatedArticlesQueryRenderer } from "./Components/ArticleVerticalRelatedArticles"
 import { ArticleVideoFragmentContainer } from "./Components/ArticleVideo"
@@ -40,7 +41,19 @@ const ArticleApp: FC<React.PropsWithChildren<ArticleAppProps>> = ({
                 return <ArticleVideoFragmentContainer article={article} />
 
               case "NEWS":
-                return <ArticleBodyFragmentContainer article={article} />
+                return (
+                  <>
+                    <ArticleBodyFragmentContainer article={article} />
+
+                    <FullBleed>
+                      <Separator />
+                    </FullBleed>
+
+                    <ArticleNewsRelatedArticlesQueryRenderer
+                      id={article.internalID}
+                    />
+                  </>
+                )
 
               case "CLASSIC":
                 return (

--- a/src/Apps/Article/Components/ArticleChannelRelatedArticles.tsx
+++ b/src/Apps/Article/Components/ArticleChannelRelatedArticles.tsx
@@ -1,8 +1,7 @@
-import { Shelf, Skeleton, SkeletonText, Text } from "@artsy/palette"
 import {
-  CellArticleFragmentContainer,
-  CellArticlePlaceholder,
-} from "Components/Cells/CellArticle"
+  ArticleRelatedArticlesShelf,
+  ArticleRelatedArticlesShelfPlaceholder,
+} from "Apps/Article/Components/ArticleRelatedArticlesShelf"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import type { ArticleChannelRelatedArticlesQuery } from "__generated__/ArticleChannelRelatedArticlesQuery.graphql"
 import type { ArticleChannelRelatedArticles_article$data } from "__generated__/ArticleChannelRelatedArticles_article.graphql"
@@ -16,25 +15,11 @@ interface ArticleChannelRelatedArticlesProps {
 const ArticleChannelRelatedArticles: FC<
   React.PropsWithChildren<ArticleChannelRelatedArticlesProps>
 > = ({ article }) => {
-  if (article.channelArticles.length === 0) return null
-
   return (
-    <>
-      <Text variant="lg-display" mb={4}>
-        More From {article.channel?.name || article.byline}
-      </Text>
-
-      <Shelf alignItems="flex-start">
-        {article.channelArticles.map(article => {
-          return (
-            <CellArticleFragmentContainer
-              key={article.internalID}
-              article={article}
-            />
-          )
-        })}
-      </Shelf>
-    </>
+    <ArticleRelatedArticlesShelf
+      articles={article.channelArticles}
+      heading={`More From ${article.channel?.name || article.byline}`}
+    />
   )
 }
 
@@ -97,16 +82,6 @@ const ArticleChannelRelatedArticlesPlaceholder: FC<
   React.PropsWithChildren<unknown>
 > = () => {
   return (
-    <Skeleton>
-      <SkeletonText variant="lg-display" mb={4}>
-        More From This Author
-      </SkeletonText>
-
-      <Shelf alignItems="flex-start">
-        {[...new Array(8)].map((_, index) => {
-          return <CellArticlePlaceholder key={index} />
-        })}
-      </Shelf>
-    </Skeleton>
+    <ArticleRelatedArticlesShelfPlaceholder heading="More From This Author" />
   )
 }

--- a/src/Apps/Article/Components/ArticleNewsRelatedArticles.tsx
+++ b/src/Apps/Article/Components/ArticleNewsRelatedArticles.tsx
@@ -1,0 +1,98 @@
+import { Shelf, Skeleton } from "@artsy/palette"
+import {
+  CellArticleFragmentContainer,
+  CellArticlePlaceholder,
+} from "Components/Cells/CellArticle"
+import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
+import type { ArticleNewsRelatedArticlesQuery } from "__generated__/ArticleNewsRelatedArticlesQuery.graphql"
+import type { ArticleNewsRelatedArticles_article$data } from "__generated__/ArticleNewsRelatedArticles_article.graphql"
+import type { FC } from "react"
+import { createFragmentContainer, graphql } from "react-relay"
+
+interface ArticleNewsRelatedArticlesProps {
+  article: ArticleNewsRelatedArticles_article$data
+}
+
+const ArticleNewsRelatedArticles: FC<
+  React.PropsWithChildren<ArticleNewsRelatedArticlesProps>
+> = ({ article }) => {
+  if (article.newsRelatedArticles.length === 0) return null
+
+  return (
+    <Shelf alignItems="flex-start">
+      {article.newsRelatedArticles.map(article => {
+        return (
+          <CellArticleFragmentContainer
+            key={article.internalID}
+            article={article}
+          />
+        )
+      })}
+    </Shelf>
+  )
+}
+
+export const ArticleNewsRelatedArticlesFragmentContainer =
+  createFragmentContainer(ArticleNewsRelatedArticles, {
+    article: graphql`
+      fragment ArticleNewsRelatedArticles_article on Article {
+        newsRelatedArticles: relatedArticles(size: 8) {
+          internalID
+          ...CellArticle_article
+        }
+      }
+    `,
+  })
+
+interface ArticleNewsRelatedArticlesQueryRendererProps {
+  id: string
+}
+
+export const ArticleNewsRelatedArticlesQueryRenderer: FC<
+  React.PropsWithChildren<ArticleNewsRelatedArticlesQueryRendererProps>
+> = ({ id }) => {
+  return (
+    <SystemQueryRenderer<ArticleNewsRelatedArticlesQuery>
+      lazyLoad
+      placeholder={<ArticleNewsRelatedArticlesPlaceholder />}
+      variables={{ id }}
+      query={graphql`
+        query ArticleNewsRelatedArticlesQuery($id: String!) @cacheable {
+          article(id: $id) {
+            ...ArticleNewsRelatedArticles_article
+          }
+        }
+      `}
+      render={({ error, props }) => {
+        if (error) {
+          console.error(error)
+          return null
+        }
+
+        if (!props?.article) {
+          return <ArticleNewsRelatedArticlesPlaceholder />
+        }
+
+        return (
+          <ArticleNewsRelatedArticlesFragmentContainer
+            article={props.article}
+          />
+        )
+      }}
+    />
+  )
+}
+
+const ArticleNewsRelatedArticlesPlaceholder: FC<
+  React.PropsWithChildren<unknown>
+> = () => {
+  return (
+    <Skeleton>
+      <Shelf alignItems="flex-start">
+        {[...new Array(8)].map((_, index) => {
+          return <CellArticlePlaceholder key={index} />
+        })}
+      </Shelf>
+    </Skeleton>
+  )
+}

--- a/src/Apps/Article/Components/ArticleNewsRelatedArticles.tsx
+++ b/src/Apps/Article/Components/ArticleNewsRelatedArticles.tsx
@@ -1,8 +1,7 @@
-import { Shelf, Skeleton } from "@artsy/palette"
 import {
-  CellArticleFragmentContainer,
-  CellArticlePlaceholder,
-} from "Components/Cells/CellArticle"
+  ArticleRelatedArticlesShelf,
+  ArticleRelatedArticlesShelfPlaceholder,
+} from "Apps/Article/Components/ArticleRelatedArticlesShelf"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import type { ArticleNewsRelatedArticlesQuery } from "__generated__/ArticleNewsRelatedArticlesQuery.graphql"
 import type { ArticleNewsRelatedArticles_article$data } from "__generated__/ArticleNewsRelatedArticles_article.graphql"
@@ -16,20 +15,7 @@ interface ArticleNewsRelatedArticlesProps {
 const ArticleNewsRelatedArticles: FC<
   React.PropsWithChildren<ArticleNewsRelatedArticlesProps>
 > = ({ article }) => {
-  if (article.newsRelatedArticles.length === 0) return null
-
-  return (
-    <Shelf alignItems="flex-start">
-      {article.newsRelatedArticles.map(article => {
-        return (
-          <CellArticleFragmentContainer
-            key={article.internalID}
-            article={article}
-          />
-        )
-      })}
-    </Shelf>
-  )
+  return <ArticleRelatedArticlesShelf articles={article.newsRelatedArticles} />
 }
 
 export const ArticleNewsRelatedArticlesFragmentContainer =
@@ -86,13 +72,5 @@ export const ArticleNewsRelatedArticlesQueryRenderer: FC<
 const ArticleNewsRelatedArticlesPlaceholder: FC<
   React.PropsWithChildren<unknown>
 > = () => {
-  return (
-    <Skeleton>
-      <Shelf alignItems="flex-start">
-        {[...new Array(8)].map((_, index) => {
-          return <CellArticlePlaceholder key={index} />
-        })}
-      </Shelf>
-    </Skeleton>
-  )
+  return <ArticleRelatedArticlesShelfPlaceholder />
 }

--- a/src/Apps/Article/Components/ArticleNewsRelatedArticles.tsx
+++ b/src/Apps/Article/Components/ArticleNewsRelatedArticles.tsx
@@ -22,7 +22,7 @@ export const ArticleNewsRelatedArticlesFragmentContainer =
   createFragmentContainer(ArticleNewsRelatedArticles, {
     article: graphql`
       fragment ArticleNewsRelatedArticles_article on Article {
-        newsRelatedArticles: relatedArticles(size: 8) {
+        newsRelatedArticles: relatedArticles(size: 3) {
           internalID
           ...CellArticle_article
         }

--- a/src/Apps/Article/Components/ArticleRelatedArticlesShelf.tsx
+++ b/src/Apps/Article/Components/ArticleRelatedArticlesShelf.tsx
@@ -1,0 +1,66 @@
+import { Shelf, Skeleton, SkeletonText, Text } from "@artsy/palette"
+import {
+  CellArticleFragmentContainer,
+  CellArticlePlaceholder,
+} from "Components/Cells/CellArticle"
+import type { ComponentProps, FC } from "react"
+
+type CellArticle = ComponentProps<
+  typeof CellArticleFragmentContainer
+>["article"]
+
+interface ArticleRelatedArticlesShelfProps {
+  articles: ReadonlyArray<{ internalID: string } & CellArticle>
+  heading?: string
+}
+
+export const ArticleRelatedArticlesShelf: FC<
+  React.PropsWithChildren<ArticleRelatedArticlesShelfProps>
+> = ({ articles, heading }) => {
+  if (articles.length === 0) return null
+
+  return (
+    <>
+      {heading && (
+        <Text variant="lg-display" mb={4}>
+          {heading}
+        </Text>
+      )}
+
+      <Shelf alignItems="flex-start">
+        {articles.map(article => {
+          return (
+            <CellArticleFragmentContainer
+              key={article.internalID}
+              article={article}
+            />
+          )
+        })}
+      </Shelf>
+    </>
+  )
+}
+
+interface ArticleRelatedArticlesShelfPlaceholderProps {
+  heading?: string
+}
+
+export const ArticleRelatedArticlesShelfPlaceholder: FC<
+  React.PropsWithChildren<ArticleRelatedArticlesShelfPlaceholderProps>
+> = ({ heading }) => {
+  return (
+    <Skeleton>
+      {heading && (
+        <SkeletonText variant="lg-display" mb={4}>
+          {heading}
+        </SkeletonText>
+      )}
+
+      <Shelf alignItems="flex-start">
+        {[...new Array(8)].map((_, index) => {
+          return <CellArticlePlaceholder key={index} />
+        })}
+      </Shelf>
+    </Skeleton>
+  )
+}

--- a/src/Apps/Article/Components/ArticleVerticalRelatedArticles.tsx
+++ b/src/Apps/Article/Components/ArticleVerticalRelatedArticles.tsx
@@ -1,8 +1,7 @@
-import { Shelf, Skeleton, SkeletonText, Text } from "@artsy/palette"
 import {
-  CellArticleFragmentContainer,
-  CellArticlePlaceholder,
-} from "Components/Cells/CellArticle"
+  ArticleRelatedArticlesShelf,
+  ArticleRelatedArticlesShelfPlaceholder,
+} from "Apps/Article/Components/ArticleRelatedArticlesShelf"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import type { ArticleVerticalRelatedArticlesQuery } from "__generated__/ArticleVerticalRelatedArticlesQuery.graphql"
 import type { ArticleVerticalRelatedArticles_article$data } from "__generated__/ArticleVerticalRelatedArticles_article.graphql"
@@ -16,25 +15,11 @@ interface ArticleVerticalRelatedArticlesProps {
 const ArticleVerticalRelatedArticles: FC<
   React.PropsWithChildren<ArticleVerticalRelatedArticlesProps>
 > = ({ article }) => {
-  if (article.verticalRelatedArticles.length === 0) return null
-
   return (
-    <>
-      <Text variant="lg-display" mb={4}>
-        Further Reading in {article.vertical}
-      </Text>
-
-      <Shelf alignItems="flex-start">
-        {article.verticalRelatedArticles.map(article => {
-          return (
-            <CellArticleFragmentContainer
-              key={article.internalID}
-              article={article}
-            />
-          )
-        })}
-      </Shelf>
-    </>
+    <ArticleRelatedArticlesShelf
+      articles={article.verticalRelatedArticles}
+      heading={`Further Reading in ${article.vertical}`}
+    />
   )
 }
 
@@ -94,16 +79,6 @@ const ArticleVerticalRelatedArticlesPlaceholder: FC<
   React.PropsWithChildren<unknown>
 > = () => {
   return (
-    <Skeleton>
-      <SkeletonText variant="lg-display" mb={4}>
-        Further Reading in Vertical
-      </SkeletonText>
-
-      <Shelf alignItems="flex-start">
-        {[...new Array(8)].map((_, index) => {
-          return <CellArticlePlaceholder key={index} />
-        })}
-      </Shelf>
-    </Skeleton>
+    <ArticleRelatedArticlesShelfPlaceholder heading="Further Reading in Vertical" />
   )
 }

--- a/src/Apps/Article/Components/__tests__/ArticleChannelRelatedArticles.jest.tsx
+++ b/src/Apps/Article/Components/__tests__/ArticleChannelRelatedArticles.jest.tsx
@@ -1,0 +1,40 @@
+import { screen } from "@testing-library/react"
+import { ArticleChannelRelatedArticlesFragmentContainer } from "Apps/Article/Components/ArticleChannelRelatedArticles"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
+import { graphql } from "react-relay"
+
+jest.unmock("react-relay")
+
+const { renderWithRelay } = setupTestWrapperTL({
+  Component: ArticleChannelRelatedArticlesFragmentContainer,
+  query: graphql`
+    query ArticleChannelRelatedArticles_test_Query @relay_test_operation {
+      article(id: "example") {
+        ...ArticleChannelRelatedArticles_article
+      }
+    }
+  `,
+})
+
+describe("ArticleChannelRelatedArticles", () => {
+  it("renders a related article with a channel-specific heading", () => {
+    renderWithRelay({
+      Article: () => ({
+        channelArticles: [{}],
+      }),
+    })
+
+    expect(screen.getAllByRole("link")).toHaveLength(1)
+    expect(screen.getByText(/More From/)).toBeInTheDocument()
+  })
+
+  it("renders nothing when there are no related articles", () => {
+    const { container } = renderWithRelay({
+      Article: () => ({
+        channelArticles: [],
+      }),
+    })
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/src/Apps/Article/Components/__tests__/ArticleNewsRelatedArticles.jest.tsx
+++ b/src/Apps/Article/Components/__tests__/ArticleNewsRelatedArticles.jest.tsx
@@ -1,0 +1,39 @@
+import { screen } from "@testing-library/react"
+import { ArticleNewsRelatedArticlesFragmentContainer } from "Apps/Article/Components/ArticleNewsRelatedArticles"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
+import { graphql } from "react-relay"
+
+jest.unmock("react-relay")
+
+const { renderWithRelay } = setupTestWrapperTL({
+  Component: ArticleNewsRelatedArticlesFragmentContainer,
+  query: graphql`
+    query ArticleNewsRelatedArticles_test_Query @relay_test_operation {
+      article(id: "example") {
+        ...ArticleNewsRelatedArticles_article
+      }
+    }
+  `,
+})
+
+describe("ArticleNewsRelatedArticles", () => {
+  it("renders a related article", () => {
+    renderWithRelay({
+      Article: () => ({
+        newsRelatedArticles: [{}],
+      }),
+    })
+
+    expect(screen.getAllByRole("link")).toHaveLength(1)
+  })
+
+  it("renders nothing when there are no related articles", () => {
+    const { container } = renderWithRelay({
+      Article: () => ({
+        newsRelatedArticles: [],
+      }),
+    })
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/src/Apps/Article/Components/__tests__/ArticleVerticalRelatedArticles.jest.tsx
+++ b/src/Apps/Article/Components/__tests__/ArticleVerticalRelatedArticles.jest.tsx
@@ -1,0 +1,41 @@
+import { screen } from "@testing-library/react"
+import { ArticleVerticalRelatedArticlesFragmentContainer } from "Apps/Article/Components/ArticleVerticalRelatedArticles"
+import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
+import { graphql } from "react-relay"
+
+jest.unmock("react-relay")
+
+const { renderWithRelay } = setupTestWrapperTL({
+  Component: ArticleVerticalRelatedArticlesFragmentContainer,
+  query: graphql`
+    query ArticleVerticalRelatedArticles_test_Query @relay_test_operation {
+      article(id: "example") {
+        ...ArticleVerticalRelatedArticles_article
+      }
+    }
+  `,
+})
+
+describe("ArticleVerticalRelatedArticles", () => {
+  it("renders a related article with a vertical-specific heading", () => {
+    renderWithRelay({
+      Article: () => ({
+        vertical: "Art Market",
+        verticalRelatedArticles: [{}],
+      }),
+    })
+
+    expect(screen.getAllByRole("link")).toHaveLength(1)
+    expect(screen.getByText(/Further Reading in/)).toBeInTheDocument()
+  })
+
+  it("renders nothing when there are no related articles", () => {
+    const { container } = renderWithRelay({
+      Article: () => ({
+        verticalRelatedArticles: [],
+      }),
+    })
+
+    expect(container).toBeEmptyDOMElement()
+  })
+})

--- a/src/__generated__/ArticleChannelRelatedArticles_test_Query.graphql.ts
+++ b/src/__generated__/ArticleChannelRelatedArticles_test_Query.graphql.ts
@@ -1,0 +1,321 @@
+/**
+ * @generated SignedSource<<c1c38a09656beedf4816c4b21ed40a00>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ArticleChannelRelatedArticles_test_Query$variables = Record<PropertyKey, never>;
+export type ArticleChannelRelatedArticles_test_Query$data = {
+  readonly article: {
+    readonly " $fragmentSpreads": FragmentRefs<"ArticleChannelRelatedArticles_article">;
+  } | null | undefined;
+};
+export type ArticleChannelRelatedArticles_test_Query = {
+  response: ArticleChannelRelatedArticles_test_Query$data;
+  variables: ArticleChannelRelatedArticles_test_Query$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "example"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "byline",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v4 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v5 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "String"
+},
+v6 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "Int"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ArticleChannelRelatedArticles_test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Article",
+        "kind": "LinkedField",
+        "name": "article",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ArticleChannelRelatedArticles_article"
+          }
+        ],
+        "storageKey": "article(id:\"example\")"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "ArticleChannelRelatedArticles_test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Article",
+        "kind": "LinkedField",
+        "name": "article",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Channel",
+            "kind": "LinkedField",
+            "name": "channel",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "name",
+                "storageKey": null
+              },
+              (v2/*: any*/)
+            ],
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "concreteType": "Article",
+            "kind": "LinkedField",
+            "name": "channelArticles",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "internalID",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "vertical",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "title",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "thumbnailTitle",
+                "storageKey": null
+              },
+              (v1/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "href",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "format",
+                    "value": "MMM D, YYYY"
+                  }
+                ],
+                "kind": "ScalarField",
+                "name": "publishedAt",
+                "storageKey": "publishedAt(format:\"MMM D, YYYY\")"
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Image",
+                "kind": "LinkedField",
+                "name": "thumbnailImage",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 334
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 445
+                      }
+                    ],
+                    "concreteType": "CroppedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "cropped",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "width",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "height",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "src",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "srcSet",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": "cropped(height:334,width:445)"
+                  }
+                ],
+                "storageKey": null
+              },
+              (v2/*: any*/)
+            ],
+            "storageKey": null
+          },
+          (v2/*: any*/)
+        ],
+        "storageKey": "article(id:\"example\")"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "5ca7bf6765952d5cb57ba46db6b15ab1",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "article": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Article"
+        },
+        "article.byline": (v3/*: any*/),
+        "article.channel": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Channel"
+        },
+        "article.channel.id": (v4/*: any*/),
+        "article.channel.name": (v5/*: any*/),
+        "article.channelArticles": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": true,
+          "type": "Article"
+        },
+        "article.channelArticles.byline": (v3/*: any*/),
+        "article.channelArticles.href": (v3/*: any*/),
+        "article.channelArticles.id": (v4/*: any*/),
+        "article.channelArticles.internalID": (v4/*: any*/),
+        "article.channelArticles.publishedAt": (v3/*: any*/),
+        "article.channelArticles.thumbnailImage": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Image"
+        },
+        "article.channelArticles.thumbnailImage.cropped": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "CroppedImageUrl"
+        },
+        "article.channelArticles.thumbnailImage.cropped.height": (v6/*: any*/),
+        "article.channelArticles.thumbnailImage.cropped.src": (v5/*: any*/),
+        "article.channelArticles.thumbnailImage.cropped.srcSet": (v5/*: any*/),
+        "article.channelArticles.thumbnailImage.cropped.width": (v6/*: any*/),
+        "article.channelArticles.thumbnailTitle": (v3/*: any*/),
+        "article.channelArticles.title": (v3/*: any*/),
+        "article.channelArticles.vertical": (v3/*: any*/),
+        "article.id": (v4/*: any*/)
+      }
+    },
+    "name": "ArticleChannelRelatedArticles_test_Query",
+    "operationKind": "query",
+    "text": "query ArticleChannelRelatedArticles_test_Query {\n  article(id: \"example\") {\n    ...ArticleChannelRelatedArticles_article\n    id\n  }\n}\n\nfragment ArticleChannelRelatedArticles_article on Article {\n  byline\n  channel {\n    name\n    id\n  }\n  channelArticles {\n    internalID\n    ...CellArticle_article\n    id\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "1fd030ef5f382076780b258c06f0f60c";
+
+export default node;

--- a/src/__generated__/ArticleNewsRelatedArticlesQuery.graphql.ts
+++ b/src/__generated__/ArticleNewsRelatedArticlesQuery.graphql.ts
@@ -1,0 +1,242 @@
+/**
+ * @generated SignedSource<<004183ada7f3bb8cf78fc97f5893f50a>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ArticleNewsRelatedArticlesQuery$variables = {
+  id: string;
+};
+export type ArticleNewsRelatedArticlesQuery$data = {
+  readonly article: {
+    readonly " $fragmentSpreads": FragmentRefs<"ArticleNewsRelatedArticles_article">;
+  } | null | undefined;
+};
+export type ArticleNewsRelatedArticlesQuery = {
+  response: ArticleNewsRelatedArticlesQuery$data;
+  variables: ArticleNewsRelatedArticlesQuery$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "defaultValue": null,
+    "kind": "LocalArgument",
+    "name": "id"
+  }
+],
+v1 = [
+  {
+    "kind": "Variable",
+    "name": "id",
+    "variableName": "id"
+  }
+],
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+};
+return {
+  "fragment": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ArticleNewsRelatedArticlesQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Article",
+        "kind": "LinkedField",
+        "name": "article",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ArticleNewsRelatedArticles_article"
+          }
+        ],
+        "storageKey": null
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": (v0/*: any*/),
+    "kind": "Operation",
+    "name": "ArticleNewsRelatedArticlesQuery",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v1/*: any*/),
+        "concreteType": "Article",
+        "kind": "LinkedField",
+        "name": "article",
+        "plural": false,
+        "selections": [
+          {
+            "alias": "newsRelatedArticles",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "size",
+                "value": 8
+              }
+            ],
+            "concreteType": "Article",
+            "kind": "LinkedField",
+            "name": "relatedArticles",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "internalID",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "vertical",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "title",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "thumbnailTitle",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "byline",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "href",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "format",
+                    "value": "MMM D, YYYY"
+                  }
+                ],
+                "kind": "ScalarField",
+                "name": "publishedAt",
+                "storageKey": "publishedAt(format:\"MMM D, YYYY\")"
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Image",
+                "kind": "LinkedField",
+                "name": "thumbnailImage",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 334
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 445
+                      }
+                    ],
+                    "concreteType": "CroppedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "cropped",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "width",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "height",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "src",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "srcSet",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": "cropped(height:334,width:445)"
+                  }
+                ],
+                "storageKey": null
+              },
+              (v2/*: any*/)
+            ],
+            "storageKey": "relatedArticles(size:8)"
+          },
+          (v2/*: any*/)
+        ],
+        "storageKey": null
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "cd7710ae24328410ddf7435358549a69",
+    "id": null,
+    "metadata": {},
+    "name": "ArticleNewsRelatedArticlesQuery",
+    "operationKind": "query",
+    "text": "query ArticleNewsRelatedArticlesQuery(\n  $id: String!\n) @cacheable {\n  article(id: $id) {\n    ...ArticleNewsRelatedArticles_article\n    id\n  }\n}\n\nfragment ArticleNewsRelatedArticles_article on Article {\n  newsRelatedArticles: relatedArticles(size: 8) {\n    internalID\n    ...CellArticle_article\n    id\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "edd41a9cce4be2c7c63f26ab700b5c4b";
+
+export default node;

--- a/src/__generated__/ArticleNewsRelatedArticlesQuery.graphql.ts
+++ b/src/__generated__/ArticleNewsRelatedArticlesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<004183ada7f3bb8cf78fc97f5893f50a>>
+ * @generated SignedSource<<76931afb7e14a8eb0836994e8c554b25>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -92,7 +92,7 @@ return {
               {
                 "kind": "Literal",
                 "name": "size",
-                "value": 8
+                "value": 3
               }
             ],
             "concreteType": "Article",
@@ -218,7 +218,7 @@ return {
               },
               (v2/*: any*/)
             ],
-            "storageKey": "relatedArticles(size:8)"
+            "storageKey": "relatedArticles(size:3)"
           },
           (v2/*: any*/)
         ],
@@ -227,12 +227,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "cd7710ae24328410ddf7435358549a69",
+    "cacheID": "1f9c0096e7fefcfff84051df7b4d075d",
     "id": null,
     "metadata": {},
     "name": "ArticleNewsRelatedArticlesQuery",
     "operationKind": "query",
-    "text": "query ArticleNewsRelatedArticlesQuery(\n  $id: String!\n) @cacheable {\n  article(id: $id) {\n    ...ArticleNewsRelatedArticles_article\n    id\n  }\n}\n\nfragment ArticleNewsRelatedArticles_article on Article {\n  newsRelatedArticles: relatedArticles(size: 8) {\n    internalID\n    ...CellArticle_article\n    id\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n"
+    "text": "query ArticleNewsRelatedArticlesQuery(\n  $id: String!\n) @cacheable {\n  article(id: $id) {\n    ...ArticleNewsRelatedArticles_article\n    id\n  }\n}\n\nfragment ArticleNewsRelatedArticles_article on Article {\n  newsRelatedArticles: relatedArticles(size: 3) {\n    internalID\n    ...CellArticle_article\n    id\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArticleNewsRelatedArticles_article.graphql.ts
+++ b/src/__generated__/ArticleNewsRelatedArticles_article.graphql.ts
@@ -1,0 +1,67 @@
+/**
+ * @generated SignedSource<<3c55efde2af1e3be9497317c38d2b5db>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ReaderFragment } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ArticleNewsRelatedArticles_article$data = {
+  readonly newsRelatedArticles: ReadonlyArray<{
+    readonly internalID: string;
+    readonly " $fragmentSpreads": FragmentRefs<"CellArticle_article">;
+  }>;
+  readonly " $fragmentType": "ArticleNewsRelatedArticles_article";
+};
+export type ArticleNewsRelatedArticles_article$key = {
+  readonly " $data"?: ArticleNewsRelatedArticles_article$data;
+  readonly " $fragmentSpreads": FragmentRefs<"ArticleNewsRelatedArticles_article">;
+};
+
+const node: ReaderFragment = {
+  "argumentDefinitions": [],
+  "kind": "Fragment",
+  "metadata": null,
+  "name": "ArticleNewsRelatedArticles_article",
+  "selections": [
+    {
+      "alias": "newsRelatedArticles",
+      "args": [
+        {
+          "kind": "Literal",
+          "name": "size",
+          "value": 8
+        }
+      ],
+      "concreteType": "Article",
+      "kind": "LinkedField",
+      "name": "relatedArticles",
+      "plural": true,
+      "selections": [
+        {
+          "alias": null,
+          "args": null,
+          "kind": "ScalarField",
+          "name": "internalID",
+          "storageKey": null
+        },
+        {
+          "args": null,
+          "kind": "FragmentSpread",
+          "name": "CellArticle_article"
+        }
+      ],
+      "storageKey": "relatedArticles(size:8)"
+    }
+  ],
+  "type": "Article",
+  "abstractKey": null
+};
+
+(node as any).hash = "f917acf1f9be1d77662137171fa38bb8";
+
+export default node;

--- a/src/__generated__/ArticleNewsRelatedArticles_article.graphql.ts
+++ b/src/__generated__/ArticleNewsRelatedArticles_article.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3c55efde2af1e3be9497317c38d2b5db>>
+ * @generated SignedSource<<91b8b9f5797087f6d5cfa58f3fd3be22>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -34,7 +34,7 @@ const node: ReaderFragment = {
         {
           "kind": "Literal",
           "name": "size",
-          "value": 8
+          "value": 3
         }
       ],
       "concreteType": "Article",
@@ -55,13 +55,13 @@ const node: ReaderFragment = {
           "name": "CellArticle_article"
         }
       ],
-      "storageKey": "relatedArticles(size:8)"
+      "storageKey": "relatedArticles(size:3)"
     }
   ],
   "type": "Article",
   "abstractKey": null
 };
 
-(node as any).hash = "f917acf1f9be1d77662137171fa38bb8";
+(node as any).hash = "92d51d42e350f13ba55746b02b032e92";
 
 export default node;

--- a/src/__generated__/ArticleNewsRelatedArticles_test_Query.graphql.ts
+++ b/src/__generated__/ArticleNewsRelatedArticles_test_Query.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<83ef9e61b87f1c136837f7434949491e>>
+ * @generated SignedSource<<30f16147c38fee54b5457ce28a3c325d>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -107,7 +107,7 @@ return {
               {
                 "kind": "Literal",
                 "name": "size",
-                "value": 8
+                "value": 3
               }
             ],
             "concreteType": "Article",
@@ -233,7 +233,7 @@ return {
               },
               (v1/*: any*/)
             ],
-            "storageKey": "relatedArticles(size:8)"
+            "storageKey": "relatedArticles(size:3)"
           },
           (v1/*: any*/)
         ],
@@ -242,7 +242,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "2c2d14c321b4326cdf86b60cedc39d5e",
+    "cacheID": "463aea9a21a8af906fc23a6b758f9b92",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -287,7 +287,7 @@ return {
     },
     "name": "ArticleNewsRelatedArticles_test_Query",
     "operationKind": "query",
-    "text": "query ArticleNewsRelatedArticles_test_Query {\n  article(id: \"example\") {\n    ...ArticleNewsRelatedArticles_article\n    id\n  }\n}\n\nfragment ArticleNewsRelatedArticles_article on Article {\n  newsRelatedArticles: relatedArticles(size: 8) {\n    internalID\n    ...CellArticle_article\n    id\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n"
+    "text": "query ArticleNewsRelatedArticles_test_Query {\n  article(id: \"example\") {\n    ...ArticleNewsRelatedArticles_article\n    id\n  }\n}\n\nfragment ArticleNewsRelatedArticles_article on Article {\n  newsRelatedArticles: relatedArticles(size: 3) {\n    internalID\n    ...CellArticle_article\n    id\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/ArticleNewsRelatedArticles_test_Query.graphql.ts
+++ b/src/__generated__/ArticleNewsRelatedArticles_test_Query.graphql.ts
@@ -1,0 +1,297 @@
+/**
+ * @generated SignedSource<<83ef9e61b87f1c136837f7434949491e>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ArticleNewsRelatedArticles_test_Query$variables = Record<PropertyKey, never>;
+export type ArticleNewsRelatedArticles_test_Query$data = {
+  readonly article: {
+    readonly " $fragmentSpreads": FragmentRefs<"ArticleNewsRelatedArticles_article">;
+  } | null | undefined;
+};
+export type ArticleNewsRelatedArticles_test_Query = {
+  response: ArticleNewsRelatedArticles_test_Query$data;
+  variables: ArticleNewsRelatedArticles_test_Query$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "example"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v2 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v3 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v4 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "Int"
+},
+v5 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "String"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ArticleNewsRelatedArticles_test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Article",
+        "kind": "LinkedField",
+        "name": "article",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ArticleNewsRelatedArticles_article"
+          }
+        ],
+        "storageKey": "article(id:\"example\")"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "ArticleNewsRelatedArticles_test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Article",
+        "kind": "LinkedField",
+        "name": "article",
+        "plural": false,
+        "selections": [
+          {
+            "alias": "newsRelatedArticles",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "size",
+                "value": 8
+              }
+            ],
+            "concreteType": "Article",
+            "kind": "LinkedField",
+            "name": "relatedArticles",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "internalID",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "vertical",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "title",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "thumbnailTitle",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "byline",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "href",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "format",
+                    "value": "MMM D, YYYY"
+                  }
+                ],
+                "kind": "ScalarField",
+                "name": "publishedAt",
+                "storageKey": "publishedAt(format:\"MMM D, YYYY\")"
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Image",
+                "kind": "LinkedField",
+                "name": "thumbnailImage",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 334
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 445
+                      }
+                    ],
+                    "concreteType": "CroppedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "cropped",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "width",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "height",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "src",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "srcSet",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": "cropped(height:334,width:445)"
+                  }
+                ],
+                "storageKey": null
+              },
+              (v1/*: any*/)
+            ],
+            "storageKey": "relatedArticles(size:8)"
+          },
+          (v1/*: any*/)
+        ],
+        "storageKey": "article(id:\"example\")"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "2c2d14c321b4326cdf86b60cedc39d5e",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "article": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Article"
+        },
+        "article.id": (v2/*: any*/),
+        "article.newsRelatedArticles": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": true,
+          "type": "Article"
+        },
+        "article.newsRelatedArticles.byline": (v3/*: any*/),
+        "article.newsRelatedArticles.href": (v3/*: any*/),
+        "article.newsRelatedArticles.id": (v2/*: any*/),
+        "article.newsRelatedArticles.internalID": (v2/*: any*/),
+        "article.newsRelatedArticles.publishedAt": (v3/*: any*/),
+        "article.newsRelatedArticles.thumbnailImage": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Image"
+        },
+        "article.newsRelatedArticles.thumbnailImage.cropped": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "CroppedImageUrl"
+        },
+        "article.newsRelatedArticles.thumbnailImage.cropped.height": (v4/*: any*/),
+        "article.newsRelatedArticles.thumbnailImage.cropped.src": (v5/*: any*/),
+        "article.newsRelatedArticles.thumbnailImage.cropped.srcSet": (v5/*: any*/),
+        "article.newsRelatedArticles.thumbnailImage.cropped.width": (v4/*: any*/),
+        "article.newsRelatedArticles.thumbnailTitle": (v3/*: any*/),
+        "article.newsRelatedArticles.title": (v3/*: any*/),
+        "article.newsRelatedArticles.vertical": (v3/*: any*/)
+      }
+    },
+    "name": "ArticleNewsRelatedArticles_test_Query",
+    "operationKind": "query",
+    "text": "query ArticleNewsRelatedArticles_test_Query {\n  article(id: \"example\") {\n    ...ArticleNewsRelatedArticles_article\n    id\n  }\n}\n\nfragment ArticleNewsRelatedArticles_article on Article {\n  newsRelatedArticles: relatedArticles(size: 8) {\n    internalID\n    ...CellArticle_article\n    id\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "9fd45f6e4bc411dedbf70109d1511f1a";
+
+export default node;

--- a/src/__generated__/ArticleVerticalRelatedArticles_test_Query.graphql.ts
+++ b/src/__generated__/ArticleVerticalRelatedArticles_test_Query.graphql.ts
@@ -1,0 +1,305 @@
+/**
+ * @generated SignedSource<<f54522d82fc3766439725ec5064c4911>>
+ * @lightSyntaxTransform
+ * @nogrep
+ */
+
+/* tslint:disable */
+/* eslint-disable */
+// @ts-nocheck
+
+import { ConcreteRequest } from 'relay-runtime';
+import { FragmentRefs } from "relay-runtime";
+export type ArticleVerticalRelatedArticles_test_Query$variables = Record<PropertyKey, never>;
+export type ArticleVerticalRelatedArticles_test_Query$data = {
+  readonly article: {
+    readonly " $fragmentSpreads": FragmentRefs<"ArticleVerticalRelatedArticles_article">;
+  } | null | undefined;
+};
+export type ArticleVerticalRelatedArticles_test_Query = {
+  response: ArticleVerticalRelatedArticles_test_Query$data;
+  variables: ArticleVerticalRelatedArticles_test_Query$variables;
+};
+
+const node: ConcreteRequest = (function(){
+var v0 = [
+  {
+    "kind": "Literal",
+    "name": "id",
+    "value": "example"
+  }
+],
+v1 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "vertical",
+  "storageKey": null
+},
+v2 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "id",
+  "storageKey": null
+},
+v3 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "ID"
+},
+v4 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "String"
+},
+v5 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "Int"
+},
+v6 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "String"
+};
+return {
+  "fragment": {
+    "argumentDefinitions": [],
+    "kind": "Fragment",
+    "metadata": null,
+    "name": "ArticleVerticalRelatedArticles_test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Article",
+        "kind": "LinkedField",
+        "name": "article",
+        "plural": false,
+        "selections": [
+          {
+            "args": null,
+            "kind": "FragmentSpread",
+            "name": "ArticleVerticalRelatedArticles_article"
+          }
+        ],
+        "storageKey": "article(id:\"example\")"
+      }
+    ],
+    "type": "Query",
+    "abstractKey": null
+  },
+  "kind": "Request",
+  "operation": {
+    "argumentDefinitions": [],
+    "kind": "Operation",
+    "name": "ArticleVerticalRelatedArticles_test_Query",
+    "selections": [
+      {
+        "alias": null,
+        "args": (v0/*: any*/),
+        "concreteType": "Article",
+        "kind": "LinkedField",
+        "name": "article",
+        "plural": false,
+        "selections": [
+          (v1/*: any*/),
+          {
+            "alias": "verticalRelatedArticles",
+            "args": [
+              {
+                "kind": "Literal",
+                "name": "inVertical",
+                "value": true
+              },
+              {
+                "kind": "Literal",
+                "name": "size",
+                "value": 8
+              }
+            ],
+            "concreteType": "Article",
+            "kind": "LinkedField",
+            "name": "relatedArticles",
+            "plural": true,
+            "selections": [
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "internalID",
+                "storageKey": null
+              },
+              (v1/*: any*/),
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "title",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "thumbnailTitle",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "byline",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": null,
+                "kind": "ScalarField",
+                "name": "href",
+                "storageKey": null
+              },
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "format",
+                    "value": "MMM D, YYYY"
+                  }
+                ],
+                "kind": "ScalarField",
+                "name": "publishedAt",
+                "storageKey": "publishedAt(format:\"MMM D, YYYY\")"
+              },
+              {
+                "alias": null,
+                "args": null,
+                "concreteType": "Image",
+                "kind": "LinkedField",
+                "name": "thumbnailImage",
+                "plural": false,
+                "selections": [
+                  {
+                    "alias": null,
+                    "args": [
+                      {
+                        "kind": "Literal",
+                        "name": "height",
+                        "value": 334
+                      },
+                      {
+                        "kind": "Literal",
+                        "name": "width",
+                        "value": 445
+                      }
+                    ],
+                    "concreteType": "CroppedImageUrl",
+                    "kind": "LinkedField",
+                    "name": "cropped",
+                    "plural": false,
+                    "selections": [
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "width",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "height",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "src",
+                        "storageKey": null
+                      },
+                      {
+                        "alias": null,
+                        "args": null,
+                        "kind": "ScalarField",
+                        "name": "srcSet",
+                        "storageKey": null
+                      }
+                    ],
+                    "storageKey": "cropped(height:334,width:445)"
+                  }
+                ],
+                "storageKey": null
+              },
+              (v2/*: any*/)
+            ],
+            "storageKey": "relatedArticles(inVertical:true,size:8)"
+          },
+          (v2/*: any*/)
+        ],
+        "storageKey": "article(id:\"example\")"
+      }
+    ]
+  },
+  "params": {
+    "cacheID": "ce7290aecd176a7f940d5703acae53b5",
+    "id": null,
+    "metadata": {
+      "relayTestingSelectionTypeInfo": {
+        "article": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Article"
+        },
+        "article.id": (v3/*: any*/),
+        "article.vertical": (v4/*: any*/),
+        "article.verticalRelatedArticles": {
+          "enumValues": null,
+          "nullable": false,
+          "plural": true,
+          "type": "Article"
+        },
+        "article.verticalRelatedArticles.byline": (v4/*: any*/),
+        "article.verticalRelatedArticles.href": (v4/*: any*/),
+        "article.verticalRelatedArticles.id": (v3/*: any*/),
+        "article.verticalRelatedArticles.internalID": (v3/*: any*/),
+        "article.verticalRelatedArticles.publishedAt": (v4/*: any*/),
+        "article.verticalRelatedArticles.thumbnailImage": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "Image"
+        },
+        "article.verticalRelatedArticles.thumbnailImage.cropped": {
+          "enumValues": null,
+          "nullable": true,
+          "plural": false,
+          "type": "CroppedImageUrl"
+        },
+        "article.verticalRelatedArticles.thumbnailImage.cropped.height": (v5/*: any*/),
+        "article.verticalRelatedArticles.thumbnailImage.cropped.src": (v6/*: any*/),
+        "article.verticalRelatedArticles.thumbnailImage.cropped.srcSet": (v6/*: any*/),
+        "article.verticalRelatedArticles.thumbnailImage.cropped.width": (v5/*: any*/),
+        "article.verticalRelatedArticles.thumbnailTitle": (v4/*: any*/),
+        "article.verticalRelatedArticles.title": (v4/*: any*/),
+        "article.verticalRelatedArticles.vertical": (v4/*: any*/)
+      }
+    },
+    "name": "ArticleVerticalRelatedArticles_test_Query",
+    "operationKind": "query",
+    "text": "query ArticleVerticalRelatedArticles_test_Query {\n  article(id: \"example\") {\n    ...ArticleVerticalRelatedArticles_article\n    id\n  }\n}\n\nfragment ArticleVerticalRelatedArticles_article on Article {\n  vertical\n  verticalRelatedArticles: relatedArticles(inVertical: true, size: 8) {\n    internalID\n    ...CellArticle_article\n    id\n  }\n}\n\nfragment CellArticle_article on Article {\n  vertical\n  title\n  thumbnailTitle\n  byline\n  href\n  publishedAt(format: \"MMM D, YYYY\")\n  thumbnailImage {\n    cropped(width: 445, height: 334) {\n      width\n      height\n      src\n      srcSet\n    }\n  }\n}\n"
+  }
+};
+})();
+
+(node as any).hash = "af9e1314229d372897f32f22894ee7ff";
+
+export default node;


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves https://app.notion.com/p/artsy/Redesign-Artsy-news-layout-pages-399cab0764a08052a15aececb3adc176

Assisted-by: Claude:Opus-4.8
Assisted-by: Claude:Sonnet-5

### Description

Currently over 90% of news items have "related articles" manually assigned to them by our editors in Positron.

We display those articles in a rail in the mobile app, but not on web.

This PR brings desktop and mobile web to parity by adding the same content, following the existing style for article rails on web/mweb.

| App | mWeb (new) | Web (new) |
|--------|--------|--------|
| <img width="1524" height="3050" alt="app" src="https://github.com/user-attachments/assets/3be431dc-ce8a-4932-ab84-be5f711bbcd2" /> | <img width="1040" height="2220" alt="mweb" src="https://github.com/user-attachments/assets/a3095e35-7e15-4caf-be9b-bacad7da4aab" /> | <img width="2044" height="2266" alt="desk" src="https://github.com/user-attachments/assets/f023e31b-bff1-48e2-b928-b2755e506733" /> |

## Refactor

The first commit brought the total of RelatedArticles rails to 3, all nearly identical apart from data-fetching…

- `ArticleChannelRelatedArticles.tsx`
- `ArticleNewsRelatedArticles.tsx`
- `ArticleVerticalRelatedArticles.tsx`

…so I rule-of-three'd this into an extraction in the second commit. Now all of those are simplified and make use of a presentation-only component called `ArticleRelatedArticlesShelf.tsx`

<details>
<summary>📸 Here are some screenshots to manually verify that there are no visual regressions after that refactor for other article types besides News</summary >


| Article type | Before-and-after |
|--------|--------|
| Standard | <img width="5120" height="2880" alt="standard2" src="https://github.com/user-attachments/assets/31eaf815-d46b-4f68-adb3-27fd89bcd4d7" /> |
| Feature | <img width="5120" height="2880" alt="feature" src="https://github.com/user-attachments/assets/4b4026bc-9802-4c69-8097-e71e6a9f2c7d" /> |
| Classic | <img width="5120" height="2880" alt="classic" src="https://github.com/user-attachments/assets/eccd3258-5c5a-4631-acd7-1b8c98615d5d" /> | 

</details>


