### PR TITLE
fix: remove /signup and /login from search indexing

### DIFF
--- a/src/Apps/Authentication/Components/AuthenticationInlineDialog.tsx
+++ b/src/Apps/Authentication/Components/AuthenticationInlineDialog.tsx
@@ -69,7 +69,7 @@ const AuthenticationInlineDialogContents: FC<
 
   return (
     <>
-      <MetaTags title={pageTitle} pathname={location.pathname} />
+      <MetaTags title={pageTitle} pathname={location.pathname} blockRobots />
 
       <Flex
         alignItems="center"

--- a/src/Apps/Authentication/Routes/SignupLanding/SignupLandingPage.tsx
+++ b/src/Apps/Authentication/Routes/SignupLanding/SignupLandingPage.tsx
@@ -16,6 +16,7 @@ export const SignupLandingPage: FC<React.PropsWithChildren<unknown>> = () => {
           title="Join Artsy - Discover and Buy Art That Moves You"
           description="Join over 3.4 million art collectors and enthusiasts. Explore 1.6 million original artworks for sale from galleries, museums, and artists worldwide."
           pathname="/signup"
+          blockRobots
         />
 
         <SignupHeader />

--- a/src/Apps/Sitemaps/sitemapsServerApp.tsx
+++ b/src/Apps/Sitemaps/sitemapsServerApp.tsx
@@ -50,13 +50,11 @@ sitemapsServerApp
       { loc: `${APP_URL}/institution-partnerships` },
       { loc: `${APP_URL}/institutions` },
       { loc: `${APP_URL}/jobs` },
-      { loc: `${APP_URL}/login` },
       { loc: `${APP_URL}/press/in-the-media` },
       { loc: `${APP_URL}/press/press-releases` },
       { loc: `${APP_URL}/privacy` },
       { loc: `${APP_URL}/security` },
       { loc: `${APP_URL}/shows`, priority: 1 },
-      { loc: `${APP_URL}/signup` },
       { loc: `${APP_URL}/terms` },
       { loc: `${APP_URL}/viewing-rooms` },
     ]


### PR DESCRIPTION
> [!TIP]
> I'm using this small pair of changes to try out [GitHub Stacked PRs](https://github.github.com/gh-stack/).
>
> You can use the lil stack menu above to independently review the two PRs in this "stack":
>
> <img height="200" alt="Screenshot 2026-08-21 at 7 37 07 PM" src="https://github.com/user-attachments/assets/7eb9a38c-3474-4a07-a6ac-afb1e2dec172" />
> 
> Once they are approved I will merge the upper one, and the lower one(s) will be auto-merged along with it. 
>
> Overkill for this set of changes, but will probably soon come in handy for big agent-driven sweeps.



The type of this PR is: Fix

This PR solves [DI-566](https://www.notion.so/3c3cab0764a08032b281e0f5437b8666)

### Description

Small (stacked!) follow-up to #17592 that simply removes /login and /signup links from Google's index. This is less a crawl budget issue than simple index hygiene: there is no point in indexing content if we don't want it to rank. 

cc @artsy/diamond-devs 

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>