### PR TITLE
feat(articles): intercept non-artsy.net links and open them in a new window

### DIFF
--- a/src/Apps/Article/Components/ArticleHTML.tsx
+++ b/src/Apps/Article/Components/ArticleHTML.tsx
@@ -39,17 +39,24 @@ export const ArticleHTML: FC<ArticleHTMLProps> = ({ children, ...rest }) => {
 
 /**
  * Looks for links and if they are internal and a supported entity type,
- * inserts the relevant tooltip.
+ * inserts the relevant tooltip. If they are external, open them in a
+ * new window
  */
 const transformNode = (node: Element, i: number) => {
   if (node.tagName !== "A") return
 
-  const { href } = node as HTMLAnchorElement
+  const anchor = node as HTMLAnchorElement
 
   try {
-    const uri = new URL(href)
+    const uri = new URL(anchor.href)
+    const isExternalLink = !uri.hostname.includes("artsy.net")
+    anchor.dataset.linkChecked = "true" // convenience for testing
 
-    if (!uri.hostname.includes("artsy.net")) return
+    if (isExternalLink) {
+      anchor.target = "_blank"
+      anchor.rel = "noopener"
+      return
+    }
 
     const [_, entity, id] = uri.pathname.split("/")
 
@@ -66,7 +73,7 @@ const transformNode = (node: Element, i: number) => {
     if (isArtistHeading) {
       return (
         <Flex alignItems="center" gap={1} key={[i, id].join("-")}>
-          <ArticleTooltip entity={entity} id={id} href={href}>
+          <ArticleTooltip entity={entity} id={id} href={anchor.href}>
             {node.textContent}
           </ArticleTooltip>
 
@@ -82,7 +89,7 @@ const transformNode = (node: Element, i: number) => {
     if (isPartnerHeading) {
       return (
         <Flex alignItems="center" gap={1} key={[i, id].join("-")}>
-          <ArticleTooltip entity={entity} id={id} href={href}>
+          <ArticleTooltip entity={entity} id={id} href={anchor.href}>
             {node.textContent}
           </ArticleTooltip>
 
@@ -100,7 +107,7 @@ const transformNode = (node: Element, i: number) => {
         key={[i, id].join("-")}
         entity={entity}
         id={id}
-        href={href}
+        href={anchor.href}
       >
         {node.textContent}
       </ArticleTooltip>

--- a/src/Apps/Article/Components/__tests__/ArticleHTML.jest.tsx
+++ b/src/Apps/Article/Components/__tests__/ArticleHTML.jest.tsx
@@ -1,0 +1,88 @@
+import { render, screen, waitFor } from "@testing-library/react"
+import { ArticleHTML } from "Apps/Article/Components/ArticleHTML"
+
+/**
+ * Helper method that asserts the link has _actually_ been checked and possibly
+ * transformed.
+ *
+ * Without this assertion, some tests below give false red or green
+ * because `expect toHaveAttribute` assertions are _2 Fast 2 Spurious_,
+ * due to the odd lifecycle of `ArticleHTML`.
+ *
+ * See `ArticleHTML`’s dynamic import of `@artsy/react-html-parser`, and its
+ * initial use of `dangerouslySetInnerHTML` which allows `screen.getByRole("link")`
+ * to return an element _before_ the transformation has taken place
+ */
+async function assertLinkHasBeenChecked() {
+  let link: HTMLAnchorElement | undefined
+
+  await waitFor(() => {
+    link = screen.getByRole<HTMLAnchorElement>("link")
+    expect(link).toHaveAttribute("data-link-checked", "true")
+  })
+
+  return link
+}
+
+describe("ArticleHTML", () => {
+  describe("external links", () => {
+    it("opens them in a new window", async () => {
+      render(
+        <ArticleHTML>
+          {`<p>
+            <a href="https://example.com/story">
+              Example
+            </a>
+          </p>`}
+        </ArticleHTML>,
+      )
+
+      const link = await assertLinkHasBeenChecked()
+      expect(link).toHaveAttribute("target", "_blank")
+      expect(link).toHaveAttribute("rel", "noopener")
+    })
+  })
+
+  describe("internal links", () => {
+    it("leaves them in the same window", async () => {
+      render(
+        <ArticleHTML>
+          {`<p>
+            <a href="https://www.artsy.net/collect">
+              Collect
+            </a>
+          </p>`}
+        </ArticleHTML>,
+      )
+
+      const link = await assertLinkHasBeenChecked()
+      expect(link).not.toHaveAttribute("target")
+      expect(link).not.toHaveAttribute("rel")
+    })
+
+    it("wraps supported entities in a tooltip", async () => {
+      render(
+        <ArticleHTML>
+          {`<p>
+            <a href="https://www.artsy.net/artist/andy-warhol">
+              Andy Warhol
+            </a>
+          </p>`}
+        </ArticleHTML>,
+      )
+
+      let link: HTMLAnchorElement | undefined
+
+      await waitFor(() => {
+        link = screen.getByRole<HTMLAnchorElement>("link")
+        expect(link.parentNode).toHaveClass(/EntityTooltip/)
+      })
+    })
+  })
+
+  it("renders non-anchor markup unchanged", async () => {
+    render(<ArticleHTML>{"<p>Just text</p>"}</ArticleHTML>)
+
+    expect(screen.getByText("Just text")).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
The type of this PR is: **Feat**

This PR solves [DI-556](https://www.notion.so/3bccab0764a081cea2e0c580aafef2c6)

### Description

Previously editorial articles containing links to external (non-artsy.net) domains would open in the same window or tab, thus shunting people off platform.

This change intercepts external links in article HTML and decorates them with `target=_blank rel=noopener` to safely open them in a separate window or tab.

(Adds previously missing test coverage as well.)

Screencap below demonstrates:

- internal links still open in the same winodw
- internal links for eligible entities (artists, partners, genes) still get the rich tooltip behavior
- external links now open in separate window/tab

<img width="742" height="720" alt="links10 50" src="https://github.com/user-attachments/assets/ab29edca-7a89-4d05-b6c5-7022badb618c" />



cc @artsy/diamond-devs 

Assisted-by: Claude:Sonnet-5 