### PR TITLE
feat(search): opt artwork queries into keyword typo tolerance

### DIFF
--- a/src/Apps/Search/Routes/SearchResultsArtworks.tsx
+++ b/src/Apps/Search/Routes/SearchResultsArtworks.tsx
@@ -30,16 +30,16 @@ export const SearchResultsArtworksRoute: React.FC<
   )
   const { viewer } = props
   const { sidebar } = viewer
+  const { pathname, query } = match.location
+  const { term } = query
 
   useEffect(() => {
-    const term = match.location.query.term
-
     // This is to avoid remounting the component when moving away from the search page (e.g. by clicking on a search result).
-    if (match.location.pathname !== SEARCH_PATH_NAME || !term) return
+    if (pathname !== SEARCH_PATH_NAME || !term) return
 
     // refresh artwork filter on query change
     setSearchFilterKey(term)
-  }, [match.location.query.term])
+  }, [pathname, term])
 
   return (
     <ArtworkGridContextProvider>
@@ -49,6 +49,11 @@ export const SearchResultsArtworksRoute: React.FC<
         viewer={viewer}
         filters={match.location.query}
         onChange={updateUrl}
+        relayRefetchInputVariables={{
+          // Lets the backend retry the search with typo tolerance (fuzzy
+          // matching) when the exact keyword returns no results.
+          keywordTypoTolerance: true,
+        }}
         ZeroState={ZeroState}
         aggregations={
           sidebar?.aggregations as SharedArtworkFilterContextProps["aggregations"]

--- a/src/Apps/Search/Routes/__tests__/SearchResultsArtworks.jest.tsx
+++ b/src/Apps/Search/Routes/__tests__/SearchResultsArtworks.jest.tsx
@@ -104,4 +104,17 @@ describe("SearchResultsArtworks", () => {
 
     expect(screen.getByText("Sort: Recommended")).toBeInTheDocument()
   })
+
+  it("requests typo tolerance when refetching after a filter change", async () => {
+    const { env, user } = renderWithRelay()
+
+    await user.click(screen.getByText("Sort: Recommended"))
+    await user.click(screen.getByText("Recently Added"))
+
+    const operation = env.mock.getMostRecentOperation()
+
+    expect(operation.request.variables.input).toMatchObject({
+      keywordTypoTolerance: true,
+    })
+  })
 })

--- a/src/Apps/Search/Routes/__tests__/SearchResultsArtworks.jest.tsx
+++ b/src/Apps/Search/Routes/__tests__/SearchResultsArtworks.jest.tsx
@@ -105,7 +105,7 @@ describe("SearchResultsArtworks", () => {
     expect(screen.getByText("Sort: Recommended")).toBeInTheDocument()
   })
 
-  it("requests typo tolerance when refetching after a filter change", async () => {
+  it("requests typo tolerance when refetching after a sort change", async () => {
     const { env, user } = renderWithRelay()
 
     await user.click(screen.getByText("Sort: Recommended"))
@@ -114,6 +114,21 @@ describe("SearchResultsArtworks", () => {
     const operation = env.mock.getMostRecentOperation()
 
     expect(operation.request.variables.input).toMatchObject({
+      keywordTypoTolerance: true,
+    })
+  })
+
+  it("requests typo tolerance when refetching after a filter change", async () => {
+    const { env, user } = renderWithRelay()
+
+    // Quick filters are rendered for both mobile and desktop, hence `getAllByText`
+    await user.click(screen.getAllByText("Rarity")[0])
+    await user.click(screen.getAllByText("Unique")[0])
+
+    const operation = env.mock.getMostRecentOperation()
+
+    expect(operation.request.variables.input).toMatchObject({
+      attributionClass: ["unique"],
       keywordTypoTolerance: true,
     })
   })

--- a/src/Apps/Search/SearchApp.tsx
+++ b/src/Apps/Search/SearchApp.tsx
@@ -172,7 +172,12 @@ export const SearchAppFragmentContainer = createFragmentContainer(SearchApp, {
           }
         }
       }
-      artworksConnection(keyword: $term, size: 0, aggregations: [TOTAL]) {
+      artworksConnection(
+        keyword: $term
+        size: 0
+        aggregations: [TOTAL]
+        keywordTypoTolerance: true
+      ) {
         counts {
           total
         }

--- a/src/Apps/Search/__tests__/searchRoutes.jest.tsx
+++ b/src/Apps/Search/__tests__/searchRoutes.jest.tsx
@@ -1,6 +1,38 @@
-import { prepareVariables } from "Apps/Search/searchRoutes"
+import { prepareVariables, searchRoutes } from "Apps/Search/searchRoutes"
 
 describe("searchRoutes", () => {
+  describe("the artworks tab", () => {
+    const prepareArtworksVariables = searchRoutes
+      .find(route => route.path === "/search")
+      ?.children?.find(child => child.path === "")?.prepareVariables
+
+    const getVariables = () => {
+      const variables = prepareArtworksVariables?.({}, {
+        location: { query: { term: "andy" } },
+        context: {},
+      } as any)
+
+      return variables as {
+        input: Record<string, unknown>
+        sidebarInput: Record<string, unknown>
+      }
+    }
+
+    it("requests typo tolerance for the artwork grid", () => {
+      expect(getVariables().input).toMatchObject({
+        keyword: "andy",
+        keywordTypoTolerance: true,
+      })
+    })
+
+    it("requests typo tolerance for the sidebar aggregations", () => {
+      expect(getVariables().sidebarInput).toMatchObject({
+        keyword: "andy",
+        keywordTypoTolerance: true,
+      })
+    })
+  })
+
   describe("prepareVariables", () => {
     it("passes the term through as the keyword", () => {
       const variables = prepareVariables(

--- a/src/Apps/Search/searchRoutes.tsx
+++ b/src/Apps/Search/searchRoutes.tsx
@@ -136,6 +136,9 @@ export const searchRoutes: RouteProps[] = [
           const input: Record<string, any> = {
             ...allowedFilters(other),
             first: 30,
+            // Lets the backend retry the search with typo tolerance (fuzzy
+            // matching) when the exact keyword returns no results.
+            keywordTypoTolerance: true,
           }
           const aggregations = [...sourceAggregations, "ARTIST"]
 
@@ -145,6 +148,7 @@ export const searchRoutes: RouteProps[] = [
             sidebarInput: {
               aggregations,
               keyword: input.keyword,
+              keywordTypoTolerance: true,
             },
           }
         },

--- a/src/__generated__/SearchAppTestQuery.graphql.ts
+++ b/src/__generated__/SearchAppTestQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<eae75b4162146428c82e3a4073bc6f14>>
+ * @generated SignedSource<<6272321f9c6b646807cf2f2d01be5851>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -249,6 +249,11 @@ return {
               },
               {
                 "kind": "Literal",
+                "name": "keywordTypoTolerance",
+                "value": true
+              },
+              {
+                "kind": "Literal",
                 "name": "size",
                 "value": 0
               }
@@ -278,7 +283,7 @@ return {
               },
               (v1/*: any*/)
             ],
-            "storageKey": "artworksConnection(aggregations:[\"TOTAL\"],keyword:\"andy\",size:0)"
+            "storageKey": "artworksConnection(aggregations:[\"TOTAL\"],keyword:\"andy\",keywordTypoTolerance:true,size:0)"
           }
         ],
         "storageKey": null
@@ -286,7 +291,7 @@ return {
     ]
   },
   "params": {
-    "cacheID": "a16f03b0e2c1c2b7a5cef92893d6a44a",
+    "cacheID": "92300b2d3095f6a657e78020c6e280ab",
     "id": null,
     "metadata": {
       "relayTestingSelectionTypeInfo": {
@@ -368,7 +373,7 @@ return {
     },
     "name": "SearchAppTestQuery",
     "operationKind": "query",
-    "text": "query SearchAppTestQuery {\n  viewer {\n    ...SearchApp_viewer_2rc5k6\n  }\n}\n\nfragment NavigationTabs_searchableConnection on SearchableConnection {\n  aggregations {\n    slice\n    counts {\n      count\n      name\n    }\n  }\n}\n\nfragment SearchApp_viewer_2rc5k6 on Viewer {\n  searchConnection(query: \"andy\", first: 1, aggregations: [TYPE]) {\n    aggregations {\n      slice\n      counts {\n        count\n        name\n      }\n    }\n    ...NavigationTabs_searchableConnection\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          slug\n          displayLabel\n          displayType\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n  artworksConnection(keyword: \"andy\", size: 0, aggregations: [TOTAL]) {\n    counts {\n      total\n    }\n    id\n  }\n}\n"
+    "text": "query SearchAppTestQuery {\n  viewer {\n    ...SearchApp_viewer_2rc5k6\n  }\n}\n\nfragment NavigationTabs_searchableConnection on SearchableConnection {\n  aggregations {\n    slice\n    counts {\n      count\n      name\n    }\n  }\n}\n\nfragment SearchApp_viewer_2rc5k6 on Viewer {\n  searchConnection(query: \"andy\", first: 1, aggregations: [TYPE]) {\n    aggregations {\n      slice\n      counts {\n        count\n        name\n      }\n    }\n    ...NavigationTabs_searchableConnection\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          slug\n          displayLabel\n          displayType\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n  artworksConnection(keyword: \"andy\", size: 0, aggregations: [TOTAL], keywordTypoTolerance: true) {\n    counts {\n      total\n    }\n    id\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/SearchApp_viewer.graphql.ts
+++ b/src/__generated__/SearchApp_viewer.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<db7249f6afff09bffd274ac67b367c91>>
+ * @generated SignedSource<<bac05a0e5f8e6b7976830b5b0aea69ea>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -197,6 +197,11 @@ const node: ReaderFragment = {
         },
         {
           "kind": "Literal",
+          "name": "keywordTypoTolerance",
+          "value": true
+        },
+        {
+          "kind": "Literal",
           "name": "size",
           "value": 0
         }
@@ -232,6 +237,6 @@ const node: ReaderFragment = {
   "abstractKey": null
 };
 
-(node as any).hash = "35e201abf8d672d14777050f0cca8a84";
+(node as any).hash = "549f27717efcf9510f447761c5abde12";
 
 export default node;

--- a/src/__generated__/searchRoutes_SearchResultsTopLevelQuery.graphql.ts
+++ b/src/__generated__/searchRoutes_SearchResultsTopLevelQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<1c7f25a76acd6fe6b9507ecadd535834>>
+ * @generated SignedSource<<dae4a0417c09592f2cfb48be71a02af7>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -239,6 +239,11 @@ return {
               },
               {
                 "kind": "Literal",
+                "name": "keywordTypoTolerance",
+                "value": true
+              },
+              {
+                "kind": "Literal",
                 "name": "size",
                 "value": 0
               }
@@ -276,12 +281,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "29135631f3bc0ca939f6d9397bbd8532",
+    "cacheID": "b158792e4ac9c05464863c7f83a484c5",
     "id": null,
     "metadata": {},
     "name": "searchRoutes_SearchResultsTopLevelQuery",
     "operationKind": "query",
-    "text": "query searchRoutes_SearchResultsTopLevelQuery(\n  $keyword: String!\n) {\n  viewer {\n    ...SearchApp_viewer_2hPz0N\n  }\n}\n\nfragment NavigationTabs_searchableConnection on SearchableConnection {\n  aggregations {\n    slice\n    counts {\n      count\n      name\n    }\n  }\n}\n\nfragment SearchApp_viewer_2hPz0N on Viewer {\n  searchConnection(query: $keyword, first: 1, aggregations: [TYPE]) {\n    aggregations {\n      slice\n      counts {\n        count\n        name\n      }\n    }\n    ...NavigationTabs_searchableConnection\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          slug\n          displayLabel\n          displayType\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n  artworksConnection(keyword: $keyword, size: 0, aggregations: [TOTAL]) {\n    counts {\n      total\n    }\n    id\n  }\n}\n"
+    "text": "query searchRoutes_SearchResultsTopLevelQuery(\n  $keyword: String!\n) {\n  viewer {\n    ...SearchApp_viewer_2hPz0N\n  }\n}\n\nfragment NavigationTabs_searchableConnection on SearchableConnection {\n  aggregations {\n    slice\n    counts {\n      count\n      name\n    }\n  }\n}\n\nfragment SearchApp_viewer_2hPz0N on Viewer {\n  searchConnection(query: $keyword, first: 1, aggregations: [TYPE]) {\n    aggregations {\n      slice\n      counts {\n        count\n        name\n      }\n    }\n    ...NavigationTabs_searchableConnection\n    edges {\n      node {\n        __typename\n        ... on SearchableItem {\n          slug\n          displayLabel\n          displayType\n        }\n        ... on Node {\n          __isNode: __typename\n          id\n        }\n      }\n    }\n  }\n  artworksConnection(keyword: $keyword, size: 0, aggregations: [TOTAL], keywordTypoTolerance: true) {\n    counts {\n      total\n    }\n    id\n  }\n}\n"
   }
 };
 })();


### PR DESCRIPTION
Assisted-by: Claude <noreply@anthropic.com>

This PR solves [ONYX-2219]

### Description

Adds `keywordTypoTolerance: true` to every `artworksConnection` query on /search (artwork grid, sidebar aggregations, and the Artworks tab count) so the backend retries the search with fuzzy matching when an exact keyword match returns nothing.

| before | after |
|---|---|
| <img width="1624" height="1060" alt="image" src="https://github.com/user-attachments/assets/0c834504-ec36-4b63-b781-9c4de3592b4c" /> | <img width="1624" height="1060" alt="image" src="https://github.com/user-attachments/assets/b0bcbec9-d550-40ec-8cd5-314df6ee5151" /> |

[ONYX-2219]: https://artsyproduct.atlassian.net/browse/ONYX-2219?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ