### PR TITLE
fix(search): reflect save state on trending artwork hearts

### DIFF
--- a/src/Components/Search/Mobile/Overlay.tsx
+++ b/src/Components/Search/Mobile/Overlay.tsx
@@ -4,20 +4,21 @@ import { useFlag } from "@unleash/proxy-client-react"
 import { type FC, useCallback, useEffect, useRef, useState } from "react"
 
 import { ActionType } from "@artsy/cohesion"
+import { ManageArtworkForSavesProvider } from "Components/Artwork/ManageArtworkForSaves"
 import {
   OVERLAY_CONTENT_ID,
   OverlayBase,
 } from "Components/Search/Mobile/OverlayBase"
 import { SearchInputPillsFragmentContainer } from "Components/Search/SearchInputPills"
+import { TrendingSearches } from "Components/Search/TrendingSearches/TrendingSearches"
 import {
   type PillType,
   SEARCH_DEBOUNCE_DELAY,
   TOP_PILL,
 } from "Components/Search/constants"
+import { useTrendingImpressionSession } from "Components/Search/hooks/useTrendingImpressionSession"
 import { reportPerformanceMeasurement } from "Components/Search/utils/reportPerformanceMeasurement"
 import { shouldStartSearching } from "Components/Search/utils/shouldStartSearching"
-import { TrendingSearches } from "Components/Search/TrendingSearches/TrendingSearches"
-import { useTrendingImpressionSession } from "Components/Search/hooks/useTrendingImpressionSession"
 import createLogger from "Utils/logger"
 import type { Overlay_viewer$data } from "__generated__/Overlay_viewer.graphql"
 import {
@@ -123,50 +124,55 @@ export const Overlay: FC<React.PropsWithChildren<OverlayProps>> = ({
     isSessionActive: true,
   })
 
+  // Hosts the save-to-lists state, modal, and toast action used by the
+  // trending panel's artwork save buttons (kept above the trending panel so
+  // the modal survives the panel swapping out when the user starts typing).
   return (
-    <OverlayBase
-      onClose={onClose}
-      header={
-        <>
-          <Box mt={-15}>
-            <LabeledInput
-              mx={2}
-              ref={inputCallbackRef}
-              value={inputValue}
-              placeholder="Search Artsy"
-              label={<SearchIcon fill="mono60" aria-hidden size={18} />}
-              onChange={handleValueChange}
-            />
-          </Box>
+    <ManageArtworkForSavesProvider>
+      <OverlayBase
+        onClose={onClose}
+        header={
+          <>
+            <Box mt={-15}>
+              <LabeledInput
+                mx={2}
+                ref={inputCallbackRef}
+                value={inputValue}
+                placeholder="Search Artsy"
+                label={<SearchIcon fill="mono60" aria-hidden size={18} />}
+                onChange={handleValueChange}
+              />
+            </Box>
 
-          {shouldStartSearching(inputValue) && (
-            <SearchInputPillsFragmentContainer
-              onPillClick={handlePillClick}
-              viewer={viewer}
-              selectedPill={selectedPill}
-              enableChevronNavigation={false}
-              forceDisabled={disablePills}
-            />
-          )}
-        </>
-      }
-    >
-      {shouldStartSearching(inputValue) ? (
-        <SearchResultsListPaginationContainer
-          viewer={viewer}
-          query={inputValue}
-          selectedPill={selectedPill}
-          onClose={onClose}
-        />
-      ) : (
-        isTrendingEnabled && (
-          <TrendingSearches
-            onNavigate={onClose}
-            shouldTrackImpressions={shouldTrackTrendingImpressions}
+            {shouldStartSearching(inputValue) && (
+              <SearchInputPillsFragmentContainer
+                onPillClick={handlePillClick}
+                viewer={viewer}
+                selectedPill={selectedPill}
+                enableChevronNavigation={false}
+                forceDisabled={disablePills}
+              />
+            )}
+          </>
+        }
+      >
+        {shouldStartSearching(inputValue) ? (
+          <SearchResultsListPaginationContainer
+            viewer={viewer}
+            query={inputValue}
+            selectedPill={selectedPill}
+            onClose={onClose}
           />
-        )
-      )}
-    </OverlayBase>
+        ) : (
+          isTrendingEnabled && (
+            <TrendingSearches
+              onNavigate={onClose}
+              shouldTrackImpressions={shouldTrackTrendingImpressions}
+            />
+          )
+        )}
+      </OverlayBase>
+    </ManageArtworkForSavesProvider>
   )
 }
 

--- a/src/Components/Search/SearchBarInput.tsx
+++ b/src/Components/Search/SearchBarInput.tsx
@@ -1,4 +1,5 @@
 import { AutocompleteInput, Box, useDidMount } from "@artsy/palette"
+import { themeGet } from "@styled-system/theme-get"
 import { useFlag } from "@unleash/proxy-client-react"
 import {
   type ChangeEvent,
@@ -10,7 +11,6 @@ import {
   useState,
 } from "react"
 import styled from "styled-components"
-import { themeGet } from "@styled-system/theme-get"
 
 import {
   ActionType,
@@ -19,6 +19,7 @@ import {
   type SelectedItemFromSearch,
 } from "@artsy/cohesion"
 import { Z } from "Apps/Components/constants"
+import { ManageArtworkForSavesProvider } from "Components/Artwork/ManageArtworkForSaves"
 import { DESKTOP_NAV_BAR_TOP_TIER_HEIGHT } from "Components/NavBar/constants"
 import { useAnalyticsContext } from "System/Hooks/useAnalyticsContext"
 import { useRouter } from "System/Hooks/useRouter"
@@ -39,9 +40,9 @@ import {
   type SuggestionItemOptionProps,
 } from "./SuggestionItem/SuggestionItem"
 import { TrendingSearches } from "./TrendingSearches/TrendingSearches"
+import { type PillType, SEARCH_DEBOUNCE_DELAY, TOP_PILL } from "./constants"
 import { useRecentSearches } from "./hooks/useRecentSearches"
 import { useTrendingImpressionSession } from "./hooks/useTrendingImpressionSession"
-import { type PillType, SEARCH_DEBOUNCE_DELAY, TOP_PILL } from "./constants"
 import { getLabel } from "./utils/getLabel"
 import { isModifiedClick } from "./utils/isModifiedClick"
 import { searchResultsHref } from "./utils/searchResultsHref"
@@ -388,89 +389,96 @@ export const SearchBarInput: FC<
   }
 
   return (
-    <Box
-      position="relative"
-      onBlur={handleContainerBlur}
-      onKeyDown={handleContainerKeyDown}
-    >
-      <AutocompleteInput
-        forwardRef={ref}
-        key={match.location.pathname}
-        value={value}
-        placeholder="Search by artist, gallery, style, theme, tag, etc."
-        spellCheck={false}
-        options={shouldStartSearching(value) ? formattedOptions : []}
-        defaultValue={value}
-        onChange={handleChange}
-        onClear={resetValue}
-        onSelect={handleSelect}
-        onSubmit={handleSubmit}
-        onFocus={handleFocus}
-        onPaste={handlePaste}
-        header={
-          data?.viewer ? (
-            <SearchInputPillsFragmentContainer
-              viewer={data.viewer}
-              selectedPill={selectedPill}
-              onPillClick={handlePillClick}
-            />
-          ) : null
-        }
-        renderOption={option => {
-          if (!value) return <></>
-
-          if (option.typename === "Footer") {
-            return (
-              <SearchBarFooter
-                query={value}
-                href={encodedSearchURL}
+    // Hosts the save-to-lists state, modal, and toast action used by the
+    // trending panel's artwork save buttons. Mounted here, OUTSIDE the panel,
+    // because the panel unmounts on blur the moment the lists modal (or the
+    // toast's "Add to a List" action) takes focus — a provider inside the
+    // panel would take the modal down with it.
+    <ManageArtworkForSavesProvider>
+      <Box
+        position="relative"
+        onBlur={handleContainerBlur}
+        onKeyDown={handleContainerKeyDown}
+      >
+        <AutocompleteInput
+          forwardRef={ref}
+          key={match.location.pathname}
+          value={value}
+          placeholder="Search by artist, gallery, style, theme, tag, etc."
+          spellCheck={false}
+          options={shouldStartSearching(value) ? formattedOptions : []}
+          defaultValue={value}
+          onChange={handleChange}
+          onClear={resetValue}
+          onSelect={handleSelect}
+          onSubmit={handleSubmit}
+          onFocus={handleFocus}
+          onPaste={handlePaste}
+          header={
+            data?.viewer ? (
+              <SearchInputPillsFragmentContainer
+                viewer={data.viewer}
                 selectedPill={selectedPill}
+                onPillClick={handlePillClick}
+              />
+            ) : null
+          }
+          renderOption={option => {
+            if (!value) return <></>
+
+            if (option.typename === "Footer") {
+              return (
+                <SearchBarFooter
+                  query={value}
+                  href={encodedSearchURL}
+                  selectedPill={selectedPill}
+                />
+              )
+            }
+
+            return (
+              <SuggestionItem
+                query={value}
+                option={option}
+                onClick={handleSuggestionClick}
+                onQuickNavClick={handleQuickNavClick}
               />
             )
-          }
+          }}
+          dropdownMaxHeight={SEARCH_DROPDOWN_MAX_HEIGHT}
+          dropdownMinWidth={SEARCH_DROPDOWN_MIN_WIDTH}
+          flip={false}
+          height={40}
+        />
 
-          return (
-            <SuggestionItem
-              query={value}
-              option={option}
-              onClick={handleSuggestionClick}
-              onQuickNavClick={handleQuickNavClick}
+        {isTrendingVisible && (
+          <TrendingPanel
+            position="absolute"
+            // Mirrors the results dropdown exactly (same anchor, offset, width,
+            // min-width, and shadow) so trending and autosuggest read as one
+            // overlay swapping content rather than two differently-sized surfaces.
+            top="calc(100% + 10px)"
+            left={0}
+            width="100%"
+            minWidth={SEARCH_DROPDOWN_MIN_WIDTH}
+            zIndex={Z.dropdown}
+            bg="mono0"
+            maxHeight={SEARCH_DROPDOWN_MAX_HEIGHT}
+            overflowY="auto"
+            // Keep input focused so the panel stays open while clicking inside it
+            onMouseDown={event => event.preventDefault()}
+          >
+            <TrendingSearches
+              // closeDropdown (not just setIsFocused) so the input also blurs:
+              // otherwise a same-pathname navigation leaves the input focused
+              // with the panel unable to reopen on the next click
+              onNavigate={closeDropdown}
+              shouldTrackImpressions={shouldTrackTrendingImpressions}
             />
-          )
-        }}
-        dropdownMaxHeight={SEARCH_DROPDOWN_MAX_HEIGHT}
-        dropdownMinWidth={SEARCH_DROPDOWN_MIN_WIDTH}
-        flip={false}
-        height={40}
-      />
-
-      {isTrendingVisible && (
-        <TrendingPanel
-          position="absolute"
-          // Mirrors the results dropdown exactly (same anchor, offset, width,
-          // min-width, and shadow) so trending and autosuggest read as one
-          // overlay swapping content rather than two differently-sized surfaces.
-          top="calc(100% + 10px)"
-          left={0}
-          width="100%"
-          minWidth={SEARCH_DROPDOWN_MIN_WIDTH}
-          zIndex={Z.dropdown}
-          bg="mono0"
-          maxHeight={SEARCH_DROPDOWN_MAX_HEIGHT}
-          overflowY="auto"
-          // Keep input focused so the panel stays open while clicking inside it
-          onMouseDown={event => event.preventDefault()}
-        >
-          <TrendingSearches
-            // closeDropdown (not just setIsFocused) so the input also blurs:
-            // otherwise a same-pathname navigation leaves the input focused
-            // with the panel unable to reopen on the next click
-            onNavigate={closeDropdown}
-            shouldTrackImpressions={shouldTrackTrendingImpressions}
-          />
-        </TrendingPanel>
-      )}
-    </Box>
+          </TrendingPanel>
+        )}
+      </Box>
+    </ManageArtworkForSavesProvider>
   )
 }
 

--- a/src/Components/Search/TrendingSearches/Components/TrendingArtworkCard.tsx
+++ b/src/Components/Search/TrendingSearches/Components/TrendingArtworkCard.tsx
@@ -1,6 +1,6 @@
 import { ContextModule } from "@artsy/cohesion"
 import { Box, Image, Text } from "@artsy/palette"
-import { SaveButtonFragmentContainer } from "Components/Artwork/SaveButton/SaveButton"
+import { SaveArtworkToListsButtonFragmentContainer } from "Components/Artwork/SaveButton/SaveArtworkToListsButton"
 import { RouterLink } from "System/Components/RouterLink"
 import type { TrendingSearchesQuery } from "__generated__/TrendingSearchesQuery.graphql"
 import type { FC, MouseEvent } from "react"
@@ -54,7 +54,11 @@ export const TrendingArtworkCard: FC<TrendingArtworkCardProps> = ({
 
       <Box position="relative" mt={1}>
         <Box position="absolute" top={0} right={0}>
-          <SaveButtonFragmentContainer
+          {/* Requires a ManageArtworkForSavesProvider. It is mounted in the
+              HOSTS (SearchBarInput / Mobile Overlay), not per-card like
+              ShelfArtwork does: the save flow's list modal and toast action
+              outlive the panel, which unmounts on blur as the modal opens. */}
+          <SaveArtworkToListsButtonFragmentContainer
             artwork={artwork}
             contextModule={ContextModule.trendingArtworksRail}
           />

--- a/src/Components/Search/TrendingSearches/TrendingSearches.tsx
+++ b/src/Components/Search/TrendingSearches/TrendingSearches.tsx
@@ -649,7 +649,7 @@ export const TRENDING_WINDOW_FRAGMENT = graphql`
             height
           }
         }
-        ...SaveButton_artwork
+        ...SaveArtworkToListsButton_artwork
       }
     }
   }

--- a/src/Components/Search/TrendingSearches/__tests__/TrendingSearches.jest.tsx
+++ b/src/Components/Search/TrendingSearches/__tests__/TrendingSearches.jest.tsx
@@ -8,8 +8,8 @@ import { TrendingSearches } from "../TrendingSearches"
 jest.mock("Utils/Hooks/useClientQuery", () => ({ useClientQuery: jest.fn() }))
 jest.mock("react-tracking")
 
-jest.mock("Components/Artwork/SaveButton/SaveButton", () => ({
-  SaveButtonFragmentContainer: () => {
+jest.mock("Components/Artwork/SaveButton/SaveArtworkToListsButton", () => ({
+  SaveArtworkToListsButtonFragmentContainer: () => {
     return <button type="button">Save</button>
   },
 }))

--- a/src/__generated__/TrendingSearchesQuery.graphql.ts
+++ b/src/__generated__/TrendingSearchesQuery.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<24414eed4db28ae83957d81fb62e7303>>
+ * @generated SignedSource<<04628f6e9a4d47ce601deb695d6118b0>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -52,7 +52,7 @@ export type TrendingSearchesQuery$data = {
           readonly saleMessage: string | null | undefined;
           readonly slug: string;
           readonly title: string | null | undefined;
-          readonly " $fragmentSpreads": FragmentRefs<"SaveButton_artwork">;
+          readonly " $fragmentSpreads": FragmentRefs<"SaveArtworkToListsButton_artwork">;
         } | null | undefined;
         readonly internalID: string;
       }> | null | undefined;
@@ -97,7 +97,7 @@ export type TrendingSearchesQuery$data = {
           readonly saleMessage: string | null | undefined;
           readonly slug: string;
           readonly title: string | null | undefined;
-          readonly " $fragmentSpreads": FragmentRefs<"SaveButton_artwork">;
+          readonly " $fragmentSpreads": FragmentRefs<"SaveArtworkToListsButton_artwork">;
         } | null | undefined;
         readonly internalID: string;
       }> | null | undefined;
@@ -142,7 +142,7 @@ export type TrendingSearchesQuery$data = {
           readonly saleMessage: string | null | undefined;
           readonly slug: string;
           readonly title: string | null | undefined;
-          readonly " $fragmentSpreads": FragmentRefs<"SaveButton_artwork">;
+          readonly " $fragmentSpreads": FragmentRefs<"SaveArtworkToListsButton_artwork">;
         } | null | undefined;
         readonly internalID: string;
       }> | null | undefined;
@@ -452,7 +452,7 @@ v18 = [
           {
             "args": null,
             "kind": "FragmentSpread",
-            "name": "SaveButton_artwork"
+            "name": "SaveArtworkToListsButton_artwork"
           }
         ],
         "storageKey": null
@@ -566,10 +566,41 @@ v22 = [
           (v17/*: any*/),
           (v21/*: any*/),
           {
+            "alias": "preview",
+            "args": null,
+            "concreteType": "Image",
+            "kind": "LinkedField",
+            "name": "image",
+            "plural": false,
+            "selections": [
+              {
+                "alias": null,
+                "args": [
+                  {
+                    "kind": "Literal",
+                    "name": "version",
+                    "value": "square"
+                  }
+                ],
+                "kind": "ScalarField",
+                "name": "url",
+                "storageKey": "url(version:\"square\")"
+              }
+            ],
+            "storageKey": null
+          },
+          {
             "alias": null,
             "args": null,
             "kind": "ScalarField",
-            "name": "isSaved",
+            "name": "isInAuction",
+            "storageKey": null
+          },
+          {
+            "alias": null,
+            "args": null,
+            "kind": "ScalarField",
+            "name": "isSavedToAnyList",
             "storageKey": null
           },
           {
@@ -600,6 +631,13 @@ v22 = [
                     "args": null,
                     "kind": "ScalarField",
                     "name": "lotClosesAt",
+                    "storageKey": null
+                  },
+                  {
+                    "alias": null,
+                    "args": null,
+                    "kind": "ScalarField",
+                    "name": "liveBiddingStarted",
                     "storageKey": null
                   }
                 ],
@@ -717,12 +755,12 @@ return {
     ]
   },
   "params": {
-    "cacheID": "d462514ca4b1f82e32e0c39a30b4fdba",
+    "cacheID": "3a94f8a4e2d244bbab92e559921f9816",
     "id": null,
     "metadata": {},
     "name": "TrendingSearchesQuery",
     "operationKind": "query",
-    "text": "query TrendingSearchesQuery {\n  searchDropdown {\n    oneDay: trending(period: ONE_DAY) {\n      label\n      artists(first: 12) {\n        internalID\n        artist {\n          internalID\n          slug\n          name\n          href\n          initials\n          coverArtwork {\n            image {\n              cropped(width: 128, height: 128, version: [\"square\", \"small\", \"large\"]) {\n                src\n                srcSet\n              }\n            }\n            id\n          }\n          id\n        }\n      }\n      artworks(first: 8) {\n        internalID\n        artwork {\n          internalID\n          slug\n          href\n          title\n          date\n          artistNames\n          saleMessage\n          partner(shallow: true) {\n            name\n            id\n          }\n          image {\n            resized(width: 240, height: 280, version: [\"larger\", \"large\", \"medium\"]) {\n              src\n              srcSet\n              width\n              height\n            }\n          }\n          ...SaveButton_artwork\n          id\n        }\n      }\n    }\n    sevenDays: trending(period: SEVEN_DAYS) {\n      label\n      artists(first: 12) {\n        internalID\n        artist {\n          internalID\n          slug\n          name\n          href\n          initials\n          coverArtwork {\n            image {\n              cropped(width: 128, height: 128, version: [\"square\", \"small\", \"large\"]) {\n                src\n                srcSet\n              }\n            }\n            id\n          }\n          id\n        }\n      }\n      artworks(first: 8) {\n        internalID\n        artwork {\n          internalID\n          slug\n          href\n          title\n          date\n          artistNames\n          saleMessage\n          partner(shallow: true) {\n            name\n            id\n          }\n          image {\n            resized(width: 240, height: 280, version: [\"larger\", \"large\", \"medium\"]) {\n              src\n              srcSet\n              width\n              height\n            }\n          }\n          ...SaveButton_artwork\n          id\n        }\n      }\n    }\n    thirtyDays: trending(period: THIRTY_DAYS) {\n      label\n      artists(first: 12) {\n        internalID\n        artist {\n          internalID\n          slug\n          name\n          href\n          initials\n          coverArtwork {\n            image {\n              cropped(width: 128, height: 128, version: [\"square\", \"small\", \"large\"]) {\n                src\n                srcSet\n              }\n            }\n            id\n          }\n          id\n        }\n      }\n      artworks(first: 8) {\n        internalID\n        artwork {\n          internalID\n          slug\n          href\n          title\n          date\n          artistNames\n          saleMessage\n          partner(shallow: true) {\n            name\n            id\n          }\n          image {\n            resized(width: 240, height: 280, version: [\"larger\", \"large\", \"medium\"]) {\n              src\n              srcSet\n              width\n              height\n            }\n          }\n          ...SaveButton_artwork\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment SaveButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  isSaved\n  title\n  collectorSignals {\n    auction {\n      lotWatcherCount\n      lotClosesAt\n    }\n  }\n}\n"
+    "text": "query TrendingSearchesQuery {\n  searchDropdown {\n    oneDay: trending(period: ONE_DAY) {\n      label\n      artists(first: 12) {\n        internalID\n        artist {\n          internalID\n          slug\n          name\n          href\n          initials\n          coverArtwork {\n            image {\n              cropped(width: 128, height: 128, version: [\"square\", \"small\", \"large\"]) {\n                src\n                srcSet\n              }\n            }\n            id\n          }\n          id\n        }\n      }\n      artworks(first: 8) {\n        internalID\n        artwork {\n          internalID\n          slug\n          href\n          title\n          date\n          artistNames\n          saleMessage\n          partner(shallow: true) {\n            name\n            id\n          }\n          image {\n            resized(width: 240, height: 280, version: [\"larger\", \"large\", \"medium\"]) {\n              src\n              srcSet\n              width\n              height\n            }\n          }\n          ...SaveArtworkToListsButton_artwork\n          id\n        }\n      }\n    }\n    sevenDays: trending(period: SEVEN_DAYS) {\n      label\n      artists(first: 12) {\n        internalID\n        artist {\n          internalID\n          slug\n          name\n          href\n          initials\n          coverArtwork {\n            image {\n              cropped(width: 128, height: 128, version: [\"square\", \"small\", \"large\"]) {\n                src\n                srcSet\n              }\n            }\n            id\n          }\n          id\n        }\n      }\n      artworks(first: 8) {\n        internalID\n        artwork {\n          internalID\n          slug\n          href\n          title\n          date\n          artistNames\n          saleMessage\n          partner(shallow: true) {\n            name\n            id\n          }\n          image {\n            resized(width: 240, height: 280, version: [\"larger\", \"large\", \"medium\"]) {\n              src\n              srcSet\n              width\n              height\n            }\n          }\n          ...SaveArtworkToListsButton_artwork\n          id\n        }\n      }\n    }\n    thirtyDays: trending(period: THIRTY_DAYS) {\n      label\n      artists(first: 12) {\n        internalID\n        artist {\n          internalID\n          slug\n          name\n          href\n          initials\n          coverArtwork {\n            image {\n              cropped(width: 128, height: 128, version: [\"square\", \"small\", \"large\"]) {\n                src\n                srcSet\n              }\n            }\n            id\n          }\n          id\n        }\n      }\n      artworks(first: 8) {\n        internalID\n        artwork {\n          internalID\n          slug\n          href\n          title\n          date\n          artistNames\n          saleMessage\n          partner(shallow: true) {\n            name\n            id\n          }\n          image {\n            resized(width: 240, height: 280, version: [\"larger\", \"large\", \"medium\"]) {\n              src\n              srcSet\n              width\n              height\n            }\n          }\n          ...SaveArtworkToListsButton_artwork\n          id\n        }\n      }\n    }\n  }\n}\n\nfragment SaveArtworkToListsButton_artwork on Artwork {\n  id\n  internalID\n  slug\n  title\n  date\n  artistNames\n  preview: image {\n    url(version: \"square\")\n  }\n  isInAuction\n  isSavedToAnyList\n  collectorSignals {\n    auction {\n      lotWatcherCount\n      lotClosesAt\n      liveBiddingStarted\n    }\n  }\n}\n"
   }
 };
 })();

--- a/src/__generated__/TrendingSearches_trending.graphql.ts
+++ b/src/__generated__/TrendingSearches_trending.graphql.ts
@@ -1,5 +1,5 @@
 /**
- * @generated SignedSource<<53b9af09cac7dd31d1fa00c3480bcfc1>>
+ * @generated SignedSource<<153366be9ccc7f94872ba15f36b68a09>>
  * @lightSyntaxTransform
  * @nogrep
  */
@@ -49,7 +49,7 @@ export type TrendingSearches_trending$data = {
       readonly saleMessage: string | null | undefined;
       readonly slug: string;
       readonly title: string | null | undefined;
-      readonly " $fragmentSpreads": FragmentRefs<"SaveButton_artwork">;
+      readonly " $fragmentSpreads": FragmentRefs<"SaveArtworkToListsButton_artwork">;
     } | null | undefined;
     readonly internalID: string;
   }> | null | undefined;
@@ -345,7 +345,7 @@ return {
             {
               "args": null,
               "kind": "FragmentSpread",
-              "name": "SaveButton_artwork"
+              "name": "SaveArtworkToListsButton_artwork"
             }
           ],
           "storageKey": null
@@ -359,6 +359,6 @@ return {
 };
 })();
 
-(node as any).hash = "485b7615513f238d3107dc9c7632c5e6";
+(node as any).hash = "009e2901731fde7749256bfb3433d389";
 
 export default node;


### PR DESCRIPTION
### Bug

[UI is not reflecting when I save/un-save an artwork](https://app.notion.com/p/artsy/UI-is-not-reflecting-when-I-save-un-save-an-artwork-in-reality-changes-are-happening-just-not-visib-3c2cab0764a080ce82bcf6d06cd077c9) (Notion) — found in QA of the trending searches panel (#17572): saving/unsaving a trending artwork persisted server-side, but the heart never updated visually.

### Root cause

The trending artwork card used the legacy `SaveButtonFragmentContainer`, whose fragment renders from `isSaved` — a field the shared `SaveArtworkMutation` never writes back to the Relay store (its selection and optimistic response only carry `isSavedToAnyList`). So the mutation succeeded but the field the heart renders from never changed.

### Fix

- Swap the card to `SaveArtworkToListsButtonFragmentContainer` — the site-wide default save button (same as `Details.tsx`), which renders from `isSavedToAnyList` — and update the fragment spread + test mock accordingly.
- Mount its required `ManageArtworkForSavesProvider` in the **hosts** (`SearchBarInput` and mobile `Overlay`), deliberately *not* per-card like `ShelfArtwork`/`GridItem`: the lists modal and the toast's “Add to a List” action outlive the trending panel, which unmounts on blur the moment the modal takes focus — a per-card provider would take the modal down with it. The provider is render-inert until a save (it renders nothing but context until an artwork is dispatched).

### QA (staging, verified in browser)

- Heart fills/empties instantly on save/unsave, with “Artwork saved” / “Removed” toasts
- Toast's “Add to a List” → lists modal opens and survives the panel closing behind it
- Artwork already in a custom list → manage-lists modal opens (not a silent unsave)
- Same flows in the mobile overlay; logged out → auth dialog (unchanged)


🤖 Generated with [Claude Code](https://claude.com/claude-code)