### PR TITLE
fix(Inquiry): guard-rails when autocomplete fails to load locations from Google

### DIFF
--- a/src/Components/LocationAutocompleteInput.tsx
+++ b/src/Components/LocationAutocompleteInput.tsx
@@ -27,6 +27,10 @@ const GOOGLE_PLACES_API_SRC = `https://maps.googleapis.com/maps/api/js?key=${get
   "SESSION_ID",
 )}&callback=__googleMapsCallback`
 
+const isGooglePlacesLoaded = (): boolean => {
+  return typeof google !== "undefined" && !!google.maps?.places
+}
+
 interface LocationAutocompleteInputProps
   extends Omit<
     AutocompleteInputProps<AutocompleteInputOptionType>,
@@ -49,7 +53,7 @@ export const LocationAutocompleteInput: FC<
   const geocoderRef = useRef<google.maps.Geocoder | null>(null)
 
   useEffect(() => {
-    if (typeof google === "undefined") {
+    if (!isGooglePlacesLoaded()) {
       window.__googleMapsCallback = () => {
         setReady(true)
       }
@@ -60,7 +64,7 @@ export const LocationAutocompleteInput: FC<
   }, [])
 
   useEffect(() => {
-    if (typeof google === "undefined" || !ready) return
+    if (!ready || !isGooglePlacesLoaded()) return
     autocompleteServiceRef.current =
       new google.maps.places.AutocompleteService()
     geocoderRef.current = new google.maps.Geocoder()

--- a/src/Components/__tests__/LocationAutocompleteInput.jest.tsx
+++ b/src/Components/__tests__/LocationAutocompleteInput.jest.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, screen, waitFor } from "@testing-library/react"
+import { act, fireEvent, screen, waitFor } from "@testing-library/react"
 import { render } from "@testing-library/react"
 import {
   LocationAutocompleteInput,
@@ -177,6 +177,43 @@ describe("LocationAutocompleteInput", () => {
       await waitFor(() => {
         expect(screen.getAllByRole("option", { hidden: true })).toHaveLength(2)
       })
+    })
+  })
+})
+
+describe("when another Google script defines window.google without Maps", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    // @ts-ignore
+    global.window.google = { accounts: {} }
+    global.window.__googleMapsCallback = undefined
+  })
+
+  afterEach(() => {
+    setupGoogleMapsMock()
+    global.window.__googleMapsCallback = undefined
+  })
+
+  it("renders without crashing and waits for the Maps script", () => {
+    render(<LocationAutocompleteInput name="location" title="Location" />)
+
+    expect(screen.getByTestId("autocomplete-location")).toBeInTheDocument()
+    expect(AutocompleteService).not.toHaveBeenCalled()
+    expect(typeof global.window.__googleMapsCallback).toBe("function")
+  })
+
+  it("initializes the Places services once the Maps script loads", async () => {
+    render(<LocationAutocompleteInput name="location" title="Location" />)
+
+    setupGoogleMapsMock()
+
+    act(() => {
+      global.window.__googleMapsCallback?.()
+    })
+
+    await waitFor(() => {
+      expect(AutocompleteService).toHaveBeenCalledTimes(1)
+      expect(Geocoder).toHaveBeenCalledTimes(1)
     })
   })
 })


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

### Description

Logged-out users were crashing when trying to inquire due to the Google locations were not loaded.
This band-aid prevents the crash; we still need to understand and fix the google locations loading(maybe API key expired or so) 
