### PR TITLE
feat(search): re-show the mobile search overlay on browser back

### DIFF
--- a/src/Components/Search/Mobile/MobileSearchBar.tsx
+++ b/src/Components/Search/Mobile/MobileSearchBar.tsx
@@ -1,8 +1,10 @@
 import SearchIcon from "@artsy/icons/SearchIcon"
 import { LabeledInput, useDidMount } from "@artsy/palette"
-import { type FC, useState } from "react"
+import { useFlag } from "@unleash/proxy-client-react"
+import { type FC, useEffect, useState } from "react"
 import { OverlayRefetchContainer } from "./Overlay"
 import { StaticSearchContainer } from "Components/Search/StaticSearchContainer"
+import { useRouter } from "System/Hooks/useRouter"
 import { useSystemContext } from "System/Hooks/useSystemContext"
 import { SystemQueryRenderer } from "System/Relay/SystemQueryRenderer"
 import type {
@@ -16,26 +18,62 @@ interface MobileSearchBarProps {
   onClose: () => void
 }
 
+// The history entry the overlay was opened on, so back navigation re-shows it
+interface OverlaySession {
+  locationKey: string
+  hasNavigatedAway: boolean
+}
+
 export const MobileSearchBar: FC<
   React.PropsWithChildren<MobileSearchBarProps>
 > = ({ viewer, onClose }) => {
-  const [overlayDisplayed, setOverlayDisplayed] = useState(false)
+  const { match } = useRouter()
+  // The initial page-load entry carries no farce key (history.state is null
+  // until farce stamps it); the URL identifies that entry instead
+  const locationKey =
+    match.location.key ?? `${match.location.pathname}${match.location.search}`
+
+  const isTrendingEnabled = useFlag("onyx_trending-searches")
+
+  const [session, setSession] = useState<OverlaySession | null>(null)
+
+  // Re-shows after back skip the autofocus (see shouldAutoFocus below)
+  useEffect(() => {
+    if (!session || session.hasNavigatedAway) return
+
+    if (locationKey !== session.locationKey) {
+      setSession({ ...session, hasNavigatedAway: true })
+    }
+  }, [locationKey, session])
 
   const displayOverlay = () => {
-    setOverlayDisplayed(true)
+    setSession({ locationKey, hasNavigatedAway: false })
   }
 
   const handleOverlayClose = () => {
-    setOverlayDisplayed(false)
+    setSession(null)
     onClose()
   }
 
+  // Result clicks keep the session: the location change hides the overlay and
+  // browser back re-shows it. Flag off closes as before.
+  const handleOverlayNavigate = () => {
+    if (!isTrendingEnabled) {
+      handleOverlayClose()
+    }
+  }
+
+  const visibleSession =
+    session && session.locationKey === locationKey ? session : null
+
   return (
     <>
-      {overlayDisplayed && (
+      {visibleSession && (
         <OverlayRefetchContainer
           viewer={viewer}
           onClose={handleOverlayClose}
+          onNavigate={handleOverlayNavigate}
+          shouldAutoFocus={!visibleSession.hasNavigatedAway}
           variant="experiment"
         />
       )}

--- a/src/Components/Search/Mobile/Overlay.tsx
+++ b/src/Components/Search/Mobile/Overlay.tsx
@@ -40,6 +40,10 @@ interface OverlayProps {
   viewer: Overlay_viewer$data
   relay: RelayRefetchProp
   onClose: () => void
+  /** Called after a result click; falls back to onClose */
+  onNavigate?: () => void
+  /** Pass false to skip the input autofocus (and its tracking) on mount */
+  shouldAutoFocus?: boolean
   variant?: string
 }
 
@@ -47,6 +51,8 @@ export const Overlay: FC<React.PropsWithChildren<OverlayProps>> = ({
   viewer,
   relay,
   onClose,
+  onNavigate,
+  shouldAutoFocus = true,
   variant,
 }) => {
   const tracking = useTracking()
@@ -60,7 +66,7 @@ export const Overlay: FC<React.PropsWithChildren<OverlayProps>> = ({
   // biome-ignore lint/correctness/useExhaustiveDependencies: Should only focus and track once on mount, not re-run when pill changes
   const inputCallbackRef = useCallback((node: HTMLInputElement | null) => {
     inputRef.current = node
-    if (node) {
+    if (node && shouldAutoFocus) {
       node.focus()
       tracking.trackEvent({
         action_type: ActionType.focusedOnSearchInput,
@@ -131,6 +137,8 @@ export const Overlay: FC<React.PropsWithChildren<OverlayProps>> = ({
     [relay, variant],
   )
 
+  const handleNavigate = onNavigate ?? onClose
+
   const handlePillClick = (pill: PillType) => {
     setSelectedPill(pill)
   }
@@ -187,12 +195,12 @@ export const Overlay: FC<React.PropsWithChildren<OverlayProps>> = ({
             viewer={viewer}
             query={inputValue}
             selectedPill={selectedPill}
-            onClose={onClose}
+            onClose={handleNavigate}
           />
         ) : (
           isTrendingEnabled && (
             <TrendingSearches
-              onNavigate={onClose}
+              onNavigate={handleNavigate}
               shouldTrackImpressions={shouldTrackTrendingImpressions}
             />
           )

--- a/src/Components/Search/Mobile/__tests__/MobileSearchBar.jest.tsx
+++ b/src/Components/Search/Mobile/__tests__/MobileSearchBar.jest.tsx
@@ -1,0 +1,155 @@
+import { fireEvent, render, screen } from "@testing-library/react"
+import { MobileSearchBar } from "Components/Search/Mobile/MobileSearchBar"
+import { useRouter } from "System/Hooks/useRouter"
+import type { MobileSearchBarSuggestQuery$data } from "__generated__/MobileSearchBarSuggestQuery.graphql"
+
+jest.mock("System/Hooks/useRouter", () => ({ useRouter: jest.fn() }))
+
+jest.mock("@unleash/proxy-client-react", () => ({
+  useFlag: jest.fn(() => true),
+}))
+
+jest.mock("Components/Search/Mobile/Overlay", () => ({
+  OverlayRefetchContainer: ({
+    onClose,
+    onNavigate,
+    shouldAutoFocus,
+  }: {
+    onClose: () => void
+    onNavigate: () => void
+    shouldAutoFocus: boolean
+  }) => {
+    return (
+      <div data-testid="overlay" data-autofocus={String(shouldAutoFocus)}>
+        <button type="button" onClick={onClose}>
+          Close
+        </button>
+        <button type="button" onClick={onNavigate}>
+          Navigate
+        </button>
+      </div>
+    )
+  },
+}))
+
+const mockUseRouter = useRouter as jest.Mock
+
+const setLocation = (location: {
+  key?: string
+  pathname?: string
+  search?: string
+}) => {
+  mockUseRouter.mockReturnValue({
+    match: { location: { pathname: "/", search: "", ...location } },
+  })
+}
+
+describe("MobileSearchBar", () => {
+  const onClose = jest.fn()
+
+  const renderSearchBar = () => {
+    return render(
+      <MobileSearchBar
+        viewer={{} as NonNullable<MobileSearchBarSuggestQuery$data["viewer"]>}
+        onClose={onClose}
+      />,
+    )
+  }
+
+  const rerenderSearchBar = (
+    rerender: ReturnType<typeof render>["rerender"],
+  ) => {
+    rerender(
+      <MobileSearchBar
+        viewer={{} as NonNullable<MobileSearchBarSuggestQuery$data["viewer"]>}
+        onClose={onClose}
+      />,
+    )
+  }
+
+  const openOverlay = () => {
+    fireEvent.click(screen.getByPlaceholderText("Search Artsy"))
+  }
+
+  beforeEach(() => {
+    setLocation({ key: "home" })
+  })
+
+  afterEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("shows the overlay with autofocus when the search input is tapped", () => {
+    renderSearchBar()
+
+    expect(screen.queryByTestId("overlay")).not.toBeInTheDocument()
+
+    openOverlay()
+
+    expect(screen.getByTestId("overlay")).toHaveAttribute(
+      "data-autofocus",
+      "true",
+    )
+  })
+
+  it("hides the overlay when navigating away and re-shows it without autofocus on back", () => {
+    const { rerender } = renderSearchBar()
+    openOverlay()
+
+    // Result click keeps the session; the route change hides the overlay
+    fireEvent.click(screen.getByRole("button", { name: "Navigate" }))
+    setLocation({ key: "artist", pathname: "/artist/banksy" })
+    rerenderSearchBar(rerender)
+
+    expect(screen.queryByTestId("overlay")).not.toBeInTheDocument()
+
+    // Browser back restores the opening entry's key
+    setLocation({ key: "home" })
+    rerenderSearchBar(rerender)
+
+    expect(screen.getByTestId("overlay")).toHaveAttribute(
+      "data-autofocus",
+      "false",
+    )
+  })
+
+  it("keeps the overlay closed after an explicit close, including across back", () => {
+    const { rerender } = renderSearchBar()
+    openOverlay()
+
+    fireEvent.click(screen.getByRole("button", { name: "Close" }))
+
+    expect(screen.queryByTestId("overlay")).not.toBeInTheDocument()
+    expect(onClose).toHaveBeenCalled()
+
+    setLocation({ key: "artist", pathname: "/artist/banksy" })
+    rerenderSearchBar(rerender)
+    setLocation({ key: "home" })
+    rerenderSearchBar(rerender)
+
+    expect(screen.queryByTestId("overlay")).not.toBeInTheDocument()
+  })
+
+  it("re-shows the overlay on back to the keyless initial page-load entry", () => {
+    // A fresh page load has no farce key until farce stamps history.state;
+    // the entry is identified by its URL instead
+    setLocation({ key: undefined })
+    const { rerender } = renderSearchBar()
+    openOverlay()
+
+    fireEvent.click(screen.getByRole("button", { name: "Navigate" }))
+    setLocation({ key: "artist", pathname: "/artist/banksy" })
+    rerenderSearchBar(rerender)
+
+    expect(screen.queryByTestId("overlay")).not.toBeInTheDocument()
+
+    // Back restores the initial entry, still keyless
+    setLocation({ key: undefined })
+    rerenderSearchBar(rerender)
+
+    expect(screen.getByTestId("overlay")).toHaveAttribute(
+      "data-autofocus",
+      "false",
+    )
+  })
+})

--- a/src/Components/Search/Mobile/__tests__/Overlay.jest.tsx
+++ b/src/Components/Search/Mobile/__tests__/Overlay.jest.tsx
@@ -24,12 +24,13 @@ describe("Overlay", () => {
     jest.clearAllMocks()
   })
 
-  const renderOverlay = () => {
+  const renderOverlay = (props?: { shouldAutoFocus?: boolean }) => {
     return render(
       <Overlay
         viewer={{} as Overlay_viewer$data}
         relay={{ refetch: jest.fn() } as unknown as RelayRefetchProp}
         onClose={jest.fn()}
+        {...props}
       />,
     )
   }
@@ -59,6 +60,18 @@ describe("Overlay", () => {
     renderOverlay()
 
     expect(screen.getByPlaceholderText("Search Artsy")).toHaveFocus()
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ action_type: "focusedOnSearchInput" }),
+    )
+  })
+
+  it("skips the autofocus and its tracking when shouldAutoFocus is false", () => {
+    renderOverlay({ shouldAutoFocus: false })
+
+    expect(screen.getByPlaceholderText("Search Artsy")).not.toHaveFocus()
+    expect(mockTrackEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ action_type: "focusedOnSearchInput" }),
+    )
   })
 
   it("blurs the search input when the user drags the overlay content", () => {


### PR DESCRIPTION
> **Draft on purpose** — this changes a long-standing mWeb convention (overlays close on back), so before merging, let's debate the pros and cons below and agree on a back-button contract for mWeb overlays site-wide, not just this one.

### Context

[mWeb — when I navigate back from an artist or an artwork I end up on the home page with dropdown closed](https://app.notion.com/p/artsy/mWeb-When-I-navigate-back-from-an-artist-or-an-artwork-I-end-up-on-the-home-page-with-dropdown-c-3c2cab0764a080bebef7f3c353e3ae78) (Notion, from trending QA). Tapping a search result discarded the overlay: back landed on the previous page with the search context gone. Eigen keeps its search screen in the navigation stack, so back feels right there; mWeb had nothing equivalent. Deferred pre-launch by agreement; treated as a **feature proposal** now, not a bug fix.

### How it works

The overlay's visibility is tied to the history entry it was opened on — derived **read-only** from the router:

- `MobileSearchBar` records the entry's farce `location.key` when the overlay opens. The initial page-load entry carries no key (farce never stamps `history.state` for it), so the URL identifies that entry instead — safe, because every farce navigation stamps keys, so two keyless same-URL entries can only be the same initial entry.
- A result click keeps that session: the route change hides the overlay, and browser back / the swipe gesture restores the entry's key, which re-shows it — with trending + recents (including the artist just visited), and **without** re-firing the input autofocus or its `focusedOnSearchInput` tracking event.
- The X discards the session (closed stays closed across back/forward), and with `onyx_trending-searches` **off**, every path closes on navigation exactly as today.

We never write to history — no `pushState`, no synthetic entries, no popstate interception — so router behavior, found-scroll restoration, and page-view analytics are structurally untouched. A `router.replace`-based alternative (stamping the initial entry with a key on open) was rejected: it turns opening the overlay into a navigation, with route re-resolution and analytics side effects.

### Known limitations (by design — part of the debate)

- **It re-opens, it doesn't rewind.** The overlay remounts fresh: scroll position, the selected trending tab (7/30 days), and any typed query are reset to the neutral trending state. Searching “nan goldin”, tapping the artist, and pressing back lands on the neutral dropdown, not the typed results. A partial memory can arguably feel more inconsistent than the old always-closed behavior — that's the core pro/con to weigh.
- **Brief flicker on back**: the restored page paints first, then the overlay mounts over it. Structural (the overlay is part of that page's tree); a design-blessed fade-in could soften it as a follow-up.
- The session has no expiry: back through history to the opening entry re-shows the overlay however much later, matching native stack semantics.
- If other code `replace`s the current location while a session is alive, the entry is re-keyed and the overlay silently won't re-show (fails toward absence, never toward wrongly appearing).
- Rail impressions (`railViewed`) re-fire on a back-re-show — same semantics as today's manual re-open, but back-returns aren't distinguishable in the dashboard.

### The wider mWeb overlay picture (out of scope, found on production during QA of this)

Overlay behavior on mWeb is inconsistent today, which is why this PR asks for a site-wide contract rather than a one-off:

- Creating an alert: browser back / swipe closes the dropdown AND navigates away from the page the user was creating the alert on
- After “Your alert has been saved”: selecting an artwork opens it in the background but the overlay never closes

Both worth follow-up fixes toward whichever back-button contract we agree on here.

### QA

Verified on device (iPhone Safari via Web Inspector) and desktop Chrome, both engines confirmed restoring the entry identity correctly, including the keyless fresh-tab case. New jest suite covers the session state machine: open-with-autofocus, hide-on-navigate + re-show-without-autofocus, explicit close surviving back/forward, and the keyless initial-entry round trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)