### PR TITLE
feat(gene): update title and description meta tags for SEO

### DIFF
--- a/playwright/e2e/gene.spec.ts
+++ b/playwright/e2e/gene.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test"
+import { expect, test } from "@playwright/test"
 
 test.describe("Gene", () => {
   test("/gene/:id", async ({ page }) => {
@@ -7,6 +7,8 @@ test.describe("Gene", () => {
     await expect(page.locator("h1").first()).toContainText(
       "Contemporary Figurative Painting",
     )
-    await expect(page).toHaveTitle("Contemporary Figurative Painting | Artsy")
+    await expect(page).toHaveTitle(
+      "Contemporary Figurative Painting - Art & Prints for Sale | Artsy",
+    )
   })
 })

--- a/src/Apps/Gene/Components/GeneMeta.tsx
+++ b/src/Apps/Gene/Components/GeneMeta.tsx
@@ -10,17 +10,32 @@ interface GeneMetaProps {
 const GeneMeta: React.FC<React.PropsWithChildren<GeneMetaProps>> = ({
   gene,
 }) => {
-  const fallbackDescription = `Explore ${gene.name} art on Artsy. Browse works by size, price, and medium.`
-  const title = `${gene.displayName || gene.name} | Artsy`
+  const title = buildTitle(gene)
+  const description = buildDescription(gene)
 
   return (
     <MetaTags
       title={title}
-      description={gene.meta.description || fallbackDescription}
+      description={description}
       pathname={gene.href}
       imageURL={gene.image?.cropped?.src}
     />
   )
+}
+
+function buildTitle(gene: GeneMeta_gene$data): string {
+  return `${gene.displayName || gene.name} - Art & Prints for Sale | Artsy`
+}
+
+function buildDescription(gene: GeneMeta_gene$data): string {
+  const description = [
+    gene.meta.description,
+    `Browse ${gene.name} art on Artsy.`,
+  ]
+    .filter(Boolean)
+    .join(" ")
+
+  return description
 }
 
 export const GeneMetaFragmentContainer = createFragmentContainer(GeneMeta, {

--- a/src/Apps/Gene/Routes/__tests__/GeneShow.jest.tsx
+++ b/src/Apps/Gene/Routes/__tests__/GeneShow.jest.tsx
@@ -1,7 +1,7 @@
+import { screen } from "@testing-library/react"
 import { GeneShowFragmentContainer } from "Apps/Gene/Routes/GeneShow"
 import { MockBoot } from "DevTools/MockBoot"
 import { setupTestWrapperTL } from "DevTools/setupTestWrapperTL"
-import { screen } from "@testing-library/react"
 import type { GeneShowTestQuery } from "__generated__/GeneShowTestQuery.graphql"
 import { graphql } from "react-relay"
 
@@ -41,34 +41,22 @@ describe("GeneShow", () => {
     expect(screen.getByText("Display Name")).toBeInTheDocument()
   })
 
-  it("renders fallback title correctly", () => {
-    renderWithRelay({
-      Gene: () => ({
-        name: "Example Gene",
-        displayName: "",
-      }),
-    })
-
-    expect(screen.getByRole("heading", { level: 1 })).toBeInTheDocument()
-    expect(screen.getAllByText("Example Gene")).toHaveLength(2)
-  })
-
   it("renders meta description and title from query", () => {
     renderWithRelay({
       Gene: () => ({
-        meta: { description: "Gene Meta Description" },
-        displayName: "Display Name",
-        name: "name",
+        meta: { description: "Example Gene meta description." },
+        displayName: "Example Gene Display Name",
+        name: "Example Gene Name",
       }),
     })
 
     expect(document.querySelector('meta[name="description"]')).toHaveAttribute(
       "content",
-      "Gene Meta Description",
+      "Example Gene meta description. Browse Example Gene Name art on Artsy.",
     )
     expect(document.querySelector('meta[name="title"]')).toHaveAttribute(
       "content",
-      "Display Name | Artsy",
+      "Example Gene Display Name - Art & Prints for Sale | Artsy",
     )
   })
 
@@ -83,11 +71,11 @@ describe("GeneShow", () => {
 
     expect(document.querySelector('meta[name="description"]')).toHaveAttribute(
       "content",
-      "Explore Design art on Artsy. Browse works by size, price, and medium.",
+      "Browse Design art on Artsy.",
     )
     expect(document.querySelector('meta[name="title"]')).toHaveAttribute(
       "content",
-      "Design | Artsy",
+      "Design - Art & Prints for Sale | Artsy",
     )
   })
 })


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [DI-545](https://www.notion.so/3b5cab0764a080089b3bfc18a80a6642)

### Description

Updates `title`, `meta name="title"`, and `meta name="description"` tags for SEO:

|  | Before | After |
|--------|--------|--------|
| `title` | {name} \| Artsy | {name} - Art & Prints for Sale \| Artsy |
| `description` | {description} | {description}. Browse  {name}  art on Artsy. |

<img width="3428" height="2826" alt="gene meta" src="https://github.com/user-attachments/assets/29a39aca-652e-4aa2-bfac-d68a99709389" />

