### PR TITLE
feat(search): add suggested filters row to the search dropdown

### DIFF
--- a/src/Components/Search/SearchBarInput.tsx
+++ b/src/Components/Search/SearchBarInput.tsx
@@ -7,6 +7,7 @@ import {
   type FocusEvent,
   type MouseEvent,
   useEffect,
+  useMemo,
   useRef,
   useState,
 } from "react"
@@ -18,6 +19,7 @@ import {
   type SearchedWithResults,
   type SelectedItemFromSearch,
 } from "@artsy/cohesion"
+import { buildUrlForCollectApp } from "Apps/Collect/Utils/urlBuilder"
 import { Z } from "Apps/Components/constants"
 import { ManageArtworkForSavesProvider } from "Components/Artwork/ManageArtworkForSaves"
 import { DESKTOP_NAV_BAR_TOP_TIER_HEIGHT } from "Components/NavBar/constants"
@@ -35,6 +37,7 @@ import { useDebounce } from "use-debounce"
 import { SearchBarFooter } from "./SearchBarFooter"
 import { SearchInputPillsFragmentContainer } from "./SearchInputPills"
 import { StaticSearchContainer } from "./StaticSearchContainer"
+import { SuggestedFiltersItem } from "./SuggestedFiltersItem"
 import {
   SuggestionItem,
   type SuggestionItemOptionProps,
@@ -45,6 +48,7 @@ import { useRecentSearches } from "./hooks/useRecentSearches"
 import { useTrendingImpressionSession } from "./hooks/useTrendingImpressionSession"
 import { getLabel } from "./utils/getLabel"
 import { isModifiedClick } from "./utils/isModifiedClick"
+import { parseFilterQuery } from "./utils/parseFilterQuery"
 import { searchResultsHref } from "./utils/searchResultsHref"
 import { shouldStartSearching } from "./utils/shouldStartSearching"
 
@@ -99,12 +103,49 @@ export const SearchBarInput: FC<
 
   const edges = data?.viewer?.searchConnection?.edges ?? []
 
+  const isSuggestedFiltersEnabled = useFlag("onyx_suggested-filters")
+
+  // Parsed from `debouncedValue`, not `value`. Parsing is synchronous, so `value`
+  // would land the row a beat sooner — but the row is prepended, so appearing
+  // and disappearing per keystroke while the entity results lag behind shifts
+  // every option index under the user's cursor. Matching the entity list's
+  // cadence keeps the list stable to click and arrow through.
+  const parsedFilters = useMemo(() => {
+    return parseFilterQuery(debouncedValue)
+  }, [debouncedValue])
+
+  // The entity pills scope the search to a single type, where a link out to
+  // browsing artworks is off-topic.
+  const shouldShowSuggestedFilters =
+    isSuggestedFiltersEnabled && !!parsedFilters && selectedPill === TOP_PILL
+
+  const suggestedFiltersHref = parsedFilters
+    ? buildUrlForCollectApp(parsedFilters.filters)
+    : ""
+
   const formattedOptions: SuggestionItemOptionProps[] = [
+    ...(shouldShowSuggestedFilters
+      ? [
+          {
+            kind: "suggestedFilters" as const,
+            text: value,
+            value: value,
+            subtitle: "",
+            imageUrl: "",
+            showAuctionResultsButton: false,
+            href: suggestedFiltersHref,
+            typename: "SuggestedFilters",
+            item_id: "suggested-filters",
+            item_type: "filter-suggestion",
+          },
+        ]
+      : []),
     ...edges.flatMap((edge, index) => {
       const option = edge?.node
       if (!option) return []
       return [
         {
+          kind: "entity" as const,
           text: option.displayLabel ?? "Unknown",
           value: option.displayLabel ?? "unknown",
           subtitle:
@@ -124,6 +165,7 @@ export const SearchBarInput: FC<
       ]
     }),
     {
+      kind: "footer" as const,
       text: value,
       value: value,
       subtitle: "",
@@ -255,8 +297,12 @@ export const SearchBarInput: FC<
   }
 
   const trackSelection = (option: SuggestionItemOptionProps) => {
-    // Only track if this is an actual search result, not the footer
-    if (option.typename !== "Footer") {
+    // Only real search results belong in this event. The footer has never been
+    // tracked here, and the suggested-filters row is not an entity in a ranked
+    // list — emitting it with a synthetic item_number would pollute the
+    // dataset. Its own viewed/clicked events land in a follow-up PR, so clicks
+    // on the row are deliberately untracked for now.
+    if (option.kind === undefined || option.kind === "entity") {
       const analyticsEvent: SelectedItemFromSearch = {
         action: ActionType.selectedItemFromSearch,
         context_module: selectedPill.analyticsContextModule,
@@ -426,7 +472,20 @@ export const SearchBarInput: FC<
           renderOption={option => {
             if (!value) return <></>
 
-            if (option.typename === "Footer") {
+            if (option.kind === "suggestedFilters" && parsedFilters) {
+            return (
+              <SuggestedFiltersItem
+                parsed={parsedFilters}
+                href={suggestedFiltersHref}
+                query={debouncedValue}
+                onClick={event => {
+                  handleSuggestionClick(option, event)
+                }}
+              />
+            )
+          }
+
+          if (option.kind === "footer") {
               return (
                 <SearchBarFooter
                   query={value}

--- a/src/Components/Search/SearchBarInput.tsx
+++ b/src/Components/Search/SearchBarInput.tsx
@@ -15,6 +15,8 @@ import styled from "styled-components"
 
 import {
   ActionType,
+  ContextModule,
+  type RailViewed,
   type SearchedWithNoResults,
   type SearchedWithResults,
   type SelectedItemFromSearch,
@@ -105,15 +107,9 @@ export const SearchBarInput: FC<
 
   const isSuggestedFiltersEnabled = useFlag("onyx_suggested-filters")
 
-  // Parsed from `debouncedValue`, not `value`. Parsing is synchronous, so `value`
-  // would land the row a beat sooner — but the row is prepended, so appearing
-  // and disappearing per keystroke while the entity results lag behind shifts
-  // every option index under the user's cursor. Matching the entity list's
-  // cadence keeps the list stable to click and arrow through.
-  //
-  // Gated on the flag inside the memo rather than at the render site: while
-  // this is a partial rollout most users can't see the row, and shouldn't pay
-  // to parse every debounced keystroke — nor to build the href below.
+  // Debounced, not live: the row is prepended, so appearing per keystroke
+  // shifts option indices under the cursor. Gated here rather than at render
+  // so users who can't see the row don't pay to parse.
   const parsedFilters = useMemo(() => {
     if (!isSuggestedFiltersEnabled) return null
 
@@ -142,6 +138,8 @@ export const SearchBarInput: FC<
             href: suggestedFiltersHref,
             typename: "SuggestedFilters",
             item_id: "suggested-filters",
+            // Position within its own context module, not the entity ranking
+            item_number: 0,
             item_type: "filter-suggestion",
           },
         ]
@@ -303,23 +301,25 @@ export const SearchBarInput: FC<
   }
 
   const trackSelection = (option: SuggestionItemOptionProps) => {
-    // Only real search results belong in this event. The footer has never been
-    // tracked here, and the suggested-filters row is not an entity in a ranked
-    // list — emitting it with a synthetic item_number would pollute the
-    // dataset. Its own viewed/clicked events land in a follow-up PR, so clicks
-    // on the row are deliberately untracked for now.
-    if (option.kind === undefined || option.kind === "entity") {
-      const analyticsEvent: SelectedItemFromSearch = {
-        action: ActionType.selectedItemFromSearch,
-        context_module: selectedPill.analyticsContextModule,
-        destination_path: option.href,
-        query: value,
-        item_id: option.item_id!,
-        item_number: option.item_number!,
-        item_type: option.item_type!,
-      }
-      tracking.trackEvent(analyticsEvent)
+    // The "See all results" footer has never been tracked here
+    if (option.kind === "footer") return
+
+    // Its own module, so the row's clicks are separable from entity results
+    const contextModule =
+      option.kind === "suggestedFilters"
+        ? ContextModule.suggestedFilters
+        : selectedPill.analyticsContextModule
+
+    const analyticsEvent: SelectedItemFromSearch = {
+      action: ActionType.selectedItemFromSearch,
+      context_module: contextModule,
+      destination_path: option.href,
+      query: value,
+      item_id: option.item_id!,
+      item_number: option.item_number!,
+      item_type: option.item_type!,
     }
+    tracking.trackEvent(analyticsEvent)
   }
 
   const handleSelect = (option: SuggestionItemOptionProps) => {
@@ -357,6 +357,34 @@ export const SearchBarInput: FC<
     resetValue()
     redirect(`${option.href}/auction-results`)
   }
+
+  // Once per focus session, not per keystroke: the row changes as the query is
+  // refined, and counting each appearance would inflate the CTR denominator.
+  const hasTrackedSuggestedFiltersRef = useRef(false)
+
+  useEffect(() => {
+    if (!isFocused) {
+      hasTrackedSuggestedFiltersRef.current = false
+      return
+    }
+
+    if (!shouldShowSuggestedFilters) return
+    if (hasTrackedSuggestedFiltersRef.current) return
+
+    hasTrackedSuggestedFiltersRef.current = true
+
+    const event: RailViewed = {
+      action: ActionType.railViewed,
+      context_module: ContextModule.suggestedFilters,
+      context_screen: contextPageOwnerType,
+    }
+    tracking.trackEvent(event)
+  }, [
+    isFocused,
+    shouldShowSuggestedFilters,
+    contextPageOwnerType,
+    tracking.trackEvent,
+  ])
 
   const handleFocus = () => {
     // Skip Palette's programmatic post-selection refocus (see closeDropdown)

--- a/src/Components/Search/SearchBarInput.tsx
+++ b/src/Components/Search/SearchBarInput.tsx
@@ -110,14 +110,20 @@ export const SearchBarInput: FC<
   // and disappearing per keystroke while the entity results lag behind shifts
   // every option index under the user's cursor. Matching the entity list's
   // cadence keeps the list stable to click and arrow through.
+  //
+  // Gated on the flag inside the memo rather than at the render site: while
+  // this is a partial rollout most users can't see the row, and shouldn't pay
+  // to parse every debounced keystroke — nor to build the href below.
   const parsedFilters = useMemo(() => {
+    if (!isSuggestedFiltersEnabled) return null
+
     return parseFilterQuery(debouncedValue)
-  }, [debouncedValue])
+  }, [debouncedValue, isSuggestedFiltersEnabled])
 
   // The entity pills scope the search to a single type, where a link out to
   // browsing artworks is off-topic.
   const shouldShowSuggestedFilters =
-    isSuggestedFiltersEnabled && !!parsedFilters && selectedPill === TOP_PILL
+    !!parsedFilters && selectedPill === TOP_PILL
 
   const suggestedFiltersHref = parsedFilters
     ? buildUrlForCollectApp(parsedFilters.filters)
@@ -473,19 +479,19 @@ export const SearchBarInput: FC<
             if (!value) return <></>
 
             if (option.kind === "suggestedFilters" && parsedFilters) {
-            return (
-              <SuggestedFiltersItem
-                parsed={parsedFilters}
-                href={suggestedFiltersHref}
-                query={debouncedValue}
-                onClick={event => {
-                  handleSuggestionClick(option, event)
-                }}
-              />
-            )
-          }
+              return (
+                <SuggestedFiltersItem
+                  parsed={parsedFilters}
+                  href={suggestedFiltersHref}
+                  query={debouncedValue}
+                  onClick={event => {
+                    handleSuggestionClick(option, event)
+                  }}
+                />
+              )
+            }
 
-          if (option.kind === "footer") {
+            if (option.kind === "footer") {
               return (
                 <SearchBarFooter
                   query={value}

--- a/src/Components/Search/SuggestedFiltersIcon.tsx
+++ b/src/Components/Search/SuggestedFiltersIcon.tsx
@@ -3,22 +3,13 @@ import type { FC } from "react"
 import styled, { keyframes } from "styled-components"
 
 /**
- * Two dots drifting together and apart, marking the row as a derived
- * suggestion rather than a search result.
+ * Two dots drifting together and apart, marking the row as a suggestion.
  *
- * The static form of this mark ships in @artsy/icons as `Eclipse`, but this
- * component keeps its own paths rather than importing it, for two reasons:
- *
- *  - The two shapes animate in opposite directions, which needs them addressed
- *    individually. The generated icon renders two unlabelled <path> elements,
- *    so importing it would mean targeting `path:nth-child(n)` — silently wrong
- *    if the export order ever changes.
- *  - The viewBox has to be wider than the artwork to give the drift room; a
- *    square icon canvas clips it.
- *
- * The animation lives here rather than in the icon on purpose: SMIL inside the
- * SVG animates on web but is silently dropped on native, and it cannot be
- * disabled for prefers-reduced-motion.
+ * The static mark ships in @artsy/icons as `Eclipse`, but isn't imported here:
+ * the shapes animate in opposite directions so they need addressing
+ * individually, and the viewBox must be wider than the artwork to give the
+ * drift room. SMIL inside the SVG would drop silently on native and couldn't
+ * honour prefers-reduced-motion.
  */
 export const SuggestedFiltersIcon: FC = () => {
   return (
@@ -81,8 +72,7 @@ const Disc = styled(Dot)`
   animation-name: ${driftLeft};
 `
 
-// A true hole rather than a background-coloured fill, so the mark works on any
-// surface — and matches the asset going into @artsy/icons
+// A true hole rather than a background-coloured fill, so it works anywhere
 const Ring = styled(Dot)`
   animation-name: ${driftRight};
 `

--- a/src/Components/Search/SuggestedFiltersIcon.tsx
+++ b/src/Components/Search/SuggestedFiltersIcon.tsx
@@ -1,0 +1,88 @@
+import { themeGet } from "@styled-system/theme-get"
+import type { FC } from "react"
+import styled, { keyframes } from "styled-components"
+
+/**
+ * Two dots drifting together and apart, marking the row as a derived
+ * suggestion rather than a search result.
+ *
+ * The static form of this mark ships in @artsy/icons as `Eclipse`, but this
+ * component keeps its own paths rather than importing it, for two reasons:
+ *
+ *  - The two shapes animate in opposite directions, which needs them addressed
+ *    individually. The generated icon renders two unlabelled <path> elements,
+ *    so importing it would mean targeting `path:nth-child(n)` — silently wrong
+ *    if the export order ever changes.
+ *  - The viewBox has to be wider than the artwork to give the drift room; a
+ *    square icon canvas clips it.
+ *
+ * The animation lives here rather than in the icon on purpose: SMIL inside the
+ * SVG animates on web but is silently dropped on native, and it cannot be
+ * disabled for prefers-reduced-motion.
+ */
+export const SuggestedFiltersIcon: FC = () => {
+  return (
+    <Eclipse
+      width="26"
+      height="20"
+      viewBox="-4 0 26 18"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <Ring
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M11 3.5A5.5 5.5 0 1 0 11 14.5A5.5 5.5 0 1 0 11 3.5ZM11 4.9A4.1 4.1 0 1 0 11 13.1A4.1 4.1 0 1 0 11 4.9Z"
+      />
+      <Disc d="M7 3.5A5.5 5.5 0 1 0 7 14.5A5.5 5.5 0 1 0 7 3.5Z" />
+    </Eclipse>
+  )
+}
+
+const DRIFT_DURATION = "2.4s"
+// The viewBox is padded by this much on each side so the drift isn't clipped
+const DRIFT_OFFSET = "4px"
+
+const driftLeft = keyframes`
+  0%, 10% { transform: translateX(-${DRIFT_OFFSET}); }
+  45%, 60% { transform: translateX(0); }
+  100% { transform: translateX(-${DRIFT_OFFSET}); }
+`
+
+const driftRight = keyframes`
+  0%, 10% { transform: translateX(${DRIFT_OFFSET}); }
+  45%, 60% { transform: translateX(0); }
+  100% { transform: translateX(${DRIFT_OFFSET}); }
+`
+
+const Eclipse = styled.svg`
+  flex: none;
+`
+
+// transform-box/origin keep translateX relative to each shape, not the svg
+const Dot = styled.path`
+  fill: ${themeGet("colors.mono100")};
+  transform-box: fill-box;
+  transform-origin: center;
+  animation-duration: ${DRIFT_DURATION};
+  animation-timing-function: ease-in-out;
+  animation-iteration-count: infinite;
+
+  /* Hold the dots at rest rather than looping indefinitely */
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+    transform: translateX(0);
+  }
+`
+
+const Disc = styled(Dot)`
+  animation-name: ${driftLeft};
+`
+
+// A true hole rather than a background-coloured fill, so the mark works on any
+// surface — and matches the asset going into @artsy/icons
+const Ring = styled(Dot)`
+  animation-name: ${driftRight};
+`

--- a/src/Components/Search/SuggestedFiltersItem.tsx
+++ b/src/Components/Search/SuggestedFiltersItem.tsx
@@ -1,20 +1,32 @@
-import FilterIcon from "@artsy/icons/FilterIcon"
-import { Flex, Spacer, Text } from "@artsy/palette"
+import { themeGet } from "@styled-system/theme-get"
+import { Flex, Text } from "@artsy/palette"
 import type { FC, MouseEvent } from "react"
+import styled from "styled-components"
+import { SuggestedFiltersIcon } from "./SuggestedFiltersIcon"
 import { SuggestionItemLink } from "./SuggestionItem/SuggestionItemLink"
+import { highlightMatchedTokens } from "./utils/highlightMatchedTokens"
 import type { ParsedFilterQuery } from "./utils/parseFilterQuery"
 
-const PREVIEW_SIZE = 50
+const ICON_TILE_SIZE = 48
+// Off the theme space scale (1 = 10px, 2 = 20px), so set directly
+const ROW_PADDING_Y = "16px"
+const ICON_GAP = "14px"
 
 interface SuggestedFiltersItemProps {
   parsed: ParsedFilterQuery
   href: string
+  /**
+   * The query the filters were parsed from — not the live input value, so the
+   * highlighted terms always correspond to what produced this row.
+   */
+  query: string
   onClick: (event?: MouseEvent<HTMLElement>) => void
 }
 
 export const SuggestedFiltersItem: FC<SuggestedFiltersItemProps> = ({
   parsed,
   href,
+  query,
   onClick,
 }) => {
   const handleClick = (event: MouseEvent<HTMLElement>) => {
@@ -32,35 +44,61 @@ export const SuggestedFiltersItem: FC<SuggestedFiltersItemProps> = ({
   const detail = parsed.keyword ? parsed.labels : restLabels
 
   return (
-    <SuggestionItemLink
+    <SuggestedFiltersLink
       onClick={handleClick}
       onMouseDown={handleMouseDown}
       to={href}
+      data-testid="suggestedFiltersRow"
     >
-      <Flex alignItems="center">
+      <Flex alignItems="center" style={{ gap: ICON_GAP }}>
         <Flex
-          width={PREVIEW_SIZE}
-          height={PREVIEW_SIZE}
-          bg="mono5"
+          width={ICON_TILE_SIZE}
+          height={ICON_TILE_SIZE}
+          bg="mono10"
           alignItems="center"
           justifyContent="center"
           flexShrink={0}
         >
-          <FilterIcon />
+          <SuggestedFiltersIcon />
         </Flex>
-
-        <Spacer x={1} />
 
         <Flex flexDirection="column" flex={1} overflow="hidden">
-          <Text variant="sm-display" overflowEllipsis>
-            {title}
+          <Text variant="md" overflowEllipsis>
+            {highlightMatchedTokens(title, query)}
           </Text>
 
-          <Text color="mono60" variant="xs" overflowEllipsis>
-            {detail.length > 0 ? `in ${detail.join(" · ")}` : "Browse artworks"}
-          </Text>
+          {detail.length > 0 && (
+            <Text variant="xs" color="mono60" mt="2px" overflowEllipsis>
+              in {highlightMatchedTokens(detail.join(" · "), query)}
+            </Text>
+          )}
         </Flex>
       </Flex>
-    </SuggestionItemLink>
+    </SuggestedFiltersLink>
   )
 }
+
+/**
+ * Tinted so the row reads as a suggestion rather than another result. Its
+ * resting state is the entity rows' hover colour, so hover goes one step
+ * darker.
+ */
+const SuggestedFiltersLink = styled(SuggestionItemLink)`
+  background-color: ${themeGet("colors.mono5")};
+  padding-top: ${ROW_PADDING_Y};
+  padding-bottom: ${ROW_PADDING_Y};
+
+  &:hover {
+    background-color: ${themeGet("colors.mono10")};
+  }
+
+  /*
+   * Matched terms are marked up with <Highlight>, a styled <strong>, so they
+   * pick up the UA stylesheet's bold. The design distinguishes them by colour
+   * alone — and at this row's 20px title, bold reads far heavier than it does
+   * on the 16px entity rows. Colour is carried by Highlight itself.
+   */
+  strong {
+    font-weight: inherit;
+  }
+`

--- a/src/Components/Search/SuggestedFiltersItem.tsx
+++ b/src/Components/Search/SuggestedFiltersItem.tsx
@@ -11,6 +11,7 @@ const ICON_TILE_SIZE = 48
 // Off the theme space scale (1 = 10px, 2 = 20px), so set directly
 const ROW_PADDING_Y = "16px"
 const ICON_GAP = "14px"
+const LABEL_SEPARATOR = " · "
 
 interface SuggestedFiltersItemProps {
   parsed: ParsedFilterQuery
@@ -38,10 +39,16 @@ export const SuggestedFiltersItem: FC<SuggestedFiltersItemProps> = ({
     event.stopPropagation()
   }
 
-  // With no leftover text the filters themselves are the headline
-  const [firstLabel, ...restLabels] = parsed.labels
-  const title = parsed.keyword || firstLabel
-  const detail = parsed.keyword ? parsed.labels : restLabels
+  /*
+   * The two lines mean different things: the headline is what you're looking
+   * for, the second line is where it's filtered to. When the whole query became
+   * filters there is no "what", so the filters are the headline and the "in"
+   * line is dropped — borrowing the first filter up to the headline made
+   * "unique prints under 10000" read as the keyword "Prints" filtered "in
+   * Under $10,000".
+   */
+  const title = parsed.keyword || parsed.labels.join(LABEL_SEPARATOR)
+  const detail = parsed.keyword ? parsed.labels.join(LABEL_SEPARATOR) : null
 
   return (
     <SuggestedFiltersLink
@@ -67,9 +74,9 @@ export const SuggestedFiltersItem: FC<SuggestedFiltersItemProps> = ({
             {highlightMatchedTokens(title, query)}
           </Text>
 
-          {detail.length > 0 && (
+          {detail && (
             <Text variant="xs" color="mono60" mt="2px" overflowEllipsis>
-              in {highlightMatchedTokens(detail.join(" · "), query)}
+              in {highlightMatchedTokens(detail, query)}
             </Text>
           )}
         </Flex>

--- a/src/Components/Search/SuggestedFiltersItem.tsx
+++ b/src/Components/Search/SuggestedFiltersItem.tsx
@@ -16,10 +16,7 @@ const LABEL_SEPARATOR = " · "
 interface SuggestedFiltersItemProps {
   parsed: ParsedFilterQuery
   href: string
-  /**
-   * The query the filters were parsed from — not the live input value, so the
-   * highlighted terms always correspond to what produced this row.
-   */
+  /** The query the filters were parsed from, not the live input value */
   query: string
   onClick: (event?: MouseEvent<HTMLElement>) => void
 }
@@ -39,14 +36,9 @@ export const SuggestedFiltersItem: FC<SuggestedFiltersItemProps> = ({
     event.stopPropagation()
   }
 
-  /*
-   * The two lines mean different things: the headline is what you're looking
-   * for, the second line is where it's filtered to. When the whole query became
-   * filters there is no "what", so the filters are the headline and the "in"
-   * line is dropped — borrowing the first filter up to the headline made
-   * "unique prints under 10000" read as the keyword "Prints" filtered "in
-   * Under $10,000".
-   */
+  // Headline is the free text, second line is what it's filtered to. With no
+  // free text the filters become the headline — promoting just the first one
+  // made "unique prints under 10000" read as "Prints" in "Under $10,000".
   const title = parsed.keyword || parsed.labels.join(LABEL_SEPARATOR)
   const detail = parsed.keyword ? parsed.labels.join(LABEL_SEPARATOR) : null
 
@@ -85,11 +77,8 @@ export const SuggestedFiltersItem: FC<SuggestedFiltersItemProps> = ({
   )
 }
 
-/**
- * Tinted so the row reads as a suggestion rather than another result. Its
- * resting state is the entity rows' hover colour, so hover goes one step
- * darker.
- */
+// Tinted so the row reads as a suggestion. Its resting state is the entity
+// rows' hover colour, so hover goes a step darker.
 const SuggestedFiltersLink = styled(SuggestionItemLink)`
   background-color: ${themeGet("colors.mono5")};
   padding-top: ${ROW_PADDING_Y};
@@ -99,12 +88,8 @@ const SuggestedFiltersLink = styled(SuggestionItemLink)`
     background-color: ${themeGet("colors.mono10")};
   }
 
-  /*
-   * Matched terms are marked up with <Highlight>, a styled <strong>, so they
-   * pick up the UA stylesheet's bold. The design distinguishes them by colour
-   * alone — and at this row's 20px title, bold reads far heavier than it does
-   * on the 16px entity rows. Colour is carried by Highlight itself.
-   */
+  /* <Highlight> is a <strong>; the design distinguishes matches by colour
+     alone, and bold reads far heavier at this row's 20px title */
   strong {
     font-weight: inherit;
   }

--- a/src/Components/Search/SuggestedFiltersItem.tsx
+++ b/src/Components/Search/SuggestedFiltersItem.tsx
@@ -1,0 +1,66 @@
+import FilterIcon from "@artsy/icons/FilterIcon"
+import { Flex, Spacer, Text } from "@artsy/palette"
+import type { FC, MouseEvent } from "react"
+import { SuggestionItemLink } from "./SuggestionItem/SuggestionItemLink"
+import type { ParsedFilterQuery } from "./utils/parseFilterQuery"
+
+const PREVIEW_SIZE = 50
+
+interface SuggestedFiltersItemProps {
+  parsed: ParsedFilterQuery
+  href: string
+  onClick: (event?: MouseEvent<HTMLElement>) => void
+}
+
+export const SuggestedFiltersItem: FC<SuggestedFiltersItemProps> = ({
+  parsed,
+  href,
+  onClick,
+}) => {
+  const handleClick = (event: MouseEvent<HTMLElement>) => {
+    onClick(event)
+  }
+
+  const handleMouseDown = (event: MouseEvent<HTMLAnchorElement>) => {
+    // Prevent AutocompleteInput mousedown selection so native link behavior is preserved.
+    event.stopPropagation()
+  }
+
+  // With no leftover text the filters themselves are the headline
+  const [firstLabel, ...restLabels] = parsed.labels
+  const title = parsed.keyword || firstLabel
+  const detail = parsed.keyword ? parsed.labels : restLabels
+
+  return (
+    <SuggestionItemLink
+      onClick={handleClick}
+      onMouseDown={handleMouseDown}
+      to={href}
+    >
+      <Flex alignItems="center">
+        <Flex
+          width={PREVIEW_SIZE}
+          height={PREVIEW_SIZE}
+          bg="mono5"
+          alignItems="center"
+          justifyContent="center"
+          flexShrink={0}
+        >
+          <FilterIcon />
+        </Flex>
+
+        <Spacer x={1} />
+
+        <Flex flexDirection="column" flex={1} overflow="hidden">
+          <Text variant="sm-display" overflowEllipsis>
+            {title}
+          </Text>
+
+          <Text color="mono60" variant="xs" overflowEllipsis>
+            {detail.length > 0 ? `in ${detail.join(" · ")}` : "Browse artworks"}
+          </Text>
+        </Flex>
+      </Flex>
+    </SuggestionItemLink>
+  )
+}

--- a/src/Components/Search/SuggestionItem/SuggestionItem.tsx
+++ b/src/Components/Search/SuggestionItem/SuggestionItem.tsx
@@ -5,7 +5,14 @@ import { DefaultSuggestion } from "./DefaultSuggestion"
 import { SuggestionItemLink } from "./SuggestionItemLink"
 import type { SearchHighlightData } from "./parseHighlightFragments"
 
+/**
+ * Distinguishes the synthetic dropdown rows from real search results. Absent
+ * means an entity row, so existing option builders need no change.
+ */
+export type SuggestionItemKind = "entity" | "footer" | "suggestedFilters"
+
 export interface SuggestionItemOptionProps {
+  kind?: SuggestionItemKind
   text: string
   value: string
   subtitle: string

--- a/src/Components/Search/__tests__/SearchBarInput.jest.tsx
+++ b/src/Components/Search/__tests__/SearchBarInput.jest.tsx
@@ -602,19 +602,59 @@ describe("SearchBarInput", () => {
       expect(row()).not.toBeInTheDocument()
     })
 
-    it("does not emit selectedItemFromSearch on click", async () => {
-      // Tracking for this row lands in a follow-up PR. Until then it must not
-      // masquerade as an entity in the existing event.
+    it("tracks the click under its own context module", async () => {
       enableSuggestedFilters()
       render(<SearchBarInput searchTerm="warhol prints under 5000" />)
 
       await userEvent.click(row() as HTMLElement)
 
-      expect(mockTrackEvent).not.toHaveBeenCalledWith(
+      expect(mockTrackEvent).toHaveBeenCalledWith(
         expect.objectContaining({
           action: ActionType.selectedItemFromSearch,
+          context_module: ContextModule.suggestedFilters,
+          item_id: "suggested-filters",
+          item_number: 0,
           item_type: "filter-suggestion",
         }),
+      )
+    })
+
+    it("leaves entity clicks reporting the selected pill", async () => {
+      enableSuggestedFilters()
+      render(<SearchBarInput searchTerm="warhol prints under 5000" />)
+
+      await userEvent.click(screen.getByRole("link", { name: "Andy Warhol" }))
+
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: ActionType.selectedItemFromSearch,
+          context_module: ContextModule.topTab,
+        }),
+      )
+    })
+
+    it("tracks one impression per focus session", () => {
+      enableSuggestedFilters()
+      render(<SearchBarInput searchTerm="warhol prints under 5000" />)
+
+      fireEvent.focus(screen.getByRole("textbox"))
+
+      const impressions = mockTrackEvent.mock.calls.filter(([event]) => {
+        return (
+          event.action === ActionType.railViewed &&
+          event.context_module === ContextModule.suggestedFilters
+        )
+      })
+
+      expect(impressions).toHaveLength(1)
+    })
+
+    it("does not track an impression before the dropdown is focused", () => {
+      enableSuggestedFilters()
+      render(<SearchBarInput searchTerm="warhol prints under 5000" />)
+
+      expect(mockTrackEvent).not.toHaveBeenCalledWith(
+        expect.objectContaining({ action: ActionType.railViewed }),
       )
     })
   })

--- a/src/Components/Search/__tests__/SearchBarInput.jest.tsx
+++ b/src/Components/Search/__tests__/SearchBarInput.jest.tsx
@@ -492,4 +492,98 @@ describe("SearchBarInput", () => {
       query: "andy",
     })
   })
+
+  describe("suggested filters row", () => {
+    // Both flags on: the row ships behind its own flag, and the surrounding
+    // suite runs with the trending panel enabled
+    const enableSuggestedFilters = () => {
+      ;(useFlag as jest.Mock).mockImplementation((flag: string) => {
+        return (
+          flag === "onyx_trending-searches" || flag === "onyx_suggested-filters"
+        )
+      })
+    }
+
+    const row = () => screen.queryByTestId("suggestedFiltersRow")
+
+    it("does not render when the feature flag is off", () => {
+      // beforeEach leaves onyx_suggested-filters off
+      render(<SearchBarInput searchTerm="warhol prints under 5000" />)
+
+      expect(row()).not.toBeInTheDocument()
+    })
+
+    it("renders the parsed filters and links to the collect page", () => {
+      enableSuggestedFilters()
+      render(<SearchBarInput searchTerm="warhol prints under 5000" />)
+
+      // toHaveTextContent flattens the <Highlight> wrappers around matched terms
+      expect(row()).toHaveTextContent("warhol")
+      expect(row()).toHaveTextContent("in Prints · Under $5,000")
+
+      const href = row()?.getAttribute("href")
+      expect(href).toContain("/collect/prints")
+      expect(href).toContain("keyword=warhol")
+    })
+
+    it("highlights every term the user typed, including inside derived labels", () => {
+      enableSuggestedFilters()
+      render(<SearchBarInput searchTerm="warhol prints under 5000" />)
+
+      const highlighted = row()?.querySelectorAll("strong")
+      const texts = Array.from(highlighted ?? []).map(node => node.textContent)
+
+      // "prints" lights up the Prints label; "under" and "5000" light up the
+      // formatted price label, since those are the words that were typed
+      expect(texts).toEqual(["warhol", "Prints", "Under", "$5,000"])
+    })
+
+    it("leaves terms the user did not type unhighlighted", () => {
+      enableSuggestedFilters()
+      render(<SearchBarInput searchTerm="banksy prints" />)
+
+      const highlighted = row()?.querySelectorAll("strong")
+      const texts = Array.from(highlighted ?? []).map(node => node.textContent)
+
+      expect(texts).toEqual(["banksy", "Prints"])
+    })
+
+    it("renders no detail line when the filters are the headline", () => {
+      enableSuggestedFilters()
+      render(<SearchBarInput searchTerm="prints between 1k and 5k" />)
+
+      expect(row()).toHaveTextContent("Prints")
+      expect(row()).toHaveTextContent("in $1,000–$5,000")
+    })
+
+    it.each([
+      ["no prints", "negated intent"],
+      ["warhol 1962-1964", "a date range, not a price"],
+      ["prints and photography", "two mediums"],
+      ["design miami", "a medium word inside a fair name"],
+      ["paintings under £5000", "non-USD"],
+      ["warhol", "a bare entity name"],
+    ])("does not render for %p — %s", query => {
+      enableSuggestedFilters()
+      render(<SearchBarInput searchTerm={query} />)
+
+      expect(row()).not.toBeInTheDocument()
+    })
+
+    it("does not emit selectedItemFromSearch on click", async () => {
+      // Tracking for this row lands in a follow-up PR. Until then it must not
+      // masquerade as an entity in the existing event.
+      enableSuggestedFilters()
+      render(<SearchBarInput searchTerm="warhol prints under 5000" />)
+
+      await userEvent.click(row() as HTMLElement)
+
+      expect(mockTrackEvent).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: ActionType.selectedItemFromSearch,
+          item_type: "filter-suggestion",
+        }),
+      )
+    })
+  })
 })

--- a/src/Components/Search/__tests__/SearchBarInput.jest.tsx
+++ b/src/Components/Search/__tests__/SearchBarInput.jest.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "System/Hooks/useRouter"
 import { useClientQuery } from "Utils/Hooks/useClientQuery"
 import { useTracking } from "react-tracking"
 import { SearchBarInput } from "../SearchBarInput"
+import { parseFilterQuery } from "../utils/parseFilterQuery"
 
 jest.mock("@unleash/proxy-client-react", () => ({ useFlag: jest.fn() }))
 
@@ -47,6 +48,12 @@ jest.mock("@artsy/palette", () => ({
 }))
 
 jest.mock("System/Hooks/useRouter", () => ({ useRouter: jest.fn() }))
+
+jest.mock("../utils/parseFilterQuery", () => ({
+  parseFilterQuery: jest.fn(
+    jest.requireActual("../utils/parseFilterQuery").parseFilterQuery,
+  ),
+}))
 
 jest.mock("Utils/Hooks/useClientQuery", () => ({ useClientQuery: jest.fn() }))
 jest.mock("react-tracking")
@@ -513,6 +520,21 @@ describe("SearchBarInput", () => {
       expect(row()).not.toBeInTheDocument()
     })
 
+    it("does not parse the query at all when the feature flag is off", () => {
+      // While this is a partial rollout, users who can't see the row shouldn't
+      // pay to parse every debounced keystroke
+      render(<SearchBarInput searchTerm="warhol prints under 5000" />)
+
+      expect(parseFilterQuery).not.toHaveBeenCalled()
+    })
+
+    it("parses the query when the feature flag is on", () => {
+      enableSuggestedFilters()
+      render(<SearchBarInput searchTerm="warhol prints under 5000" />)
+
+      expect(parseFilterQuery).toHaveBeenCalledWith("warhol prints under 5000")
+    })
+
     it("renders the parsed filters and links to the collect page", () => {
       enableSuggestedFilters()
       render(<SearchBarInput searchTerm="warhol prints under 5000" />)
@@ -548,12 +570,22 @@ describe("SearchBarInput", () => {
       expect(texts).toEqual(["banksy", "Prints"])
     })
 
-    it("renders no detail line when the filters are the headline", () => {
+    it("makes the filters the headline when the query leaves no keyword", () => {
       enableSuggestedFilters()
       render(<SearchBarInput searchTerm="prints between 1k and 5k" />)
 
-      expect(row()).toHaveTextContent("Prints")
-      expect(row()).toHaveTextContent("in $1,000–$5,000")
+      // No "in" line: there is no free text for the filters to qualify
+      expect(row()).toHaveTextContent("Prints · $1,000–$5,000")
+      expect(row()).not.toHaveTextContent("in ")
+    })
+
+    it("does not promote a filter into the keyword slot", () => {
+      enableSuggestedFilters()
+      render(<SearchBarInput searchTerm="unique prints under 10000" />)
+
+      // Previously rendered as keyword "Prints" filtered "in Under $10,000"
+      expect(row()).toHaveTextContent("Prints · Unique · Under $10,000")
+      expect(row()).not.toHaveTextContent("in Unique")
     })
 
     it.each([

--- a/src/Components/Search/__tests__/SuggestedFiltersItem.jest.tsx
+++ b/src/Components/Search/__tests__/SuggestedFiltersItem.jest.tsx
@@ -1,0 +1,153 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { SuggestedFiltersItem } from "Components/Search/SuggestedFiltersItem"
+import type { ParsedFilterQuery } from "Components/Search/utils/parseFilterQuery"
+import { useRouter } from "System/Hooks/useRouter"
+
+jest.mock("System/Hooks/useRouter", () => ({ useRouter: jest.fn() }))
+
+/**
+ * The row has two lines and they mean different things: the headline is the
+ * free text the user is looking for, the second line is the filters it's
+ * narrowed to. These specs pin that rule — see the “fully consumed query”
+ * block for the case it originally got wrong.
+ */
+describe("SuggestedFiltersItem", () => {
+  beforeEach(() => {
+    ;(useRouter as jest.Mock).mockReturnValue({
+      match: { location: { pathname: "/" } },
+      router: { push: jest.fn() },
+    })
+  })
+
+  const parsed = (keyword: string, labels: string[]): ParsedFilterQuery => {
+    return { filters: {}, keyword, labels }
+  }
+
+  const renderRow = ({
+    keyword,
+    labels,
+    query,
+    onClick = jest.fn(),
+  }: {
+    keyword: string
+    labels: string[]
+    query: string
+    onClick?: () => void
+  }) => {
+    render(
+      <SuggestedFiltersItem
+        parsed={parsed(keyword, labels)}
+        href="/collect/prints"
+        query={query}
+        onClick={onClick}
+      />,
+    )
+
+    return screen.getByTestId("suggestedFiltersRow")
+  }
+
+  describe("when the query leaves free text", () => {
+    it("puts the free text in the headline and the filters behind “in”", () => {
+      const row = renderRow({
+        keyword: "warhol",
+        labels: ["Prints", "Under $5,000"],
+        query: "warhol prints under 5000",
+      })
+
+      expect(row).toHaveTextContent("warhol")
+      expect(row).toHaveTextContent("in Prints · Under $5,000")
+    })
+
+    it("handles a single filter", () => {
+      const row = renderRow({
+        keyword: "cat",
+        labels: ["Prints"],
+        query: "cat prints",
+      })
+
+      expect(row).toHaveTextContent("cat")
+      expect(row).toHaveTextContent("in Prints")
+    })
+  })
+
+  describe("when the query is fully consumed by filters", () => {
+    // Regression: the first label used to be promoted into the headline, so
+    // “unique prints under 10000” read as the keyword “Prints” narrowed “in
+    // Under $10,000” — presenting a price as though it were a category.
+    it("makes the filters the headline and drops the “in” line", () => {
+      const row = renderRow({
+        keyword: "",
+        labels: ["Prints", "Unique", "Under $10,000"],
+        query: "unique prints under 10000",
+      })
+
+      expect(row).toHaveTextContent("Prints · Unique · Under $10,000")
+      expect(row).not.toHaveTextContent("in ")
+    })
+
+    it("does not leave a filter standing alone in the headline", () => {
+      const row = renderRow({
+        keyword: "",
+        labels: ["Prints", "$1,000–$5,000"],
+        query: "prints between 1k and 5k",
+      })
+
+      expect(row).toHaveTextContent("Prints · $1,000–$5,000")
+      expect(row).not.toHaveTextContent("in ")
+    })
+  })
+
+  describe("highlighting", () => {
+    it("colours the terms the user typed, in both lines", () => {
+      const row = renderRow({
+        keyword: "warhol",
+        labels: ["Prints", "Under $5,000"],
+        query: "warhol prints under 5000",
+      })
+
+      const highlighted = Array.from(row.querySelectorAll("strong")).map(
+        node => node.textContent,
+      )
+
+      expect(highlighted).toEqual(["warhol", "Prints", "Under", "$5,000"])
+    })
+
+    it("leaves terms the user did not type unhighlighted", () => {
+      const row = renderRow({
+        keyword: "cat",
+        labels: ["Prints", "Unique"],
+        query: "cat prints",
+      })
+
+      const highlighted = Array.from(row.querySelectorAll("strong")).map(
+        node => node.textContent,
+      )
+
+      expect(highlighted).toEqual(["cat", "Prints"])
+    })
+  })
+
+  it("links to the given href", () => {
+    const row = renderRow({
+      keyword: "warhol",
+      labels: ["Prints"],
+      query: "warhol prints",
+    })
+
+    expect(row).toHaveAttribute("href", "/collect/prints")
+  })
+
+  it("calls onClick when the row is clicked", () => {
+    const onClick = jest.fn()
+    const row = renderRow({
+      keyword: "warhol",
+      labels: ["Prints"],
+      query: "warhol prints",
+      onClick,
+    })
+
+    fireEvent.click(row)
+
+    expect(onClick).toHaveBeenCalled()
+  })
+})

--- a/src/Components/Search/utils/__tests__/parseFilterQuery.jest.ts
+++ b/src/Components/Search/utils/__tests__/parseFilterQuery.jest.ts
@@ -1,0 +1,194 @@
+import { parseFilterQuery } from "../parseFilterQuery"
+
+/**
+ * Query strings marked “(production)” are real, taken from 30 days of search
+ * logs. They are the reason the corresponding guard exists — please don’t
+ * replace them with invented equivalents.
+ */
+describe("parseFilterQuery", () => {
+  describe("suggests filters", () => {
+    it("combines a medium, a price and a leftover artist name", () => {
+      const result = parseFilterQuery("warhol prints under 5000")
+
+      expect(result).not.toBeNull()
+      expect(result?.filters).toEqual({
+        medium: "prints",
+        priceRange: "*-5000",
+        attributionClass: undefined,
+        keyword: "warhol",
+      })
+      expect(result?.labels).toEqual(["Prints", "Under $5,000"])
+    })
+
+    it("combines a medium, a rarity and a price", () => {
+      const result = parseFilterQuery("banksy limited edition prints under 10k")
+
+      expect(result?.filters).toEqual({
+        medium: "prints",
+        priceRange: "*-10000",
+        attributionClass: ["limited edition"],
+        keyword: "banksy",
+      })
+    })
+
+    it("suggests a medium alongside free text", () => {
+      const result = parseFilterQuery("kaws sculpture")
+
+      expect(result?.filters.medium).toEqual("sculpture")
+      expect(result?.keyword).toEqual("kaws")
+    })
+
+    it("reads a two-sided range with an explicit operator", () => {
+      const result = parseFilterQuery("prints between 1k and 5k")
+
+      expect(result?.filters.priceRange).toEqual("1000-5000")
+    })
+
+    it("reads a bare range carrying a money marker", () => {
+      const result = parseFilterQuery("prints $1000-5000")
+
+      expect(result?.filters.priceRange).toEqual("1000-5000")
+    })
+  })
+
+  describe("stays silent when a single filter is the whole query", () => {
+    // The gene/collection entity the backend already returns is a better
+    // answer than a link out to /collect
+    it.each(["warhol", "prints", "yayoi kusama", "gagosian", "painting"])(
+      "returns null for %p",
+      query => {
+        expect(parseFilterQuery(query)).toBeNull()
+      },
+    )
+  })
+
+  describe("does not read dates or numbering as prices", () => {
+    it.each([
+      ["jack dowling (american, 1931-2021)", "artist life dates (production)"],
+      ["yun hyong-keun 1977-1978", "work dates (production)"],
+      ["bridget riley brouillard 1981-2003", "work dates (production)"],
+      ["untitled 1980-1990", "date range"],
+      ["warhol 1962-1964", "working period"],
+      ["abstract 1960 - 1970", "spaced dash"],
+    ])("returns null for %p — %s", query => {
+      expect(parseFilterQuery(query)).toBeNull()
+    })
+
+    it.each([
+      ["edition 5-10", "edition numbering"],
+      ["1-54", "an art fair (production)"],
+      ["chen qiang 23-20", "descending pair (production)"],
+      ["50-50 collective", "numbers inside a name"],
+    ])("returns null for %p — %s", query => {
+      expect(parseFilterQuery(query)).toBeNull()
+    })
+
+    it("does not read a bare year as a price floor", () => {
+      // The medium still stands; only the price is withheld
+      const result = parseFilterQuery("prints from 1990")
+
+      expect(result?.filters.priceRange).toBeUndefined()
+      expect(result?.filters.medium).toEqual("prints")
+    })
+
+    it("still reads a price floor when the operator is unambiguous", () => {
+      expect(parseFilterQuery("prints over 2000")?.filters.priceRange).toEqual(
+        "2000-*",
+      )
+    })
+
+    it("still reads a price floor from an ambiguous operator plus a marker", () => {
+      expect(parseFilterQuery("prints from $1990")?.filters.priceRange).toEqual(
+        "1990-*",
+      )
+    })
+  })
+
+  describe("does not invert negated intent", () => {
+    it.each([
+      "no prints",
+      "everything except sculpture",
+      "not painting",
+      "no photography",
+    ])("returns null for %p", query => {
+      expect(parseFilterQuery(query)).toBeNull()
+    })
+
+    it("only guards terms it would otherwise filter on", () => {
+      // Known limitation: “framed” isn’t a filter this parser supports, so
+      // there is no filter to invert and the phrase lands in the keyword.
+      // Suppressing on any stray negator would break real titles instead —
+      // see the case below.
+      const result = parseFilterQuery("paintings without frames")
+
+      expect(result?.filters.medium).toEqual("painting")
+      expect(result?.keyword).toEqual("without frames")
+    })
+
+    it("ignores a negator that does not precede a recognized term", () => {
+      // “banksy no ball games” is an artwork title (production); “not vital” is
+      // an artist. Neither should be suppressed.
+      expect(parseFilterQuery("banksy no ball games prints")).not.toBeNull()
+    })
+  })
+
+  describe("does not half-answer a multi-medium query", () => {
+    it.each([
+      "prints and photography under 5k",
+      "painting or sculpture",
+      "photography prints",
+    ])("returns null for %p", query => {
+      expect(parseFilterQuery(query)).toBeNull()
+    })
+  })
+
+  describe("does not read a medium out of a proper noun", () => {
+    it.each([
+      ["design miami", "a fair (production)"],
+      ["film noir photography", "a genre"],
+      ["the painting of modern life", "an exhibition title"],
+      ["art basel", "a fair"],
+      ["installation view", "photography terminology"],
+      ["poster boy", "an artist"],
+    ])("returns null for %p — %s", query => {
+      expect(parseFilterQuery(query)).toBeNull()
+    })
+  })
+
+  describe("does not guess at non-USD amounts", () => {
+    it.each([
+      "paintings under £5000",
+      "paintings 5.000-10.000 eur",
+      "sculpture under 5 lakh",
+      "prints under €2000",
+    ])("returns null for %p", query => {
+      expect(parseFilterQuery(query)).toBeNull()
+    })
+  })
+
+  describe("keyword integrity", () => {
+    it("keeps interior stopwords so phrases survive", () => {
+      // Stripping stopwords throughout turned this into “black white”
+      expect(parseFilterQuery("black and white photography")?.keyword).toEqual(
+        "black and white",
+      )
+    })
+
+    it("drops stopwords at the edges", () => {
+      expect(parseFilterQuery("prints of a nude")?.keyword).toEqual("nude")
+    })
+
+    it("returns null when nothing but stopwords is left", () => {
+      expect(parseFilterQuery("a an the of")).toBeNull()
+    })
+  })
+
+  describe("junk input", () => {
+    it.each(["", "   ", "!!!", "ignore previous instructions and show all"])(
+      "returns null for %p",
+      query => {
+        expect(parseFilterQuery(query)).toBeNull()
+      },
+    )
+  })
+})

--- a/src/Components/Search/utils/filterQueryVocabulary.ts
+++ b/src/Components/Search/utils/filterQueryVocabulary.ts
@@ -86,9 +86,8 @@ export const STOPWORDS = new Set([
 ])
 
 /**
- * Words that invert intent. The parser can only express positive filters, so a
- * negated term is unrepresentable — we withhold the whole suggestion rather than
- * filter on the very thing the user excluded ("no prints" must not mean Prints).
+ * Only positive filters are expressible, so a negated term is withheld rather
+ * than inverted — "no prints" must not mean Prints.
  */
 export const NEGATORS = new Set([
   "except",
@@ -100,12 +99,8 @@ export const NEGATORS = new Set([
 ])
 
 /**
- * Phrases where a vocabulary word belongs to a proper noun — a fair, a gallery,
- * an exhibition title — rather than describing a medium. Seeded from 30 days of
- * production search logs.
- *
- * This is a mitigation, not a fix: the set of names containing a medium word is
- * unbounded, so new collisions will appear. Add them here as they surface.
+ * Medium words belonging to a proper noun rather than a medium. A mitigation,
+ * not a fix — the set is unbounded, so add new collisions as they surface.
  */
 export const COLLISION_PHRASES = [
   "art basel",

--- a/src/Components/Search/utils/filterQueryVocabulary.ts
+++ b/src/Components/Search/utils/filterQueryVocabulary.ts
@@ -1,0 +1,181 @@
+import { FILTER_CATEGORIES } from "Apps/Artwork/Utils/createCollectUrl"
+import { ATTRIBUTION_CLASS_OPTIONS } from "Components/ArtworkFilter/ArtworkFilters/AttributionClassFilter"
+import { MEDIUM_OPTIONS } from "Components/ArtworkFilter/ArtworkFilters/MediumFilter"
+
+export type VocabularyType = "medium" | "attributionClass"
+
+export interface VocabularyEntry {
+  type: VocabularyType
+  /** The value written into ArtworkFilters, e.g. "prints" / "limited edition" */
+  value: string
+  /** The label shown in the suggestion row, e.g. "Prints" */
+  label: string
+}
+
+/**
+ * Phrases the option lists don't cover but people actually type. Keys are
+ * normalized (lowercase, single-spaced); values are medium slugs.
+ */
+const MEDIUM_ALIASES: Record<string, string> = {
+  print: "prints",
+  paintings: "painting",
+  photo: "photography",
+  photos: "photography",
+  photograph: "photography",
+  photographs: "photography",
+  photographic: "photography",
+  sculptures: "sculpture",
+  drawings: "drawing",
+  collage: "work-on-paper",
+  collages: "work-on-paper",
+  "paper works": "work-on-paper",
+  "works on paper": "work-on-paper",
+  video: "film-slash-video",
+  videos: "film-slash-video",
+  film: "film-slash-video",
+  films: "film-slash-video",
+  animation: "film-slash-video",
+  posters: "poster",
+  textile: "textiles",
+  nfts: "nft",
+  installations: "installation",
+  jewellery: "jewelry",
+  "mixed media": "mixed-media",
+  "digital art": "digital-art",
+  "performance art": "performance-art",
+  "books and portfolios": "books-and-portfolios",
+}
+
+const ATTRIBUTION_ALIASES: Record<string, string> = {
+  "one of a kind": "unique",
+  "one-of-a-kind": "unique",
+  "limited-edition": "limited edition",
+  "limited editions": "limited edition",
+  "open-edition": "open edition",
+  "open editions": "open edition",
+}
+
+/**
+ * Words that carry no filter meaning and shouldn't survive into the keyword.
+ * Multi-word phrases ("work on paper", "digital art") are consumed by the
+ * vocabulary before stopword stripping runs, so "work" and "art" are safe here.
+ */
+export const STOPWORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "art",
+  "artwork",
+  "artworks",
+  "buck",
+  "bucks",
+  "by",
+  "dollar",
+  "dollars",
+  "for",
+  "from",
+  "in",
+  "of",
+  "piece",
+  "pieces",
+  "the",
+  "usd",
+  "with",
+  "work",
+  "works",
+])
+
+export const normalizePhrase = (phrase: string): string => {
+  return phrase.toLowerCase().replace(/\s+/g, " ").trim()
+}
+
+const deslugify = (slug: string): string => {
+  return slug.replace(/-/g, " ")
+}
+
+/**
+ * Descriptive option names longer than this ("Drawing, Collage or other Work
+ * on Paper") are never typed into a search box, and indexing them would widen
+ * the matcher's lookahead window for nothing.
+ */
+const MAX_INDEXED_WORDS = 3
+
+const buildVocabulary = (): Map<string, VocabularyEntry> => {
+  const vocabulary = new Map<string, VocabularyEntry>()
+
+  const add = (phrase: string, entry: VocabularyEntry) => {
+    const key = normalizePhrase(phrase)
+
+    // First writer wins, so curated labels aren't clobbered by later sources
+    if (!key || vocabulary.has(key)) return
+    if (key.split(" ").length > MAX_INDEXED_WORDS) return
+    if (/[,/]/.test(key)) return
+
+    vocabulary.set(key, entry)
+  }
+
+  // Canonical medium options — these own the display labels
+  MEDIUM_OPTIONS.forEach(({ value, name, plural }) => {
+    const entry: VocabularyEntry = { type: "medium", value, label: name }
+
+    add(name, entry)
+    add(plural, entry)
+    add(deslugify(value), entry)
+  })
+
+  // Superset of slugs valid as a /collect/:medium path segment. Where a slug
+  // already came from MEDIUM_OPTIONS, keep that label so "print" and "prints"
+  // don't render as two different things.
+  const mediumLabels = new Map(
+    [...vocabulary.values()].map(entry => [entry.value, entry.label]),
+  )
+
+  Object.entries(FILTER_CATEGORIES).forEach(([name, value]) => {
+    const entry: VocabularyEntry = {
+      type: "medium",
+      value,
+      label: mediumLabels.get(value) ?? name,
+    }
+
+    add(name, entry)
+    add(deslugify(value), entry)
+  })
+
+  ATTRIBUTION_CLASS_OPTIONS.forEach(({ name, value }) => {
+    const entry: VocabularyEntry = {
+      type: "attributionClass",
+      value,
+      label: name,
+    }
+
+    add(name, entry)
+    add(value, entry)
+  })
+
+  // Aliases resolve to an entry already in the map so labels stay consistent
+  const addAliases = (aliases: Record<string, string>) => {
+    Object.entries(aliases).forEach(([alias, value]) => {
+      const canonical = [...vocabulary.values()].find(
+        entry => entry.value === value,
+      )
+
+      if (!canonical) return
+
+      add(alias, canonical)
+    })
+  }
+
+  addAliases(MEDIUM_ALIASES)
+  addAliases(ATTRIBUTION_ALIASES)
+
+  return vocabulary
+}
+
+export const FILTER_VOCABULARY: ReadonlyMap<string, VocabularyEntry> =
+  buildVocabulary()
+
+/** Longest phrase in the vocabulary, so the matcher window adapts to the data */
+export const MAX_PHRASE_WORDS: number = [...FILTER_VOCABULARY.keys()].reduce(
+  (max, key) => Math.max(max, key.split(" ").length),
+  1,
+)

--- a/src/Components/Search/utils/filterQueryVocabulary.ts
+++ b/src/Components/Search/utils/filterQueryVocabulary.ts
@@ -85,6 +85,38 @@ export const STOPWORDS = new Set([
   "works",
 ])
 
+/**
+ * Words that invert intent. The parser can only express positive filters, so a
+ * negated term is unrepresentable — we withhold the whole suggestion rather than
+ * filter on the very thing the user excluded ("no prints" must not mean Prints).
+ */
+export const NEGATORS = new Set([
+  "except",
+  "excluding",
+  "no",
+  "non",
+  "not",
+  "without",
+])
+
+/**
+ * Phrases where a vocabulary word belongs to a proper noun — a fair, a gallery,
+ * an exhibition title — rather than describing a medium. Seeded from 30 days of
+ * production search logs.
+ *
+ * This is a mitigation, not a fix: the set of names containing a medium word is
+ * unbounded, so new collisions will appear. Add them here as they surface.
+ */
+export const COLLISION_PHRASES = [
+  "art basel",
+  "design miami",
+  "film noir",
+  "installation view",
+  "poster boy",
+  "print club",
+  "the painting of modern life",
+]
+
 export const normalizePhrase = (phrase: string): string => {
   return phrase.toLowerCase().replace(/\s+/g, " ").trim()
 }

--- a/src/Components/Search/utils/highlightMatchedTokens.tsx
+++ b/src/Components/Search/utils/highlightMatchedTokens.tsx
@@ -2,10 +2,8 @@ import { Highlight } from "Components/Search/SuggestionItem/Highlight"
 import type { ReactNode } from "react"
 
 /**
- * Colours the words of `text` that the user actually typed, matching how the
- * entity rows highlight their server-provided fragments. The suggested-filters
- * row is parsed client-side, so there are no OpenSearch <em> fragments to reuse
- * — see parseHighlightFragments for that path.
+ * Colours the words the user typed. The entity rows use server-provided <em>
+ * fragments instead — see parseHighlightFragments; this row is parsed locally.
  */
 export const highlightMatchedTokens = (
   text: string,

--- a/src/Components/Search/utils/highlightMatchedTokens.tsx
+++ b/src/Components/Search/utils/highlightMatchedTokens.tsx
@@ -1,0 +1,37 @@
+import { Highlight } from "Components/Search/SuggestionItem/Highlight"
+import type { ReactNode } from "react"
+
+/**
+ * Colours the words of `text` that the user actually typed, matching how the
+ * entity rows highlight their server-provided fragments. The suggested-filters
+ * row is parsed client-side, so there are no OpenSearch <em> fragments to reuse
+ * — see parseHighlightFragments for that path.
+ */
+export const highlightMatchedTokens = (
+  text: string,
+  query: string,
+): ReactNode[] => {
+  const queryKeys = new Set(query.split(/\s+/).map(toKey).filter(Boolean))
+
+  // Split retaining whitespace so the original spacing survives
+  return text.split(/(\s+)/).map((part, index) => {
+    const key = toKey(part)
+
+    if (!key || !queryKeys.has(key)) return part
+
+    return <Highlight key={index}>{part}</Highlight>
+  })
+}
+
+const normalize = (word: string): string => {
+  return word.toLowerCase().replace(/[^a-z0-9]/g, "")
+}
+
+/** So a typed "prints" still lights up a "Print" label, and vice versa */
+const singularize = (word: string): string => {
+  return word.length > 3 && word.endsWith("s") ? word.slice(0, -1) : word
+}
+
+const toKey = (word: string): string => {
+  return singularize(normalize(word))
+}

--- a/src/Components/Search/utils/parseFilterQuery.ts
+++ b/src/Components/Search/utils/parseFilterQuery.ts
@@ -1,12 +1,22 @@
 import type { ArtworkFilters } from "Components/ArtworkFilter/ArtworkFilterTypes"
 import {
+  COLLISION_PHRASES,
   FILTER_VOCABULARY,
   MAX_PHRASE_WORDS,
+  NEGATORS,
   STOPWORDS,
   type VocabularyEntry,
   normalizePhrase,
 } from "./filterQueryVocabulary"
 
+/**
+ * `medium` rather than `additionalGeneIDs` is deliberate, and not a mismatch
+ * with MediumFilter. `buildCollectUrlFragmentFromState`
+ * (Apps/Collect/Utils/urlBuilder) destructures `medium` into the
+ * `/collect/:medium` path segment, and this parser's medium slugs come from
+ * FILTER_CATEGORIES — exactly the set of valid path segments. It also means one
+ * medium per query: see the multi-medium guard in `parseFilterQuery`.
+ */
 export type SuggestedFilters = Pick<
   ArtworkFilters,
   "medium" | "priceRange" | "attributionClass" | "keyword"
@@ -23,7 +33,45 @@ export interface ParsedFilterQuery {
 interface PricePattern {
   regex: RegExp
   toRange: (match: RegExpMatchArray) => string
+  /**
+   * Guards against numbers that aren't money. Defaults to true when a pattern
+   * can't be misread.
+   */
+  isPlausible?: (match: RegExpMatchArray) => boolean
 }
+
+/** A "$" or a k/m suffix survives `clean` and marks an amount as money */
+const MONEY_MARKER = /[$]|[km]\s*$/i
+
+const hasMoneyMarker = (raw: string): boolean => {
+  return MONEY_MARKER.test(raw.trim())
+}
+
+/**
+ * Artist life dates, work dates and exhibition years all look like this. Real
+ * production examples: "jack dowling (american, 1931-2021)",
+ * "yun hyong-keun 1977-1978", "untitled 1980-1990".
+ */
+const YEAR_RANGE = { min: 1000, max: 2100 }
+
+const isYearLike = (amount: number): boolean => {
+  return amount >= YEAR_RANGE.min && amount <= YEAR_RANGE.max
+}
+
+/**
+ * Below this, a bare range is edition or lot numbering rather than a price.
+ * Production examples: "edition 5-10", "1-54" (an art fair), "50-50 collective",
+ * "chen qiang 23-20". Only applies to bare ranges — "under 50" still parses,
+ * because the operator establishes the intent.
+ */
+const MIN_PLAUSIBLE_BARE_PRICE = 100
+
+/** Currencies the priceRange filter can't express — it is USD-only */
+const NON_USD =
+  /[£€¥₹₩]|\b(eur|gbp|chf|hkd|jpy|cad|aud|krw|rmb|cny|inr|lakh|crore)\b/i
+
+/** "from 1990" is a date far more often than a price floor */
+const DATE_AMBIGUOUS_OPERATOR = /^(from|starting\s+at)/i
 
 const AMOUNT = String.raw`\$?\d[\d,.]*\s?[km]?`
 
@@ -38,29 +86,51 @@ const AMOUNT = String.raw`\$?\d[\d,.]*\s?[km]?`
 const PRICE_PATTERNS: PricePattern[] = [
   {
     regex: new RegExp(
-      String.raw`\b(?:between\s+|from\s+)?(${AMOUNT})\s*(?:-|–|—|to|and)\s*(${AMOUNT})\b`,
+      String.raw`\b(between\s+|from\s+)?(${AMOUNT})\s*(?:-|–|—|to|and)\s*(${AMOUNT})\b`,
       "i",
     ),
     toRange: match => {
-      return `${normalizeAmount(match[1])}-${normalizeAmount(match[2])}`
+      return `${normalizeAmount(match[2])}-${normalizeAmount(match[3])}`
+    },
+    isPlausible: match => {
+      // An explicit operator word is intent enough: "between 1k and 5k"
+      if (match[1]) return true
+      // So is a money marker on either side: "$1000-5000", "1k-5k"
+      if (hasMoneyMarker(match[2]) || hasMoneyMarker(match[3])) return true
+
+      const min = normalizeAmount(match[2])
+      const max = normalizeAmount(match[3])
+
+      if (isYearLike(min) && isYearLike(max)) return false
+      if (max <= MIN_PLAUSIBLE_BARE_PRICE) return false
+
+      return true
     },
   },
   {
     regex: new RegExp(
-      String.raw`\b(?:under|below|less\s+than|cheaper\s+than|up\s+to|max|maximum)\s+(${AMOUNT})`,
+      String.raw`\b(under|below|less\s+than|cheaper\s+than|up\s+to|max|maximum)\s+(${AMOUNT})`,
       "i",
     ),
     toRange: match => {
-      return `*-${normalizeAmount(match[1])}`
+      return `*-${normalizeAmount(match[2])}`
     },
   },
   {
     regex: new RegExp(
-      String.raw`\b(?:over|above|more\s+than|at\s+least|starting\s+at|from|min|minimum)\s+(${AMOUNT})`,
+      String.raw`\b(over|above|more\s+than|at\s+least|starting\s+at|from|min|minimum)\s+(${AMOUNT})`,
       "i",
     ),
     toRange: match => {
-      return `${normalizeAmount(match[1])}-*`
+      return `${normalizeAmount(match[2])}-*`
+    },
+    isPlausible: match => {
+      // "over 2000" reads as money; "from 1990" reads as a date. Only the
+      // ambiguous operators need a year check.
+      if (!DATE_AMBIGUOUS_OPERATOR.test(match[1])) return true
+      if (hasMoneyMarker(match[2])) return true
+
+      return !isYearLike(normalizeAmount(match[2]))
     },
   },
 ]
@@ -101,8 +171,10 @@ interface PriceResult {
 const extractPrice = (query: string): PriceResult => {
   const hit = PRICE_PATTERNS.map(pattern => {
     return { pattern, match: query.match(pattern.regex) }
-  }).find(({ match }) => {
-    return !!match
+  }).find(({ pattern, match }) => {
+    if (!match) return false
+
+    return pattern.isPlausible ? pattern.isPlausible(match) : true
   })
 
   const match = hit?.match
@@ -122,6 +194,8 @@ interface PhraseAccumulator {
   matches: VocabularyEntry[]
   leftover: string[]
   skipUntil: number
+  /** A recognized term was preceded by "no" / "not" / "without" / … */
+  hasNegatedMatch: boolean
 }
 
 const extractVocabulary = (tokens: string[]): PhraseAccumulator => {
@@ -150,14 +224,44 @@ const extractVocabulary = (tokens: string[]): PhraseAccumulator => {
         return { ...acc, leftover: [...acc.leftover, tokens[index]] }
       }
 
+      const previousToken = index > 0 ? tokens[index - 1] : undefined
+      const isNegated =
+        !!previousToken && NEGATORS.has(normalizePhrase(previousToken))
+
       return {
         matches: [...acc.matches, hit.entry],
         leftover: acc.leftover,
         skipUntil: index + hit.size,
+        hasNegatedMatch: acc.hasNegatedMatch || isNegated,
       }
     },
-    { matches: [], leftover: [], skipUntil: 0 },
+    { matches: [], leftover: [], skipUntil: 0, hasNegatedMatch: false },
   )
+}
+
+/**
+ * Drops stopwords from the edges only. Stripping them throughout would mangle
+ * interior phrases — "black and white photography" became "black white".
+ */
+const trimStopwords = (words: string[]): string[] => {
+  const isStopword = (word: string): boolean => {
+    return STOPWORDS.has(word.toLowerCase())
+  }
+
+  const first = words.findIndex(word => {
+    return !isStopword(word)
+  })
+
+  if (first === -1) return []
+
+  const fromEnd = words
+    .slice()
+    .reverse()
+    .findIndex(word => {
+      return !isStopword(word)
+    })
+
+  return words.slice(first, words.length - fromEnd)
 }
 
 const formatPriceLabel = (range: string): string => {
@@ -190,12 +294,49 @@ const CURRENCY_FORMATTER = new Intl.NumberFormat("en-US", {
 export const parseFilterQuery = (query: string): ParsedFilterQuery | null => {
   if (!query.trim()) return null
 
+  const normalizedQuery = normalizePhrase(query)
+
+  // A medium word inside a fair, gallery or exhibition name is not a medium
+  // request: "design miami", "film noir photography"
+  if (
+    COLLISION_PHRASES.some(phrase => {
+      return normalizedQuery.includes(phrase)
+    })
+  ) {
+    return null
+  }
+
+  // priceRange is USD-only, and `clean` strips the currency symbol — parsing on
+  // would reinterpret "under £5000" as $5,000. Dropping only the price is no
+  // better: it leaves a keyword of "under 5000" and quietly discards the
+  // constraint that was asked for.
+  if (NON_USD.test(query)) return null
+
   const { priceRange, rest } = extractPrice(clean(query))
 
   const tokens = rest.split(/\s+/).filter(Boolean)
-  const { matches, leftover } = extractVocabulary(tokens)
+  const { matches, leftover, hasNegatedMatch } = extractVocabulary(tokens)
 
-  const medium = matches.find(entry => entry.type === "medium")
+  // Only positive filters are expressible, so an exclusion can't be honoured —
+  // and filtering *to* the excluded value is worse than staying quiet
+  if (hasNegatedMatch) return null
+
+  const mediumEntries = matches.filter(entry => {
+    return entry.type === "medium"
+  })
+  const mediumValues = [
+    ...new Set(
+      mediumEntries.map(entry => {
+        return entry.value
+      }),
+    ),
+  ]
+
+  // The collect URL carries a single medium as its path segment, so a second
+  // one would be dropped without the user seeing it go
+  if (mediumValues.length > 1) return null
+
+  const medium = mediumEntries[0]
 
   const attributionEntries = matches.filter(entry => {
     return entry.type === "attributionClass"
@@ -204,15 +345,13 @@ export const parseFilterQuery = (query: string): ParsedFilterQuery | null => {
     ...new Set(attributionEntries.map(entry => entry.value)),
   ]
 
-  const keyword = leftover
+  const keyword = trimStopwords(
     // A price like "$1000-5000" leaves its "$" behind, since the amount itself
     // starts at a word boundary
-    .filter(token => {
+    leftover.filter(token => {
       return /\w/.test(token)
-    })
-    .filter(token => {
-      return !STOPWORDS.has(token.toLowerCase())
-    })
+    }),
+  )
     .join(" ")
     .trim()
 

--- a/src/Components/Search/utils/parseFilterQuery.ts
+++ b/src/Components/Search/utils/parseFilterQuery.ts
@@ -10,12 +10,8 @@ import {
 } from "./filterQueryVocabulary"
 
 /**
- * `medium` rather than `additionalGeneIDs` is deliberate, and not a mismatch
- * with MediumFilter. `buildCollectUrlFragmentFromState`
- * (Apps/Collect/Utils/urlBuilder) destructures `medium` into the
- * `/collect/:medium` path segment, and this parser's medium slugs come from
- * FILTER_CATEGORIES — exactly the set of valid path segments. It also means one
- * medium per query: see the multi-medium guard in `parseFilterQuery`.
+ * `medium`, not `additionalGeneIDs`: urlBuilder turns it into the
+ * `/collect/:medium` path segment. Hence one medium per query.
  */
 export type SuggestedFilters = Pick<
   ArtworkFilters,
@@ -47,11 +43,7 @@ const hasMoneyMarker = (raw: string): boolean => {
   return MONEY_MARKER.test(raw.trim())
 }
 
-/**
- * Artist life dates, work dates and exhibition years all look like this. Real
- * production examples: "jack dowling (american, 1931-2021)",
- * "yun hyong-keun 1977-1978", "untitled 1980-1990".
- */
+/** Artist life dates and work dates: "jack dowling (american, 1931-2021)" */
 const YEAR_RANGE = { min: 1000, max: 2100 }
 
 const isYearLike = (amount: number): boolean => {
@@ -59,10 +51,8 @@ const isYearLike = (amount: number): boolean => {
 }
 
 /**
- * Below this, a bare range is edition or lot numbering rather than a price.
- * Production examples: "edition 5-10", "1-54" (an art fair), "50-50 collective",
- * "chen qiang 23-20". Only applies to bare ranges — "under 50" still parses,
- * because the operator establishes the intent.
+ * Below this a bare range is edition or lot numbering: "edition 5-10", "1-54"
+ * (a fair). Bare ranges only — "under 50" still parses.
  */
 const MIN_PLAUSIBLE_BARE_PRICE = 100
 

--- a/src/Components/Search/utils/parseFilterQuery.ts
+++ b/src/Components/Search/utils/parseFilterQuery.ts
@@ -1,0 +1,257 @@
+import type { ArtworkFilters } from "Components/ArtworkFilter/ArtworkFilterTypes"
+import {
+  FILTER_VOCABULARY,
+  MAX_PHRASE_WORDS,
+  STOPWORDS,
+  type VocabularyEntry,
+  normalizePhrase,
+} from "./filterQueryVocabulary"
+
+export type SuggestedFilters = Pick<
+  ArtworkFilters,
+  "medium" | "priceRange" | "attributionClass" | "keyword"
+>
+
+export interface ParsedFilterQuery {
+  filters: SuggestedFilters
+  /** Everything the parser didn't consume; goes into the keyword filter */
+  keyword: string
+  /** Human labels in display order: medium, rarity, price */
+  labels: string[]
+}
+
+interface PricePattern {
+  regex: RegExp
+  toRange: (match: RegExpMatchArray) => string
+}
+
+const AMOUNT = String.raw`\$?\d[\d,.]*\s?[km]?`
+
+/**
+ * Ordered: the two-sided range must win before the one-sided operators, so
+ * "between 1k and 5k" isn't read as "from 1k".
+ *
+ * Every pattern requires an operator word or two amounts joined by a
+ * separator. A bare number is therefore never a price — "warhol 1954" stays
+ * free text.
+ */
+const PRICE_PATTERNS: PricePattern[] = [
+  {
+    regex: new RegExp(
+      String.raw`\b(?:between\s+|from\s+)?(${AMOUNT})\s*(?:-|–|—|to|and)\s*(${AMOUNT})\b`,
+      "i",
+    ),
+    toRange: match => {
+      return `${normalizeAmount(match[1])}-${normalizeAmount(match[2])}`
+    },
+  },
+  {
+    regex: new RegExp(
+      String.raw`\b(?:under|below|less\s+than|cheaper\s+than|up\s+to|max|maximum)\s+(${AMOUNT})`,
+      "i",
+    ),
+    toRange: match => {
+      return `*-${normalizeAmount(match[1])}`
+    },
+  },
+  {
+    regex: new RegExp(
+      String.raw`\b(?:over|above|more\s+than|at\s+least|starting\s+at|from|min|minimum)\s+(${AMOUNT})`,
+      "i",
+    ),
+    toRange: match => {
+      return `${normalizeAmount(match[1])}-*`
+    },
+  },
+]
+
+const normalizeAmount = (raw: string): number => {
+  const cleaned = raw.replace(/[$,\s]/g, "").toLowerCase()
+  const multiplier = getMultiplier(cleaned)
+  const amount = Number.parseFloat(cleaned.replace(/[km]$/, ""))
+
+  return Math.round(amount * multiplier)
+}
+
+const getMultiplier = (cleaned: string): number => {
+  if (cleaned.endsWith("k")) {
+    return 1_000
+  }
+
+  if (cleaned.endsWith("m")) {
+    return 1_000_000
+  }
+
+  return 1
+}
+
+/** Drop punctuation the grammar doesn't use, but keep case for the keyword */
+const clean = (query: string): string => {
+  return query
+    .replace(/[^\w\s$,.–—-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+interface PriceResult {
+  priceRange?: string
+  rest: string
+}
+
+const extractPrice = (query: string): PriceResult => {
+  const hit = PRICE_PATTERNS.map(pattern => {
+    return { pattern, match: query.match(pattern.regex) }
+  }).find(({ match }) => {
+    return !!match
+  })
+
+  const match = hit?.match
+
+  if (!match || match.index === undefined) {
+    return { rest: query }
+  }
+
+  const rest = `${query.slice(0, match.index)} ${query.slice(
+    match.index + match[0].length,
+  )}`
+
+  return { priceRange: hit.pattern.toRange(match), rest }
+}
+
+interface PhraseAccumulator {
+  matches: VocabularyEntry[]
+  leftover: string[]
+  skipUntil: number
+}
+
+const extractVocabulary = (tokens: string[]): PhraseAccumulator => {
+  return tokens.reduce<PhraseAccumulator>(
+    (acc, _token, index) => {
+      if (index < acc.skipUntil) return acc
+
+      // Longest match first, so "work on paper" beats "work"
+      const maxSize = Math.min(MAX_PHRASE_WORDS, tokens.length - index)
+      const sizes = Array.from({ length: maxSize }, (_, offset) => {
+        return maxSize - offset
+      })
+
+      const hit = sizes
+        .map(size => {
+          const phrase = normalizePhrase(
+            tokens.slice(index, index + size).join(" "),
+          )
+          return { size, entry: FILTER_VOCABULARY.get(phrase) }
+        })
+        .find(({ entry }) => {
+          return !!entry
+        })
+
+      if (!hit?.entry) {
+        return { ...acc, leftover: [...acc.leftover, tokens[index]] }
+      }
+
+      return {
+        matches: [...acc.matches, hit.entry],
+        leftover: acc.leftover,
+        skipUntil: index + hit.size,
+      }
+    },
+    { matches: [], leftover: [], skipUntil: 0 },
+  )
+}
+
+const formatPriceLabel = (range: string): string => {
+  const [min, max] = range.split("-")
+  const format = (amount: string) => {
+    return CURRENCY_FORMATTER.format(Number(amount))
+  }
+
+  if (min === "*") {
+    return `Under ${format(max)}`
+  }
+
+  if (max === "*") {
+    return `${format(min)} and up`
+  }
+
+  return `${format(min)}–${format(max)}`
+}
+
+const CURRENCY_FORMATTER = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+})
+
+/**
+ * Parses artwork-filter intent out of a raw search query, entirely on the
+ * client. Returns null when there's nothing worth suggesting.
+ */
+export const parseFilterQuery = (query: string): ParsedFilterQuery | null => {
+  if (!query.trim()) return null
+
+  const { priceRange, rest } = extractPrice(clean(query))
+
+  const tokens = rest.split(/\s+/).filter(Boolean)
+  const { matches, leftover } = extractVocabulary(tokens)
+
+  const medium = matches.find(entry => entry.type === "medium")
+
+  const attributionEntries = matches.filter(entry => {
+    return entry.type === "attributionClass"
+  })
+  const attributionClass = [
+    ...new Set(attributionEntries.map(entry => entry.value)),
+  ]
+
+  const keyword = leftover
+    // A price like "$1000-5000" leaves its "$" behind, since the amount itself
+    // starts at a word boundary
+    .filter(token => {
+      return /\w/.test(token)
+    })
+    .filter(token => {
+      return !STOPWORDS.has(token.toLowerCase())
+    })
+    .join(" ")
+    .trim()
+
+  const filterCount =
+    (medium ? 1 : 0) + (priceRange ? 1 : 0) + attributionClass.length
+
+  if (!shouldSuggestFilters({ filterCount, keyword })) return null
+
+  const labels = [
+    medium?.label,
+    ...attributionEntries.map(entry => entry.label),
+    priceRange ? formatPriceLabel(priceRange) : undefined,
+  ].filter(Boolean) as string[]
+
+  return {
+    filters: {
+      medium: medium?.value,
+      priceRange,
+      attributionClass: attributionClass.length ? attributionClass : undefined,
+      keyword: keyword || undefined,
+    },
+    keyword,
+    labels,
+  }
+}
+
+/**
+ * A single recognized filter with no keyword ("prints") is better served by the
+ * gene/collection entity the backend already returns, so hold the row back
+ * until there's either free text to carry over or a second filter.
+ */
+const shouldSuggestFilters = ({
+  filterCount,
+  keyword,
+}: {
+  filterCount: number
+  keyword: string
+}): boolean => {
+  if (filterCount === 0) return false
+
+  return keyword.length > 0 || filterCount >= 2
+}


### PR DESCRIPTION
## Suggested filters

Turns a search like `french paintings under 3000` into a row at the top of the dropdown that links to a filtered `/collect` page. Behind the `onyx_suggested-filters` feature flag, on for staging/review/dev off for production.


<img width="1154" height="779" alt="Screenshot 2026-08-28 at 11 29 10" src="https://github.com/user-attachments/assets/a37fc400-1268-46bf-9cb2-cb7bb86534e4" />

<img width="1159" height="815" alt="Screenshot 2026-08-28 at 11 31 34" src="https://github.com/user-attachments/assets/43e0258c-14df-4dd9-ae06-a7e23d390fcd" />

<img width="1154" height="809" alt="Screenshot 2026-08-28 at 11 31 46" src="https://github.com/user-attachments/assets/ea2a30c8-cc50-4264-9440-e0c6893b705b" />



### Covers

Medium, price and rarity. One medium per query, USD only. No colour, size, nationality, period, way-to-buy, materials or location.

### Shows a row

| Query | Row |
|---|---|
| `warhol prints under 5000` | warhol / in Prints · Under $5,000 |
| `banksy limited edition prints under 10k` | banksy / in Prints · Limited Edition · Under $10,000 |
| `french paintings` | french / in Painting |
| `kaws sculpture` | kaws / in Sculpture |
| `banksy under 2000` | banksy / in Under $2,000 |
| `prints between 1k and 5k` | Prints / in $1,000–$5,000 |
| `photography over 2000` | Photography / in $2,000 and up |
| `unique painting under 20000` | Painting / in Unique · Under $20,000 |
| `work on paper under 3000` | Work on Paper / in Under $3,000 |
| `open edition prints` | Prints / in Open Edition |

### Shows nothing — these were the bugs

| Query | Used to produce |
|---|---|
| `warhol 1962-1964` | price $1,962–$1,964 |
| `jack dowling (american, 1931-2021)` | price $1,931–$2,021 |
| `1-54` | price $1–$54 (it's an art fair) |
| `edition 5-10` | price $5–$10 |
| `no prints` | medium = Prints |
| `everything except sculpture` | medium = Sculpture |
| `prints and photography under 5k` | Prints only, photography dropped silently |
| `design miami` | medium = Design |
| `film noir photography` | medium = Film/Video |
| `paintings under £5000` | price lost, keyword became "5000" |

### Shows nothing

`warhol` · `prints` · `gagosian`  a bare entity name or a single filter. The existing artist/gene result is the better answer.

### Known limitations

- **Proper-noun collisions are mitigated, not solved.** Any title, gallery or fair containing a medium word can still produce a wrong medium; the blocklist covers the cases we found.
- **Negated terms outside the vocabulary land in the keyword.** `paintings without frames` gives medium = Painting, keyword "without frames". Suppressing on any stray negator would break real titles like `banksy no ball games`.
- **The row parses the debounced value**, so it appears a beat after you stop typing. It's prepended, and appearing per-keystroke shifted the option indices under the cursor. 

Assisted-by: Claude Opus 5.0
