### PR TITLE
feat(hack16): demo of 3D gaussian splat viewer for three dimensional works of art

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "found-scroll": "^1.1.1",
     "glob": "7.1.3",
     "graphql": "15.8.0",
+    "gsplat": "^1.2.9",
     "helmet": "2.3.0",
     "http-proxy": "1.18.1",
     "http-shutdown": "1.2.1",

--- a/src/Apps/Artwork/Components/Artwork3DViewer/Artwork3DViewer.tsx
+++ b/src/Apps/Artwork/Components/Artwork3DViewer/Artwork3DViewer.tsx
@@ -1,0 +1,177 @@
+import * as DeprecatedAnalyticsSchema from "@artsy/cohesion/dist/DeprecatedSchema"
+import { Box, ModalBase, Spinner } from "@artsy/palette"
+import { DeepZoomCloseButton } from "Components/DeepZoom/DeepZoomCloseButton"
+import { useDidMount } from "Utils/Hooks/useDidMount"
+import { useCallback, useEffect, useRef, useState } from "react"
+import type * as React from "react"
+import { useTracking } from "react-tracking"
+
+interface Artwork3DViewerProps {
+  splatUrl: string
+  onClose(): void
+}
+
+const isPlyUrl = (url: string): boolean => {
+  return new URL(url).pathname.toLowerCase().endsWith(".ply")
+}
+
+export const Artwork3DViewer: React.FC<
+  React.PropsWithChildren<Artwork3DViewerProps>
+> = ({ splatUrl, onClose }) => {
+  const rendererRef = useRef<any | null>(null)
+  const controlsRef = useRef<any | null>(null)
+  const rafRef = useRef<number | null>(null)
+  const disposedRef = useRef(false)
+
+  const [isLoading, setIsLoading] = useState(true)
+  const [hasError, setHasError] = useState(false)
+
+  const initializeViewer = useCallback(
+    (element: HTMLDivElement | null) => {
+      if (!element) return
+
+      import(/* webpackChunkName: "gsplat" */ "gsplat")
+        .then(SPLAT => {
+          if (disposedRef.current) return
+
+          const canvas = document.createElement("canvas")
+          canvas.style.width = "100%"
+          canvas.style.height = "100%"
+          canvas.style.display = "block"
+          element.appendChild(canvas)
+
+          const scene = new SPLAT.Scene()
+          const camera = new SPLAT.Camera()
+          const renderer = new SPLAT.WebGLRenderer(canvas)
+
+          rendererRef.current = renderer
+
+          const frame = () => {
+            if (disposedRef.current) return
+            controlsRef.current?.update()
+            renderer.render(scene, camera)
+            rafRef.current = requestAnimationFrame(frame)
+          }
+
+          const load = isPlyUrl(splatUrl)
+            ? SPLAT.PLYLoader.LoadAsync(splatUrl, scene, () => {})
+            : SPLAT.Loader.LoadAsync(splatUrl, scene, () => {})
+
+          load
+            .then(splat => {
+              if (disposedRef.current) return
+
+              splat.recalculateBounds()
+              const center = splat.bounds.center()
+              const diagonal = Math.max(splat.bounds.size().magnitude(), 0.1)
+              const radius = diagonal * 1.5
+
+              const controls = new SPLAT.OrbitControls(
+                camera,
+                renderer.canvas,
+                undefined,
+                undefined,
+                radius,
+                undefined,
+                center,
+              )
+              controls.minZoom = diagonal * 0.1
+              controls.maxZoom = diagonal * 5
+
+              controlsRef.current = controls
+
+              setIsLoading(false)
+              frame()
+            })
+            .catch((error: unknown) => {
+              console.error("Artwork3DViewer failed to load splat", error)
+              setHasError(true)
+            })
+        })
+        .catch((error: unknown) => {
+          console.error("Artwork3DViewer failed to load gsplat", error)
+          setHasError(true)
+        })
+    },
+    [splatUrl],
+  )
+
+  useEffect(() => {
+    return () => {
+      disposedRef.current = true
+
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current)
+        rafRef.current = null
+      }
+
+      controlsRef.current?.dispose?.()
+      controlsRef.current = null
+
+      rendererRef.current?.dispose?.()
+      rendererRef.current = null
+    }
+  }, [])
+
+  const isMounted = useDidMount()
+
+  // Fail silently: hide the viewer entirely rather than breaking the page.
+  useEffect(() => {
+    if (hasError) {
+      onClose()
+    }
+  }, [hasError, onClose])
+
+  if (hasError) {
+    return null
+  }
+
+  return (
+    <ModalBase onClose={onClose}>
+      <Box
+        ref={initializeViewer}
+        width="100vw"
+        height="100vh"
+        bg="mono100"
+        style={{ transition: "opacity 250ms", opacity: isMounted ? 1 : 0 }}
+      >
+        {isLoading && <Spinner color="mono0" />}
+      </Box>
+
+      <DeepZoomCloseButton
+        position="absolute"
+        top={0}
+        right={0}
+        p={2}
+        onClick={onClose}
+      />
+    </ModalBase>
+  )
+}
+
+export const use3DViewer = () => {
+  const [is3DViewerVisible, setIs3DViewerVisible] = useState(false)
+
+  const { trackEvent } = useTracking()
+
+  const show3DViewer = () => {
+    setIs3DViewerVisible(true)
+
+    trackEvent({
+      context_module: DeprecatedAnalyticsSchema.ContextModule.Zoom,
+      type: DeprecatedAnalyticsSchema.Type.Button,
+      flow: DeprecatedAnalyticsSchema.Flow.ArtworkZoom,
+      action_type: DeprecatedAnalyticsSchema.ActionType.Click,
+    })
+  }
+
+  const hide3DViewer = () => {
+    setIs3DViewerVisible(false)
+  }
+
+  return {
+    show3DViewer,
+    hide3DViewer,
+    is3DViewerVisible,
+  }
+}

--- a/src/Apps/Artwork/Components/Artwork3DViewer/__tests__/demoSplats.jest.ts
+++ b/src/Apps/Artwork/Components/Artwork3DViewer/__tests__/demoSplats.jest.ts
@@ -1,0 +1,37 @@
+import {
+  DEMO_SPLATS,
+  get3DAssetUrl,
+  has3DAsset,
+} from "Apps/Artwork/Components/Artwork3DViewer/demoSplats"
+
+describe("demoSplats", () => {
+  describe("has3DAsset", () => {
+    it("returns false for a slug with no configured splat asset", () => {
+      expect(has3DAsset("no-such-artwork")).toBe(false)
+    })
+
+    it("returns true for a slug present in DEMO_SPLATS", () => {
+      DEMO_SPLATS["a-test-sculpture"] = "https://files.artsy.net/test.splat"
+
+      expect(has3DAsset("a-test-sculpture")).toBe(true)
+
+      delete DEMO_SPLATS["a-test-sculpture"]
+    })
+  })
+
+  describe("get3DAssetUrl", () => {
+    it("returns null for a slug with no configured splat asset", () => {
+      expect(get3DAssetUrl("no-such-artwork")).toBeNull()
+    })
+
+    it("returns the configured URL for a known slug", () => {
+      DEMO_SPLATS["a-test-sculpture"] = "https://files.artsy.net/test.splat"
+
+      expect(get3DAssetUrl("a-test-sculpture")).toBe(
+        "https://files.artsy.net/test.splat",
+      )
+
+      delete DEMO_SPLATS["a-test-sculpture"]
+    })
+  })
+})

--- a/src/Apps/Artwork/Components/Artwork3DViewer/demoSplats.ts
+++ b/src/Apps/Artwork/Components/Artwork3DViewer/demoSplats.ts
@@ -1,0 +1,25 @@
+/**
+ * Hackathon demo only: hardcoded map of artwork slug to a hosted 3D Gaussian
+ * Splat asset URL (`.ply` or `.splat`, see `Artwork3DViewer`). There is no
+ * Metaphysics schema field for this yet — see scratch.3DGS.md for the full
+ * context and post-hackathon follow-ups.
+ *
+ * Raw `.ply` scans (e.g. Luma AI exports) are often hundreds of MB. To keep
+ * demo assets under ~80MB: load into SuperSplat (https://superspl.at/convert),
+ * decimate the splat count (~30% kept has worked well in practice), and
+ * export as Standard `.ply`. Note SuperSplat's `.compressed.ply` and `.sog`
+ * export formats are NOT supported by the installed `gsplat` version — stick
+ * to Standard `.ply` or `.splat`.
+ */
+export const DEMO_SPLATS: Record<string, string> = {
+  "jon-allured-mask":
+    "https://s3.amazonaws.com/artsy-vanity-files-staging/other/mask.ply",
+}
+
+export const has3DAsset = (slug: string): boolean => {
+  return slug in DEMO_SPLATS
+}
+
+export const get3DAssetUrl = (slug: string): string | null => {
+  return DEMO_SPLATS[slug] ?? null
+}

--- a/src/Apps/Artwork/Components/Artwork3DViewer/demoSplats.ts
+++ b/src/Apps/Artwork/Components/Artwork3DViewer/demoSplats.ts
@@ -14,6 +14,8 @@
 export const DEMO_SPLATS: Record<string, string> = {
   "jon-allured-mask":
     "https://s3.amazonaws.com/artsy-vanity-files-staging/other/mask.ply",
+  "chris-wolston-plant-chair":
+    "https://s3.amazonaws.com/artsy-vanity-files-staging/other/chair-smaller-sphere-float-cc.ply",
 }
 
 export const has3DAsset = (slug: string): boolean => {

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActions.tsx
@@ -2,6 +2,14 @@ import * as DeprecatedAnalyticsSchema from "@artsy/cohesion/dist/DeprecatedSchem
 import { Box, Flex, Join, Popover, Spacer } from "@artsy/palette"
 import { ArtworkActionsSaveButtonFragmentContainer } from "Apps/Artwork/Components/ArtworkImageBrowser/ArtworkActionsSaveButton"
 import { ArtworkDownloadButtonFragmentContainer } from "Apps/Artwork/Components/ArtworkImageBrowser/ArtworkDownloadButton"
+import {
+  Artwork3DViewer,
+  use3DViewer,
+} from "Apps/Artwork/Components/Artwork3DViewer/Artwork3DViewer"
+import {
+  get3DAssetUrl,
+  has3DAsset,
+} from "Apps/Artwork/Components/Artwork3DViewer/demoSplats"
 import { ManageArtworkForSavesProvider } from "Components/Artwork/ManageArtworkForSaves"
 import {
   ViewInRoomFragmentContainer,
@@ -45,6 +53,8 @@ export const ArtworkActions: React.FC<
   const { showViewInRoom, hideViewInRoom, isViewInRoomVisible } =
     useViewInRoom()
 
+  const { show3DViewer, hide3DViewer, is3DViewerVisible } = use3DViewer()
+
   const ViewInRoomButton = (
     <UtilButton
       name="viewInRoom"
@@ -54,6 +64,10 @@ export const ArtworkActions: React.FC<
         showViewInRoom()
       }}
     />
+  )
+
+  const ViewIn3DButton = (
+    <UtilButton name="viewIn3D" label="View in 3D" onClick={show3DViewer} />
   )
 
   const ShareButton = (
@@ -119,6 +133,11 @@ export const ArtworkActions: React.FC<
       content: ViewInRoomButton,
     },
     {
+      name: "viewIn3D",
+      condition: !artwork.isHangable && has3DAsset(artwork.slug),
+      content: ViewIn3DButton,
+    },
+    {
       name: "share",
       condition: !artwork.isUnlisted,
       content: ShareButton,
@@ -150,6 +169,13 @@ export const ArtworkActions: React.FC<
         <ViewInRoomFragmentContainer
           artwork={artwork}
           onClose={hideViewInRoom}
+        />
+      )}
+
+      {is3DViewerVisible && get3DAssetUrl(artwork.slug) && (
+        <Artwork3DViewer
+          splatUrl={get3DAssetUrl(artwork.slug)!}
+          onClose={hide3DViewer}
         />
       )}
 

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/UtilButton.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/UtilButton.tsx
@@ -30,6 +30,7 @@ interface UtilButtonProps {
     | "inspectImages"
     | "more"
     | "share"
+    | "viewIn3D"
     | "viewInRoom"
   href?: string
   download?: string
@@ -80,6 +81,8 @@ export const UtilButton = React.forwardRef(
           return MoreIcon
         case "share":
           return ShareIcon
+        case "viewIn3D":
+          return ShowIcon
         case "viewInRoom":
           return ShowIcon
       }

--- a/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkActions.jest.tsx
+++ b/src/Apps/Artwork/Components/ArtworkImageBrowser/__tests__/ArtworkActions.jest.tsx
@@ -8,6 +8,14 @@ import { graphql } from "react-relay"
 
 jest.unmock("react-relay")
 
+jest.mock("Apps/Artwork/Components/Artwork3DViewer/demoSplats", () => ({
+  has3DAsset: (slug: string) => slug === "a-3d-scanned-sculpture",
+  get3DAssetUrl: (slug: string) =>
+    slug === "a-3d-scanned-sculpture"
+      ? "https://files.artsy.net/demo/sculpture.splat"
+      : null,
+}))
+
 jest.mock("System/Contexts/SystemContext", () => ({
   SystemContextProvider: ({ children }) => children,
   useSystemContext: jest.fn().mockReturnValue({ user: {} }),
@@ -141,6 +149,41 @@ describe("ArtworkActions", () => {
         })
 
         expect(screen.queryByText("View in room")).not.toBeInTheDocument()
+      })
+    })
+
+    describe("view in 3D", () => {
+      it("is available for non-hangable artworks with a configured splat asset", () => {
+        renderWithRelay({
+          Artwork: () => ({
+            isHangable: false,
+            slug: "a-3d-scanned-sculpture",
+          }),
+        })
+
+        expect(screen.getByText("View in 3D")).toBeInTheDocument()
+      })
+
+      it("is not available for hangable artworks, even with a configured splat asset", () => {
+        renderWithRelay({
+          Artwork: () => ({
+            isHangable: true,
+            slug: "a-3d-scanned-sculpture",
+          }),
+        })
+
+        expect(screen.queryByText("View in 3D")).not.toBeInTheDocument()
+      })
+
+      it("is not available for non-hangable artworks without a configured splat asset", () => {
+        renderWithRelay({
+          Artwork: () => ({
+            isHangable: false,
+            slug: "some-other-artwork",
+          }),
+        })
+
+        expect(screen.queryByText("View in 3D")).not.toBeInTheDocument()
       })
     })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -9432,6 +9432,7 @@ __metadata:
     fsevents: "npm:*"
     glob: "npm:7.1.3"
     graphql: "npm:15.8.0"
+    gsplat: "npm:^1.2.9"
     helmet: "npm:2.3.0"
     http-proxy: "npm:1.18.1"
     http-shutdown: "npm:1.2.1"
@@ -10151,6 +10152,13 @@ __metadata:
   dependencies:
     iterall: "npm:^1.2.2"
   checksum: 10c0/0d0c6011b5e6ce17a2302b2d862f9351b27b2de9995ad03075ba82e0d87eb59ba893adf5e9a29e2141fe9dd6f2f267268c8b6f35a8b842eb66dbf0f7ef8d79f3
+  languageName: node
+  linkType: hard
+
+"gsplat@npm:^1.2.9":
+  version: 1.2.9
+  resolution: "gsplat@npm:1.2.9"
+  checksum: 10c0/78cab96d76c106f04452a9c1aff9faa9483ec3ae892453e912b578ab0da30772da022feeafe47d22766715c22478d3185257bd3b9b53d5e7935b5ff09fc8a423
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [Hackathon 16: 3DGS viewer on artwork pages for 3-dimensional works of art](https://app.notion.com/p/artsy/3DGS-viewer-on-artwork-pages-for-3-dimensional-works-of-art-38ecab0764a080dbbbcbc7188fd63fa0)

### Description

For posterity I'm going to open and immediately close this PR so that there is a record of this experiment.

Below is what it looked like at demo time.

For more details see the [Hackathon card](https://app.notion.com/p/artsy/3DGS-viewer-on-artwork-pages-for-3-dimensional-works-of-art-38ecab0764a080dbbbcbc7188fd63fa0) or the [demo slides](https://docs.google.com/presentation/d/104-Dz0qCmq5Liyg8F_MbHl-AWhxgCIH7DeRDFL0K51Q/edit?slide=id.g3f54572a746_0_0#slide=id.g3f54572a746_0_0)

| Mask (via superspl.at) | Chair (created from scratch for demo) |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/fb90564f-23b2-4064-9078-2281e41afa8b"></video> | <video src="https://github.com/user-attachments/assets/25c1facc-691e-435d-a44e-be832657d0bb"></video> | 


The 3d splat files were uploaded via Forque:

- **Mask**: https://tools-staging.artsy.net/uploads/other%2Fmask.ply
  - https://s3.amazonaws.com/artsy-vanity-files-staging/other/mask.ply
- **Chair**: https://tools-staging.artsy.net/uploads/other%2Fchair-smaller-sphere-float-cc.ply
  - https://s3.amazonaws.com/artsy-vanity-files-staging/other/chair-smaller-sphere-float-cc.ply

The viewer code is pretty much entirely…

Assisted-by: Claude:Opus-4.8
Assisted-by: Claude:Sonnet-5
