### PR TITLE
fix(search): reset trending rail scroll on tab switch, align card sizing with site rails

### DIFF
--- a/src/Components/Search/TrendingSearches/Components/TrendingArtworkCard.tsx
+++ b/src/Components/Search/TrendingSearches/Components/TrendingArtworkCard.tsx
@@ -2,9 +2,9 @@ import { ContextModule } from "@artsy/cohesion"
 import { Box, Image, Text } from "@artsy/palette"
 import { SaveArtworkToListsButtonFragmentContainer } from "Components/Artwork/SaveButton/SaveArtworkToListsButton"
 import { RouterLink } from "System/Components/RouterLink"
+import { maxDimensionsByArea } from "Utils/resized"
 import type { TrendingSearchesQuery } from "__generated__/TrendingSearchesQuery.graphql"
 import type { FC, MouseEvent } from "react"
-import styled from "styled-components"
 
 export type TrendingArtworkNode = NonNullable<
   NonNullable<
@@ -14,9 +14,12 @@ export type TrendingArtworkNode = NonNullable<
   >[number]["artwork"]
 >
 
-export const ARTWORK_IMAGE_HEIGHT = 200
-// Cards keep at least this width; the rail scrolls when space runs out.
-export const ARTWORK_CARD_FLEX = "1 0 160px"
+// ShelfArtwork's equal-area sizing, scaled down to this compact panel
+const ARTWORK_IMAGE_ROW_HEIGHT = 200
+const ARTWORK_IMAGE_AREA = 160 * 160
+// Keep in sync with resized(width:) in TrendingSearches' query
+const ARTWORK_CARD_MAX_WIDTH = 240
+const ARTWORK_CARD_FALLBACK_WIDTH = Math.sqrt(ARTWORK_IMAGE_AREA)
 
 export interface TrendingArtworkCardProps {
   artwork: TrendingArtworkNode
@@ -34,21 +37,29 @@ export const TrendingArtworkCard: FC<TrendingArtworkCardProps> = ({
     return null
   }
 
+  const { width, aspectRatio } = getTrendingCardLayout(image)
+
   return (
-    <Box flex={ARTWORK_CARD_FLEX} minWidth={0}>
+    <Box width={width} maxWidth={ARTWORK_CARD_MAX_WIDTH} flexShrink={0}>
       <RouterLink to={href} onClick={onClick} display="block">
-        <Box width="100%" height={ARTWORK_IMAGE_HEIGHT}>
-          <CardImage
-            src={image.src}
-            srcSet={image.srcSet}
-            width={image.width}
-            height={image.height}
-            alt={artwork.title ?? ""}
-            // Native attribute, not Palette's lazyLoad prop: the prop swaps in
-            // a wrapper Box that receives this styled component's className,
-            // breaking the object-fit sizing on the actual img
-            loading="lazy"
-          />
+        {/* Mixed aspect ratios share a bottom baseline, like ShelfArtwork */}
+        <Box
+          height={ARTWORK_IMAGE_ROW_HEIGHT}
+          display="flex"
+          alignItems="flex-end"
+          overflow="hidden"
+        >
+          <Box width="100%" style={{ aspectRatio }} bg="mono10">
+            <Image
+              src={image.src}
+              srcSet={image.srcSet}
+              width="100%"
+              height="100%"
+              alt={artwork.title ?? ""}
+              lazyLoad
+              style={{ display: "block", objectFit: "cover" }}
+            />
+          </Box>
         </Box>
       </RouterLink>
 
@@ -70,10 +81,11 @@ export const TrendingArtworkCard: FC<TrendingArtworkCardProps> = ({
           display="block"
           textDecoration="none"
         >
+          {/* Single-line text keeps card heights uniform across tabs */}
           <Text variant="sm-display" overflowEllipsis pr={4}>
             {artwork.artistNames}
           </Text>
-          <Text variant="xs" color="mono60">
+          <Text variant="xs" color="mono60" overflowEllipsis>
             {artwork.title}
             {artwork.date ? `, ${artwork.date}` : ""}
           </Text>
@@ -83,7 +95,7 @@ export const TrendingArtworkCard: FC<TrendingArtworkCardProps> = ({
             </Text>
           )}
           {artwork.saleMessage && (
-            <Text variant="xs" fontWeight="bold" mt={0.5}>
+            <Text variant="xs" fontWeight="bold" mt={0.5} overflowEllipsis>
               {artwork.saleMessage}
             </Text>
           )}
@@ -93,11 +105,26 @@ export const TrendingArtworkCard: FC<TrendingArtworkCardProps> = ({
   )
 }
 
-// Bottom-left anchored so rows of mixed aspect ratios share a baseline
-const CardImage = styled(Image)`
-  display: block;
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-  object-position: bottom left;
-`
+interface TrendingCardLayout {
+  width: number
+  aspectRatio: string
+}
+
+/** Missing or zero dimensions fall back to a neutral square. */
+export const getTrendingCardLayout = (image: {
+  width: number | null | undefined
+  height: number | null | undefined
+}): TrendingCardLayout => {
+  if (!image.width || !image.height) {
+    return { width: ARTWORK_CARD_FALLBACK_WIDTH, aspectRatio: "1 / 1" }
+  }
+
+  return {
+    width: maxDimensionsByArea({
+      area: ARTWORK_IMAGE_AREA,
+      width: image.width,
+      height: image.height,
+    }).width,
+    aspectRatio: `${image.width} / ${image.height}`,
+  }
+}

--- a/src/Components/Search/TrendingSearches/Components/__tests__/TrendingArtworkCard.jest.tsx
+++ b/src/Components/Search/TrendingSearches/Components/__tests__/TrendingArtworkCard.jest.tsx
@@ -1,0 +1,66 @@
+import { getTrendingCardLayout } from "../TrendingArtworkCard"
+
+describe("getTrendingCardLayout", () => {
+  it("derives the card width from the image's aspect ratio and keeps the exact ratio for the box", () => {
+    // 165×230 portrait: √(25600 × 165/230) ≈ 136
+    expect(getTrendingCardLayout({ width: 165, height: 230 })).toEqual({
+      width: 136,
+      aspectRatio: "165 / 230",
+    })
+  })
+
+  it("gives extreme aspect ratios roughly the same image area as a square", () => {
+    const square = getTrendingCardLayout({ width: 200, height: 200 })
+    const landscape = getTrendingCardLayout({ width: 240, height: 80 })
+    const portrait = getTrendingCardLayout({ width: 93, height: 280 })
+
+    expect(square.width).toBe(160)
+    // 3:1 landscape spreads the same area wide (CSS clamps render at 240)
+    expect(landscape.width).toBe(277)
+    // 1:3 portrait concentrates it narrow
+    expect(portrait.width).toBe(92)
+
+    const areaOf = (layout: { width: number; aspectRatio: string }) => {
+      const [w, h] = layout.aspectRatio.split(" / ").map(Number)
+      return layout.width * (layout.width * (h / w))
+    }
+    expect(areaOf(landscape)).toBeCloseTo(160 * 160, -3)
+    expect(areaOf(portrait)).toBeCloseTo(160 * 160, -3)
+  })
+
+  it("falls back to a neutral square when dimensions are missing entirely", () => {
+    expect(getTrendingCardLayout({ width: null, height: null })).toEqual({
+      width: 160,
+      aspectRatio: "1 / 1",
+    })
+    expect(
+      getTrendingCardLayout({ width: undefined, height: undefined }),
+    ).toEqual({
+      width: 160,
+      aspectRatio: "1 / 1",
+    })
+  })
+
+  it("falls back to a neutral square when only one dimension is present", () => {
+    // Regression: separate guards once yielded a 160px card with ratio 240/1
+    expect(getTrendingCardLayout({ width: 240, height: null })).toEqual({
+      width: 160,
+      aspectRatio: "1 / 1",
+    })
+    expect(getTrendingCardLayout({ width: null, height: 280 })).toEqual({
+      width: 160,
+      aspectRatio: "1 / 1",
+    })
+  })
+
+  it("treats zero dimensions as missing instead of dividing by zero", () => {
+    expect(getTrendingCardLayout({ width: 0, height: 0 })).toEqual({
+      width: 160,
+      aspectRatio: "1 / 1",
+    })
+    expect(getTrendingCardLayout({ width: 240, height: 0 })).toEqual({
+      width: 160,
+      aspectRatio: "1 / 1",
+    })
+  })
+})

--- a/src/Components/Search/TrendingSearches/TrendingSearches.tsx
+++ b/src/Components/Search/TrendingSearches/TrendingSearches.tsx
@@ -309,6 +309,7 @@ export const TrendingSearches: FC<TrendingSearchesProps> = ({
 
           <ScrollRail
             contentKey={`artists-${activeIndex}`}
+            scrollResetKey={activeIndex}
             shouldShowScrollBar={false}
           >
             {artists.map((artist, index) => {
@@ -341,6 +342,7 @@ export const TrendingSearches: FC<TrendingSearchesProps> = ({
 
           <ScrollRail
             contentKey={`artworks-${activeIndex}`}
+            scrollResetKey={activeIndex}
             alignItems="flex-start"
           >
             {artworks.map((artwork, index) => {
@@ -389,6 +391,8 @@ interface ScrollRailProps {
   children: ReactNode
   /** Changes whenever the rail's content changes, to re-measure overflow */
   contentKey: string
+  /** Changes when the rail should scroll back to the start (tab switch) */
+  scrollResetKey?: string | number
   alignItems?: FlexProps["alignItems"]
   gap?: FlexProps["gap"]
   /** Whether to show the scroll indicator when content overflows */
@@ -400,6 +404,7 @@ interface ScrollRailProps {
 const ScrollRail: FC<ScrollRailProps> = ({
   children,
   contentKey,
+  scrollResetKey,
   alignItems,
   gap = 2,
   shouldShowScrollBar = true,
@@ -419,6 +424,12 @@ const ScrollRail: FC<ScrollRailProps> = ({
 
   // …and when the rail resizes (viewport changes)
   useResizeObserver({ target: element, onResize: updateScrollability })
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scrollResetKey drives the reset
+  useEffect(() => {
+    // Optional-chained: jsdom doesn't implement scrollTo
+    element?.scrollTo?.({ left: 0 })
+  }, [element, scrollResetKey])
 
   return (
     <>
@@ -644,6 +655,7 @@ export const TRENDING_WINDOW_FRAGMENT = graphql`
           name
         }
         image {
+          # Keep in sync with ARTWORK_CARD_MAX_WIDTH in TrendingArtworkCard
           resized(
             width: 240
             height: 280


### PR DESCRIPTION
Two QA follow-ups for the trending searches panel ([QA session](https://app.notion.com/p/3c2cab0764a081ab9e64d1b9a59c4ad4)):

- [Scroll keeps old state when changing tabs](https://app.notion.com/p/artsy/Web-Scroll-is-keeping-the-old-state-when-changing-between-tabs-1d-7d-30d-3c6cab0764a080d0a84ae34d89006bad)
- [Artwork rail card size off / whitespace between image and header](https://app.notion.com/p/artsy/Web-artwork-rail-card-size-off-and-created-bigger-whitespace-between-image-and-headline-3c3cab0764a0809b8e28f5f4ed68b7ed)

### Fixes

**Rail scroll reset on tab switch.** The trending rails kept their scroll offset when switching between Today / 7 Days / 30 Days. `ScrollRail` now takes a `scrollResetKey` prop that scrolls back to the start when the active window changes. Deliberately an effect rather than a `key` remount: a remount blanks the `ShelfScrollBar` (+ its spacer) for a frame — the panel visibly shrinks/regrows on every tab tap — and re-decodes every image. The recents rail is unaffected, so removing a chip keeps its scroll position.

**Card sizing parity with site-wide artwork rails.** The card used a fixed 200px `object-fit: contain` box with equal-width stretching cards (`flex: 1 0 160px`) — a trending-only pattern that letterboxed images and left dead whitespace between the section header and the artworks. It now follows `ShelfArtwork`'s approach, scaled to the compact panel: card width derived from the image's aspect ratio via `maxDimensionsByArea` (equal-area, 160² in a 200px row vs the shelf's 200² in 250px), exact `aspect-ratio` box with `cover`, bottom-anchored so mixed ratios share a baseline, and Palette's `lazyLoad`.

**Stable panel height across tabs.** The height jumps when switching windows came from unclamped card text (wrapping titles, optional partner/price lines), not the images — all card text lines are now single-line ellipsized, matching shelf metadata.


https://github.com/user-attachments/assets/477445f0-a7c9-4fe9-aba4-1df715db1941


### Test plan

- [x] 96/96 Search jest tests, type-check, lint
- [x] Browser QA (desktop + mobile overlay, flag override): rails snap to start on tab switch with no scrollbar blink; whitespace gone; edge-case shapes eyeballed via a temporary dimension stub

🤖 Generated with [Claude Code](https://claude.com/claude-code)