### PR TITLE
fix(EMI-3284): no autoscroll on load if express checkout is visible

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Hooks/__tests__/useCheckoutAutoScroll.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/__tests__/useCheckoutAutoScroll.jest.tsx
@@ -109,6 +109,58 @@ describe("useCheckoutAutoScroll", () => {
     expect(mockJumpTo).not.toHaveBeenCalled()
   })
 
+  it("does not scroll on load if express checkout is available and we are on a non-first, non-review step", () => {
+    const steps = createSteps(CheckoutStepName.PAYMENT)
+
+    mockUseCheckoutContext.mockReturnValue({
+      isLoading: true,
+      steps,
+      expressCheckoutPaymentMethods: null,
+    })
+
+    const { rerender } = renderHook(() => useCheckoutAutoScroll())
+
+    mockUseCheckoutContext.mockReturnValue({
+      isLoading: false,
+      steps,
+      expressCheckoutPaymentMethods: ["CREDIT_CARD"],
+    })
+
+    rerender()
+    jest.runAllTimers()
+
+    // The initial load scroll (first useEffect) should NOT fire for the first step (activeStepIndex = 0)
+    // The step navigation scroll (second useEffect) should also not fire because step hasn't changed
+    // We expect 0 calls, confirming no unwanted scrolling on load for the first step
+    expect(mockJumpTo).not.toHaveBeenCalled()
+  })
+
+  it("does  scroll on load if express checkout is available and we are on the review step", () => {
+    const steps = createSteps(CheckoutStepName.CONFIRMATION)
+
+    mockUseCheckoutContext.mockReturnValue({
+      isLoading: true,
+      steps,
+      expressCheckoutPaymentMethods: null,
+    })
+
+    const { rerender } = renderHook(() => useCheckoutAutoScroll())
+
+    mockUseCheckoutContext.mockReturnValue({
+      isLoading: false,
+      steps,
+      expressCheckoutPaymentMethods: ["CREDIT_CARD"],
+    })
+
+    rerender()
+    jest.runAllTimers()
+
+    // The initial load scroll (first useEffect) should NOT fire for the first step (activeStepIndex = 0)
+    // The step navigation scroll (second useEffect) should also not fire because step hasn't changed
+    // We expect 0 calls, confirming no unwanted scrolling on load for the first step
+    expect(mockJumpTo).toHaveBeenCalled()
+  })
+
   it("scrolls to confirmation when it becomes active", () => {
     mockUseCheckoutContext.mockReturnValue({
       isLoading: false,

--- a/src/Apps/Order2/Routes/Checkout/Hooks/__tests__/useCheckoutAutoScroll.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/__tests__/useCheckoutAutoScroll.jest.tsx
@@ -129,13 +129,10 @@ describe("useCheckoutAutoScroll", () => {
     rerender()
     jest.runAllTimers()
 
-    // The initial load scroll (first useEffect) should NOT fire for the first step (activeStepIndex = 0)
-    // The step navigation scroll (second useEffect) should also not fire because step hasn't changed
-    // We expect 0 calls, confirming no unwanted scrolling on load for the first step
     expect(mockJumpTo).not.toHaveBeenCalled()
   })
 
-  it("does  scroll on load if express checkout is available and we are on the review step", () => {
+  it("does scroll on load if express checkout is available and we are on the review step", () => {
     const steps = createSteps(CheckoutStepName.CONFIRMATION)
 
     mockUseCheckoutContext.mockReturnValue({
@@ -155,9 +152,6 @@ describe("useCheckoutAutoScroll", () => {
     rerender()
     jest.runAllTimers()
 
-    // The initial load scroll (first useEffect) should NOT fire for the first step (activeStepIndex = 0)
-    // The step navigation scroll (second useEffect) should also not fire because step hasn't changed
-    // We expect 0 calls, confirming no unwanted scrolling on load for the first step
     expect(mockJumpTo).toHaveBeenCalled()
   })
 

--- a/src/Apps/Order2/Routes/Checkout/Hooks/useCheckoutAutoScroll.ts
+++ b/src/Apps/Order2/Routes/Checkout/Hooks/useCheckoutAutoScroll.ts
@@ -21,7 +21,8 @@ const stepWithIndex = (
 }
 
 export const useCheckoutAutoScroll = () => {
-  const { isLoading, steps } = useCheckoutContext()
+  const { isLoading, steps, expressCheckoutPaymentMethods } =
+    useCheckoutContext()
   const { scrollToStep } = useScrollToStep()
 
   // Combined steps (FULFILLMENT_DETAILS + DELIVERY_OPTION) are ACTIVE
@@ -41,18 +42,28 @@ export const useCheckoutAutoScroll = () => {
 
   const initialScrollComplete = useRef(false)
 
+  const expressCheckoutAvailable =
+    expressCheckoutPaymentMethods && expressCheckoutPaymentMethods.length > 0
+
   // Scroll to active step when loading completes
   useEffect(() => {
     if (initialScrollComplete.current) {
       return
     }
+
     if (justLoaded) {
-      if (activeStep && activeStepIndex > 0) {
+      if (!expressCheckoutAvailable && activeStep && activeStepIndex > 0) {
         scrollToStep(activeStep.name)
       }
       initialScrollComplete.current = true
     }
-  }, [justLoaded, activeStep, scrollToStep, activeStepIndex])
+  }, [
+    justLoaded,
+    activeStep,
+    scrollToStep,
+    activeStepIndex,
+    expressCheckoutAvailable,
+  ])
 
   // Auto-scroll as user advances through steps
   useEffect(() => {


### PR DESCRIPTION
The type of this PR is: **fix**

This PR solves [EMI-3284]

### Description

This PR updates express checkout to not autoscroll to a later (non-review) step on load if express checkout is visible.


[EMI-3284]: https://artsyproduct.atlassian.net/browse/EMI-3284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ