### PR TITLE
feat: One Tap sign-ups — accept ToS + email opt-in on onboarding

### DIFF
--- a/src/Components/AuthDialog/Hooks/useCountryCode.ts
+++ b/src/Components/AuthDialog/Hooks/useCountryCode.ts
@@ -12,7 +12,14 @@ const USE_COUNTRY_CODE_QUERY = graphql`
   }
 `
 
-export const useCountryCode = () => {
+interface UseCountryCodeProps {
+  // By default the query is skipped for logged-in users (the auth dialog only
+  // needs it while signed out). Callers that need the country post-login — e.g.
+  // the post-signup email opt-in modal — can override this.
+  skip?: boolean
+}
+
+export const useCountryCode = ({ skip }: UseCountryCodeProps = {}) => {
   const { isLoggedIn } = useSystemContext()
 
   const { data, loading, error } = useClientQuery<useCountryCodeQuery>({
@@ -25,8 +32,7 @@ export const useCountryCode = () => {
         force: false,
       },
     },
-    // If the user is logged in, we don't need the country code
-    skip: isLoggedIn,
+    skip: skip ?? isLoggedIn,
   })
 
   const countryCode = data?.requestLocation?.countryCode

--- a/src/Components/AuthDialog/Hooks/useSocialAuthTracking.ts
+++ b/src/Components/AuthDialog/Hooks/useSocialAuthTracking.ts
@@ -1,5 +1,6 @@
 import type { AuthDialogAnalytics } from "Components/AuthDialog/AuthDialogContext"
 import { useAuthDialogTracking } from "Components/AuthDialog/Hooks/useAuthDialogTracking"
+import { markOneTapEmailOptInPending } from "Utils/oneTapEmailOptIn"
 import { useRouter } from "System/Hooks/useRouter"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import Cookies from "cookies-js"
@@ -63,6 +64,12 @@ export const useSocialAuthTracking = () => {
       const onboarding =
         new URLSearchParams(location.search).get("onboarding") === "true"
       track.signedUp({ ...params, onboarding })
+
+      // One Tap has no signup-time consent UI, so flag fresh One Tap sign-ups to
+      // show the email opt-in modal once onboarding is dismissed.
+      if (value.method === "one-tap") {
+        markOneTapEmailOptInPending()
+      }
     } else {
       track.loggedIn(params)
     }

--- a/src/Components/AuthDialog/Hooks/useSocialAuthTracking.ts
+++ b/src/Components/AuthDialog/Hooks/useSocialAuthTracking.ts
@@ -65,8 +65,8 @@ export const useSocialAuthTracking = () => {
         new URLSearchParams(location.search).get("onboarding") === "true"
       track.signedUp({ ...params, onboarding })
 
-      // One Tap has no signup-time consent UI, so flag fresh One Tap sign-ups to
-      // show the email opt-in modal once onboarding is dismissed.
+      // Flag fresh One Tap sign-ups so the onboarding welcome screen shows the
+      // email opt-in.
       if (value.method === "one-tap") {
         markOneTapEmailOptInPending()
       }

--- a/src/Components/Onboarding/Views/OnboardingWelcome.tsx
+++ b/src/Components/Onboarding/Views/OnboardingWelcome.tsx
@@ -12,7 +12,7 @@ import {
   clearOneTapEmailOptInPending,
   peekOneTapEmailOptInPending,
 } from "Utils/oneTapEmailOptIn"
-import { useEffect, useRef, useState } from "react"
+import { useState } from "react"
 
 export const OnboardingWelcome = () => {
   const { user } = useSystemContext()
@@ -32,19 +32,16 @@ export const OnboardingWelcome = () => {
 
   const { submitUpdateMyUserProfile } = useUpdateMyUserProfile()
 
-  const [agreedToReceiveEmails, setAgreedToReceiveEmails] = useState(false)
+  // Region default: preselected for non-GDPR, unchecked for GDPR. Derive the
+  // value so a manual toggle (userChoice) is never clobbered when the country
+  // query resolves.
+  const [userChoice, setUserChoice] = useState<boolean | null>(null)
+  const agreedToReceiveEmails = userChoice ?? isAutomaticallySubscribed
 
-  // Seed the checkbox from the region default (preselected for non-GDPR,
-  // unchecked for GDPR)
-  const initialized = useRef(false)
-  useEffect(() => {
-    if (!isOneTapSignup || isCountryLoading || initialized.current) {
-      return
-    }
-
-    setAgreedToReceiveEmails(isAutomaticallySubscribed)
-    initialized.current = true
-  }, [isOneTapSignup, isCountryLoading, isAutomaticallySubscribed])
+  // Don't let the user act on the opt-in before the region default is known:
+  // otherwise a fast click would persist the (unchecked) initial value and a
+  // non-GDPR user would silently miss the auto-subscribe default.
+  const isConsentPending = isOneTapSignup && isCountryLoading
 
   const persistEmailOptIn = () => {
     if (!isOneTapSignup) {
@@ -95,11 +92,11 @@ export const OnboardingWelcome = () => {
           <Spacer y={1} />
 
           <Box width="100%">
-            {isOneTapSignup && (
+            {isOneTapSignup && !isCountryLoading && (
               <>
                 <Checkbox
                   selected={agreedToReceiveEmails}
-                  onSelect={setAgreedToReceiveEmails}
+                  onSelect={setUserChoice}
                   data-testid="onboarding-email-optin"
                 >
                   <Text variant="xs">
@@ -114,7 +111,7 @@ export const OnboardingWelcome = () => {
             )}
 
             <Button
-              disabled={loading}
+              disabled={loading || isConsentPending}
               loading={loading}
               onClick={() => {
                 persistEmailOptIn()
@@ -130,9 +127,13 @@ export const OnboardingWelcome = () => {
               variant="tertiary"
               mt={1}
               width="100%"
+              disabled={isConsentPending}
               // @ts-ignore
               as={RouterLink}
               onClick={() => {
+                if (isConsentPending) {
+                  return
+                }
                 persistEmailOptIn()
                 onClose()
               }}

--- a/src/Components/Onboarding/Views/OnboardingWelcome.tsx
+++ b/src/Components/Onboarding/Views/OnboardingWelcome.tsx
@@ -24,8 +24,7 @@ export const OnboardingWelcome = () => {
   const tracking = useOnboardingTracking()
 
   // One Tap sign-ups have no consent UI at sign-up, so we surface the marketing
-  // email opt-in here. Other sign-up paths already captured a choice, so the
-  // checkbox is only shown for a pending One Tap sign-up.
+  // email opt-in here.
   const [isOneTapSignup] = useState(() => peekOneTapEmailOptInPending())
 
   const { isAutomaticallySubscribed, loading: isCountryLoading } =
@@ -36,8 +35,7 @@ export const OnboardingWelcome = () => {
   const [agreedToReceiveEmails, setAgreedToReceiveEmails] = useState(false)
 
   // Seed the checkbox from the region default (preselected for non-GDPR,
-  // unchecked for GDPR) once the country resolves, without clobbering a choice
-  // the user has already made.
+  // unchecked for GDPR)
   const initialized = useRef(false)
   useEffect(() => {
     if (!isOneTapSignup || isCountryLoading || initialized.current) {
@@ -53,8 +51,8 @@ export const OnboardingWelcome = () => {
       return
     }
 
-    // Consent is idempotent in Gravity (never cleared), so only write when
-    // opting in. Fire-and-forget so it never blocks leaving the welcome screen.
+    // Consent is never cleared in Gravity, only write when
+    // opting in.
     if (agreedToReceiveEmails) {
       submitUpdateMyUserProfile({ agreedToReceiveEmails: true }).catch(err => {
         console.error(

--- a/src/Components/Onboarding/Views/OnboardingWelcome.tsx
+++ b/src/Components/Onboarding/Views/OnboardingWelcome.tsx
@@ -14,9 +14,8 @@ import {
 } from "Utils/oneTapEmailOptIn"
 import { useEffect, useState } from "react"
 
-// Fallback so a slow/hung geo lookup can never block One Tap users from
-// leaving the welcome screen; after this we proceed with the GDPR-safe
-// (unchecked) default while still letting them opt in.
+// Fall back to the unchecked default if the geo lookup stalls, so users are
+// never blocked from proceeding.
 const GEO_LOOKUP_TIMEOUT_MS = 5000
 
 export const OnboardingWelcome = () => {
@@ -28,8 +27,7 @@ export const OnboardingWelcome = () => {
 
   const tracking = useOnboardingTracking()
 
-  // One Tap sign-ups have no consent UI at sign-up, so we surface the marketing
-  // email opt-in here.
+  // One Tap has no consent UI at sign-up, so we surface the opt-in here.
   const [isOneTapSignup] = useState(() => peekOneTapEmailOptInPending())
 
   const { isAutomaticallySubscribed, loading: isCountryLoading } =
@@ -37,14 +35,11 @@ export const OnboardingWelcome = () => {
 
   const { submitUpdateMyUserProfile } = useUpdateMyUserProfile()
 
-  // Region default: preselected for non-GDPR, unchecked for GDPR. Derive the
-  // value so a manual toggle (userChoice) is never clobbered when the country
-  // query resolves.
+  // Derived, not state+effect, so a manual toggle survives the geo lookup
+  // resolving. Falls back to unchecked until the region default is known.
   const [userChoice, setUserChoice] = useState<boolean | null>(null)
   const agreedToReceiveEmails = userChoice ?? isAutomaticallySubscribed
 
-  // Give up waiting on the geo lookup after a timeout so a slow/hung request
-  // can never strand the user on the welcome screen.
   const [hasGeoTimedOut, setHasGeoTimedOut] = useState(false)
   useEffect(() => {
     if (!isOneTapSignup) {
@@ -58,14 +53,10 @@ export const OnboardingWelcome = () => {
     return () => clearTimeout(timeout)
   }, [isOneTapSignup])
 
-  // Don't let the user act on the opt-in before the region default is known:
-  // otherwise a fast click would persist the (unchecked) initial value and a
-  // non-GDPR user would silently miss the auto-subscribe default. Once the geo
-  // lookup times out we stop blocking and fall back to the unchecked default.
+  // Block the CTA until the region default is known, else a fast click persists
+  // the wrong default.
   const isConsentPending = isOneTapSignup && isCountryLoading && !hasGeoTimedOut
 
-  // Show the opt-in once the region default is known — or once we've given up
-  // waiting for it.
   const showEmailOptIn = isOneTapSignup && (!isCountryLoading || hasGeoTimedOut)
 
   const persistEmailOptIn = () => {
@@ -73,8 +64,7 @@ export const OnboardingWelcome = () => {
       return
     }
 
-    // Consent is never cleared in Gravity, only write when
-    // opting in.
+    // Idempotent in Gravity; only write on opt-in.
     if (agreedToReceiveEmails) {
       submitUpdateMyUserProfile({ agreedToReceiveEmails: true }).catch(err => {
         console.error(

--- a/src/Components/Onboarding/Views/OnboardingWelcome.tsx
+++ b/src/Components/Onboarding/Views/OnboardingWelcome.tsx
@@ -1,4 +1,5 @@
-import { Box, Button, Flex, Spacer, Text } from "@artsy/palette"
+import { Box, Button, Checkbox, Flex, Spacer, Text } from "@artsy/palette"
+import { useCountryCode } from "Components/AuthDialog/Hooks/useCountryCode"
 import { OnboardingWelcomeAnimatedPanel } from "Components/Onboarding/Components/OnboardingWelcomeAnimatedPanel"
 import { useOnboardingContext } from "Components/Onboarding/Hooks/useOnboardingContext"
 import { useOnboardingFadeTransition } from "Components/Onboarding/Hooks/useOnboardingFadeTransition"
@@ -6,6 +7,12 @@ import { useOnboardingTracking } from "Components/Onboarding/Hooks/useOnboarding
 import { SplitLayout } from "Components/SplitLayout"
 import { RouterLink } from "System/Components/RouterLink"
 import { useSystemContext } from "System/Hooks/useSystemContext"
+import { useUpdateMyUserProfile } from "Utils/Hooks/Mutations/useUpdateMyUserProfile"
+import {
+  clearOneTapEmailOptInPending,
+  peekOneTapEmailOptInPending,
+} from "Utils/oneTapEmailOptIn"
+import { useEffect, useRef, useState } from "react"
 
 export const OnboardingWelcome = () => {
   const { user } = useSystemContext()
@@ -15,6 +22,50 @@ export const OnboardingWelcome = () => {
   })
 
   const tracking = useOnboardingTracking()
+
+  // One Tap sign-ups have no consent UI at sign-up, so we surface the marketing
+  // email opt-in here. Other sign-up paths already captured a choice, so the
+  // checkbox is only shown for a pending One Tap sign-up.
+  const [isOneTapSignup] = useState(() => peekOneTapEmailOptInPending())
+
+  const { isAutomaticallySubscribed, loading: isCountryLoading } =
+    useCountryCode({ skip: !isOneTapSignup })
+
+  const { submitUpdateMyUserProfile } = useUpdateMyUserProfile()
+
+  const [agreedToReceiveEmails, setAgreedToReceiveEmails] = useState(false)
+
+  // Seed the checkbox from the region default (preselected for non-GDPR,
+  // unchecked for GDPR) once the country resolves, without clobbering a choice
+  // the user has already made.
+  const initialized = useRef(false)
+  useEffect(() => {
+    if (!isOneTapSignup || isCountryLoading || initialized.current) {
+      return
+    }
+
+    setAgreedToReceiveEmails(isAutomaticallySubscribed)
+    initialized.current = true
+  }, [isOneTapSignup, isCountryLoading, isAutomaticallySubscribed])
+
+  const persistEmailOptIn = () => {
+    if (!isOneTapSignup) {
+      return
+    }
+
+    // Consent is idempotent in Gravity (never cleared), so only write when
+    // opting in. Fire-and-forget so it never blocks leaving the welcome screen.
+    if (agreedToReceiveEmails) {
+      submitUpdateMyUserProfile({ agreedToReceiveEmails: true }).catch(err => {
+        console.error(
+          "[OnboardingWelcome] Failed to save email preference",
+          err,
+        )
+      })
+    }
+
+    clearOneTapEmailOptInPending()
+  }
 
   return (
     <SplitLayout
@@ -46,10 +97,29 @@ export const OnboardingWelcome = () => {
           <Spacer y={1} />
 
           <Box width="100%">
+            {isOneTapSignup && (
+              <>
+                <Checkbox
+                  selected={agreedToReceiveEmails}
+                  onSelect={setAgreedToReceiveEmails}
+                  data-testid="onboarding-email-optin"
+                >
+                  <Text variant="xs">
+                    Subscribe to email to hear about our products, services,
+                    editorials, and other promotional content. Unsubscribe at
+                    any time.
+                  </Text>
+                </Checkbox>
+
+                <Spacer y={2} />
+              </>
+            )}
+
             <Button
               disabled={loading}
               loading={loading}
               onClick={() => {
+                persistEmailOptIn()
                 tracking.userStartedOnboarding()
                 handleNext()
               }}
@@ -64,7 +134,10 @@ export const OnboardingWelcome = () => {
               width="100%"
               // @ts-ignore
               as={RouterLink}
-              onClick={onClose}
+              onClick={() => {
+                persistEmailOptIn()
+                onClose()
+              }}
               data-test="onboarding-skip-button"
             >
               Skip

--- a/src/Components/Onboarding/Views/OnboardingWelcome.tsx
+++ b/src/Components/Onboarding/Views/OnboardingWelcome.tsx
@@ -12,7 +12,12 @@ import {
   clearOneTapEmailOptInPending,
   peekOneTapEmailOptInPending,
 } from "Utils/oneTapEmailOptIn"
-import { useState } from "react"
+import { useEffect, useState } from "react"
+
+// Fallback so a slow/hung geo lookup can never block One Tap users from
+// leaving the welcome screen; after this we proceed with the GDPR-safe
+// (unchecked) default while still letting them opt in.
+const GEO_LOOKUP_TIMEOUT_MS = 5000
 
 export const OnboardingWelcome = () => {
   const { user } = useSystemContext()
@@ -38,10 +43,30 @@ export const OnboardingWelcome = () => {
   const [userChoice, setUserChoice] = useState<boolean | null>(null)
   const agreedToReceiveEmails = userChoice ?? isAutomaticallySubscribed
 
+  // Give up waiting on the geo lookup after a timeout so a slow/hung request
+  // can never strand the user on the welcome screen.
+  const [hasGeoTimedOut, setHasGeoTimedOut] = useState(false)
+  useEffect(() => {
+    if (!isOneTapSignup) {
+      return
+    }
+
+    const timeout = setTimeout(() => {
+      setHasGeoTimedOut(true)
+    }, GEO_LOOKUP_TIMEOUT_MS)
+
+    return () => clearTimeout(timeout)
+  }, [isOneTapSignup])
+
   // Don't let the user act on the opt-in before the region default is known:
   // otherwise a fast click would persist the (unchecked) initial value and a
-  // non-GDPR user would silently miss the auto-subscribe default.
-  const isConsentPending = isOneTapSignup && isCountryLoading
+  // non-GDPR user would silently miss the auto-subscribe default. Once the geo
+  // lookup times out we stop blocking and fall back to the unchecked default.
+  const isConsentPending = isOneTapSignup && isCountryLoading && !hasGeoTimedOut
+
+  // Show the opt-in once the region default is known — or once we've given up
+  // waiting for it.
+  const showEmailOptIn = isOneTapSignup && (!isCountryLoading || hasGeoTimedOut)
 
   const persistEmailOptIn = () => {
     if (!isOneTapSignup) {
@@ -92,7 +117,7 @@ export const OnboardingWelcome = () => {
           <Spacer y={1} />
 
           <Box width="100%">
-            {isOneTapSignup && !isCountryLoading && (
+            {showEmailOptIn && (
               <>
                 <Checkbox
                   selected={agreedToReceiveEmails}

--- a/src/Components/Onboarding/Views/__tests__/OnboardingWelcome.jest.tsx
+++ b/src/Components/Onboarding/Views/__tests__/OnboardingWelcome.jest.tsx
@@ -1,0 +1,129 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { useCountryCode } from "Components/AuthDialog/Hooks/useCountryCode"
+import { OnboardingWelcome } from "Components/Onboarding/Views/OnboardingWelcome"
+import { useUpdateMyUserProfile } from "Utils/Hooks/Mutations/useUpdateMyUserProfile"
+import {
+  clearOneTapEmailOptInPending,
+  peekOneTapEmailOptInPending,
+} from "Utils/oneTapEmailOptIn"
+
+const mockNext = jest.fn()
+const mockOnClose = jest.fn()
+const mockHandleNext = jest.fn()
+
+jest.mock("System/Hooks/useSystemContext", () => ({
+  useSystemContext: () => ({ user: { name: "Ada" } }),
+}))
+jest.mock("Components/Onboarding/Hooks/useOnboardingContext", () => ({
+  useOnboardingContext: () => ({ next: mockNext, onClose: mockOnClose }),
+}))
+jest.mock("Components/Onboarding/Hooks/useOnboardingFadeTransition", () => ({
+  useOnboardingFadeTransition: () => ({
+    register: () => undefined,
+    handleNext: mockHandleNext,
+    loading: false,
+  }),
+}))
+jest.mock("Components/Onboarding/Hooks/useOnboardingTracking", () => ({
+  useOnboardingTracking: () => ({ userStartedOnboarding: jest.fn() }),
+}))
+jest.mock(
+  "Components/Onboarding/Components/OnboardingWelcomeAnimatedPanel",
+  () => ({
+    OnboardingWelcomeAnimatedPanel: () => null,
+  }),
+)
+jest.mock("Components/SplitLayout", () => ({
+  SplitLayout: ({ right }: { right: React.ReactNode }) => <div>{right}</div>,
+}))
+jest.mock("System/Components/RouterLink", () => ({
+  RouterLink: "a",
+}))
+jest.mock("Components/AuthDialog/Hooks/useCountryCode", () => ({
+  useCountryCode: jest.fn(),
+}))
+jest.mock("Utils/Hooks/Mutations/useUpdateMyUserProfile", () => ({
+  useUpdateMyUserProfile: jest.fn(),
+}))
+jest.mock("Utils/oneTapEmailOptIn", () => ({
+  peekOneTapEmailOptInPending: jest.fn(),
+  clearOneTapEmailOptInPending: jest.fn(),
+}))
+
+const mockUseCountryCode = useCountryCode as jest.Mock
+const mockUseUpdateMyUserProfile = useUpdateMyUserProfile as jest.Mock
+const mockPeek = peekOneTapEmailOptInPending as jest.Mock
+const mockClear = clearOneTapEmailOptInPending as jest.Mock
+const mockSubmit = jest.fn().mockResolvedValue({})
+
+describe("OnboardingWelcome email opt-in", () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockSubmit.mockResolvedValue({})
+    mockUseUpdateMyUserProfile.mockReturnValue({
+      submitUpdateMyUserProfile: mockSubmit,
+    })
+    mockUseCountryCode.mockReturnValue({
+      isAutomaticallySubscribed: true,
+      loading: false,
+    })
+  })
+
+  const checkbox = () =>
+    screen.getByTestId("onboarding-email-optin") as HTMLInputElement
+
+  it("does not show the checkbox for non One Tap sign-ups", () => {
+    mockPeek.mockReturnValue(false)
+    render(<OnboardingWelcome />)
+    expect(screen.queryByTestId("onboarding-email-optin")).toBeNull()
+  })
+
+  it("shows the checkbox for a pending One Tap sign-up", () => {
+    mockPeek.mockReturnValue(true)
+    render(<OnboardingWelcome />)
+    expect(screen.getByTestId("onboarding-email-optin")).toBeInTheDocument()
+  })
+
+  it("preselects for non-GDPR and leaves unchecked for GDPR", () => {
+    mockPeek.mockReturnValue(true)
+
+    const { unmount } = render(<OnboardingWelcome />)
+    expect(checkbox()).toBeChecked()
+    unmount()
+
+    mockUseCountryCode.mockReturnValue({
+      isAutomaticallySubscribed: false,
+      loading: false,
+    })
+    render(<OnboardingWelcome />)
+    expect(checkbox()).not.toBeChecked()
+  })
+
+  it("writes consent and clears the flag on Get Started when checked", async () => {
+    mockPeek.mockReturnValue(true)
+    render(<OnboardingWelcome />)
+
+    fireEvent.click(screen.getByText("Get Started"))
+
+    await waitFor(() => {
+      expect(mockSubmit).toHaveBeenCalledWith({ agreedToReceiveEmails: true })
+    })
+    expect(mockClear).toHaveBeenCalled()
+    expect(mockHandleNext).toHaveBeenCalled()
+  })
+
+  it("clears the flag and skips the write on Skip when unchecked", async () => {
+    mockPeek.mockReturnValue(true)
+    mockUseCountryCode.mockReturnValue({
+      isAutomaticallySubscribed: false,
+      loading: false,
+    })
+    render(<OnboardingWelcome />)
+
+    fireEvent.click(screen.getByText("Skip"))
+
+    expect(mockSubmit).not.toHaveBeenCalled()
+    expect(mockClear).toHaveBeenCalled()
+    expect(mockOnClose).toHaveBeenCalled()
+  })
+})

--- a/src/Components/Onboarding/Views/__tests__/OnboardingWelcome.jest.tsx
+++ b/src/Components/Onboarding/Views/__tests__/OnboardingWelcome.jest.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { useCountryCode } from "Components/AuthDialog/Hooks/useCountryCode"
 import { OnboardingWelcome } from "Components/Onboarding/Views/OnboardingWelcome"
 import { useUpdateMyUserProfile } from "Utils/Hooks/Mutations/useUpdateMyUserProfile"
@@ -111,6 +111,38 @@ describe("OnboardingWelcome email opt-in", () => {
     expect(mockSubmit).not.toHaveBeenCalled()
     expect(mockClear).not.toHaveBeenCalled()
     expect(mockHandleNext).not.toHaveBeenCalled()
+  })
+
+  it("falls back to the unchecked default and unblocks if the geo lookup hangs", () => {
+    jest.useFakeTimers()
+    mockPeek.mockReturnValue(true)
+    mockUseCountryCode.mockReturnValue({
+      isAutomaticallySubscribed: false,
+      loading: true,
+    })
+
+    render(<OnboardingWelcome />)
+
+    // Blocked while the lookup is in flight.
+    expect(screen.queryByTestId("onboarding-email-optin")).toBeNull()
+    expect(screen.getByRole("button", { name: "Get Started" })).toBeDisabled()
+
+    // After the timeout, the opt-in appears (unchecked) and the user can proceed.
+    act(() => {
+      jest.advanceTimersByTime(5000)
+    })
+
+    expect(checkbox()).not.toBeChecked()
+    expect(
+      screen.getByRole("button", { name: "Get Started" }),
+    ).not.toBeDisabled()
+
+    fireEvent.click(screen.getByText("Get Started"))
+    expect(mockClear).toHaveBeenCalled()
+    expect(mockHandleNext).toHaveBeenCalled()
+    expect(mockSubmit).not.toHaveBeenCalled()
+
+    jest.useRealTimers()
   })
 
   it("preselects for non-GDPR and leaves unchecked for GDPR", () => {

--- a/src/Components/Onboarding/Views/__tests__/OnboardingWelcome.jest.tsx
+++ b/src/Components/Onboarding/Views/__tests__/OnboardingWelcome.jest.tsx
@@ -84,6 +84,35 @@ describe("OnboardingWelcome email opt-in", () => {
     expect(screen.getByTestId("onboarding-email-optin")).toBeInTheDocument()
   })
 
+  it("hides the checkbox and disables Get Started while the country is loading", () => {
+    mockPeek.mockReturnValue(true)
+    mockUseCountryCode.mockReturnValue({
+      isAutomaticallySubscribed: false,
+      loading: true,
+    })
+
+    render(<OnboardingWelcome />)
+
+    expect(screen.queryByTestId("onboarding-email-optin")).toBeNull()
+    expect(screen.getByRole("button", { name: "Get Started" })).toBeDisabled()
+  })
+
+  it("does not persist a premature default if Get Started is somehow clicked while loading", () => {
+    mockPeek.mockReturnValue(true)
+    mockUseCountryCode.mockReturnValue({
+      isAutomaticallySubscribed: false,
+      loading: true,
+    })
+
+    render(<OnboardingWelcome />)
+
+    fireEvent.click(screen.getByText("Get Started"))
+
+    expect(mockSubmit).not.toHaveBeenCalled()
+    expect(mockClear).not.toHaveBeenCalled()
+    expect(mockHandleNext).not.toHaveBeenCalled()
+  })
+
   it("preselects for non-GDPR and leaves unchecked for GDPR", () => {
     mockPeek.mockReturnValue(true)
 

--- a/src/Server/passport/lib/app/__tests__/lifecycle.jest.ts
+++ b/src/Server/passport/lib/app/__tests__/lifecycle.jest.ts
@@ -494,6 +494,16 @@ describe("lifecycle", () => {
         expect(req.session.redirectTo).toBe("/collect")
       })
 
+      it("accepts terms of service (shown natively in the One Tap prompt)", () => {
+        lifecycle.afterSocialAuth("google", "one-tap")(req, res, next)
+        expect(req.session.accepted_terms_of_service).toBe("true")
+      })
+
+      it("does not set marketing email consent (collected post-signup)", () => {
+        lifecycle.afterSocialAuth("google", "one-tap")(req, res, next)
+        expect(req.session.agreed_to_receive_emails).toBeUndefined()
+      })
+
       it("sets the suppress cookie on auth error", () => {
         passport.authenticate.mockReturnValueOnce((_req, _res, next) =>
           next(new Error("auth error")),

--- a/src/Server/passport/lib/app/lifecycle.ts
+++ b/src/Server/passport/lib/app/lifecycle.ts
@@ -256,10 +256,15 @@ export const afterSocialAuth =
     const isOneTap = provider === "google" && mode === "one-tap"
     const strategyName = isOneTap ? "google-one-tap" : provider
 
-    // One-tap has no beforeSocialAuth step to capture redirect-to, so fall back
-    // to the Referer header to return the user to the page they were on.
-    if (isOneTap && !req.session.redirectTo && req.headers?.referer) {
-      req.session.redirectTo = req.headers.referer
+    if (isOneTap) {
+      if (!req.session.redirectTo && req.headers?.referer) {
+        req.session.redirectTo = req.headers.referer
+      }
+      // One-tap has no beforeSocialAuth step to carry these params. Terms are
+      // accepted here because Google renders our Terms of Service link in the
+      // One Tap prompt itself. Marketing email consent is intentionally NOT set
+      // — it's collected post-signup via an explicit opt-in (GDPR-aware).
+      req.session.accepted_terms_of_service = "true"
     }
 
     if (req.query.denied) {

--- a/src/Server/passport/lib/app/lifecycle.ts
+++ b/src/Server/passport/lib/app/lifecycle.ts
@@ -260,10 +260,8 @@ export const afterSocialAuth =
       if (!req.session.redirectTo && req.headers?.referer) {
         req.session.redirectTo = req.headers.referer
       }
-      // One-tap has no beforeSocialAuth step to carry these params. Terms are
-      // accepted here because Google renders our Terms of Service link in the
-      // One Tap prompt itself. Marketing email consent is intentionally NOT set
-      // — it's collected post-signup via an explicit opt-in (GDPR-aware).
+      // One-tap has no beforeSocialAuth step so terms are
+      // accepted here, shown in oauth flow.
       req.session.accepted_terms_of_service = "true"
     }
 

--- a/src/Utils/oneTapEmailOptIn.ts
+++ b/src/Utils/oneTapEmailOptIn.ts
@@ -1,0 +1,39 @@
+const PENDING_KEY = "one-tap-welcome-email-pending"
+
+/**
+ * Records that the current session is a fresh Google One Tap sign-up. One Tap
+ * has no sign-up-time consent UI (unlike the auth dialog), so we surface the
+ * marketing-email opt-in on the onboarding welcome screen instead. Set when the
+ * post-signup tracking cookie is read; peeked/cleared during onboarding.
+ */
+export const markOneTapEmailOptInPending = (): void => {
+  try {
+    sessionStorage.setItem(PENDING_KEY, "1")
+  } catch {
+    // sessionStorage can be unavailable (SSR, privacy modes); safe to ignore.
+  }
+}
+
+/**
+ * Returns whether a One Tap email opt-in is pending, without clearing it, so the
+ * onboarding welcome screen can decide whether to render the opt-in checkbox.
+ */
+export const peekOneTapEmailOptInPending = (): boolean => {
+  try {
+    return sessionStorage.getItem(PENDING_KEY) === "1"
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Clears the pending flag once the user has acted on the opt-in (or dismissed
+ * the welcome screen), so it is only ever shown a single time.
+ */
+export const clearOneTapEmailOptInPending = (): void => {
+  try {
+    sessionStorage.removeItem(PENDING_KEY)
+  } catch {
+    // Safe to ignore — see markOneTapEmailOptInPending.
+  }
+}

--- a/src/Utils/oneTapEmailOptIn.ts
+++ b/src/Utils/oneTapEmailOptIn.ts
@@ -1,23 +1,15 @@
+// One Tap has no consent UI at sign-up, so we flag the fresh sign-up here and
+// carry it to the onboarding welcome screen where the opt-in is shown.
 const PENDING_KEY = "one-tap-welcome-email-pending"
 
-/**
- * Records that the current session is a fresh Google One Tap sign-up. One Tap
- * has no sign-up-time consent UI (unlike the auth dialog), so we surface the
- * marketing-email opt-in on the onboarding welcome screen instead. Set when the
- * post-signup tracking cookie is read; peeked/cleared during onboarding.
- */
 export const markOneTapEmailOptInPending = (): void => {
   try {
     sessionStorage.setItem(PENDING_KEY, "1")
   } catch {
-    // sessionStorage can be unavailable (SSR, privacy modes); safe to ignore.
+    // sessionStorage can be unavailable (SSR, privacy modes).
   }
 }
 
-/**
- * Returns whether a One Tap email opt-in is pending, without clearing it, so the
- * onboarding welcome screen can decide whether to render the opt-in checkbox.
- */
 export const peekOneTapEmailOptInPending = (): boolean => {
   try {
     return sessionStorage.getItem(PENDING_KEY) === "1"
@@ -26,14 +18,10 @@ export const peekOneTapEmailOptInPending = (): boolean => {
   }
 }
 
-/**
- * Clears the pending flag once the user has acted on the opt-in (or dismissed
- * the welcome screen), so it is only ever shown a single time.
- */
 export const clearOneTapEmailOptInPending = (): void => {
   try {
     sessionStorage.removeItem(PENDING_KEY)
   } catch {
-    // Safe to ignore — see markOneTapEmailOptInPending.
+    // sessionStorage can be unavailable (SSR, privacy modes).
   }
 }


### PR DESCRIPTION
## Description

Adds proper consent capture for Google One Tap sign-ups, which (unlike the standard auth dialog) have no sign-up-time consent UI.

- **Terms of service:** the One Tap server callback now records `accepted_terms_of_service` (Google renders our ToS link natively in the One Tap prompt).
- **Marketing email:** collected *after* signup via an opt-in checkbox on the onboarding **welcome** screen — shown for One Tap sign-ups only (other paths already capture a choice). Region-aware default: preselected for non-GDPR, unchecked for GDPR. Both **Get Started** and **Skip** persist the choice via `updateMyUserProfile`.

<img width="384" height="333" alt="Screenshot 2026-08-20 at 10 25 07 AM" src="https://github.com/user-attachments/assets/88e534ab-5718-42fc-8463-7a161eb0db6c" />





## Notes

- Depends on Metaphysics [artsy/metaphysics#7829](https://github.com/artsy/metaphysics/pull/7829) (`agreedToReceiveEmails` on `updateMyUserProfile`), already merged + in the committed schema.
- `agreed_to_receive_emails_at` is the master Braze gate (idempotent, never cleared); setting it auto-enrolls default subscription groups.
- Clean-history rebuild of `brian/one-tap-email-opt-in`.

## Tests

65 passing across onboarding welcome, lifecycle, and social-auth tracking; type-check + lint clean.