### PR TITLE
fix(Order2): prevent duplicate payment-failure tracking in checkout

### DIFF
--- a/src/Apps/Order2/Routes/Checkout/Components/CheckoutErrorBanner.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/CheckoutErrorBanner.tsx
@@ -19,11 +19,19 @@ export type CheckoutErrorBannerMessage =
       message: React.ReactNode
       displayText: string
       code?: string
+      /**
+       * When true, the banner renders but does not fire the
+       * `errorMessageViewed` tracking event. Use for errors that were
+       * already tracked elsewhere (e.g. re-displayed after a modal) to
+       * avoid double reporting.
+       */
+      skipTracking?: boolean
     }
   | {
       title: string
       message: string
       code?: string
+      skipTracking?: boolean
     }
 
 /**
@@ -62,7 +70,7 @@ export const CheckoutErrorBanner = forwardRef<
 
   // Track when error is displayed to user
   useEffect(() => {
-    if (!error || !flow) return
+    if (!error || !flow || error.skipTracking) return
 
     const messageText =
       "displayText" in error ? error.displayText : error.message

--- a/src/Apps/Order2/Routes/Checkout/Components/Order2ReviewStep.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2ReviewStep.tsx
@@ -26,7 +26,6 @@ const logger = createLogger("Order2ReviewStep.tsx")
 const PAYMENT_METHOD_UPDATE_REQUIRED: CheckoutErrorBannerMessage = {
   title: "Payment error",
   message: "Please update your payment method",
-  code: "charge_authorization_failed",
   // The failure was already tracked via the payment-processing-failed modal;
   // skip tracking here so the re-displayed banner does not double report.
   skipTracking: true,

--- a/src/Apps/Order2/Routes/Checkout/Components/Order2ReviewStep.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/Order2ReviewStep.tsx
@@ -27,6 +27,9 @@ const PAYMENT_METHOD_UPDATE_REQUIRED: CheckoutErrorBannerMessage = {
   title: "Payment error",
   message: "Please update your payment method",
   code: "charge_authorization_failed",
+  // The failure was already tracked via the payment-processing-failed modal;
+  // skip tracking here so the re-displayed banner does not double report.
+  skipTracking: true,
 }
 
 interface Order2ReviewStepProps {

--- a/src/Apps/Order2/Routes/Checkout/Components/__tests__/CheckoutErrorBanner.jest.tsx
+++ b/src/Apps/Order2/Routes/Checkout/Components/__tests__/CheckoutErrorBanner.jest.tsx
@@ -17,7 +17,10 @@ describe("CheckoutErrorBanner", () => {
     }
 
     render(
-      <CheckoutErrorBanner error={error} checkoutTracking={mockCheckoutTracking} />,
+      <CheckoutErrorBanner
+        error={error}
+        checkoutTracking={mockCheckoutTracking}
+      />,
     )
 
     expect(screen.getByText("Test Error")).toBeInTheDocument()
@@ -26,7 +29,10 @@ describe("CheckoutErrorBanner", () => {
 
   it("renders nothing when error is null", () => {
     const { container } = render(
-      <CheckoutErrorBanner error={null} checkoutTracking={mockCheckoutTracking} />,
+      <CheckoutErrorBanner
+        error={null}
+        checkoutTracking={mockCheckoutTracking}
+      />,
     )
 
     expect(container.firstChild).toBeNull()
@@ -124,9 +130,39 @@ describe("CheckoutErrorBanner", () => {
     }
 
     render(
-      <CheckoutErrorBanner error={error} checkoutTracking={mockCheckoutTracking} />,
+      <CheckoutErrorBanner
+        error={error}
+        checkoutTracking={mockCheckoutTracking}
+      />,
     )
 
+    expect(mockCheckoutTracking.errorMessageViewed).not.toHaveBeenCalled()
+  })
+
+  it("does not track when the error has skipTracking set, but still renders", () => {
+    const error = {
+      title: "Payment error",
+      message: "Please update your payment method",
+      code: "charge_authorization_failed",
+      skipTracking: true,
+    }
+
+    const analytics = {
+      flow: "User setting payment",
+    }
+
+    render(
+      <CheckoutErrorBanner
+        error={error}
+        checkoutTracking={mockCheckoutTracking}
+        analytics={analytics}
+      />,
+    )
+
+    expect(screen.getByText("Payment error")).toBeInTheDocument()
+    expect(
+      screen.getByText("Please update your payment method"),
+    ).toBeInTheDocument()
     expect(mockCheckoutTracking.errorMessageViewed).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
The type of this PR is: **Fix**

This PR solves [EMI-3290]

### Description

#### Problem

A single payment failure on the checkout review step was reported to Segment twice:

1. The `PAYMENT_PROCESSING_FAILED` modal fires `errorMessageViewed` when shown.
2. On dismiss, the review step re-surfaces the error as a payment-step banner, which fires `errorMessageViewed` again — with a different `error_code` (`charge_authorization_failed`).

This inflated error-view counts and split one failure across two codes.

#### Fix

Add an opt-out `skipTracking` flag to `CheckoutErrorBannerMessage` and set it on the re-displayed `PAYMENT_METHOD_UPDATE_REQUIRED` banner. The banner still renders; it just no longer fires the duplicate event. Now the failure is reported once, via the modal.

The flag is scoped to this one message — the banner's tracking is otherwise unchanged, so express checkout and all other banner usages keep tracking normally.

<img width="1905" height="985" alt="double-reporting-payment-error" src="https://github.com/user-attachments/assets/21db241a-dc64-47f5-9a12-5047cfaa7c76" />


[EMI-3290]: https://artsyproduct.atlassian.net/browse/EMI-3290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ