### PR TITLE
fix(Order2): align offer history left spacing with other sections

### DIFF
--- a/src/Apps/Order2/Routes/Respond/Components/Order2OfferHistory.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/Order2OfferHistory.tsx
@@ -36,7 +36,7 @@ export const Order2OfferHistory: React.FC<Order2OfferHistoryProps> = ({
     <Box backgroundColor="mono0" px={[2, 2, 4]}>
       <Expandable
         expanded
-        label={<SectionHeading>Offer history</SectionHeading>}
+        label={<SectionHeading ml="30px">Offer history</SectionHeading>}
         borderColor="transparent"
         backgroundColor="mono0"
         pb={1}
@@ -44,46 +44,48 @@ export const Order2OfferHistory: React.FC<Order2OfferHistoryProps> = ({
           checkoutTracking.toggledOfferHistory(isExpanded)
         }}
       >
-        <Flex justifyContent="flex-end" mb={1}>
-          <Text variant="xs">Incl. shipping &amp; taxes</Text>
-        </Flex>
+        <Box ml="30px">
+          <Flex justifyContent="flex-end" mb={1}>
+            <Text variant="xs">Incl. shipping &amp; taxes</Text>
+          </Flex>
 
-        <Box pb={1}>
-          {submittedOffers.map(offer => {
-            const isSeller = offer.fromParticipant === "SELLER"
-            return (
-              <Flex
-                key={offer.internalID}
-                mt={1}
-                backgroundColor={isSeller ? "mono0" : "mono5"}
-              >
-                <Box flex={COLUMNS[0]}>
-                  <Text variant={["xs", "sm"]} justifySelf="flex-start">
-                    {offer.createdAt}
-                  </Text>
-                </Box>
-                <Box flex={COLUMNS[1]}>
-                  <Text variant={["xs", "sm"]}>
-                    {sourceLabel(offer.fromParticipant)}
-                  </Text>
-                </Box>
-                <Box flex={COLUMNS[2]}>
-                  <Text variant={["xs", "sm"]} justifySelf="flex-start">
-                    {offer.amount &&
-                      `${offer.amount.currencySymbol}${offer.amount.amount}`}
-                  </Text>
-                </Box>
-                <Box flex={COLUMNS[3]} textAlign="right">
-                  {/* buyerTotal is undefined for incomplete (original) offers */}
-                  <Text variant={["xs", "sm"]}>
-                    {offer.buyerTotal
-                      ? `${offer.buyerTotal.currencySymbol}${offer.buyerTotal.amount}`
-                      : "N/A"}
-                  </Text>
-                </Box>
-              </Flex>
-            )
-          })}
+          <Box pb={1}>
+            {submittedOffers.map(offer => {
+              const isSeller = offer.fromParticipant === "SELLER"
+              return (
+                <Flex
+                  key={offer.internalID}
+                  mt={1}
+                  backgroundColor={isSeller ? "mono0" : "mono5"}
+                >
+                  <Box flex={COLUMNS[0]}>
+                    <Text variant={["xs", "sm"]} justifySelf="flex-start">
+                      {offer.createdAt}
+                    </Text>
+                  </Box>
+                  <Box flex={COLUMNS[1]}>
+                    <Text variant={["xs", "sm"]}>
+                      {sourceLabel(offer.fromParticipant)}
+                    </Text>
+                  </Box>
+                  <Box flex={COLUMNS[2]}>
+                    <Text variant={["xs", "sm"]} justifySelf="flex-start">
+                      {offer.amount &&
+                        `${offer.amount.currencySymbol}${offer.amount.amount}`}
+                    </Text>
+                  </Box>
+                  <Box flex={COLUMNS[3]} textAlign="right">
+                    {/* buyerTotal is undefined for incomplete (original) offers */}
+                    <Text variant={["xs", "sm"]}>
+                      {offer.buyerTotal
+                        ? `${offer.buyerTotal.currencySymbol}${offer.buyerTotal.amount}`
+                        : "N/A"}
+                    </Text>
+                  </Box>
+                </Flex>
+              )
+            })}
+          </Box>
         </Box>
       </Expandable>
     </Box>


### PR DESCRIPTION


The type of this PR is: **Fix**

This PR solves [EMI-3317]

### Description


Indent the Order2 offer history title and content by 30px to match the checkmark-reserved left spacing used by the other respond-flow sections.

Before
<img width="1281" height="816" alt="Screenshot 2026-07-24 at 4 19 02 PM" src="https://github.com/user-attachments/assets/55167a83-043a-48ed-b430-49fb8a587af3" />

After
<img width="1276" height="813" alt="Screenshot 2026-07-24 at 4 18 44 PM" src="https://github.com/user-attachments/assets/46ea1044-7069-472b-bdcf-e307f9111f13" />


[EMI-3317]: https://artsyproduct.atlassian.net/browse/EMI-3317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ