### PR TITLE
fix(search): wrap trending artist names to two lines before truncating

### DIFF
--- a/src/Components/Search/TrendingSearches/TrendingSearches.tsx
+++ b/src/Components/Search/TrendingSearches/TrendingSearches.tsx
@@ -448,7 +448,12 @@ const ArtistAvatar: FC<ArtistAvatarProps> = ({ artist, onClick }) => {
   const image = artist.coverArtwork?.image?.cropped
 
   return (
-    <AvatarItem to={artist.href ?? `/artist/${artist.slug}`} onClick={onClick}>
+    <AvatarItem
+      to={artist.href ?? `/artist/${artist.slug}`}
+      onClick={onClick}
+      // Full name on desktop hover for the rare 3+ line names that still clamp
+      title={artist.name ?? undefined}
+    >
       {image?.src ? (
         <AvatarImage
           src={image.src}
@@ -469,13 +474,14 @@ const ArtistAvatar: FC<ArtistAvatarProps> = ({ artist, onClick }) => {
         </AvatarFallback>
       )}
 
-      {/* maxWidth is required for the ellipsis: nowrap text otherwise forces
-          the flex item wider than the 80px avatar column */}
+      {/* Eigen parity (TrendingArtistsAvatarsRail): same 80px column, but the
+          name wraps to two lines before ellipsizing. maxWidth keeps rare
+          unbreakable words from forcing the flex item wider than the column */}
       <Text
         variant="xs"
         mt={0.5}
         maxWidth="100%"
-        overflowEllipsis
+        lineClamp={2}
         textAlign="center"
       >
         {artist.name}


### PR DESCRIPTION
### Bug

[[Web] Should we find a way to show the full artist name in the “Trending Artist” section?](https://app.notion.com/p/artsy/Web-Should-we-find-a-way-to-show-the-full-artist-name-in-the-Trending-Artist-section-3c3cab0764a080c2b7fde0e746f9f073) (Notion, launch-blocking) — found in QA of the trending searches panel: artist names in the 80px avatar column truncated after ~10 characters (“David LaChapelle” → “David LaCh…”).

### Fix — Eigen parity

Eigen's `TrendingArtistsAvatarsRail` uses the **same dimensions** (`AVATAR_ITEM_WIDTH = 80`, 68px avatar) — the only reason names read fully there is `numberOfLines={2}` on the name text. This PR adopts the web equivalent:

- The name now renders with Palette's `lineClamp={2}` instead of single-line `overflowEllipsis` — “David LaChapelle” wraps to “David” / “LaChapelle”, and only names exceeding two lines still ellipsize.
- The avatar link carries the full name as a `title` attribute, so desktop users can hover for it in those rare clamped cases. (Screen readers already get the full name — the truncation is CSS-only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)