### PR TITLE
feat(EMI-3175): counteroffer error handling

### DIFF
--- a/src/Apps/Order2/Routes/Respond/Components/Order2RespondErrorModal.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/Order2RespondErrorModal.tsx
@@ -1,0 +1,77 @@
+import { Button, Flex, ModalDialog, Text } from "@artsy/palette"
+import { useRespondContext } from "Apps/Order2/Routes/Respond/Hooks/useRespondContext"
+import { useEffect } from "react"
+
+export enum RespondErrorModalType {
+  SUBMIT_ERROR = "submit_error",
+  PAYMENT_PROCESSING_FAILED = "payment_processing_failed",
+}
+
+const MODAL_CONTENT: Record<
+  RespondErrorModalType,
+  { title: string; description: string; ctaText: string }
+> = {
+  [RespondErrorModalType.SUBMIT_ERROR]: {
+    title: "An error occurred",
+    description:
+      "Something went wrong while submitting your response. Please try again.",
+    ctaText: "Continue",
+  },
+  [RespondErrorModalType.PAYMENT_PROCESSING_FAILED]: {
+    title: "An error occurred while processing your payment",
+    description: "Please choose a different payment method and try again.",
+    ctaText: "Update payment method",
+  },
+}
+
+export interface Order2RespondErrorModalProps {
+  error: RespondErrorModalType | null
+  overrideDescription?: string | null
+  onClose: () => void
+  onFixPayment: () => void
+}
+
+export const Order2RespondErrorModal: React.FC<
+  Order2RespondErrorModalProps
+> = ({ error, overrideDescription, onClose, onFixPayment }) => {
+  const { checkoutTracking } = useRespondContext()
+
+  const content = error ? MODAL_CONTENT[error] : null
+  const title = content?.title
+  const description = overrideDescription ?? content?.description
+
+  useEffect(() => {
+    if (!error || !title || !description) {
+      return
+    }
+
+    checkoutTracking.errorMessageViewed({
+      error_code: error,
+      title,
+      message: description,
+    })
+  }, [error, title, description, checkoutTracking])
+
+  if (!error || !content || !title || !description) {
+    return null
+  }
+
+  const isPaymentFailure =
+    error === RespondErrorModalType.PAYMENT_PROCESSING_FAILED
+
+  return (
+    <ModalDialog title={title} width="450px" onClose={onClose}>
+      <Text variant="sm" mb={2}>
+        {description}
+      </Text>
+      <Flex justifyContent="center">
+        <Button
+          variant="primaryBlack"
+          onClick={isPaymentFailure ? onFixPayment : onClose}
+        >
+          {content.ctaText}
+        </Button>
+      </Flex>
+    </ModalDialog>
+  )
+}

--- a/src/Apps/Order2/Routes/Respond/Components/Order2RespondErrorModal.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/Order2RespondErrorModal.tsx
@@ -36,7 +36,7 @@ const MODAL_CONTENT: Record<
   [RespondErrorModalType.OFFER_NO_LONGER_AVAILABLE]: {
     title: "This offer is no longer available",
     description:
-      "The offer has expired or the order is no longer awaiting your response. Please review your order for the latest details.",
+      "The offer has expired or the order is no longer awaiting your response.",
     ctaText: "Continue",
     ctaAction: "viewOrderDetails",
   },

--- a/src/Apps/Order2/Routes/Respond/Components/Order2RespondErrorModal.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/Order2RespondErrorModal.tsx
@@ -5,22 +5,40 @@ import { useEffect } from "react"
 export enum RespondErrorModalType {
   SUBMIT_ERROR = "submit_error",
   PAYMENT_PROCESSING_FAILED = "payment_processing_failed",
+  OFFER_NO_LONGER_AVAILABLE = "offer_no_longer_available",
 }
+
+type RespondErrorModalCtaAction = "close" | "fixPayment" | "viewOrderDetails"
 
 const MODAL_CONTENT: Record<
   RespondErrorModalType,
-  { title: string; description: string; ctaText: string }
+  {
+    title: string
+    description: string
+    ctaText: string
+    ctaAction: RespondErrorModalCtaAction
+  }
 > = {
   [RespondErrorModalType.SUBMIT_ERROR]: {
     title: "An error occurred",
     description:
       "Something went wrong while submitting your response. Please try again.",
     ctaText: "Continue",
+    ctaAction: "close",
   },
   [RespondErrorModalType.PAYMENT_PROCESSING_FAILED]: {
     title: "An error occurred while processing your payment",
-    description: "Please choose a different payment method and try again.",
+    description:
+      "We are unable to authenticate your payment method. Please choose a different payment method and try again.",
     ctaText: "Update payment method",
+    ctaAction: "fixPayment",
+  },
+  [RespondErrorModalType.OFFER_NO_LONGER_AVAILABLE]: {
+    title: "This offer is no longer available",
+    description:
+      "The offer has expired or the order is no longer awaiting your response. Please review your order for the latest details.",
+    ctaText: "Continue",
+    ctaAction: "viewOrderDetails",
   },
 }
 
@@ -29,11 +47,18 @@ export interface Order2RespondErrorModalProps {
   overrideDescription?: string | null
   onClose: () => void
   onFixPayment: () => void
+  onViewOrderDetails: () => void
 }
 
 export const Order2RespondErrorModal: React.FC<
   Order2RespondErrorModalProps
-> = ({ error, overrideDescription, onClose, onFixPayment }) => {
+> = ({
+  error,
+  overrideDescription,
+  onClose,
+  onFixPayment,
+  onViewOrderDetails,
+}) => {
   const { checkoutTracking } = useRespondContext()
 
   const content = error ? MODAL_CONTENT[error] : null
@@ -56,8 +81,11 @@ export const Order2RespondErrorModal: React.FC<
     return null
   }
 
-  const isPaymentFailure =
-    error === RespondErrorModalType.PAYMENT_PROCESSING_FAILED
+  const ctaHandlers: Record<RespondErrorModalCtaAction, () => void> = {
+    close: onClose,
+    fixPayment: onFixPayment,
+    viewOrderDetails: onViewOrderDetails,
+  }
 
   return (
     <ModalDialog title={title} width="450px" onClose={onClose}>
@@ -65,10 +93,7 @@ export const Order2RespondErrorModal: React.FC<
         {description}
       </Text>
       <Flex justifyContent="center">
-        <Button
-          variant="primaryBlack"
-          onClick={isPaymentFailure ? onFixPayment : onClose}
-        >
+        <Button variant="primaryBlack" onClick={ctaHandlers[content.ctaAction]}>
           {content.ctaText}
         </Button>
       </Flex>

--- a/src/Apps/Order2/Routes/Respond/Components/Order2RespondForm.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/Order2RespondForm.tsx
@@ -7,7 +7,6 @@ import {
   Clickable,
   Flex,
   Input,
-  Message,
   Radio,
   RadioGroup,
   Spacer,
@@ -15,7 +14,11 @@ import {
 } from "@artsy/palette"
 import { Order2EditButton } from "Apps/Order2/Components/Order2EditButton"
 import { SectionHeading } from "Apps/Order2/Components/SectionHeading"
-import { CheckoutErrorBanner } from "Apps/Order2/Routes/Checkout/Components/CheckoutErrorBanner"
+import {
+  CheckoutErrorBanner,
+  type CheckoutErrorBannerMessage,
+  fallbackError,
+} from "Apps/Order2/Routes/Checkout/Components/CheckoutErrorBanner"
 import { Order2RespondOfferDetails } from "Apps/Order2/Routes/Respond/Components/Order2RespondOfferDetails"
 import { useRespondContext } from "Apps/Order2/Routes/Respond/Hooks/useRespondContext"
 import { useScrollToRespondSubmit } from "Apps/Order2/Routes/Respond/Hooks/useScrollToRespondSubmit"
@@ -31,8 +34,6 @@ import { useState } from "react"
 import { graphql, useFragment } from "react-relay"
 
 const logger = createLogger("Order2RespondForm")
-
-const GENERIC_ERROR = "Something went wrong. Please try again."
 
 interface Order2RespondFormProps {
   order: Order2RespondForm_order$key
@@ -61,6 +62,9 @@ const RESPONSE_REQUIRED_MESSAGE =
 
 const COUNTEROFFER_TOO_LOW_TITLE = "Counteroffer amount too low"
 const COUNTEROFFER_TOO_LOW_MESSAGE = "Please increase amount"
+
+// The `whileClause` for the generic fallback error
+const SENDING_COUNTEROFFER = "sending your counteroffer"
 
 interface CompletedResponse {
   title: string
@@ -116,14 +120,9 @@ export const Order2RespondForm: React.FC<Order2RespondFormProps> = ({
 
   const [isOfferDetailsExpanded, setIsOfferDetailsExpanded] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [errorMessage, setErrorMessage] = useState<string | null>(null)
-  const [hasValidationError, setHasValidationError] = useState(false)
+  const [error, setError] = useState<CheckoutErrorBannerMessage | null>(null)
 
-  // Pre-fill the input from the buyer’s draft counteroffer (e.g. after a
-  // refresh) so they can edit it rather than start from a blank field. Only use
-  // a draft that belongs to the current round — a pending offer from an earlier
-  // round (buyer countered, gallery countered back) is stale and must be
-  // ignored.
+  // Pre-fill the input from the buyer’s draft counteroffer
   const draftCounterofferAmount = isCurrentCounterofferDraft
     ? orderData.pendingOffer?.amount?.major
     : null
@@ -147,7 +146,7 @@ export const Order2RespondForm: React.FC<Order2RespondFormProps> = ({
   const isCounterofferValid =
     selectedAction !== "COUNTEROFFER" || Number(counterofferAmount) > 0
 
-  const getValidationError = () => {
+  const getValidationError = (): CheckoutErrorBannerMessage => {
     if (selectedAction === "COUNTEROFFER" && !isCounterofferValid) {
       return {
         title: COUNTEROFFER_TOO_LOW_TITLE,
@@ -165,7 +164,7 @@ export const Order2RespondForm: React.FC<Order2RespondFormProps> = ({
 
   const handleSelectAction = (value: string) => {
     const action = value as RespondAction
-    setHasValidationError(false)
+    setError(null)
     setRespondAction(action)
 
     const amount = orderData.lastSubmittedOffer?.amount?.major
@@ -183,12 +182,12 @@ export const Order2RespondForm: React.FC<Order2RespondFormProps> = ({
 
   const handleContinueToReview = async () => {
     if (!selectedAction || !isCounterofferValid) {
-      setHasValidationError(true)
+      setError(getValidationError())
       return
     }
 
     checkoutTracking.clickedOrderProgression(ContextModule.ordersCounter)
-    setHasValidationError(false)
+    setError(null)
 
     // No response is submitted here — every response is submitted from the
     // summary’s Submit CTA. Accept/decline just advance to that step.
@@ -202,11 +201,12 @@ export const Order2RespondForm: React.FC<Order2RespondFormProps> = ({
     // the gallery’s offer) before advancing to the summary’s Submit CTA.
     const respondsToID = orderData.lastSubmittedOffer?.internalID
     if (!respondsToID) {
+      logger.error("Missing gallery offer to respond to")
+      setError(fallbackError(SENDING_COUNTEROFFER))
       return
     }
 
     try {
-      setErrorMessage(null)
       setIsSubmitting(true)
 
       const response = await createCounterOffer({
@@ -222,17 +222,19 @@ export const Order2RespondForm: React.FC<Order2RespondFormProps> = ({
       const offerOrError = response.createBuyerOffer?.offerOrError
 
       if (offerOrError && "mutationError" in offerOrError) {
-        // TODO: proper error handling is tracked in EMI-3175.
-        setErrorMessage(offerOrError.mutationError?.message ?? GENERIC_ERROR)
+        const { mutationError } = offerOrError
+        logger.error(mutationError)
+        setError(
+          fallbackError(SENDING_COUNTEROFFER, mutationError?.code ?? undefined),
+        )
         return
       }
 
       setRespondComplete()
       scrollToSubmitCTA()
     } catch (error) {
-      // TODO: proper error handling is tracked in EMI-3175.
       logger.error(error)
-      setErrorMessage(GENERIC_ERROR)
+      setError(fallbackError(SENDING_COUNTEROFFER))
     } finally {
       setIsSubmitting(false)
     }
@@ -302,10 +304,10 @@ export const Order2RespondForm: React.FC<Order2RespondFormProps> = ({
 
       <Spacer y={2} />
 
-      {hasValidationError && (
+      {error && (
         <>
           <CheckoutErrorBanner
-            error={getValidationError()}
+            error={error}
             checkoutTracking={checkoutTracking}
             analytics={{ flow: "User responding to offer" }}
           />
@@ -339,7 +341,7 @@ export const Order2RespondForm: React.FC<Order2RespondFormProps> = ({
                       inputMode="numeric"
                       value={counterofferAmount}
                       onChange={event => {
-                        setHasValidationError(false)
+                        setError(null)
                         // Keep digits only.
                         setCounterofferAmount(
                           event.currentTarget.value.replace(/[^\d]/g, ""),
@@ -358,15 +360,6 @@ export const Order2RespondForm: React.FC<Order2RespondFormProps> = ({
           )
         })}
       </RadioGroup>
-
-      {errorMessage && (
-        <>
-          <Spacer y={2} />
-          <Message variant="error" p={1}>
-            <Text variant="xs">{errorMessage}</Text>
-          </Message>
-        </>
-      )}
 
       <Spacer y={2} />
 

--- a/src/Apps/Order2/Routes/Respond/Components/Order2RespondForm.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/Order2RespondForm.tsx
@@ -64,7 +64,7 @@ const COUNTEROFFER_TOO_LOW_TITLE = "Counteroffer amount too low"
 const COUNTEROFFER_TOO_LOW_MESSAGE = "Please increase amount"
 
 // The `whileClause` for the generic fallback error
-const SENDING_COUNTEROFFER = "sending your counteroffer"
+const SELECTING_COUNTEROFFER_AMOUNT = "selecting your counteroffer amount"
 
 interface CompletedResponse {
   title: string
@@ -202,7 +202,7 @@ export const Order2RespondForm: React.FC<Order2RespondFormProps> = ({
     const respondsToID = orderData.lastSubmittedOffer?.internalID
     if (!respondsToID) {
       logger.error("Missing gallery offer to respond to")
-      setError(fallbackError(SENDING_COUNTEROFFER))
+      setError(fallbackError(SELECTING_COUNTEROFFER_AMOUNT))
       return
     }
 
@@ -225,7 +225,10 @@ export const Order2RespondForm: React.FC<Order2RespondFormProps> = ({
         const { mutationError } = offerOrError
         logger.error(mutationError)
         setError(
-          fallbackError(SENDING_COUNTEROFFER, mutationError?.code ?? undefined),
+          fallbackError(
+            SELECTING_COUNTEROFFER_AMOUNT,
+            mutationError?.code ?? undefined,
+          ),
         )
         return
       }
@@ -234,7 +237,7 @@ export const Order2RespondForm: React.FC<Order2RespondFormProps> = ({
       scrollToSubmitCTA()
     } catch (error) {
       logger.error(error)
-      setError(fallbackError(SENDING_COUNTEROFFER))
+      setError(fallbackError(SELECTING_COUNTEROFFER_AMOUNT))
     } finally {
       setIsSubmitting(false)
     }

--- a/src/Apps/Order2/Routes/Respond/Components/Order2RespondSummary.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/Order2RespondSummary.tsx
@@ -16,6 +16,10 @@ import {
   RespondStepName,
   RespondStepState,
 } from "Apps/Order2/Routes/Respond/RespondContext/types"
+import {
+  OFFER_UNAVAILABLE_CODES,
+  PAYMENT_FAILURE_CODES,
+} from "Apps/Order2/Utils/exchangeErrorCodes"
 import { useRouter } from "System/Hooks/useRouter"
 import { Jump } from "Utils/Hooks/useJump"
 import createLogger from "Utils/logger"
@@ -60,6 +64,28 @@ export const Order2RespondSummary: React.FC<Order2RespondSummaryProps> = ({
     setErrorModal({ type: RespondErrorModalType.SUBMIT_ERROR })
   }
 
+  const showMutationErrorModal = (mutationError?: {
+    code: string
+    message: string
+  }) => {
+    if (!mutationError) {
+      showSubmitErrorModal()
+      return
+    }
+
+    if (PAYMENT_FAILURE_CODES.includes(mutationError.code)) {
+      setErrorModal({ type: RespondErrorModalType.PAYMENT_PROCESSING_FAILED })
+      return
+    }
+
+    if (OFFER_UNAVAILABLE_CODES.includes(mutationError.code)) {
+      setErrorModal({ type: RespondErrorModalType.OFFER_NO_LONGER_AVAILABLE })
+      return
+    }
+
+    showSubmitErrorModal()
+  }
+
   const artwork = useOrder2LineItemData(orderData.lineItems[0]!)
 
   // The Submit CTA appears once the respond step is completed and the
@@ -98,7 +124,7 @@ export const Order2RespondSummary: React.FC<Order2RespondSummaryProps> = ({
 
     if (offerOrError && "mutationError" in offerOrError) {
       logger.error(offerOrError.mutationError)
-      showSubmitErrorModal()
+      showMutationErrorModal(offerOrError.mutationError)
       return
     }
 
@@ -120,7 +146,7 @@ export const Order2RespondSummary: React.FC<Order2RespondSummaryProps> = ({
 
     if (orderOrError && "mutationError" in orderOrError) {
       logger.error(orderOrError.mutationError)
-      showSubmitErrorModal()
+      showMutationErrorModal(orderOrError.mutationError)
       return
     }
 
@@ -161,9 +187,7 @@ export const Order2RespondSummary: React.FC<Order2RespondSummaryProps> = ({
     if (orderOrError?.__typename === "OrderMutationError") {
       const { mutationError } = orderOrError
       logger.error(mutationError)
-      setErrorModal({
-        type: RespondErrorModalType.PAYMENT_PROCESSING_FAILED,
-      })
+      showMutationErrorModal(mutationError)
       return
     }
 
@@ -243,6 +267,7 @@ export const Order2RespondSummary: React.FC<Order2RespondSummaryProps> = ({
               setErrorModal(null)
             }}
             onFixPayment={redirectToNewPayment}
+            onViewOrderDetails={redirectToOrderDetails}
           />
         </>
       )}

--- a/src/Apps/Order2/Routes/Respond/Components/Order2RespondSummary.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/Order2RespondSummary.tsx
@@ -1,9 +1,13 @@
 import { ContextModule } from "@artsy/cohesion"
-import { Button, Message, Spacer, Text } from "@artsy/palette"
+import { Button, Spacer } from "@artsy/palette"
 import { useStripe } from "@stripe/react-stripe-js"
 import { Order2OrderSummary } from "Apps/Order2/Components/Order2OrderSummary"
 import { TermsAndConditions } from "Apps/Order2/Components/TermsAndConditions"
 import { useOrder2LineItemData } from "Apps/Order2/Hooks/useOrder2LineItemData"
+import {
+  Order2RespondErrorModal,
+  RespondErrorModalType,
+} from "Apps/Order2/Routes/Respond/Components/Order2RespondErrorModal"
 import { useRespondContext } from "Apps/Order2/Routes/Respond/Hooks/useRespondContext"
 import { useOrder2AcceptOfferMutation } from "Apps/Order2/Routes/Respond/Mutations/useOrder2AcceptOfferMutation"
 import { useOrder2DeclineOfferMutation } from "Apps/Order2/Routes/Respond/Mutations/useOrder2DeclineOfferMutation"
@@ -20,8 +24,6 @@ import { useState } from "react"
 import { graphql, useFragment } from "react-relay"
 
 const logger = createLogger("Order2RespondSummary")
-
-const GENERIC_ERROR = "Something went wrong. Please try again."
 
 interface Order2RespondSummaryProps {
   order: Order2RespondSummary_order$key
@@ -48,7 +50,15 @@ export const Order2RespondSummary: React.FC<Order2RespondSummaryProps> = ({
   const { submitMutation: acceptOffer } = useOrder2AcceptOfferMutation()
   const { submitMutation: declineOffer } = useOrder2DeclineOfferMutation()
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const [errorMessage, setErrorMessage] = useState<string | null>(null)
+
+  const [errorModal, setErrorModal] = useState<{
+    type: RespondErrorModalType
+    description?: string | null
+  } | null>(null)
+
+  const showSubmitErrorModal = () => {
+    setErrorModal({ type: RespondErrorModalType.SUBMIT_ERROR })
+  }
 
   const artwork = useOrder2LineItemData(orderData.lineItems[0]!)
 
@@ -68,8 +78,16 @@ export const Order2RespondSummary: React.FC<Order2RespondSummaryProps> = ({
     router.replace(`/orders/${orderID}/details`)
   }
 
+  // The Order2 respond route has no payment step, so a declined card is fixed
+  // on the legacy payment route.
+  const redirectToNewPayment = () => {
+    router.push(`/orders/${orderID}/payment/new`)
+  }
+
   const submitCounter = async () => {
     if (!pendingOfferID) {
+      logger.error("Missing pending offer to submit")
+      showSubmitErrorModal()
       return
     }
 
@@ -79,8 +97,8 @@ export const Order2RespondSummary: React.FC<Order2RespondSummaryProps> = ({
     const offerOrError = response.submitBuyerOffer?.offerOrError
 
     if (offerOrError && "mutationError" in offerOrError) {
-      // TODO: proper error handling is tracked in EMI-3175.
-      setErrorMessage(offerOrError.mutationError?.message ?? GENERIC_ERROR)
+      logger.error(offerOrError.mutationError)
+      showSubmitErrorModal()
       return
     }
 
@@ -90,6 +108,8 @@ export const Order2RespondSummary: React.FC<Order2RespondSummaryProps> = ({
 
   const decline = async () => {
     if (!galleryOfferID) {
+      logger.error("Missing gallery offer to decline")
+      showSubmitErrorModal()
       return
     }
 
@@ -99,8 +119,8 @@ export const Order2RespondSummary: React.FC<Order2RespondSummaryProps> = ({
     const orderOrError = response.rejectSellerOffer?.orderOrError
 
     if (orderOrError && "mutationError" in orderOrError) {
-      // TODO: proper error handling is tracked in EMI-3175.
-      setErrorMessage(orderOrError.mutationError?.message ?? GENERIC_ERROR)
+      logger.error(orderOrError.mutationError)
+      showSubmitErrorModal()
       return
     }
 
@@ -109,6 +129,8 @@ export const Order2RespondSummary: React.FC<Order2RespondSummaryProps> = ({
 
   const accept = async () => {
     if (!stripe || !galleryOfferID) {
+      logger.error("Missing Stripe or gallery offer to accept")
+      showSubmitErrorModal()
       return
     }
 
@@ -124,8 +146,11 @@ export const Order2RespondSummary: React.FC<Order2RespondSummaryProps> = ({
       })
 
       if (error) {
-        // TODO: proper error handling is tracked in EMI-3175.
-        setErrorMessage(error.message ?? GENERIC_ERROR)
+        logger.error(error)
+        setErrorModal({
+          type: RespondErrorModalType.PAYMENT_PROCESSING_FAILED,
+          description: error.message,
+        })
         return
       }
 
@@ -134,8 +159,11 @@ export const Order2RespondSummary: React.FC<Order2RespondSummaryProps> = ({
     }
 
     if (orderOrError?.__typename === "OrderMutationError") {
-      // TODO: proper error handling is tracked in EMI-3175.
-      setErrorMessage(orderOrError.mutationError?.message ?? GENERIC_ERROR)
+      const { mutationError } = orderOrError
+      logger.error(mutationError)
+      setErrorModal({
+        type: RespondErrorModalType.PAYMENT_PROCESSING_FAILED,
+      })
       return
     }
 
@@ -148,7 +176,7 @@ export const Order2RespondSummary: React.FC<Order2RespondSummaryProps> = ({
     }
 
     try {
-      setErrorMessage(null)
+      setErrorModal(null)
       setIsSubmitting(true)
 
       if (selectedAction === "COUNTEROFFER") {
@@ -159,9 +187,8 @@ export const Order2RespondSummary: React.FC<Order2RespondSummaryProps> = ({
         await accept()
       }
     } catch (error) {
-      // TODO: proper error handling is tracked in EMI-3175.
       logger.error(error)
-      setErrorMessage(GENERIC_ERROR)
+      showSubmitErrorModal()
     } finally {
       setIsSubmitting(false)
     }
@@ -209,14 +236,14 @@ export const Order2RespondSummary: React.FC<Order2RespondSummaryProps> = ({
 
           <Spacer y={2} />
 
-          {errorMessage && (
-            <>
-              <Spacer y={1} />
-              <Message variant="error" p={1}>
-                <Text variant="xs">{errorMessage}</Text>
-              </Message>
-            </>
-          )}
+          <Order2RespondErrorModal
+            error={errorModal?.type ?? null}
+            overrideDescription={errorModal?.description}
+            onClose={() => {
+              setErrorModal(null)
+            }}
+            onFixPayment={redirectToNewPayment}
+          />
         </>
       )}
     </Order2OrderSummary>

--- a/src/Apps/Order2/Routes/Respond/Components/__tests__/Order2RespondForm.jest.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/__tests__/Order2RespondForm.jest.tsx
@@ -289,7 +289,9 @@ describe("Order2RespondForm", () => {
       expect(screen.getByText("An error occurred")).toBeInTheDocument()
     })
     expect(
-      screen.getByText(/Something went wrong while sending your counteroffer/),
+      screen.getByText(
+        /Something went wrong while selecting your counteroffer amount/,
+      ),
     ).toBeInTheDocument()
     // Still on the editable form — not collapsed.
     expect(screen.queryByText("Your counteroffer")).not.toBeInTheDocument()

--- a/src/Apps/Order2/Routes/Respond/Components/__tests__/Order2RespondForm.jest.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/__tests__/Order2RespondForm.jest.tsx
@@ -267,7 +267,7 @@ describe("Order2RespondForm", () => {
     })
   })
 
-  it("keeps the form open and surfaces an error when the counteroffer fails", async () => {
+  it("keeps the form open and surfaces the error banner when the counteroffer mutation errors", async () => {
     mockCreateCounterOffer.mockResolvedValue({
       createBuyerOffer: {
         offerOrError: {
@@ -286,10 +286,52 @@ describe("Order2RespondForm", () => {
     fireEvent.click(continueButton())
 
     await waitFor(() => {
-      expect(screen.getByText("Offer too low")).toBeInTheDocument()
+      expect(screen.getByText("An error occurred")).toBeInTheDocument()
     })
+    expect(
+      screen.getByText(/Something went wrong while sending your counteroffer/),
+    ).toBeInTheDocument()
     // Still on the editable form — not collapsed.
     expect(screen.queryByText("Your counteroffer")).not.toBeInTheDocument()
+  })
+
+  it("surfaces the error banner when the counteroffer request throws", async () => {
+    mockCreateCounterOffer.mockRejectedValue(new Error("Network error"))
+
+    renderWithRelay(defaultResolvers)
+
+    fireEvent.click(screen.getByText("Send counteroffer"))
+    fireEvent.change(screen.getByPlaceholderText(COUNTEROFFER_PLACEHOLDER), {
+      target: { value: "500" },
+    })
+    fireEvent.click(continueButton())
+
+    await waitFor(() => {
+      expect(screen.getByText("An error occurred")).toBeInTheDocument()
+    })
+    expect(screen.queryByText("Your counteroffer")).not.toBeInTheDocument()
+  })
+
+  it("clears the submission error banner when the counteroffer amount is edited", async () => {
+    mockCreateCounterOffer.mockRejectedValue(new Error("Network error"))
+
+    renderWithRelay(defaultResolvers)
+
+    fireEvent.click(screen.getByText("Send counteroffer"))
+    fireEvent.change(screen.getByPlaceholderText(COUNTEROFFER_PLACEHOLDER), {
+      target: { value: "500" },
+    })
+    fireEvent.click(continueButton())
+
+    await waitFor(() => {
+      expect(screen.getByText("An error occurred")).toBeInTheDocument()
+    })
+
+    fireEvent.change(screen.getByPlaceholderText(COUNTEROFFER_PLACEHOLDER), {
+      target: { value: "600" },
+    })
+
+    expect(screen.queryByText("An error occurred")).not.toBeInTheDocument()
   })
 
   it("does not create an offer for accept or decline", () => {
@@ -429,6 +471,51 @@ describe("Order2RespondForm", () => {
         })
       },
     )
+
+    it("tracks errorMessageViewed for validation errors", () => {
+      renderWithRelay(defaultResolvers)
+
+      fireEvent.click(continueButton())
+
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: "errorMessageViewed",
+          error_code: "response_required",
+          title: "Response required",
+          flow: "User responding to offer",
+        }),
+      )
+    })
+
+    it("tracks errorMessageViewed for counteroffer submission errors", async () => {
+      mockCreateCounterOffer.mockResolvedValue({
+        createBuyerOffer: {
+          offerOrError: {
+            __typename: "OfferMutationError",
+            mutationError: { code: "invalid", message: "Offer too low" },
+          },
+        },
+      })
+
+      renderWithRelay(defaultResolvers)
+
+      fireEvent.click(screen.getByText("Send counteroffer"))
+      fireEvent.change(screen.getByPlaceholderText(COUNTEROFFER_PLACEHOLDER), {
+        target: { value: "500" },
+      })
+      fireEvent.click(continueButton())
+
+      await waitFor(() => {
+        expect(mockTrackEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            action: "errorMessageViewed",
+            error_code: "invalid",
+            title: "An error occurred",
+            flow: "User responding to offer",
+          }),
+        )
+      })
+    })
 
     it("tracks clickedOrderProgression when Save and Review is clicked", () => {
       renderWithRelay(defaultResolvers)

--- a/src/Apps/Order2/Routes/Respond/Components/__tests__/Order2RespondSummary.jest.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/__tests__/Order2RespondSummary.jest.tsx
@@ -229,6 +229,9 @@ describe("Order2RespondSummary", () => {
     const SUBMIT_ERROR_TITLE = "An error occurred"
     const SUBMIT_ERROR_MESSAGE =
       "Something went wrong while submitting your response. Please try again."
+    const OFFER_UNAVAILABLE_TITLE = "This offer is no longer available"
+    const OFFER_UNAVAILABLE_MESSAGE =
+      "The offer has expired or the order is no longer awaiting your response. Please review your order for the latest details."
 
     const galleryOfferResolvers = {
       Order: () => ({
@@ -325,6 +328,47 @@ describe("Order2RespondSummary", () => {
       expect(await screen.findByText(SUBMIT_ERROR_TITLE)).toBeInTheDocument()
     })
 
+    it("re-submits the acceptance after 3DS authentication succeeds", async () => {
+      mockAcceptOffer
+        .mockResolvedValueOnce({
+          acceptSellerOffer: {
+            orderOrError: {
+              __typename: "OrderMutationActionRequired",
+              actionData: { clientSecret: "secret" },
+            },
+          },
+        })
+        .mockResolvedValueOnce({
+          acceptSellerOffer: {
+            orderOrError: { __typename: "OrderMutationSuccess" },
+          },
+        })
+
+      renderWithRelay(galleryOfferResolvers)
+
+      fireEvent.click(screen.getByText("Accept gallery offer"))
+      fireEvent.click(continueButton())
+      fireEvent.click(await screen.findByRole("button", { name: "Submit" }))
+
+      await waitFor(() => {
+        expect(mockRouterReplace).toHaveBeenCalledWith(
+          "/orders/order-id/details",
+        )
+      })
+
+      expect(mockHandleNextAction).toHaveBeenCalledWith({
+        clientSecret: "secret",
+      })
+      // The retry hits the same mutation with the same input.
+      expect(mockAcceptOffer).toHaveBeenCalledTimes(2)
+      expect(mockAcceptOffer).toHaveBeenLastCalledWith({
+        variables: {
+          input: { orderID: "order-id", offerID: "gallery-offer-id" },
+        },
+      })
+      expect(screen.queryByText(SUBMIT_ERROR_TITLE)).not.toBeInTheDocument()
+    })
+
     it("shows Stripe’s own message when 3DS authentication fails", async () => {
       mockAcceptOffer.mockResolvedValue({
         acceptSellerOffer: {
@@ -353,18 +397,13 @@ describe("Order2RespondSummary", () => {
       expect(screen.queryByText(SUBMIT_ERROR_MESSAGE)).not.toBeInTheDocument()
     })
 
-    it.each([
-      "capture_failed",
-      "charge_authorization_failed",
-      "payment_method_confirmation_failed",
-      "payment_failed",
-    ])("shows the payment modal for a %s card failure", async code => {
+    it("shows the payment modal for a card failure", async () => {
       mockAcceptOffer.mockResolvedValue({
         acceptSellerOffer: {
           orderOrError: {
             __typename: "OrderMutationError",
             mutationError: {
-              code,
+              code: "capture_failed",
               message: "Exchange: capture failed for charge ch_123",
             },
           },
@@ -393,14 +432,14 @@ describe("Order2RespondSummary", () => {
       expect(screen.queryByText(SUBMIT_ERROR_TITLE)).not.toBeInTheDocument()
     })
 
-    it("keeps the generic modal for non-payment mutation errors", async () => {
+    it("keeps the generic modal for unrecognized mutation errors", async () => {
       mockAcceptOffer.mockResolvedValue({
         acceptSellerOffer: {
           orderOrError: {
             __typename: "OrderMutationError",
             mutationError: {
-              code: "cannot_accept_offer",
-              message: "Offer is no longer available",
+              code: "internal_error",
+              message: "Something unexpected happened",
             },
           },
         },
@@ -446,6 +485,122 @@ describe("Order2RespondSummary", () => {
       )
     })
 
+    it("shows the offer unavailable modal when the offer can no longer be accepted", async () => {
+      mockAcceptOffer.mockResolvedValue({
+        acceptSellerOffer: {
+          orderOrError: {
+            __typename: "OrderMutationError",
+            mutationError: {
+              code: "invalid_state",
+              message: "Exchange: invalid state",
+            },
+          },
+        },
+      })
+
+      renderWithRelay(galleryOfferResolvers)
+
+      fireEvent.click(screen.getByText("Accept gallery offer"))
+      fireEvent.click(continueButton())
+      fireEvent.click(await screen.findByRole("button", { name: "Submit" }))
+
+      expect(
+        await screen.findByText(OFFER_UNAVAILABLE_TITLE),
+      ).toBeInTheDocument()
+      expect(screen.getByText(OFFER_UNAVAILABLE_MESSAGE)).toBeInTheDocument()
+      expect(screen.queryByText(SUBMIT_ERROR_TITLE)).not.toBeInTheDocument()
+    })
+
+    it("shows the offer unavailable modal when the declined offer has lapsed", async () => {
+      mockDeclineOffer.mockResolvedValue({
+        rejectSellerOffer: {
+          orderOrError: {
+            __typename: "OrderMutationError",
+            mutationError: {
+              code: "invalid_state",
+              message: "Exchange: invalid state",
+            },
+          },
+        },
+      })
+
+      renderWithRelay(galleryOfferResolvers)
+
+      fireEvent.click(screen.getByText("Decline gallery offer"))
+      fireEvent.click(continueButton())
+      fireEvent.click(await screen.findByRole("button", { name: "Submit" }))
+
+      expect(
+        await screen.findByText(OFFER_UNAVAILABLE_TITLE),
+      ).toBeInTheDocument()
+    })
+
+    it("shows the offer unavailable modal when the counteroffer can no longer be submitted", async () => {
+      mockSubmitCounterOffer.mockResolvedValue({
+        submitBuyerOffer: {
+          offerOrError: {
+            __typename: "OfferMutationError",
+            mutationError: {
+              code: "not_last_offer",
+              message: "Exchange: not the last offer",
+            },
+          },
+        },
+      })
+
+      renderWithRelay({
+        Order: () => ({
+          mode: "OFFER",
+          internalID: "order-id",
+          pendingOffer: {
+            internalID: "pending-offer-id",
+            amount: { major: 500 },
+          },
+        }),
+        Money: () => ({ display: "$1,000.00" }),
+      })
+
+      fireEvent.click(screen.getByText("Send counteroffer"))
+      fireEvent.change(
+        screen.getByPlaceholderText("Enter amount excluding shipping & tax"),
+        { target: { value: "500" } },
+      )
+      fireEvent.click(continueButton())
+      fireEvent.click(await screen.findByRole("button", { name: "Submit" }))
+
+      expect(
+        await screen.findByText(OFFER_UNAVAILABLE_TITLE),
+      ).toBeInTheDocument()
+    })
+
+    it("sends the buyer to the order details from the offer unavailable modal CTA", async () => {
+      mockAcceptOffer.mockResolvedValue({
+        acceptSellerOffer: {
+          orderOrError: {
+            __typename: "OrderMutationError",
+            mutationError: {
+              code: "invalid_state",
+              message: "Exchange: invalid state",
+            },
+          },
+        },
+      })
+
+      renderWithRelay(galleryOfferResolvers)
+
+      fireEvent.click(screen.getByText("Accept gallery offer"))
+      fireEvent.click(continueButton())
+      fireEvent.click(await screen.findByRole("button", { name: "Submit" }))
+
+      expect(
+        await screen.findByText(OFFER_UNAVAILABLE_TITLE),
+      ).toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole("button", { name: "Continue" }))
+
+      expect(mockRouterReplace).toHaveBeenCalledWith("/orders/order-id/details")
+    })
+
     it("dismisses the modal and stays on the page via Continue", async () => {
       mockAcceptOffer.mockRejectedValue(new Error("Network error"))
 
@@ -464,6 +619,62 @@ describe("Order2RespondSummary", () => {
       })
       // Still on the review step, able to retry.
       expect(screen.getByRole("button", { name: "Submit" })).toBeInTheDocument()
+    })
+
+    describe("when the offer to act on is missing", () => {
+      const noGalleryOfferResolvers = {
+        Order: () => ({
+          mode: "OFFER",
+          internalID: "order-id",
+          lastSubmittedOffer: null,
+        }),
+        Money: () => ({ display: "$1,000.00" }),
+      }
+
+      it("shows the error modal without accepting", async () => {
+        renderWithRelay(noGalleryOfferResolvers)
+
+        fireEvent.click(screen.getByText("Accept gallery offer"))
+        fireEvent.click(continueButton())
+        fireEvent.click(await screen.findByRole("button", { name: "Submit" }))
+
+        expect(await screen.findByText(SUBMIT_ERROR_TITLE)).toBeInTheDocument()
+        expect(mockAcceptOffer).not.toHaveBeenCalled()
+      })
+
+      it("shows the error modal without declining", async () => {
+        renderWithRelay(noGalleryOfferResolvers)
+
+        fireEvent.click(screen.getByText("Decline gallery offer"))
+        fireEvent.click(continueButton())
+        fireEvent.click(await screen.findByRole("button", { name: "Submit" }))
+
+        expect(await screen.findByText(SUBMIT_ERROR_TITLE)).toBeInTheDocument()
+        expect(mockDeclineOffer).not.toHaveBeenCalled()
+      })
+
+      it("shows the error modal without submitting the counteroffer when the pending draft is missing", async () => {
+        renderWithRelay({
+          Order: () => ({
+            mode: "OFFER",
+            internalID: "order-id",
+            lastSubmittedOffer: { internalID: "gallery-offer-id" },
+            pendingOffer: null,
+          }),
+          Money: () => ({ display: "$1,000.00" }),
+        })
+
+        fireEvent.click(screen.getByText("Send counteroffer"))
+        fireEvent.change(
+          screen.getByPlaceholderText("Enter amount excluding shipping & tax"),
+          { target: { value: "500" } },
+        )
+        fireEvent.click(continueButton())
+        fireEvent.click(await screen.findByRole("button", { name: "Submit" }))
+
+        expect(await screen.findByText(SUBMIT_ERROR_TITLE)).toBeInTheDocument()
+        expect(mockSubmitCounterOffer).not.toHaveBeenCalled()
+      })
     })
   })
 

--- a/src/Apps/Order2/Routes/Respond/Components/__tests__/Order2RespondSummary.jest.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/__tests__/Order2RespondSummary.jest.tsx
@@ -231,7 +231,7 @@ describe("Order2RespondSummary", () => {
       "Something went wrong while submitting your response. Please try again."
     const OFFER_UNAVAILABLE_TITLE = "This offer is no longer available"
     const OFFER_UNAVAILABLE_MESSAGE =
-      "The offer has expired or the order is no longer awaiting your response. Please review your order for the latest details."
+      "The offer has expired or the order is no longer awaiting your response."
 
     const galleryOfferResolvers = {
       Order: () => ({

--- a/src/Apps/Order2/Routes/Respond/Components/__tests__/Order2RespondSummary.jest.tsx
+++ b/src/Apps/Order2/Routes/Respond/Components/__tests__/Order2RespondSummary.jest.tsx
@@ -13,8 +13,17 @@ import { useTracking } from "react-tracking"
 
 jest.unmock("react-relay")
 
+const mockHandleNextAction = jest.fn()
 jest.mock("@stripe/react-stripe-js", () => ({
-  useStripe: () => ({ handleNextAction: jest.fn().mockResolvedValue({}) }),
+  useStripe: () => ({ handleNextAction: mockHandleNextAction }),
+}))
+
+const mockRouterPush = jest.fn()
+const mockRouterReplace = jest.fn()
+jest.mock("System/Hooks/useRouter", () => ({
+  useRouter: () => ({
+    router: { push: mockRouterPush, replace: mockRouterReplace },
+  }),
 }))
 
 jest.mock("System/Hooks/useAnalyticsContext", () => ({
@@ -40,6 +49,9 @@ const mockAcceptOffer = jest.fn()
 const mockDeclineOffer = jest.fn()
 
 beforeEach(() => {
+  mockRouterPush.mockReset()
+  mockRouterReplace.mockReset()
+  mockHandleNextAction.mockReset().mockResolvedValue({})
   mockCreateCounterOffer.mockReset().mockResolvedValue({
     createBuyerOffer: {
       offerOrError: {
@@ -213,6 +225,248 @@ describe("Order2RespondSummary", () => {
     })
   })
 
+  describe("submission errors", () => {
+    const SUBMIT_ERROR_TITLE = "An error occurred"
+    const SUBMIT_ERROR_MESSAGE =
+      "Something went wrong while submitting your response. Please try again."
+
+    const galleryOfferResolvers = {
+      Order: () => ({
+        mode: "OFFER",
+        internalID: "order-id",
+        lastSubmittedOffer: { internalID: "gallery-offer-id" },
+      }),
+      Money: () => ({ display: "$1,000.00" }),
+    }
+
+    it("shows the error modal instead of a banner when accepting fails", async () => {
+      mockAcceptOffer.mockResolvedValue({
+        acceptSellerOffer: {
+          orderOrError: {
+            __typename: "OrderMutationError",
+            mutationError: { code: "invalid", message: "Cannot accept" },
+          },
+        },
+      })
+
+      renderWithRelay(galleryOfferResolvers)
+
+      fireEvent.click(screen.getByText("Accept gallery offer"))
+      fireEvent.click(continueButton())
+      fireEvent.click(await screen.findByRole("button", { name: "Submit" }))
+
+      expect(await screen.findByText(SUBMIT_ERROR_TITLE)).toBeInTheDocument()
+      expect(screen.getByText(SUBMIT_ERROR_MESSAGE)).toBeInTheDocument()
+    })
+
+    it("shows the error modal when declining fails", async () => {
+      mockDeclineOffer.mockResolvedValue({
+        rejectSellerOffer: {
+          orderOrError: {
+            __typename: "OrderMutationError",
+            mutationError: { code: "invalid", message: "Cannot decline" },
+          },
+        },
+      })
+
+      renderWithRelay(galleryOfferResolvers)
+
+      fireEvent.click(screen.getByText("Decline gallery offer"))
+      fireEvent.click(continueButton())
+      fireEvent.click(await screen.findByRole("button", { name: "Submit" }))
+
+      expect(await screen.findByText(SUBMIT_ERROR_TITLE)).toBeInTheDocument()
+      expect(screen.getByText(SUBMIT_ERROR_MESSAGE)).toBeInTheDocument()
+    })
+
+    it("shows the error modal when submitting the counteroffer fails", async () => {
+      mockSubmitCounterOffer.mockResolvedValue({
+        submitBuyerOffer: {
+          offerOrError: {
+            __typename: "OfferMutationError",
+            mutationError: { code: "invalid", message: "Offer too low" },
+          },
+        },
+      })
+
+      renderWithRelay({
+        Order: () => ({
+          mode: "OFFER",
+          internalID: "order-id",
+          pendingOffer: {
+            internalID: "pending-offer-id",
+            amount: { major: 500 },
+          },
+        }),
+        Money: () => ({ display: "$1,000.00" }),
+      })
+
+      fireEvent.click(screen.getByText("Send counteroffer"))
+      fireEvent.change(
+        screen.getByPlaceholderText("Enter amount excluding shipping & tax"),
+        { target: { value: "500" } },
+      )
+      fireEvent.click(continueButton())
+      fireEvent.click(await screen.findByRole("button", { name: "Submit" }))
+
+      expect(await screen.findByText(SUBMIT_ERROR_TITLE)).toBeInTheDocument()
+      expect(screen.getByText(SUBMIT_ERROR_MESSAGE)).toBeInTheDocument()
+    })
+
+    it("shows the error modal when the request throws", async () => {
+      mockAcceptOffer.mockRejectedValue(new Error("Network error"))
+
+      renderWithRelay(galleryOfferResolvers)
+
+      fireEvent.click(screen.getByText("Accept gallery offer"))
+      fireEvent.click(continueButton())
+      fireEvent.click(await screen.findByRole("button", { name: "Submit" }))
+
+      expect(await screen.findByText(SUBMIT_ERROR_TITLE)).toBeInTheDocument()
+    })
+
+    it("shows Stripe’s own message when 3DS authentication fails", async () => {
+      mockAcceptOffer.mockResolvedValue({
+        acceptSellerOffer: {
+          orderOrError: {
+            __typename: "OrderMutationActionRequired",
+            actionData: { clientSecret: "secret" },
+          },
+        },
+      })
+      mockHandleNextAction.mockResolvedValue({
+        error: { message: "Your card was declined." },
+      })
+
+      renderWithRelay(galleryOfferResolvers)
+
+      fireEvent.click(screen.getByText("Accept gallery offer"))
+      fireEvent.click(continueButton())
+      fireEvent.click(await screen.findByRole("button", { name: "Submit" }))
+
+      expect(
+        await screen.findByText(
+          "An error occurred while processing your payment",
+        ),
+      ).toBeInTheDocument()
+      expect(screen.getByText("Your card was declined.")).toBeInTheDocument()
+      expect(screen.queryByText(SUBMIT_ERROR_MESSAGE)).not.toBeInTheDocument()
+    })
+
+    it.each([
+      "capture_failed",
+      "charge_authorization_failed",
+      "payment_method_confirmation_failed",
+      "payment_failed",
+    ])("shows the payment modal for a %s card failure", async code => {
+      mockAcceptOffer.mockResolvedValue({
+        acceptSellerOffer: {
+          orderOrError: {
+            __typename: "OrderMutationError",
+            mutationError: {
+              code,
+              message: "Exchange: capture failed for charge ch_123",
+            },
+          },
+        },
+      })
+
+      renderWithRelay(galleryOfferResolvers)
+
+      fireEvent.click(screen.getByText("Accept gallery offer"))
+      fireEvent.click(continueButton())
+      fireEvent.click(await screen.findByRole("button", { name: "Submit" }))
+
+      expect(
+        await screen.findByText(
+          "An error occurred while processing your payment",
+        ),
+      ).toBeInTheDocument()
+      expect(
+        screen.getByText(
+          "We are unable to authenticate your payment method. Please choose a different payment method and try again.",
+        ),
+      ).toBeInTheDocument()
+      expect(
+        screen.queryByText("Exchange: capture failed for charge ch_123"),
+      ).not.toBeInTheDocument()
+      expect(screen.queryByText(SUBMIT_ERROR_TITLE)).not.toBeInTheDocument()
+    })
+
+    it("keeps the generic modal for non-payment mutation errors", async () => {
+      mockAcceptOffer.mockResolvedValue({
+        acceptSellerOffer: {
+          orderOrError: {
+            __typename: "OrderMutationError",
+            mutationError: {
+              code: "cannot_accept_offer",
+              message: "Offer is no longer available",
+            },
+          },
+        },
+      })
+
+      renderWithRelay(galleryOfferResolvers)
+
+      fireEvent.click(screen.getByText("Accept gallery offer"))
+      fireEvent.click(continueButton())
+      fireEvent.click(await screen.findByRole("button", { name: "Submit" }))
+
+      expect(await screen.findByText(SUBMIT_ERROR_TITLE)).toBeInTheDocument()
+      expect(
+        screen.queryByText("An error occurred while processing your payment"),
+      ).not.toBeInTheDocument()
+    })
+
+    it("sends the buyer to the legacy payment route from the payment modal CTA", async () => {
+      mockAcceptOffer.mockResolvedValue({
+        acceptSellerOffer: {
+          orderOrError: {
+            __typename: "OrderMutationError",
+            mutationError: {
+              code: "capture_failed",
+              message: "Your card was declined.",
+            },
+          },
+        },
+      })
+
+      renderWithRelay(galleryOfferResolvers)
+
+      fireEvent.click(screen.getByText("Accept gallery offer"))
+      fireEvent.click(continueButton())
+      fireEvent.click(await screen.findByRole("button", { name: "Submit" }))
+
+      fireEvent.click(
+        await screen.findByRole("button", { name: "Update payment method" }),
+      )
+
+      expect(mockRouterPush).toHaveBeenCalledWith(
+        "/orders/order-id/payment/new",
+      )
+    })
+
+    it("dismisses the modal and stays on the page via Continue", async () => {
+      mockAcceptOffer.mockRejectedValue(new Error("Network error"))
+
+      renderWithRelay(galleryOfferResolvers)
+
+      fireEvent.click(screen.getByText("Accept gallery offer"))
+      fireEvent.click(continueButton())
+      fireEvent.click(await screen.findByRole("button", { name: "Submit" }))
+
+      expect(await screen.findByText(SUBMIT_ERROR_TITLE)).toBeInTheDocument()
+
+      fireEvent.click(screen.getByRole("button", { name: "Continue" }))
+
+      await waitFor(() => {
+        expect(screen.queryByText(SUBMIT_ERROR_TITLE)).not.toBeInTheDocument()
+      })
+      // Still on the review step, able to retry.
+      expect(screen.getByRole("button", { name: "Submit" })).toBeInTheDocument()
+    })
+  })
+
   describe("analytics", () => {
     const mockTrackEvent = jest.fn()
 
@@ -280,6 +534,35 @@ describe("Order2RespondSummary", () => {
           context_page_owner_id: "order-id",
           context_page_owner_type: "orders-respond",
         })
+      })
+    })
+
+    it("tracks errorMessageViewed when the error modal is shown", async () => {
+      mockAcceptOffer.mockRejectedValue(new Error("Network error"))
+
+      renderWithRelay({
+        Order: () => ({
+          mode: "OFFER",
+          internalID: "order-id",
+          lastSubmittedOffer: { internalID: "gallery-offer-id" },
+        }),
+        Money: () => ({ display: "$1,000.00" }),
+      })
+
+      fireEvent.click(screen.getByText("Accept gallery offer"))
+      fireEvent.click(continueButton())
+      fireEvent.click(await screen.findByRole("button", { name: "Submit" }))
+
+      await waitFor(() => {
+        expect(mockTrackEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            action: "errorMessageViewed",
+            error_code: "submit_error",
+            title: "An error occurred",
+            message:
+              "Something went wrong while submitting your response. Please try again.",
+          }),
+        )
       })
     })
 

--- a/src/Apps/Order2/Utils/exchangeErrorCodes.ts
+++ b/src/Apps/Order2/Utils/exchangeErrorCodes.ts
@@ -17,4 +17,5 @@ export const OFFER_UNAVAILABLE_CODES = [
   "cannot_reject_offer",
   "cannot_offer",
   "cannot_update_submitted_offer",
+  "cannot_counter",
 ]

--- a/src/Apps/Order2/Utils/exchangeErrorCodes.ts
+++ b/src/Apps/Order2/Utils/exchangeErrorCodes.ts
@@ -1,0 +1,20 @@
+/**
+ * `mutationError.code` values Exchange returns from order and offer mutations.
+ */
+
+export const PAYMENT_FAILURE_CODES = [
+  "capture_failed",
+  "charge_authorization_failed",
+  "payment_method_confirmation_failed",
+  "payment_failed",
+]
+
+export const OFFER_UNAVAILABLE_CODES = [
+  "invalid_state",
+  "not_last_offer",
+  "invalid_offer",
+  "cannot_accept_offer",
+  "cannot_reject_offer",
+  "cannot_offer",
+  "cannot_update_submitted_offer",
+]


### PR DESCRIPTION
The type of this PR is: **Feat**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-3175]

### Description

- If submit fails on payment, show error message inside modal and redirect user to failed payment page
- If time is expired or failure or offer is not in correct state, show error modal and redirect to order details page
- General try again error for fallbacks on respond and submit steps that are not related to payment or offer state

<!-- Implementation description -->

https://github.com/user-attachments/assets/c2cf746d-6303-487e-a74e-3b93873622c1

<img width="806" height="550" alt="Screenshot 2026-07-30 at 9 05 11 AM" src="https://github.com/user-attachments/assets/88556751-bf78-4af2-a3b2-641f84d209aa" />


[EMI-3175]: https://artsyproduct.atlassian.net/browse/EMI-3175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ