### PR TITLE
fix(EMI-3323): add context module to the tracking of terms and conditions click

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/ExpressCheckout/Order2ExpressCheckoutUI.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/ExpressCheckout/Order2ExpressCheckoutUI.tsx
@@ -1,3 +1,4 @@
+import { ContextModule } from "@artsy/cohesion"
 import { Box, Spacer } from "@artsy/palette"
 import {
   ExpressCheckoutElement,
@@ -678,7 +679,9 @@ export const Order2ExpressCheckoutUI: React.FC<
       <Spacer y={[1, 1, 2]} />
       <TermsAndConditions
         onClickTermsAndConditions={() => {
-          checkoutTracking.clickedTermsAndConditions()
+          checkoutTracking.clickedTermsAndConditions(
+            ContextModule.ordersCheckout,
+          )
         }}
       />
     </Box>

--- a/src/Apps/Order2/Routes/Checkout/Components/ExpressCheckout/__tests__/Order2ExpressCheckoutUI.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/ExpressCheckout/__tests__/Order2ExpressCheckoutUI.jest.tsx
@@ -1,3 +1,4 @@
+import { ContextModule } from "@artsy/cohesion"
 import { ExpressCheckoutElement } from "@stripe/react-stripe-js"
 import { fireEvent, waitFor } from "@testing-library/react"
 import { screen } from "@testing-library/react"
@@ -223,6 +224,7 @@ describe("ExpressCheckoutUI", () => {
       device: Device.Unknown,
       downloadAppUrl: "",
     })
+    mockCheckoutContext.expressCheckoutPaymentMethods = undefined
     // Reset messages
     mockMessages.EXPRESS_CHECKOUT = { error: null }
     mockMessages.FULFILLMENT_DETAILS = { error: null }
@@ -981,6 +983,27 @@ describe("ExpressCheckoutUI", () => {
         }),
       })
       expect(mockReject).toHaveBeenCalled()
+    })
+  })
+
+  describe("Terms and conditions", () => {
+    it("tracks clickedTermsAndConditions with the ordersCheckout context module", async () => {
+      mockCheckoutContext.expressCheckoutPaymentMethods = ["applePay"]
+
+      renderWithRelay({
+        Order: () => ({ ...orderData }),
+      })
+
+      fireEvent.click(
+        await screen.findByText("General Terms and Conditions of Sale."),
+      )
+
+      expect(trackEvent).toHaveBeenCalledWith({
+        action: "clickedTermsAndConditions",
+        context_module: ContextModule.ordersCheckout,
+        context_page_owner_type: "owner-type-from-context",
+        context_page_owner_id: "order-id-from-context",
+      })
     })
   })
 })

--- a/src/Apps/Order2/Routes/Checkout/Components/Order2ReviewStep.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2ReviewStep.tsx
@@ -230,7 +230,9 @@ export const Order2ReviewStep: React.FC<Order2ReviewStepProps> = ({
           <Spacer y={2} />
           <TermsAndConditions
             onClickTermsAndConditions={() =>
-              checkoutTracking.clickedTermsAndConditions()
+              checkoutTracking.clickedTermsAndConditions(
+                ContextModule.ordersReview,
+              )
             }
           />
           <Spacer y={2} />

--- a/src/Apps/Order2/Routes/Checkout/Components/__tests__/Order2ReviewStep.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/__tests__/Order2ReviewStep.jest.tsx
@@ -1,3 +1,4 @@
+import { ContextModule } from "@artsy/cohesion"
 import { screen, waitFor } from "@testing-library/react"
 import userEvent from "@testing-library/user-event"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
@@ -40,6 +41,7 @@ const mockCheckoutContext = {
     clickedOrderProgression: jest.fn(),
     submittedOrder: jest.fn(),
     clickedBuyerProtection: jest.fn(),
+    clickedTermsAndConditions: jest.fn(),
   },
   artworkPath: "/artwork/test-artwork",
 }
@@ -462,6 +464,24 @@ describe("Order2ReviewStep", () => {
       // SEPA cannot be saved, so oneTimeUse should always be true
       expect(input.oneTimeUse).toBe(true)
       expect(input.confirmationToken).toBeUndefined()
+    })
+  })
+
+  describe("Terms and conditions", () => {
+    it("tracks clickedTermsAndConditions with the ordersReview context module", async () => {
+      renderWithRelay({
+        Me: () => ({
+          order: createBuyOrder(),
+        }),
+      })
+
+      await userEvent.click(
+        screen.getByText("General Terms and Conditions of Sale."),
+      )
+
+      expect(
+        mockCheckoutContext.checkoutTracking.clickedTermsAndConditions,
+      ).toHaveBeenCalledWith(ContextModule.ordersReview)
     })
   })
 

--- a/src/Apps/Order2/Routes/Checkout/Hooks/__tests__/useCheckoutTracking.jest.ts
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/__tests__/useCheckoutTracking.jest.ts
@@ -1,3 +1,4 @@
+import { ContextModule } from "@artsy/cohesion"
 import { act, renderHook } from "@testing-library/react-hooks"
 import type { ProcessedUserAddress } from "Apps/Order2/Routes/Checkout/Components/FulfillmentDetailsStep/utils"
 import { useTracking } from "react-tracking"
@@ -127,12 +128,12 @@ describe("useCheckoutTracking", () => {
       )
 
       act(() => {
-        result.current.clickedTermsAndConditions()
+        result.current.clickedTermsAndConditions(ContextModule.ordersCheckout)
       })
 
       assertTracked({
         action: "clickedTermsAndConditions",
-        context_module: "ordersReview",
+        context_module: "ordersCheckout",
         context_page_owner_type: "orders-checkout",
         context_page_owner_id: "order-id",
       })

--- a/src/Apps/Order2/Routes/Checkout/Hooks/useCheckoutTracking.ts
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/useCheckoutTracking.ts
@@ -247,10 +247,10 @@ export const useCheckoutTracking = ({
         trackEvent(payload)
       },
 
-      clickedTermsAndConditions: () => {
+      clickedTermsAndConditions: (contextModule: ContextModule) => {
         const payload: ClickedTermsAndConditions = {
           action: ActionType.clickedTermsAndConditions,
-          context_module: ContextModule.ordersReview,
+          context_module: contextModule,
           context_page_owner_type: contextPageOwnerType,
           context_page_owner_id: contextPageOwnerId,
         }

--- a/src/Apps/Order2/Routes/Respond/Components/Order2RespondSummary.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/Order2RespondSummary.tsx
@@ -197,7 +197,9 @@ export const Order2RespondSummary: React.FC<Order2RespondSummaryProps> = ({
 
           <TermsAndConditions
             onClickTermsAndConditions={() =>
-              checkoutTracking.clickedTermsAndConditions()
+              checkoutTracking.clickedTermsAndConditions(
+                ContextModule.ordersReview,
+              )
             }
           />
 


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-3323]

### Description

<!-- Implementation description -->

Previously the `clickedTermsAndConditions` event hardcoded `context_module: ordersReview` across all flows. This parameterizes it so each source is distinguishable.

| Flow | Component | `context_module` | `context_page_owner_type` |
|---|---|---|---|
| Express checkout | `Order2ExpressCheckoutUI.tsx` | `ordersCheckout` | `orders-checkout` |
| Submit — normal order | `Order2ReviewStep.tsx` | `ordersReview` | `orders-checkout` |
| Submit — counteroffer | `Order2RespondSummary.tsx` | `ordersReview` | `orders-respond` |

[EMI-3323]: https://artsyproduct.atlassian.net/browse/EMI-3323?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ