### PR TITLE
chore: update About page leadership team and headshots

### DIFF
--- a/src/Apps/About/Components/AboutOurTeam.tsx
+++ b/src/Apps/About/Components/AboutOurTeam.tsx
@@ -48,7 +48,7 @@ export const AboutOurTeam = () => {
                     gap={1}
                     flexDirection={["column", "row"]}
                   >
-                    {TEAM_MEMBERS.slice(0, 3).map(member => (
+                    {TEAM_MEMBERS.slice(0, 4).map(member => (
                       <Box key={member.name} flexBasis={["100%", "25%"]}>
                         <AboutOurTeamItem {...member} />
                       </Box>
@@ -56,7 +56,7 @@ export const AboutOurTeam = () => {
                   </Flex>
 
                   <GridColumns gridColumnGap={1}>
-                    {TEAM_MEMBERS.slice(3).map(member => (
+                    {TEAM_MEMBERS.slice(4).map(member => (
                       <AboutOurTeamItem key={member.name} {...member} />
                     ))}
                   </GridColumns>
@@ -86,37 +86,52 @@ const TEAM_MEMBERS = [
   {
     name: "Jeffrey Yin",
     title: "CEO",
-    src: "https://files.artsy.net/images/about-our-team-jeffrey-yin.png",
+    src: "https://files.artsy.net/images/about-our-team-jeffrey-yin-v2.png",
   },
   {
     name: "Dustyn Kim",
     title: "President",
-    src: "https://files.artsy.net/images/about-our-team-dustyn-kim.png",
+    src: "https://files.artsy.net/images/about-our-team-dustyn-kim-v2.png",
   },
   {
     name: "Angela Vinci",
     title: "Chief Product Officer",
-    src: "https://files.artsy.net/images/about-our-team-angela-vinci-1.png",
+    src: "https://files.artsy.net/images/about-our-team-angela-vinci-v2.png",
   },
   {
-    name: "Joey Aghion",
-    title: "VP, Engineering",
-    src: "https://files.artsy.net/images/about-our-team-joey-aghion.png",
-  },
-  {
-    name: "Alex Forbes",
-    title: "VP, Global Partnerships",
-    src: "https://files.artsy.net/images/about-our-team-alex-forbes.png",
+    name: "Katie Foley",
+    title: "Chief Operating Officer",
+    src: "https://files.artsy.net/images/about-our-team-kathryn-foley-v2.png",
   },
   {
     name: "Ani Petrov",
     title: "VP, Marketing & Data Analytics",
-    src: "https://files.artsy.net/images/about-our-team-ani-petrov-1.png",
+    src: "https://files.artsy.net/images/about-our-team-ani-petrov-v2.png",
+  },
+  {
+    name: "Alex Forbes",
+    title: "VP, Global Partnerships",
+    src: "https://files.artsy.net/images/about-our-team-alex-forbes-v2.png",
+  },
+  {
+    name: "Joey Aghion",
+    title: "VP, Engineering",
+    src: "https://files.artsy.net/images/about-our-team-joey-aghion-v2.png",
   },
   {
     name: "Christopher Young",
     title: "VP, Finance & Corporate Development",
-    src: "https://files.artsy.net/images/about-our-team-christopher-young-1.png",
+    src: "https://files.artsy.net/images/about-our-team-christopher-young-v2.png",
+  },
+  {
+    name: "Bill Fine",
+    title: "EVP, Strategic Accounts",
+    src: "https://files.artsy.net/images/about-our-team-bill-fine-v2.png",
+  },
+  {
+    name: "Gray Holubar",
+    title: "VP of People",
+    src: "https://files.artsy.net/images/about-our-team-gray-holubar-v2.png",
   },
 ]
 


### PR DESCRIPTION
The type of this PR is: **Chore**

This PR solves [DI-520](https://www.notion.so/3abcab0764a0807db11bf9453821501a)

### Description

Refreshes the list of leadership team titles and headshots on the About page.

- **Headshots** — [uses the new cropping across the board](https://artsy.slack.com/archives/C0AR60390MN/p1786383320720389?thread_ts=1785183659.017329&cid=C0AR60390MN), since we have only those for the new headshots

- **Order** —  [C-suite first, then shuffles the order ](https://artsy.slack.com/archives/C0AR60390MN/p1785191132203059?thread_ts=1785183659.017329&cid=C0AR60390MN) to maintain alternating background colors in both mobile and desktop views

| Desktop | mWeb |
|--------|--------|
| <img width="1722" height="2214" alt="desk" src="https://github.com/user-attachments/assets/c3eceab7-9b1e-4639-97ed-9fc53db73f0c" /> | <img width="828" height="2208" alt="mweb" src="https://github.com/user-attachments/assets/fbf06df4-091b-4a44-b16c-bab05a6b95c3" /> | 

