### PR TITLE
feat(suggested-search): redirect to term page with filters

### DIFF
--- a/src/Apps/Search/Components/SearchResultsFilterPills.tsx
+++ b/src/Apps/Search/Components/SearchResultsFilterPills.tsx
@@ -1,0 +1,54 @@
+import { Flex, Text } from "@artsy/palette"
+import { ATTRIBUTION_CLASS_OPTIONS } from "Components/ArtworkFilter/ArtworkFilters/AttributionClassFilter"
+import { MEDIUM_OPTIONS } from "Components/ArtworkFilter/ArtworkFilters/MediumFilter"
+import {
+  TIME_PERIOD_OPTIONS,
+  getTimePeriodToDisplay,
+} from "Components/ArtworkFilter/ArtworkFilters/TimePeriodFilter"
+import { FilterQuick } from "Components/ArtworkFilter/ArtworkFiltersQuick/FilterQuick"
+import { PriceRangeFilterQuick } from "Components/ArtworkFilter/ArtworkFiltersQuick/PriceRangeFilterQuick"
+import type { FC } from "react"
+
+/** Keep in sync with the pills below, so "All Filters" doesn't double-count */
+export const SEARCH_RESULTS_FILTER_PILL_FIELDS = [
+  "additionalGeneIDs",
+  "attributionClass",
+  "priceRange",
+  "majorPeriods",
+]
+
+export const SearchResultsFilterPills: FC = () => {
+  return (
+    <Flex alignItems="center" gap={1}>
+      <Text variant="xs" color="mono60" flexShrink={0}>
+        Filter:
+      </Text>
+
+      <FilterQuick
+        label="Rarity"
+        name="attributionClass"
+        options={ATTRIBUTION_CLASS_OPTIONS}
+        labelAppliedValues
+      />
+
+      <FilterQuick
+        label="Medium"
+        name="additionalGeneIDs"
+        slice="MEDIUM"
+        options={MEDIUM_OPTIONS}
+        labelAppliedValues
+      />
+
+      <PriceRangeFilterQuick labelAppliedValues />
+
+      <FilterQuick
+        label="Years"
+        name="majorPeriods"
+        slice="MAJOR_PERIOD"
+        options={TIME_PERIOD_OPTIONS}
+        formatOptionName={getTimePeriodToDisplay}
+        labelAppliedValues
+      />
+    </Flex>
+  )
+}

--- a/src/Apps/Search/Components/__tests__/SearchResultsFilterPills.jest.tsx
+++ b/src/Apps/Search/Components/__tests__/SearchResultsFilterPills.jest.tsx
@@ -1,0 +1,115 @@
+import { screen, render } from "@testing-library/react"
+import { SearchResultsFilterPills } from "Apps/Search/Components/SearchResultsFilterPills"
+import {
+  ArtworkFilterContextProvider,
+  type SharedArtworkFilterContextProps,
+} from "Components/ArtworkFilter/ArtworkFilterContext"
+import { FILTER_VOCABULARY } from "Components/Search/utils/filterQueryVocabulary"
+
+const renderPills = (
+  filters: SharedArtworkFilterContextProps["filters"],
+  aggregations?: SharedArtworkFilterContextProps["aggregations"],
+) => {
+  render(
+    <ArtworkFilterContextProvider filters={filters} aggregations={aggregations}>
+      <SearchResultsFilterPills />
+    </ArtworkFilterContextProvider>,
+  )
+}
+
+describe("SearchResultsFilterPills", () => {
+  it("renders a pill per filter", () => {
+    renderPills({})
+
+    expect(screen.getByText("Filter:")).toBeInTheDocument()
+    expect(screen.getByText("Medium")).toBeInTheDocument()
+    expect(screen.getByText("Rarity")).toBeInTheDocument()
+    expect(screen.getByText("Price Range")).toBeInTheDocument()
+    expect(screen.getByText("Years")).toBeInTheDocument()
+  })
+
+  it("names the applied medium in place of the label", () => {
+    renderPills({ additionalGeneIDs: ["work-on-paper"] })
+
+    expect(screen.getByText("Work on Paper")).toBeInTheDocument()
+    expect(screen.queryByText("Medium")).not.toBeInTheDocument()
+  })
+
+  it("names the applied rarity", () => {
+    renderPills({ attributionClass: ["limited edition"] })
+
+    expect(screen.getByText("Limited Edition")).toBeInTheDocument()
+    expect(screen.queryByText("Rarity")).not.toBeInTheDocument()
+  })
+
+  it("formats the applied price range", () => {
+    renderPills({ priceRange: "*-5000" })
+
+    expect(screen.getByText("Under $5,000")).toBeInTheDocument()
+    expect(screen.queryByText("Price Range")).not.toBeInTheDocument()
+  })
+
+  it("names the applied years", () => {
+    renderPills({ majorPeriods: ["1990"] })
+
+    expect(screen.getByText("1990s")).toBeInTheDocument()
+    expect(screen.queryByText("Years")).not.toBeInTheDocument()
+  })
+
+  it("formats the years from a live aggregation, not just the static options", () => {
+    // The route doesn't request MAJOR_PERIOD today, but the sidebar's own
+    // filter formats these names either way
+    renderPills({ majorPeriods: ["1990"] }, [
+      {
+        slice: "MAJOR_PERIOD",
+        counts: [{ name: "1990", value: "1990", count: 12 }],
+      },
+    ])
+
+    expect(screen.getByText("1990s")).toBeInTheDocument()
+    expect(screen.queryByText("1990")).not.toBeInTheDocument()
+  })
+
+  describe("every medium the search parser can produce", () => {
+    // A medium the options don't carry renders as an unlit "Medium" pill
+    // while the results are silently filtered.
+    const vocabularyMediums = [
+      ...new Set(
+        [...FILTER_VOCABULARY.values()]
+          .filter(entry => {
+            return entry.type === "medium"
+          })
+          .map(entry => {
+            return entry.value
+          }),
+      ),
+    ]
+
+    it.each(vocabularyMediums)("lights up the pill for %s", medium => {
+      renderPills({ additionalGeneIDs: [medium] })
+
+      expect(screen.queryByText("Medium")).not.toBeInTheDocument()
+    })
+  })
+
+  it("counts the rest rather than listing every applied value", () => {
+    renderPills({ additionalGeneIDs: ["painting", "prints", "sculpture"] })
+
+    expect(screen.getByText("Painting +2")).toBeInTheDocument()
+  })
+
+  it("counts a value it cannot name", () => {
+    // An option list narrowed by a live aggregation can omit an applied value;
+    // the pill still has to account for it
+    renderPills({ additionalGeneIDs: ["painting", "not-a-medium"] })
+
+    expect(screen.getByText("Painting +1")).toBeInTheDocument()
+  })
+
+  it("names the value applied first, not the first in the option list", () => {
+    // "painting" precedes "prints" in MEDIUM_OPTIONS
+    renderPills({ additionalGeneIDs: ["prints", "painting"] })
+
+    expect(screen.getByText("Prints +1")).toBeInTheDocument()
+  })
+})

--- a/src/Apps/Search/Routes/SearchResultsArtworks.tsx
+++ b/src/Apps/Search/Routes/SearchResultsArtworks.tsx
@@ -1,4 +1,9 @@
+import { useFlag } from "@unleash/proxy-client-react"
 import { SearchResultsArtworksFilters } from "Apps/Search/Components/SearchResultsArtworksFilters"
+import {
+  SEARCH_RESULTS_FILTER_PILL_FIELDS,
+  SearchResultsFilterPills,
+} from "Apps/Search/Components/SearchResultsFilterPills"
 import { ZeroState } from "Apps/Search/Components/ZeroState"
 import { ArtworkFilter } from "Components/ArtworkFilter"
 import type {
@@ -25,6 +30,9 @@ export const SearchResultsArtworksRoute: React.FC<
 > = props => {
   const { match } = useRouter()
   const { userPreferences } = useSystemContext()
+
+  // Same flag as the dropdown row that lands here
+  const isSuggestedFiltersEnabled = useFlag("onyx_suggested-filters")
   const [searchFilterKey, setSearchFilterKey] = useState(
     match.location.query.term,
   )
@@ -69,6 +77,12 @@ export const SearchResultsArtworksRoute: React.FC<
           { value: "year", text: "Artwork Year (Ascending)" },
         ]}
         Filters={<SearchResultsArtworksFilters />}
+        {...(isSuggestedFiltersEnabled
+          ? {
+              QuickFilters: <SearchResultsFilterPills />,
+              quickFilterFields: SEARCH_RESULTS_FILTER_PILL_FIELDS,
+            }
+          : {})}
         userPreferredMetric={userPreferences?.metric}
       />
     </ArtworkGridContextProvider>

--- a/src/Components/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFilters/TimePeriodFilter.tsx
@@ -15,8 +15,10 @@ export interface TimePeriodFilterProps {
   expanded?: boolean // set to true to force expansion
 }
 
-export const getTimePeriodToDisplay = period =>
-  isNaN(period) ? period : `${period}s`
+export const getTimePeriodToDisplay = period => {
+  // Decades get an "s"; named periods ("Late 19th Century") are already labels
+  return Number.isNaN(Number(period)) ? period : `${period}s`
+}
 
 export const TimePeriodFilter: FC<
   React.PropsWithChildren<TimePeriodFilterProps>
@@ -84,7 +86,7 @@ export const TimePeriodFilter: FC<
   )
 }
 
-const allowedPeriods = [
+export const allowedPeriods = [
   "2020",
   "2010",
   "2000",
@@ -103,3 +105,11 @@ const allowedPeriods = [
   "Early 19th Century",
   "18th Century & Earlier",
 ]
+
+/**
+ * `allowedPeriods` in the shape the quick filters take. Names stay raw, as the
+ * MAJOR_PERIOD aggregation returns them, so callers format both sources alike.
+ */
+export const TIME_PERIOD_OPTIONS = allowedPeriods.map(period => {
+  return { name: period, value: period }
+})

--- a/src/Components/ArtworkFilter/ArtworkFiltersQuick/FilterQuick.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFiltersQuick/FilterQuick.tsx
@@ -18,7 +18,7 @@ import {
   useCurrentlySelectedFilters,
 } from "Components/ArtworkFilter/ArtworkFilterContext"
 import type { MultiSelectArtworkFilters } from "Components/ArtworkFilter/ArtworkFilterTypes"
-import { type FC, useMemo } from "react"
+import { type FC, useCallback, useMemo } from "react"
 
 interface FilterQuickProps
   extends Omit<DropdownProps, "dropdown" | "children"> {
@@ -26,6 +26,10 @@ interface FilterQuickProps
   name: keyof MultiSelectArtworkFilters
   options: { name: string; value: string }[]
   slice?: Slice
+  /** Show the applied values instead of the label: "Painting", not "Medium • 1" */
+  labelAppliedValues?: boolean
+  /** For slices whose names aren't display-ready — periods arrive as "1990" */
+  formatOptionName?: (name: string) => string
 }
 
 export const FilterQuick: FC<React.PropsWithChildren<FilterQuickProps>> = ({
@@ -33,6 +37,8 @@ export const FilterQuick: FC<React.PropsWithChildren<FilterQuickProps>> = ({
   label,
   options: _options,
   slice,
+  labelAppliedValues,
+  formatOptionName,
   ...rest
 }) => {
   const { selectedFiltersCounts, aggregations = [] } = useArtworkFilterContext()
@@ -55,6 +61,28 @@ export const FilterQuick: FC<React.PropsWithChildren<FilterQuickProps>> = ({
 
     return aggregation.counts
   }, [_options, aggregations, slice])
+
+  const displayName = useCallback(
+    (name: string): string => {
+      return formatOptionName ? formatOptionName(name) : name
+    },
+    [formatOptionName],
+  )
+
+  // Walks `currentValue`, so the pill names the value applied first rather than
+  // whichever comes first in `options`. Names come from `options`, so the pill
+  // reads "Work on Paper", not "work-on-paper".
+  const appliedLabels = useMemo(() => {
+    if (!labelAppliedValues) return undefined
+
+    return currentValue.flatMap(value => {
+      const option = options.find(option => {
+        return option.value === value
+      })
+
+      return option ? [displayName(option.name)] : []
+    })
+  }, [labelAppliedValues, options, currentValue, displayName])
 
   const handleSelect = (value: string) => (selected: boolean) => {
     const nextValue = selected
@@ -90,7 +118,7 @@ export const FilterQuick: FC<React.PropsWithChildren<FilterQuickProps>> = ({
                     onSelect={handleSelect(value)}
                     selected={currentValue.includes(value)}
                   >
-                    {name}
+                    {displayName(name)}
                   </Checkbox>
                 )
               })}
@@ -104,7 +132,12 @@ export const FilterQuick: FC<React.PropsWithChildren<FilterQuickProps>> = ({
     >
       {props => {
         return (
-          <FilterQuickDropdownAnchor label={label} count={count} {...props} />
+          <FilterQuickDropdownAnchor
+            label={label}
+            count={count}
+            appliedLabels={appliedLabels}
+            {...props}
+          />
         )
       }}
     </Dropdown>
@@ -114,21 +147,27 @@ export const FilterQuick: FC<React.PropsWithChildren<FilterQuickProps>> = ({
 interface FilterQuickDropdownAnchorProps extends DropdownActions {
   label: string
   count: number
+  /** When present, replaces the label and the pill reads as selected */
+  appliedLabels?: string[]
 }
 
 export const FilterQuickDropdownAnchor: FC<
   React.PropsWithChildren<FilterQuickDropdownAnchorProps>
-> = ({ anchorProps, anchorRef, label, count, visible }) => {
+> = ({ anchorProps, anchorRef, label, count, appliedLabels, visible }) => {
+  const hasAppliedLabels = !!appliedLabels?.length
+
   return (
     <Pill
       ref={anchorRef as any}
       size="small"
+      selected={hasAppliedLabels}
       Icon={visible ? ChevronSmallUpIcon : ChevronSmallDownIcon}
       iconPosition="right"
       {...anchorProps}
     >
-      {label}
-      {count > 0 && (
+      {hasAppliedLabels ? formatAppliedLabels(appliedLabels, count) : label}
+
+      {!hasAppliedLabels && count > 0 && (
         <Box as="span" color="blue100">
           {" "}
           • {count}
@@ -136,6 +175,24 @@ export const FilterQuickDropdownAnchor: FC<
       )}
     </Pill>
   )
+}
+
+/**
+ * Only the first value is named; joining them all overflows the row. The
+ * remainder is counted off `count` rather than the named labels, so a value
+ * `options` can't name still shows up in the total.
+ */
+const formatAppliedLabels = (
+  appliedLabels: string[],
+  count: number,
+): string => {
+  const [first] = appliedLabels
+
+  if (count <= 1) {
+    return first
+  }
+
+  return `${first} +${count - 1}`
 }
 
 interface FilterQuickDropdownPanelProps extends BoxProps {

--- a/src/Components/ArtworkFilter/ArtworkFiltersQuick/PriceRangeFilterQuick.tsx
+++ b/src/Components/ArtworkFilter/ArtworkFiltersQuick/PriceRangeFilterQuick.tsx
@@ -6,17 +6,27 @@ import {
   FilterQuickDropdownAnchor,
   FilterQuickDropdownPanel,
 } from "Components/ArtworkFilter/ArtworkFiltersQuick/FilterQuick"
+import { formatPriceRangeLabel } from "Components/ArtworkFilter/Utils/formatPriceRangeLabel"
 import { PriceRange } from "Components/PriceRange/PriceRange"
 import type { FC } from "react"
 
 export interface PriceRangeFilterQuickProps
-  extends Omit<DropdownProps, "dropdown" | "children"> {}
+  extends Omit<DropdownProps, "dropdown" | "children"> {
+  label?: string
+  /**
+   * Renders the applied range in place of the label, in a pill that reads as
+   * selected — "Under $5,000" rather than "Price Range • 1".
+   */
+  labelAppliedValues?: boolean
+}
 
 export const PriceRangeFilterQuick: FC<
   React.PropsWithChildren<PriceRangeFilterQuickProps>
-> = props => {
-  const { count, filters, range, histogram, onPriceRangeUpdate } =
+> = ({ label = "Price Range", labelAppliedValues, ...props }) => {
+  const { count, field, filters, range, histogram, onPriceRangeUpdate } =
     usePriceRangeFilter()
+
+  const appliedLabel = labelAppliedValues ? formatPriceRangeLabel(field) : null
 
   const handleClear = () => {
     filters.setFilter("priceRange", initialArtworkFilterState.priceRange)
@@ -54,8 +64,9 @@ export const PriceRangeFilterQuick: FC<
       {props => {
         return (
           <FilterQuickDropdownAnchor
-            label="Price Range"
+            label={label}
             count={count}
+            appliedLabels={appliedLabel ? [appliedLabel] : undefined}
             {...props}
           />
         )

--- a/src/Components/ArtworkFilter/Utils/__tests__/formatPriceRangeLabel.jest.ts
+++ b/src/Components/ArtworkFilter/Utils/__tests__/formatPriceRangeLabel.jest.ts
@@ -1,0 +1,37 @@
+import { formatPriceRangeLabel } from "Components/ArtworkFilter/Utils/formatPriceRangeLabel"
+
+describe("formatPriceRangeLabel", () => {
+  it("names an upper bound", () => {
+    expect(formatPriceRangeLabel("*-5000")).toBe("Under $5,000")
+  })
+
+  it("names a lower bound", () => {
+    expect(formatPriceRangeLabel("2000-*")).toBe("$2,000 and up")
+  })
+
+  it("joins two bounds with an en dash", () => {
+    expect(formatPriceRangeLabel("1000-5000")).toBe("$1,000–$5,000")
+  })
+
+  it("drops the cents", () => {
+    expect(formatPriceRangeLabel("1500.75-5000.25")).toBe("$1,501–$5,000")
+  })
+
+  it("has no label for an unbounded range", () => {
+    // The filter's cleared state
+    expect(formatPriceRangeLabel("*-*")).toBeNull()
+  })
+
+  it("has no label for a range missing a bound", () => {
+    // Would have formatted as "Under $NaN"
+    expect(formatPriceRangeLabel("5000")).toBeNull()
+    expect(formatPriceRangeLabel("5000-")).toBeNull()
+    expect(formatPriceRangeLabel("-5000")).toBeNull()
+  })
+
+  it("has no label when the filter is unset", () => {
+    expect(formatPriceRangeLabel(undefined)).toBeNull()
+    expect(formatPriceRangeLabel(null)).toBeNull()
+    expect(formatPriceRangeLabel("")).toBeNull()
+  })
+})

--- a/src/Components/ArtworkFilter/Utils/formatPriceRangeLabel.ts
+++ b/src/Components/ArtworkFilter/Utils/formatPriceRangeLabel.ts
@@ -1,0 +1,34 @@
+const CURRENCY_FORMATTER = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 0,
+})
+
+/**
+ * Turns a `priceRange` value ("*-5000", "1000-5000") into its label. Null when
+ * unbounded, which is what the filter's cleared state looks like.
+ */
+export const formatPriceRangeLabel = (
+  priceRange: string | undefined | null,
+): string | null => {
+  if (!priceRange) return null
+
+  const [min, max] = priceRange.split("-")
+
+  if (!min || !max) return null
+  if (min === "*" && max === "*") return null
+
+  const format = (amount: string): string => {
+    return CURRENCY_FORMATTER.format(Number(amount))
+  }
+
+  if (min === "*") {
+    return `Under ${format(max)}`
+  }
+
+  if (max === "*") {
+    return `${format(min)} and up`
+  }
+
+  return `${format(min)}–${format(max)}`
+}

--- a/src/Components/ArtworkFilter/index.tsx
+++ b/src/Components/ArtworkFilter/index.tsx
@@ -68,6 +68,10 @@ import { getTotalSelectedFiltersCount } from "./Utils/getTotalSelectedFiltersCou
 
 interface ArtworkFilterProps extends SharedArtworkFilterContextProps, BoxProps {
   Filters?: JSX.Element
+  /** Replaces the default quick-filter pill row in the sticky bar */
+  QuickFilters?: JSX.Element
+  /** The fields `QuickFilters` covers, so "All Filters" doesn't double-count */
+  quickFilterFields?: string[]
   offset?: number
   // Input variables passed to FilterArtworkConnection `input` argument
   relayRefetchInputVariables?: object
@@ -124,6 +128,8 @@ export const BaseArtworkFilter: React.FC<
 > = ({
   children,
   Filters,
+  QuickFilters,
+  quickFilterFields = ARTWORK_FILTERS_QUICK_FIELDS,
   offset,
   relay,
   relayRefetchInputVariables = {},
@@ -195,12 +201,12 @@ export const BaseArtworkFilter: React.FC<
   const quickArtworkFiltersCount = useMemo(() => {
     return Object.entries(filterContext.selectedFiltersCounts || {}).reduce(
       (acc, [field, count]) => {
-        if (!ARTWORK_FILTERS_QUICK_FIELDS.includes(field)) return acc
+        if (!quickFilterFields.includes(field)) return acc
         return acc + count
       },
       0,
     )
-  }, [filterContext.selectedFiltersCounts])
+  }, [filterContext.selectedFiltersCounts, quickFilterFields])
 
   const extendedFiltersCount =
     revisedArtworkFiltersCount - quickArtworkFiltersCount
@@ -433,9 +439,11 @@ export const BaseArtworkFilter: React.FC<
                             </Pill>
                           </Flex>
 
-                          <ArtworkFiltersQuick
-                            featuredKeywords={featuredKeywords}
-                          />
+                          {QuickFilters ?? (
+                            <ArtworkFiltersQuick
+                              featuredKeywords={featuredKeywords}
+                            />
+                          )}
                         </Flex>
                       </HorizontalOverflow>
 

--- a/src/Components/Search/SearchBarInput.tsx
+++ b/src/Components/Search/SearchBarInput.tsx
@@ -21,7 +21,6 @@ import {
   type SearchedWithResults,
   type SelectedItemFromSearch,
 } from "@artsy/cohesion"
-import { buildUrlForCollectApp } from "Apps/Collect/Utils/urlBuilder"
 import { Z } from "Apps/Components/constants"
 import { ManageArtworkForSavesProvider } from "Components/Artwork/ManageArtworkForSaves"
 import { DESKTOP_NAV_BAR_TOP_TIER_HEIGHT } from "Components/NavBar/constants"
@@ -50,6 +49,7 @@ import { useRecentSearches } from "./hooks/useRecentSearches"
 import { useTrendingImpressionSession } from "./hooks/useTrendingImpressionSession"
 import { getLabel } from "./utils/getLabel"
 import { isModifiedClick } from "./utils/isModifiedClick"
+import { buildSuggestedFiltersUrl } from "./utils/buildSuggestedFiltersUrl"
 import { parseFilterQuery } from "./utils/parseFilterQuery"
 import { searchResultsHref } from "./utils/searchResultsHref"
 import { shouldStartSearching } from "./utils/shouldStartSearching"
@@ -122,7 +122,7 @@ export const SearchBarInput: FC<
     !!parsedFilters && selectedPill === TOP_PILL
 
   const suggestedFiltersHref = parsedFilters
-    ? buildUrlForCollectApp(parsedFilters.filters)
+    ? buildSuggestedFiltersUrl(parsedFilters)
     : ""
 
   const formattedOptions: SuggestionItemOptionProps[] = [

--- a/src/Components/Search/__tests__/SearchBarInput.jest.tsx
+++ b/src/Components/Search/__tests__/SearchBarInput.jest.tsx
@@ -535,7 +535,7 @@ describe("SearchBarInput", () => {
       expect(parseFilterQuery).toHaveBeenCalledWith("warhol prints under 5000")
     })
 
-    it("renders the parsed filters and links to the collect page", () => {
+    it("renders the parsed filters and links to the search results page", () => {
       enableSuggestedFilters()
       render(<SearchBarInput searchTerm="warhol prints under 5000" />)
 
@@ -544,8 +544,10 @@ describe("SearchBarInput", () => {
       expect(row()).toHaveTextContent("in Prints · Under $5,000")
 
       const href = row()?.getAttribute("href")
-      expect(href).toContain("/collect/prints")
-      expect(href).toContain("keyword=warhol")
+      expect(href).toContain("/search?")
+      expect(href).toContain("term=warhol&")
+      expect(href).toContain("additional_gene_ids%5B0%5D=prints")
+      expect(href).toContain("price_range=%2A-5000")
     })
 
     it("highlights every term the user typed, including inside derived labels", () => {

--- a/src/Components/Search/utils/__tests__/buildSuggestedFiltersUrl.jest.ts
+++ b/src/Components/Search/utils/__tests__/buildSuggestedFiltersUrl.jest.ts
@@ -1,0 +1,67 @@
+import { buildSuggestedFiltersUrl } from "Components/Search/utils/buildSuggestedFiltersUrl"
+import { parseFilterQuery } from "Components/Search/utils/parseFilterQuery"
+
+const urlFor = (query: string): string => {
+  const parsed = parseFilterQuery(query)
+
+  if (!parsed) throw new Error(`Expected "${query}" to parse`)
+
+  return decodeURIComponent(
+    buildSuggestedFiltersUrl(parsed).replace(/%5B|%5D/g, match => {
+      return match === "%5B" ? "[" : "]"
+    }),
+  )
+}
+
+describe("buildSuggestedFiltersUrl", () => {
+  it("points at the search results page, not collect", () => {
+    expect(urlFor("warhol prints under 5000")).toMatch(/^\/search\?/)
+  })
+
+  it("carries only the free text as the search term", () => {
+    // The term doubles as the artworks keyword, so the filter words have to go:
+    // searching "warhol prints under 5000" alongside the filters they produced
+    // returns nothing at all
+    const url = urlFor("warhol prints under 5000")
+
+    expect(url).toContain("term=warhol&")
+    expect(url).not.toContain("term=warhol prints")
+  })
+
+  it("sends the medium as a gene id, so the Medium filter reflects it", () => {
+    expect(urlFor("warhol prints under 5000")).toContain(
+      "additional_gene_ids[0]=prints",
+    )
+  })
+
+  it("sends the price as a range", () => {
+    expect(urlFor("warhol prints under 5000")).toContain("price_range=*-5000")
+  })
+
+  it("sends rarity as attribution classes", () => {
+    expect(urlFor("banksy limited edition prints")).toContain(
+      "attribution_class[0]=limited edition",
+    )
+  })
+
+  it("omits filters the query didn't ask for", () => {
+    const url = urlFor("warhol prints")
+
+    expect(url).not.toContain("price_range")
+    expect(url).not.toContain("attribution_class")
+  })
+
+  it("stands the leading filter label in when there is no free text", () => {
+    // An empty term leaves the heading reading `results for ""`, and the raw
+    // query would search the filter words again
+    expect(urlFor("prints between 1k and 5k")).toContain("term=Prints&")
+  })
+
+  it("never sends the filter words as the term", () => {
+    // The removed raw-query fallback used to reintroduce them
+    const url = urlFor("prints between 1k and 5k")
+
+    expect(url).not.toContain("between")
+    expect(url).not.toContain("1k")
+  })
+})

--- a/src/Components/Search/utils/__tests__/parseFilterQuery.jest.ts
+++ b/src/Components/Search/utils/__tests__/parseFilterQuery.jest.ts
@@ -1,3 +1,5 @@
+import { MEDIUM_OPTIONS } from "Components/ArtworkFilter/ArtworkFilters/MediumFilter"
+import { FILTER_VOCABULARY } from "../filterQueryVocabulary"
 import { parseFilterQuery } from "../parseFilterQuery"
 
 /**
@@ -6,6 +8,37 @@ import { parseFilterQuery } from "../parseFilterQuery"
  * replace them with invented equivalents.
  */
 describe("parseFilterQuery", () => {
+  describe("only suggests mediums the filter UI can name", () => {
+    // Both the pill and the drawer's MediumFilter name an applied medium out
+    // of MEDIUM_OPTIONS; a value outside them filters results invisibly.
+    const nameableMediums = new Set(
+      MEDIUM_OPTIONS.map(option => {
+        return option.value
+      }),
+    )
+
+    const vocabularyMediums = [
+      ...new Set(
+        [...FILTER_VOCABULARY.values()]
+          .filter(entry => {
+            return entry.type === "medium"
+          })
+          .map(entry => {
+            return entry.value
+          }),
+      ),
+    ]
+
+    it.each(vocabularyMediums)("%s is in MEDIUM_OPTIONS", medium => {
+      expect(nameableMediums.has(medium)).toBe(true)
+    })
+
+    it("does not suggest a medium the Medium filter cannot display", () => {
+      // Valid as a /collect path segment, absent from MEDIUM_OPTIONS
+      expect(parseFilterQuery("warhol posters")?.filters.medium).toBeUndefined()
+    })
+  })
+
   describe("suggests filters", () => {
     it("combines a medium, a price and a leftover artist name", () => {
       const result = parseFilterQuery("warhol prints under 5000")

--- a/src/Components/Search/utils/buildSuggestedFiltersUrl.ts
+++ b/src/Components/Search/utils/buildSuggestedFiltersUrl.ts
@@ -1,0 +1,33 @@
+import { paramsToSnakeCase } from "Components/ArtworkFilter/Utils/paramsCasing"
+import qs from "qs"
+import type { ParsedFilterQuery } from "./parseFilterQuery"
+
+/**
+ * Builds the term page URL for a parsed query, where the filters show up as
+ * pills a wrong parse can be corrected in.
+ *
+ * The medium goes out as `additionalGeneIDs`, not `medium`: it's what the
+ * page's Medium filter reads, so the pill shows as applied.
+ */
+export const buildSuggestedFiltersUrl = (parsed: ParsedFilterQuery): string => {
+  const { medium, priceRange, attributionClass } = parsed.filters
+
+  const params = {
+    // Free text only: the term doubles as the artworks keyword, and searching
+    // the filter words too returns nothing ("warhol prints under 5000" -> 0,
+    // "warhol" plus the same filters -> ~1,500). With no free text the leading
+    // label stands in, keeping the heading readable. A row always carries one
+    // or the other, so there is deliberately no raw-query fallback here.
+    term: parsed.keyword || parsed.labels[0],
+    additionalGeneIDs: medium ? [medium] : undefined,
+    attributionClass,
+    priceRange,
+  }
+
+  // Default `arrayFormat`, matching the filter panel's own `buildUrl`
+  const queryString = qs.stringify(paramsToSnakeCase(params), {
+    skipNulls: true,
+  })
+
+  return `/search?${queryString}`
+}

--- a/src/Components/Search/utils/filterQueryVocabulary.ts
+++ b/src/Components/Search/utils/filterQueryVocabulary.ts
@@ -150,19 +150,20 @@ const buildVocabulary = (): Map<string, VocabularyEntry> => {
     add(deslugify(value), entry)
   })
 
-  // Superset of slugs valid as a /collect/:medium path segment. Where a slug
-  // already came from MEDIUM_OPTIONS, keep that label so "print" and "prints"
-  // don't render as two different things.
+  // Reuse the MEDIUM_OPTIONS label so "print" and "prints" don't render as two
+  // different things.
   const mediumLabels = new Map(
     [...vocabulary.values()].map(entry => [entry.value, entry.label]),
   )
 
   Object.entries(FILTER_CATEGORIES).forEach(([name, value]) => {
-    const entry: VocabularyEntry = {
-      type: "medium",
-      value,
-      label: mediumLabels.get(value) ?? name,
-    }
+    const label = mediumLabels.get(value)
+
+    // Skip slugs the Medium filter has no option for ("poster", "textiles"):
+    // they filter results that no pill or checkbox can name or untick.
+    if (!label) return
+
+    const entry: VocabularyEntry = { type: "medium", value, label }
 
     add(name, entry)
     add(deslugify(value), entry)

--- a/src/Components/Search/utils/parseFilterQuery.ts
+++ b/src/Components/Search/utils/parseFilterQuery.ts
@@ -1,4 +1,5 @@
 import type { ArtworkFilters } from "Components/ArtworkFilter/ArtworkFilterTypes"
+import { formatPriceRangeLabel } from "Components/ArtworkFilter/Utils/formatPriceRangeLabel"
 import {
   COLLISION_PHRASES,
   FILTER_VOCABULARY,
@@ -10,8 +11,9 @@ import {
 } from "./filterQueryVocabulary"
 
 /**
- * `medium`, not `additionalGeneIDs`: urlBuilder turns it into the
- * `/collect/:medium` path segment. Hence one medium per query.
+ * `medium` holds a single gene slug; `buildSuggestedFiltersUrl` sends it on as
+ * a one-element `additionalGeneIDs`. Widening it to several mediums is possible
+ * now the URL is no longer a `/collect/:medium` path — see the cap below.
  */
 export type SuggestedFilters = Pick<
   ArtworkFilters,
@@ -254,29 +256,6 @@ const trimStopwords = (words: string[]): string[] => {
   return words.slice(first, words.length - fromEnd)
 }
 
-const formatPriceLabel = (range: string): string => {
-  const [min, max] = range.split("-")
-  const format = (amount: string) => {
-    return CURRENCY_FORMATTER.format(Number(amount))
-  }
-
-  if (min === "*") {
-    return `Under ${format(max)}`
-  }
-
-  if (max === "*") {
-    return `${format(min)} and up`
-  }
-
-  return `${format(min)}–${format(max)}`
-}
-
-const CURRENCY_FORMATTER = new Intl.NumberFormat("en-US", {
-  style: "currency",
-  currency: "USD",
-  maximumFractionDigits: 0,
-})
-
 /**
  * Parses artwork-filter intent out of a raw search query, entirely on the
  * client. Returns null when there's nothing worth suggesting.
@@ -322,8 +301,10 @@ export const parseFilterQuery = (query: string): ParsedFilterQuery | null => {
     ),
   ]
 
-  // The collect URL carries a single medium as its path segment, so a second
-  // one would be dropped without the user seeing it go
+  // Only one medium is carried, so a second would be dropped without the user
+  // seeing it go. The `/collect/:medium` path segment that forced this is gone
+  // — `additionalGeneIDs` takes a list — so "prints and paintings" could be
+  // supported by widening `medium`, the pill already renders "Prints +1".
   if (mediumValues.length > 1) return null
 
   const medium = mediumEntries[0]
@@ -353,7 +334,7 @@ export const parseFilterQuery = (query: string): ParsedFilterQuery | null => {
   const labels = [
     medium?.label,
     ...attributionEntries.map(entry => entry.label),
-    priceRange ? formatPriceLabel(priceRange) : undefined,
+    priceRange ? formatPriceRangeLabel(priceRange) : undefined,
   ].filter(Boolean) as string[]
 
   return {


### PR DESCRIPTION
The type of this PR is: **Feat**

### Description

The suggested-filters row in the search dropdown now links to the search results page `/search?term=french+paintings&additional_gene_ids[0]=painting` rather than a filtered `/collect` page, so the query stays visible in the heading and a wrong parse is correctable instead of silently applied. 

Only the free text becomes the search term eg. `warhol prints under 5000` sends term=warhol plus the two filters, because searching the filter words on top of the filters they produced returns 0 results where the parsed keyword returns ~1500 results.

# Before 
<img width="2048" height="1092" alt="Screenshot 2026-09-01 at 13 01 46" src="https://github.com/user-attachments/assets/c54e188c-6343-4d61-b083-307a786c52dc" />

# After  
<img width="2048" height="1043" alt="Screenshot 2026-09-01 at 13 01 36" src="https://github.com/user-attachments/assets/1e643ef5-ae02-4d27-94d8-3ec44847d0ec" />

<!-- Implementation description -->
