### PR TITLE
fix(EMI-3313): banner error zero amount and tracking 

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/CheckoutErrorBanner.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/CheckoutErrorBanner.tsx
@@ -1,6 +1,6 @@
 import { ErrorBanner } from "Apps/Order2/Components/ErrorBanner"
+import type { useCheckoutTracking } from "Apps/Order2/Routes/Checkout/Hooks/useCheckoutTracking"
 import { forwardRef, useEffect } from "react"
-import { useCheckoutContext } from "../Hooks/useCheckoutContext"
 
 export const ORDER_SUPPORT_EMAIL = "orders@artsy.net" as const
 
@@ -48,6 +48,7 @@ export const fallbackError = (
 
 export interface CheckoutErrorBannerProps {
   error?: CheckoutErrorBannerMessage | null
+  checkoutTracking: ReturnType<typeof useCheckoutTracking>
   analytics?: {
     flow: string
   }
@@ -56,8 +57,7 @@ export interface CheckoutErrorBannerProps {
 export const CheckoutErrorBanner = forwardRef<
   HTMLDivElement,
   CheckoutErrorBannerProps
->(({ error, analytics }, ref) => {
-  const { checkoutTracking } = useCheckoutContext()
+>(({ error, checkoutTracking, analytics }, ref) => {
   const flow = analytics?.flow
 
   // Track when error is displayed to user

--- a/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/Order2DeliveryOptionsForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/DeliveryOptionsStep/Order2DeliveryOptionsForm.tsx
@@ -150,6 +150,7 @@ export const Order2DeliveryOptionsForm: React.FC<
           <CheckoutErrorBanner
             ref={errorBannerRef}
             error={deliveryOptionError}
+            checkoutTracking={checkoutTracking}
             analytics={{ flow: "User setting delivery method" }}
           />
           <Spacer y={2} />

--- a/src/Apps/Order2/Routes/Checkout/Components/ExpressCheckout/Order2ExpressCheckoutUI.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/ExpressCheckout/Order2ExpressCheckoutUI.tsx
@@ -666,6 +666,7 @@ export const Order2ExpressCheckoutUI: React.FC<
         <>
           <CheckoutErrorBanner
             error={error}
+            checkoutTracking={checkoutTracking}
             analytics={{
               flow: "Express checkout",
             }}

--- a/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/Order2DeliveryForm.tsx
@@ -389,6 +389,7 @@ export const Order2DeliveryForm: React.FC<Order2DeliveryFormProps> = ({
                 <CheckoutErrorBanner
                   ref={errorBannerRef}
                   error={fulfillmentDetailsError}
+                  checkoutTracking={checkoutTracking}
                   analytics={{ flow: "User setting shipping address" }}
                 />
                 <Spacer y={2} />

--- a/src/Apps/Order2/Routes/Checkout/Components/OfferStep/Order2OfferStep.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/OfferStep/Order2OfferStep.tsx
@@ -306,6 +306,7 @@ const Order2OfferStepFormContent: React.FC<Order2OfferStepFormContentProps> = ({
             <CheckoutErrorBanner
               ref={errorBannerRef}
               error={offerAmountError}
+              checkoutTracking={checkoutTracking}
               analytics={{ flow: "User setting offer" }}
             />
           )}

--- a/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/PaymentStep/Order2PaymentForm.tsx
@@ -829,6 +829,7 @@ const PaymentFormContent: React.FC<PaymentFormContentProps> = ({
           <CheckoutErrorBanner
             ref={errorBannerRef}
             error={paymentError}
+            checkoutTracking={checkoutTracking}
             analytics={{ flow: "User setting payment" }}
           />
           <Spacer y={4} />

--- a/src/Apps/Order2/Routes/Checkout/Components/__tests__/CheckoutErrorBanner.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/__tests__/CheckoutErrorBanner.jest.tsx
@@ -3,13 +3,7 @@ import { CheckoutErrorBanner } from "../CheckoutErrorBanner"
 
 const mockCheckoutTracking = {
   errorMessageViewed: jest.fn(),
-}
-
-jest.mock("../../Hooks/useCheckoutContext", () => ({
-  useCheckoutContext: () => ({
-    checkoutTracking: mockCheckoutTracking,
-  }),
-}))
+} as any
 
 beforeEach(() => {
   jest.clearAllMocks()
@@ -22,14 +16,18 @@ describe("CheckoutErrorBanner", () => {
       message: "This is a test error message",
     }
 
-    render(<CheckoutErrorBanner error={error} />)
+    render(
+      <CheckoutErrorBanner error={error} checkoutTracking={mockCheckoutTracking} />,
+    )
 
     expect(screen.getByText("Test Error")).toBeInTheDocument()
     expect(screen.getByText("This is a test error message")).toBeInTheDocument()
   })
 
   it("renders nothing when error is null", () => {
-    const { container } = render(<CheckoutErrorBanner error={null} />)
+    const { container } = render(
+      <CheckoutErrorBanner error={null} checkoutTracking={mockCheckoutTracking} />,
+    )
 
     expect(container.firstChild).toBeNull()
   })
@@ -45,7 +43,13 @@ describe("CheckoutErrorBanner", () => {
       flow: "User setting payment",
     }
 
-    render(<CheckoutErrorBanner error={error} analytics={analytics} />)
+    render(
+      <CheckoutErrorBanner
+        error={error}
+        checkoutTracking={mockCheckoutTracking}
+        analytics={analytics}
+      />,
+    )
 
     expect(mockCheckoutTracking.errorMessageViewed).toHaveBeenCalledWith({
       error_code: "payment_failed",
@@ -71,7 +75,13 @@ describe("CheckoutErrorBanner", () => {
       flow: "User setting delivery",
     }
 
-    render(<CheckoutErrorBanner error={error} analytics={analytics} />)
+    render(
+      <CheckoutErrorBanner
+        error={error}
+        checkoutTracking={mockCheckoutTracking}
+        analytics={analytics}
+      />,
+    )
 
     expect(mockCheckoutTracking.errorMessageViewed).toHaveBeenCalledWith({
       error_code: "complex_error",
@@ -91,7 +101,13 @@ describe("CheckoutErrorBanner", () => {
       flow: "User setting offer",
     }
 
-    render(<CheckoutErrorBanner error={error} analytics={analytics} />)
+    render(
+      <CheckoutErrorBanner
+        error={error}
+        checkoutTracking={mockCheckoutTracking}
+        analytics={analytics}
+      />,
+    )
 
     expect(mockCheckoutTracking.errorMessageViewed).toHaveBeenCalledWith({
       error_code: "unknown",
@@ -107,7 +123,9 @@ describe("CheckoutErrorBanner", () => {
       message: "This should not be tracked",
     }
 
-    render(<CheckoutErrorBanner error={error} />)
+    render(
+      <CheckoutErrorBanner error={error} checkoutTracking={mockCheckoutTracking} />,
+    )
 
     expect(mockCheckoutTracking.errorMessageViewed).not.toHaveBeenCalled()
   })

--- a/src/Apps/Order2/Routes/Respond/Components/Order2RespondForm.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/Order2RespondForm.tsx
@@ -58,6 +58,9 @@ const RESPONSE_REQUIRED_TITLE = "Response required"
 const RESPONSE_REQUIRED_MESSAGE =
   "Please accept, counter, or decline the gallery’s offer to continue."
 
+const COUNTEROFFER_TOO_LOW_TITLE = "Counteroffer amount too low"
+const COUNTEROFFER_TOO_LOW_MESSAGE = "Please increase amount"
+
 interface CompletedResponse {
   title: string
   detail?: string
@@ -142,6 +145,22 @@ export const Order2RespondForm: React.FC<Order2RespondFormProps> = ({
   // Require a counteroffer amount before continuing.
   const isCounterofferValid =
     selectedAction !== "COUNTEROFFER" || Number(counterofferAmount) > 0
+
+  const getValidationError = () => {
+    if (selectedAction === "COUNTEROFFER" && !isCounterofferValid) {
+      return {
+        title: COUNTEROFFER_TOO_LOW_TITLE,
+        message: COUNTEROFFER_TOO_LOW_MESSAGE,
+        code: "counteroffer_amount_too_low",
+      }
+    }
+
+    return {
+      title: RESPONSE_REQUIRED_TITLE,
+      message: RESPONSE_REQUIRED_MESSAGE,
+      code: "response_required",
+    }
+  }
 
   const handleSelectAction = (value: string) => {
     const action = value as RespondAction
@@ -277,11 +296,7 @@ export const Order2RespondForm: React.FC<Order2RespondFormProps> = ({
       {hasValidationError && (
         <>
           <CheckoutErrorBanner
-            error={{
-              title: RESPONSE_REQUIRED_TITLE,
-              message: RESPONSE_REQUIRED_MESSAGE,
-              code: "response_required",
-            }}
+            error={getValidationError()}
             checkoutTracking={checkoutTracking}
             analytics={{ flow: "User responding to offer" }}
           />

--- a/src/Apps/Order2/Routes/Respond/Components/Order2RespondForm.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/Order2RespondForm.tsx
@@ -13,8 +13,8 @@ import {
   Spacer,
   Text,
 } from "@artsy/palette"
-import { ErrorBanner } from "Apps/Order2/Components/ErrorBanner"
 import { SectionHeading } from "Apps/Order2/Components/SectionHeading"
+import { CheckoutErrorBanner } from "Apps/Order2/Routes/Checkout/Components/CheckoutErrorBanner"
 import { Order2RespondOfferDetails } from "Apps/Order2/Routes/Respond/Components/Order2RespondOfferDetails"
 import { useRespondContext } from "Apps/Order2/Routes/Respond/Hooks/useRespondContext"
 import { useOrder2CreateCounterOfferMutation } from "Apps/Order2/Routes/Respond/Mutations/useOrder2CreateCounterOfferMutation"
@@ -276,9 +276,15 @@ export const Order2RespondForm: React.FC<Order2RespondFormProps> = ({
 
       {hasValidationError && (
         <>
-          <ErrorBanner title={RESPONSE_REQUIRED_TITLE}>
-            {RESPONSE_REQUIRED_MESSAGE}
-          </ErrorBanner>
+          <CheckoutErrorBanner
+            error={{
+              title: RESPONSE_REQUIRED_TITLE,
+              message: RESPONSE_REQUIRED_MESSAGE,
+              code: "response_required",
+            }}
+            checkoutTracking={checkoutTracking}
+            analytics={{ flow: "User responding to offer" }}
+          />
           <Spacer y={2} />
         </>
       )}

--- a/src/Apps/Order2/Routes/Respond/Components/__tests__/Order2RespondForm.jest.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/__tests__/Order2RespondForm.jest.tsx
@@ -179,20 +179,24 @@ describe("Order2RespondForm", () => {
     ).toBeInTheDocument()
   })
 
-  it("shows the response-required banner when submitting a counteroffer without an amount", () => {
+  it("shows the amount-too-low banner when submitting a counteroffer without an amount", () => {
     renderWithRelay(defaultResolvers)
 
     fireEvent.click(screen.getByText("Send counteroffer"))
     fireEvent.click(continueButton())
 
-    expect(screen.getByText("Response required")).toBeInTheDocument()
+    expect(screen.getByText("Counteroffer amount too low")).toBeInTheDocument()
+    expect(screen.getByText("Please increase amount")).toBeInTheDocument()
+    expect(screen.queryByText("Response required")).not.toBeInTheDocument()
 
     // Entering an amount clears the banner.
     fireEvent.change(screen.getByPlaceholderText(COUNTEROFFER_PLACEHOLDER), {
       target: { value: "500" },
     })
 
-    expect(screen.queryByText("Response required")).not.toBeInTheDocument()
+    expect(
+      screen.queryByText("Counteroffer amount too low"),
+    ).not.toBeInTheDocument()
   })
 
   it("collapses to the completed state after accepting", () => {


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-3313]

### Description

- Adds tracking to error banner for respond route
- Adds zero amount error for counteroffers with 0 amount

<img width="834" height="539" alt="Screenshot 2026-07-14 at 10 50 05 PM" src="https://github.com/user-attachments/assets/65c3bb6a-8f28-4386-a335-d204705dfc50" />


<!-- Implementation description -->


[EMI-3313]: https://artsyproduct.atlassian.net/browse/EMI-3313?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ