### PR TITLE
fix: hydration mismatch in google one tap's enabled state

### DIFF
--- a/src/Utils/GoogleOneTapContainer.tsx
+++ b/src/Utils/GoogleOneTapContainer.tsx
@@ -1,4 +1,4 @@
-import { useToasts } from "@artsy/palette"
+import { useDidMount, useToasts } from "@artsy/palette"
 import { useAuthDialogContext } from "Components/AuthDialog/AuthDialogContext"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import { AUTH_ERROR_CODES } from "Utils/authConstants"
@@ -34,10 +34,14 @@ export const GoogleOneTapContainer = () => {
   const { sendToast } = useToasts()
   const { state: authDialogState } = useAuthDialogContext()
 
-  // `window` guard keeps this from throwing during SSR, where the pathname
-  // check below would otherwise run against an undefined `window`.
+  // `useDidMount` is false during SSR and during the client's first render
+  // pass, only flipping to true after that first pass commits. This keeps
+  // `enabled` in sync between the server and the client's first paint, avoiding
+  // a hydration mismatch.
+  const isMounted = useDidMount()
+
   const enabled =
-    typeof window !== "undefined" &&
+    isMounted &&
     !isLoggedIn &&
     !!googleClientId &&
     !isAuthPath(window.location.pathname) &&

--- a/src/Utils/__tests__/GoogleOneTapContainer.jest.tsx
+++ b/src/Utils/__tests__/GoogleOneTapContainer.jest.tsx
@@ -1,5 +1,5 @@
 import { act, render } from "@testing-library/react"
-import { useToasts } from "@artsy/palette"
+import { useDidMount, useToasts } from "@artsy/palette"
 import { useAuthDialogContext } from "Components/AuthDialog/AuthDialogContext"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import { GoogleOneTapContainer } from "Utils/GoogleOneTapContainer"
@@ -13,7 +13,9 @@ jest.mock("@sentry/browser", () => ({
 }))
 
 jest.mock("@artsy/palette", () => ({
+  ...jest.requireActual("@artsy/palette"),
   useToasts: jest.fn(),
+  useDidMount: jest.fn(),
 }))
 
 jest.mock("Utils/getENV", () => ({
@@ -33,6 +35,7 @@ describe("GoogleOneTapContainer", () => {
   const mockUseSystemContext = useSystemContext as jest.Mock
   const mockUseToasts = useToasts as jest.Mock
   const mockUseAuthDialogContext = useAuthDialogContext as jest.Mock
+  const mockUseDidMount = useDidMount as jest.Mock
 
   const enableOneTap = () => {
     mockUseSystemContext.mockReturnValue({ isLoggedIn: false })
@@ -51,6 +54,7 @@ describe("GoogleOneTapContainer", () => {
     mockCaptureException.mockClear()
     mockSendToast.mockClear()
     mockUseToasts.mockReturnValue({ sendToast: mockSendToast })
+    mockUseDidMount.mockReturnValue(true)
   })
 
   afterEach(() => {
@@ -61,6 +65,18 @@ describe("GoogleOneTapContainer", () => {
     document.body.querySelector(
       "script[src='https://accounts.google.com/gsi/client']",
     ) as HTMLScriptElement | null
+
+  describe("hydration safety", () => {
+    it("does not render the g_id_onload div before the client has mounted, even when otherwise eligible", () => {
+      enableOneTap()
+      mockUseDidMount.mockReturnValue(false)
+
+      render(<GoogleOneTapContainer />)
+
+      expect(document.getElementById("g_id_onload")).not.toBeInTheDocument()
+      expect(gsiScript()).not.toBeInTheDocument()
+    })
+  })
 
   describe("g_id_onload div", () => {
     it("renders when GOOGLE_CLIENT_ID is set and user is logged out", () => {


### PR DESCRIPTION
Assisted-by: Claude:Sonnet-5

I noticed a hydration mismatch error message appear when I ran Force locally this morning. It seems like the value of `enabled` can become mismatched between SSR and the client's first render pass. The mismatch happens because `window` is undefined during SSR (so `enabled` is always false) but is defined when the client renders this component (so `enabled` can be true when all the other conditions are met).

This PR prevents that that error message from appearing by forcing `enabled` to be false until we know the component has mounted.

_Ideally_ we would compute `enabled` the same on the server as we do on the client, but since this component relies on `window.location.pathname` to determine if the user is on an auth path, that would involve a larger refactor, so this is more of a patch than a fix.

<img width="1840" height="1098" alt="Screenshot 2026-08-19 at 10 51 21 AM" src="https://github.com/user-attachments/assets/cd43b3b6-f8ee-49f0-be29-2a49df9bc06e" />