### PR TITLE
fix: trending searches alignment

### DIFF
--- a/src/Components/Search/TrendingSearches/Components/TrendingArtworkCard.tsx
+++ b/src/Components/Search/TrendingSearches/Components/TrendingArtworkCard.tsx
@@ -1,14 +1,16 @@
-import { Box, Image, Text } from "@artsy/palette"
-import styled from "styled-components"
 import { ContextModule } from "@artsy/cohesion"
+import { Box, Image, Text } from "@artsy/palette"
 import { SaveButtonFragmentContainer } from "Components/Artwork/SaveButton/SaveButton"
 import { RouterLink } from "System/Components/RouterLink"
 import type { TrendingSearchesQuery } from "__generated__/TrendingSearchesQuery.graphql"
 import type { FC, MouseEvent } from "react"
+import styled from "styled-components"
 
 export type TrendingArtworkNode = NonNullable<
   NonNullable<
-    TrendingSearchesQuery["response"]["searchDropdown"]["oneDay"]["artworks"]
+    NonNullable<
+      TrendingSearchesQuery["response"]["searchDropdown"]["oneDay"]
+    >["artworks"]
   >[number]["artwork"]
 >
 

--- a/src/Components/Search/TrendingSearches/TrendingSearches.tsx
+++ b/src/Components/Search/TrendingSearches/TrendingSearches.tsx
@@ -59,8 +59,9 @@ const TRENDING_WINDOWS = [
   { key: "thirtyDays", fallbackLabel: "Past 30 Days" },
 ] as const
 
-type TrendingWindowData =
+type TrendingWindowData = NonNullable<
   TrendingSearchesQuery["response"]["searchDropdown"]["oneDay"]
+>
 
 type TrendingArtistNode = NonNullable<
   NonNullable<TrendingWindowData["artists"]>[number]["artist"]

--- a/src/Components/Search/TrendingSearches/TrendingSearches.tsx
+++ b/src/Components/Search/TrendingSearches/TrendingSearches.tsx
@@ -1,3 +1,11 @@
+import {
+  ActionType,
+  type ClickedArtistGroup,
+  ContextModule,
+  OwnerType,
+  type RailViewed,
+  type SelectedItemFromSearch,
+} from "@artsy/cohesion"
 import CloseIcon from "@artsy/icons/CloseIcon"
 import {
   Box,
@@ -9,19 +17,16 @@ import {
   Text,
   useResizeObserver,
 } from "@artsy/palette"
+import { themeGet } from "@styled-system/theme-get"
 import {
-  ActionType,
-  type ClickedArtistGroup,
-  ContextModule,
-  OwnerType,
-  type RailViewed,
-  type SelectedItemFromSearch,
-} from "@artsy/cohesion"
-import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
-import { useTracking } from "react-tracking"
+  type RecentSearch,
+  useRecentSearches,
+} from "Components/Search/hooks/useRecentSearches"
+import { isModifiedClick } from "Components/Search/utils/isModifiedClick"
 import { RouterLink } from "System/Components/RouterLink"
-import { trackHelpers } from "Utils/cohesionHelpers"
+import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
 import { useClientQuery } from "Utils/Hooks/useClientQuery"
+import { trackHelpers } from "Utils/cohesionHelpers"
 import type { TrendingSearchesQuery } from "__generated__/TrendingSearchesQuery.graphql"
 import {
   type FC,
@@ -32,13 +37,8 @@ import {
   useState,
 } from "react"
 import { graphql } from "react-relay"
+import { useTracking } from "react-tracking"
 import styled from "styled-components"
-import { themeGet } from "@styled-system/theme-get"
-import {
-  type RecentSearch,
-  useRecentSearches,
-} from "Components/Search/hooks/useRecentSearches"
-import { isModifiedClick } from "Components/Search/utils/isModifiedClick"
 import { TrendingArtworkCard } from "./Components/TrendingArtworkCard"
 
 interface TrendingSearchesProps {
@@ -340,7 +340,7 @@ export const TrendingSearches: FC<TrendingSearchesProps> = ({
 
           <ScrollRail
             contentKey={`artworks-${activeIndex}`}
-            alignItems="flex-end"
+            alignItems="flex-start"
           >
             {artworks.map((artwork, index) => {
               return (

--- a/src/__generated__/TrendingSearchesQuery.graphql.ts
+++ b/src/__generated__/TrendingSearchesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<388cd8b91d190d314ec1f9a6b3c44263>>
+ * @generated SignedSource<<24414eed4db28ae83957d81fb62e7303>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -57,7 +57,7 @@ export type TrendingSearchesQuery$data = {
         readonly internalID: string;
       }> | null | undefined;
       readonly label: string;
-    };
+    } | null | undefined;
     readonly sevenDays: {
       readonly artists: ReadonlyArray<{
         readonly artist: {
@@ -102,7 +102,7 @@ export type TrendingSearchesQuery$data = {
         readonly internalID: string;
       }> | null | undefined;
       readonly label: string;
-    };
+    } | null | undefined;
     readonly thirtyDays: {
       readonly artists: ReadonlyArray<{
         readonly artist: {
@@ -147,7 +147,7 @@ export type TrendingSearchesQuery$data = {
         readonly internalID: string;
       }> | null | undefined;
       readonly label: string;
-    };
+    } | null | undefined;
   };
 };
 export type TrendingSearchesQuery = {


### PR DESCRIPTION
The type of this PR is: **Fix**

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

### Description

Alignment of artwork cards in trending search. See before/after in video.
Rest of changes are related to https://github.com/artsy/force/pull/17575/changes

https://github.com/user-attachments/assets/d3d75135-db6c-424a-bb4a-0b15d395bf48


