### PR TITLE
fix(EMI-3299): jump to counteroffer submit

### DIFF
--- a/src/Apps/Order2/Routes/Respond/Components/Order2RespondForm.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/Order2RespondForm.tsx
@@ -18,6 +18,7 @@ import { SectionHeading } from "Apps/Order2/Components/SectionHeading"
 import { CheckoutErrorBanner } from "Apps/Order2/Routes/Checkout/Components/CheckoutErrorBanner"
 import { Order2RespondOfferDetails } from "Apps/Order2/Routes/Respond/Components/Order2RespondOfferDetails"
 import { useRespondContext } from "Apps/Order2/Routes/Respond/Hooks/useRespondContext"
+import { useScrollToRespondSubmit } from "Apps/Order2/Routes/Respond/Hooks/useScrollToRespondSubmit"
 import { useOrder2CreateCounterOfferMutation } from "Apps/Order2/Routes/Respond/Mutations/useOrder2CreateCounterOfferMutation"
 import {
   type RespondAction,
@@ -133,6 +134,8 @@ export const Order2RespondForm: React.FC<Order2RespondFormProps> = ({
   const { submitMutation: createCounterOffer } =
     useOrder2CreateCounterOfferMutation()
 
+  const { scrollToSubmitCTA } = useScrollToRespondSubmit()
+
   // The gallery’s offer amount, excluding shipping and taxes.
   const offerPrice = orderData.lastSubmittedOffer?.amount?.display
 
@@ -191,6 +194,7 @@ export const Order2RespondForm: React.FC<Order2RespondFormProps> = ({
     // summary’s Submit CTA. Accept/decline just advance to that step.
     if (selectedAction !== "COUNTEROFFER") {
       setRespondComplete()
+      scrollToSubmitCTA()
       return
     }
 
@@ -224,6 +228,7 @@ export const Order2RespondForm: React.FC<Order2RespondFormProps> = ({
       }
 
       setRespondComplete()
+      scrollToSubmitCTA()
     } catch (error) {
       // TODO: proper error handling is tracked in EMI-3175.
       logger.error(error)

--- a/src/Apps/Order2/Routes/Respond/Components/Order2RespondSummary.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/Order2RespondSummary.tsx
@@ -13,6 +13,7 @@ import {
   RespondStepState,
 } from "Apps/Order2/Routes/Respond/RespondContext/types"
 import { useRouter } from "System/Hooks/useRouter"
+import { Jump } from "Utils/Hooks/useJump"
 import createLogger from "Utils/logger"
 import type { Order2RespondSummary_order$key } from "__generated__/Order2RespondSummary_order.graphql"
 import { useState } from "react"
@@ -24,10 +25,12 @@ const GENERIC_ERROR = "Something went wrong. Please try again."
 
 interface Order2RespondSummaryProps {
   order: Order2RespondSummary_order$key
+  jumpToSubmit?: boolean
 }
 
 export const Order2RespondSummary: React.FC<Order2RespondSummaryProps> = ({
   order,
+  jumpToSubmit,
 }) => {
   const orderData = useFragment(FRAGMENT, order)
   const {
@@ -179,6 +182,7 @@ export const Order2RespondSummary: React.FC<Order2RespondSummaryProps> = ({
       {isConfirmationActive && (
         <>
           <Spacer y={2} />
+          {jumpToSubmit && <Jump id="respond-submit-cta" />}
           <Button
             variant="primaryBlack"
             width="100%"

--- a/src/Apps/Order2/Routes/Respond/Components/__tests__/Order2RespondForm.jest.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/__tests__/Order2RespondForm.jest.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react"
+import { act, fireEvent, screen, waitFor } from "@testing-library/react"
 import { Order2RespondForm } from "Apps/Order2/Routes/Respond/Components/Order2RespondForm"
 import { useOrder2CreateCounterOfferMutation } from "Apps/Order2/Routes/Respond/Mutations/useOrder2CreateCounterOfferMutation"
 import { Order2RespondContextProvider } from "Apps/Order2/Routes/Respond/RespondContext/Order2RespondContext"
@@ -13,6 +13,16 @@ jest.mock(
   "Apps/Order2/Routes/Respond/Mutations/useOrder2CreateCounterOfferMutation",
 )
 
+const mockJumpTo = jest.fn()
+jest.mock("Utils/Hooks/useJump", () => ({
+  useJump: () => ({ jumpTo: mockJumpTo }),
+}))
+
+const mockUseMatchMedia = jest.fn()
+jest.mock("Utils/Hooks/useMatchMedia", () => ({
+  __internal__useMatchMedia: (...args: any[]) => mockUseMatchMedia(...args),
+}))
+
 jest.mock("System/Hooks/useAnalyticsContext", () => ({
   useAnalyticsContext: jest.fn(() => ({
     contextPageOwnerId: "order-id",
@@ -26,6 +36,10 @@ const COUNTEROFFER_PLACEHOLDER = "Enter amount excluding shipping & tax"
 const mockCreateCounterOffer = jest.fn()
 
 beforeEach(() => {
+  mockJumpTo.mockReset()
+  // Default to the mobile/mWeb layout, where the Submit CTA is below the fold.
+  mockUseMatchMedia.mockReset()
+  mockUseMatchMedia.mockReturnValue(true)
   mockCreateCounterOffer.mockReset()
   mockCreateCounterOffer.mockResolvedValue({
     createBuyerOffer: {
@@ -299,6 +313,72 @@ describe("Order2RespondForm", () => {
 
     expect(screen.getByText("Respond to gallery offer")).toBeInTheDocument()
     expect(screen.getByText("Decline gallery offer")).toBeInTheDocument()
+  })
+
+  describe("scrolling to the Submit CTA", () => {
+    beforeEach(() => {
+      jest.useFakeTimers()
+    })
+
+    afterEach(() => {
+      act(() => {
+        jest.runOnlyPendingTimers()
+      })
+      jest.useRealTimers()
+    })
+
+    it("scrolls to the Submit CTA after continuing on mobile", () => {
+      renderWithRelay(defaultResolvers)
+
+      fireEvent.click(screen.getByText("Accept gallery offer"))
+      fireEvent.click(continueButton())
+
+      act(() => {
+        jest.advanceTimersByTime(100)
+      })
+
+      expect(mockJumpTo).toHaveBeenCalledWith("respond-submit-cta", {
+        behavior: "smooth",
+        offset: 30,
+      })
+    })
+
+    it("scrolls to the Submit CTA after creating a counteroffer on mobile", async () => {
+      renderWithRelay(defaultResolvers)
+
+      fireEvent.click(screen.getByText("Send counteroffer"))
+      fireEvent.change(screen.getByPlaceholderText(COUNTEROFFER_PLACEHOLDER), {
+        target: { value: "500" },
+      })
+      fireEvent.click(continueButton())
+
+      await act(async () => {
+        await Promise.resolve()
+        jest.advanceTimersByTime(100)
+      })
+
+      expect(mockJumpTo).toHaveBeenCalledWith("respond-submit-cta", {
+        behavior: "smooth",
+        offset: 30,
+      })
+    })
+
+    it("does not scroll on desktop, where the Submit CTA is already visible", () => {
+      // Desktop layout: neither the xs nor sm media query matches.
+      mockUseMatchMedia.mockReturnValue(false)
+
+      renderWithRelay(defaultResolvers)
+
+      fireEvent.click(screen.getByText("Accept gallery offer"))
+      fireEvent.click(continueButton())
+
+      act(() => {
+        jest.advanceTimersByTime(100)
+      })
+
+      expect(screen.getByText("Accepted gallery offer")).toBeInTheDocument()
+      expect(mockJumpTo).not.toHaveBeenCalled()
+    })
   })
 
   describe("analytics", () => {

--- a/src/Apps/Order2/Routes/Respond/Hooks/useScrollToRespondSubmit.ts
+++ b/src/Apps/Order2/Routes/Respond/Hooks/useScrollToRespondSubmit.ts
@@ -1,0 +1,26 @@
+import { THEME } from "@artsy/palette"
+import { useJump } from "Utils/Hooks/useJump"
+import { __internal__useMatchMedia } from "Utils/Hooks/useMatchMedia"
+
+export const RESPOND_SUBMIT_JUMP_ID = "respond-submit-cta"
+
+const OFFSET = 30
+
+export const useScrollToRespondSubmit = () => {
+  const { jumpTo } = useJump({ behavior: "smooth" })
+  const isXs = __internal__useMatchMedia(THEME.mediaQueries.xs)
+  const isSm = __internal__useMatchMedia(THEME.mediaQueries.sm)
+  const isMobileLayout = !!isXs || !!isSm
+
+  const scrollToSubmitCTA = () => {
+    if (!isMobileLayout) {
+      return
+    }
+
+    setTimeout(() => {
+      jumpTo(RESPOND_SUBMIT_JUMP_ID, { behavior: "smooth", offset: OFFSET })
+    }, 100)
+  }
+
+  return { scrollToSubmitCTA }
+}

--- a/src/Apps/Order2/Routes/Respond/Order2RespondApp.tsx
+++ b/src/Apps/Order2/Routes/Respond/Order2RespondApp.tsx
@@ -84,7 +84,7 @@ export const Order2RespondApp: React.FC<Order2RespondAppProps> = ({
               )}
 
               <Box display={["block", "block", "none"]}>
-                <Order2RespondSummary order={orderData} />
+                <Order2RespondSummary order={orderData} jumpToSubmit />
                 <Order2HelpLinksWithInquiry
                   order={orderData}
                   artworkID={artworkSlug as string}


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-3299]

### Description

On mobile/mWeb the offer summary (and its Submit CTA) renders inline at the bottom of a long scroll, so clicking "Continue to Review" gave no visible feedback. This smooth-scrolls to the Submit CTA once the response step is completed.

<!-- Implementation description -->

https://github.com/user-attachments/assets/7fff2112-07be-4b41-9dfa-dcb8ae776ef7



[EMI-3299]: https://artsyproduct.atlassian.net/browse/EMI-3299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ