### PR TITLE
fix(EMI-3363): partner offer image fix

### DIFF
--- a/src/Components/Notifications/PartnerOfferArtwork.tsx
+++ b/src/Components/Notifications/PartnerOfferArtwork.tsx
@@ -11,6 +11,8 @@ import type { PartnerOfferArtwork_artwork$key } from "__generated__/PartnerOffer
 import type { FC } from "react"
 import { graphql, useFragment } from "react-relay"
 
+const MAX_IMAGE_HEIGHT = "35vh"
+
 interface PartnerOfferArtworkProps {
   artwork: PartnerOfferArtwork_artwork$key
   targetHref: string
@@ -41,6 +43,8 @@ export const PartnerOfferArtwork: FC<
   const artwork = useFragment(partnerOfferArtworkFragment, artworkProp)
   const priceListed = artwork.price || "Not publicly listed"
   const image = resized(artwork?.image?.src ?? "", { width: CARD_MAX_WIDTH })
+  const imageWidth = artwork.image?.width ?? 1
+  const imageHeight = artwork.image?.height ?? 1
   const label =
     (artwork.title ?? "Artwork") +
     (artwork.artistNames ? ` by ${artwork.artistNames}` : "")
@@ -75,12 +79,12 @@ export const PartnerOfferArtwork: FC<
       >
         <Box
           width="100%"
+          mx="auto"
+          overflow="hidden"
           style={{
-            aspectRatio: `${artwork.image?.width ?? 1} / ${
-              artwork.image?.height ?? 1
-            }`,
+            aspectRatio: `${imageWidth} / ${imageHeight}`,
+            maxWidth: `calc(${MAX_IMAGE_HEIGHT} * ${imageWidth} / ${imageHeight})`,
           }}
-          maxHeight={"35vh"}
         >
           <Link href={fullyAvailable ? artworkListingHref : href}>
             <Image


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [EMI-3363]

### Description

Fixes artwork title overlap with the image in an expired partner offer notification

Before
<img width="603" height="1311" alt="IMG_7050" src="https://github.com/user-attachments/assets/b1362569-a58e-478a-b651-fc866cb39a8f" />

After
<img width="1206" height="2232" alt="IMG_7049" src="https://github.com/user-attachments/assets/6559f7b7-8cc5-4334-afff-3fc0311bd727" />


_assisted by claude opus 5_

[EMI-3363]: https://artsyproduct.atlassian.net/browse/EMI-3363?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ