### PR TITLE
fix: guard GoogleOneTapContainer against SSR window access

### DIFF
--- a/src/Utils/GoogleOneTapContainer.tsx
+++ b/src/Utils/GoogleOneTapContainer.tsx
@@ -34,7 +34,10 @@ export const GoogleOneTapContainer = () => {
   const { sendToast } = useToasts()
   const { state: authDialogState } = useAuthDialogContext()
 
+  // `window` guard keeps this from throwing during SSR, where the pathname
+  // check below would otherwise run against an undefined `window`.
   const enabled =
+    typeof window !== "undefined" &&
     !isLoggedIn &&
     !!googleClientId &&
     !isAuthPath(window.location.pathname) &&


### PR DESCRIPTION


The type of this PR is: **Fix**

### Description

<!-- Implementation description -->

Removing the feature flag dropped the short-circuit that previously kept the window.location.pathname check from running during SSR, causing a "window is not defined" 500. Guard the enabled check with a typeof window test so it resolves to false on the server.

Assisted-By: Claude <noreply@anthropic.com>