### PR TITLE
fix: prevent crawling of `/users/auth/*` social sign-in links

### DIFF
--- a/src/Apps/Sitemaps/sitemapsServerApp.tsx
+++ b/src/Apps/Sitemaps/sitemapsServerApp.tsx
@@ -109,6 +109,7 @@ Disallow: /*?dns_source=
 Disallow: /*?microsite=
 Disallow: /*?from-show-guide=
 Disallow: /search
+Disallow: /users/auth
 Sitemap: ${APP_URL}/sitemap-articles.xml
 Sitemap: ${APP_URL}/sitemap-artists.xml
 Sitemap: ${APP_URL}/sitemap-artist-images.xml


### PR DESCRIPTION
> [!TIP]
> I'm using this small pair of changes to try out [GitHub Stacked PRs](https://github.github.com/gh-stack/).
>
> You can use the lil stack menu above to independently review the two PRs in this "stack":
>
> <img height="200" alt="Screenshot 2026-08-21 at 7 37 16 PM" src="https://github.com/user-attachments/assets/2ee9776d-6c93-47c1-b4c3-7f1e50b76926" />
> 
> Once they are approved I will merge the upper one, and the lower one(s) will be auto-merged along with it. 
>
> Overkill for this set of changes, but will probably soon come in handy for big agent-driven sweeps.


The type of this PR is: Fix

<!-- Build / Chore / CI / Docs / Feat / Fix / Perf / Refactor / Revert / Style / Test -->

<!-- If applicable, write the Jira ticket number in square brackets e.g. `[PROJECT-XX]`
     The Jira integration will turn it into a clickable link for you. -->

This PR solves [DI-567](https://www.notion.so/3c3cab0764a080548829fa03cf286557)

### Description

Instructs crawlers never to bother with `/users/auth/*` urls, which are generated by social sign-in links and which currently eat up zillions of links worth of crawl budget without yielding any indexable content, as seen in [Google Search Console](https://search.google.com/search-console/index/drilldown?resource_id=sc-domain%3Aartsy.net&item_key=CAMYCCAC):

<img height="300" alt="Screenshot 2026-08-21 at 7 21 38 PM" src="https://github.com/user-attachments/assets/877c512f-5901-426b-8de0-a70a17fe3188" />


cc @artsy/diamond-devs 



---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>