### PR TITLE
chore: update counteroffer heading to have price symbol only

### DIFF
--- a/src/Apps/Order2/Routes/Respond/Components/Order2RespondForm.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/Order2RespondForm.tsx
@@ -134,7 +134,7 @@ export const Order2RespondForm: React.FC<Order2RespondFormProps> = ({
     useOrder2CreateCounterOfferMutation()
 
   // The gallery’s offer amount, excluding shipping and taxes.
-  const offerPrice = orderData.lastSubmittedOffer?.amount?.display
+  const offerPrice = `${orderData.lastSubmittedOffer?.amount?.currencySymbol}${orderData.lastSubmittedOffer?.amount?.amount}`
 
   const isRespondCompleted =
     steps.find(step => step.name === RespondStepName.RESPOND)?.state ===
@@ -246,7 +246,13 @@ export const Order2RespondForm: React.FC<Order2RespondFormProps> = ({
 
   return (
     <RespondCard>
-      <Text variant={["sm", "md"]}>Respond to gallery offer</Text>
+      <Text
+        color="mono100"
+        fontWeight="bold"
+        variant={["sm-display", "sm-display", "md"]}
+      >
+        Respond to gallery offer
+      </Text>
 
       {offerPrice && (
         <>
@@ -430,7 +436,8 @@ const FRAGMENT = graphql`
       amount {
         major
         currencyCode
-        display
+        currencySymbol
+        amount
       }
     }
     pendingOffer {

--- a/src/Apps/Order2/Routes/Respond/Components/__tests__/Order2RespondForm.jest.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/__tests__/Order2RespondForm.jest.tsx
@@ -68,7 +68,13 @@ const { renderWithRelay } = setupTestWrapperTL<Order2RespondFormTestQuery>({
 
 const defaultResolvers = {
   Order: () => ({ mode: "OFFER", pendingOffer: null }),
-  Money: () => ({ display: "$1,000.00", major: 1000, currencyCode: "USD" }),
+  Money: () => ({
+    display: "US$1,000.00",
+    amount: "1,000.00",
+    currencySymbol: "$",
+    major: 1000,
+    currencyCode: "USD",
+  }),
 }
 
 const continueButton = () =>
@@ -81,6 +87,13 @@ describe("Order2RespondForm", () => {
     expect(screen.getByText("Accept gallery offer")).toBeInTheDocument()
     expect(screen.getByText("Send counteroffer")).toBeInTheDocument()
     expect(screen.getByText("Decline gallery offer")).toBeInTheDocument()
+  })
+
+  it("shows the gallery offer amount with a plain $ instead of US$", () => {
+    renderWithRelay(defaultResolvers)
+
+    expect(screen.getAllByText("$1,000.00").length).toBeGreaterThan(0)
+    expect(screen.queryByText("US$1,000.00")).not.toBeInTheDocument()
   })
 
   it("shows the response-required banner when submitting without a selection", () => {

--- a/src/__generated__/Order2RespondFormTestQuery.graphql.ts
+++ b/src/__generated__/Order2RespondFormTestQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<4c364492cd25c12b0e3d349c548992ae>>
+ * @generated SignedSource<<2daa026937fc13c6abb556c30dc0a377>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -63,24 +63,31 @@ v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "display",
+  "name": "currencySymbol",
   "storageKey": null
 },
 v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "displayName",
+  "name": "amount",
   "storageKey": null
 },
 v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "amountFallbackText",
+  "name": "displayName",
   "storageKey": null
 },
 v8 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "amountFallbackText",
+  "storageKey": null
+},
+v9 = {
   "alias": null,
   "args": null,
   "concreteType": "Money",
@@ -88,29 +95,17 @@ v8 = {
   "name": "amount",
   "plural": false,
   "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "amount",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "currencySymbol",
-      "storageKey": null
-    }
+    (v6/*: any*/),
+    (v5/*: any*/)
   ],
   "storageKey": null
 },
-v9 = [
-  (v6/*: any*/),
+v10 = [
   (v7/*: any*/),
-  (v8/*: any*/)
+  (v8/*: any*/),
+  (v9/*: any*/)
 ],
-v10 = {
+v11 = {
   "alias": null,
   "args": null,
   "concreteType": null,
@@ -127,21 +122,21 @@ v10 = {
     },
     {
       "kind": "InlineFragment",
-      "selections": (v9/*: any*/),
+      "selections": (v10/*: any*/),
       "type": "ShippingLine",
       "abstractKey": null
     },
     {
       "kind": "InlineFragment",
-      "selections": (v9/*: any*/),
+      "selections": (v10/*: any*/),
       "type": "TaxLine",
       "abstractKey": null
     },
     {
       "kind": "InlineFragment",
       "selections": [
-        (v6/*: any*/),
-        (v8/*: any*/)
+        (v7/*: any*/),
+        (v9/*: any*/)
       ],
       "type": "SubtotalLine",
       "abstractKey": null
@@ -149,8 +144,8 @@ v10 = {
     {
       "kind": "InlineFragment",
       "selections": [
-        (v6/*: any*/),
         (v7/*: any*/),
+        (v8/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -159,7 +154,13 @@ v10 = {
           "name": "amount",
           "plural": false,
           "selections": [
-            (v5/*: any*/)
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "display",
+              "storageKey": null
+            }
           ],
           "storageKey": null
         }
@@ -170,43 +171,43 @@ v10 = {
   ],
   "storageKey": null
 },
-v11 = {
+v12 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v12 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "String"
-},
 v13 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Offer"
+  "type": "String"
 },
 v14 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Money"
+  "type": "Offer"
 },
 v15 = {
   "enumValues": null,
-  "nullable": false,
+  "nullable": true,
   "plural": false,
-  "type": "String"
+  "type": "Money"
 },
 v16 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
-  "type": "Float"
+  "type": "String"
 },
 v17 = {
+  "enumValues": null,
+  "nullable": false,
+  "plural": false,
+  "type": "Float"
+},
+v18 = {
   "enumValues": null,
   "nullable": false,
   "plural": true,
@@ -318,7 +319,8 @@ return {
                         "name": "currencyCode",
                         "storageKey": null
                       },
-                      (v5/*: any*/)
+                      (v5/*: any*/),
+                      (v6/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -347,7 +349,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v10/*: any*/)
+                  (v11/*: any*/)
                 ],
                 "storageKey": null
               },
@@ -397,7 +399,7 @@ return {
                 "name": "buyerStateExpiresAt",
                 "storageKey": null
               },
-              (v10/*: any*/),
+              (v11/*: any*/),
               (v2/*: any*/)
             ],
             "storageKey": "order(id:\"order-id\")"
@@ -409,7 +411,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "278bb93f8888f14b975170dda17b3df8",
+    "cacheID": "033f84b60a8ad800b7d285f2314e1ef1",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -419,7 +421,7 @@ return {
           "plural": false,
           "type": "Me"
         },
-        "me.id": (v11/*: any*/),
+        "me.id": (v12/*: any*/),
         "me.order": {
           "enumValues": null,
           "nullable": true,
@@ -448,17 +450,18 @@ return {
           "plural": false,
           "type": "OrderBuyerStateEnum"
         },
-        "me.order.buyerStateExpiresAt": (v12/*: any*/),
-        "me.order.id": (v11/*: any*/),
-        "me.order.internalID": (v11/*: any*/),
-        "me.order.lastSubmittedOffer": (v13/*: any*/),
-        "me.order.lastSubmittedOffer.amount": (v14/*: any*/),
-        "me.order.lastSubmittedOffer.amount.currencyCode": (v15/*: any*/),
-        "me.order.lastSubmittedOffer.amount.display": (v12/*: any*/),
-        "me.order.lastSubmittedOffer.amount.major": (v16/*: any*/),
-        "me.order.lastSubmittedOffer.createdAt": (v12/*: any*/),
-        "me.order.lastSubmittedOffer.id": (v11/*: any*/),
-        "me.order.lastSubmittedOffer.internalID": (v11/*: any*/),
+        "me.order.buyerStateExpiresAt": (v13/*: any*/),
+        "me.order.id": (v12/*: any*/),
+        "me.order.internalID": (v12/*: any*/),
+        "me.order.lastSubmittedOffer": (v14/*: any*/),
+        "me.order.lastSubmittedOffer.amount": (v15/*: any*/),
+        "me.order.lastSubmittedOffer.amount.amount": (v13/*: any*/),
+        "me.order.lastSubmittedOffer.amount.currencyCode": (v16/*: any*/),
+        "me.order.lastSubmittedOffer.amount.currencySymbol": (v13/*: any*/),
+        "me.order.lastSubmittedOffer.amount.major": (v17/*: any*/),
+        "me.order.lastSubmittedOffer.createdAt": (v13/*: any*/),
+        "me.order.lastSubmittedOffer.id": (v12/*: any*/),
+        "me.order.lastSubmittedOffer.internalID": (v12/*: any*/),
         "me.order.lineItems": {
           "enumValues": null,
           "nullable": false,
@@ -471,9 +474,9 @@ return {
           "plural": false,
           "type": "Artwork"
         },
-        "me.order.lineItems.artwork.id": (v11/*: any*/),
-        "me.order.lineItems.artwork.slug": (v11/*: any*/),
-        "me.order.lineItems.id": (v11/*: any*/),
+        "me.order.lineItems.artwork.id": (v12/*: any*/),
+        "me.order.lineItems.artwork.slug": (v12/*: any*/),
+        "me.order.lineItems.id": (v12/*: any*/),
         "me.order.mode": {
           "enumValues": [
             "BUY",
@@ -483,27 +486,27 @@ return {
           "plural": false,
           "type": "OrderModeEnum"
         },
-        "me.order.pendingOffer": (v13/*: any*/),
-        "me.order.pendingOffer.amount": (v14/*: any*/),
-        "me.order.pendingOffer.amount.major": (v16/*: any*/),
-        "me.order.pendingOffer.createdAt": (v12/*: any*/),
-        "me.order.pendingOffer.id": (v11/*: any*/),
-        "me.order.pendingOffer.pricingBreakdownLines": (v17/*: any*/),
-        "me.order.pendingOffer.pricingBreakdownLines.__typename": (v15/*: any*/),
-        "me.order.pendingOffer.pricingBreakdownLines.amount": (v14/*: any*/),
-        "me.order.pendingOffer.pricingBreakdownLines.amount.amount": (v12/*: any*/),
-        "me.order.pendingOffer.pricingBreakdownLines.amount.currencySymbol": (v12/*: any*/),
-        "me.order.pendingOffer.pricingBreakdownLines.amount.display": (v12/*: any*/),
-        "me.order.pendingOffer.pricingBreakdownLines.amountFallbackText": (v12/*: any*/),
-        "me.order.pendingOffer.pricingBreakdownLines.displayName": (v15/*: any*/),
-        "me.order.pricingBreakdownLines": (v17/*: any*/),
-        "me.order.pricingBreakdownLines.__typename": (v15/*: any*/),
-        "me.order.pricingBreakdownLines.amount": (v14/*: any*/),
-        "me.order.pricingBreakdownLines.amount.amount": (v12/*: any*/),
-        "me.order.pricingBreakdownLines.amount.currencySymbol": (v12/*: any*/),
-        "me.order.pricingBreakdownLines.amount.display": (v12/*: any*/),
-        "me.order.pricingBreakdownLines.amountFallbackText": (v12/*: any*/),
-        "me.order.pricingBreakdownLines.displayName": (v15/*: any*/),
+        "me.order.pendingOffer": (v14/*: any*/),
+        "me.order.pendingOffer.amount": (v15/*: any*/),
+        "me.order.pendingOffer.amount.major": (v17/*: any*/),
+        "me.order.pendingOffer.createdAt": (v13/*: any*/),
+        "me.order.pendingOffer.id": (v12/*: any*/),
+        "me.order.pendingOffer.pricingBreakdownLines": (v18/*: any*/),
+        "me.order.pendingOffer.pricingBreakdownLines.__typename": (v16/*: any*/),
+        "me.order.pendingOffer.pricingBreakdownLines.amount": (v15/*: any*/),
+        "me.order.pendingOffer.pricingBreakdownLines.amount.amount": (v13/*: any*/),
+        "me.order.pendingOffer.pricingBreakdownLines.amount.currencySymbol": (v13/*: any*/),
+        "me.order.pendingOffer.pricingBreakdownLines.amount.display": (v13/*: any*/),
+        "me.order.pendingOffer.pricingBreakdownLines.amountFallbackText": (v13/*: any*/),
+        "me.order.pendingOffer.pricingBreakdownLines.displayName": (v16/*: any*/),
+        "me.order.pricingBreakdownLines": (v18/*: any*/),
+        "me.order.pricingBreakdownLines.__typename": (v16/*: any*/),
+        "me.order.pricingBreakdownLines.amount": (v15/*: any*/),
+        "me.order.pricingBreakdownLines.amount.amount": (v13/*: any*/),
+        "me.order.pricingBreakdownLines.amount.currencySymbol": (v13/*: any*/),
+        "me.order.pricingBreakdownLines.amount.display": (v13/*: any*/),
+        "me.order.pricingBreakdownLines.amountFallbackText": (v13/*: any*/),
+        "me.order.pricingBreakdownLines.displayName": (v16/*: any*/),
         "me.order.source": {
           "enumValues": [
             "ARTWORK_PAGE",
@@ -519,7 +522,7 @@ return {
     },
     "name": "Order2RespondFormTestQuery",
     "operationKind": "query",
-    "text": "query Order2RespondFormTestQuery {\n  me {\n    order(id: \"order-id\") {\n      ...Order2RespondContext_order\n      ...Order2RespondForm_order\n      id\n    }\n    id\n  }\n}\n\nfragment Order2PricingBreakdown_order on Order {\n  source\n  mode\n  buyerState\n  buyerStateExpiresAt\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n  pendingOffer {\n    pricingBreakdownLines {\n      __typename\n      ... on ShippingLine {\n        displayName\n        amountFallbackText\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on TaxLine {\n        displayName\n        amountFallbackText\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on SubtotalLine {\n        displayName\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on TotalLine {\n        displayName\n        amountFallbackText\n        amount {\n          display\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Order2RespondContext_order on Order {\n  source\n  mode\n  lastSubmittedOffer {\n    createdAt\n    id\n  }\n  pendingOffer {\n    createdAt\n    id\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    id\n  }\n}\n\nfragment Order2RespondForm_order on Order {\n  internalID\n  lastSubmittedOffer {\n    internalID\n    amount {\n      major\n      currencyCode\n      display\n    }\n    id\n  }\n  pendingOffer {\n    amount {\n      major\n    }\n    id\n  }\n  ...Order2RespondOfferDetails_order\n}\n\nfragment Order2RespondOfferDetails_order on Order {\n  ...Order2PricingBreakdown_order\n}\n"
+    "text": "query Order2RespondFormTestQuery {\n  me {\n    order(id: \"order-id\") {\n      ...Order2RespondContext_order\n      ...Order2RespondForm_order\n      id\n    }\n    id\n  }\n}\n\nfragment Order2PricingBreakdown_order on Order {\n  source\n  mode\n  buyerState\n  buyerStateExpiresAt\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n  pendingOffer {\n    pricingBreakdownLines {\n      __typename\n      ... on ShippingLine {\n        displayName\n        amountFallbackText\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on TaxLine {\n        displayName\n        amountFallbackText\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on SubtotalLine {\n        displayName\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on TotalLine {\n        displayName\n        amountFallbackText\n        amount {\n          display\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Order2RespondContext_order on Order {\n  source\n  mode\n  lastSubmittedOffer {\n    createdAt\n    id\n  }\n  pendingOffer {\n    createdAt\n    id\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    id\n  }\n}\n\nfragment Order2RespondForm_order on Order {\n  internalID\n  lastSubmittedOffer {\n    internalID\n    amount {\n      major\n      currencyCode\n      currencySymbol\n      amount\n    }\n    id\n  }\n  pendingOffer {\n    amount {\n      major\n    }\n    id\n  }\n  ...Order2RespondOfferDetails_order\n}\n\nfragment Order2RespondOfferDetails_order on Order {\n  ...Order2PricingBreakdown_order\n}\n"
   }
 };
 })();

--- a/src/__generated__/Order2RespondForm_order.graphql.ts
+++ b/src/__generated__/Order2RespondForm_order.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<87ed048704315482da2bc58e788e9455>>
+ * @generated SignedSource<<dcfcb94b23e54c1b5b8ee13de4f16d66>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -14,8 +14,9 @@ export type Order2RespondForm_order$data = {
   readonly internalID: string;
   readonly lastSubmittedOffer: {
     readonly amount: {
+      readonly amount: string | null | undefined;
       readonly currencyCode: string;
-      readonly display: string | null | undefined;
+      readonly currencySymbol: string | null | undefined;
       readonly major: number;
     } | null | undefined;
     readonly internalID: string;
@@ -84,7 +85,14 @@ return {
               "alias": null,
               "args": null,
               "kind": "ScalarField",
-              "name": "display",
+              "name": "currencySymbol",
+              "storageKey": null
+            },
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "amount",
               "storageKey": null
             }
           ],
@@ -127,6 +135,6 @@ return {
 };
 })();
 
-(node as any).hash = "3d3b96aabcc242e905a494cd152b4e30";
+(node as any).hash = "10d0b470dddc037220b75913f664fb2f";
 
 export default node;

--- a/src/__generated__/Order2RespondSummaryTestQuery.graphql.ts
+++ b/src/__generated__/Order2RespondSummaryTestQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<3ce3ced9d9a6c70ac70f229ebe52be28>>
+ * @generated SignedSource<<8fa0b08889c70057a0f6b9667c4055ee>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -63,31 +63,38 @@ v5 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "display",
+  "name": "currencySymbol",
   "storageKey": null
 },
 v6 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "__typename",
+  "name": "amount",
   "storageKey": null
 },
 v7 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "displayName",
+  "name": "__typename",
   "storageKey": null
 },
 v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "amountFallbackText",
+  "name": "displayName",
   "storageKey": null
 },
 v9 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "amountFallbackText",
+  "storageKey": null
+},
+v10 = {
   "alias": null,
   "args": null,
   "concreteType": "Money",
@@ -95,29 +102,17 @@ v9 = {
   "name": "amount",
   "plural": false,
   "selections": [
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "amount",
-      "storageKey": null
-    },
-    {
-      "alias": null,
-      "args": null,
-      "kind": "ScalarField",
-      "name": "currencySymbol",
-      "storageKey": null
-    }
+    (v6/*: any*/),
+    (v5/*: any*/)
   ],
   "storageKey": null
 },
-v10 = [
-  (v7/*: any*/),
+v11 = [
   (v8/*: any*/),
-  (v9/*: any*/)
+  (v9/*: any*/),
+  (v10/*: any*/)
 ],
-v11 = {
+v12 = {
   "alias": null,
   "args": null,
   "concreteType": null,
@@ -125,24 +120,24 @@ v11 = {
   "name": "pricingBreakdownLines",
   "plural": true,
   "selections": [
-    (v6/*: any*/),
+    (v7/*: any*/),
     {
       "kind": "InlineFragment",
-      "selections": (v10/*: any*/),
+      "selections": (v11/*: any*/),
       "type": "ShippingLine",
       "abstractKey": null
     },
     {
       "kind": "InlineFragment",
-      "selections": (v10/*: any*/),
+      "selections": (v11/*: any*/),
       "type": "TaxLine",
       "abstractKey": null
     },
     {
       "kind": "InlineFragment",
       "selections": [
-        (v7/*: any*/),
-        (v9/*: any*/)
+        (v8/*: any*/),
+        (v10/*: any*/)
       ],
       "type": "SubtotalLine",
       "abstractKey": null
@@ -150,8 +145,8 @@ v11 = {
     {
       "kind": "InlineFragment",
       "selections": [
-        (v7/*: any*/),
         (v8/*: any*/),
+        (v9/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -160,7 +155,13 @@ v11 = {
           "name": "amount",
           "plural": false,
           "selections": [
-            (v5/*: any*/)
+            {
+              "alias": null,
+              "args": null,
+              "kind": "ScalarField",
+              "name": "display",
+              "storageKey": null
+            }
           ],
           "storageKey": null
         }
@@ -171,14 +172,14 @@ v11 = {
   ],
   "storageKey": null
 },
-v12 = {
+v13 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "url",
   "storageKey": null
 },
-v13 = {
+v14 = {
   "alias": null,
   "args": [
     {
@@ -197,21 +198,21 @@ v13 = {
   "name": "resized",
   "plural": false,
   "selections": [
-    (v12/*: any*/)
+    (v13/*: any*/)
   ],
   "storageKey": "resized(height:138,width:185)"
 },
-v14 = [
+v15 = [
   (v2/*: any*/)
 ],
-v15 = {
+v16 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "price",
   "storageKey": null
 },
-v16 = [
+v17 = [
   {
     "alias": null,
     "args": null,
@@ -227,75 +228,75 @@ v16 = [
     "storageKey": null
   }
 ],
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "concreteType": "dimensions",
   "kind": "LinkedField",
   "name": "dimensions",
   "plural": false,
-  "selections": (v16/*: any*/),
+  "selections": (v17/*: any*/),
   "storageKey": null
 },
-v18 = {
+v19 = {
   "alias": null,
   "args": null,
   "concreteType": "dimensions",
   "kind": "LinkedField",
   "name": "framedDimensions",
   "plural": false,
-  "selections": (v16/*: any*/),
+  "selections": (v17/*: any*/),
   "storageKey": null
 },
-v19 = {
+v20 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
   "type": "ID"
 },
-v20 = {
-  "enumValues": null,
-  "nullable": true,
-  "plural": false,
-  "type": "String"
-},
 v21 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Offer"
+  "type": "String"
 },
 v22 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "Money"
+  "type": "Offer"
 },
 v23 = {
   "enumValues": null,
-  "nullable": false,
+  "nullable": true,
   "plural": false,
-  "type": "String"
+  "type": "Money"
 },
 v24 = {
   "enumValues": null,
   "nullable": false,
   "plural": false,
-  "type": "Float"
+  "type": "String"
 },
 v25 = {
   "enumValues": null,
-  "nullable": true,
+  "nullable": false,
   "plural": false,
-  "type": "ResizedImageUrl"
+  "type": "Float"
 },
 v26 = {
   "enumValues": null,
   "nullable": true,
   "plural": false,
-  "type": "dimensions"
+  "type": "ResizedImageUrl"
 },
 v27 = {
+  "enumValues": null,
+  "nullable": true,
+  "plural": false,
+  "type": "dimensions"
+},
+v28 = {
   "enumValues": null,
   "nullable": false,
   "plural": true,
@@ -412,7 +413,8 @@ return {
                         "name": "currencyCode",
                         "storageKey": null
                       },
-                      (v5/*: any*/)
+                      (v5/*: any*/),
+                      (v6/*: any*/)
                     ],
                     "storageKey": null
                   }
@@ -441,7 +443,7 @@ return {
                     ],
                     "storageKey": null
                   },
-                  (v11/*: any*/),
+                  (v12/*: any*/),
                   (v3/*: any*/)
                 ],
                 "storageKey": null
@@ -511,18 +513,18 @@ return {
                         "name": "figures",
                         "plural": true,
                         "selections": [
-                          (v6/*: any*/),
+                          (v7/*: any*/),
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v13/*: any*/)
+                              (v14/*: any*/)
                             ],
                             "type": "Image",
                             "abstractKey": null
                           },
                           {
                             "kind": "InlineFragment",
-                            "selections": (v14/*: any*/),
+                            "selections": (v15/*: any*/),
                             "type": "Video",
                             "abstractKey": null
                           }
@@ -541,13 +543,13 @@ return {
                     "name": "artworkOrEditionSet",
                     "plural": false,
                     "selections": [
-                      (v6/*: any*/),
+                      (v7/*: any*/),
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v15/*: any*/),
-                          (v17/*: any*/),
-                          (v18/*: any*/)
+                          (v16/*: any*/),
+                          (v18/*: any*/),
+                          (v19/*: any*/)
                         ],
                         "type": "Artwork",
                         "abstractKey": null
@@ -555,9 +557,9 @@ return {
                       {
                         "kind": "InlineFragment",
                         "selections": [
-                          (v15/*: any*/),
-                          (v17/*: any*/),
+                          (v16/*: any*/),
                           (v18/*: any*/),
+                          (v19/*: any*/),
                           (v2/*: any*/)
                         ],
                         "type": "EditionSet",
@@ -565,7 +567,7 @@ return {
                       },
                       {
                         "kind": "InlineFragment",
-                        "selections": (v14/*: any*/),
+                        "selections": (v15/*: any*/),
                         "type": "Node",
                         "abstractKey": "__isNode"
                       }
@@ -628,8 +630,8 @@ return {
                         "name": "image",
                         "plural": false,
                         "selections": [
-                          (v12/*: any*/),
-                          (v13/*: any*/)
+                          (v13/*: any*/),
+                          (v14/*: any*/)
                         ],
                         "storageKey": null
                       },
@@ -655,7 +657,7 @@ return {
                 "name": "buyerStateExpiresAt",
                 "storageKey": null
               },
-              (v11/*: any*/),
+              (v12/*: any*/),
               (v2/*: any*/)
             ],
             "storageKey": "order(id:\"order-id\")"
@@ -667,7 +669,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f84d7a62711539cdc2e0867059a16de1",
+    "cacheID": "e93166bfd8e26be07d77d025cf1e848a",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -677,7 +679,7 @@ return {
           "plural": false,
           "type": "Me"
         },
-        "me.id": (v19/*: any*/),
+        "me.id": (v20/*: any*/),
         "me.order": {
           "enumValues": null,
           "nullable": true,
@@ -706,17 +708,18 @@ return {
           "plural": false,
           "type": "OrderBuyerStateEnum"
         },
-        "me.order.buyerStateExpiresAt": (v20/*: any*/),
-        "me.order.id": (v19/*: any*/),
-        "me.order.internalID": (v19/*: any*/),
-        "me.order.lastSubmittedOffer": (v21/*: any*/),
-        "me.order.lastSubmittedOffer.amount": (v22/*: any*/),
-        "me.order.lastSubmittedOffer.amount.currencyCode": (v23/*: any*/),
-        "me.order.lastSubmittedOffer.amount.display": (v20/*: any*/),
-        "me.order.lastSubmittedOffer.amount.major": (v24/*: any*/),
-        "me.order.lastSubmittedOffer.createdAt": (v20/*: any*/),
-        "me.order.lastSubmittedOffer.id": (v19/*: any*/),
-        "me.order.lastSubmittedOffer.internalID": (v19/*: any*/),
+        "me.order.buyerStateExpiresAt": (v21/*: any*/),
+        "me.order.id": (v20/*: any*/),
+        "me.order.internalID": (v20/*: any*/),
+        "me.order.lastSubmittedOffer": (v22/*: any*/),
+        "me.order.lastSubmittedOffer.amount": (v23/*: any*/),
+        "me.order.lastSubmittedOffer.amount.amount": (v21/*: any*/),
+        "me.order.lastSubmittedOffer.amount.currencyCode": (v24/*: any*/),
+        "me.order.lastSubmittedOffer.amount.currencySymbol": (v21/*: any*/),
+        "me.order.lastSubmittedOffer.amount.major": (v25/*: any*/),
+        "me.order.lastSubmittedOffer.createdAt": (v21/*: any*/),
+        "me.order.lastSubmittedOffer.id": (v20/*: any*/),
+        "me.order.lastSubmittedOffer.internalID": (v20/*: any*/),
         "me.order.lineItems": {
           "enumValues": null,
           "nullable": false,
@@ -735,66 +738,66 @@ return {
           "plural": true,
           "type": "ArtworkFigures"
         },
-        "me.order.lineItems.artwork.figures.__typename": (v23/*: any*/),
-        "me.order.lineItems.artwork.figures.id": (v19/*: any*/),
-        "me.order.lineItems.artwork.figures.resized": (v25/*: any*/),
-        "me.order.lineItems.artwork.figures.resized.url": (v23/*: any*/),
-        "me.order.lineItems.artwork.id": (v19/*: any*/),
-        "me.order.lineItems.artwork.internalID": (v19/*: any*/),
+        "me.order.lineItems.artwork.figures.__typename": (v24/*: any*/),
+        "me.order.lineItems.artwork.figures.id": (v20/*: any*/),
+        "me.order.lineItems.artwork.figures.resized": (v26/*: any*/),
+        "me.order.lineItems.artwork.figures.resized.url": (v24/*: any*/),
+        "me.order.lineItems.artwork.id": (v20/*: any*/),
+        "me.order.lineItems.artwork.internalID": (v20/*: any*/),
         "me.order.lineItems.artwork.partner": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Partner"
         },
-        "me.order.lineItems.artwork.partner.href": (v20/*: any*/),
-        "me.order.lineItems.artwork.partner.id": (v19/*: any*/),
-        "me.order.lineItems.artwork.partner.name": (v20/*: any*/),
-        "me.order.lineItems.artwork.slug": (v19/*: any*/),
+        "me.order.lineItems.artwork.partner.href": (v21/*: any*/),
+        "me.order.lineItems.artwork.partner.id": (v20/*: any*/),
+        "me.order.lineItems.artwork.partner.name": (v21/*: any*/),
+        "me.order.lineItems.artwork.slug": (v20/*: any*/),
         "me.order.lineItems.artworkOrEditionSet": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtworkOrEditionSetType"
         },
-        "me.order.lineItems.artworkOrEditionSet.__isNode": (v23/*: any*/),
-        "me.order.lineItems.artworkOrEditionSet.__typename": (v23/*: any*/),
-        "me.order.lineItems.artworkOrEditionSet.dimensions": (v26/*: any*/),
-        "me.order.lineItems.artworkOrEditionSet.dimensions.cm": (v20/*: any*/),
-        "me.order.lineItems.artworkOrEditionSet.dimensions.in": (v20/*: any*/),
-        "me.order.lineItems.artworkOrEditionSet.framedDimensions": (v26/*: any*/),
-        "me.order.lineItems.artworkOrEditionSet.framedDimensions.cm": (v20/*: any*/),
-        "me.order.lineItems.artworkOrEditionSet.framedDimensions.in": (v20/*: any*/),
-        "me.order.lineItems.artworkOrEditionSet.id": (v19/*: any*/),
-        "me.order.lineItems.artworkOrEditionSet.price": (v20/*: any*/),
+        "me.order.lineItems.artworkOrEditionSet.__isNode": (v24/*: any*/),
+        "me.order.lineItems.artworkOrEditionSet.__typename": (v24/*: any*/),
+        "me.order.lineItems.artworkOrEditionSet.dimensions": (v27/*: any*/),
+        "me.order.lineItems.artworkOrEditionSet.dimensions.cm": (v21/*: any*/),
+        "me.order.lineItems.artworkOrEditionSet.dimensions.in": (v21/*: any*/),
+        "me.order.lineItems.artworkOrEditionSet.framedDimensions": (v27/*: any*/),
+        "me.order.lineItems.artworkOrEditionSet.framedDimensions.cm": (v21/*: any*/),
+        "me.order.lineItems.artworkOrEditionSet.framedDimensions.in": (v21/*: any*/),
+        "me.order.lineItems.artworkOrEditionSet.id": (v20/*: any*/),
+        "me.order.lineItems.artworkOrEditionSet.price": (v21/*: any*/),
         "me.order.lineItems.artworkVersion": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "ArtworkVersion"
         },
-        "me.order.lineItems.artworkVersion.artistNames": (v20/*: any*/),
+        "me.order.lineItems.artworkVersion.artistNames": (v21/*: any*/),
         "me.order.lineItems.artworkVersion.attributionClass": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "AttributionClass"
         },
-        "me.order.lineItems.artworkVersion.attributionClass.id": (v19/*: any*/),
-        "me.order.lineItems.artworkVersion.attributionClass.shortDescription": (v20/*: any*/),
-        "me.order.lineItems.artworkVersion.date": (v20/*: any*/),
-        "me.order.lineItems.artworkVersion.id": (v19/*: any*/),
+        "me.order.lineItems.artworkVersion.attributionClass.id": (v20/*: any*/),
+        "me.order.lineItems.artworkVersion.attributionClass.shortDescription": (v21/*: any*/),
+        "me.order.lineItems.artworkVersion.date": (v21/*: any*/),
+        "me.order.lineItems.artworkVersion.id": (v20/*: any*/),
         "me.order.lineItems.artworkVersion.image": {
           "enumValues": null,
           "nullable": true,
           "plural": false,
           "type": "Image"
         },
-        "me.order.lineItems.artworkVersion.image.resized": (v25/*: any*/),
-        "me.order.lineItems.artworkVersion.image.resized.url": (v23/*: any*/),
-        "me.order.lineItems.artworkVersion.image.url": (v20/*: any*/),
-        "me.order.lineItems.artworkVersion.title": (v20/*: any*/),
-        "me.order.lineItems.id": (v19/*: any*/),
+        "me.order.lineItems.artworkVersion.image.resized": (v26/*: any*/),
+        "me.order.lineItems.artworkVersion.image.resized.url": (v24/*: any*/),
+        "me.order.lineItems.artworkVersion.image.url": (v21/*: any*/),
+        "me.order.lineItems.artworkVersion.title": (v21/*: any*/),
+        "me.order.lineItems.id": (v20/*: any*/),
         "me.order.mode": {
           "enumValues": [
             "BUY",
@@ -804,28 +807,28 @@ return {
           "plural": false,
           "type": "OrderModeEnum"
         },
-        "me.order.pendingOffer": (v21/*: any*/),
-        "me.order.pendingOffer.amount": (v22/*: any*/),
-        "me.order.pendingOffer.amount.major": (v24/*: any*/),
-        "me.order.pendingOffer.createdAt": (v20/*: any*/),
-        "me.order.pendingOffer.id": (v19/*: any*/),
-        "me.order.pendingOffer.internalID": (v19/*: any*/),
-        "me.order.pendingOffer.pricingBreakdownLines": (v27/*: any*/),
-        "me.order.pendingOffer.pricingBreakdownLines.__typename": (v23/*: any*/),
-        "me.order.pendingOffer.pricingBreakdownLines.amount": (v22/*: any*/),
-        "me.order.pendingOffer.pricingBreakdownLines.amount.amount": (v20/*: any*/),
-        "me.order.pendingOffer.pricingBreakdownLines.amount.currencySymbol": (v20/*: any*/),
-        "me.order.pendingOffer.pricingBreakdownLines.amount.display": (v20/*: any*/),
-        "me.order.pendingOffer.pricingBreakdownLines.amountFallbackText": (v20/*: any*/),
-        "me.order.pendingOffer.pricingBreakdownLines.displayName": (v23/*: any*/),
-        "me.order.pricingBreakdownLines": (v27/*: any*/),
-        "me.order.pricingBreakdownLines.__typename": (v23/*: any*/),
-        "me.order.pricingBreakdownLines.amount": (v22/*: any*/),
-        "me.order.pricingBreakdownLines.amount.amount": (v20/*: any*/),
-        "me.order.pricingBreakdownLines.amount.currencySymbol": (v20/*: any*/),
-        "me.order.pricingBreakdownLines.amount.display": (v20/*: any*/),
-        "me.order.pricingBreakdownLines.amountFallbackText": (v20/*: any*/),
-        "me.order.pricingBreakdownLines.displayName": (v23/*: any*/),
+        "me.order.pendingOffer": (v22/*: any*/),
+        "me.order.pendingOffer.amount": (v23/*: any*/),
+        "me.order.pendingOffer.amount.major": (v25/*: any*/),
+        "me.order.pendingOffer.createdAt": (v21/*: any*/),
+        "me.order.pendingOffer.id": (v20/*: any*/),
+        "me.order.pendingOffer.internalID": (v20/*: any*/),
+        "me.order.pendingOffer.pricingBreakdownLines": (v28/*: any*/),
+        "me.order.pendingOffer.pricingBreakdownLines.__typename": (v24/*: any*/),
+        "me.order.pendingOffer.pricingBreakdownLines.amount": (v23/*: any*/),
+        "me.order.pendingOffer.pricingBreakdownLines.amount.amount": (v21/*: any*/),
+        "me.order.pendingOffer.pricingBreakdownLines.amount.currencySymbol": (v21/*: any*/),
+        "me.order.pendingOffer.pricingBreakdownLines.amount.display": (v21/*: any*/),
+        "me.order.pendingOffer.pricingBreakdownLines.amountFallbackText": (v21/*: any*/),
+        "me.order.pendingOffer.pricingBreakdownLines.displayName": (v24/*: any*/),
+        "me.order.pricingBreakdownLines": (v28/*: any*/),
+        "me.order.pricingBreakdownLines.__typename": (v24/*: any*/),
+        "me.order.pricingBreakdownLines.amount": (v23/*: any*/),
+        "me.order.pricingBreakdownLines.amount.amount": (v21/*: any*/),
+        "me.order.pricingBreakdownLines.amount.currencySymbol": (v21/*: any*/),
+        "me.order.pricingBreakdownLines.amount.display": (v21/*: any*/),
+        "me.order.pricingBreakdownLines.amountFallbackText": (v21/*: any*/),
+        "me.order.pricingBreakdownLines.displayName": (v24/*: any*/),
         "me.order.source": {
           "enumValues": [
             "ARTWORK_PAGE",
@@ -841,7 +844,7 @@ return {
     },
     "name": "Order2RespondSummaryTestQuery",
     "operationKind": "query",
-    "text": "query Order2RespondSummaryTestQuery {\n  me {\n    order(id: \"order-id\") {\n      ...Order2RespondContext_order\n      ...Order2RespondForm_order\n      ...Order2RespondSummary_order\n      id\n    }\n    id\n  }\n}\n\nfragment Order2OrderSummary_order on Order {\n  ...Order2PricingBreakdown_order\n}\n\nfragment Order2PricingBreakdown_order on Order {\n  source\n  mode\n  buyerState\n  buyerStateExpiresAt\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n  pendingOffer {\n    pricingBreakdownLines {\n      __typename\n      ... on ShippingLine {\n        displayName\n        amountFallbackText\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on TaxLine {\n        displayName\n        amountFallbackText\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on SubtotalLine {\n        displayName\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on TotalLine {\n        displayName\n        amountFallbackText\n        amount {\n          display\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Order2RespondContext_order on Order {\n  source\n  mode\n  lastSubmittedOffer {\n    createdAt\n    id\n  }\n  pendingOffer {\n    createdAt\n    id\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    id\n  }\n}\n\nfragment Order2RespondForm_order on Order {\n  internalID\n  lastSubmittedOffer {\n    internalID\n    amount {\n      major\n      currencyCode\n      display\n    }\n    id\n  }\n  pendingOffer {\n    amount {\n      major\n    }\n    id\n  }\n  ...Order2RespondOfferDetails_order\n}\n\nfragment Order2RespondOfferDetails_order on Order {\n  ...Order2PricingBreakdown_order\n}\n\nfragment Order2RespondSummary_order on Order {\n  ...Order2OrderSummary_order\n  internalID\n  lastSubmittedOffer {\n    internalID\n    id\n  }\n  pendingOffer {\n    internalID\n    id\n  }\n  lineItems {\n    ...useOrder2LineItemData_lineItem\n    id\n  }\n}\n\nfragment useOrder2LineItemData_lineItem on LineItem {\n  artworkOrEditionSet {\n    __typename\n    ... on Artwork {\n      price\n      dimensions {\n        in\n        cm\n      }\n      framedDimensions {\n        in\n        cm\n      }\n    }\n    ... on EditionSet {\n      price\n      dimensions {\n        in\n        cm\n      }\n      framedDimensions {\n        in\n        cm\n      }\n      id\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  artworkVersion {\n    title\n    artistNames\n    date\n    attributionClass {\n      shortDescription\n      id\n    }\n    image {\n      url\n      resized(width: 185, height: 138) {\n        url\n      }\n    }\n    id\n  }\n  artwork {\n    internalID\n    partner {\n      name\n      href\n      id\n    }\n    figures(includeAll: false) {\n      __typename\n      ... on Image {\n        resized(width: 185, height: 138) {\n          url\n        }\n      }\n      ... on Video {\n        id\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query Order2RespondSummaryTestQuery {\n  me {\n    order(id: \"order-id\") {\n      ...Order2RespondContext_order\n      ...Order2RespondForm_order\n      ...Order2RespondSummary_order\n      id\n    }\n    id\n  }\n}\n\nfragment Order2OrderSummary_order on Order {\n  ...Order2PricingBreakdown_order\n}\n\nfragment Order2PricingBreakdown_order on Order {\n  source\n  mode\n  buyerState\n  buyerStateExpiresAt\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n  pendingOffer {\n    pricingBreakdownLines {\n      __typename\n      ... on ShippingLine {\n        displayName\n        amountFallbackText\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on TaxLine {\n        displayName\n        amountFallbackText\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on SubtotalLine {\n        displayName\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on TotalLine {\n        displayName\n        amountFallbackText\n        amount {\n          display\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Order2RespondContext_order on Order {\n  source\n  mode\n  lastSubmittedOffer {\n    createdAt\n    id\n  }\n  pendingOffer {\n    createdAt\n    id\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    id\n  }\n}\n\nfragment Order2RespondForm_order on Order {\n  internalID\n  lastSubmittedOffer {\n    internalID\n    amount {\n      major\n      currencyCode\n      currencySymbol\n      amount\n    }\n    id\n  }\n  pendingOffer {\n    amount {\n      major\n    }\n    id\n  }\n  ...Order2RespondOfferDetails_order\n}\n\nfragment Order2RespondOfferDetails_order on Order {\n  ...Order2PricingBreakdown_order\n}\n\nfragment Order2RespondSummary_order on Order {\n  ...Order2OrderSummary_order\n  internalID\n  lastSubmittedOffer {\n    internalID\n    id\n  }\n  pendingOffer {\n    internalID\n    id\n  }\n  lineItems {\n    ...useOrder2LineItemData_lineItem\n    id\n  }\n}\n\nfragment useOrder2LineItemData_lineItem on LineItem {\n  artworkOrEditionSet {\n    __typename\n    ... on Artwork {\n      price\n      dimensions {\n        in\n        cm\n      }\n      framedDimensions {\n        in\n        cm\n      }\n    }\n    ... on EditionSet {\n      price\n      dimensions {\n        in\n        cm\n      }\n      framedDimensions {\n        in\n        cm\n      }\n      id\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  artworkVersion {\n    title\n    artistNames\n    date\n    attributionClass {\n      shortDescription\n      id\n    }\n    image {\n      url\n      resized(width: 185, height: 138) {\n        url\n      }\n    }\n    id\n  }\n  artwork {\n    internalID\n    partner {\n      name\n      href\n      id\n    }\n    figures(includeAll: false) {\n      __typename\n      ... on Image {\n        resized(width: 185, height: 138) {\n          url\n        }\n      }\n      ... on Video {\n        id\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/order2Routes_RespondQuery.graphql.ts
+++ b/src/__generated__/order2Routes_RespondQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<12be0a9cd754d4cc0e051676770bee41>>
+ * @generated SignedSource<<a7d1dd71a747735653df97993915c7ef>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -93,46 +93,40 @@ v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "display",
+  "name": "currencySymbol",
   "storageKey": null
 },
 v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "__typename",
+  "name": "amount",
   "storageKey": null
 },
 v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "displayName",
+  "name": "__typename",
   "storageKey": null
 },
 v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "amountFallbackText",
+  "name": "displayName",
   "storageKey": null
 },
 v12 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "currencySymbol",
+  "name": "amountFallbackText",
   "storageKey": null
 },
 v13 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "amount",
-    "storageKey": null
-  },
-  (v12/*: any*/)
+  (v9/*: any*/),
+  (v8/*: any*/)
 ],
 v14 = {
   "alias": null,
@@ -145,11 +139,18 @@ v14 = {
   "storageKey": null
 },
 v15 = [
-  (v10/*: any*/),
   (v11/*: any*/),
+  (v12/*: any*/),
   (v14/*: any*/)
 ],
 v16 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "display",
+  "storageKey": null
+},
+v17 = {
   "alias": null,
   "args": null,
   "concreteType": null,
@@ -157,7 +158,7 @@ v16 = {
   "name": "pricingBreakdownLines",
   "plural": true,
   "selections": [
-    (v9/*: any*/),
+    (v10/*: any*/),
     {
       "kind": "InlineFragment",
       "selections": (v15/*: any*/),
@@ -173,7 +174,7 @@ v16 = {
     {
       "kind": "InlineFragment",
       "selections": [
-        (v10/*: any*/),
+        (v11/*: any*/),
         (v14/*: any*/)
       ],
       "type": "SubtotalLine",
@@ -182,8 +183,8 @@ v16 = {
     {
       "kind": "InlineFragment",
       "selections": [
-        (v10/*: any*/),
         (v11/*: any*/),
+        (v12/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -192,7 +193,7 @@ v16 = {
           "name": "amount",
           "plural": false,
           "selections": [
-            (v8/*: any*/)
+            (v16/*: any*/)
           ],
           "storageKey": null
         }
@@ -203,21 +204,21 @@ v16 = {
   ],
   "storageKey": null
 },
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v18 = {
+v19 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "url",
   "storageKey": null
 },
-v19 = {
+v20 = {
   "alias": null,
   "args": [
     {
@@ -236,21 +237,21 @@ v19 = {
   "name": "resized",
   "plural": false,
   "selections": [
-    (v18/*: any*/)
+    (v19/*: any*/)
   ],
   "storageKey": "resized(height:138,width:185)"
 },
-v20 = [
+v21 = [
   (v5/*: any*/)
 ],
-v21 = {
+v22 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "price",
   "storageKey": null
 },
-v22 = [
+v23 = [
   {
     "alias": null,
     "args": null,
@@ -266,24 +267,24 @@ v22 = [
     "storageKey": null
   }
 ],
-v23 = {
+v24 = {
   "alias": null,
   "args": null,
   "concreteType": "dimensions",
   "kind": "LinkedField",
   "name": "dimensions",
   "plural": false,
-  "selections": (v22/*: any*/),
+  "selections": (v23/*: any*/),
   "storageKey": null
 },
-v24 = {
+v25 = {
   "alias": null,
   "args": null,
   "concreteType": "dimensions",
   "kind": "LinkedField",
   "name": "framedDimensions",
   "plural": false,
-  "selections": (v22/*: any*/),
+  "selections": (v23/*: any*/),
   "storageKey": null
 };
 return {
@@ -412,7 +413,8 @@ return {
                             "name": "currencyCode",
                             "storageKey": null
                           },
-                          (v8/*: any*/)
+                          (v8/*: any*/),
+                          (v9/*: any*/)
                         ],
                         "storageKey": null
                       }
@@ -429,7 +431,7 @@ return {
                     "selections": [
                       (v6/*: any*/),
                       (v5/*: any*/),
-                      (v16/*: any*/),
+                      (v17/*: any*/),
                       (v2/*: any*/),
                       {
                         "alias": null,
@@ -479,7 +481,7 @@ return {
                             "name": "partner",
                             "plural": false,
                             "selections": [
-                              (v17/*: any*/),
+                              (v18/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -505,18 +507,18 @@ return {
                             "name": "figures",
                             "plural": true,
                             "selections": [
-                              (v9/*: any*/),
+                              (v10/*: any*/),
                               {
                                 "kind": "InlineFragment",
                                 "selections": [
-                                  (v19/*: any*/)
+                                  (v20/*: any*/)
                                 ],
                                 "type": "Image",
                                 "abstractKey": null
                               },
                               {
                                 "kind": "InlineFragment",
-                                "selections": (v20/*: any*/),
+                                "selections": (v21/*: any*/),
                                 "type": "Video",
                                 "abstractKey": null
                               }
@@ -535,13 +537,13 @@ return {
                         "name": "artworkOrEditionSet",
                         "plural": false,
                         "selections": [
-                          (v9/*: any*/),
+                          (v10/*: any*/),
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v21/*: any*/),
-                              (v23/*: any*/),
-                              (v24/*: any*/)
+                              (v22/*: any*/),
+                              (v24/*: any*/),
+                              (v25/*: any*/)
                             ],
                             "type": "Artwork",
                             "abstractKey": null
@@ -549,9 +551,9 @@ return {
                           {
                             "kind": "InlineFragment",
                             "selections": [
-                              (v21/*: any*/),
-                              (v23/*: any*/),
+                              (v22/*: any*/),
                               (v24/*: any*/),
+                              (v25/*: any*/),
                               (v5/*: any*/)
                             ],
                             "type": "EditionSet",
@@ -559,7 +561,7 @@ return {
                           },
                           {
                             "kind": "InlineFragment",
-                            "selections": (v20/*: any*/),
+                            "selections": (v21/*: any*/),
                             "type": "Node",
                             "abstractKey": "__isNode"
                           }
@@ -622,8 +624,8 @@ return {
                             "name": "image",
                             "plural": false,
                             "selections": [
-                              (v18/*: any*/),
-                              (v19/*: any*/)
+                              (v19/*: any*/),
+                              (v20/*: any*/)
                             ],
                             "storageKey": null
                           },
@@ -648,7 +650,7 @@ return {
                     "name": "buyerStateExpiresAt",
                     "storageKey": null
                   },
-                  (v16/*: any*/),
+                  (v17/*: any*/),
                   {
                     "alias": null,
                     "args": null,
@@ -685,7 +687,7 @@ return {
                         "name": "country",
                         "storageKey": null
                       },
-                      (v17/*: any*/),
+                      (v18/*: any*/),
                       {
                         "alias": null,
                         "args": null,
@@ -757,8 +759,8 @@ return {
                             "name": "minor",
                             "storageKey": null
                           },
+                          (v16/*: any*/),
                           (v8/*: any*/),
-                          (v12/*: any*/),
                           (v7/*: any*/)
                         ],
                         "storageKey": null
@@ -788,7 +790,7 @@ return {
                     "name": "paymentMethodDetails",
                     "plural": false,
                     "selections": [
-                      (v9/*: any*/),
+                      (v10/*: any*/),
                       {
                         "kind": "InlineFragment",
                         "selections": [
@@ -921,12 +923,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "f56db326ad51862a6474ac765f9397f0",
+    "cacheID": "18773c5e05a69930faa1337333c10843",
     "id": null,
     "metadata": {},
     "name": "order2Routes_RespondQuery",
     "operationKind": "query",
-    "text": "query order2Routes_RespondQuery(\n  $orderID: ID!\n) {\n  viewer {\n    me {\n      order(id: $orderID) {\n        internalID\n        mode\n        buyerState\n        id\n      }\n      id\n    }\n    ...Order2RespondRoute_viewer_3HPek8\n  }\n}\n\nfragment Order2HelpLinks_order on Order {\n  internalID\n  mode\n  source\n}\n\nfragment Order2OfferHistory_order on Order {\n  submittedOffers {\n    internalID\n    createdAt(format: \"MMMM D, YYYY\")\n    fromParticipant\n    amount {\n      amount\n      currencySymbol\n    }\n    buyerTotal {\n      amount\n      currencySymbol\n    }\n    id\n  }\n}\n\nfragment Order2OrderSummary_order on Order {\n  ...Order2PricingBreakdown_order\n}\n\nfragment Order2PaymentCompletedView_order on Order {\n  paymentMethod\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      brand\n      lastDigits\n      expirationYear\n      expirationMonth\n      id\n    }\n    ... on BankAccount {\n      last4\n      bankName\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n}\n\nfragment Order2PricingBreakdown_order on Order {\n  source\n  mode\n  buyerState\n  buyerStateExpiresAt\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n  pendingOffer {\n    pricingBreakdownLines {\n      __typename\n      ... on ShippingLine {\n        displayName\n        amountFallbackText\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on TaxLine {\n        displayName\n        amountFallbackText\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on SubtotalLine {\n        displayName\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on TotalLine {\n        displayName\n        amountFallbackText\n        amount {\n          display\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Order2RespondApp_order on Order {\n  paymentMethod\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    id\n  }\n  ...Order2RespondSummary_order\n  ...useCompleteFulfillmentDetailsData_order\n  ...useCompleteDeliveryOptionData_order\n  ...Order2PaymentCompletedView_order\n  ...Order2RespondForm_order\n  ...Order2OfferHistory_order\n  ...Order2HelpLinks_order\n}\n\nfragment Order2RespondContext_order on Order {\n  source\n  mode\n  lastSubmittedOffer {\n    createdAt\n    id\n  }\n  pendingOffer {\n    createdAt\n    id\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    id\n  }\n}\n\nfragment Order2RespondForm_order on Order {\n  internalID\n  lastSubmittedOffer {\n    internalID\n    amount {\n      major\n      currencyCode\n      display\n    }\n    id\n  }\n  pendingOffer {\n    amount {\n      major\n    }\n    id\n  }\n  ...Order2RespondOfferDetails_order\n}\n\nfragment Order2RespondOfferDetails_order on Order {\n  ...Order2PricingBreakdown_order\n}\n\nfragment Order2RespondRoute_viewer_3HPek8 on Viewer {\n  me {\n    order(id: $orderID) {\n      internalID\n      ...Order2RespondContext_order\n      ...Order2RespondApp_order\n      id\n    }\n    id\n  }\n}\n\nfragment Order2RespondSummary_order on Order {\n  ...Order2OrderSummary_order\n  internalID\n  lastSubmittedOffer {\n    internalID\n    id\n  }\n  pendingOffer {\n    internalID\n    id\n  }\n  lineItems {\n    ...useOrder2LineItemData_lineItem\n    id\n  }\n}\n\nfragment useCompleteDeliveryOptionData_order on Order {\n  shippingOrigin\n  shippingRadius\n  selectedFulfillmentOption {\n    type\n    amount {\n      minor\n      display\n      currencySymbol\n      major\n    }\n  }\n}\n\nfragment useCompleteFulfillmentDetailsData_order on Order {\n  mode\n  fulfillmentDetails {\n    addressLine1\n    addressLine2\n    city\n    country\n    name\n    postalCode\n    region\n    phoneNumber {\n      display(format: INTERNATIONAL)\n    }\n  }\n  selectedFulfillmentOption {\n    type\n  }\n}\n\nfragment useOrder2LineItemData_lineItem on LineItem {\n  artworkOrEditionSet {\n    __typename\n    ... on Artwork {\n      price\n      dimensions {\n        in\n        cm\n      }\n      framedDimensions {\n        in\n        cm\n      }\n    }\n    ... on EditionSet {\n      price\n      dimensions {\n        in\n        cm\n      }\n      framedDimensions {\n        in\n        cm\n      }\n      id\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  artworkVersion {\n    title\n    artistNames\n    date\n    attributionClass {\n      shortDescription\n      id\n    }\n    image {\n      url\n      resized(width: 185, height: 138) {\n        url\n      }\n    }\n    id\n  }\n  artwork {\n    internalID\n    partner {\n      name\n      href\n      id\n    }\n    figures(includeAll: false) {\n      __typename\n      ... on Image {\n        resized(width: 185, height: 138) {\n          url\n        }\n      }\n      ... on Video {\n        id\n      }\n    }\n    id\n  }\n}\n"
+    "text": "query order2Routes_RespondQuery(\n  $orderID: ID!\n) {\n  viewer {\n    me {\n      order(id: $orderID) {\n        internalID\n        mode\n        buyerState\n        id\n      }\n      id\n    }\n    ...Order2RespondRoute_viewer_3HPek8\n  }\n}\n\nfragment Order2HelpLinks_order on Order {\n  internalID\n  mode\n  source\n}\n\nfragment Order2OfferHistory_order on Order {\n  submittedOffers {\n    internalID\n    createdAt(format: \"MMMM D, YYYY\")\n    fromParticipant\n    amount {\n      amount\n      currencySymbol\n    }\n    buyerTotal {\n      amount\n      currencySymbol\n    }\n    id\n  }\n}\n\nfragment Order2OrderSummary_order on Order {\n  ...Order2PricingBreakdown_order\n}\n\nfragment Order2PaymentCompletedView_order on Order {\n  paymentMethod\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      brand\n      lastDigits\n      expirationYear\n      expirationMonth\n      id\n    }\n    ... on BankAccount {\n      last4\n      bankName\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n}\n\nfragment Order2PricingBreakdown_order on Order {\n  source\n  mode\n  buyerState\n  buyerStateExpiresAt\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n  pendingOffer {\n    pricingBreakdownLines {\n      __typename\n      ... on ShippingLine {\n        displayName\n        amountFallbackText\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on TaxLine {\n        displayName\n        amountFallbackText\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on SubtotalLine {\n        displayName\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on TotalLine {\n        displayName\n        amountFallbackText\n        amount {\n          display\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Order2RespondApp_order on Order {\n  paymentMethod\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    id\n  }\n  ...Order2RespondSummary_order\n  ...useCompleteFulfillmentDetailsData_order\n  ...useCompleteDeliveryOptionData_order\n  ...Order2PaymentCompletedView_order\n  ...Order2RespondForm_order\n  ...Order2OfferHistory_order\n  ...Order2HelpLinks_order\n}\n\nfragment Order2RespondContext_order on Order {\n  source\n  mode\n  lastSubmittedOffer {\n    createdAt\n    id\n  }\n  pendingOffer {\n    createdAt\n    id\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    id\n  }\n}\n\nfragment Order2RespondForm_order on Order {\n  internalID\n  lastSubmittedOffer {\n    internalID\n    amount {\n      major\n      currencyCode\n      currencySymbol\n      amount\n    }\n    id\n  }\n  pendingOffer {\n    amount {\n      major\n    }\n    id\n  }\n  ...Order2RespondOfferDetails_order\n}\n\nfragment Order2RespondOfferDetails_order on Order {\n  ...Order2PricingBreakdown_order\n}\n\nfragment Order2RespondRoute_viewer_3HPek8 on Viewer {\n  me {\n    order(id: $orderID) {\n      internalID\n      ...Order2RespondContext_order\n      ...Order2RespondApp_order\n      id\n    }\n    id\n  }\n}\n\nfragment Order2RespondSummary_order on Order {\n  ...Order2OrderSummary_order\n  internalID\n  lastSubmittedOffer {\n    internalID\n    id\n  }\n  pendingOffer {\n    internalID\n    id\n  }\n  lineItems {\n    ...useOrder2LineItemData_lineItem\n    id\n  }\n}\n\nfragment useCompleteDeliveryOptionData_order on Order {\n  shippingOrigin\n  shippingRadius\n  selectedFulfillmentOption {\n    type\n    amount {\n      minor\n      display\n      currencySymbol\n      major\n    }\n  }\n}\n\nfragment useCompleteFulfillmentDetailsData_order on Order {\n  mode\n  fulfillmentDetails {\n    addressLine1\n    addressLine2\n    city\n    country\n    name\n    postalCode\n    region\n    phoneNumber {\n      display(format: INTERNATIONAL)\n    }\n  }\n  selectedFulfillmentOption {\n    type\n  }\n}\n\nfragment useOrder2LineItemData_lineItem on LineItem {\n  artworkOrEditionSet {\n    __typename\n    ... on Artwork {\n      price\n      dimensions {\n        in\n        cm\n      }\n      framedDimensions {\n        in\n        cm\n      }\n    }\n    ... on EditionSet {\n      price\n      dimensions {\n        in\n        cm\n      }\n      framedDimensions {\n        in\n        cm\n      }\n      id\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  artworkVersion {\n    title\n    artistNames\n    date\n    attributionClass {\n      shortDescription\n      id\n    }\n    image {\n      url\n      resized(width: 185, height: 138) {\n        url\n      }\n    }\n    id\n  }\n  artwork {\n    internalID\n    partner {\n      name\n      href\n      id\n    }\n    figures(includeAll: false) {\n      __typename\n      ... on Image {\n        resized(width: 185, height: 138) {\n          url\n        }\n      }\n      ... on Video {\n        id\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/useOrder2CreateCounterOfferMutation.graphql.ts
+++ b/src/__generated__/useOrder2CreateCounterOfferMutation.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<00a1bd9a01fed577dbdf57da593b0b01>>
+ * @generated SignedSource<<e8ffa832cd347a2af6d3d1a35b7b99ac>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -128,39 +128,33 @@ v8 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "display",
+  "name": "currencySymbol",
   "storageKey": null
 },
 v9 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "displayName",
+  "name": "amount",
   "storageKey": null
 },
 v10 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "amountFallbackText",
+  "name": "displayName",
   "storageKey": null
 },
 v11 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
-  "name": "currencySymbol",
+  "name": "amountFallbackText",
   "storageKey": null
 },
 v12 = [
-  {
-    "alias": null,
-    "args": null,
-    "kind": "ScalarField",
-    "name": "amount",
-    "storageKey": null
-  },
-  (v11/*: any*/)
+  (v9/*: any*/),
+  (v8/*: any*/)
 ],
 v13 = {
   "alias": null,
@@ -173,11 +167,18 @@ v13 = {
   "storageKey": null
 },
 v14 = [
-  (v9/*: any*/),
   (v10/*: any*/),
+  (v11/*: any*/),
   (v13/*: any*/)
 ],
 v15 = {
+  "alias": null,
+  "args": null,
+  "kind": "ScalarField",
+  "name": "display",
+  "storageKey": null
+},
+v16 = {
   "alias": null,
   "args": null,
   "concreteType": null,
@@ -201,7 +202,7 @@ v15 = {
     {
       "kind": "InlineFragment",
       "selections": [
-        (v9/*: any*/),
+        (v10/*: any*/),
         (v13/*: any*/)
       ],
       "type": "SubtotalLine",
@@ -210,8 +211,8 @@ v15 = {
     {
       "kind": "InlineFragment",
       "selections": [
-        (v9/*: any*/),
         (v10/*: any*/),
+        (v11/*: any*/),
         {
           "alias": null,
           "args": null,
@@ -220,7 +221,7 @@ v15 = {
           "name": "amount",
           "plural": false,
           "selections": [
-            (v8/*: any*/)
+            (v15/*: any*/)
           ],
           "storageKey": null
         }
@@ -231,21 +232,21 @@ v15 = {
   ],
   "storageKey": null
 },
-v16 = {
+v17 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "name",
   "storageKey": null
 },
-v17 = {
+v18 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "url",
   "storageKey": null
 },
-v18 = {
+v19 = {
   "alias": null,
   "args": [
     {
@@ -264,21 +265,21 @@ v18 = {
   "name": "resized",
   "plural": false,
   "selections": [
-    (v17/*: any*/)
+    (v18/*: any*/)
   ],
   "storageKey": "resized(height:138,width:185)"
 },
-v19 = [
+v20 = [
   (v3/*: any*/)
 ],
-v20 = {
+v21 = {
   "alias": null,
   "args": null,
   "kind": "ScalarField",
   "name": "price",
   "storageKey": null
 },
-v21 = [
+v22 = [
   {
     "alias": null,
     "args": null,
@@ -294,24 +295,24 @@ v21 = [
     "storageKey": null
   }
 ],
-v22 = {
+v23 = {
   "alias": null,
   "args": null,
   "concreteType": "dimensions",
   "kind": "LinkedField",
   "name": "dimensions",
   "plural": false,
-  "selections": (v21/*: any*/),
+  "selections": (v22/*: any*/),
   "storageKey": null
 },
-v23 = {
+v24 = {
   "alias": null,
   "args": null,
   "concreteType": "dimensions",
   "kind": "LinkedField",
   "name": "framedDimensions",
   "plural": false,
-  "selections": (v21/*: any*/),
+  "selections": (v22/*: any*/),
   "storageKey": null
 };
 return {
@@ -473,7 +474,8 @@ return {
                                     "name": "currencyCode",
                                     "storageKey": null
                                   },
-                                  (v8/*: any*/)
+                                  (v8/*: any*/),
+                                  (v9/*: any*/)
                                 ],
                                 "storageKey": null
                               }
@@ -490,7 +492,7 @@ return {
                             "selections": [
                               (v5/*: any*/),
                               (v3/*: any*/),
-                              (v15/*: any*/),
+                              (v16/*: any*/),
                               (v6/*: any*/),
                               {
                                 "alias": null,
@@ -540,7 +542,7 @@ return {
                                     "name": "partner",
                                     "plural": false,
                                     "selections": [
-                                      (v16/*: any*/),
+                                      (v17/*: any*/),
                                       {
                                         "alias": null,
                                         "args": null,
@@ -570,14 +572,14 @@ return {
                                       {
                                         "kind": "InlineFragment",
                                         "selections": [
-                                          (v18/*: any*/)
+                                          (v19/*: any*/)
                                         ],
                                         "type": "Image",
                                         "abstractKey": null
                                       },
                                       {
                                         "kind": "InlineFragment",
-                                        "selections": (v19/*: any*/),
+                                        "selections": (v20/*: any*/),
                                         "type": "Video",
                                         "abstractKey": null
                                       }
@@ -600,9 +602,9 @@ return {
                                   {
                                     "kind": "InlineFragment",
                                     "selections": [
-                                      (v20/*: any*/),
-                                      (v22/*: any*/),
-                                      (v23/*: any*/)
+                                      (v21/*: any*/),
+                                      (v23/*: any*/),
+                                      (v24/*: any*/)
                                     ],
                                     "type": "Artwork",
                                     "abstractKey": null
@@ -610,9 +612,9 @@ return {
                                   {
                                     "kind": "InlineFragment",
                                     "selections": [
-                                      (v20/*: any*/),
-                                      (v22/*: any*/),
+                                      (v21/*: any*/),
                                       (v23/*: any*/),
+                                      (v24/*: any*/),
                                       (v3/*: any*/)
                                     ],
                                     "type": "EditionSet",
@@ -620,7 +622,7 @@ return {
                                   },
                                   {
                                     "kind": "InlineFragment",
-                                    "selections": (v19/*: any*/),
+                                    "selections": (v20/*: any*/),
                                     "type": "Node",
                                     "abstractKey": "__isNode"
                                   }
@@ -683,8 +685,8 @@ return {
                                     "name": "image",
                                     "plural": false,
                                     "selections": [
-                                      (v17/*: any*/),
-                                      (v18/*: any*/)
+                                      (v18/*: any*/),
+                                      (v19/*: any*/)
                                     ],
                                     "storageKey": null
                                   },
@@ -716,7 +718,7 @@ return {
                             "name": "buyerStateExpiresAt",
                             "storageKey": null
                           },
-                          (v15/*: any*/),
+                          (v16/*: any*/),
                           (v6/*: any*/),
                           {
                             "alias": null,
@@ -754,7 +756,7 @@ return {
                                 "name": "country",
                                 "storageKey": null
                               },
-                              (v16/*: any*/),
+                              (v17/*: any*/),
                               {
                                 "alias": null,
                                 "args": null,
@@ -826,8 +828,8 @@ return {
                                     "name": "minor",
                                     "storageKey": null
                                   },
+                                  (v15/*: any*/),
                                   (v8/*: any*/),
-                                  (v11/*: any*/),
                                   (v7/*: any*/)
                                 ],
                                 "storageKey": null
@@ -998,12 +1000,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "939047fbea4f432511dea565db2bcad4",
+    "cacheID": "16f55b953765d8e68803637e7809d792",
     "id": null,
     "metadata": {},
     "name": "useOrder2CreateCounterOfferMutation",
     "operationKind": "mutation",
-    "text": "mutation useOrder2CreateCounterOfferMutation(\n  $input: createBuyerOfferInput!\n) {\n  createBuyerOffer(input: $input) {\n    offerOrError {\n      __typename\n      ... on OfferMutationSuccess {\n        __typename\n        offer {\n          order {\n            id\n            ...Order2RespondContext_order\n            ...Order2RespondApp_order\n          }\n          id\n        }\n      }\n      ... on OfferMutationError {\n        mutationError {\n          code\n          message\n        }\n      }\n    }\n  }\n}\n\nfragment Order2HelpLinks_order on Order {\n  internalID\n  mode\n  source\n}\n\nfragment Order2OfferHistory_order on Order {\n  submittedOffers {\n    internalID\n    createdAt(format: \"MMMM D, YYYY\")\n    fromParticipant\n    amount {\n      amount\n      currencySymbol\n    }\n    buyerTotal {\n      amount\n      currencySymbol\n    }\n    id\n  }\n}\n\nfragment Order2OrderSummary_order on Order {\n  ...Order2PricingBreakdown_order\n}\n\nfragment Order2PaymentCompletedView_order on Order {\n  paymentMethod\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      brand\n      lastDigits\n      expirationYear\n      expirationMonth\n      id\n    }\n    ... on BankAccount {\n      last4\n      bankName\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n}\n\nfragment Order2PricingBreakdown_order on Order {\n  source\n  mode\n  buyerState\n  buyerStateExpiresAt\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n  pendingOffer {\n    pricingBreakdownLines {\n      __typename\n      ... on ShippingLine {\n        displayName\n        amountFallbackText\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on TaxLine {\n        displayName\n        amountFallbackText\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on SubtotalLine {\n        displayName\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on TotalLine {\n        displayName\n        amountFallbackText\n        amount {\n          display\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Order2RespondApp_order on Order {\n  paymentMethod\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    id\n  }\n  ...Order2RespondSummary_order\n  ...useCompleteFulfillmentDetailsData_order\n  ...useCompleteDeliveryOptionData_order\n  ...Order2PaymentCompletedView_order\n  ...Order2RespondForm_order\n  ...Order2OfferHistory_order\n  ...Order2HelpLinks_order\n}\n\nfragment Order2RespondContext_order on Order {\n  source\n  mode\n  lastSubmittedOffer {\n    createdAt\n    id\n  }\n  pendingOffer {\n    createdAt\n    id\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    id\n  }\n}\n\nfragment Order2RespondForm_order on Order {\n  internalID\n  lastSubmittedOffer {\n    internalID\n    amount {\n      major\n      currencyCode\n      display\n    }\n    id\n  }\n  pendingOffer {\n    amount {\n      major\n    }\n    id\n  }\n  ...Order2RespondOfferDetails_order\n}\n\nfragment Order2RespondOfferDetails_order on Order {\n  ...Order2PricingBreakdown_order\n}\n\nfragment Order2RespondSummary_order on Order {\n  ...Order2OrderSummary_order\n  internalID\n  lastSubmittedOffer {\n    internalID\n    id\n  }\n  pendingOffer {\n    internalID\n    id\n  }\n  lineItems {\n    ...useOrder2LineItemData_lineItem\n    id\n  }\n}\n\nfragment useCompleteDeliveryOptionData_order on Order {\n  shippingOrigin\n  shippingRadius\n  selectedFulfillmentOption {\n    type\n    amount {\n      minor\n      display\n      currencySymbol\n      major\n    }\n  }\n}\n\nfragment useCompleteFulfillmentDetailsData_order on Order {\n  mode\n  fulfillmentDetails {\n    addressLine1\n    addressLine2\n    city\n    country\n    name\n    postalCode\n    region\n    phoneNumber {\n      display(format: INTERNATIONAL)\n    }\n  }\n  selectedFulfillmentOption {\n    type\n  }\n}\n\nfragment useOrder2LineItemData_lineItem on LineItem {\n  artworkOrEditionSet {\n    __typename\n    ... on Artwork {\n      price\n      dimensions {\n        in\n        cm\n      }\n      framedDimensions {\n        in\n        cm\n      }\n    }\n    ... on EditionSet {\n      price\n      dimensions {\n        in\n        cm\n      }\n      framedDimensions {\n        in\n        cm\n      }\n      id\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  artworkVersion {\n    title\n    artistNames\n    date\n    attributionClass {\n      shortDescription\n      id\n    }\n    image {\n      url\n      resized(width: 185, height: 138) {\n        url\n      }\n    }\n    id\n  }\n  artwork {\n    internalID\n    partner {\n      name\n      href\n      id\n    }\n    figures(includeAll: false) {\n      __typename\n      ... on Image {\n        resized(width: 185, height: 138) {\n          url\n        }\n      }\n      ... on Video {\n        id\n      }\n    }\n    id\n  }\n}\n"
+    "text": "mutation useOrder2CreateCounterOfferMutation(\n  $input: createBuyerOfferInput!\n) {\n  createBuyerOffer(input: $input) {\n    offerOrError {\n      __typename\n      ... on OfferMutationSuccess {\n        __typename\n        offer {\n          order {\n            id\n            ...Order2RespondContext_order\n            ...Order2RespondApp_order\n          }\n          id\n        }\n      }\n      ... on OfferMutationError {\n        mutationError {\n          code\n          message\n        }\n      }\n    }\n  }\n}\n\nfragment Order2HelpLinks_order on Order {\n  internalID\n  mode\n  source\n}\n\nfragment Order2OfferHistory_order on Order {\n  submittedOffers {\n    internalID\n    createdAt(format: \"MMMM D, YYYY\")\n    fromParticipant\n    amount {\n      amount\n      currencySymbol\n    }\n    buyerTotal {\n      amount\n      currencySymbol\n    }\n    id\n  }\n}\n\nfragment Order2OrderSummary_order on Order {\n  ...Order2PricingBreakdown_order\n}\n\nfragment Order2PaymentCompletedView_order on Order {\n  paymentMethod\n  paymentMethodDetails {\n    __typename\n    ... on CreditCard {\n      brand\n      lastDigits\n      expirationYear\n      expirationMonth\n      id\n    }\n    ... on BankAccount {\n      last4\n      bankName\n      id\n    }\n    ... on WireTransfer {\n      isManualPayment\n    }\n  }\n}\n\nfragment Order2PricingBreakdown_order on Order {\n  source\n  mode\n  buyerState\n  buyerStateExpiresAt\n  pricingBreakdownLines {\n    __typename\n    ... on ShippingLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TaxLine {\n      displayName\n      amountFallbackText\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on SubtotalLine {\n      displayName\n      amount {\n        amount\n        currencySymbol\n      }\n    }\n    ... on TotalLine {\n      displayName\n      amountFallbackText\n      amount {\n        display\n      }\n    }\n  }\n  pendingOffer {\n    pricingBreakdownLines {\n      __typename\n      ... on ShippingLine {\n        displayName\n        amountFallbackText\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on TaxLine {\n        displayName\n        amountFallbackText\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on SubtotalLine {\n        displayName\n        amount {\n          amount\n          currencySymbol\n        }\n      }\n      ... on TotalLine {\n        displayName\n        amountFallbackText\n        amount {\n          display\n        }\n      }\n    }\n    id\n  }\n}\n\nfragment Order2RespondApp_order on Order {\n  paymentMethod\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    id\n  }\n  ...Order2RespondSummary_order\n  ...useCompleteFulfillmentDetailsData_order\n  ...useCompleteDeliveryOptionData_order\n  ...Order2PaymentCompletedView_order\n  ...Order2RespondForm_order\n  ...Order2OfferHistory_order\n  ...Order2HelpLinks_order\n}\n\nfragment Order2RespondContext_order on Order {\n  source\n  mode\n  lastSubmittedOffer {\n    createdAt\n    id\n  }\n  pendingOffer {\n    createdAt\n    id\n  }\n  lineItems {\n    artwork {\n      slug\n      id\n    }\n    id\n  }\n}\n\nfragment Order2RespondForm_order on Order {\n  internalID\n  lastSubmittedOffer {\n    internalID\n    amount {\n      major\n      currencyCode\n      currencySymbol\n      amount\n    }\n    id\n  }\n  pendingOffer {\n    amount {\n      major\n    }\n    id\n  }\n  ...Order2RespondOfferDetails_order\n}\n\nfragment Order2RespondOfferDetails_order on Order {\n  ...Order2PricingBreakdown_order\n}\n\nfragment Order2RespondSummary_order on Order {\n  ...Order2OrderSummary_order\n  internalID\n  lastSubmittedOffer {\n    internalID\n    id\n  }\n  pendingOffer {\n    internalID\n    id\n  }\n  lineItems {\n    ...useOrder2LineItemData_lineItem\n    id\n  }\n}\n\nfragment useCompleteDeliveryOptionData_order on Order {\n  shippingOrigin\n  shippingRadius\n  selectedFulfillmentOption {\n    type\n    amount {\n      minor\n      display\n      currencySymbol\n      major\n    }\n  }\n}\n\nfragment useCompleteFulfillmentDetailsData_order on Order {\n  mode\n  fulfillmentDetails {\n    addressLine1\n    addressLine2\n    city\n    country\n    name\n    postalCode\n    region\n    phoneNumber {\n      display(format: INTERNATIONAL)\n    }\n  }\n  selectedFulfillmentOption {\n    type\n  }\n}\n\nfragment useOrder2LineItemData_lineItem on LineItem {\n  artworkOrEditionSet {\n    __typename\n    ... on Artwork {\n      price\n      dimensions {\n        in\n        cm\n      }\n      framedDimensions {\n        in\n        cm\n      }\n    }\n    ... on EditionSet {\n      price\n      dimensions {\n        in\n        cm\n      }\n      framedDimensions {\n        in\n        cm\n      }\n      id\n    }\n    ... on Node {\n      __isNode: __typename\n      id\n    }\n  }\n  artworkVersion {\n    title\n    artistNames\n    date\n    attributionClass {\n      shortDescription\n      id\n    }\n    image {\n      url\n      resized(width: 185, height: 138) {\n        url\n      }\n    }\n    id\n  }\n  artwork {\n    internalID\n    partner {\n      name\n      href\n      id\n    }\n    figures(includeAll: false) {\n      __typename\n      ... on Image {\n        resized(width: 185, height: 138) {\n          url\n        }\n      }\n      ... on Video {\n        id\n      }\n    }\n    id\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Noticing that we lost the bolding on the title somehow and we also want just symbol for the price that is not total.

Before: 
<img width="1342" height="878" alt="Screenshot 2026-07-20 at 10 20 02 AM" src="https://github.com/user-attachments/assets/95a9cb3b-d252-4c7f-852e-c1df30488e08" />

After:
<img width="1327" height="858" alt="Screenshot 2026-07-20 at 2 40 13 PM" src="https://github.com/user-attachments/assets/99510801-8bbf-4e3b-b227-1ca97f71c21b" />
