### PR TITLE
chore: remove one-tap and inline-account-link feature flags

### DIFF
--- a/src/Apps/Authentication/Components/AuthenticationInlineDialog.tsx
+++ b/src/Apps/Authentication/Components/AuthenticationInlineDialog.tsx
@@ -9,7 +9,6 @@ import { MetaTags } from "Components/MetaTags"
 import { useRouter } from "System/Hooks/useRouter"
 import { useRecaptcha } from "Utils/EnableRecaptcha"
 import { AUTH_ERROR_CODES, AUTH_PROVIDERS } from "Utils/authConstants"
-import { useFlag, useFlagsStatus } from "@unleash/proxy-client-react"
 import { type FC, useEffect } from "react"
 
 const AuthenticationInlineDialogContents: FC<
@@ -20,42 +19,23 @@ const AuthenticationInlineDialogContents: FC<
 
   const { sendToast } = useToasts()
   const { dispatch } = useAuthDialogContext()
-  const isInlineAccountLinkingEnabled = !!useFlag(
-    "diamond_inline-account-linking",
-  )
-  const { flagsReady } = useFlagsStatus()
 
   const {
     match: { location },
   } = useRouter()
 
   // When an OAuth attempt finds an existing account, switch to the link
-  // accounts view instead of showing a generic error toast. Wait for the flag
-  // to hydrate so we don't act on a stale initial value.
+  // accounts view instead of showing a generic error toast.
   useEffect(() => {
-    if (!flagsReady) return
     if (location.query.error_code !== "ALREADY_EXISTS") return
-    if (!isInlineAccountLinkingEnabled) return
     dispatch({ type: "MODE", payload: { mode: "LinkAccounts" } })
-  }, [
-    flagsReady,
-    location.query.error_code,
-    dispatch,
-    isInlineAccountLinkingEnabled,
-  ])
+  }, [location.query.error_code, dispatch])
 
-  // All other OAuth errors surface as a toast.
-  // When the inline account linking flag is off, ALREADY_EXISTS also surfaces
-  // as a toast directing the user to link via settings.
+  // All other OAuth errors surface as a toast. ALREADY_EXISTS is handled by the
+  // link accounts view above, so it is skipped here.
   useEffect(() => {
-    if (!flagsReady) return
     if (!location.query.error_code) return
-    if (
-      location.query.error_code === "ALREADY_EXISTS" &&
-      isInlineAccountLinkingEnabled
-    ) {
-      return
-    }
+    if (location.query.error_code === "ALREADY_EXISTS") return
 
     const message = (
       AUTH_ERROR_CODES[location.query.error_code] || AUTH_ERROR_CODES.UNKNOWN
@@ -67,8 +47,6 @@ const AuthenticationInlineDialogContents: FC<
 
     sendToast({ message, variant: "error", ttl: Number.POSITIVE_INFINITY })
   }, [
-    flagsReady,
-    isInlineAccountLinkingEnabled,
     location.query.error,
     location.query.error_code,
     location.query.provider,

--- a/src/Server/passport/lib/app/__tests__/lifecycle.jest.ts
+++ b/src/Server/passport/lib/app/__tests__/lifecycle.jest.ts
@@ -12,10 +12,6 @@ jest.mock("Server/passport/lib/options", () => ({
   ARTSY_URL: "https://api.artsy.net",
 }))
 
-jest.mock("System/FeatureFlags/unleashServer", () => ({
-  isFeatureFlagEnabled: jest.fn().mockReturnValue(true),
-}))
-
 jest.mock("../../http")
 jest.mock("passport", () => {
   return {

--- a/src/Server/passport/lib/app/lifecycle.ts
+++ b/src/Server/passport/lib/app/lifecycle.ts
@@ -14,7 +14,6 @@ import type { NextFunction } from "express"
 import { get, isFunction, isString } from "lodash"
 import passport from "passport"
 import { type GravityError, requestGravity } from "../http"
-import { isFeatureFlagEnabled } from "System/FeatureFlags/unleashServer"
 import type { LinkingTokenData } from "../types"
 import forwardedFor from "./forwarded_for"
 import redirectBack from "./redirectBack"
@@ -281,34 +280,24 @@ export const afterSocialAuth =
         err?.response?.body?.error === "User Already Exists" &&
         req.socialProfileEmail
       ) {
-        if (isFeatureFlagEnabled("diamond_inline-account-linking")) {
-          req.session.linkingToken = req.socialTokenData
+        req.session.linkingToken = req.socialTokenData
 
-          const gravityProviders = (
-            (err.response.body.providers as string[] | undefined) ?? []
-          ).map((p: string) => p.toLowerCase())
+        const gravityProviders = (
+          (err.response.body.providers as string[] | undefined) ?? []
+        ).map((p: string) => p.toLowerCase())
 
-          if (
-            err.response.body.has_password === true &&
-            !gravityProviders.includes("email")
-          ) {
-            gravityProviders.unshift("email")
-          }
-
-          return res.redirect(
-            redirectWithQuery(redirectPath, {
-              email: req.socialProfileEmail,
-              error_code: "ALREADY_EXISTS",
-              existing_providers: gravityProviders.join(",") || "email",
-              provider,
-            }),
-          )
+        if (
+          err.response.body.has_password === true &&
+          !gravityProviders.includes("email")
+        ) {
+          gravityProviders.unshift("email")
         }
 
         return res.redirect(
           redirectWithQuery(redirectPath, {
             email: req.socialProfileEmail,
             error_code: "ALREADY_EXISTS",
+            existing_providers: gravityProviders.join(",") || "email",
             provider,
           }),
         )

--- a/src/Utils/GoogleOneTapContainer.tsx
+++ b/src/Utils/GoogleOneTapContainer.tsx
@@ -1,8 +1,5 @@
-import { ActionType } from "@artsy/cohesion"
 import { useToasts } from "@artsy/palette"
-import { useFlag, useFlagsStatus } from "@unleash/proxy-client-react"
 import { useAuthDialogContext } from "Components/AuthDialog/AuthDialogContext"
-import { pathToOwnerType } from "System/Contexts/AnalyticsContext"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import { AUTH_ERROR_CODES } from "Utils/authConstants"
 import { getENV } from "Utils/getENV"
@@ -33,19 +30,12 @@ const isInputFocused = () => {
 
 export const GoogleOneTapContainer = () => {
   const { isLoggedIn } = useSystemContext()
-  const isGoogleOneTapEnabled = !!useFlag("diamond_google-one-tap")
-  const { flagsReady } = useFlagsStatus()
   const googleClientId = getENV("GOOGLE_CLIENT_ID")
   const { sendToast } = useToasts()
   const { state: authDialogState } = useAuthDialogContext()
 
-  const forceEnabled =
-    typeof window !== "undefined" &&
-    new URLSearchParams(window.location.search).has("force_one_tap")
-
   const enabled =
     !isLoggedIn &&
-    (isGoogleOneTapEnabled || forceEnabled) &&
     !!googleClientId &&
     !isAuthPath(window.location.pathname) &&
     !authDialogState.isVisible
@@ -65,22 +55,6 @@ export const GoogleOneTapContainer = () => {
     cleanUrl.searchParams.delete("g_one_tap_error")
     window.history.replaceState({}, "", cleanUrl.toString())
   }, [sendToast])
-
-  useEffect(() => {
-    if (!flagsReady) return
-
-    const path = window.location.pathname
-    const pageParts = path.split("/")
-
-    // We don't use hook since we don't have access to router here
-    window?.analytics?.track(ActionType.experimentViewed, {
-      service: "unleash",
-      experiment_name: "diamond_google-one-tap",
-      variant_name: isGoogleOneTapEnabled ? "experiment" : "control",
-      context_owner_type: pathToOwnerType(path),
-      context_owner_slug: pageParts[2],
-    })
-  }, [isGoogleOneTapEnabled, flagsReady])
 
   useEffect(() => {
     if (!authDialogState.isVisible)

--- a/src/Utils/__tests__/GoogleOneTapContainer.jest.tsx
+++ b/src/Utils/__tests__/GoogleOneTapContainer.jest.tsx
@@ -1,6 +1,5 @@
 import { act, render } from "@testing-library/react"
 import { useToasts } from "@artsy/palette"
-import { useFlag, useFlagsStatus } from "@unleash/proxy-client-react"
 import { useAuthDialogContext } from "Components/AuthDialog/AuthDialogContext"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import { GoogleOneTapContainer } from "Utils/GoogleOneTapContainer"
@@ -21,11 +20,6 @@ jest.mock("Utils/getENV", () => ({
   getENV: jest.fn(),
 }))
 
-jest.mock("@unleash/proxy-client-react", () => ({
-  useFlag: jest.fn(),
-  useFlagsStatus: jest.fn(),
-}))
-
 jest.mock("System/Hooks/useSystemContext", () => ({
   useSystemContext: jest.fn(),
 }))
@@ -35,16 +29,12 @@ jest.mock("Components/AuthDialog/AuthDialogContext", () => ({
 }))
 
 describe("GoogleOneTapContainer", () => {
-  const mockUseFlag = useFlag as jest.Mock
-  const mockUseFlagsStatus = useFlagsStatus as jest.Mock
   const mockGetENV = getENV as jest.Mock
   const mockUseSystemContext = useSystemContext as jest.Mock
   const mockUseToasts = useToasts as jest.Mock
   const mockUseAuthDialogContext = useAuthDialogContext as jest.Mock
 
   const enableOneTap = () => {
-    mockUseFlag.mockReturnValue(true)
-    mockUseFlagsStatus.mockReturnValue({ flagsReady: true })
     mockUseSystemContext.mockReturnValue({ isLoggedIn: false })
     mockUseAuthDialogContext.mockReturnValue({ state: { isVisible: false } })
     mockGetENV.mockImplementation((key: string) => {
@@ -55,8 +45,6 @@ describe("GoogleOneTapContainer", () => {
   }
 
   beforeEach(() => {
-    mockUseFlag.mockReturnValue(false)
-    mockUseFlagsStatus.mockReturnValue({ flagsReady: true })
     mockUseSystemContext.mockReturnValue({ isLoggedIn: false })
     mockUseAuthDialogContext.mockReturnValue({ state: { isVisible: false } })
     mockGetENV.mockReturnValue(null)
@@ -75,7 +63,7 @@ describe("GoogleOneTapContainer", () => {
     ) as HTMLScriptElement | null
 
   describe("g_id_onload div", () => {
-    it("renders when feature flag is on, GOOGLE_CLIENT_ID is set, and user is logged out", () => {
+    it("renders when GOOGLE_CLIENT_ID is set and user is logged out", () => {
       enableOneTap()
       render(<GoogleOneTapContainer />)
       expect(document.getElementById("g_id_onload")).toBeInTheDocument()
@@ -89,16 +77,7 @@ describe("GoogleOneTapContainer", () => {
       )
     })
 
-    it("does not render when feature flag is off", () => {
-      mockUseFlag.mockReturnValue(false)
-      mockUseSystemContext.mockReturnValue({ isLoggedIn: false })
-      mockGetENV.mockReturnValue("test-client-id")
-      render(<GoogleOneTapContainer />)
-      expect(document.getElementById("g_id_onload")).not.toBeInTheDocument()
-    })
-
     it("does not render when GOOGLE_CLIENT_ID is not set", () => {
-      mockUseFlag.mockReturnValue(true)
       mockUseSystemContext.mockReturnValue({ isLoggedIn: false })
       mockGetENV.mockReturnValue(null)
       render(<GoogleOneTapContainer />)
@@ -106,7 +85,6 @@ describe("GoogleOneTapContainer", () => {
     })
 
     it("does not render when user is logged in", () => {
-      mockUseFlag.mockReturnValue(true)
       mockUseSystemContext.mockReturnValue({ isLoggedIn: true })
       mockGetENV.mockReturnValue("test-client-id")
       render(<GoogleOneTapContainer />)
@@ -144,7 +122,7 @@ describe("GoogleOneTapContainer", () => {
   })
 
   describe("GSI script injection", () => {
-    it("appends script to body when feature flag is on and user is logged out", () => {
+    it("appends script to body when user is logged out", () => {
       enableOneTap()
       render(<GoogleOneTapContainer />)
       expect(gsiScript()).toBeInTheDocument()
@@ -168,16 +146,7 @@ describe("GoogleOneTapContainer", () => {
       input.remove()
     })
 
-    it("does not append script when feature flag is off", () => {
-      mockUseFlag.mockReturnValue(false)
-      mockUseSystemContext.mockReturnValue({ isLoggedIn: false })
-      mockGetENV.mockReturnValue("test-client-id")
-      render(<GoogleOneTapContainer />)
-      expect(gsiScript()).not.toBeInTheDocument()
-    })
-
     it("does not append script when GOOGLE_CLIENT_ID is not set", () => {
-      mockUseFlag.mockReturnValue(true)
       mockUseSystemContext.mockReturnValue({ isLoggedIn: false })
       mockGetENV.mockReturnValue(null)
       render(<GoogleOneTapContainer />)
@@ -185,7 +154,6 @@ describe("GoogleOneTapContainer", () => {
     })
 
     it("does not append script when user is logged in", () => {
-      mockUseFlag.mockReturnValue(true)
       mockUseSystemContext.mockReturnValue({ isLoggedIn: true })
       mockGetENV.mockReturnValue("test-client-id")
       render(<GoogleOneTapContainer />)
@@ -197,46 +165,6 @@ describe("GoogleOneTapContainer", () => {
       mockUseAuthDialogContext.mockReturnValue({ state: { isVisible: true } })
       render(<GoogleOneTapContainer />)
       expect(gsiScript()).not.toBeInTheDocument()
-    })
-  })
-
-  describe("experiment tracking", () => {
-    let mockTrack: jest.Mock
-
-    beforeEach(() => {
-      mockTrack = jest.fn()
-      ;(window as any).analytics = { track: mockTrack }
-    })
-
-    afterEach(() => {
-      delete (window as any).analytics
-    })
-
-    it("fires experiment_viewed with variant_name: experiment when flag is enabled", () => {
-      enableOneTap()
-      render(<GoogleOneTapContainer />)
-
-      expect(mockTrack).toHaveBeenCalledWith(
-        "experiment_viewed",
-        expect.objectContaining({
-          service: "unleash",
-          experiment_name: "diamond_google-one-tap",
-          variant_name: "experiment",
-        }),
-      )
-    })
-
-    it("fires experiment_viewed with variant_name: control when flag is disabled", () => {
-      render(<GoogleOneTapContainer />)
-
-      expect(mockTrack).toHaveBeenCalledWith(
-        "experiment_viewed",
-        expect.objectContaining({
-          service: "unleash",
-          experiment_name: "diamond_google-one-tap",
-          variant_name: "control",
-        }),
-      )
     })
   })
 


### PR DESCRIPTION

The type of this PR is: **Chore**

This PR solves [DI-253](https://www.notion.so/350cab0764a081a5a0ebff93455dc9ca)

### Description

<!-- Implementation description -->

Both flags have fully rolled out. Remove the flag gates so Google One Tap and inline account linking are permanently on, and delete the associated A/B experiment tracking and dead off-branch code paths.

Assisted-By: Claude <noreply@anthropic.com>

