### PR TITLE
fix(search): dismiss mobile keyboard when dragging the search overlay

### DIFF
--- a/src/Components/Search/Mobile/Overlay.tsx
+++ b/src/Components/Search/Mobile/Overlay.tsx
@@ -74,6 +74,32 @@ export const Overlay: FC<React.PropsWithChildren<OverlayProps>> = ({
     }
   }, [debouncedValue, selectedPill.searchEntityName])
 
+  // Dismiss the keyboard as soon as the user drags the overlay content
+  // (Eigen's keyboardDismissMode="on-drag"). On iOS the keyboard overlays
+  // the fixed-position overlay without resizing it, leaving the bottom half
+  // of the content unreachable while the keyboard is up. Listens on document
+  // because ModalBase portals its content in after mount; the content element
+  // is resolved at event time.
+  useEffect(() => {
+    const handleTouchMove = (event: TouchEvent) => {
+      const input = inputRef.current
+
+      if (!input || document.activeElement !== input) return
+
+      const content = document.getElementById(OVERLAY_CONTENT_ID)
+
+      if (content?.contains(event.target as Node)) {
+        input.blur()
+      }
+    }
+
+    document.addEventListener("touchmove", handleTouchMove, { passive: true })
+
+    return () => {
+      document.removeEventListener("touchmove", handleTouchMove)
+    }
+  }, [])
+
   const refetch = useCallback(
     (value: string, entity?: string) => {
       const entities = entity ? [entity] : []

--- a/src/Components/Search/Mobile/__tests__/Overlay.jest.tsx
+++ b/src/Components/Search/Mobile/__tests__/Overlay.jest.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { Overlay } from "Components/Search/Mobile/Overlay"
+import { OVERLAY_CONTENT_ID } from "Components/Search/Mobile/OverlayBase"
+import type { Overlay_viewer$data } from "__generated__/Overlay_viewer.graphql"
+import type { RelayRefetchProp } from "react-relay"
+import { useTracking } from "react-tracking"
+
+jest.mock("@unleash/proxy-client-react", () => ({
+  useFlag: jest.fn(() => false),
+}))
+
+jest.mock("react-tracking")
+
+const mockTrackEvent = jest.fn()
+
+describe("Overlay", () => {
+  beforeEach(() => {
+    ;(useTracking as jest.Mock).mockImplementation(() => {
+      return { trackEvent: mockTrackEvent }
+    })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  const renderOverlay = () => {
+    return render(
+      <Overlay
+        viewer={{} as Overlay_viewer$data}
+        relay={{ refetch: jest.fn() } as unknown as RelayRefetchProp}
+        onClose={jest.fn()}
+      />,
+    )
+  }
+
+  // ModalBase's scroll lock (react-remove-scroll) reads touch coordinates
+  // from document-level listeners, so the synthetic event needs touch data
+  const dragContent = (content: HTMLElement) => {
+    const touch = { clientX: 0, clientY: 10 }
+
+    fireEvent.touchMove(content, {
+      touches: [touch],
+      changedTouches: [touch],
+    })
+  }
+
+  const getContent = () => {
+    const content = document.getElementById(OVERLAY_CONTENT_ID)
+
+    if (!content) {
+      throw new Error("Overlay content element not found")
+    }
+
+    return content
+  }
+
+  it("focuses the search input on mount", () => {
+    renderOverlay()
+
+    expect(screen.getByPlaceholderText("Search Artsy")).toHaveFocus()
+  })
+
+  it("blurs the search input when the user drags the overlay content", () => {
+    renderOverlay()
+
+    const input = screen.getByPlaceholderText("Search Artsy")
+    expect(input).toHaveFocus()
+
+    dragContent(getContent())
+
+    expect(input).not.toHaveFocus()
+  })
+
+  it("leaves focus alone when dragging while the input is not focused", () => {
+    renderOverlay()
+
+    const close = screen.getByRole("button", { name: "Close" })
+    close.focus()
+
+    dragContent(getContent())
+
+    expect(close).toHaveFocus()
+  })
+})


### PR DESCRIPTION
### Bug

[mWeb (real device) — keyboard hides artworks and scrolling doesn't appear to work](https://app.notion.com/p/artsy/mWeb-real-device-keyboard-hides-artworks-and-scrolling-doesn-t-appear-to-work-3c2cab0764a0805f8ff5d1efdcfda908) (Notion, launch-blocking) — found in QA of the trending searches panel: on a real iPhone the search overlay auto-focuses the input, the keyboard covers the bottom ~45% of the screen, and the Trending Artworks grid behind it can't be scrolled into view.

### Root cause

Palette's `ModalBase` pins the overlay to the **layout viewport** (`position: fixed; inset: 0; height: 100%`), and iOS Safari does not shrink the layout viewport when the keyboard opens — only the visual viewport. The inner scroll container therefore believes it has the full screen height, so both its layout and its scroll range end behind the keyboard. Stock iOS-Safari-vs-fixed-overlay behavior, not specific to the trending code.

### Fix

Dismiss the keyboard as soon as the user drags the overlay content — Eigen parity (`keyboardDismissMode="on-drag"`). Blurring the input collapses the keyboard, restoring the full overlay height and scroll range. Details:

- The `touchmove` listener sits on `document` because `ModalBase` portals its content in after mount; the content element is resolved at event time.
- Drags are scoped to the content area, so text-selection drags on the input itself don't dismiss.
- No-op when the input isn't focused; benefits the search *results* list as well as the trending panel.

### QA

Verified in the iOS Simulator (real iOS Safari + software keyboard) against a local dev server: keyboard dismisses on first drag, trending artworks scroll into view, taps on cards/chips/pills unaffected, keyboard returns on tapping the input.

New jest suite for the mobile Overlay covers input auto-focus on mount, blur-on-drag, and focus being left alone when the input isn't focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)